### PR TITLE
NAS-109849 / 12.0 / prevent failover log spam when remote node goes offline

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
@@ -197,6 +197,15 @@ class RemoteClient(object):
         if self._remote_os_version is None:
             try:
                 self._remote_os_version = self.client.call('system.version')
+            except AttributeError:
+                # happens when other node goes offline
+                # (upgrade, reboot, etc) self.client gets
+                # set to None which is expected. However,
+                # the JournalSync thread calls this method
+                # every 5 seconds which is particularly
+                # painful on m-series devices since those
+                # systems can take upwards of 15mins to reboot.
+                pass
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
@@ -194,18 +194,9 @@ class RemoteClient(object):
 
     def get_remote_os_version(self):
 
-        if self._remote_os_version is None:
+        if self.client is not None and self._remote_os_version is None:
             try:
                 self._remote_os_version = self.client.call('system.version')
-            except AttributeError:
-                # happens when other node goes offline
-                # (upgrade, reboot, etc) self.client gets
-                # set to None which is expected. However,
-                # the JournalSync thread calls this method
-                # every 5 seconds which is particularly
-                # painful on m-series devices since those
-                # systems can take upwards of 15mins to reboot.
-                pass
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 


### PR DESCRIPTION
- m-series devices can take upwards of 15mins to reboot so spamming `exc_info` every 5 seconds for 15mins (or more depending on what the state of the node is in that's offline) is too noisy and does nothing but muddy the log file
- clarify the verbiage when the `JournalSync` thread is sync'ing db queries to the other node.