### PR TITLE
Add the mii monitoring during bond creation

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -37,7 +37,7 @@ class LaggMixin:
         run(["ip", "link", "set", self.name, "down"])
         for port in self.ports:
             self.delete_port(port[0])
-        run(["ip", "link", "set", self.name, "type", "bond", "mode", value.value])
+        run(["ip", "link", "set", self.name, "type", "bond", "miimon", "100", "mode", value.value])
         run(["ip", "link", "set", self.name, "up"])
 
     @property


### PR DESCRIPTION
This PR add the miimon polling rate during the creation of the
bond interface. The missing miimon configuration prevent the failover of
the interface.

This fix can be improved, the selection of monitoring and monitoring
rate is now static, an addition to the UI can be useful to select the
wanted monitoring type (ARP or MII), polling rate and/or arp target

This issue is referenced [here in the forum](https://www.truenas.com/community/threads/truenas-scale-linux-mode-1-bond.91745/#post-635570)