### PR TITLE
NAS-109584 / 21.04 / Do not retrieve complete k8s cluster dump in debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/kubernetes_linux/kubernetes.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/kubernetes_linux/kubernetes.sh
@@ -55,9 +55,5 @@ kubernetes_func()
 		section_header "docker images -a"
 		docker images -a
 		section_footer
-
-		section_header "k3s kubectl cluster-info dump"
-		k3s kubectl cluster-info dump
-		section_footer
 	fi
 }


### PR DESCRIPTION
This commit adds changes to not retrieve complete k8s cluster dump in debug, it can grow very large which can result in lots of space being consuemd by the debug as whole. If required, we can request user for this explicitly.