### PR TITLE
NAS-109743 / 21.04 / Explicitly set tdbsam as passdb backend when stopping ldap (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -988,7 +988,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('service.restart', 'cifs')
             await self.middleware.call('smb.synchronize_passdb')
             await self.middleware.call('smb.synchronize_group_mappings')
-            await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
+        await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
         await self.middleware.call('cache.pop', 'LDAP_cache')
         await self.middleware.call('service.stop', 'dscache')
         await self.nslcd_cmd('stop')


### PR DESCRIPTION
Original idea behind only doing this when the samba schema was enabled
for the LDAP service overlooked the possibilty that the end-user might
enable the samba schema, disable it, then stop the LDAP service. This
was root cause for an API test failure related to SMB DOS modes.

Original PR: https://github.com/truenas/middleware/pull/6589