### PR TITLE
NAS-109861 / 21.04 / Selectively add locked key

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2867,7 +2867,8 @@ class PoolDatasetService(CRUDService):
                     dataset[i]['value'] = method(dataset[i]['value'])
             del dataset['properties']
 
-            dataset['locked'] = dataset['encrypted'] and not dataset['key_loaded']
+            if all(k in dataset for k in ('encrypted', 'key_loaded')):
+                dataset['locked'] = dataset['encrypted'] and not dataset['key_loaded']
 
             if retrieve_children:
                 rv = []


### PR DESCRIPTION
This commit introduces a change where we only add `locked` key to `pool.dataset.query` output if encryption properties are retrieved.