### PR TITLE
NAS-109599 / 21.04 / fix KeyError in jails (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -618,7 +618,7 @@ class PluginService(CRUDService):
 
             # We construct our version in the following manner
             # epoch!manifest_version.version.revision
-            available_version = f'{plugin_dict["epoch"]}!{plugin_git_manifest["revision"]}.' \
+            available_version = f'{plugin_dict["epoch"]}!{plugin_git_manifest.get("revision", "0")}.' \
                                 f'{plugin_dict["version"]}.{plugin_dict["revision"]}'
             plugin_version = f'{plugin["epoch"]}!{plugin_manifest.get("revision", "0")}.' \
                              f'{plugin["version"]}.{plugin["revision"]}'


### PR DESCRIPTION
[2021/02/15 12:54:26] (ERROR) middlewared.job.run():379 - Job <bound method PluginService.plugin_updates of <middlewared.plugins.jail_freebsd.PluginService object at 0x81ce9c100>> failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 367, in run
    await self.future
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 405, in __run_body
    rv = await self.middleware.run_in_thread(self.method, *([self] + args))
  File "/usr/local/lib/python3.8/site-packages/middlewared/utils/run_in_thread.py", line 10, in run_in_thread
    return await self.loop.run_in_executor(self.run_in_thread_executor, functools.partial(method, *args, **kwargs))
  File "/usr/local/lib/python3.8/site-packages/middlewared/utils/io_thread_pool_executor.py", line 25, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/jail_freebsd.py", line 615, in plugin_updates
    available_version = f'{plugin_dict["epoch"]}!{plugin_git_manifest["revision"]}.' \
KeyError: 'revision'

Original PR: https://github.com/truenas/middleware/pull/6496