### PR TITLE
NAS-109314 / 21.04 / Save preferred trains for a user

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.1/2021-02-10_00-23_preferred_catalog_trains.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2021-02-10_00-23_preferred_catalog_trains.py
@@ -1,0 +1,27 @@
+"""
+Add Preferred Train option for catalogs
+
+Revision ID: daa17e858eaf
+Revises: c747d1692290
+Create Date: 2021-02-10 00:23:15.609666+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'daa17e858eaf'
+down_revision = 'c747d1692290'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_catalog', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('preferred_trains', sa.TEXT(), nullable=True))
+
+    op.execute("UPDATE services_catalog SET preferred_trains = '[\"charts\"]'")
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/12.1/2021-02-10_00-23_preferred_catalog_trains.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2021-02-10_00-23_preferred_catalog_trains.py
@@ -18,9 +18,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('services_catalog', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('preferred_trains', sa.TEXT(), nullable=True))
-
-    op.execute("UPDATE services_catalog SET preferred_trains = '[\"charts\"]'")
+        batch_op.add_column(sa.Column('preferred_trains', sa.TEXT(), nullable=False, server_default='[\"charts\"]'))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -100,6 +100,9 @@ class CatalogService(CRUDService):
 
         verrors.check()
 
+        if not data['preferred_trains']:
+            data['preferred_trains'] = ['charts']
+
         if not data.pop('force'):
             # We will validate the catalog now to ensure it's valid wrt contents / format
             path = os.path.join(

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -70,6 +70,11 @@ class CatalogService(CRUDService):
                 f'{schema}.preferred_trains',
                 f'{", ".join(diff)} trains were not found in catalog.'
             )
+        if not data['preferred_trains']:
+            verrors.add(
+                f'{schema}.preferred_trains',
+                'At least 1 preferred train must be specified for a catalog.'
+            )
 
         verrors.check()
 
@@ -85,6 +90,9 @@ class CatalogService(CRUDService):
         )
     )
     async def do_create(self, data):
+        """
+        `catalog_create.preferred_trains` specifies trains which will be displayed in the UI directly for a user.
+        """
         verrors = ValidationErrors()
         # We normalize the label
         data['label'] = data['label'].upper()

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -5,7 +5,7 @@ import shutil
 
 import middlewared.sqlalchemy as sa
 
-from middlewared.schema import Bool, Dict, Str, ValidationErrors
+from middlewared.schema import Bool, Dict, List, Str, ValidationErrors
 from middlewared.service import accepts, CallError, CRUDService, private
 from middlewared.validators import Match
 
@@ -22,6 +22,7 @@ class CatalogModel(sa.Model):
     repository = sa.Column(sa.Text(), nullable=False)
     branch = sa.Column(sa.String(255), nullable=False)
     builtin = sa.Column(sa.Boolean(), nullable=False, default=False)
+    preferred_trains = sa.Column(sa.JSON(type=list))
 
 
 class CatalogService(CRUDService):

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1019,7 +1019,7 @@ class CoreService(Service):
                             for j in i['properties'].values():
                                 names.add(j['_name_'])
 
-                    args_descriptions_doc = doc
+                    args_descriptions_doc = doc or ''
                     if attr == 'update':
                         if do_create := getattr(svc, 'do_create', None):
                             args_descriptions_doc += "\n" + inspect.getdoc(do_create)


### PR DESCRIPTION
This PR introduces changes where we save preferred train for a user which UI will use to display catalog items. This helps the user to not have to each time go and change/select train for a catalog in the UI for installing some application.