### PR TITLE
FreeBD diff reduction: generate and save the sshd host keys in gui instead of TrueOS.

### DIFF
--- a/nanobsd/Files/etc/ix.rc.d/ix-sshd
+++ b/nanobsd/Files/etc/ix.rc.d/ix-sshd
@@ -69,6 +69,18 @@ EOF
 	/usr/bin/ssh-keygen -qt rsa -N "" -C "Key for replication" -b 2048 -f /data/ssh/replication
     fi
     ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT ssh_remote_hostkey FROM storage_replremote" > /etc/ssh/ssh_known_hosts
+
+    # extract the saved host keys from the database.
+    for i in "ssh_host_key" "ssh_host_key.pub" "ssh_host_dsa_key" "ssh_host_dsa_key.pub" "ssh_host_ecdsa_key" "ssh_host_ecdsa_key.pub" "ssh_host_rsa_key" "ssh_host_rsa_key.pub" 
+    do
+        column=`echo ${i} | tr "." "_"`
+        _tmp=`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT ${column} from services_ssh"`
+        _tmpx=`echo ${_tmp} | tr '\n' '1'`
+        if ! [ "${_tmpx}" = "1" ] ; then
+            echo ${_tmp} | /usr/local/bin/base64 -d > /etc/ssh/${i}
+        fi
+    done
+    chmod 600 /etc/ssh/ssh_host_key /etc/ssh/ssh_host_dsa_key /etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_rsa_key 2>/dev/null
 }
 
 name="ix-sshd"

--- a/nanobsd/Files/etc/ix.rc.d/ix_sshd_save_keys
+++ b/nanobsd/Files/etc/ix.rc.d/ix_sshd_save_keys
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# $FreeBSD$
+#
+
+# PROVIDE: ix_sshd_save_keys
+# REQUIRE: sshd
+
+#
+# Save any generated keys by /etc/rc.d/sshd into the config db.
+#
+
+. /etc/rc.subr
+
+save_keys()
+{
+    for i in "ssh_host_key" "ssh_host_key.pub" "ssh_host_dsa_key" "ssh_host_dsa_key.pub" "ssh_host_ecdsa_key" "ssh_host_ecdsa_key.pub" "ssh_host_rsa_key" "ssh_host_rsa_key.pub" 
+    do
+        if [ -f /etc/ssh/${i} ] ; then
+            _tmp=`cat /etc/ssh/${i} | /usr/local/bin/base64`
+            column=`echo ${i} | tr "." "_"`
+            cmd="UPDATE services_ssh SET '${column}' = '${_tmp}' WHERE id = (SELECT id FROM services_ssh ORDER BY id LIMIT 1);" 
+            echo ${cmd} | ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG}
+        fi
+    done
+}
+
+name="ix_sshd_save_keys"
+start_cmd='save_keys'
+stop_cmd=':'
+
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
Before this was being handled by modification to FreeBSD in TrueOS.

To remove the modification from FreeBSD we instead move the parts to extract the generated keys to ix-sshd which runs before /etc/rc.d/sshd and move the parts that save the keys to a new script ix_sshd_save_keys.

This allows us to remove the TrueOS patch  trueos/trueos@b82f03dbc266e9425bd38182b894caa4887e5f93

After this pull request is taken, then the commit to trueos should be reverted.
