### PR TITLE
change app-readme.md from plaintext into markdown

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -151,7 +151,7 @@ class CatalogService(Service):
         for key, filename, parser in (
             ('chart_metadata', 'Chart.yaml', yaml.safe_load),
             ('schema', 'questions.yaml', yaml.safe_load),
-            ('app_readme', 'app-readme.txt', str.strip),
+            ('app_readme', 'app-readme.md', markdown.markdown),
             ('detailed_readme', 'README.md', markdown.markdown),
         ):
             with open(os.path.join(version_path, filename), 'r') as f:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -151,7 +151,7 @@ class CatalogService(Service):
         for key, filename, parser in (
             ('chart_metadata', 'Chart.yaml', yaml.safe_load),
             ('schema', 'questions.yaml', yaml.safe_load),
-            ('app_readme', 'app-readme.md', str.strip),
+            ('app_readme', 'app-readme.txt', str.strip),
             ('detailed_readme', 'README.md', markdown.markdown),
         ):
             with open(os.path.join(version_path, filename), 'r') as f:


### PR DESCRIPTION
app-readme isn't actually a markdown file, as it's loaded as `str.strip`, not `markdown.markdown`

This leads to confusion when creation Charts because chart creators will assume it's rendered as markdown, while it's just plaintext (hence txt).