### PR TITLE
NAS-109491 / 21.04 / cache if the system is licensed for HA

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -200,9 +200,10 @@ class FailoverService(ConfigService):
         """
         if self.HA_LICENSED is None:
             info = self.middleware.call_sync('system.info')
-            if not info['license'] or not info['license']['system_serial_ha']:
+            if info['license'] and info['license']['system_serial_ha']:
+                self.HA_LICENSED = True
+            else:
                 self.HA_LICENSED = False
-            self.HA_LICENSED = True
 
         return self.HA_LICENSED
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -107,6 +107,7 @@ class FailoverModel(sa.Model):
 class FailoverService(ConfigService):
 
     HA_MODE = None
+    HA_LICENSED = None
     LAST_STATUS = None
     LAST_DISABLEDREASONS = None
 
@@ -197,10 +198,13 @@ class FailoverService(ConfigService):
         """
         Checks whether this instance is licensed as a HA unit.
         """
-        info = self.middleware.call_sync('system.info')
-        if not info['license'] or not info['license']['system_serial_ha']:
-            return False
-        return True
+        if self.HA_LICENSED is None:
+            info = self.middleware.call_sync('system.info')
+            if not info['license'] or not info['license']['system_serial_ha']:
+                self.HA_LICENSED = False
+            self.HA_LICENSED = True
+
+        return self.HA_LICENSED
 
     @private
     async def ha_mode(self):
@@ -1507,6 +1511,7 @@ async def hook_restart_devd(middleware, *args, **kwargs):
 
 async def hook_license_update(middleware, *args, **kwargs):
     FailoverService.HA_MODE = None
+    FailoverService.HA_LICENSED = None
 
     if not await middleware.call('failover.licensed'):
         return


### PR DESCRIPTION
Adding/changing a license is an explicit event done by end-user. On an HA system, we should cache the license event to prevent an unnecessary call to read a file from disk (after the 1st time it's read).