### PR TITLE
Quote filename in Content-Disposition header field (config backup)

### DIFF
--- a/gui/system/views.py
+++ b/gui/system/views.py
@@ -177,7 +177,7 @@ def config_save(request):
     response = HttpResponse(wrapper, content_type='application/octet-stream')
     response['Content-Length'] = os.path.getsize(filename)
     response['Content-Disposition'] = \
-        'attachment; filename=%s-%s-%s.db' % (
+        'attachment; filename="%s-%s-%s.db"' % (
             hostname.encode('utf-8'),
             freenas_build,
             time.strftime('%Y%m%d%H%M%S'))


### PR DESCRIPTION
**Short version:**
`gui/system/views.py` does not properly quote the `filename` parameter value of the `Content-Disposition` HTTP header field when saving the current config. This violates `RFC 2231` (http://tools.ietf.org/html/rfc2231) and leads to undesired behavior, at least when using Firefox to save the config. 

**Long version:**
This aims to fix https://bugs.freenas.org/issues/3881
Firefox seems to cut the config filename at the first space character (i.e. between x64 and the revision in brackets). With Chrome 31 it works. 

This is a HTTP header field parameter quotation issue. If properly quoted, Firefox would correctly interpret the filename. Chrome seems to have non-standard behavior here: According to `RFC 5987` and `RFC 2231` the `filename` parameter of the `Content-Disposition` header field _must_ be quoted if it contains spaces or other special characters (cf. the corresponding RFCs). Unfortunately, many web applications seem to get this wrong and therefore this has been the source of many discussions on the Firefox bug tracker. Firefox devs, however, chose to keep standards compliance rather than "fixing" this on their end. A convincing comment:

https://bugzilla.mozilla.org/show_bug.cgi?id=221028#c88

The fact that this is a rather complex topic in general can also be seen from this compilation of (extremely useful) discussions and test cases including their results on recent browser versions:
http://greenbytes.de/tech/tc2231/
- http://greenbytes.de/tech/tc2231/#attwithasciifilenamenqws is exactly the test case corresponding to current FreeNAS' behavior (no special characters in filename except for one space, no quotes). The result as listed by the authors of this compilation is the same as observed here (for chrome it works, firefox cuts).
- Double quotes for a name without space works on all tested browsers:
  http://greenbytes.de/tech/tc2231/#attwithasciifilename
- Double quotes for a name with space is not listed as a test case there, this then should obviously work.

A nice discussion can also be found here: http://stackoverflow.com/a/7969807/145400

All in all, to make FreeNAS more standards compliant, we should quote the filename parameter value with double quotes.

In the future, one should consider using  `RFC 5987`-compliant values (where the encoding becomes mandatory).
