### PR TITLE
Allow custom URL for web interface

### DIFF
--- a/nanobsd/Files/etc/rc.d/ix-nginx
+++ b/nanobsd/Files/etc/rc.d/ix-nginx
@@ -232,7 +232,7 @@ __EOF__
     server {
 	listen ${addr}:80;
 	server_name localhost;
-	rewrite ^ https://\$server_addr:${port}\$request_uri? permanent;
+	rewrite ^(.*) https://\$host\$1 permanent;
     }
 __EOF__
 	fi


### PR DESCRIPTION
Remove IP redirection to avoid SSL certificates to appear as untrusted.
Allow custom domain name as URL.
