### PR TITLE
NAS-108202 / 21.04 / Configure ocsp stapling in nginx

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -153,9 +153,12 @@ http {
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA${"" if disabled_ciphers else "+SHA256"}:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS${disabled_ciphers};
         add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
-        ## TODO: OCSP Stapling
-        #ssl_stapling on;
-        #ssl_stapling_verify on;
+        ## If oscsp stapling is a must in cert extensions, we should make sure nginx respects that
+        ## and handles clients accordingly.
+        % if 'Tlsfeature' in cert['extensions']:
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        % endif
         #resolver ;
         #ssl_trusted_certificate ;
 % endif


### PR DESCRIPTION
This commit introduces changes to configure nginx with ocsp stapling if the certificate being used for UI has ocsp stapling extension set which if nginx does not configure itself with ocsp will result in failed requests.