### PR TITLE
NAS-108987 / 21.06 / Unable to import pool - pool shows up in dialog import list, but fails at zfs.find_import

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
@@ -117,7 +117,14 @@ class DiskService(Service, DiskInfoBase):
 
     def label_to_disk(self, label, *args):
         part_disk = self.label_to_dev(label)
-        return self.get_disk_from_partition(part_disk) if part_disk else None
+        if not part_disk:
+            # the label is already a disk
+            return label
+        elif os.path.exists(os.path.join('/sys/block', part_disk)):
+            # it's imported with a label, but it's a whole disk
+            return part_disk
+        else:
+            return self.get_disk_from_partition(part_disk)
 
     def get_disk_from_partition(self, part_name):
         if not os.path.exists(os.path.join('/dev', part_name)):

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -369,7 +369,7 @@ class ZFSPoolService(CRUDService):
         found = False
         with libzfs.ZFS() as zfs:
             for pool in zfs.find_import(
-                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', 'dev/disk/by-uuid'] if osc.IS_LINUX else None
+                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', '/dev'] if osc.IS_LINUX else None
             ):
                 if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
                     found = pool

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -369,7 +369,7 @@ class ZFSPoolService(CRUDService):
         found = False
         with libzfs.ZFS() as zfs:
             for pool in zfs.find_import(
-                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid'] if osc.IS_LINUX else None
+                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', 'dev/disk/by-uuid'] if osc.IS_LINUX else None
             ):
                 if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
                     found = pool


### PR DESCRIPTION
This is just a quick hack to look for importable pools on whole disks, too.

See discussion here: https://jira.ixsystems.com/browse/NAS-108987