### PR TITLE
Use /dev/zero instead of /dev/random when initializing encrypted disks.

### DIFF
--- a/gui/middleware/encryption.py
+++ b/gui/middleware/encryption.py
@@ -70,7 +70,7 @@ class RandomWorker(threading.Thread):
         proc = subprocess.Popen(
             [
                 "dd",
-                "if=/dev/random",
+                "if=/dev/zero",
                 "of=%s" % self._dev,
                 "bs=1m",
             ],


### PR DESCRIPTION
https://bugs.freenas.org/issues/3804
