### PR TITLE
Amend help text following bus. logic change

### DIFF
--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -828,8 +828,7 @@ class Replication(Model):
         default=True,
         verbose_name=_("Enabled"),
         help_text=_(
-            "Disabling will stop any new replications being queued. "
-            "It will not stop any replications which are queued or in progress."),
+            "Disabling will not stop any replications which are in progress. "),
     ) 
     repl_filesystem = models.CharField(
         max_length=150,


### PR DESCRIPTION
Changeset 79e6610 amended replicator behaviour such that queued (freenas:state=NEW) snaps are no longer replicated if replication task is disabled; amended help text to reflect.  

Note some ambiguity on 'queued' terminology as this is not quoted in UI anywhere.  However as function has changed it is good to change help text to reflect that there has at least been a change
