### PR TITLE
NAS-109907 / 21.04 / Add listen directive for wireguard ip for TC

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -1,5 +1,6 @@
 <%
     import contextlib
+    import ipaddress
     import os
 
     from cryptography.hazmat.backends import default_backend
@@ -55,6 +56,10 @@
                 'wildcard': '::',
             })
     ip6_list = [f'[{ip}]' for ip in ip6_list]
+
+    wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
+    if wg_config['enabled'] and wg_config['wg_address']:
+        ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list
 

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -58,7 +58,7 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if wg_config['enabled'] and wg_config['wg_address']:
+    if middleware.call_sync('truecommand.connected')['connected'] and wg_config['wg_address']:
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list


### PR DESCRIPTION
This commit adds changes where we add a listen directive in nginx for TC, motivation for this change is that when nginx is listening on some specific ip and not a wildcard one, TC instance is unable to connect to nginx as it uses the wireguard ip of the NAS to do so and nginx refuses connections on that.