### PR TITLE
NAS-109966 / 12.0 / allow failover config on HA systems

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -760,7 +760,7 @@ Acceptable formats are 255.255.255.0,
             break
 
     while True:
-        if failover_licensed:
+        if not failover_licensed:
             break
         yes = input(_("Configure failover settings? (y/n) "))
         if yes.lower().startswith("y"):


### PR DESCRIPTION
7974b7f6b1c caused this regression. However...that occurred back in 2019. Not really sure how this has gone this far without someone noticing.

Spotted by: `bcanning`