### PR TITLE
https://bugs.freenas.org/issues/4095 - retain hostname on https redirection

### DIFF
--- a/nanobsd/Files/etc/ix.rc.d/ix-nginx
+++ b/nanobsd/Files/etc/ix.rc.d/ix-nginx
@@ -234,7 +234,7 @@ __EOF__
 	listen ${addr}:80;
 	listen [${addr6}]:80;
 	server_name localhost;
-	rewrite ^ https://\$server_addr:${httpsport}\$request_uri? permanent;
+	return 307 https://\$host:${httpsport}\$request_uri;
     }
 __EOF__
 	fi


### PR DESCRIPTION
 https://bugs.freenas.org/issues/4095 With this change, hostname will now remain intact on a redirect and a temporary (307) redirect is used instead of a permanent (301), which would now stop browsers from caching the redirection.  Permanent redirections have to be manually flushed from your browser if the https settings are changed (e.g. removed or port changed)
