### PR TITLE
NAS-109853 / 21.04 / Add metadata on chart release operation

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -538,7 +538,7 @@ class ChartReleaseService(CRUDService):
         await self.perform_actions(context)
 
         config[CONTEXT_KEY_NAME].update({
-            **get_action_context(data['release_name']),
+            **get_action_context(chart_release),
             'operation': 'UPDATE',
             'isUpdate': True,
         })

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -13,7 +13,7 @@ from middlewared.schema import Bool, Dict, Str
 from middlewared.service import accepts, CallError, job, periodic, private, Service, ValidationErrors
 
 from .schema import clean_values_for_upgrade
-from .utils import CONTEXT_KEY_NAME
+from .utils import CONTEXT_KEY_NAME, get_action_context
 
 
 class ChartReleaseService(Service):
@@ -211,6 +211,7 @@ class ChartReleaseService(Service):
         # Helm considers simple config change as an upgrade as well, and we have no way of determining the old/new
         # chart versions during helm upgrade in the helm template, hence the requirement for a context object.
         config[CONTEXT_KEY_NAME].update({
+            **get_action_context(release_name),
             'operation': 'UPGRADE',
             'isUpgrade': True,
             'upgradeMetadata': {

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -1,3 +1,4 @@
+import copy
 import enum
 import os
 
@@ -23,6 +24,17 @@ class Resources(enum.Enum):
     PERSISTENT_VOLUME_CLAIM = 'persistent_volume_claims'
     POD = 'pods'
     STATEFULSET = 'statefulsets'
+
+
+def get_action_context(release_name):
+    return copy.deepcopy({
+        'operation': None,
+        'isInstall': False,
+        'isUpdate': False,
+        'isUpgrade': False,
+        'storageClassName': get_storage_class_name(release_name),
+        'upgradeMetadata': {},
+    })
 
 
 def get_namespace(release_name):


### PR DESCRIPTION
This commit adds changes to add metadata to each chart release operation so each chart while rendering k8s resources has access to this metadata. This is useful for cases like upgrade should be performed ( for helm upgrade equals to value changes and upgrade of chart itself which is not true for us ) or specifying storage class which the chart release can consume which offers rollbacks.