### PR TITLE
NAS-109417 / 21.04 / Set zvol_volmode to 2 in SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info_linux.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info_linux.py
@@ -59,3 +59,6 @@ class SysctlService(Service, SysctlInfoBase):
 
     def set_arc_max(self, value):
         return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zfs_arc_max'), value)
+
+    def set_zvol_volmode(self, value):
+        return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zvol_volmode'), value)

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1801,4 +1801,7 @@ async def setup(middleware):
     os.makedirs(CRASH_DIR, exist_ok=True)
     os.chmod(CRASH_DIR, 0o775)
 
+    if osc.IS_LINUX:
+        await middleware.call('sysctl.set_zvol_volmode', 2)
+
     middleware.register_hook('system.post_license_update', hook_license_update, sync=False)


### PR DESCRIPTION
We should set `zvol_volmode` to `2` keeping in line with freebsd and to speed up pool imports as fewer devices are created under /dev. 