### PR TITLE
Prevent Permission denied: './ValidateUpdate' when system dataset is …

### DIFF
--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -409,6 +409,7 @@ class UpdateService(Service):
         else:
             path = UPLOAD_LOCATION
         os.makedirs(path, exist_ok=True)
+        os.chmod(path, 0o755)
         return path
 
     @private


### PR DESCRIPTION
…not mounted