### PR TITLE
NAS-109526 / 21.04 / Use get_instance endpoint when using middleware call

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/minio/certificates.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/certificates.py
@@ -12,7 +12,7 @@ def render(service, middleware):
     else:
         middleware.call_sync('certificate.cert_services_validation', cert, 's3.certificate')
 
-        cert = middleware.call_sync('certificate._get_instance', cert)
+        cert = middleware.call_sync('certificate.get_instance', cert)
 
         minio_path = "/usr/local/etc/minio"
 

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -199,7 +199,7 @@ class ACMERegistrationService(CRUDService):
             }
         )
 
-        return self.middleware.call_sync(f'{self._config.namespace}._get_instance', registration_id)
+        return self.middleware.call_sync(f'{self._config.namespace}.get_instance', registration_id)
 
 
 class ACMEDNSAuthenticatorModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -218,7 +218,7 @@ class CronJobService(CRUDService):
             job.logs_fd.write(line)
             syslog.syslog(syslog.LOG_INFO, line.decode())
 
-        cron_task = self.middleware.call_sync('cronjob._get_instance', id)
+        cron_task = self.middleware.call_sync('cronjob.get_instance', id)
         if skip_disabled and not cron_task['enabled']:
             raise CallError('Cron job is disabled', errno.EINVAL)
 

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1771,7 +1771,7 @@ class CertificateService(CRUDService):
     def __create_acme_certificate(self, job, data):
 
         csr_data = self.middleware.call_sync(
-            'certificate._get_instance', data['csr_id']
+            'certificate.get_instance', data['csr_id']
         )
 
         data['acme_directory_uri'] += '/' if data['acme_directory_uri'][-1] != '/' else ''
@@ -2085,7 +2085,7 @@ class CertificateService(CRUDService):
         """
         check_dependencies(self.middleware, 'CERT', id)
 
-        certificate = self.middleware.call_sync('certificate._get_instance', id)
+        certificate = self.middleware.call_sync('certificate.get_instance', id)
 
         if certificate.get('acme'):
             client, key = self.get_acme_client_and_key(certificate['acme']['directory'], True)

--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -303,7 +303,7 @@ class PluginService(CRUDService):
             'branch': branch,
         })
 
-        new_plugin = self.middleware.call_sync('plugin._get_instance', jail_name)
+        new_plugin = self.middleware.call_sync('plugin.get_instance', jail_name)
         new_plugin['install_notes'] = install_notes.strip()
 
         return new_plugin
@@ -910,7 +910,7 @@ class JailService(CRUDService):
 
         job.set_progress(100, f'Created: {uuid}')
 
-        return self.middleware.call_sync('jail._get_instance', uuid)
+        return self.middleware.call_sync('jail.get_instance', uuid)
 
     @item_method
     @accepts(
@@ -956,7 +956,7 @@ class JailService(CRUDService):
 
         job.set_progress(100, 'Jail has been successfully cloned.')
 
-        return self.middleware.call_sync('jail._get_instance', options['uuid'])
+        return self.middleware.call_sync('jail.get_instance', options['uuid'])
 
     @accepts(
         Str('jail'),

--- a/src/middlewared/middlewared/plugins/kmip/update.py
+++ b/src/middlewared/middlewared/plugins/kmip/update.py
@@ -91,7 +91,7 @@ class KMIPService(ConfigService):
             ca = ca[0]
             if not await self.middleware.call(
                 'cryptokey.validate_cert_with_chain',
-                (await self.middleware.call('certificate._get_instance', new['certificate']))['certificate'],
+                (await self.middleware.call('certificate.get_instance', new['certificate']))['certificate'],
                 [ca['certificate']]
             ):
                 verrors.add(

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2335,7 +2335,7 @@ class StaticRouteService(CRUDService):
         """
         Delete Static Route of `id`.
         """
-        staticroute = self.middleware.call_sync('staticroute._get_instance', id)
+        staticroute = self.middleware.call_sync('staticroute.get_instance', id)
         rv = self.middleware.call_sync('datastore.delete', self._config.datastore, id)
         try:
             rt = netif.RoutingTable()


### PR DESCRIPTION
This commit fixes an issue where service parts remove endpoints starting with '_' which results in call failing. We introduce change to use 'get_instance' instead when we are using middleware call.