### PR TITLE
NAS-109813 / 21.04 / Add "apps" user to more groups

### DIFF
--- a/src/middlewared/middlewared/assets/account/builtin/linux/group
+++ b/src/middlewared/middlewared/assets/account/builtin/linux/group
@@ -1,3 +1,7 @@
+tty:x:5:apps
+dialout:x:20:apps
+cdrom:x:24:apps
+video:x:44:apps
 minio:x:473:
 builtin_administrators:x:544:
 builtin_users:x:545:


### PR DESCRIPTION
This PR adds the App user to more groups, to accomplice the goal of NAS-109813:
Using this user for non-privileged containers that use USB devices (such as zwave dongles), cd-roms (for transcoding cd/dvd's) and/or GPU's (hardware transcoding)


In case we do not want to use this to edit build-in groups, an alternative is a post-install command:
`usermod -a -G tty,dialout,video,cdrom apps` 
added to:
`middleware/debian/debian/postinst`

But i'm not sure that solution is as persistent enough and this one should be stable with the group-merge script.

It should not interfere with the function of `middleware/src/middlewared/middlewared/plugins/etc.py`


---

Note:
besides this the GID's also need to be set inside the container ofcoarse, but it at least enables us to do so.