### PR TITLE
NAS-109468 / 21.04 / Change Application Update Alerts

### DIFF
--- a/src/middlewared/middlewared/alert/source/applications_linux.py
+++ b/src/middlewared/middlewared/alert/source/applications_linux.py
@@ -34,8 +34,8 @@ class ChartReleaseUpdateAlertClass(AlertClass, OneShotAlertClass):
 
     category = AlertCategory.APPLICATIONS
     level = AlertLevel.INFO
-    title = 'Chart Release Update Available'
-    text = 'An update is available for "%(name)s" chart release.'
+    title = 'Application Update Available'
+    text = 'An update is available for "%(name)s" application.'
 
     async def create(self, args):
         return Alert(ChartReleaseUpdateAlertClass, args, key=args['id'])

--- a/src/middlewared/middlewared/alert/source/applications_linux.py
+++ b/src/middlewared/middlewared/alert/source/applications_linux.py
@@ -45,18 +45,3 @@ class ChartReleaseUpdateAlertClass(AlertClass, OneShotAlertClass):
             lambda alert: alert.key != str(query),
             alerts
         ))
-
-
-class DockerImageUpdateAlertClass(AlertClass, OneShotAlertClass):
-    deleted_automatically = False
-
-    category = AlertCategory.APPLICATIONS
-    level = AlertLevel.INFO
-    title = 'Docker Image Update Available'
-    text = 'An update is available for docker image with "%(tag)s" tag.'
-
-    async def create(self, args):
-        return Alert(DockerImageUpdateAlertClass, args, key=args['tag'])
-
-    async def delete(self, alerts, query):
-        return list(filter(lambda alert: alert.key != f'"{query}"', alerts))

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -148,6 +148,7 @@ class CatalogService(Service):
     def item_version_details(self, version_path):
         version_data = {'location': version_path, 'required_features': set()}
         for key, filename, parser in (
+            ('chart_metadata', 'Chart.yaml', yaml.safe_load),
             ('schema', 'questions.yaml', yaml.safe_load),
             ('app_readme', 'app-readme.md', str.strip),
             ('detailed_readme', 'README.md', markdown.markdown),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -185,6 +185,11 @@ class ChartReleaseService(CRUDService):
             release_data['portals'] = await self.middleware.call(
                 'chart.release.retrieve_portals_for_chart_release', release_data, k8s_node_ip
             )
+            if release_data['chart_metadata'].get('appVersion'):
+                release_data['ui_version'] = f'{release_data["chart_metadata"]["appVersion"]}_{current_version}'
+            else:
+                release_data['ui_version'] = str(current_version)
+
             if 'icon' not in release_data['chart_metadata']:
                 release_data['chart_metadata']['icon'] = None
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import subprocess
 import tempfile
-import yaml
 
 from pkg_resources import parse_version
 
@@ -14,7 +13,7 @@ from middlewared.schema import Bool, Dict, Str
 from middlewared.service import accepts, CallError, job, periodic, private, Service, ValidationErrors
 
 from .schema import clean_values_for_upgrade
-from .utils import CONTEXT_KEY_NAME, get_namespace, run
+from .utils import CONTEXT_KEY_NAME
 
 
 class ChartReleaseService(Service):
@@ -38,8 +37,10 @@ class ChartReleaseService(Service):
 
         `upgrade_options.item_version` specifies to which item version chart release should be upgraded to.
 
-        System will update container images being used by `release_name` chart release if
-        `upgrade_options.update_container_images` is set.
+        System will update container images being used by `release_name` chart release. This can be controlled
+        right now by `upgrade_options.update_container_images` option but this is deprecated and will be removed
+        in the future where system will always update container images in use by a chart release as a chart release
+        upgrade is not considered complete until the images in use have also been updated to latest versions.
 
         During upgrade, `upgrade_options.values` can be specified to apply configuration changes for configuration
         changes for the chart release in question.

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -57,9 +57,11 @@ class ChartReleaseService(Service):
         # in question needs newer image hashes.
         if options['update_container_images']:
             # TODO: Always do this in the future
+            job.set_progress(10, 'Updating container images')
             await (
                 await self.middleware.call('chart.release.pull_container_images', release_name, {'redeploy': False})
             ).wait(raise_error=True)
+            job.set_progress(30, 'Updated container images')
 
         job.set_progress(40, 'Created snapshot for upgrade')
         # If a snapshot of the volumes already exist with the same name in case of a failed upgrade, we will remove
@@ -147,7 +149,7 @@ class ChartReleaseService(Service):
         config, context = await self.middleware.call(
             'chart.release.normalise_and_validate_values', catalog_item, config, False, release['dataset'],
         )
-        job.set_progress(25, 'Initial validation complete')
+        job.set_progress(50, 'Initial validation complete for upgrading chart version')
 
         # We have validated configuration now
 
@@ -171,7 +173,7 @@ class ChartReleaseService(Service):
             }
         })
 
-        job.set_progress(50, 'Upgrading chart release')
+        job.set_progress(60, 'Upgrading chart release version')
 
         await self.middleware.call('chart.release.helm_action', release_name, chart_path, config, 'upgrade')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -28,13 +28,13 @@ class ChartReleaseService(Service):
             get_schema(q, update) for q in item_version_details['schema']['questions']
         ))
         dict_obj = update_conditional_defaults(
-            Dict(schema_name, *attrs, update=update), {
+            Dict(schema_name, *attrs, update=update, additional_attrs=True), {
                 'schema': {'attrs': item_version_details['schema']['questions']}
             }
         )
 
         verrors = validate_attributes(
-            attrs, {'values': new_values}, attr_key='values', dict_kwargs={
+            attrs, {'values': new_values}, True, attr_key='values', dict_kwargs={
                 'conditional_defaults': dict_obj.conditional_defaults, 'update': update,
             }
         )
@@ -63,7 +63,7 @@ class ChartReleaseService(Service):
             if 'subquestions' in variable.get('schema', {}):
                 for sub_variable in variable['schema']['subquestions']:
                     questions[sub_variable['variable']] = sub_variable
-        for key in new_values:
+        for key in filter(lambda k: k in questions, new_values):
             await self.validate_question(
                 verrors, new_values[key], questions[key], dict_obj.attrs[key], schema_name, release_data,
             )

--- a/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
@@ -57,16 +57,12 @@ class DockerImagesService(Service, DockerClientMixin):
         parsed_tag = await self.parse_image_tag(tag)
         if await self.compare_id_digests(image_details, parsed_tag['registry'], parsed_tag['image'], parsed_tag['tag']):
             self.IMAGE_CACHE[tag] = True
-            await self.middleware.call(
-                'alert.oneshot_create', 'DockerImageUpdate', {'tag': tag, 'id': tag}
-            )
         else:
             await self.clear_update_flag_for_tag(tag)
 
     @private
     async def clear_update_flag_for_tag(self, tag):
         self.IMAGE_CACHE[tag] = False
-        await self.middleware.call('alert.oneshot_delete', 'DockerImageUpdate', tag)
 
     @private
     async def compare_id_digests(self, image_details, registry, image_str, tag_str):
@@ -88,4 +84,3 @@ class DockerImagesService(Service, DockerClientMixin):
     async def remove_image_from_cache(self, image):
         for tag in image['repo_tags']:
             self.IMAGE_CACHE.pop(tag, None)
-            await self.middleware.call('alert.oneshot_delete', 'DockerImageUpdate', tag)


### PR DESCRIPTION
This PR introduces following changes:

1) Raise alert that an update is available for a chart release if any of it's container images are outdated.
2) Remove docker image alerts as they cause confusion for the end user i.e alert says plex docker image is outdated but updating docker image only will not mean that the plex chart release is at latest version as well.
3) Do not validate values from `ix_values.yaml` as we don't have their schema and that's something we allow chart devs to control.
4) Concatenate app version and chart version which will be displayed in the UI.
5) Retrieve more information about container images in use by chart releases.