### PR TITLE
NAS-109949 / 21.04 / Bring back cgroupsv2

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -22,10 +22,9 @@ if __name__ == "__main__":
     advanced = {k.replace("adv_", ""): v for k, v in c.fetchone().items()}
 
     # We need to allow tpm in grub as sedutil-cli requires it
-    # TODO: Please remove kernel flag to use cgroups v1 when upstream k3s has support for cgroups v2
     config = [
         'GRUB_DISTRIBUTOR="TrueNAS Scale"',
-        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1 systemd.unified_cgroup_hierarchy=0"',
+        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1"',
     ]
 
     terminal = ["console"]


### PR DESCRIPTION
This commit adds changes to have scale use cgroups2. With newer upstream version of k3s, we have cgroupsv2 support fixed and working so we bring cgroupsv2 back.