### PR TITLE
NAS-109278 / 21.04 / Allow specifying properties for ix volumes

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/ix_volumes.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/ix_volumes.py
@@ -22,7 +22,9 @@ class ChartReleaseService(Service):
 
         for create_ds in set(user_wants) - existing_datasets:
             await self.middleware.call(
-                'zfs.dataset.create', {**user_wants[create_ds]['properties'], 'name': create_ds, 'type': 'FILESYSTEM'}
+                'zfs.dataset.create', {
+                    'properties': user_wants[create_ds]['properties'], 'name': create_ds, 'type': 'FILESYSTEM'
+                }
             )
             await self.middleware.call('zfs.dataset.mount', create_ds)
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -109,13 +109,17 @@ class ChartReleaseService(Service):
         # Let's allow ix volume attr to be a string as well making it easier to define a volume in questions.yaml
         assert isinstance(attr, (Dict, Str)) is True
 
-        ds_name = value['datasetName'] if isinstance(attr, Dict) else value
+        if isinstance(attr, Dict):
+            vol_data = {'name': value['datasetName'], 'properties': value.get('properties') or {}}
+        else:
+            vol_data = {'name': value, 'properties': {}}
+        ds_name = vol_data['name']
 
         action_dict = next((d for d in context['actions'] if d['method'] == 'update_volumes_for_release'), None)
         if not action_dict:
             context['actions'].append({
                 'method': 'update_volumes_for_release',
-                'args': [copy.deepcopy(context['release']), [ds_name]],
+                'args': [copy.deepcopy(context['release']), [vol_data]],
             })
         elif ds_name not in action_dict['args'][-1]:
             action_dict['args'][-1].append(ds_name)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -121,8 +121,8 @@ class ChartReleaseService(Service):
                 'method': 'update_volumes_for_release',
                 'args': [copy.deepcopy(context['release']), [vol_data]],
             })
-        elif ds_name not in action_dict['args'][-1]:
-            action_dict['args'][-1].append(ds_name)
+        elif ds_name not in [v['name'] for v in action_dict['args'][-1]]:
+            action_dict['args'][-1].append(vol_data)
         else:
             # We already have this in action dict, let's not add a duplicate
             return value


### PR DESCRIPTION
This PR introduces changes to allow chart devs to specify properties for ix volumes. This is not restrictive on what type of properties can be supplied. We can add validation on `catalog_validation` repository to restrict / allow what kind of properties we want to allow users to change.