### PR TITLE
Dont create remote filesystem, as 'zfs receive' will do that

### DIFF
--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -267,10 +267,8 @@ Hello,
         destroycmd = '%s -p %d %s /sbin/zfs destroy -rRf %s' % (sshcmd, remote_port, remote, remotefs_final)
         system(destroycmd)
         known_latest_snapshot = ''
-    if known_latest_snapshot == '':
-        last_snapshot = ''
-    else:
-        last_snapshot = known_latest_snapshot
+
+    last_snapshot = known_latest_snapshot
 
     for snapname in wanted_list:
         if replication.repl_limit != 0:


### PR DESCRIPTION
This enables replicating zvols, but removes the readonly attribute from
the dataset. But as we use 'zfs receive -F', it will reset the dataset
even if it got modified.
