### PR TITLE
NAS-109454 / 12.0 / Don't generate corefile alerts on enterprise product

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -157,6 +157,10 @@ if [ "${limit}" != "-1" ] ; then
 	truncate_files "${limit}"
 fi
 
+echo "** 97%: Copying Core Dumps"
+mkdir "$dir/cores"
+find /var/db/system/cores -type f -size -524288c -exec cp {} "$dir/cores/" \;
+
 if is_freebsd; then
 	if ! dumpfile_to_submit_exists $dumpdir ; then
 		if [ $? = 2 ] ; then

--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -37,6 +37,8 @@ class CoreFilesArePresentAlertSource(ThreadedAlertSource):
             unlink = False
             if IS_FREEBSD and file == "syslog-ng.core":
                 unlink = True
+            elif file == "su.core":
+                unlink = True
             elif os.stat(path).st_mtime < time.time() - 86400 * 5:
                 unlink = True
             else:

--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -16,6 +16,9 @@ class CoreFilesArePresentAlertClass(AlertClass):
 class CoreFilesArePresentAlertSource(ThreadedAlertSource):
     def check_sync(self):
         cores = "/var/db/system/cores"
+        if self.middleware.call_sync("system.is_enterprise"):
+            return
+
         try:
             listdir = os.listdir(cores)
         except Exception:

--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -9,22 +9,23 @@ class CoreFilesArePresentAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
     title = "Core Files Found in System Database"
-    text = ("System core files were found in /var/db/system/cores. Please create a ticket at "
-            "https://jira.ixsystems.com/ and remove these files.")
+    text = ("The following system core files were found: %(corefiles)s. Please create a ticket at "
+            "https://jira.ixsystems.com/ and attach the relevant core files along with a system debug. "
+            "Once the core files have been archived and attached to the ticket, they may be removed "
+            "by running the following command in shell: 'rm /var/db/system/cores/*'.")
+    products = ("CORE", "SCALE")
 
 
 class CoreFilesArePresentAlertSource(ThreadedAlertSource):
     def check_sync(self):
         cores = "/var/db/system/cores"
-        if self.middleware.call_sync("system.is_enterprise"):
-            return
+        corefiles = []
 
         try:
             listdir = os.listdir(cores)
         except Exception:
             return
 
-        has_core_file = False
         for file in listdir:
             if not file.endswith(".core"):
                 continue
@@ -39,10 +40,10 @@ class CoreFilesArePresentAlertSource(ThreadedAlertSource):
             elif os.stat(path).st_mtime < time.time() - 86400 * 5:
                 unlink = True
             else:
-                has_core_file = True
+                corefiles.append(file)
 
             if unlink:
                 os.unlink(path)
 
-        if has_core_file:
-            return Alert(CoreFilesArePresentAlertClass)
+        if corefiles:
+            return Alert(CoreFilesArePresentAlertClass, {"corefiles": ', '.join(corefiles)})

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, date, timezone
+from pathlib import Path
 from middlewared.event import EventSource
 from middlewared.i18n import set_language
 from middlewared.logger import CrashReporting
@@ -1686,5 +1687,12 @@ async def setup(middleware):
     CRASH_DIR = '/data/crash'
     os.makedirs(CRASH_DIR, exist_ok=True)
     os.chmod(CRASH_DIR, 0o775)
+    if await middleware.call('keyvalue.get', 'run_migration', False):
+        try:
+            cores = Path("/var/db/system/cores")
+            for corefile in cores.iterdir():
+                corefile.unlink()
+        except Exception:
+            self.logger.warning("Failed to clear old core files.", exc_info=True)
 
     middleware.register_hook('system.post_license_update', hook_license_update, sync=False)


### PR DESCRIPTION
We seem to be generating a fair number of these early on in the free version. We can fix the actionable ones there and avoid creating extra load for support team.