### PR TITLE
NAS-109944 / 21.04 / Allow specifying default identifier field for tables

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -31,6 +31,7 @@ class CatalogService(CRUDService):
         datastore = 'services.catalog'
         datastore_extend = 'catalog.catalog_extend'
         datastore_extend_context = 'catalog.catalog_extend_context'
+        datastore_primary_key = 'label'
         cli_namespace = 'app.catalog'
 
     @private

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -67,6 +67,7 @@ class DiskService(CRUDService):
         datastore_prefix = 'disk_'
         datastore_extend = 'disk.disk_extend'
         datastore_extend_context = 'disk.disk_extend_context'
+        datastore_primary_key = 'identifier'
         event_register = False
         event_send = False
         cli_namespace = 'storage.disk'

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -265,6 +265,7 @@ def service_config(klass, config):
         'datastore_prefix': '',
         'datastore_extend': None,
         'datastore_extend_context': None,
+        'datastore_primary_key': 'id',
         'event_register': True,
         'event_send': True,
         'service': None,
@@ -537,7 +538,11 @@ class CRUDService(ServiceChangeMixin, Service):
         """
         Helper method to get an instance from a collection given the `id`.
         """
-        instance = await self.middleware.call(f'{self._config.namespace}.query', [['id', '=', id]], {'force_sql_filters': True})
+        instance = await self.middleware.call(
+            f'{self._config.namespace}.query',
+            [[self._config.datastore_primary_key, '=', id]],
+            {'force_sql_filters': True}
+        )
         if not instance:
             raise ValidationError(None, f'{self._config.verbose_name} {id} does not exist', errno.ENOENT)
         return instance[0]


### PR DESCRIPTION
This commit adds changes to allow specifying custom default identifier field. Before even if id attribute was added in extend, that would work but with recent changes that does not work as we are forcing the use of sql filters to speed up retrieval.