### PR TITLE
NAS-107302 / 12.1 / Reword error messages (by Mrt134)

### DIFF
--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -294,13 +294,13 @@ class PeriodicSnapshotTaskService(CRUDService):
         if data['dataset'] not in (await self.middleware.call('pool.filesystem_choices')):
             verrors.add(
                 'dataset',
-                'Invalid ZFS dataset'
+                'ZFS dataset or zvol not found'
             )
 
         if not data['recursive'] and data['exclude']:
             verrors.add(
                 'exclude',
-                'Excluding datasets has no sense for non-recursive periodic snapshot tasks'
+                'Excluding datasets is not necessary for non-recursive periodic snapshot tasks'
             )
 
         for i, v in enumerate(data['exclude']):


### PR DESCRIPTION
- Rework dataset not found to be clear that a dataset or zvol was not found. This should solve multi-window/user situations where a dataset/zvol is deleted while the other window has it selected.
- Clarify the exclude message a little.

Original PR: https://github.com/freenas/freenas/pull/5520