### PR TITLE
NAS-109959 / 21.04 / Fix AD cache fill with alternate character sets

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -81,7 +81,7 @@ class SMBPath(enum.Enum):
     LEGACYPRIVATE = ('/root/samba/private', '/root/samba/private', 0o700, True)
     MSG_SOCK = ('/var/db/system/samba4/private/msg.sock', '/var/db/system/samba4/private/msg.sock', 0o700, False)
     RUNDIR = ('/var/run/samba4', '/var/run/samba', 0o755, True)
-    LOCKDIR = ('/var/lock', '/var/run/samba-lock', 0o755, True)
+    LOCKDIR = ('/var/run/samba4', '/var/run/samba-lock', 0o755, True)
     LOGDIR = ('/var/log/samba4', '/var/log/samba4', 0o755, True)
     IPCSHARE = ('/var/tmp', '/tmp', 0o1777, True)
 


### PR DESCRIPTION
User reported AD cache fill failing on Shift-JIS encoded AD usernames
with a unicode decode error. Switch from using "net cache list" to
using py-tdb to iterate keys in a copy of samba's gencache.tdb file
comparing bytes of beginning of key to IDMAP/UID2SID and IDMAP/GID2SID.
This side-steps the name-to-sid entries that were choking us on decoding
output of subprocess.

We use gencache.tdb IDMAP/{X}ID2SID keys to determine before building
our user/group cache so that users in large AD environments can opt to have
us rely on entries already cached in winbindd. This reduces network traffic and
load on the AD DC.