### PR TITLE
use native zfs functionality for protecting  snaps with clones

### DIFF
--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -192,16 +192,6 @@ for line in lines:
                     else:
                         snapshots[(fs, snap_ret_policy)] = snap_infodict
 
-# Exclude snapshots that have clones associated from being deleted
-if len(snapshots_pending_delete) > 0:
-    snapshots_cloned = set()
-    zfsproc = pipeopen("/sbin/zfs list -H -t filesystem,volume -o origin", debug, logger=log)
-    lines = zfsproc.communicate()[0].split('\n')
-    for snapshot_name in lines:
-        if snapshot_name != '-':
-            snapshots_cloned.add(snapshot_name)
-    snapshots_pending_delete = snapshots_pending_delete.difference(snapshots_cloned)
-
 list_mp = mp_to_task_map.keys()
 
 for mpkey in list_mp:
@@ -253,7 +243,7 @@ for snapshot in snapshots_pending_delete:
     if output != '':
         fsname, attrname, value, source = output.split('\n')[0].split('\t')
         if value == '-':
-            snapcmd = '/sbin/zfs destroy -r %s' % (snapshot)
+            snapcmd = '/sbin/zfs destroy -r -d %s' % (snapshot) #snapshots with clones will have destruction deferred
             proc = pipeopen(snapcmd, logger=log)
             err = proc.communicate()[1]
             if proc.returncode != 0:


### PR DESCRIPTION
Replace code to exclude snapshots with clones with native zfs functionality.  zfs -d destroy will mark snapshot for deletion when any clones (and any holds) are destroyed (removed)

In theory there should be no need for recursive destroy (-r) as autosnap.py will recursively queue snapshots which have expired - but there is a bug with recursive snaps which have replication.  I will raise bug report and have retained -r
