### PR TITLE
NAS-109336 / 21.04 / Delete snapshots in descendant filesystems as well on chart release upgrade

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -120,7 +120,7 @@ class ChartReleaseService(Service):
         volumes_ds = os.path.join(release['dataset'], 'volumes/ix_volumes')
         snap_name = f'{volumes_ds}@{release["version"]}'
         if await self.middleware.call('zfs.snapshot.query', [['id', '=', snap_name]]):
-            await self.middleware.call('zfs.snapshot.delete', snap_name)
+            await self.middleware.call('zfs.snapshot.delete', snap_name, {'recursive': True})
 
         await self.middleware.call(
             'zfs.snapshot.create', {'dataset': volumes_ds, 'name': release['version'], 'recursive': True}

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -1063,7 +1063,11 @@ class ZFSSnapshot(CRUDService):
 
     @accepts(
         Str('id'),
-        Dict('options', Bool('defer', default=False)),
+        Dict(
+            'options',
+            Bool('defer', default=False),
+            Bool('recursive', default=False),
+        ),
     )
     def do_delete(self, id, options):
         """
@@ -1074,7 +1078,7 @@ class ZFSSnapshot(CRUDService):
         try:
             with libzfs.ZFS() as zfs:
                 snap = zfs.get_snapshot(id)
-                snap.delete(defer=options['defer'])
+                snap.delete(defer=options['defer'], recursive=options['recursive'])
         except libzfs.ZFSException as e:
             raise CallError(str(e))
         else:


### PR DESCRIPTION
This PR adds changes to delete snapshots of descendant chart release filesystems as well if they exist with the same name which can happen on failed upgrades.