### PR TITLE
NAS-109921 / 21.04 / Correctly display CertBot validation errors

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/issue_cert.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/issue_cert.py
@@ -107,7 +107,7 @@ class ACMEService(Service):
                                 f'\nChallenge Type: {challenge.chall.typ}' \
                                 f'\n\nError information:' \
                                 f'\n- Type: {challenge.error.typ if challenge.error else "No error type found"}' \
-                                f'\n- Details: {challenge.error.detail if challenge.error else "No error details where found"}\n\n'
+                                f'\n- Details: {challenge.error.detail if challenge.error else "No error details were found"}\n\n'
                     raise CallError(f'Certificate request for final order failed: {msg}')
             finally:
                 self.cleanup_authorizations(order, dns_mapping, key)


### PR DESCRIPTION
Currently CertBot validation errors are not displayed.
They are however also not in an easy-to-display format, as they where not considered by the certbot devs to be displayed.

This PR ports a modified version of an old certbot PR, that makes those errors readable.
It's manually verified to output readable error output from CertBot validation errors.