### PR TITLE
Restart collectd when importing/decrypting a pool.

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -3088,6 +3088,7 @@ class notifier:
             # These should probably be options that are configurable from the GUI
             self.__system("zfs set aclmode=passthrough %s" % name)
             self.__system("zfs set aclinherit=passthrough %s" % name)
+            self.restart("collectd")
             return True
         else:
             log.error("Importing %s [%s] failed with: %s",


### PR DESCRIPTION
Scenario:
Assumption: There are both encrypted and unencrypted pools
1. FreeNAS boots and automounts unencrypted pools
2. collectd starts to track free space on the pools
3. User unlocks the encrypted pols
Before fix: collectd doesn't track free space of the "new" pools
After fix: collectd correctly starts tracking free space of the unlocked pools
