### PR TITLE
Add collectd disk plugin graphing to rrd.py

### DIFF
--- a/gui/reporting/rrd.py
+++ b/gui/reporting/rrd.py
@@ -720,6 +720,8 @@ class DiskPlugin(RRDBase):
         ids = []
         for entry in glob.glob('%s/disk-*' % self._base_path):
             ident = entry.split('-', 1)[-1]
+            if not os.path.exists('/dev/%s' % ident):
+                continue
             if os.path.exists(os.path.join(entry, 'disk_octets.rrd')):
                 ids.append(ident)
         return ids
@@ -735,18 +737,22 @@ class DiskPlugin(RRDBase):
             'DEF:min_wr=%s:write:MIN' % path,
             'DEF:avg_wr=%s:write:AVERAGE' % path,
             'DEF:max_wr=%s:write:MAX' % path,
-            'AREA:max_rd#bfffbf',
-            'AREA:min_rd#FFFFFF',
-            'LINE1:avg_rd#00ff00: read ',
-            'GPRINT:min_rd:MIN:%6.2lf%s Min,',
-            'GPRINT:avg_rd:AVERAGE:%6.2lf%s Avg,',
-            'GPRINT:max_rd:MAX:%6.2lf%s Max,',
-            'GPRINT:avg_rd:LAST:%6.2lf%s Last\l',
-            'LINE1:avg_wr#0000ff: write',
-            'GPRINT:min_wr:MIN:%6.2lf%s Min,',
-            'GPRINT:avg_wr:AVERAGE:%6.2lf%s Avg,',
-            'GPRINT:max_wr:MAX:%6.2lf%s Max,',
-            'GPRINT:max_wr:LAST:%6.2lf%s Last\l',
+            'VDEF:tot_rd=avg_rd,TOTAL',
+            'VDEF:tot_wr=avg_wr,TOTAL',
+            'AREA:avg_rd#bfbfff',
+            'AREA:avg_wr#bfe0cf',
+            'LINE1:avg_rd#0000ff:Read ',
+            'GPRINT:min_rd:MIN:%5.1lf%s Min\g',
+            'GPRINT:avg_rd:AVERAGE: %5.1lf%s Avg\g',
+            'GPRINT:max_rd:MAX: %5.1lf%s Max\g',
+            'GPRINT:avg_rd:LAST: %5.1lf%s Last\g',
+            'GPRINT:tot_rd: %3.0lf%s Total\l',
+            'LINE1:avg_wr#00b000:Write',
+            'GPRINT:min_wr:MIN:%5.1lf%s Min\g',
+            'GPRINT:avg_wr:AVERAGE: %5.1lf%s Avg\g',
+            'GPRINT:max_wr:MAX: %5.1lf%s Max\g',
+            'GPRINT:avg_wr:LAST: %5.1lf%s Last\g',
+            'GPRINT:tot_wr: %3.0lf%s Total\l',
         ]
 
         return args


### PR DESCRIPTION
Added DiskPlugin to rrd.py to enable graphing of the collectd disk read- and write-octects datasource

Related: http://forums.freenas.org/threads/reporting-gui-page-reporting-jails-that-have-been-deleted.14217/#post-89878

I'm not the member on the forum who originally posted the code, but I needed the change also.  I improved the originally posted code by correctly formatting and aligning the legend labels and removing a disk name filter that was there.
