### PR TITLE
NAS-107319 / 12.0 / Enable time machine in preset

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -114,6 +114,7 @@ class SMBSharePreset(enum.Enum):
     }}
     ENHANCED_TIMEMACHINE = {"verbose_name": "Multi-user time machine", "params": {
         'path_suffix': '%U',
+        'timemachine': True,
         'auxsmbconf': '\n'.join([
             'ixnas:zfs_auto_homedir=true',
             'ixnas:default_user_quota=1T',


### PR DESCRIPTION
Setting this in the preset will prevent users from disabling time machine on the time machine share.