### PR TITLE
NAS-108938 / 21.04 / Add validation for network cidr being specified for kubernetes

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["Interface"]
 
 CLONED_PREFIXES = [
-    'lo', 'tun', 'tap', 'br', 'vlan', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy',
+    'lo', 'tun', 'tap', 'br', 'vlan', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy', 'vnet', 'openvpn',
 ]
 
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -51,11 +51,12 @@ class KubernetesService(ConfigService):
     async def validate_data(self, data, schema):
         verrors = ValidationErrors()
 
-        network_cidrs = [
+        network_cidrs = set([
             ipaddress.ip_network(f'{ip_config["address"]}/{ip_config["netmask"]}', False)
             for interface in await self.middleware.call('interface.query')
-            for ip_config in interface['aliases']
-        ]
+            for ip_config in itertools.chain(interface['aliases'], interface['state']['aliases'])
+            if ip_config['type'] != 'LINK'
+        ])
 
         unused_cidrs = []
         if not data['cluster_cidr'] or not data['service_cidr']:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -60,6 +60,11 @@ class KubernetesService(ConfigService):
             verrors.add(f'{schema}.cluster_cidr', 'Value cannot be similar to service CIDR.')
             verrors.add(f'{schema}.service_cidr', 'Value cannot be similar to cluster CIDR.')
 
+        if ipaddress.ip_network(data['cluster_cidr'], False).overlaps(
+            ipaddress.ip_network(data['service_cidr'], False)
+        ):
+            verrors.add(f'{schema}.cluster_cidr', 'Must not overlap with service CIDR.')
+
         if ipaddress.ip_address(data['cluster_dns_ip']) not in ipaddress.ip_network(data['service_cidr']):
             verrors.add(f'{schema}.cluster_dns_ip', 'Must be in range of "service_cidr".')
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -56,6 +56,10 @@ class KubernetesService(ConfigService):
         ):
             verrors.add(f'{schema}.{k}', 'Requested CIDR is already in use.')
 
+        if data['cluster_cidr'] == data['service_cidr']:
+            verrors.add(f'{schema}.cluster_cidr', 'Value cannot be similar to service CIDR.')
+            verrors.add(f'{schema}.service_cidr', 'Value cannot be similar to cluster CIDR.')
+
         if ipaddress.ip_address(data['cluster_dns_ip']) not in ipaddress.ip_network(data['service_cidr']):
             verrors.add(f'{schema}.cluster_dns_ip', 'Must be in range of "service_cidr".')
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -13,9 +13,9 @@ class KubernetesModel(sa.Model):
 
     id = sa.Column(sa.Integer(), primary_key=True)
     pool = sa.Column(sa.String(255), default=None, nullable=True)
-    cluster_cidr = sa.Column(sa.String(128), default='172.16.0.0/16')
-    service_cidr = sa.Column(sa.String(128), default='172.17.0.0/16')
-    cluster_dns_ip = sa.Column(sa.String(128), default='172.17.0.10')
+    cluster_cidr = sa.Column(sa.String(128), default='')
+    service_cidr = sa.Column(sa.String(128), default='')
+    cluster_dns_ip = sa.Column(sa.String(128), default='')
     route_v4_interface = sa.Column(sa.String(128), nullable=True)
     route_v4_gateway = sa.Column(sa.String(128), nullable=True)
     route_v6_interface = sa.Column(sa.String(128), nullable=True)
@@ -107,9 +107,9 @@ class KubernetesService(ConfigService):
         Dict(
             'kubernetes_update',
             Str('pool', empty=False, null=True),
-            IPAddr('cluster_cidr', cidr=True),
-            IPAddr('service_cidr', cidr=True),
-            IPAddr('cluster_dns_ip'),
+            IPAddr('cluster_cidr', cidr=True, empty=True),
+            IPAddr('service_cidr', cidr=True, empty=True),
+            IPAddr('cluster_dns_ip', empty=True),
             IPAddr('node_ip'),
             Str('route_v4_interface', null=True),
             IPAddr('route_v4_gateway', null=True, v6=False),


### PR DESCRIPTION
This PR introduces following changes:

1) Do not return `vnetX` interface in `interface.query`
2) Do a best effort to check if cluster/service CIDR are already being used by the system.
3) Do not allow cluster/service CIDR to be similar
4) Service/Cluster CIDR must not overlap