### PR TITLE
[Readme] Make clear the commands are whitelist-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the master branch of freenas, which is used for the creation and testing
 
 When submitting a pull-request, Jenkins will attempt to verify the changes to ensure it does not break our builds and/or passes QA tests.
 
-The following commands may be used to interact with that service:
+Once whitelisted, the following commands may be used to interact with that service:
 
     "ok to test" to accept this pull request for testing
     "test this please" for a one time test run


### PR DESCRIPTION
The CI commands are only for people that are whitelisted.
To avoid confusion, it's good to reference it as such.