### PR TITLE
NAS-109732 / 12.0 / Clear various AD-related caches when service explicitly stopped

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -750,6 +750,18 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('etc.generate', 'pam')
         await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'])
+        try:
+            os.unlink('/var/db/system/.AD_cache_backup')
+        except FileNotFoundError:
+            pass
+        except Exception:
+            self.logger.error("Failed to remove AD cache backup. Depending on the circumstances, this may result "
+                              "in non-existent usernames and groups appearing in webui dropdown menus.", exc_info=True)
+        await self.middleware.call('cache.pop', 'AD_cache')
+        flush = await run([SMBCmd.NET.value, "cache", "flush"], check=False)
+        if flush.returncode != 0:
+            self.logger.warning("Failed to flush samba's general cache after stopping Active Directory service.")
+
         if (await self.middleware.call('smb.get_smb_ha_mode')) == "LEGACY" and (await self.middleware.call('failover.status')) == 'MASTER':
             try:
                 await self.middleware.call('failover.call_remote', 'activedirectory.stop')


### PR DESCRIPTION
A not-insignificant number of users will first try deploying TrueNAS
in a lab / test domain before migrating to the final production domain.
This may be done haphazardly without cleanly leaving the old AD domain.
To ease the migration process, we should clear out middleware user
cache when the AD service is explicitly stopped and flush samba caches.