### PR TITLE
NAS-109371 / 12.0 / Recursively delete snapshots of vm zvols when deleting vms (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1534,7 +1534,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
                     disk_name = zvol['attributes']['path'].rsplit(
                         '/dev/zvol/'
                     )[-1]
-                    await self.middleware.call('zfs.dataset.delete', disk_name)
+                    await self.middleware.call('zfs.dataset.delete', disk_name, {'recursive': True})
 
             await self.middleware.call('vm.undefine_vm', vm)
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 07ac366d7316c94d002e692b24c946cc06575e1f



Original PR: https://github.com/truenas/middleware/pull/6448