### PR TITLE
NAS-109498 / 21.04 / add gluster.fuse API

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -23,13 +23,17 @@ class CtdbSharedVolumeService(Service):
         for i in await self.middleware.call('gluster.volume.query', filters):
             err_msg = f'A volume named "{CTDB_VOL_NAME}" already exists '
             if i['type'] != 'REPLICATE':
-                err_msg += '''but is not a "REPLICATE" type volume. \
-                    Please delete or rename this volume and try again.'''
+                err_msg += (
+                    'but is not a "REPLICATE" type volume. '
+                    'Please delete or rename this volume and try again.'
+                )
                 raise CallError(err_msg)
             elif i['replicate'] < 3 or i['num_bricks'] < 3:
-                err_msg += '''but is configured in a way that \
-                        could cause data corruption. Please delete \
-                        or rename this volume and try again.'''
+                err_msg += (
+                    'but is configured in a way that '
+                    'could cause data corruption. Please delete '
+                    'or rename this volume and try again.'
+                )
                 raise CallError(err_msg)
         else:
             # it's expected that ctdb shared volume exists when

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -1,8 +1,6 @@
-import os
-import pathlib
+from pathlib import Path
 from glustercli.cli import volume
 
-from middlewared.utils import run
 from middlewared.service import Service, CallError, job
 from middlewared.plugins.cluster_linux.utils import CTDBConfig
 
@@ -19,31 +17,26 @@ class CtdbSharedVolumeService(Service):
         namespace = 'ctdb.shared.volume'
         private = True
 
-    async def exists_and_started(self):
-
-        exists = started = False
-
+    async def validate(self):
         filters = [('id', '=', CTDB_VOL_NAME)]
-        vol = await self.middleware.call('gluster.volume.query', filters)
-        if vol:
-            if vol[0]['type'] != 'REPLICATE':
+        for i in await self.middleware.call('gluster.volume.query', filters):
+            start_msg = f'A volume named "{CTDB_VOL_NAME}" already exists '
+            if i['type'] != 'REPLICATE':
                 raise CallError(
-                    f'A volume with the name "{CTDB_VOL_NAME}" already exists '
-                    'but is not a REPLICATE type volume. Please delete or rename '
-                    'this volume and try again.'
+                    start_msg,
+                    'but is not a "REPLICATE" type volume. Please delete or '
+                    'rename this volume and try again.'
                 )
-            elif vol[0]['replica'] < 3 or vol[0]['num_bricks'] < 3:
+            elif i['replicate'] < 3 or i['num_bricks'] < 3:
                 raise CallError(
-                    f'A volume with the name "{CTDB_VOL_NAME}" already exists '
-                    'but is configured in a way that could cause split-brain. '
-                    'Please delete or rename this volume and try again.'
+                    start_msg,
+                    'but is configured in a way that could cause data corruption.'
+                    ' Please delete or rename this volume and try again.'
                 )
-            elif vol[0]['status'] != 'Started':
-                exists = True
-            else:
-                exists = started = True
-
-        return exists, started
+        else:
+            # it's expected that ctdb shared volume exists when
+            # calling this method
+            raise CallError(f'{CTDB_VOL_NAME} does not exist')
 
     @job(lock=CRE_OR_DEL_LOCK)
     async def create(self, job):
@@ -53,9 +46,10 @@ class CtdbSharedVolumeService(Service):
         """
 
         # check if ctdb shared volume already exists and started
-        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
-
-        if not exists:
+        info = await self.middleware.call(
+            'gluster.volume.exists_and_started', CTDB_VOL_NAME
+        )
+        if not info['exists']:
             # get the peers in the TSP
             peers = await self.middleware.call('gluster.peer.query')
             if not peers:
@@ -72,7 +66,7 @@ class CtdbSharedVolumeService(Service):
 
             # get the system dataset location
             ctdb_sysds_path = (await self.middleware.call('systemdataset.config'))['path']
-            ctdb_sysds_path = os.path.join(ctdb_sysds_path, CTDB_VOL_NAME)
+            ctdb_sysds_path = str(Path(ctdb_sysds_path).joinpath(CTDB_VOL_NAME))
 
             bricks = []
             for i in con_peers:
@@ -82,14 +76,21 @@ class CtdbSharedVolumeService(Service):
             options['kwargs'] = {'replica': len(con_peers), 'force': True}
             await self.middleware.call('gluster.method.run', volume.create, options)
 
-        if not started:
+        # make sure the shared volume is configured properly to prevent
+        # possibility of split-brain/data corruption with ctdb service
+        await self.middleware.call('ctdb.shared.volume.validate')
+
+        if not info['started']:
             # start it if we get here
             options = {'args': (CTDB_VOL_NAME,)}
             await self.middleware.call('gluster.method.run', volume.start, options)
 
         # try to mount it locally
-        mount_job = await self.middleware.call('ctdb.shared.volume.mount')
-        await mount_job.wait(raise_error=True)
+        mount_job = await self.middleware.call(
+            'gluster.fuse.mount', {'name': CTDB_VOL_NAME}
+        )
+        if not await mount_job.wait():
+            raise CallError(f'Failed to FUSE mount {CTDB_VOL_NAME}. Check logs')
 
         return await self.get_instance(CTDB_VOL_NAME)
 
@@ -100,126 +101,23 @@ class CtdbSharedVolumeService(Service):
         """
 
         # nothing to delete if it doesn't exist
-        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
-        if not exists:
+        info = await self.middleware.call(
+            'gluster.volume.exists_and_started', CTDB_VOL_NAME
+        )
+        if not info['started']:
             return
 
         # umount it first
-        umount_job = await self.middleware.call('ctdb.shared.volume.umount')
-        await umount_job.wait(raise_error=True)
+        umount_job = await self.middleware.call(
+            'gluster.volume.umount', {'name': CTDB_VOL_NAME}
+        )
+        if not await umount_job.wait():
+            raise CallError(f'Failed to unmount {CTDB_VOL_NAME}. Check logs')
 
-        if started:
+        if info['started']:
             # stop the volume
             options = {'args': (CTDB_VOL_NAME,), 'kwargs': {'force': True}}
             await self.middleware.call('gluster.method.run', volume.stop, options)
 
         # now delete it
         await self.middleware.call('gluster.method.run', volume.delete, {'args': (CTDB_VOL_NAME,)})
-
-    async def is_mounted(self):
-        """
-        Return a boolean if ctdb shared volume is mounted locally.
-        """
-
-        try:
-            mounted = pathlib.Path(CTDB_LOCAL_MOUNT).is_mount()
-        except Exception:
-            # happens when mounted but glusterd service is stopped/crashed
-            mounted = False
-
-        return mounted
-
-    @job(lock=MOUNT_UMOUNT_LOCK)
-    async def mount(self, job):
-        """
-        FUSE mount the ctdb shared volume locally.
-        """
-
-        mounted = False
-
-        # if you try to mount without the service being started,
-        # the mount utility simply returns a msg to stderr stating
-        # "Mounting glusterfs on /cluster/ctdb_shared_vol failed" which is
-        # expected since the service isn't running
-        if not await self.middleware.call('service.started', 'glusterd'):
-            self.logger.warning('The "glusterd" service is not running. Not mounting.')
-            return mounted
-
-        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
-        if not exists or not started:
-            return mounted
-
-        try:
-            # make sure the dirs are there
-            pathlib.Path(CTDB_LOCAL_MOUNT).mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            raise CallError(f'Failed creating directory with error: {e}')
-
-        # we have to stop the glustereventsd service because when the volume is mounted
-        # it triggers an event which then gets processed by middlewared and calls this
-        # method again....
-        # Furthermore, there is a scenario which can cause a mount/umount loop. If the
-        # shared volume is in a self-heal situation because, say, 1 of the peers is down.
-        # when we `mount -t glusterfs`, 2 events get generated with identical timestamps.
-        # There is nothing we can do about the events and since the timestamps are in
-        # seconds (which means they appear at the "same" time), then you can get into a
-        # really bad loop. In the above scenario, when mounting a AFR_SUBVOLS_DOWN event
-        # is generated and an AFR_SUBVOL_UP event is generated and they both have the same
-        # timestamp. Well, according to testing, the SUBVOLS_DOWN event comes "first"
-        # while the SUBVOL_UP event comes "second". This means on SUBVOLS_DOWN event, we
-        # call the `ctdb.shared.volume.umount` method which generates another `SUBVOLS_DOWN`
-        # method and because we processed a `SUBVOL_UP` event, we run this method which
-        # generates another SUBVOL_UP event........This causes a mount/umount loop.
-        # So, as an easy work-around we stop the glusterevevntsd service which prevents
-        # any more events from being triggered while we mount/umount the volume.
-        await self.middleware.call('service.stop', 'glustereventsd')
-        try:
-            cmd = ['mount', '-t', 'glusterfs', 'localhost:/' + CTDB_VOL_NAME, CTDB_LOCAL_MOUNT]
-            cp = await run(cmd, check=False)
-            if cp.returncode:
-                if b'is already mounted' in cp.stderr:
-                    mounted = True
-                else:
-                    errmsg = cp.stderr.decode().strip()
-                    self.logger.error(f'Failed to mount {CTDB_LOCAL_MOUNT} with error: {errmsg}')
-            else:
-                mounted = True
-        except Exception:
-            self.logger.error(
-                'Unhandled exception when trying to mount ctdb shared volume', exc_info=True
-            )
-        finally:
-            await self.middleware.call('service.start', 'glustereventsd')
-
-        return mounted
-
-    @job(lock=MOUNT_UMOUNT_LOCK)
-    async def umount(self, job):
-        """
-        Unmount the locally FUSE mounted ctdb shared volume.
-        """
-
-        umounted = False
-
-        # read the above comment in the `def mount` method on why we stop and
-        # start this service before we umount the volume
-        await self.middleware.call('service.stop', 'glustereventsd')
-        try:
-            cmd = ['umount', '-R', CTDB_LOCAL_MOUNT]
-            cp = await run(cmd, check=False)
-            if cp.returncode:
-                errmsg = cp.stderr.decode().strip()
-                if 'not mounted' in errmsg or 'ctdb_shared_vol: not found' in errmsg:
-                    umounted = True
-                else:
-                    self.logger.error(f'Failed to umount {CTDB_LOCAL_MOUNT} with error: {errmsg}')
-            else:
-                umounted = True
-        except Exception:
-            self.logger.error(
-                'Unhandled exception when trying to umount ctdb shared volume', exc_info=True
-            )
-        finally:
-            await self.middleware.call('service.start', 'glustereventsd')
-
-        return umounted

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -87,10 +87,9 @@ class CtdbSharedVolumeService(Service):
 
         # try to mount it locally
         mount_job = await self.middleware.call(
-            'gluster.fuse.mount', {'name': CTDB_VOL_NAME}
+            'gluster.fuse.mount', {'name': CTDB_VOL_NAME, 'raise': True}
         )
-        if not await mount_job.wait():
-            raise CallError(f'Failed to FUSE mount {CTDB_VOL_NAME}. Check logs')
+        await mount_job.wait(raise_error=True)
 
         return await self.get_instance(CTDB_VOL_NAME)
 
@@ -109,10 +108,9 @@ class CtdbSharedVolumeService(Service):
 
         # umount it first
         umount_job = await self.middleware.call(
-            'gluster.volume.umount', {'name': CTDB_VOL_NAME}
+            'gluster.volume.umount', {'name': CTDB_VOL_NAME, 'raise': True}
         )
-        if not await umount_job.wait():
-            raise CallError(f'Failed to unmount {CTDB_VOL_NAME}. Check logs')
+        await umount_job.wait(raise_error=True)
 
         if info['started']:
             # stop the volume

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -2,8 +2,15 @@ import os
 import enum
 
 
-class CTDBConfig(enum.Enum):
+class FuseConfig(enum.Enum):
+    """
+    Various configuration settings used for FUSE mounting
+    the gluster volumes locally.
+    """
+    FUSE_PATH_BASE = '/cluster'
 
+
+class CTDBConfig(enum.Enum):
     """
     Various configuration settings used to configure ctdb.
     """
@@ -40,7 +47,7 @@ class CTDBConfig(enum.Enum):
     GENERAL_FILE = 'ctdb.conf'
 
     # local gluster fuse client mount related config
-    LOCAL_MOUNT_BASE = '/cluster'
+    LOCAL_MOUNT_BASE = FuseConfig.FUSE_PATH_BASE.value
     CTDB_VOL_NAME = 'ctdb_shared_vol'
     CTDB_LOCAL_MOUNT = os.path.join(LOCAL_MOUNT_BASE, CTDB_VOL_NAME)
     GM_RECOVERY_FILE = os.path.join(CTDB_LOCAL_MOUNT, REC_FILE)

--- a/src/middlewared/middlewared/plugins/gluster_linux/fuse.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/fuse.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+
+from middlewared.utils import run
+from middlewared.service import (Service, CallError, job,
+                                 accepts, Dict, Str, Bool,
+                                 ValidationErrors, private)
+from middlewared.plugins.cluster_linux.utils import FuseConfig
+
+
+FUSE_BASE = FuseConfig.FUSE_PATH_BASE.value
+
+
+class GlusterFuseService(Service):
+
+    class Config:
+        namespace = 'gluster.fuse'
+        cli_namespace = 'service.gluster.fuse'
+
+    @accepts(Dict(
+        'glusterfuse_mounted',
+        Str('name', required=True),
+    ))
+    async def is_mounted(self, data):
+        """
+        Check if gluster volume is FUSE mounted locally.
+
+        `name` String representing name of the gluster volume
+        """
+        path = Path(FUSE_BASE).joinpath(data['name'])
+        try:
+            mounted = path.is_mount()
+        except Exception:
+            # can happen when mounted but glusterd service
+            # isn't functioning
+            mounted = False
+
+        return mounted
+
+    @private
+    async def common_validation(self, data, schema_name):
+        name = data.get('name', None)
+        all_vols = data.get('all', None)
+
+        verrors = ValidationErrors()
+        if not name and not all_vols:
+            verrors.add(
+                f'{schema_name}',
+                'A gluster volume name is rquired or the "all" key must be set to True'
+            )
+
+        verrors.check()
+
+    @accepts(Dict(
+        'gluserfuse_mount',
+        Str('name', default=None),
+        Bool('all', default=False),
+    ))
+    @job(lock='glusterfuse')
+    async def mount(self, job, data):
+        """
+        Mount a gluster volume using the gluster FUSE client.
+
+        `name` String representing the name of the gluster volume
+        `all` Boolean if True locally FUSE mount all detected
+                gluster volumes
+        """
+        schema_name = 'glusterfuse.mount'
+        await self.middleware.call(
+            'gluster.fuse.common_validation', data, schema_name
+        )
+
+        filters = [] if data['all'] else [('id', '=', data['name'])]
+        vols = await self.middleware.call('gluster.volume.query', filters)
+        mounted = []
+        if vols:
+            # we have to stop the glustereventsd service because when the volume is mounted
+            # it triggers an event which then gets processed by middlewared and calls this
+            # method again....
+            # Furthermore, there is a scenario which can cause a mount/umount loop. If the
+            # shared volume is in a self-heal situation because, say, 1 of the peers is down.
+            # when we `mount -t glusterfs`, 2 events get generated with identical timestamps.
+            # There is nothing we can do about the events and since the timestamps are in
+            # seconds (which means they appear at the "same" time), then you can get into a
+            # really bad loop. In the above scenario, when mounting a AFR_SUBVOLS_DOWN event
+            # is generated and an AFR_SUBVOL_UP event is generated and they both have the same
+            # timestamp. Well, according to testing, the SUBVOLS_DOWN event comes "first"
+            # while the SUBVOL_UP event comes "second". This means on SUBVOLS_DOWN event, we
+            # call the `gluster.volume.umount` method which generates another `SUBVOLS_DOWN`
+            # method and because we processed a `SUBVOL_UP` event, we run this method which
+            # generates another SUBVOL_UP event........This causes a mount/umount loop.
+            # So, as an easy work-around we stop the glusterevevntsd service which prevents
+            # any more events from being triggered while we mount/umount the volume.
+            await self.middleware.call('service.stop', 'glustereventsd')
+            for i in vols:
+                try:
+                    j = await self.middleware.call('gluster.volume.exists_and_started', i['name'])
+                    if j['exists'] and j['started']:
+                        path = Path(FUSE_BASE).joinpath(j['name'])
+                        try:
+                            # make sure the dirs are there
+                            path.mkdir(parents=True, exist_ok=True)
+                        except Exception as e:
+                            raise CallError(f'Failed creating {path} with error: {e}')
+
+                        local_path = Path('localhost:/').joinpath(j['name'])
+                        cmd = ['mount', '-t', 'glusterfs', str(local_path), str(path)]
+                        cp = await run(cmd, check=False)
+                        if cp.returncode:
+                            errmsg = cp.stderr.decode().strip()
+                            ignore1 = 'is already mounted'
+                            if ignore1 in errmsg:
+                                mounted.append(True)
+                            else:
+                                self.logger.error(
+                                    'Failed to mount %s with error: %s', path, errmsg
+                                )
+                                mounted.append(False)
+                        else:
+                            mounted.append(True)
+                except Exception:
+                    self.logger.error('Unhandled exception trying to mount %s', path, exc_info=True)
+                    continue
+
+            # always start it back up
+            await self.middleware.call('service.start', 'glustereventsd')
+
+        return all(mounted) if mounted else bool(mounted)
+
+    @accepts(Dict(
+        'glusterfuse_umount',
+        Str('name', default=None),
+        Bool('all', default=False),
+    ))
+    @job(lock='glusterfuse')
+    async def umount(self, job, data):
+        """
+        Unmount a locally FUSE mounted gluster volume.
+
+        `name` String representing the name of the gluster volume
+        `all` Boolean if True umount all locally detected FUSE
+                mounted gluster volumes
+        """
+        schema_name = 'glusterfuse.umount'
+        await self.middleware.call(
+            'gluster.fuse.common_validation', data, schema_name
+        )
+
+        filters = [] if data['all'] else [('id', '=', data['name'])]
+        vols = await self.middleware.call('gluster.volume.query', filters)
+        umounted = []
+        if vols:
+            # see commemt above on why we do this
+            await self.middleware.call('service.stop', 'glustereventsd')
+            for i in vols:
+                path = Path(FUSE_BASE).joinpath(i['name'])
+                try:
+                    cp = await run(['umount', '-R', str(path)], check=False)
+                    if cp.returncode:
+                        errmsg = cp.stderr.decode().strip()
+                        ignore1 = 'not mounted'
+                        ignore2 = i['name'] + ': not found'
+                        if ignore1 in errmsg or ignore2 in errmsg:
+                            umounted.append(True)
+                        else:
+                            self.logger.error(
+                                'Failed to umount %s with error: %s', path, errmsg
+                            )
+                            umounted.append(False)
+                    else:
+                        umounted.append(True)
+                except Exception:
+                    self.logger.error('Unhandled exception trying to umount %s', path, exc_info=True)
+                    continue
+
+            # always start it back up
+            await self.middleware.call('service.start', 'glustereventsd')
+
+        return all(umounted) if umounted else bool(umounted)


### PR DESCRIPTION
- add `gluster.fuse` API
- make `ctdb.shared.volume` use the new `gluster.fuse` API appropriately
- moved exists_and_started() from `ctdb.shared.volume` to `gluster.volume` and make it globally usable
- change `glusterd` service use the new `gluster.fuse` API
- on `gluster.volume.create` calls, make sure `glustereventsd` service is started