### PR TITLE
Fix filtering in snapshots

### DIFF
--- a/gui/templates/storage/snapshots.html
+++ b/gui/templates/storage/snapshots.html
@@ -122,6 +122,7 @@
             indirectSelection: true,
             filter: {
                 isServerSide: false,
+                fetchAllOnFirstFilter: false,
             },
         },
         structure: struc


### PR DESCRIPTION
Filtering did not work in snapshots, with this fix it does again.
