### PR TITLE
NAS-109037 / 12.0 / set comconsole,efi on UEFI booted mseries systems (by yocalebo)

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -394,7 +394,7 @@ videoconsole()
 
 mseries()
 {
-    dmidecode -s system-product-name | grep -i "TRUENAS-M" | grep -v "MINI"
+    dmidecode -s system-product-name | grep -iv "MINI" | grep -iq "TRUENAS-M"
 }
 
 save_serial_settings()

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -394,7 +394,7 @@ videoconsole()
 
 mseries()
 {
-    dmidecode -s system-product-name | grep -i "TRUENAS-M"
+    dmidecode -s system-product-name | grep -i "TRUENAS-M" | grep -v "MINI"
 }
 
 save_serial_settings()

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -392,6 +392,11 @@ videoconsole()
     fi
 }
 
+mseries()
+{
+    dmidecode -s system-product-name | grep -i "TRUENAS-M"
+}
+
 save_serial_settings()
 {
     local mnt="$1"
@@ -415,7 +420,10 @@ save_serial_settings()
 	local console="comconsole"
 	;;
     $SER_VID_BOTH)
-	if [ "$(kenv console)" = "comconsole" ]; then
+	# we skip setting only comconsole on UEFI booted mseries devices
+	# since doing so prevents the bsd boot loader screen from showing
+	# on the iKVM/HTML5 IPMI website.
+	if [ "$(kenv console)" = "comconsole" ] && ! mseries; then
 	    # We used the serial boot menu entry and efi has a serial port.
 	    # Enable only comconsole so loader output is not duplicated.
 	    local console="comconsole"


### PR DESCRIPTION
Gen3 M-series systems come with m.2 nvme boot drives. This means they're UEFI booted. The current code only enables `comconsole` if we're booted UEFI and the efi firmware provides a serial device.

If only setting `comconsole`, then the BSD boot loader doesn't appear on the convenient iKVM/HTML5 website for the m-series devices. This is undesired behavior since logging into a website as opposed to running `ipmitool sol` is subjectively easier.

This change will set the kernel console setting to `comconsole,efi` if it's UEFI booted and an m-series device.

Original PR: https://github.com/freenas/freenas/pull/6304