### PR TITLE
NAS-109884 / 21.04 / Add video device by default for guests

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -1,4 +1,4 @@
-from middlewared.plugins.vm.devices import CDROM, DISK, PCI, RAW
+from middlewared.plugins.vm.devices import CDROM, DISK, DISPLAY, PCI, RAW
 from middlewared.utils import Nid
 
 from .supervisor_base import VMSupervisorBase
@@ -55,7 +55,12 @@ class VMSupervisor(VMSupervisorBase):
                 device_xml = device.xml()
             devices.extend(device_xml if isinstance(device_xml, (tuple, list)) else [device_xml])
 
-        devices.extend([create_element('serial', type='pty')])
+        if not any(isinstance(device, DISPLAY) for device in self.devices):
+            # We should add a video device if there is no display device configured because most by
+            # default if not all headless servers like ubuntu etc require it to boot
+            devices.append(create_element('video'))
+
+        devices.append(create_element('serial', type='pty'))
         return create_element('devices', attribute_dict={'children': devices})
 
     def cpu_xml(self):


### PR DESCRIPTION
In recent display device changes, we removed adding video device by default which results in headless vms by default like ubuntu to not boot if they have no display device configured. This commit adds changes to add a video device if there are no display devices configured.