### PR TITLE
fix _event_system_ready for HA upgrades

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1864,7 +1864,7 @@ async def _event_system_ready(middleware, event_type, args):
         return
 
     if await middleware.call('keyvalue.get', 'HA_UPGRADE', False):
-        middleware.send_event('failover.upgrade_pending', 'ADDED', id='BACKUP', fields={'pending': True})
+        middleware.send_event('failover.upgrade_pending', 'ADDED', fields={'id': 'BACKUP', 'pending': True})
 
 
 def remote_status_event(middleware, *args, **kwargs):


### PR DESCRIPTION
send_event takes 3 positional arguments, not 4.