### PR TITLE
NAS-109480 / 21.04 / system.is_enterprise and failover.licensed to only failover.licensed

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -17,10 +17,9 @@ class DiskService(Service, ServiceChangeMixin):
         """
         Syncs a disk `name` with the database cache.
         """
-        if await self.middleware.call('system.is_enterprise'):
-            if await self.middleware.call('failover.licensed'):
-                if await self.middleware.call('failover.status') == 'BACKUP':
-                    return
+        if await self.middleware.call('failover.licensed'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                return
 
         # Do not sync geom classes like multipath/hast/etc
         if name.find('/') != -1:

--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -1250,7 +1250,7 @@ class JailService(CRUDService):
 
     @private
     def failover_checks(self, jail_config, verrors, schema):
-        if self.middleware.call_sync('system.is_enterprise') and self.middleware.call_sync('failover.licensed'):
+        if self.middleware.call_sync('failover.licensed'):
             jail_config = {
                 k: ioc_common.check_truthy(v) if k in IOCJson.truthy_props else v for k, v in jail_config.items()
             }

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -170,15 +170,14 @@ class NFSService(SystemServiceService):
         keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
         new_v4_krb_enabled = new["v4_krb"] or keytab_has_nfs
 
-        if new["v4"] and new_v4_krb_enabled and await self.middleware.call("system.is_enterprise"):
-            if await self.middleware.call("failover.licensed"):
-                gc = await self.middleware.call("datastore.config", "network.globalconfiguration")
-                if not gc["gc_hostname_virtual"] or not gc["gc_domain"]:
-                    verrors.add(
-                        "nfs_update.v4",
-                        "Enabling kerberos authentication on TrueNAS HA requires setting the virtual hostname and "
-                        "domain"
-                    )
+        if await self.middleware.call("failover.licensed") and new["v4"] and new_v4_krb_enabled:
+            gc = await self.middleware.call("datastore.config", "network.globalconfiguration")
+            if not gc["gc_hostname_virtual"] or not gc["gc_domain"]:
+                verrors.add(
+                    "nfs_update.v4",
+                    "Enabling kerberos authentication on TrueNAS HA requires setting the virtual hostname and "
+                    "domain"
+                )
 
         if osc.IS_LINUX:
             if len(new['bindip']) > 1:

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -489,7 +489,7 @@ class SMBService(SystemServiceService):
         if await self.middleware.call('cache.has_key', 'SMB_HA_MODE'):
             return await self.middleware.call('cache.get', 'SMB_HA_MODE')
 
-        if await self.middleware.call('system.is_enterprise') and await self.middleware.call('failover.licensed'):
+        if await self.middleware.call('failover.licensed'):
             system_dataset = await self.middleware.call('systemdataset.config')
             if system_dataset['pool'] != await self.middleware.call('boot.pool_name'):
                 hamode = SMBHAMODE['UNIFIED'].name

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -249,7 +249,7 @@ class SupportService(ConfigService):
                 'system.debug', pipes=Pipes(output=self.middleware.pipe()),
             )
 
-            if await self.middleware.call('system.is_enterprise') and await self.middleware.call('failover.licensed'):
+            if await self.middleware.call('failover.licensed'):
                 debug_name = 'debug-{}.tar'.format(time.strftime('%Y%m%d%H%M%S'))
             else:
                 debug_name = 'debug-{}-{}.txz'.format(

--- a/src/middlewared/middlewared/plugins/unscheduled_reboot_alert.py
+++ b/src/middlewared/middlewared/plugins/unscheduled_reboot_alert.py
@@ -51,7 +51,7 @@ async def setup(middleware):
         fenced_file = False
         watchdog_time = 0
         fenced_time = 0
-        if await middleware.call('system.is_enterprise') and await middleware.call('failover.licensed'):
+        if await middleware.call('failover.licensed'):
             if os.path.exists(WATCHDOG_ALERT_FILE):
                 watchdog_file = True
                 with open(WATCHDOG_ALERT_FILE, 'rb') as f:

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -454,9 +454,8 @@ class UpdateService(Service):
 
 
 async def post_update_hook(middleware):
-    if (
-        not await middleware.call('failover.licensed') or await middleware.call('failover.status') != 'BACKUP'
-    ):
+    is_ha = await middleware.call('failover.licensed')
+    if not is_ha or await middleware.call('failover.status') != 'BACKUP':
         await middleware.call('update.take_systemdataset_samba4_snapshot')
 
 

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -447,7 +447,7 @@ class VMDeviceService(CRUDService):
 
     @private
     async def failover_nic_check(self, vm_device, verrors, schema):
-        if await self.middleware.call('system.is_enterprise') and await self.middleware.call('failover.licensed'):
+        if await self.middleware.call('failover.licensed'):
             nics = await self.middleware.call('vm.device.nic_capability_checks', [vm_device])
             if nics:
                 verrors.add(


### PR DESCRIPTION
There is no reason to run `system.is_enterprise and failover.licensed`. This PR should cause no functional change and removes the extra `system.is_enterprise` calls to only `failover.licensed`.