### PR TITLE
NAS-109643 / 21.04 / Adjust default NFSv4 ACL for new datasets (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3441,7 +3441,21 @@ class PoolDatasetService(CRUDService):
                         "type": "ALLOW",
                         "perms": {"BASIC": "FULL_CONTROL"},
                         "flags": {"BASIC": "INHERIT"}
-                    }
+                    },
+                    {
+                        "tag": "GROUP",
+                        "id": 545,
+                        "type": "ALLOW",
+                        "perms": {"BASIC": "MODIFY"},
+                        "flags": {"BASIC": "INHERIT"}
+                    },
+                    {
+                        "tag": "everyone@",
+                        "id": None,
+                        "type": "ALLOW",
+                        "perms": {"BASIC": "TRAVERSE"},
+                        "flags": {"BASIC": "NOINHERIT"}
+                    },
                 ],
             ),
             Dict(


### PR DESCRIPTION
This eases permissions in the following two ways for new SMB datasets
1) SMB users (members of builtin_users) by default will be granted MODIFY
   permissions to new datasets
2) Non-inheriting entry granting TRAVERSE will be granted to everyone.
   This will make crossing boundaries of nested datasets more intuitive.

Many users do not realize that TRAVERSE is required for users to access a child dataset.
This means our default for new datasets will be slightly more open, but since the permissions
or editably in the webui, I think it's not too much for a user to adjust them.

Original PR: https://github.com/truenas/middleware/pull/6514