### PR TITLE
changed replication enabled behaviour - help correction

### DIFF
--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -827,9 +827,6 @@ class Replication(Model):
     repl_enabled = models.BooleanField(
         default=True,
         verbose_name=_("Enabled"),
-        help_text=_(
-            "Disabling will stop any new replications being queued. "
-            "It will not stop any replications which are queued or in progress."),
     ) 
     repl_filesystem = models.CharField(
         max_length=150,


### PR DESCRIPTION
Latest release has changed business logic on replication such that if a replication task is disabled no replication takes place previous logic completed queued (NEW) snapshots.  This changeset removes legacy (now inaccurate) help message
