### PR TITLE
NAS-109780 / 21.04 / Improve error message when creating ACME cert

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -1,17 +1,12 @@
-import boto3
 import josepy as jose
 import json
 import requests
-import time
 
 from middlewared.schema import Bool, Dict, Int, Str, ValidationErrors
 from middlewared.service import accepts, CallError, CRUDService, private
 import middlewared.sqlalchemy as sa
-from middlewared.validators import validate_attributes
 
 from acme import client, messages
-from botocore import exceptions as boto_exceptions
-from botocore.errorfactory import BaseClientExceptions as boto_BaseClientException
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -144,7 +139,7 @@ class ACMERegistrationService(CRUDService):
         email = (self.middleware.call_sync('user.query', [['uid', '=', 0]]))[0]['email']
         if not email:
             raise CallError(
-                'Please specify root email address which will be used with the ACME server'
+                'Please configure an email address for "root" user which will be used with the ACME server'
             )
 
         if self.middleware.call_sync(

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1626,6 +1626,13 @@ class CertificateService(CRUDService):
         csr_data = self.middleware.call_sync(
             'certificate.get_instance', data['csr_id']
         )
+        verrors = ValidationErrors()
+        email = (self.middleware.call_sync('user.query', [['uid', '=', 0]]))[0]['email']
+        if not email:
+            verrors.add(
+                'name', 'Please configure an email address for "root" user which will be used with the ACME Server.'
+            )
+        verrors.check()
 
         data['acme_directory_uri'] += '/' if data['acme_directory_uri'][-1] != '/' else ''
 


### PR DESCRIPTION
This commit adds changes to improve error message so it's clear that one needs to configure root user's email address before trying to create an ACME cert and also raises a validation error if an email is not configured.