### PR TITLE
NAS-109528 / 21.04 / ignore `docs` folder for train validation

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -59,8 +59,8 @@ class CatalogService(Service):
         unhealthy_apps = set()
         for train in os.listdir(location):
             if (
-                not os.path.isdir(os.path.join(location, train)) or train.startswith('.') or train == 'library' or
-                train == 'docs' or not VALID_TRAIN_REGEX.match(train)
+                not os.path.isdir(os.path.join(location, train)) or train.startswith('.') or 
+                train in ('library', 'docs') or not VALID_TRAIN_REGEX.match(train)
             ):
                 continue
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -52,15 +52,15 @@ class CatalogService(Service):
 
     @private
     def get_trains(self, location, options=None):
-        # We make sure we do not dive into library folder and not consider it a train
-        # This allows us to use this folder for placing helm library charts
+        # We make sure we do not dive into library and docs folders and not consider it a train
+        # This allows us to use this folder for placing helm library charts and docs respectively
         trains = {'charts': {}, 'test': {}}
         options = options or {}
         unhealthy_apps = set()
         for train in os.listdir(location):
             if (
                 not os.path.isdir(os.path.join(location, train)) or train.startswith('.') or train == 'library' or
-                not VALID_TRAIN_REGEX.match(train)
+                train == 'docs' or not VALID_TRAIN_REGEX.match(train)
             ):
                 continue
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -52,8 +52,8 @@ class CatalogService(Service):
 
     @private
     def get_trains(self, location, options=None):
-        # We make sure we do not dive into library and docs folders and not consider it a train
-        # This allows us to use this folder for placing helm library charts and docs respectively
+        # We make sure we do not dive into library and docs folders and not consider those a train
+        # This allows us to use these folders for placing helm library charts and docs respectively
         trains = {'charts': {}, 'test': {}}
         options = options or {}
         unhealthy_apps = set()


### PR DESCRIPTION
Middleware version of chart_validation:
https://github.com/truenas/catalog_validation/pull/15

docs is a special protected directory on github, which serves a special purpose.
It should not be used for charts.

Even so: Some might want to use it for its github purpose and get prevented to do so by the CI