### PR TITLE
NAS-109627 / 21.04 / Add validation to ensure we have routing properly configured for k8s

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -50,6 +50,15 @@ class KubernetesService(ConfigService):
         if data['node_ip'] not in await self.bindip_choices():
             verrors.add(f'{schema}.node_ip', 'Please provide a valid IP address.')
 
+        if not await self.middleware.call('route.configured_default_ipv4_route'):
+            if not data['route_v4_gateway']:
+                verrors.add(f'{schema}.route_v4_gateway', 'Please set a default route for system or for kubernetes.')
+            if not data['route_v4_interface']:
+                verrors.add(
+                    f'{schema}.route_v4_interface',
+                    'Please set a default route for system or specify default interface to be used for kubernetes.'
+                )
+
         for k, _ in await self.validate_interfaces(data):
             verrors.add(f'{schema}.{k}', 'Please specify a valid interface.')
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2107,6 +2107,11 @@ class RouteService(Service):
         return filter_list([r.__getstate__() for r in rtable.routes], filters, options)
 
     @private
+    async def configured_default_ipv4_route(self):
+        route = netif.RoutingTable().default_route_ipv4
+        return bool(route or (await self.middleware.call('network.configuration.config'))['ipv4gateway'])
+
+    @private
     async def sync(self):
         config = await self.middleware.call('datastore.query', 'network.globalconfiguration', [], {'get': True})
 


### PR DESCRIPTION
This commit adds validation to ensure that either the system has a default route configured or we have default route attributes set for kubernetes configurations as otherwise k8s would fail to work.