### PR TITLE
NAS-107319 / 12.1 / Enable time machine in preset (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -114,6 +114,7 @@ class SMBSharePreset(enum.Enum):
     }}
     ENHANCED_TIMEMACHINE = {"verbose_name": "Multi-user time machine", "params": {
         'path_suffix': '%U',
+        'timemachine': True,
         'auxsmbconf': '\n'.join([
             'tmprotect:auto_rollback=powerloss',
             'ixnas:zfs_auto_homedir=true',


### PR DESCRIPTION
Setting this in the preset will prevent users from disabling time machine on the time machine share.

Original PR: https://github.com/freenas/freenas/pull/5524