### PR TITLE
NAS-109827 / 21.04 / Retrieve k8s backup name after completing backup

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -76,6 +76,8 @@ class KubernetesService(Service):
 
         job.set_progress(100, f'Backup {name!r} complete')
 
+        return name
+
     @accepts()
     def list_backups(self):
         """


### PR DESCRIPTION
In cases where explicit backup name is not defined, this commit adds changes so that we retrieve the backup name which was used to create the k8s cluster backup.