### PR TITLE
NAS-107309 / 12.0 / Add ZSTD and ZSTD-FAST to middleware (by Ornias1993)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2721,7 +2721,7 @@ class PoolDatasetService(CRUDService):
             'STANDARD', 'ALWAYS', 'DISABLED',
         ]),
         Str('compression', enum=[
-            'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZLE', 'LZJB',
+            'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-5', 'ZSTD-7', 'ZSTD-FAST', 'ZLE', 'LZJB',
         ]),
         Str('atime', enum=['ON', 'OFF']),
         Str('exec', enum=['ON', 'OFF']),


### PR DESCRIPTION
Openzfs2.0 adds ZSTD and ZSTD-fast compression.
See: openzfs/zfs/pull/10278

This commit adds the following compression values to be accepted by the pool middleware:
- ZSTD
- ZSTD-5
- ZSTD-7
- ZSTD-FAST

These levels give an acceptable and balanced spread of both compression ratio and performance.
(see graphs in openzfs/zfs/pull/10278 )

Notes:
- **Requires an update to OpenZFS before being able to be used**
- Might also want to backport to 12U1 or even 12RC1
- GUI changes can be found here: freenas/webui/pull/4559

Original PR: https://github.com/freenas/freenas/pull/5517