### PR TITLE
NAS-109206 / 21.04 / add interface validation to ctdb.public.ips.create

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_ips.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_ips.py
@@ -44,6 +44,12 @@ class CtdbIpService(Service):
                     f'{schema_name}.{data["ip"]}',
                     f'"{data["ip"]}" is already added as a private IP address.'
                 )
+            elif schema_name == 'public_create':
+                if data['interface'] not in [i['id'] for i in await self.middleware.call('interface.query')]:
+                    verrors.add(
+                        f'{schema_name}.{data["interface"]}',
+                        f'"{data["interface"]}" not found on this system.',
+                    )
         else:
             address = data.get('address') or data['public_ip']
 


### PR DESCRIPTION
The `ctdbd` daemon will fail to start if a non-existing interface is given when creating a public IP. Prevent this from happening in API.