### PR TITLE
Fix for #2345 which stops replication starting if no overlapping snapsho...

### DIFF
--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#- 
+#-
 # Copyright (c) 2011, 2012 iXsystems, Inc.
 # All rights reserved.
 #
@@ -167,94 +167,94 @@ for task in TaskObjects:
             tasklist = [task]
         mp_to_task_map[(fs, expire_time)] = tasklist
 
-# Do not proceed further if we are not going to generate any snapshots for this run
-if len(mp_to_task_map) == 0:
-    exit()
+# Only proceed further if we are  going to generate any snapshots for this run
+if len(mp_to_task_map) > 0:
 
-# Grab all existing snapshot and filter out the expiring ones
-snapshots = {}
-snapshots_pending_delete = set()
-zfsproc = pipeopen("/sbin/zfs list -t snapshot -H", debug, logger=log)
-lines = zfsproc.communicate()[0].split('\n')
-reg_autosnap = re.compile('^auto-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).(?P<hour>\d{2})(?P<minute>\d{2})-(?P<retcount>\d+)(?P<retunit>[hdwmy])$')
-for line in lines:
-    if line != '':
-        snapshot_name = line.split('\t')[0]
-        fs, snapname = snapshot_name.split('@')
-        snapname_match = reg_autosnap.match(snapname)
-        if snapname_match != None:
-            snap_infodict = snapname_match.groupdict()
-            snap_ret_policy = '%s%s' % (snap_infodict['retcount'], snap_infodict['retunit'])
-            if snap_expired(snap_infodict, snaptime):
-                snapshots_pending_delete.add(snapshot_name)
-            else:
-                if mp_to_task_map.has_key((fs, snap_ret_policy)):
-                    if snapshots.has_key((fs, snap_ret_policy)):
-                        last_snapinfo = snapshots[(fs, snap_ret_policy)]
-                        if snapinfodict2datetime(last_snapinfo) < snapinfodict2datetime(snap_infodict):
+    # Grab all existing snapshot and filter out the expiring ones
+    snapshots = {}
+    snapshots_pending_delete = set()
+    zfsproc = pipeopen("/sbin/zfs list -t snapshot -H", debug, logger=log)
+    lines = zfsproc.communicate()[0].split('\n')
+    reg_autosnap = re.compile('^auto-(?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2}).(?P<hour>\d{2})(?P<minute>\d{2})-(?P<retcount>\d+)(?P<retunit>[hdwmy])$')
+    for line in lines:
+        if line != '':
+            snapshot_name = line.split('\t')[0]
+            fs, snapname = snapshot_name.split('@')
+            snapname_match = reg_autosnap.match(snapname)
+            if snapname_match != None:
+                snap_infodict = snapname_match.groupdict()
+                snap_ret_policy = '%s%s' % (snap_infodict['retcount'], snap_infodict['retunit'])
+                if snap_expired(snap_infodict, snaptime):
+                    snapshots_pending_delete.add(snapshot_name)
+                else:
+                    if mp_to_task_map.has_key((fs, snap_ret_policy)):
+                        if snapshots.has_key((fs, snap_ret_policy)):
+                            last_snapinfo = snapshots[(fs, snap_ret_policy)]
+                            if snapinfodict2datetime(last_snapinfo) < snapinfodict2datetime(snap_infodict):
+                                snapshots[(fs, snap_ret_policy)] = snap_infodict
+                        else:
                             snapshots[(fs, snap_ret_policy)] = snap_infodict
-                    else:
-                        snapshots[(fs, snap_ret_policy)] = snap_infodict
 
-list_mp = mp_to_task_map.keys()
+    list_mp = mp_to_task_map.keys()
 
-for mpkey in list_mp:
-    tasklist = mp_to_task_map[mpkey]
-    if snapshots.has_key(mpkey):
-        snapshot_time = snapinfodict2datetime(snapshots[mpkey])
-        for taskindex in range(len(tasklist) -1, -1, -1):
-            task = tasklist[taskindex]
-            if snapshot_time + timedelta(minutes = task.task_interval) > snaptime:
-                del tasklist[taskindex]
-        if len(tasklist) == 0:
-            del mp_to_task_map[mpkey]
+    for mpkey in list_mp:
+        tasklist = mp_to_task_map[mpkey]
+        if snapshots.has_key(mpkey):
+            snapshot_time = snapinfodict2datetime(snapshots[mpkey])
+            for taskindex in range(len(tasklist) -1, -1, -1):
+                task = tasklist[taskindex]
+                if snapshot_time + timedelta(minutes = task.task_interval) > snaptime:
+                    del tasklist[taskindex]
+            if len(tasklist) == 0:
+                del mp_to_task_map[mpkey]
 
-snaptime_str = snaptime.strftime('%Y%m%d.%H%M')
+    snaptime_str = snaptime.strftime('%Y%m%d.%H%M')
 
-for mpkey, tasklist in mp_to_task_map.items():
-    fs, expire = mpkey
-    recursive = False
-    for task in tasklist:
-        if task.task_recursive == True:
-            recursive = True
-    if recursive == True:
-        rflag = ' -r'
-    else:
-        rflag = ''
+    for mpkey, tasklist in mp_to_task_map.items():
+        fs, expire = mpkey
+        recursive = False
+        for task in tasklist:
+            if task.task_recursive == True:
+                recursive = True
+        if recursive == True:
+            rflag = ' -r'
+        else:
+            rflag = ''
 
-    snapname = '%s@auto-%s-%s' % (fs, snaptime_str, expire)
+        snapname = '%s@auto-%s-%s' % (fs, snaptime_str, expire)
 
-    # If there is associated replication task, mark the snapshots as 'NEW'.
-    if Replication.objects.filter(repl_filesystem=fs, repl_enabled=True).count() > 0:
-        MNTLOCK.lock()
-        snapcmd = '/sbin/zfs snapshot%s -o freenas:state=NEW %s' % (rflag, snapname)
-        proc = pipeopen(snapcmd, logger=log)
-        err = proc.communicate()[1]
-        if proc.returncode != 0:
-            log.error("Failed to create snapshot '%s': %s", snapname, err)
-        MNTLOCK.unlock()
-    else:
-        snapcmd = '/sbin/zfs snapshot%s %s' % (rflag, snapname)
-        proc = pipeopen(snapcmd, logger=log)
-        err = proc.communicate()[1]
-        if proc.returncode != 0:
-            log.error("Failed to create snapshot '%s': %s", snapname, err)
-
-MNTLOCK.lock()
-for snapshot in snapshots_pending_delete:
-    zfsproc = pipeopen('/sbin/zfs get -H freenas:state %s' % (snapshot, ), logger=log)
-    output = zfsproc.communicate()[0]
-    if output != '':
-        fsname, attrname, value, source = output.split('\n')[0].split('\t')
-        if value == '-':
-            snapcmd = '/sbin/zfs destroy -r -d %s' % (snapshot) #snapshots with clones will have destruction deferred
+        # If there is associated replication task, mark the snapshots as 'NEW'.
+        if Replication.objects.filter(repl_filesystem=fs, repl_enabled=True).count() > 0:
+            MNTLOCK.lock()
+            snapcmd = '/sbin/zfs snapshot%s -o freenas:state=NEW %s' % (rflag, snapname)
             proc = pipeopen(snapcmd, logger=log)
             err = proc.communicate()[1]
             if proc.returncode != 0:
-                log.error("Failed to destroy snapshot '%s': %s", snapshot, err)
+                log.error("Failed to create snapshot '%s': %s", snapname, err)
+            MNTLOCK.unlock()
+        else:
+            snapcmd = '/sbin/zfs snapshot%s %s' % (rflag, snapname)
+            proc = pipeopen(snapcmd, logger=log)
+            err = proc.communicate()[1]
+            if proc.returncode != 0:
+                log.error("Failed to create snapshot '%s': %s", snapname, err)
+
+    MNTLOCK.lock()
+    for snapshot in snapshots_pending_delete:
+        zfsproc = pipeopen('/sbin/zfs get -H freenas:state %s' % (snapshot, ), logger=log)
+        output = zfsproc.communicate()[0]
+        if output != '':
+            fsname, attrname, value, source = output.split('\n')[0].split('\t')
+            if value == '-':
+                snapcmd = '/sbin/zfs destroy -r -d %s' % (snapshot) #snapshots with clones will have destruction deferred
+                proc = pipeopen(snapcmd, logger=log)
+                err = proc.communicate()[1]
+                if proc.returncode != 0:
+                    log.error("Failed to destroy snapshot '%s': %s", snapshot, err)
+    MNTLOCK.unlock()
+
 
 os.unlink('/var/run/autosnap.pid')
-MNTLOCK.unlock()
 
 os.execl('/usr/local/bin/python',
          'python',


### PR DESCRIPTION
Fix for #2345 and #1875.  Replication scripts runs even if there are no snap tasks to run.  Despite look of code change (add/delete) I have only made snap creation/deletion dependent on valid snap tasks to action and then taken call of autorepl.py script outside this loop
