### PR TITLE
NAS-109903 / 21.04 / Correctly show type of identifier in rest api docs

### DIFF
--- a/src/middlewared/middlewared/plugins/bootenv.py
+++ b/src/middlewared/middlewared/plugins/bootenv.py
@@ -18,6 +18,7 @@ RE_BE_NAME = r'^[^/ *\'"?@!#$%^&()+=~<>;\\]+$'
 class BootEnvService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         cli_namespace = 'system.bootenv'
 
     BE_TOOL = 'zectl' if osc.IS_LINUX else 'beadm'

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -32,6 +32,7 @@ class CatalogService(CRUDService):
         datastore_extend = 'catalog.catalog_extend'
         datastore_extend_context = 'catalog.catalog_extend_context'
         datastore_primary_key = 'label'
+        datastore_primary_key_type = 'string'
         cli_namespace = 'app.catalog'
 
     @private

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -24,6 +24,7 @@ from .utils import (
 class ChartReleaseService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'chart.release'
         cli_namespace = 'app.chart_release'
 

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -68,6 +68,7 @@ class DiskService(CRUDService):
         datastore_extend = 'disk.disk_extend'
         datastore_extend_context = 'disk.disk_extend_context'
         datastore_primary_key = 'identifier'
+        datastore_primary_key_type = 'string'
         event_register = False
         event_send = False
         cli_namespace = 'storage.disk'

--- a/src/middlewared/middlewared/plugins/docker_linux/images.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/images.py
@@ -19,6 +19,7 @@ DEFAULT_DOCKER_IMAGES_PATH = '/usr/local/share/docker_images/docker-images.tar'
 class DockerImagesService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'container.image'
         namespace_alias = 'docker.images'
         cli_namespace = 'app.docker.image'

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -17,6 +17,7 @@ FUSE_BASE = FuseConfig.FUSE_PATH_BASE.value
 class GlusterVolumeService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'gluster.volume'
         cli_namespace = 'service.gluster.volume'
 

--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -143,6 +143,7 @@ def common_validation(middleware, options, update=False, jail=None, schema='opti
 class PluginService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         cli_private = True
 
     @accepts()
@@ -697,6 +698,7 @@ class PluginService(CRUDService):
 class JailService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         cli_private = True
 
     def __init__(self, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/multipath.py
+++ b/src/middlewared/middlewared/plugins/multipath.py
@@ -12,6 +12,8 @@ from middlewared.utils import filter_list, osc
 class MultipathService(CRUDService):
 
     class Config:
+        datastore_primary_key = 'name'
+        datastore_primary_key_type = 'string'
         cli_namespace = "storage.multipath"
 
     @filterable

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -410,6 +410,7 @@ class NetworkVlanModel(sa.Model):
 class InterfaceService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace_alias = 'interfaces'
         cli_namespace = 'network.interface'
 

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1833,6 +1833,7 @@ class PoolService(CRUDService):
 class PoolDatasetUserPropService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'pool.dataset.userprop'
         cli_namespace = 'storage.dataset.user_prop'
 
@@ -1951,6 +1952,7 @@ class PoolDatasetService(CRUDService):
     dataset_store = 'storage.encrypteddataset'
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'pool.dataset'
         event_send = False
         cli_namespace = 'storage.dataset'

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -969,6 +969,7 @@ class ZFSDatasetService(CRUDService):
 class ZFSSnapshot(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'zfs.snapshot'
         process_pool = True
         cli_namespace = 'storage.snapshot'

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -175,7 +175,7 @@ class OpenAPIResource(object):
             },
         }
 
-    def add_path(self, path, operation, methodname, params=None):
+    def add_path(self, path, operation, methodname, service_config):
         assert operation in ('get', 'post', 'put', 'delete')
         opobject = {
             'tags': [methodname.rsplit('.', 1)[0]],
@@ -236,7 +236,7 @@ class OpenAPIResource(object):
                     'name': 'id',
                     'in': 'path',
                     'required': True,
-                    'schema': self._convert_schema(accepts[0]) if accepts else {'type': 'integer'},
+                    'schema': {'type': service_config['datastore_primary_key_type']},
                 })
 
         self._paths[f'/{path}'][operation] = opobject
@@ -369,7 +369,7 @@ class Resource(object):
                 continue
             self.rest.app.router.add_route(i.upper(), f'/api/v2.0/{path}', getattr(self, f'on_{i}'))
             self.rest.app.router.add_route(i.upper(), f'/api/v2.0/{path}/', getattr(self, f'on_{i}'))
-            self.rest._openapi.add_path(path, i, operation)
+            self.rest._openapi.add_path(path, i, operation, self.service_config)
             self.__map_method_params(operation)
 
         self.middleware.logger.trace(f"add route {self.get_path()}")

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -266,6 +266,7 @@ def service_config(klass, config):
         'datastore_extend': None,
         'datastore_extend_context': None,
         'datastore_primary_key': 'id',
+        'datastore_primary_key_type': 'integer',
         'event_register': True,
         'event_send': True,
         'service': None,


### PR DESCRIPTION
This PR fixes an issue where we rendered the acceptable type of a CRUD endpoint as `array`. For example, the endpoint
`pool/dataset/{id}/` would show that the accepted parameter type of `id` is an `array`.