### PR TITLE
Option Enable AutoSnap expire if no new Snaps.  Fix #2345

### DIFF
--- a/gui/system/migrations/0057_auto__add_field_advanced_adv_autosnapdelifnosnap.py
+++ b/gui/system/migrations/0057_auto__add_field_advanced_adv_autosnapdelifnosnap.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Advanced.adv_autosnapdelifnosnap'
+        db.add_column(u'system_advanced', 'adv_autosnapdelifnosnap',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Advanced.adv_autosnapdelifnosnap'
+        db.delete_column(u'system_advanced', 'adv_autosnapdelifnosnap')
+
+
+    models = {
+        u'storage.disk': {
+            'Meta': {'ordering': "['disk_name']", 'object_name': 'Disk'},
+            'disk_acousticlevel': ('django.db.models.fields.CharField', [], {'default': "'Disabled'", 'max_length': '120'}),
+            'disk_advpowermgmt': ('django.db.models.fields.CharField', [], {'default': "'Disabled'", 'max_length': '120'}),
+            'disk_description': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'disk_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'disk_hddstandby': ('django.db.models.fields.CharField', [], {'default': "'Always On'", 'max_length': '120'}),
+            'disk_identifier': ('django.db.models.fields.CharField', [], {'max_length': '42'}),
+            'disk_multipath_member': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_multipath_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_name': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'disk_serial': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_smartoptions': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'disk_togglesmart': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'disk_transfermode': ('django.db.models.fields.CharField', [], {'default': "'Auto'", 'max_length': '120'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'system.advanced': {
+            'Meta': {'object_name': 'Advanced'},
+            'adv_advancedmode': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_anonstats': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'adv_anonstats_token': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'adv_autosnapdelifnosnap': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_autotune': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_consolemenu': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_consolemsg': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'adv_consolescreensaver': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_debugkernel': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_motd': ('django.db.models.fields.TextField', [], {'default': "'Welcome'", 'max_length': '1024'}),
+            'adv_powerdaemon': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_serialconsole': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'adv_serialspeed': ('django.db.models.fields.CharField', [], {'default': "'9600'", 'max_length': '120'}),
+            'adv_swapondrive': ('django.db.models.fields.IntegerField', [], {'default': '2'}),
+            'adv_traceback': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'system.alert': {
+            'Meta': {'object_name': 'Alert'},
+            'dismiss': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        u'system.cronjob': {
+            'Meta': {'ordering': "['cron_description', 'cron_user']", 'object_name': 'CronJob'},
+            'cron_command': ('django.db.models.fields.TextField', [], {}),
+            'cron_daymonth': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'cron_dayweek': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'cron_description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'cron_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cron_hour': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'cron_minute': ('django.db.models.fields.CharField', [], {'default': "'00'", 'max_length': '100'}),
+            'cron_month': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'cron_stderr': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'cron_stdout': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cron_user': ('freenasUI.freeadmin.models.fields.UserField', [], {'max_length': '60'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'system.email': {
+            'Meta': {'object_name': 'Email'},
+            'em_fromemail': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '120'}),
+            'em_outgoingserver': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'em_pass': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'em_port': ('django.db.models.fields.IntegerField', [], {'default': '25'}),
+            'em_security': ('django.db.models.fields.CharField', [], {'default': "'plain'", 'max_length': '120'}),
+            'em_smtp': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'em_user': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'system.initshutdown': {
+            'Meta': {'object_name': 'InitShutdown'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ini_command': ('django.db.models.fields.CharField', [], {'max_length': '300', 'blank': 'True'}),
+            'ini_script': ('freenasUI.freeadmin.models.fields.PathField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'ini_type': ('django.db.models.fields.CharField', [], {'default': "'command'", 'max_length': '15'}),
+            'ini_when': ('django.db.models.fields.CharField', [], {'max_length': '15'})
+        },
+        u'system.ntpserver': {
+            'Meta': {'ordering': "['ntp_address']", 'object_name': 'NTPServer'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ntp_address': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'ntp_burst': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ntp_iburst': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'ntp_maxpoll': ('django.db.models.fields.IntegerField', [], {'default': '10'}),
+            'ntp_minpoll': ('django.db.models.fields.IntegerField', [], {'default': '6'}),
+            'ntp_prefer': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'system.registration': {
+            'Meta': {'object_name': 'Registration'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reg_address': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_cellphone': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_city': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_company': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_email': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'reg_firstname': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'reg_homephone': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_lastname': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'reg_state': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_workphone': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'reg_zip': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'})
+        },
+        u'system.rsync': {
+            'Meta': {'ordering': "['rsync_path', 'rsync_desc']", 'object_name': 'Rsync'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'rsync_archive': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rsync_compress': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rsync_daymonth': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'rsync_dayweek': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'rsync_delete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rsync_desc': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'rsync_direction': ('django.db.models.fields.CharField', [], {'default': "'push'", 'max_length': '10'}),
+            'rsync_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rsync_extra': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rsync_hour': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'rsync_minute': ('django.db.models.fields.CharField', [], {'default': "'00'", 'max_length': '100'}),
+            'rsync_mode': ('django.db.models.fields.CharField', [], {'default': "'module'", 'max_length': '20'}),
+            'rsync_month': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'rsync_path': ('freenasUI.freeadmin.models.fields.PathField', [], {'max_length': '255'}),
+            'rsync_preserveattr': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rsync_preserveperm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rsync_quiet': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'rsync_recursive': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rsync_remotehost': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'rsync_remotemodule': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'rsync_remotepath': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'rsync_remoteport': ('django.db.models.fields.SmallIntegerField', [], {'default': '22'}),
+            'rsync_times': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rsync_user': ('freenasUI.freeadmin.models.fields.UserField', [], {'max_length': '60'})
+        },
+        u'system.settings': {
+            'Meta': {'object_name': 'Settings'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'stg_directoryservice': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'stg_guiaddress': ('django.db.models.fields.CharField', [], {'default': "'0.0.0.0'", 'max_length': '120', 'blank': 'True'}),
+            'stg_guiport': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '120', 'blank': 'True'}),
+            'stg_guiprotocol': ('django.db.models.fields.CharField', [], {'default': "'http'", 'max_length': '120'}),
+            'stg_guiv6address': ('django.db.models.fields.CharField', [], {'default': "'::'", 'max_length': '120', 'blank': 'True'}),
+            'stg_kbdmap': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'stg_language': ('django.db.models.fields.CharField', [], {'default': "'en'", 'max_length': '120'}),
+            'stg_syslogserver': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '120', 'blank': 'True'}),
+            'stg_timezone': ('django.db.models.fields.CharField', [], {'default': "'America/Los_Angeles'", 'max_length': '120'})
+        },
+        u'system.smarttest': {
+            'Meta': {'ordering': "['smarttest_type']", 'object_name': 'SMARTTest'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'smarttest_daymonth': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'smarttest_dayweek': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'smarttest_desc': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'smarttest_disks': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['storage.Disk']", 'symmetrical': 'False'}),
+            'smarttest_hour': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'smarttest_month': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'smarttest_type': ('django.db.models.fields.CharField', [], {'max_length': '2'})
+        },
+        u'system.ssl': {
+            'Meta': {'object_name': 'SSL'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ssl_certfile': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'ssl_city': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_common': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_country': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_email': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_org': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_passphrase': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_state': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssl_unit': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True', 'blank': 'True'})
+        },
+        u'system.sysctl': {
+            'Meta': {'ordering': "['sysctl_mib']", 'object_name': 'Sysctl'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sysctl_comment': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'sysctl_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'sysctl_mib': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'sysctl_value': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'system.tunable': {
+            'Meta': {'ordering': "['tun_var']", 'object_name': 'Tunable'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tun_comment': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'tun_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'tun_value': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'tun_var': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['system']

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -219,6 +219,9 @@ class Advanced(Model):
     adv_anonstats_token = models.TextField(
             blank=True,
             editable=False)
+    adv_autosnapdelifnosnap = models.BooleanField(
+            verbose_name = _("Enable auto snapshot expiration even if new snaps are not being created"),
+            default=False)
     # TODO: need geom_eli in kernel
     #adv_encswap = models.BooleanField(
     #        verbose_name = _("Encrypt swap space"),
@@ -228,7 +231,7 @@ class Advanced(Model):
         verbose_name=_("MOTD banner"),
         default='Welcome',
     )
-
+ 
     class Meta:
         verbose_name = _("Advanced")
 

--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -43,6 +43,7 @@ cache.get_apps()
 
 from freenasUI.freeadmin.apppool import appPool
 from freenasUI.storage.models import Task, Replication
+from freenasUI.system.models import Advanced
 from datetime import datetime, time, timedelta
 
 from freenasUI.common.pipesubr import pipeopen, system
@@ -107,6 +108,8 @@ def isMatchingTime(task, snaptime):
 
     return False
 
+alwaysdeletesnaps = Advanced.objects.latest('id').adv_autosnapdelifnosnap
+
 # Detect if another instance is running
 def exit_if_running(pid):
     log.debug("Checking if process %d is still alive", pid)
@@ -170,91 +173,90 @@ for task in TaskObjects:
             tasklist = [task]
         mp_to_task_map[(fs, expire_time)] = tasklist
 
-# Do not proceed further if we are not going to generate any snapshots for this run
-if len(mp_to_task_map) == 0:
-    exit()
+# Do not proceed further if we are not going to generate any snapshots for this run UNLESS alwaysdeletesnaps is set to true (system/advanced)
+if len(mp_to_task_map) > 0 or alwaysdeletesnaps == True:
 
-# Grab all existing snapshot and filter out the expiring ones
-snapshots = {}
-snapshots_pending_delete = set()
-zfsproc = pipeopen("/sbin/zfs list -t snapshot -H", debug, logger=log)
-lines = zfsproc.communicate()[0].split('\n')
-reg_autosnap = re.compile('^auto-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).(?P<hour>\d{2})(?P<minute>\d{2})-(?P<retcount>\d+)(?P<retunit>[hdwmy])$')
-for line in lines:
-    if line != '':
-        snapshot_name = line.split('\t')[0]
-        fs, snapname = snapshot_name.split('@')
-        snapname_match = reg_autosnap.match(snapname)
-        if snapname_match != None:
-            snap_infodict = snapname_match.groupdict()
-            snap_ret_policy = '%s%s' % (snap_infodict['retcount'], snap_infodict['retunit'])
-            if snap_expired(snap_infodict, snaptime):
-                snapshots_pending_delete.add(snapshot_name)
-            else:
-                if mp_to_task_map.has_key((fs, snap_ret_policy)):
-                    if snapshots.has_key((fs, snap_ret_policy)):
-                        last_snapinfo = snapshots[(fs, snap_ret_policy)]
-                        if snapinfodict2datetime(last_snapinfo) < snapinfodict2datetime(snap_infodict):
+    # Grab all existing snapshot and filter out the expiring ones
+    snapshots = {}
+    snapshots_pending_delete = set()
+    zfsproc = pipeopen("/sbin/zfs list -t snapshot -H", debug, logger=log)
+    lines = zfsproc.communicate()[0].split('\n')
+    reg_autosnap = re.compile('^auto-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).(?P<hour>\d{2})(?P<minute>\d{2})-(?P<retcount>\d+)(?P<retunit>[hdwmy])$')
+    for line in lines:
+        if line != '':
+            snapshot_name = line.split('\t')[0]
+            fs, snapname = snapshot_name.split('@')
+            snapname_match = reg_autosnap.match(snapname)
+            if snapname_match != None:
+                snap_infodict = snapname_match.groupdict()
+                snap_ret_policy = '%s%s' % (snap_infodict['retcount'], snap_infodict['retunit'])
+                if snap_expired(snap_infodict, snaptime):
+                    snapshots_pending_delete.add(snapshot_name)
+                else:
+                    if mp_to_task_map.has_key((fs, snap_ret_policy)):
+                        if snapshots.has_key((fs, snap_ret_policy)):
+                            last_snapinfo = snapshots[(fs, snap_ret_policy)]
+                            if snapinfodict2datetime(last_snapinfo) < snapinfodict2datetime(snap_infodict):
+                                snapshots[(fs, snap_ret_policy)] = snap_infodict
+                        else:
                             snapshots[(fs, snap_ret_policy)] = snap_infodict
-                    else:
-                        snapshots[(fs, snap_ret_policy)] = snap_infodict
 
-list_mp = mp_to_task_map.keys()
+    list_mp = mp_to_task_map.keys()
 
-for mpkey in list_mp:
-    tasklist = mp_to_task_map[mpkey]
-    if snapshots.has_key(mpkey):
-        snapshot_time = snapinfodict2datetime(snapshots[mpkey])
-        for taskindex in range(len(tasklist) -1, -1, -1):
-            task = tasklist[taskindex]
-            if snapshot_time + timedelta(minutes = task.task_interval) > snaptime:
-                del tasklist[taskindex]
-        if len(tasklist) == 0:
-            del mp_to_task_map[mpkey]
+    for mpkey in list_mp:
+        tasklist = mp_to_task_map[mpkey]
+        if snapshots.has_key(mpkey):
+            snapshot_time = snapinfodict2datetime(snapshots[mpkey])
+            for taskindex in range(len(tasklist) -1, -1, -1):
+                task = tasklist[taskindex]
+                if snapshot_time + timedelta(minutes = task.task_interval) > snaptime:
+                    del tasklist[taskindex]
+            if len(tasklist) == 0:
+                del mp_to_task_map[mpkey]
 
-snaptime_str = snaptime.strftime('%Y%m%d.%H%M')
+    snaptime_str = snaptime.strftime('%Y%m%d.%H%M')
 
-for mpkey, tasklist in mp_to_task_map.items():
-    fs, expire = mpkey
-    recursive = False
-    for task in tasklist:
-        if task.task_recursive == True:
-            recursive = True
-    if recursive == True:
-        rflag = ' -r'
-    else:
-        rflag = ''
+    for mpkey, tasklist in mp_to_task_map.items():
+        fs, expire = mpkey
+        recursive = False
+        for task in tasklist:
+            if task.task_recursive == True:
+                recursive = True
+        if recursive == True:
+            rflag = ' -r'
+        else:
+            rflag = ''
 
-    snapname = '%s@auto-%s-%s' % (fs, snaptime_str, expire)
+        snapname = '%s@auto-%s-%s' % (fs, snaptime_str, expire)
 
-    # If there is associated replication task, mark the snapshots as 'NEW'.
-    if Replication.objects.filter(repl_filesystem=fs, repl_enabled=True).count() > 0:
-        MNTLOCK.lock()
-        snapcmd = '/sbin/zfs snapshot%s -o freenas:state=NEW %s' % (rflag, snapname)
-        proc = pipeopen(snapcmd, logger=log)
-        err = proc.communicate()[1]
-        if proc.returncode != 0:
-            log.error("Failed to create snapshot '%s': %s", snapname, err)
-        MNTLOCK.unlock()
-    else:
-        snapcmd = '/sbin/zfs snapshot%s %s' % (rflag, snapname)
-        proc = pipeopen(snapcmd, logger=log)
-        err = proc.communicate()[1]
-        if proc.returncode != 0:
-            log.error("Failed to create snapshot '%s': %s", snapname, err)
-
-MNTLOCK.lock()
-for snapshot in snapshots_pending_delete:
-    zfsproc = pipeopen('/sbin/zfs get -H freenas:state %s' % (snapshot, ), logger=log)
-    output = zfsproc.communicate()[0]
-    if output != '':
-        fsname, attrname, value, source = output.split('\n')[0].split('\t')
-        if value == '-':
-            snapcmd = '/sbin/zfs destroy -r -d %s' % (snapshot) #snapshots with clones will have destruction deferred
+        # If there is associated replication task, mark the snapshots as 'NEW'.
+        if Replication.objects.filter(repl_filesystem=fs, repl_enabled=True).count() > 0:
+            MNTLOCK.lock()
+            snapcmd = '/sbin/zfs snapshot%s -o freenas:state=NEW %s' % (rflag, snapname)
             proc = pipeopen(snapcmd, logger=log)
             err = proc.communicate()[1]
             if proc.returncode != 0:
-                log.error("Failed to destroy snapshot '%s': %s", snapshot, err)
+                log.error("Failed to create snapshot '%s': %s", snapname, err)
+            MNTLOCK.unlock()
+        else:
+            snapcmd = '/sbin/zfs snapshot%s %s' % (rflag, snapname)
+            proc = pipeopen(snapcmd, logger=log)
+            err = proc.communicate()[1]
+            if proc.returncode != 0:
+                log.error("Failed to create snapshot '%s': %s", snapname, err)
+
+    MNTLOCK.lock()
+    for snapshot in snapshots_pending_delete:
+        zfsproc = pipeopen('/sbin/zfs get -H freenas:state %s' % (snapshot, ), logger=log)
+        output = zfsproc.communicate()[0]
+        if output != '':
+            fsname, attrname, value, source = output.split('\n')[0].split('\t')
+            if value == '-':
+                snapcmd = '/sbin/zfs destroy -r -d %s' % (snapshot) #snapshots with clones will have destruction deferred
+                proc = pipeopen(snapcmd, logger=log)
+                err = proc.communicate()[1]
+                if proc.returncode != 0:
+                    log.error("Failed to destroy snapshot '%s': %s", snapshot, err)
 
 os.unlink('/var/run/autosnap.pid')
 MNTLOCK.unlock()


### PR DESCRIPTION
Replication will now run even if AutoSnap does not defect #2345
New Option (System/Advanced) for snaps to be expired (deleted) even if new ones are not created; especially useful on replication servers which are not set to mirror primary server (enabler for differential retention period on primary and replication systems)
