### PR TITLE
Instead of explicitly specifying a /tmp/ path to mktemp, use the -t flag...

### DIFF
--- a/nanobsd/Installer/lib/functions.sh
+++ b/nanobsd/Installer/lib/functions.sh
@@ -187,7 +187,7 @@ source_conf()
 		return 1
 	fi
 
-	if ! tmpconf=$(mktemp /tmp/conf.XXXXXX)
+	if ! tmpconf=$(mktemp -t conf.XXXXXX)
 	then
 		return 1
 	fi


### PR DESCRIPTION
..., which respects TMPDIR.
