### PR TITLE
NAS-109743 / 12.0 / Explicitly set tdbsam as passdb backend when stopping ldap

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -987,7 +987,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('service.restart', 'cifs')
             await self.middleware.call('smb.synchronize_passdb')
             await self.middleware.call('smb.synchronize_group_mappings')
-            await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
+        await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
         await self.middleware.call('cache.pop', 'LDAP_cache')
         await self.nslcd_cmd('onestop')
         await self.set_state(DSStatus['DISABLED'])


### PR DESCRIPTION
Original idea behind only doing this when the samba schema was enabled
for the LDAP service overlooked the possibilty that the end-user might
enable the samba schema, disable it, then stop the LDAP service. This
was root cause for an API test failure related to SMB DOS modes.