### PR TITLE
NAS-109430 / 21.04 / Improve error handling for directory services (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -365,6 +365,12 @@ class ActiveDirectoryService(ConfigService):
         if not new["enable"]:
             return
 
+        ldap_enabled = (await self.middleware.call("ldap.config"))['enable']
+        if ldap_enabled:
+            verrors.add(
+                "activedirectory_update.enable",
+                "Active Directory service may not be enabled while LDAP service is enabled."
+            )
         if not new["bindpw"] and not new["kerberos_principal"]:
             verrors.add(
                 "activedirectory_update.bindname",

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -531,6 +531,7 @@ class ActiveDirectoryService(ConfigService):
                 self.logger.warning("NTP request to Domain Controller failed.",
                                     exc_info=True)
             except Exception as e:
+                await self.middleware.call("kerberos.stop")
                 raise ValidationError(
                     "activedirectory_update",
                     f"Failed to validate domain configuration: {e}"
@@ -793,10 +794,19 @@ class ActiveDirectoryService(ConfigService):
         if not ad:
             ad = self.middleware.call_sync('activedirectory.config')
 
-        pdc = ActiveDirectory_Conn(conf=ad, logger=self.logger).get_pdc()
-        if not pdc:
-            self.logger.warning("Unable to find PDC emulator via DNS.")
-            return {'pdc': None, 'timestamp': '0', 'clockskew': 0}
+        try:
+            pdc = ActiveDirectory_Conn(conf=ad, logger=self.logger).get_pdc()
+            if not pdc:
+                self.logger.warning("Unable to find PDC emulator via DNS.")
+                return {'pdc': None, 'timestamp': '0', 'clockskew': 0}
+        except CallError:
+            AD_DNS = ActiveDirectory_DNS(conf=ad, logger=self.logger)
+            res = AD_DNS.get_n_working_servers(SRV['DOMAINCONTROLLER'], 1)
+            if len(res) == 0:
+                self.logger.warning("Unable to find Domain Controller via DNS.")
+                return {'pdc': None, 'timestamp': '0', 'clockskew': 0}
+
+            pdc = res[0]['host']
 
         c = ntplib.NTPClient()
         response = c.request(pdc)

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -505,6 +505,13 @@ class LDAPService(ConfigService):
         if not new["enable"]:
             return
 
+        ad_enabled = (await self.middleware.call("activedirectory.config"))['enable']
+        if ad_enabled:
+            verrors.add(
+                "ldap_update.enable",
+                "LDAP service may not be enabled while Active Directory service is enabled."
+            )
+
         if new["certificate"]:
             verrors.extend(await self.middleware.call(
                 "certificate.cert_services_validation",


### PR DESCRIPTION
This PR covers a few edge cases that may trip up some users.

First off, we prevent users from simultaneously enabling AD and LDAP directory services. There are very few cases where users actually need to do this. One common example may be FreeIPA + AD in the same environment, but the typical resolution to this configuration need is to create a cross-realm trust between FreeIPA and AD and enable / configure trusted domains in the AD plugin.

Kerberos libraries will let us kinit even if clock offset is larger than 3 minutes, but services behave badly in this situation. This PR makes us try a little harder. If CLDAP ping fails to get us a DC, then we switch to performing normal DNS lookup for a DC. If time offset is too large (or our service account can't be used for netlogon connection), then destroy the service account's kerberos ticket to prevent it from being used by middleware or other processes.

Original PR: https://github.com/truenas/middleware/pull/6426