### PR TITLE
NAS-109925 / 21.06 / Allow specifying extra arguments with id keyword in rest api

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -33,12 +33,13 @@ class ChartReleaseService(CRUDService):
         """
         Query available chart releases.
 
-        `options.extra.retrieve_resources` is a boolean when set will retrieve existing kubernetes resources
+        `query-options.extra.retrieve_resources` is a boolean when set will retrieve existing kubernetes resources
         in the chart namespace.
 
-        `options.extra.history` is a boolean when set will retrieve all chart version upgrades for a chart release.
+        `query-options.extra.history` is a boolean when set will retrieve all chart version upgrades
+        for a chart release.
 
-        `options.extra.include_chart_schema` is a boolean when set will retrieve the schema being used by
+        `query-options.extra.include_chart_schema` is a boolean when set will retrieve the schema being used by
         the chart release in question.
         """
         if not await self.middleware.call('service.started', 'kubernetes'):

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -235,7 +235,10 @@ class OpenAPIResource(object):
                     },
                 ] if '{id}' not in path else []
                 desc = f'{desc}\n\n' if desc else ''
-                opobject['description'] = desc + '`query-options.extra` can be specified as query parameters.'
+                opobject['description'] = desc + '`query-options.extra` can be specified as query parameters with ' \
+                                                 'prefixing them with `extra.` prefix. For example, ' \
+                                                 '`extra.retrieve_properties=false` will pass `retrieve_properties` ' \
+                                                 'as an extra argument to pool/dataset endpoint.'
             elif accepts and not (operation == 'delete' and method['item_method'] and len(accepts) == 1) and (
                 '{id}' not in path and not method['filterable']
             ):
@@ -461,8 +464,10 @@ class Resource(object):
             elif key == 'sort':
                 options[key] = [convert(v) for v in val.split(',')]
                 continue
-            else:
+            elif key.startswith('extra.'):
+                key = key[len('extra.'):]
                 options['extra'][key] = normalize_query_parameter(val)
+                continue
 
             op_map = {
                 'eq': '=',
@@ -512,7 +517,8 @@ class Resource(object):
                         filterid = int(filterid)
                     extra = {}
                     for key, val in list(req.query.items()):
-                        extra[key] = normalize_query_parameter(val)
+                        if key.startswith('extra.'):
+                            extra[key[len('extra.'):]] = normalize_query_parameter(val)
 
                     method_args = [
                         [(self.service_config['datastore_primary_key'], '=', filterid)],

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -200,7 +200,7 @@ class OpenAPIResource(object):
                 opobject['description'] = desc
 
             accepts = method.get('accepts')
-            if method['filterable']:
+            if '{id}' not in path and method['filterable']:
                 opobject['parameters'] += [
                     {
                         'name': 'limit',


### PR DESCRIPTION
This PR adds following changes:

1) Updates documentation to not specify filterable arguments like `sort` when using `id` keyword in rest api endpoint.
2) Allows specifying `query-options.extra` arguments when using `id` keyword.
3) Fixes an issue which correctly outlines that `query-options.extra` is supported in request body with `id` keyword in rest api endpoint and not the complete `filterable` request body.