### PR TITLE
NAS-109305 / 21.04 / Read values from a yaml file as well if present for chart release

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -145,16 +145,7 @@ class ChartReleaseService(Service):
 
         job.set_progress(50, 'Upgrading chart release')
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(yaml.dump(config))
-            f.flush()
-
-            cp = await run(
-                ['helm', 'upgrade', release_name, chart_path, '-n', get_namespace(release_name), '-f', f.name],
-                check=False,
-            )
-            if cp.returncode:
-                raise CallError(f'Failed to upgrade chart release to {new_version!r}: {cp.stderr.decode()}')
+        await self.middleware.call('chart.release.helm_action', release_name, chart_path, config, 'upgrade')
 
         job.set_progress(100, 'Upgrade complete for chart release')
 


### PR DESCRIPTION
This commit adds changes to give chart devs more control on specifying values for a chart. Right now values are constructed only from questions.yaml which works but there are cases where chart dev would not like to have something modified by the user and then has to specify that value in questions.yaml as hidden and editable=false. This will allow the chart dev to specify such values separately and then change them as desired.