### PR TITLE
NAS-107639 / 21.02 / Set default compression to zstandard

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -649,7 +649,7 @@ class PoolService(CRUDService):
         formatted_disks = await self.middleware.call('pool.format_disks', job, disks)
 
         options = {
-            'feature@lz4_compress': 'enabled',
+            'feature@zstd_compress': 'enabled',
             'altroot': '/mnt',
             'cachefile': ZPOOL_CACHE_FILE,
             'failmode': 'continue',
@@ -658,7 +658,7 @@ class PoolService(CRUDService):
         }
 
         fsoptions = {
-            'compression': 'lz4',
+            'compression': 'zstd',
             'aclinherit': 'passthrough',
             'mountpoint': f'/{data["name"]}',
             **encryption_dict


### PR DESCRIPTION
This is a draft PR, investigating if there are any side effect of setting zstandard as the default compression algorithm on pool creation (which is, by default, inherited by created datasets).

Notes:
- I'm not very sure about the need to manually set the featureflag in case of zstd

*edit, after testing and checking things*
- This shouldn't apply to the boot pool, as that one isn't created using the middleware afaik (middleware specifically lists these as being mounted under /mnt, which the bootpool isn't)
- Did some performance tests on an 2c/4t intel pentium CPU, 10gbe and 3x2disk mirrors. I don't think this is going to cause any significant slowdown on less-powerfull systems
- pools created from scratch on 12, aren't compatible with 12 anyhow in a lot of cases, so this wouldn't cause significant (new) compatibility issues (you can't import a pool created in TrueNAS 12/20.10 in 11 afaik)

Some actual data:
General note:
These numbers are supposed to be bottlenecked mostly by CPU and/or RAM. However they are not made to be a representation for performance, they are supposed to be used as a **comparative** reference only, meant to give a vague idea of performance delta. If you see weird results, it mostly is due to the test being CPU bottlenecked or test environment issues.

Allan Jude has done further research on performance here:
https://docs.google.com/spreadsheets/d/1TvCAIDzFsjuLuea7124q-1UtMd0C9amTgnXm2yPtiUQ/edit#gid=0

His number are more based on a real-world hardware scenario. I highly suggest going through them.

Note about random performance:
Random has been set to an 8K "extremely low" recordsize and mixed blocksizes.

---

Sequential Read:

![image](https://user-images.githubusercontent.com/7613738/71645839-a91f8b00-2cde-11ea-911c-3b75805d484a.png)

![image](https://user-images.githubusercontent.com/7613738/71645844-b6d51080-2cde-11ea-8aa2-9cb67d351bb6.png)


---

Sequential Write

---
![image](https://user-images.githubusercontent.com/7613738/71645853-c9e7e080-2cde-11ea-8f83-fb66492831c2.png)
![image](https://user-images.githubusercontent.com/7613738/71645859-cd7b6780-2cde-11ea-8fab-223ce08171e5.png)

---

Sequential Read-Write

---
![image](https://user-images.githubusercontent.com/7613738/71645866-da985680-2cde-11ea-8bb9-c80b4f73f0cb.png)

![image](https://user-images.githubusercontent.com/7613738/71645868-de2bdd80-2cde-11ea-90a2-196f49df1470.png)


---

Random Read

---

![image](https://user-images.githubusercontent.com/7613738/71645880-fe5b9c80-2cde-11ea-9bbe-c5533674ebba.png)

![image](https://user-images.githubusercontent.com/7613738/71645882-01568d00-2cdf-11ea-85aa-ead78b761caa.png)

---

Random Write

---
![image](https://user-images.githubusercontent.com/7613738/71645885-06b3d780-2cdf-11ea-9f8a-84f48bca50f4.png)
![image](https://user-images.githubusercontent.com/7613738/71645888-0ca9b880-2cdf-11ea-8774-c4b25ae446ad.png)


---

Random Read-Write

---

![image](https://user-images.githubusercontent.com/7613738/71645891-103d3f80-2cdf-11ea-8e90-7cf73d4daf54.png)
![image](https://user-images.githubusercontent.com/7613738/71645892-13383000-2cdf-11ea-9fdc-f135feeca8d3.png)

---
RAWR DATA
---
[Compression Algorithm Performance.xlsx](https://github.com/zfsonlinux/zfs/files/4014521/Compression.Algorithm.Performance.xlsx)

[test_results_1577651989.terse.txt](https://github.com/zfsonlinux/zfs/files/4014520/test_results_1577651989.terse.txt)

Test script:
https://github.com/Ornias1993/zfs-compression-test

Note:
For the IO slides, I've been lazy and column K is actually iops instead of bandwidth ;)