### PR TITLE
NAS-109907 / 12.0 / Add listen directive for wireguard ip for TC (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -1,4 +1,5 @@
 <%
+    import ipaddress
     import os
 
     from cryptography.hazmat.backends import default_backend
@@ -45,6 +46,10 @@
                 'wildcard': '::',
             })
     ip6_list = [f'[{ip}]' for ip in ip6_list]
+
+    wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
+    if wg_config['enabled'] and wg_config['wg_address']:
+        ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list
 

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -48,7 +48,7 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if wg_config['enabled'] and wg_config['wg_address']:
+    if middleware.call_sync('truecommand.connected')['connected'] and wg_config['wg_address']:
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6e2499dcd5e8522ec6876d54c65c50c920b6785f
    git cherry-pick -x 943c19dca5dd510537df3f915a1148265eb42009

This commit adds changes where we add a listen directive in nginx for TC, motivation for this change is that when nginx is listening on some specific ip and not a wildcard one, TC instance is unable to connect to nginx as it uses the wireguard ip of the NAS to do so and nginx refuses connections on that.

Original PR: https://github.com/truenas/middleware/pull/6671