### PR TITLE
NAS-109728 / 21.04 / Allow running inadyn in daemon mode

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-mkdir /var/trash
+mkdir -p /var/trash
 for file in \
     /etc/cron.d/certbot \
     /etc/cron.d/e2scrub_all \

--- a/src/freenas/debian/control
+++ b/src/freenas/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.truenas.com
 
 Package: truenas-files
 Architecture: any
-Depends: python3-all, snmp-mibs-downloader, ${misc:Depends}, ${shlibs:Depends}
+Depends: inadyn, python3-all, snmp-mibs-downloader, ${misc:Depends}, ${shlibs:Depends}
 Description: Extra files for TrueNAS
  This package is supposed to hold all the extra files required
  to build TrueNAS, including utilities, extra plugins and whatever else

--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -1,0 +1,8 @@
+#!/bin/sh -ex
+
+mkdir -p /var/trash
+for file in \
+    /etc/default/inadyn
+do
+    dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"
+done

--- a/src/freenas/debian/rules
+++ b/src/freenas/debian/rules
@@ -10,6 +10,8 @@ override_dh_auto_install:
 		cp -a usr debian/truenas-files/; \
 		rm -rf debian/truenas-files/usr/local/bin.freebsd/; \
 		rm -rf debian/truenas-files/usr/local/sbin.freebsd/; \
+		mkdir -p debian/truenas-files/etc; \
+		cp -a etc/default debian/truenas-files/etc/; \
 		mkdir -p debian/truenas-files/usr/share/truenas; \
 		cp -a root debian/truenas-files/usr/share/truenas/; \
 		cp etc/find* debian/truenas-files/etc/; \

--- a/src/freenas/etc/default/inadyn
+++ b/src/freenas/etc/default/inadyn
@@ -1,0 +1,14 @@
+# Please note, /etc/inadyn.conf should be properly configured before
+# running inadyn
+
+# Set to "yes" if inadyn should run in daemon mode
+# If this is changed to "yes", RUN_IPUP must be set to "no".
+RUN_DAEMON="yes"
+
+# Set to "yes" if inadyn should be run every time a new ppp connection is
+# established. This might be useful, if you are using dial-on-demand.
+RUN_IPUP="no"
+
+# The user and group that inadyn should be run as.
+USER="debian-inadyn"
+GROUP="debian-inadyn"


### PR DESCRIPTION
Inadyn init script loads environment variables from /etc/default/inadyn before attempting to start the service and if the env variable dictates not to start it as a daemon, it does not do that. There is no way of overriding this default except for changing it in the default file itself. Correct fix would be to have this fixed upstream and we have an upstream debian bug for this as well ( https://bugs.debian.org/cgi-bin/bugreport.cgi\?bug\=813347 )