### PR TITLE
NAS-109722 / 21.04 / Do not add doc.txz as a default when fetching release

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -1097,7 +1097,7 @@ class JailService(CRUDService):
             List('props'),
             List(
                 'files',
-                default=['MANIFEST', 'base.txz', 'lib32.txz', 'doc.txz']
+                default=['MANIFEST', 'base.txz', 'lib32.txz']
             ),
             Str('branch', default=None, null=True)
         )


### PR DESCRIPTION
This commit adds changes updating jail plugin fetching release files to what iocage has. This fixes an issue where old eol 12.0 release version where doc.txz is not present but we still try to download it and it results in fetching release erroring out.