### PR TITLE
Mark UFS legacy in treeview

### DIFF
--- a/gui/storage/nav.py
+++ b/gui/storage/nav.py
@@ -47,7 +47,7 @@ class AddVolume(TreeNode):
 class AddVolumeUFS(TreeNode):
 
     gname = 'Add'
-    name = _(u'UFS Volume Manager')
+    name = _(u'UFS Volume Manager (legacy)')
     view = 'storage_volumemanager_ufs'
     type = 'volumewizard'
     icon = u'AddVolumeIcon'


### PR DESCRIPTION
We are trying to discourage people from making UFS volumes and have decided to go with "legacy" terminology, however the treeview is not updated with "legacy".  This fixes that.
