### PR TITLE
NAS-109648 / 21.04 / Retrieve chart release history on chart.release.query event

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -38,7 +38,9 @@ class ChartReleaseService(Service):
     async def handle_k8s_event(self, k8s_event):
         name = get_chart_release_from_namespace(k8s_event['involved_object']['namespace'])
         async with LOCKS[name]:
-            chart_release = await self.middleware.call('chart.release.query', [['id', '=', name]])
+            chart_release = await self.middleware.call(
+                'chart.release.query', [['id', '=', name]], {'extra': {'history': True}}
+            )
             if not chart_release:
                 # It's possible the chart release got deleted
                 return


### PR DESCRIPTION
This commit adds changes to retrieve chart release history as well when we send chart.release.query event as UI relies on that to render rollback function. Also this does not has a performance penalty as well because k8s gives us history anyways, we just choose to not add it by defaulti n the output.