### PR TITLE
tkt-47393 (stable) simplify ix-syslogd code

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-syslogd
+++ b/src/freenas/etc/ix.rc.d/ix-syslogd
@@ -84,8 +84,6 @@ __EOF__
                         mkdir -p /root/syslog
                 fi
 
-		date >> /tmp/THETIME
-
 		cat <<-_EOF_>> /etc/local/syslog-ng.conf
 
 		# Redmine 32700


### PR DESCRIPTION
I originally set out to try and figure out why /usr/local/etc/syslog-ng.conf was being generated with duplicate entries on the passive controller.

This commit is to simplify the code for TrueNAS HA appliances.

This does not fix why the original problem of why the files are being generated with duplicate entries. middlewared seems to be restarting services on the passive controller more than once.

With help from @jhixson74