### PR TITLE
Feature Request #2227 option for compressing replication stream

### DIFF
--- a/docs/api/resources/storage.rst
+++ b/docs/api/resources/storage.rst
@@ -768,6 +768,7 @@ List resource
                 "repl_remote_hostkey": "AAAA",
                 "repl_enabled": true,
                 "repl_resetonce": false,
+                "repl_compression": "lz4",
                 "repl_remote_hostname": "testhost",
                 "repl_lastsnapshot": "",
                 "id": 1,
@@ -823,6 +824,7 @@ Create resource
                 "repl_remote_hostkey": "AAAA",
                 "repl_enabled": true,
                 "repl_resetonce": false,
+                "repl_compression": "lz4",
                 "repl_remote_hostname": "testhost",
                 "repl_lastsnapshot": "",
                 "id": 1,
@@ -840,6 +842,7 @@ Create resource
    :json string repl_remote_dedicateduser: dedicated user to replicate
    :json boolean repl_userepl: recursively replicate and remove stale snapshot on remote side
    :json boolean repl_resetonce: initialize remote side for once
+   :json string repl_compression: replication stream compression
    :json integer repl_limit: limit the replication speed in KB/s
    :json string repl_begin: do not start replication before
    :json string repl_end: do not start replication after
@@ -887,6 +890,7 @@ Update resource
                 "repl_remote_hostkey": "AAAA",
                 "repl_enabled": false,
                 "repl_resetonce": false,
+                "repl_compression": "lz4",
                 "repl_remote_hostname": "testhost",
                 "repl_lastsnapshot": "",
                 "id": 1,
@@ -904,6 +908,7 @@ Update resource
    :json string repl_remote_dedicateduser: dedicated user to replicate
    :json boolean repl_userepl: recursively replicate and remove stale snapshot on remote side
    :json boolean repl_resetonce: initialize remote side for once
+   :json string repl_compression: replication stream compression
    :json integer repl_limit: limit the replication speed in KB/s
    :json string repl_begin: do not start replication before
    :json string repl_end: do not start replication after

--- a/gui/choices.py
+++ b/gui/choices.py
@@ -312,6 +312,12 @@ ZFS_CompressionChoices = (
         ('lzjb',    _('lzjb (legacy, not recommended)')),
         )
 
+Repl_CompressionChoices = (
+        ('off',     _('Off')),
+        ('lz4',     _('lz4 (fastest)')),
+        ('pigz',    _('pigz (all rounder)')),
+        ('plzip',   _('plzip (best compression)')),
+        )
 
 class whoChoices:
     """Populate a list of system user choices"""

--- a/gui/storage/migrations/0046_auto__add_field_replication_repl_compression.py
+++ b/gui/storage/migrations/0046_auto__add_field_replication_repl_compression.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Replication.repl_compression'
+        db.add_column(u'storage_replication', 'repl_compression',
+                      self.gf('django.db.models.fields.CharField')(default='lz4', max_length=5),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Replication.repl_compression'
+        db.delete_column(u'storage_replication', 'repl_compression')
+
+
+    models = {
+        u'storage.disk': {
+            'Meta': {'ordering': "['disk_subsystem', 'disk_number']", 'object_name': 'Disk'},
+            'disk_acousticlevel': ('django.db.models.fields.CharField', [], {'default': "'Disabled'", 'max_length': '120'}),
+            'disk_advpowermgmt': ('django.db.models.fields.CharField', [], {'default': "'Disabled'", 'max_length': '120'}),
+            'disk_description': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'disk_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'disk_hddstandby': ('django.db.models.fields.CharField', [], {'default': "'Always On'", 'max_length': '120'}),
+            'disk_identifier': ('django.db.models.fields.CharField', [], {'max_length': '42'}),
+            'disk_multipath_member': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_multipath_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_name': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'disk_number': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'disk_serial': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'disk_size': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'disk_smartoptions': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'disk_subsystem': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10'}),
+            'disk_togglesmart': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'disk_transfermode': ('django.db.models.fields.CharField', [], {'default': "'Auto'", 'max_length': '120'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'storage.encrypteddisk': {
+            'Meta': {'object_name': 'EncryptedDisk'},
+            'encrypted_disk': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Disk']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'encrypted_provider': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '120'}),
+            'encrypted_volume': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Volume']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'storage.mountpoint': {
+            'Meta': {'object_name': 'MountPoint'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mp_options': ('django.db.models.fields.CharField', [], {'max_length': '120', 'null': 'True'}),
+            'mp_path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '120'}),
+            'mp_volume': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.Volume']"})
+        },
+        u'storage.replication': {
+            'Meta': {'ordering': "['repl_filesystem']", 'object_name': 'Replication'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'repl_begin': ('django.db.models.fields.TimeField', [], {'default': 'datetime.time(0, 0)'}),
+            'repl_compression': ('django.db.models.fields.CharField', [], {'default': "'lz4'", 'max_length': '5'}),
+            'repl_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'repl_end': ('django.db.models.fields.TimeField', [], {'default': 'datetime.time(23, 59)'}),
+            'repl_filesystem': ('django.db.models.fields.CharField', [], {'max_length': '150', 'blank': 'True'}),
+            'repl_lastsnapshot': ('django.db.models.fields.CharField', [], {'max_length': '120', 'blank': 'True'}),
+            'repl_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'repl_remote': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['storage.ReplRemote']"}),
+            'repl_resetonce': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'repl_userepl': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'repl_zfs': ('django.db.models.fields.CharField', [], {'max_length': '120'})
+        },
+        u'storage.replremote': {
+            'Meta': {'object_name': 'ReplRemote'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ssh_fast_cipher': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ssh_remote_dedicateduser': ('freenasUI.freeadmin.models.fields.UserField', [], {'default': "''", 'max_length': '120', 'null': 'True', 'blank': 'True'}),
+            'ssh_remote_dedicateduser_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ssh_remote_hostkey': ('django.db.models.fields.CharField', [], {'max_length': '2048'}),
+            'ssh_remote_hostname': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'ssh_remote_port': ('django.db.models.fields.IntegerField', [], {'default': '22'})
+        },
+        u'storage.scrub': {
+            'Meta': {'ordering': "['scrub_volume__vol_name']", 'object_name': 'Scrub'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scrub_daymonth': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'scrub_dayweek': ('django.db.models.fields.CharField', [], {'default': "'7'", 'max_length': '100'}),
+            'scrub_description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'scrub_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'scrub_hour': ('django.db.models.fields.CharField', [], {'default': "'00'", 'max_length': '100'}),
+            'scrub_minute': ('django.db.models.fields.CharField', [], {'default': "'00'", 'max_length': '100'}),
+            'scrub_month': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '100'}),
+            'scrub_threshold': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '35'}),
+            'scrub_volume': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['storage.Volume']", 'unique': 'True'})
+        },
+        u'storage.task': {
+            'Meta': {'ordering': "['task_filesystem']", 'object_name': 'Task'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'task_begin': ('django.db.models.fields.TimeField', [], {'default': 'datetime.time(9, 0)'}),
+            'task_byweekday': ('django.db.models.fields.CharField', [], {'default': "'1,2,3,4,5'", 'max_length': '120', 'blank': 'True'}),
+            'task_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'task_end': ('django.db.models.fields.TimeField', [], {'default': 'datetime.time(18, 0)'}),
+            'task_filesystem': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            'task_interval': ('django.db.models.fields.PositiveIntegerField', [], {'default': '60', 'max_length': '120'}),
+            'task_recursive': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'task_repeat_unit': ('django.db.models.fields.CharField', [], {'default': "'weekly'", 'max_length': '120'}),
+            'task_ret_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '2'}),
+            'task_ret_unit': ('django.db.models.fields.CharField', [], {'default': "'week'", 'max_length': '120'})
+        },
+        u'storage.volume': {
+            'Meta': {'object_name': 'Volume'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'vol_encrypt': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'vol_encryptkey': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'vol_fstype': ('django.db.models.fields.CharField', [], {'max_length': '120'}),
+            'vol_guid': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'vol_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '120'})
+        }
+    }
+
+    complete_apps = ['storage']

--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -875,6 +875,12 @@ class Replication(Model):
             "Initialize remote side for once. (May cause data"
             " loss on remote side!)"),
     )
+    repl_compression = models.CharField(
+        max_length=5,
+        choices=choices.Repl_CompressionChoices,
+        default="lz4",
+        verbose_name=_("Replication Stream Compression"),
+    )
     repl_limit = models.IntegerField(
         default=0,
         verbose_name=_("Limit (kB/s)"),

--- a/nanobsd/os-base
+++ b/nanobsd/os-base
@@ -203,7 +203,10 @@ add_port net/mDNSResponder
 add_port dns/py-bonjour
 add_port textproc/libxml2
 add_port devel/libffi
+add_port archivers/lz4
 add_port archivers/lzo2
+add_port archivers/pigz
+add_port archivers/plzip
 add_port security/easy-rsa
 add_port security/openvpn
 add_port converters/libiconv


### PR DESCRIPTION
Adds option to compress replication streams (off, lz4, pigz, plzip) and sets default to lz4.  In testing average of doubling of throughput and only scenario where adding lz4 compression could be detrimental was limited resource server, Gb+ network and low compressable data. More details are in ticket.

Pls note I have not been able to build release from source due (I think) to environmental issue but have build all archivers from ports without issue and had replication code running without error for a week so would now welcome wider testing
