### PR TITLE
NAS-109914 / 21.04 / FUSE mnt/umnt gluster volumes on start/stop/delete

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -93,8 +93,8 @@ class CtdbSharedVolumeService(Service):
         # to all the other peers in the TSP to also
         # FUSE mount it
         data = {'event': 'VOLUME_START', 'name': CTDB_VOL_NAME, 'forward': True}
-        j = await self.middleware.call('gluster.localevents.send', data)
-        await j.wait(raise_error=True)
+        job = await self.middleware.call('gluster.localevents.send', data)
+        await job.wait(raise_error=True)
 
         return await self.middleware.call('gluster.volume.query', [('name', '=', CTDB_VOL_NAME)])
 
@@ -116,8 +116,8 @@ class CtdbSharedVolumeService(Service):
         # unmount it (this needs to happend before
         # we delete it)
         data = {'event': 'VOLUME_STOP', 'name': CTDB_VOL_NAME, 'forward': True}
-        j = await self.middleware.call('gluster.localevents.send', data)
-        await j.wait(raise_error=True)
+        job = await self.middleware.call('gluster.localevents.send', data)
+        await job.wait(raise_error=True)
 
         if info['started']:
             # stop the volume

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -89,11 +89,12 @@ class CtdbSharedVolumeService(Service):
             options = {'args': (CTDB_VOL_NAME,)}
             await self.middleware.call('gluster.method.run', volume.start, options)
 
-        # try to mount it locally
-        mount_job = await self.middleware.call(
-            'gluster.fuse.mount', {'name': CTDB_VOL_NAME, 'raise': True}
-        )
-        await mount_job.wait(raise_error=True)
+        # try to mount it locally and send a request
+        # to all the other peers in the TSP to also
+        # FUSE mount it
+        data = {'event': 'VOLUME_START', 'name': CTDB_VOL_NAME, 'forward': True}
+        j = await self.middleware.call('gluster.localevents.send', data)
+        await j.wait(raise_error=True)
 
         return await self.middleware.call('gluster.volume.query', [('name', '=', CTDB_VOL_NAME)])
 
@@ -107,14 +108,16 @@ class CtdbSharedVolumeService(Service):
         info = await self.middleware.call(
             'gluster.volume.exists_and_started', CTDB_VOL_NAME
         )
-        if not info['started']:
+        if not info['exists']:
             return
 
-        # umount it first
-        umount_job = await self.middleware.call(
-            'gluster.fuse.umount', {'name': CTDB_VOL_NAME, 'raise': True}
-        )
-        await umount_job.wait(raise_error=True)
+        # unmount it locally and send a request
+        # to all other peers in the TSP to also
+        # unmount it (this needs to happend before
+        # we delete it)
+        data = {'event': 'VOLUME_STOP', 'name': CTDB_VOL_NAME, 'forward': True}
+        j = await self.middleware.call('gluster.localevents.send', data)
+        await j.wait(raise_error=True)
 
         if info['started']:
             # stop the volume

--- a/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
@@ -105,8 +105,8 @@ class GlusterEventsdService(Service):
             result = self.run_cmd(cmd)
 
             # sync the file across to all other peers
-            j = self.middleware.call_sync('gluster.eventsd.sync')
-            j.wait_sync()
+            job = self.middleware.call_sync('gluster.eventsd.sync')
+            job.wait_sync()
 
         return result
 
@@ -131,8 +131,8 @@ class GlusterEventsdService(Service):
             result = self.run_cmd(cmd)
 
             # sync the file across to all other peers
-            j = self.middleware.call_sync('gluster.eventsd.sync')
-            j.wait_sync()
+            job = self.middleware.call_sync('gluster.eventsd.sync')
+            job.wait_sync()
 
         return result
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
@@ -3,17 +3,16 @@ import contextlib
 import json
 import pathlib
 
+from middlewared.utils import run
 from middlewared.validators import URL
 from middlewared.schema import Dict, Str
 from middlewared.service import (job, accepts, private, CallError,
                                  Service, ValidationErrors)
 from .utils import GlusterConfig
 
-
-EVENTSD_LOCK = GlusterConfig.EVENTSD_LOCK.value
-LOCAL_WEBHOOK_URL = GlusterConfig.LOCAL_EVENTSD_WEBHOOK_URL.value
+EVENTSD_CRE_OR_DEL = 'eventsd_cre_or_del'
+LOCAL_WEBHOOK_URL = GlusterConfig.LOCAL_WEBHOOK_URL.value
 WEBHOOKS_FILE = GlusterConfig.WEBHOOKS_FILE.value
-WORKDIR = GlusterConfig.WORKDIR.value
 
 
 class GlusterEventsdService(Service):
@@ -22,11 +21,11 @@ class GlusterEventsdService(Service):
         namespace = 'gluster.eventsd'
         cli_namespace = 'service.gluster.eventsd'
 
+    @private
     def format_cmd(self, data, delete=False,):
 
-        cmd = [
-            'gluster-eventsapi', 'webhook-add' if not delete else 'webhook-del'
-        ]
+        cmd = ['gluster-eventsapi']
+        cmd.append('webhook-add' if not delete else 'webhook-del')
 
         # need to add the url as the next param
         cmd.append(data['url'])
@@ -44,6 +43,7 @@ class GlusterEventsdService(Service):
 
         return cmd
 
+    @private
     def run_cmd(self, cmd):
 
         proc = subprocess.Popen(
@@ -69,43 +69,44 @@ class GlusterEventsdService(Service):
         Str('bearer_token', required=False),
         Str('secret', required=False),
     ))
-    @job(lock=EVENTSD_LOCK)
+    @job(lock=EVENTSD_CRE_OR_DEL)
     def create(self, job, data):
         """
         Add `url` webhook that will be called
-        with a POST request that will include
-        the event that was triggered along with the
-        relevant data.
+        with a JSON formatted POST request that
+        will include the event that was triggered
+        along with the relevant data.
 
         `url` is a http address (i.e. http://192.168.1.50/endpoint)
         `bearer_token` is a bearer token
-        `secret` secret to add JWT bearer token
+        `secret` secret to encode the JWT message
+
+        NOTE: This webhook will be synchronized to all
+        peers in the trusted storage pool.
         """
 
         verrors = ValidationErrors()
+        result = None
 
-        add_it = result = None
-
-        # get the current webhooks
         cw = self.middleware.call_sync('gluster.eventsd.webhooks')
         if data['url'] not in list(cw['webhooks']):
-            add_it = True
             # there doesn't seem to be an upper limit on the amount
             # of webhook endpoints that can be added to the daemon
-            # so place an arbitrary limit of 5
-            # (excluding the local middlewared webhook)
-            if len(cw['webhooks']) >= 5 and data['url'] != LOCAL_WEBHOOK_URL:
+            # so place an arbitrary limit of 5 (for now)
+            if len(cw['webhooks']) >= 5:
                 verrors.add(
                     f'webhook_create.{data["url"]}',
                     'Maximum number of webhooks has been met. '
                     'Delete one or more and try again.'
                 )
 
-        verrors.check()
-
-        if add_it:
+            verrors.check()
             cmd = self.format_cmd(data)
             result = self.run_cmd(cmd)
+
+            # sync the file across to all other peers
+            j = self.middleware.call_sync('gluster.eventsd.sync')
+            j.wait_sync()
 
         return result
 
@@ -113,7 +114,7 @@ class GlusterEventsdService(Service):
         'webhook_delete',
         Str('url', required=True, validators=[URL()]),
     ))
-    @job(lock=EVENTSD_LOCK)
+    @job(lock=EVENTSD_CRE_OR_DEL)
     def delete(self, job, data):
         """
         Delete `url` webhook
@@ -129,6 +130,10 @@ class GlusterEventsdService(Service):
             cmd = self.format_cmd(data, delete=True)
             result = self.run_cmd(cmd)
 
+            # sync the file across to all other peers
+            j = self.middleware.call_sync('gluster.eventsd.sync')
+            j.wait_sync()
+
         return result
 
     @accepts()
@@ -138,35 +143,34 @@ class GlusterEventsdService(Service):
         """
 
         result = {'webhooks': {}}
-        with contextlib.suppress(FileNotFoundError):
+        exceptions = (FileNotFoundError, json.decoder.JSONDecodeError)
+        with contextlib.suppress(exceptions):
             with open(WEBHOOKS_FILE, 'r') as f:
                 result['webhooks'] = json.load(f)
 
         return result
 
     @accepts()
-    @job(lock=EVENTSD_LOCK)
-    def sync(self, job):
+    @job(lock='EVENTSD_SYNC')
+    async def sync(self, job):
         """
         Sync the webhooks config file to all peers in the
         trusted storage pool
         """
 
-        proc = subprocess.Popen(
+        cp = await run(
             ['gluster-eventsapi', 'sync', '--json'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True,
+            check=False
         )
-        out, err = proc.communicate()
-
-        if proc.returncode == 0:
-            return json.loads(out.strip())['output']
+        if cp.returncode == 0:
+            return json.loads(cp.stdout.strip())['output']
         else:
-            raise CallError(err.strip())
+            raise CallError(cp.stderr.strip())
 
     @private
-    @job(lock=EVENTSD_LOCK)
+    @job(lock='eventsd_init')
     def init(self, job):
         """
         Initializes the webhook directory and config file
@@ -174,20 +178,15 @@ class GlusterEventsdService(Service):
         """
 
         webhook_file = pathlib.Path(WEBHOOKS_FILE)
+        glusterd_dir = webhook_file.parent.parent
 
         # check if the glusterd dataset exists
-        glusterd_dir = webhook_file.parent.parent
-        new_file = False
-
         if glusterd_dir.exists() and glusterd_dir.is_mount():
             try:
                 # make sure glusterd_dir/events subdir exists
                 webhook_file.parent.mkdir(exist_ok=True)
-
-                # now create the webhook file
-                if not webhook_file.exists():
-                    webhook_file.touch()
-                    new_file = True
+                # create the webhooks file if it doesnt exist
+                webhook_file.touch(exist_ok=True)
             except Exception as e:
                 raise CallError(
                     f'Failed creating {webhook_file} with error: {e}'
@@ -197,26 +196,12 @@ class GlusterEventsdService(Service):
                 f'{glusterd_dir} does not exist or is not mounted'
             )
 
-        init_data = {}
-        if not new_file:
-            # need to know if webhooks have already been added
-            # to the file so act accordingly
-            with webhook_file.open('r') as f:
-                init_data = json.load(f)
-
-        # dont add local URL if it's already there
-        if not init_data.get(LOCAL_WEBHOOK_URL):
-            # make sure to add local api endpoint to file
-            local_url = {LOCAL_WEBHOOK_URL: {'token': '', 'secret': ''}}
-            init_data.update(local_url)
-
-        # finally write it out
-        try:
-            with webhook_file.open('w') as f:
-                f.write(json.dumps(init_data))
-        except Exception as e:
-            raise CallError(
-                f'Failed writing to {webhook_file} with error: {e}'
-            )
-
-        return init_data
+        # at one point we tried to have glustereventsd send
+        # event messages locally to us but that proved to be
+        # fraught with errors because of upstream issues.
+        # It's pretty clear that the glustereventsd code
+        # isn't tested (or used) often because the JWT
+        # implementation is very much broken so now we remove
+        # localhost api endpoint (it if it's there)
+        data = {'url': LOCAL_WEBHOOK_URL}
+        self.middleware.call_sync('gluster.eventsd.delete', data)

--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -1,5 +1,4 @@
 import aiohttp
-import pathlib
 import contextlib
 import jwt
 import enum

--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -1,0 +1,108 @@
+import aiohttp
+import pathlib
+import contextlib
+import jwt
+import enum
+
+from middlewared.schema import Dict, Str, Bool
+from middlewared.service import (accepts, Service,
+                                 private, ValidationErrors)
+from .utils import GlusterConfig
+
+
+SECRETS_FILE = GlusterConfig.SECRETS_FILE.value
+LOCAL_WEBHOOK_URL = GlusterConfig.LOCAL_WEBHOOK_URL.value
+
+
+class AllowedEvents(enum.Enum):
+    EVENTS = (
+        'VOLUME_START',
+        'VOLUME_STOP',
+    )
+
+
+class GlusterLocalEventsService(Service):
+
+    JWT_SECRET = None
+
+    class Config:
+        namespace = 'gluster.localevents'
+        cli_namespace = 'service.gluster.localevents'
+
+    @private
+    async def validate(self, data):
+        verrors = ValidationErrors()
+        allowed = AllowedEvents.EVENTS.value
+
+        if data['event'] not in allowed:
+            verrors.add(
+                f'localevent_send.{data["event"]}',
+                f'event: "{data["event"]}" is not allowed',
+            )
+
+        vols = await self.middleware.call('gluster.volume.list')
+        if data['name'] not in vols:
+            verrors.add(
+                f'localevent_send.{data["name"]}',
+                'gluster volume: "{data["name"]}" does not exist',
+            )
+
+        verrors.check()
+
+    @accepts(Dict(
+        'localevent_send',
+        Str('event', required=True),
+        Str('name', required=True),
+        Bool('forward', default=True),
+    ))
+    @private
+    async def send(self, data):
+        await self.middleware.call('gluster.localevents.validate', data)
+        secret = await self.middleware.call('gluster.localevents.get_set_jwt_secret')
+        token = jwt.encode({'dummy': 'data'}, secret, algorithm='HS256')
+        headers = {'JWTOKEN': token.decode('utf-8'), 'content-type': 'application/json'}
+        async with aiohttp.ClientSession() as sess:
+            await sess.post(LOCAL_WEBHOOK_URL, headers=headers, json=data, timeout=5)
+
+    @accepts()
+    def get_set_jwt_secret(self):
+        """
+        Return the secret key used to encode/decode
+        JWT messages for sending/receiving gluster
+        events.
+
+        Note: this secret is only used for messages
+        that are destined for the api endpoint at
+        http://*:6000/_clusterevents for each peer
+        in the trusted storage pool.
+        """
+        if self.JWT_SECRET is None:
+            with contextlib.suppress(FileNotFoundError):
+                with open(SECRETS_FILE, 'r') as f:
+                    secret = f.read().strip()
+                    if secret:
+                        self.JWT_SECRET = secret
+
+        return self.JWT_SECRET
+
+    @accepts(Dict(
+        'add_secret',
+        Str('secret', required=True)
+    ))
+    def add_jwt_secret(self, data):
+        """
+        Add a `secret` key used to encode/decode
+        JWT messages for sending/receiving gluster
+        events.
+
+        `secret` String representing the key to be used
+                    to encode/decode JWT messages
+
+        Note: this secret is only used for messages
+        that are destined for the api endpoint at
+        http://*:6000/_clusterevents for each peer
+        in the trusted storage pool.
+        """
+        self.JWT_SECRET = data['secret']
+        with open(SECRETS_FILE, 'w+') as f:
+            f.write(data['secret'])

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -1,6 +1,7 @@
 import enum
 import os
 
+
 class GlusterConfig(enum.Enum):
 
     """
@@ -13,15 +14,9 @@ class GlusterConfig(enum.Enum):
     BASE_LOCK = 'gluster_'
     CLI_LOCK = BASE_LOCK + 'cli_operation'
 
-    # used to ensure that only one glustereventsd
-    # operation runs at any given time.
-    # gluster-eventsapi CLI commands need to be
-    # run synchronously.
-    EVENTSD_LOCK = BASE_LOCK + 'eventsd_operation'
-
-    # local webhook that gets added to the glustereventsd
-    # daemon for sending POST requests to middlewared
-    LOCAL_EVENTSD_WEBHOOK_URL = 'http://127.0.0.1:6000/_clusterevents'
+    # local webhook that gets sent messages on certain
+    # gluster.* api calls
+    LOCAL_WEBHOOK_URL = 'http://127.0.0.1:6000/_clusterevents'
 
     # dataset where global config is stored
     WORKDIR = '/var/db/system/glusterd'
@@ -30,3 +25,9 @@ class GlusterConfig(enum.Enum):
     # they automatically get written to a json formatted
     # file here
     WEBHOOKS_FILE = os.path.join(WORKDIR, 'events/webhooks.json')
+
+    # to protect the api endpoint (:6000/_clusterevents)
+    # TrueCommand will send us a secret that is used to
+    # encode/decode JWT formatted messages. That secret
+    # is stored here.
+    SECRETS_FILE = os.path.join(WORKDIR, 'events/secret')


### PR DESCRIPTION
Adding localhost to the `glustereventsd` daemon proved worthless. So this commit does a few things.

- remove the localhost:6000/_clusterevents from the `glustereventsd` daemon (if it's been added)
- repurpose localhost:6000/_clusterevents endpoint to receive custom events sent by middleware explicitly
- protect localhost:6000/_clusterevents endpoint by using JWT encoding. The JWT will be encoded using a secret key that is sent to each peer in the trusted storage pool by TC. This will be done "out of band" and stored on each peer in the gluster metadata directory.
- on gluster volume start/stop or delete, FUSE mnt/umnt the associated mountpoint and then send a request to each peer in the trusted storage pool to do the same. The reason why we do this is because when volumes were stopped/deleted previously, glusterd only sent a local event (not a cluster event) for these events. So this meant that the peer who issued the command would FUSE mnt/umnt appropriately, but the other peers would not. In the case of a delete/stop, leaving behind a stale FUSE mountpoint proved to be troublesome.
- add a public api for uploading a JWT secret key to be used for sending events to each peer in the TSP. This is sitting behind our normal authentication.