### PR TITLE
NAS-109310 / 12.0 / new firmware for E16 expansion shelf (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -576,6 +576,8 @@ class Enclosure(object):
                 self.controller = True
             else:
                 self.model = "E16"
+        elif self.encname.startswith("ECStream 3U16RJ-AC.r3"):
+            self.model = "E16"
         elif self.encname.startswith("HGST H4102-J"):
             self.model = "ES102"
         elif self.encname.startswith("CELESTIC R0904"):


### PR DESCRIPTION
Singular customer running 2x E16 expansion shelves having a temperature sensor issue. Latest firmware provided by OEM resolves this particular problem.

Original PR: https://github.com/truenas/middleware/pull/6389