### PR TITLE
NAS-109441 / 21.04 / Properly send events for event sources when arguments are specified

### DIFF
--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -16,6 +16,20 @@ class EventSourceManager:
         self.idents = {}
         self.subscriptions = defaultdict(lambda: defaultdict(set))
 
+    def short_name_arg(self, name):
+        if ':' in name:
+            shortname, arg = name.split(':', 1)
+        else:
+            shortname = name
+            arg = None
+        return shortname, arg
+
+    def get_full_name(self, name, arg):
+        if arg is None:
+            return name
+        else:
+            return f'{name}:{arg}'
+
     def register(self, name, event_source):
         if not issubclass(event_source, EventSource):
             raise RuntimeError(f"{event_source} is not EventSource subclass")
@@ -64,7 +78,7 @@ class EventSourceManager:
                 self.middleware.logger.trace("Ident %r is gone", ident)
                 continue
 
-            ident_data.app.send_event(ident_data.name, event_type, **kwargs)
+            ident_data.app.send_event(self.get_full_name(name, arg), event_type, **kwargs)
 
     async def _unsubscribe_all(self, name, arg):
         for ident in self.subscriptions[name][arg]:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -192,12 +192,7 @@ class Application(object):
                 )
 
     async def subscribe(self, ident, name):
-        if ':' in name:
-            shortname, arg = name.split(':', 1)
-        else:
-            shortname = name
-            arg = None
-
+        shortname, arg = self.middleware.event_source_manager.short_name_arg(name)
         if shortname in self.middleware.event_source_manager.event_sources:
             await self.middleware.event_source_manager.subscribe(self, self.__esm_ident(ident), shortname, arg)
         else:
@@ -220,7 +215,9 @@ class Application(object):
     def send_event(self, name, event_type, **kwargs):
         if (
             not any(i == name or i == '*' for i in self.__subscribed.values()) and
-            name not in self.middleware.event_source_manager.event_sources
+            self.middleware.event_source_manager.short_name_arg(
+                name
+            )[0] not in self.middleware.event_source_manager.event_sources
         ):
             return
         event = {


### PR DESCRIPTION
We should properly send events for event sources when arguments are specified. The subscriber relies on complete name instead of short name ( which is event source name ) for actually recieving/handling the event as there are arguments involved and the subscriber will keep track of callbacks based on the complete name ( like our midclt client does ).