### PR TITLE
NAS-109752 / 21.04 / Wait for pods to terminate which have running/pending state

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -175,5 +175,10 @@ class ChartReleaseService(Service):
     async def wait_for_pods_to_terminate(self, namespace):
         # wait for release to uninstall properly, helm right now does not support a flag for this but
         # a feature request is open in the community https://github.com/helm/helm/issues/2378
-        while await self.middleware.call('k8s.pod.query', [['metadata.namespace', '=', namespace]]):
+        while await self.middleware.call(
+            'k8s.pod.query', [
+                ['metadata.namespace', '=', namespace],
+                ['status.phase', 'in', ['Running', 'Pending']],
+            ]
+        ):
             await asyncio.sleep(5)


### PR DESCRIPTION
Pods can be left behind and not automatically cleaned by k8s if they were configured by cronjob/job(s) ( this is one example ). We should only wait for those pods to terminate which are in pending/running phase and have not completed execution. Pods in 'Terminating' state ( as reported by kubectl ), are in api terms in 'Running' state, so this case counters that as well.