### PR TITLE
NAS-109321 / 21.04 / Add basic pseudo service for directory services cache

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -705,7 +705,7 @@ class ActiveDirectoryService(ConfigService):
         if ret == neterr.JOINED:
             await self.set_state(DSStatus['HEALTHY'])
             await self.middleware.call('admonitor.start')
-            await self.middleware.call('activedirectory.get_cache')
+            await self.middleware.call('service.start', 'dscache')
             if ad['verbose_logging']:
                 self.logger.debug('Successfully started AD service for [%s].', ad['domainname'])
 
@@ -735,6 +735,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('etc.generate', 'pam')
         await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'])
+        await self.middleware.call('service.stop', 'dscache')
         if (await self.middleware.call('smb.get_smb_ha_mode')) == "LEGACY" and (await self.middleware.call('failover.status')) == 'MASTER':
             try:
                 await self.middleware.call('failover.call_remote', 'activedirectory.stop')

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -950,7 +950,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('smb.set_passdb_backend', 'ldapsam')
 
         await self.set_state(DSStatus['HEALTHY'])
-        await self.middleware.call('ldap.fill_cache')
+        await self.middleware.call('service.start', 'dscache')
 
     @private
     async def stop(self):
@@ -968,6 +968,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('smb.synchronize_group_mappings')
             await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
         await self.middleware.call('cache.pop', 'LDAP_cache')
+        await self.middleware.call('service.stop', 'dscache')
         await self.nslcd_cmd('stop')
         await self.set_state(DSStatus['DISABLED'])
 

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -35,6 +35,7 @@ from .pseudo.libvirtd import LibvirtdService
 from .pseudo.misc import (
     CronService,
     DiskService,
+    DSCacheService,
     FailoverService,
     KmipService,
     LoaderService,
@@ -63,6 +64,7 @@ from .pseudo.misc import (
 all_services = [
     AFPService,
     CIFSService,
+    DSCacheService,
     DynamicDNSService,
     FTPService,
     ISCSITargetService,

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -302,6 +302,24 @@ class TtysService(PseudoServiceBase):
         pass
 
 
+class DSCacheService(PseudoServiceBase):
+    name = "dscache"
+
+    async def start(self):
+        ad_enabled = (await self.middleware.call('activedirectory.config'))['enable']
+        if not ad_enabled:
+            await systemd_unit("nscd", "restart")
+        else:
+            await systemd_unit("nscd", "stop")
+
+        await self.middleware.call('dscache.refresh')
+
+    async def stop(self):
+        await systemd_unit("nscd", "stop")
+        await self.middleware.call('idmap.clear_idmap_cache')
+        await self.middleware.call('dscache.refresh')
+
+
 class UserService(PseudoServiceBase):
     name = "user"
 


### PR DESCRIPTION
Allow nscd to run in specific situations where it may be beneficial
(ldap), but ensure that it doesn't run when AD is enabled so that
we don't have contention between two different caching mechanisms.
Also use this as a convenient API for redoing user / group cache.