### PR TITLE
NAS-109650 / 12.0 / Properly handle invalid unicode in filesystem.file_tail_follow

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -1095,7 +1095,7 @@ class FileFollowTailEventSource(EventSource):
         if fsize < bufsize:
             bufsize = fsize
         i = 0
-        with open(path) as f:
+        with open(path, encoding='utf-8', errors='ignore') as f:
             data = []
             while True:
                 i += 1


### PR DESCRIPTION
Debug was fixed in https://github.com/truenas/middleware/pull/6539