### PR TITLE
Fix for recursive replication with multiple snapshot schedules

### DIFF
--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -313,7 +313,7 @@ Hello,
                 continue
             else:
                 log.warn("Remote and local mismatch after replication: %s vs %s" % (expected_local_snapshot, snapname))
-                rzfscmd = '"zfs list -Ho name -t snapshot %s | head -n 1 | cut -d@ -f2"' % (remotefs_final)
+                rzfscmd = '"zfs list -Ho name -t snapshot -d 1 %s | head -n 1 | cut -d@ -f2"' % (remotefs_final)
                 sshproc = pipeopen('%s -p %d %s %s' % (sshcmd, remote_port, remote, rzfscmd))
                 output = sshproc.communicate()[0]
                 if output != '':


### PR DESCRIPTION
This fixes problems when using -R replications.

In a scenario where in the same timestamp two or more snapshots were
created for a dataset, the replication could fail, because when checking
the remote side, another snapshots might get replicated, and due to the
ordering bad results came back.

Example:
~# zfs snapshot test@a && zfs snapshot test@b && sleep 1 && zfs snapshot test@c
~# zfs list -t snapshot -d 1 -H -o name test
test@a
test@b
test@c
~# zfs list -t snapshot -d 1 -H -o name -s creation test
test@a
test@b
test@c
~# zfs list -t snapshot -d 1 -H -o name -S creation test
test@c
test@a
test@b

As shown, the reverse ordering, or maybe any ordering breaks zfs
snapshot dependencies in the listing.
