### PR TITLE
NAS-109684 / 12.0 / Enable SA-based xattrs on all new datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2894,6 +2894,9 @@ class PoolDatasetService(CRUDService):
         if os.path.exists(mountpoint):
             verrors.add('pool_dataset_create.name', f'Path {mountpoint} already exists')
 
+        if data['type'] == 'FILESYSTEM':
+            data['xattr'] = 'SA'
+
         if osc.IS_LINUX and not data.get('acltype') and data['type'] == 'FILESYSTEM':
             data['acltype'] = 'POSIXACL'
 
@@ -2901,8 +2904,6 @@ class PoolDatasetService(CRUDService):
             data['casesensitivity'] = 'INSENSITIVE'
             if osc.IS_FREEBSD:
                 data['aclmode'] = 'RESTRICTED'
-
-            data['xattr'] = 'SA'
 
         if (await self.get_instance(data['name'].rsplit('/', 1)[0]))['locked']:
             verrors.add(


### PR DESCRIPTION
Initial testing was performed on only SMB-optimized datasets. No
issues have been observed so far. Transition to make this the default
for performance reasons.