### PR TITLE
Optimize API response times

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -5,7 +5,7 @@
 
     global_config = middleware.call_sync('iscsi.global.config')
     targets = middleware.call_sync('iscsi.target.query')
-    extents = {d['id']: d for d in middleware.call_sync('iscsi.extent.query', [['enabled', '=', True]])}
+    extents = {d['id']: d for d in middleware.call_sync('iscsi.extent.query') if d['enabled']}
     portals = {d['id']: d for d in middleware.call_sync('iscsi.portal.query')}
     initiators = {d['id']: d for d in middleware.call_sync('iscsi.initiator.query')}
     authenticators = defaultdict(list)

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -115,7 +115,7 @@ class DiskService(Service, ServiceChangeMixin):
                 elif disk['disk_expiretime'] < datetime.utcnow():
                     # Disk expire time has surpassed, go ahead and remove it
                     for extent in await self.middleware.call(
-                        'iscsi.extent.query', [['type', '=', 'DISK'], ['path', '=', disk['disk_identifier']]]
+                        'iscsi.extent.query', [['type', '!=', 'File'], ['path', '=', disk['disk_identifier']]]
                     ):
                         await self.middleware.call('iscsi.extent.delete', extent['id'])
                     if disk['disk_kmip_uid']:

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -1065,7 +1065,7 @@ class iSCSITargetService(CRUDService):
         namespace = 'iscsi.target'
         datastore = 'services.iscsitarget'
         datastore_prefix = 'iscsi_target_'
-        datastore_extend = 'iscsi.target.extend'
+        datastore_post_extend = 'iscsi.target.extend'
         cli_namespace = 'sharing.iscsi.target'
 
     @private

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -518,6 +518,13 @@ class iSCSITargetExtentService(SharingService):
         cli_namespace = 'sharing.iscsi.extent'
 
     @private
+    async def get_options(self, options):
+        options = await super().get_options(options)
+        options['post_extend'] = options.pop('extend', None)
+        options['extend'] = None
+        return options
+
+    @private
     async def sharing_task_determine_locked(self, data, locked_datasets):
         if data['type'] == 'ZVOL':
             return any(data['disk'][5:] == d['id'] for d in locked_datasets)
@@ -1541,7 +1548,7 @@ class ISCSIFSAttachmentDelegate(LockableFSAttachmentDelegate):
     service_class = iSCSITargetExtentService
 
     async def get_query_filters(self, enabled, options=None):
-        return [['type', '=', 'DISK']] + (await super().get_query_filters(enabled, options))
+        return [['type', '!=', 'File']] + (await super().get_query_filters(enabled, options))
 
     async def is_child_of_path(self, resource, path):
         return is_child(resource[self.path_field], os.path.join('zvol', os.path.relpath(path, '/mnt')))

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -1383,7 +1383,7 @@ class iSCSITargetToExtentService(CRUDService):
         namespace = 'iscsi.targetextent'
         datastore = 'services.iscsitargettoextent'
         datastore_prefix = 'iscsi_'
-        datastore_extend = 'iscsi.targetextent.extend'
+        datastore_post_extend = 'iscsi.targetextent.extend'
         cli_namespace = 'sharing.iscsi.target.extent'
 
     @accepts(Dict(

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -81,7 +81,7 @@ class ISCSIGlobalService(Service, GlobalActionsBase):
 
         g_config = await self.middleware.call('iscsi.global.config')
         targets = {t['id']: t for t in await self.middleware.call('iscsi.target.query')}
-        extents = {t['id']: t for t in await self.middleware.call('iscsi.extent.query', [['enabled', '=', True]])}
+        extents = {t['id']: t for t in await self.middleware.call('iscsi.extent.query') if t['enabled']}
 
         for associated_target in filter(
             lambda a: a['extent'] in extents and extents[a['extent']]['path'].startswith(f'zvol/{pool_name}/'),

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -504,8 +504,9 @@ class ZFSDatasetService(CRUDService):
                 props=props, top_level_props=top_level_props, user_props=user_properties, snapshots=snapshots,
                 retrieve_children=retrieve_children,
             )
-            if filters and len(filters) == 1 and list(filters[0][:2]) == ['id', '=']:
-                kwargs['datasets'] = [filters[0][2]]
+            for filter in filters:
+                if len(filter) == 3 and list(filter[:2]) == ['id', '=']:
+                    kwargs.setdefault('datasets', []).append(filter[2])
 
             datasets = zfs.datasets_serialized(**kwargs)
             if flat:

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -264,6 +264,7 @@ def service_config(klass, config):
         'datastore': None,
         'datastore_prefix': '',
         'datastore_extend': None,
+        'datastore_post_extend': None,
         'datastore_extend_context': None,
         'event_register': True,
         'event_send': True,
@@ -459,6 +460,7 @@ class CRUDService(ServiceChangeMixin, Service):
     async def get_options(self, options):
         options = options or {}
         options['extend'] = self._config.datastore_extend
+        options['post_extend'] = self._config.datastore_post_extend
         options['extend_context'] = self._config.datastore_extend_context
         options['prefix'] = self._config.datastore_prefix
         return options
@@ -475,6 +477,7 @@ class CRUDService(ServiceChangeMixin, Service):
             filters = []
 
         options = await self.get_options(options)
+        post_extend = options.pop('post_extend', None)
 
         # In case we are extending which may transform the result in numerous ways
         # we can only filter the final result.
@@ -489,6 +492,7 @@ class CRUDService(ServiceChangeMixin, Service):
                 filter_list, result, filters, options
             )
         else:
+            options['extend'] = post_extend
             return await self.middleware.call(
                 'datastore.query', self._config.datastore, filters, options,
             )


### PR DESCRIPTION
Avoid using filtering in code and using expensive extend operations, instead, let sql do the filtering, and extend only the result.