### PR TITLE
NAS-109732 / 21.04 / Clear various AD-related caches when service explicitly stopped (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -759,6 +759,9 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'])
         await self.middleware.call('service.stop', 'dscache')
+        flush = await run([SMBCmd.NET.value, "cache", "flush"], check=False)
+        if flush.returncode != 0:
+            self.logger.warning("Failed to flush samba's general cache after stopping Active Directory service.")
         if (await self.middleware.call('smb.get_smb_ha_mode')) == "LEGACY" and (await self.middleware.call('failover.status')) == 'MASTER':
             try:
                 await self.middleware.call('failover.call_remote', 'activedirectory.stop')

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -225,6 +225,21 @@ class DSCache(Service):
                 await self.middleware.call(f'{ds}.fill_cache', True)
             elif ds_state != 'DISABLED':
                 self.logger.debug('Unable to refresh [%s] cache, state is: %s' % (ds, ds_state))
+            else:
+                if ds == 'activedirectory':
+                    backup_path = "/var/db/system/.AD_cache"
+                elif ds == 'ldap':
+                    backup_path = "/var/db/system/.LDAP_cache"
+                else:
+                    backup_path = "/var/db/system/.NIS_cache"
+                try:
+                    os.unlink(backup_path)
+                except FileNotFoundError:
+                    pass
+                except Exception:
+                    self.logger.error("Failed to remove directory service cache backup [%s].",
+                                      backup_path, exc_info=true)
+
         await self.middleware.call('dscache.backup')
 
 


### PR DESCRIPTION
A not-insignificant number of users will first try deploying TrueNAS
in a lab / test domain before migrating to the final production domain.
This may be done haphazardly without cleanly leaving the old AD domain.
To ease the migration process, we should clear out middleware user
cache when the AD service is explicitly stopped and flush samba caches.

Original PR: https://github.com/truenas/middleware/pull/6573