### PR TITLE
NAS-109456 / 21.04 / deprecate internal usage of system.is_freenas

### DIFF
--- a/src/autotune/files/autotune.py
+++ b/src/autotune/files/autotune.py
@@ -21,10 +21,10 @@ import sys
 from middlewared.client import Client
 
 c = Client('ws+unix:///var/run/middlewared-internal.sock')
-if c.call('system.is_freenas'):
-    TRUENAS = False
+if not c.call('system.is_enterprise'):
+    ENTERPRISE = False
 else:
-    TRUENAS = True
+    ENTERPRISE = True
     hardware = c.call('truenas.get_chassis_hardware')
     hardware = hardware.replace('TRUENAS-', '')
     hardware = hardware.split('-')
@@ -111,7 +111,7 @@ DEF_KNOBS = {
 
 
 def guess_vfs_zfs_dirty_data_max_max():
-    if TRUENAS and hardware[0].startswith("M"):
+    if ENTERPRISE and hardware[0].startswith("M"):
         return 12 * GiB
     else:
         return None
@@ -161,7 +161,7 @@ def guess_vfs_zfs_arc_max():
 
     - See comments for USERLAND_RESERVED_MEM.
     """
-    if HW_PHYSMEM_GiB > 200 and TRUENAS:
+    if HW_PHYSMEM_GiB > 200 and ENTERPRISE:
         return int(max(min(int(HW_PHYSMEM * .92),
                        HW_PHYSMEM - (USERLAND_RESERVED_MEM + KERNEL_RESERVED_MEM)),
                        MIN_ZFS_RESERVED_MEM))
@@ -218,28 +218,28 @@ def guess_net_inet_tcp_recvbuf_inc():
 
 
 def guess_vfs_zfs_vdev_async_read_max_active():
-    if TRUENAS and hardware[0] == "Z50":
+    if ENTERPRISE and hardware[0] == "Z50":
         return 64
     else:
         return None
 
 
 def guess_vfs_zfs_vdev_sync_read_max_active():
-    if TRUENAS and hardware[0] == "Z50":
+    if ENTERPRISE and hardware[0] == "Z50":
         return 64
     else:
         return None
 
 
 def guess_vfs_zfs_vdev_async_write_max_active():
-    if TRUENAS and hardware[0] == "Z50":
+    if ENTERPRISE and hardware[0] == "Z50":
         return 64
     else:
         return None
 
 
 def guess_vfs_zfs_vdev_sync_write_max_active():
-    if TRUENAS and hardware[0] == "Z50":
+    if ENTERPRISE and hardware[0] == "Z50":
         return 64
     else:
         return None

--- a/src/freenas/etc/ix.rc.d/ix-syncmultipaths
+++ b/src/freenas/etc/ix.rc.d/ix-syncmultipaths
@@ -12,7 +12,7 @@ syncmultipaths()
 {
 	echo "Syncing multipaths..."
 	/usr/local/bin/midclt call disk.multipath_sync > /dev/null
-	if [ "$(/usr/local/bin/midclt call system.is_freenas)" = "False" ]; then
+	if [ "$(/usr/local/bin/midclt call system.is_enterprise)" = "True" ]; then
 		checkyesno failover_enable || /usr/local/bin/midclt call enclosure.sync_zpool > /dev/null
 	fi
 }

--- a/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
@@ -157,8 +157,8 @@ system_func()
 		section_footer
 	fi
 
-	ret1=$(midclt call system.is_freenas)
-	if [ "x${ret1}" = "xFalse" ]; then
+	ret1=$(midclt call system.is_enterprise)
+	if [ "x${ret1}" = "xTrue" ]; then
 		ret2=$(midclt call failover.status)
 		section_header "HA db journal status"
 		if [ "x${ret2}" != "xSINGLE" ]; then

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -251,7 +251,7 @@ class AlertService:
     async def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = await self.middleware.call("system.product_name")
         hostname = socket.gethostname()
-        if not await self.middleware.call("system.is_freenas"):
+        if await self.middleware.call("system.is_enterprise"):
             node_map = await self.middleware.call("alert.node_map")
         else:
             node_map = None
@@ -274,7 +274,7 @@ class ThreadedAlertService(AlertService):
     def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = self.middleware.call_sync("system.product_name")
         hostname = socket.gethostname()
-        if not self.middleware.call_sync("system.is_freenas"):
+        if self.middleware.call_sync("system.is_enterprise"):
             node_map = self.middleware.call_sync("alert.node_map")
         else:
             node_map = None

--- a/src/middlewared/middlewared/alert/source/smartd.py
+++ b/src/middlewared/middlewared/alert/source/smartd.py
@@ -15,7 +15,7 @@ class SmartdAlertSource(ThreadedAlertSource):
             if self.middleware.call_sync("system.vm"):
                 return
 
-            if not self.middleware.call_sync("system.is_freenas"):
+            if self.middleware.call_sync("system.is_enterprise"):
                 if self.middleware.call_sync("failover.status") != "MASTER":
                     return
 

--- a/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
+++ b/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
@@ -15,7 +15,7 @@ PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 ## Don't run these on TrueNAS HA standby controllers
 ## Redmine 55908
-% if middleware.call_sync("system.is_freenas") or middleware.call_sync("failover.status") != "BACKUP":
+% if not middleware.call_sync("system.is_enterprise") or middleware.call_sync("failover.status") != "BACKUP":
     % for job in middleware.call_sync("cronjob.query", [["enabled", "=", True]]):
 ${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call cronjob.run {job['id']} true"))}
     % endfor

--- a/src/middlewared/middlewared/etc_files/loader.py
+++ b/src/middlewared/middlewared/etc_files/loader.py
@@ -33,7 +33,7 @@ def generate_loader_config(middleware):
         generate_truenas_logo,
         generate_dual_nvdimm_config,
     ]
-    if middleware.call_sync("system.is_freenas"):
+    if not middleware.call_sync("system.is_enterprise"):
         generators.append(generate_xen_loader_config)
 
     config = []

--- a/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf.mako
@@ -10,13 +10,11 @@
 	):
 		middleware.logger.debug(f'UPSMON: {field} field empty, upsmon will fail to start.')
 	ident = ups_config['complete_identifier']
-	if not ups_config['shutdowncmd'] and not (
-		not (middleware.call_sync('system.is_freenas')) and (
-			middleware.call_sync('truenas.get_chassis_hardware')).startswith('TRUENAS-X')
-	):
-		shutdown_cmd = '/sbin/shutdown -p now'
+	xseries = (middleware.call_sync('truenas.get_chassis_hardware')).startswith('TRUENAS-X')
+	if not ups_config['shutdowncmd'] and not xseries
+            shutdown_cmd = '/sbin/shutdown -p now'
 	else:
-		shutdown_cmd = ups_config['shutdowncmd'] or ''
+            shutdown_cmd = ups_config['shutdowncmd'] or ''
 %>\
 MONITOR ${ident} 1 ${user} ${ups_config['monpwd']} ${ups_config['mode']}
 NOTIFYCMD ${"/usr/sbin/upssched" if IS_LINUX else "/usr/local/sbin/upssched"}

--- a/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
@@ -27,7 +27,7 @@ agentAddress udp:161,udp6:161,unix:/var/run/snmpd.sock
 sysLocation ${config["location"] or "unknown"}
 sysContact ${config["contact"] or "unknown@localhost"}
 sysDescr ${freenas_version}. Hardware: ${hw_machine} ${hw_model}. Software: ${kern_ostype} ${kern_osrelease} (revision ${kern_osrevision})
-sysObjectID 1.3.6.1.4.1.50536.3.${"1" if middleware.call_sync("system.is_freenas") else "2"}
+sysObjectID 1.3.6.1.4.1.50536.3.${"1" if not middleware.call_sync("system.is_enterprise") else "2"}
 
 master agentx
 

--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -88,7 +88,7 @@ def generate_syslog_conf(middleware):
 
 
 def generate_ha_syslog(middleware):
-    if middleware.call_sync("system.is_freenas"):
+    if not middleware.call_sync("system.is_enterprise"):
         return
 
     if not middleware.call_sync("failover.licensed"):
@@ -197,7 +197,7 @@ def use_syslog_dataset(middleware):
         except KeyError:
             pass
 
-        if middleware.call_sync("system.is_freenas"):
+        if not middleware.call_sync("system.is_enterprise"):
             return True
         else:
             return middleware.call_sync("failover.status") != "BACKUP"

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -476,8 +476,7 @@ class DNSAuthenticatorService(CRUDService):
                             }
                         }
                     ],
-                    'Comment': f'{"Free" if self.middleware.call_sync("system.is_freenas") else "True"}'
-                               'NAS-dns-route53 certificate validation'
+                    'Comment': 'TrueNAS-dns-route53 certificate validation'
                 }
             )
         except boto_BaseClientException as e:

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -539,14 +539,14 @@ class DiskService(CRUDService):
         reserved = await self.get_reserved()
 
         devlist = await camcontrol_list()
-        is_freenas = await self.middleware.call('system.is_freenas')
+        is_enterprise = await self.middleware.call('system.is_enterprise')
 
         serials = defaultdict(list)
         active_active = []
         for g in geom.class_by_name('DISK').geoms:
             if not RE_DA.match(g.name) or g.name in reserved or g.name in mp_disks:
                 continue
-            if not is_freenas:
+            if is_enterprise:
                 descr = g.provider.config.get('descr') or ''
                 if (
                     descr == 'STEC ZeusRAM' or
@@ -575,8 +575,8 @@ class DiskService(CRUDService):
         disks_pairs = [disks for disks in list(serials.values())]
         disks_pairs.sort(key=lambda x: int(x[0][2:]))
 
-        # Mode is Active/Passive for FreeNAS
-        mode = None if is_freenas else 'R'
+        # Mode is Active/Passive for TrueNAS HA
+        mode = None if not is_enterprise else 'R'
         for disks in disks_pairs:
             if not len(disks) > 1:
                 continue

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -17,12 +17,10 @@ class DiskService(Service, ServiceChangeMixin):
         """
         Syncs a disk `name` with the database cache.
         """
-        if (
-            not await self.middleware.call('system.is_freenas') and
-            await self.middleware.call('failover.licensed') and
-            await self.middleware.call('failover.status') == 'BACKUP'
-        ):
-            return
+        if await self.middleware.call('system.is_enterprise'):
+            if await self.middleware.call('failover.licensed'):
+                if await self.middleware.call('failover.status') == 'BACKUP':
+                    return
 
         # Do not sync geom classes like multipath/hast/etc
         if name.find('/') != -1:

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -84,7 +84,7 @@ class ISCSIGlobalService(SystemServiceService):
         """
         Returns whether iSCSI ALUA is enabled or not.
         """
-        if await self.middleware.call('system.is_freenas'):
+        if not await self.middleware.call('system.is_enterprise'):
             return False
         if not await self.middleware.call('failover.licensed'):
             return False

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -170,7 +170,7 @@ class NFSService(SystemServiceService):
         keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
         new_v4_krb_enabled = new["v4_krb"] or keytab_has_nfs
 
-        if new["v4"] and new_v4_krb_enabled and not await self.middleware.call("system.is_freenas"):
+        if new["v4"] and new_v4_krb_enabled and await self.middleware.call("system.is_enterprise"):
             if await self.middleware.call("failover.licensed"):
                 gc = await self.middleware.call("datastore.config", "network.globalconfiguration")
                 if not gc["gc_hostname_virtual"] or not gc["gc_domain"]:

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -489,7 +489,7 @@ class SMBService(SystemServiceService):
         if await self.middleware.call('cache.has_key', 'SMB_HA_MODE'):
             return await self.middleware.call('cache.get', 'SMB_HA_MODE')
 
-        if not await self.middleware.call('system.is_freenas') and await self.middleware.call('failover.licensed'):
+        if await self.middleware.call('system.is_enterprise') and await self.middleware.call('failover.licensed'):
             system_dataset = await self.middleware.call('systemdataset.config')
             if system_dataset['pool'] != await self.middleware.call('boot.pool_name'):
                 hamode = SMBHAMODE['UNIFIED'].name

--- a/src/middlewared/middlewared/plugins/unscheduled_reboot_alert.py
+++ b/src/middlewared/middlewared/plugins/unscheduled_reboot_alert.py
@@ -51,7 +51,7 @@ async def setup(middleware):
         fenced_file = False
         watchdog_time = 0
         fenced_time = 0
-        if not await middleware.call('system.is_freenas') and await middleware.call('failover.licensed'):
+        if await middleware.call('system.is_enterprise') and await middleware.call('failover.licensed'):
             if os.path.exists(WATCHDOG_ALERT_FILE):
                 watchdog_file = True
                 with open(WATCHDOG_ALERT_FILE, 'rb') as f:

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -409,7 +409,7 @@ class VMDeviceService(CRUDService):
 
     @private
     async def failover_nic_check(self, vm_device, verrors, schema):
-        if not await self.middleware.call('system.is_freenas') and await self.middleware.call('failover.licensed'):
+        if await self.middleware.call('system.is_enterprise') and await self.middleware.call('failover.licensed'):
             nics = await self.middleware.call('vm.device.nic_capability_checks', [vm_device])
             if nics:
                 verrors.add(

--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -36,7 +36,7 @@ class InstallWithBabel(install):
 
 setup(
     name='middlewared',
-    description='FreeNAS Middleware Daemon',
+    description='TrueNAS Middleware Daemon',
     packages=find_packages(),
     package_data={
         'middlewared.apidocs': [

--- a/src/middlewared/setup_client.py
+++ b/src/middlewared/setup_client.py
@@ -7,7 +7,7 @@ install_requires = [
 
 setup(
     name='middlewared.client',
-    description='FreeNAS Middleware Daemon Client',
+    description='TrueNAS Middleware Daemon Client',
     packages=[
         'middlewared.client',
     ],


### PR DESCRIPTION
Keep the public facing `system.is_freenas` endpoint for backwards compatibility, however remove all the internal usages of it and use the new (correct) `system.is_enterprise` endpoint.