### PR TITLE
NAS-109458 / 21.04 / try smartctl SAS to SATA translation in debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
@@ -113,7 +113,7 @@ smart_func()
 		fi
 		# double-quotes are important here to
 		# maintain original formatting
-		echo "/dev/$i msg" >> /tmp/smart.out
+		echo "/dev/$i $msg" >> /tmp/smart.out
 		echo "$output" >> /tmp/smart.out
 		echo "" >> /tmp/smart.out
 	done

--- a/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
@@ -97,7 +97,7 @@ smart_func()
 	# one involved without doing some extravagant reading of
 	# specific VPD pages from the device itself. Even doing
 	# that is fraught with errors because the interposer could
-	# not trnalsate those pages appropriately.
+	# mistranslate those pages.
 	# So, instead, we'll try to tell smartctl to do the translation
 	# and if it fails (which it will on proper SAS devices) then
 	# we'll try to run it without translation

--- a/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
@@ -103,15 +103,17 @@ smart_func()
 	# we'll try to run it without translation
 	for i in $disks
 	do
-    		echo /dev/$i >> /tmp/smart.out
 		# try with translation first
 		output=$(smartctl -a -d sat /dev/$i)
+		msg="(USING TRANSLATION)"
 		if [ $? -ne 0 ]; then
 			# oops try without translation
 			output=$(smartctl -a /dev/$i)
+			msg="(NOT USING TRANSLATION)"
 		fi
 		# double-quotes are important here to
 		# maintain original formatting
+		echo "/dev/$i msg" >> /tmp/smart.out
 		echo "$output" >> /tmp/smart.out
 		echo "" >> /tmp/smart.out
 	done

--- a/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smart/smart.sh
@@ -110,12 +110,20 @@ smart_func()
 		case "$i" in
 		    da*|sd*|vd*)
 			# try with translation first
-			output=$(smartctl -a -d sat /dev/$i)
 			msg="(USING TRANSLATION)"
-			if [ $? -ne 0 ]; then
-			    # oops try without translation
-			    output=$(smartctl -a /dev/$i)
-			    msg="(NOT USING TRANSLATION)"
+			output=$(timeout 3 smartctl -a -d sat /dev/$i)
+			rc=$?
+			if [ $rc -ne 0 ]; then
+			    if [ $rc -eq 124 ]; then
+				# timeout returns 124 rc when
+				# the called command is terminated
+				output="TIMEOUT"
+				msg="(DEVICE TOOK TOO LONG TO RESPOND)"
+			    else
+			        # oops try without translation
+			        output=$(smartctl -a /dev/$i)
+			        msg="(NOT USING TRANSLATION)"
+			    fi
 			fi
 			# double-quotes are important here to
 			# maintain original formatting


### PR DESCRIPTION
- on freeBSD, `sysctl -n kern.disks` returned `pmem` and `nvd` devices for which `smartctl` would fail
- convert the `nvd` devices to their respective `nvme` namespace devices using `nvmecontrol nsid` on freeBSD
- on linux, use `lsblk` and a specific inclusion list to, hopefully, only pull the devices that we want
- use the `timeout` command when using the SAS to SATA translation command since certain USB devices can take a long time to respond when sent those commands
- use a `case` statement and only run the `smartctl` commands on the devices that start with the expected driver names