### PR TITLE
Enable snap expiry even if no new snaps

### DIFF
--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -163,10 +163,6 @@ for task in TaskObjects:
             tasklist = [task]
         mp_to_task_map[(fs, expire_time)] = tasklist
 
-# Do not proceed further if we are not going to generate any snapshots for this run
-if len(mp_to_task_map) == 0:
-    exit()
-
 # Grab all existing snapshot and filter out the expiring ones
 snapshots = {}
 snapshots_pending_delete = set()


### PR DESCRIPTION
If autosnap does not identify that any snaps need creating it terminates preventing stale snapshots from being expired and replication from running.  This will also fix #2345

This change lets autosnap - create, expire and run replication regardless of snapshot creation.  

An alternative solution would be to split autosnap into create and expire scripts and then have three cron jobs running createsnap, expiresnap and replicate scripts.  If this is preferred approach please advise and I will look to code
