### PR TITLE
NAS-109803 / 12.0 / Ensure that domain sid component of groupmap entries updated properly

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -118,9 +118,9 @@ class SMBService(Service):
         passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
 
         if groupmap:
-            sids_fixed = await self.middleware.call('smb.fixsid', groupmap.values())
-            if not sids_fixed:
-                groupmap = []
+            groupmap_removed = await self.middleware.call('smb.fixsid', groupmap.values())
+            if groupmap_removed:
+                groupmap = {}
 
         for b in SMBBuiltin:
             entry = groupmap.get(b.value[0])


### PR DESCRIPTION
Wen Samba's netbiosname changes, the server's local SID is automatically
regenerated and reflected in Samba's passdb. Groupmap entries are not
updated in a similar way. This commit simplifies and fixes smb.fix_sid
so that the domain component of each group's SID matches our current
system SID. If it doesn't, then the group_mapping.tdb is removed and
regenerated. The system SID stored in the TrueNAS configuration database
is also updated at this time. A backgrounded groupmap synchronization
job is started when our netbios name is changed in an SMB service update.