### PR TITLE
Add dedicated unprivileged Apps user

### DIFF
--- a/src/middlewared/middlewared/assets/account/builtin/linux/group
+++ b/src/middlewared/middlewared/assets/account/builtin/linux/group
@@ -2,4 +2,5 @@ minio:x:473:
 builtin_administrators:x:544:
 builtin_users:x:545:
 builtin_guests:x:546:
+apps:x:568:
 webdav:x:666:

--- a/src/middlewared/middlewared/assets/account/builtin/linux/passwd
+++ b/src/middlewared/middlewared/assets/account/builtin/linux/passwd
@@ -1,2 +1,3 @@
 minio:x:473:473:Minio Daemon:/var/tmp/minio:/usr/sbin/nologin
+apps:x:568:568:Unprivileged Apps User:/var/empty:/usr/sbin/nologin
 webdav:x:666:666:WebDAV Anonymous User:/var/empty:/usr/sbin/nologin


### PR DESCRIPTION
Some Apps/Charts/Containers might want run using a unprivileged user, set using securitycontext.
By adding a dedicated unprivileged apps user, Apps developers get a little hint in what user to use.

UID/GUID has been carefully selected:
It's a quite unused ID except the containers by k8s-at-home which already defaults to it.

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>