### PR TITLE
NAS-109959 / 12.0 / Fix AD cache fill with alternate character sets (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -6,9 +6,11 @@ import json
 import ntplib
 import os
 import pwd
+import shutil
 import socket
 import subprocess
 import threading
+import tdb
 import time
 
 from dns import resolver
@@ -1354,13 +1356,11 @@ class ActiveDirectoryService(ConfigService):
             if id.returncode != 0:
                 self.logger.debug('failed to id AD bind account [%s]: %s', ad['bindname'], id.stderr.decode())
 
-        netlist = subprocess.run(
-            [SMBCmd.NET.value, 'cache', 'list'],
-            capture_output=True,
-            check=False
-        )
-        if netlist.returncode != 0:
-            raise CallError(f'Winbind cache dump failed with error: {netlist.stderr.decode().strip()}')
+        shutil.copyfile(f'{SMBPath.LOCKDIR.platform()}/gencache.tdb', '/tmp/gencache.tdb')
+
+        gencache = tdb.Tdb('/tmp/gencache.tdb', 0, tdb.DEFAULT, os.O_RDONLY)
+        gencache_keys = [x for x in gencache.keys()]
+        gencache.close()
 
         known_domains = []
         local_users = {}
@@ -1386,9 +1386,15 @@ class ActiveDirectoryService(ConfigService):
                     'id_type_both': True if d['idmap_backend'] in id_type_both_backends else False,
                 })
 
-        for line in netlist.stdout.decode().splitlines():
-            if line.startswith('Key: IDMAP/UID2SID'):
-                cached_uid = int((line.split())[1][14:])
+        for key in gencache_keys:
+            prefix = key[0:13]
+            if prefix != b'IDMAP/UID2SID' and prefix != b'IDMAP/GID2SID':
+                continue
+
+            line = key.decode()
+            if line.startswith('IDMAP/UID2SID'):
+                # tdb keys are terminated with \x00, this must be sliced off before converting to int
+                cached_uid = int(line[14:-1])
                 """
                 Do not cache local users. This is to avoid problems where a local user
                 may enter into the id range allotted to AD users.
@@ -1433,8 +1439,9 @@ class ActiveDirectoryService(ConfigService):
                         except KeyError:
                             break
 
-            if line.startswith('Key: IDMAP/GID2SID'):
-                cached_gid = int((line.split())[1][14:])
+            if line.startswith('IDMAP/GID2SID'):
+                # tdb keys are terminated with \x00, this must be sliced off before converting to int
+                cached_gid = int(line[14:-1])
                 if local_groups.get(cached_gid, None):
                     continue
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -76,8 +76,8 @@ class SMBPath(enum.Enum):
     LEGACYPRIVATE = ('/root/samba/private', '/root/samba/private', 0o700, True)
     MSG_SOCK = ('/var/db/system/samba4/private/msg.sock', '/var/db/system/samba4/msg.sock', 0o700, False)
     RUNDIR = ('/var/run/samba4', '/var/run/samba', 0o755, True)
-    LOCKDIR = ('/var/lock', '/var/lock', 0o755, True)
-    LOGDIR = ('/var/log/samba4', '/var/log/samba', 0o755, True)
+    LOCKDIR = ('/var/run/samba4', '/var/run/samba-lock', 0o755, True)
+    LOGDIR = ('/var/log/samba4', '/var/log/samba4', 0o755, True)
     IPCSHARE = ('/var/tmp', '/tmp', 0o1777, True)
 
     def platform(self):


### PR DESCRIPTION
User reported AD cache fill failing on Shift-JIS encoded AD usernames
with a unicode decode error. Switch from using "net cache list" to
using py-tdb to iterate keys in a copy of samba's gencache.tdb file
comparing bytes of beginning of key to IDMAP/UID2SID and IDMAP/GID2SID.
This side-steps the name-to-sid entries that were choking us on decoding
output of subprocess.

We use gencache.tdb IDMAP/{X}ID2SID keys to determine before building
our user/group cache so that users in large AD environments can opt to have
us rely on entries already cached in winbindd. This reduces network traffic and
load on the AD DC.

Original PR: https://github.com/truenas/middleware/pull/6693