### PR TITLE
NAS-109545 / 21.04 / middlewared/iscsi: skip reload after extent creation

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -580,8 +580,6 @@ class iSCSITargetExtentService(SharingService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self._service_change('iscsitarget', 'reload')
-
         return await self._get_instance(data['id'])
 
     @accepts(


### PR DESCRIPTION
As it is still not referenced, there is no need to reload the service.
With large configurations, this can save time.