### PR TITLE
NAS-109905 / 21.04 / Execute pre-init scripts after importing pools

### DIFF
--- a/debian/debian/ix-preinit.service
+++ b/debian/debian/ix-preinit.service
@@ -4,8 +4,7 @@ DefaultDependencies=no
 
 Before=network-pre.target
 
-After=middlewared.service
-Before=local-fs.target
+After=ix-zfs.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This commit adds changes to execute pre-init scripts after importing pools during boot stage