### PR TITLE
NAS-109903 / 12.0 / Correctly show type of identifier in rest api docs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/bootenv.py
+++ b/src/middlewared/middlewared/plugins/bootenv.py
@@ -17,6 +17,9 @@ RE_BE_NAME = r'^[^/ *\'"?@!#$%^&()+=~<>;\\]+$'
 
 class BootEnvService(CRUDService):
 
+    class Config:
+        datastore_primary_key_type = 'string'
+
     BE_TOOL = 'zectl' if osc.IS_LINUX else 'beadm'
 
     @filterable

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -69,6 +69,7 @@ class DiskService(CRUDService):
         datastore_prefix = 'disk_'
         datastore_extend = 'disk.disk_extend'
         datastore_extend_context = 'disk.disk_extend_context'
+        datastore_primary_key_type = 'string'
         event_register = False
         event_send = False
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -12,6 +12,7 @@ from .utils import GLUSTER_JOB_LOCK
 class GlusterVolumeService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'gluster.volume'
 
     def __volume_wrapper(self, method, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -142,6 +142,9 @@ def common_validation(middleware, options, update=False, jail=None, schema='opti
 
 class PluginService(CRUDService):
 
+    class Config:
+        datastore_primary_key_type = 'string'
+
     @accepts()
     async def official_repositories(self):
         """
@@ -689,6 +692,9 @@ class PluginService(CRUDService):
 
 
 class JailService(CRUDService):
+
+    class Config:
+        datastore_primary_key_type = 'string'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/middlewared/middlewared/plugins/multipath.py
+++ b/src/middlewared/middlewared/plugins/multipath.py
@@ -11,6 +11,9 @@ from middlewared.utils import filter_list, osc
 
 class MultipathService(CRUDService):
 
+    class Config:
+        datastore_primary_key_type = 'string'
+
     @filterable
     def query(self, filters, options):
         """

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -383,6 +383,7 @@ class NetworkVlanModel(sa.Model):
 class InterfaceService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace_alias = 'interfaces'
 
     def __init__(self, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1825,6 +1825,7 @@ class PoolService(CRUDService):
 class PoolDatasetUserPropService(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'pool.dataset.userprop'
 
     @filterable
@@ -1942,6 +1943,7 @@ class PoolDatasetService(CRUDService):
     dataset_store = 'storage.encrypteddataset'
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'pool.dataset'
 
     @accepts()

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -928,6 +928,7 @@ class ZFSDatasetService(CRUDService):
 class ZFSSnapshot(CRUDService):
 
     class Config:
+        datastore_primary_key_type = 'string'
         namespace = 'zfs.snapshot'
         process_pool = True
 

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -173,7 +173,7 @@ class OpenAPIResource(object):
             },
         }
 
-    def add_path(self, path, operation, methodname, params=None):
+    def add_path(self, path, operation, methodname, service_config):
         assert operation in ('get', 'post', 'put', 'delete')
         opobject = {
             'tags': [methodname.rsplit('.', 1)[0]],
@@ -234,7 +234,7 @@ class OpenAPIResource(object):
                     'name': 'id',
                     'in': 'path',
                     'required': True,
-                    'schema': self._convert_schema(accepts[0]) if accepts else {'type': 'integer'},
+                    'schema': {'type': service_config['datastore_primary_key_type']},
                 })
 
         self._paths[f'/{path}'][operation] = opobject
@@ -366,7 +366,7 @@ class Resource(object):
                 continue
             self.rest.app.router.add_route(i.upper(), f'/api/v2.0/{path}', getattr(self, f'on_{i}'))
             self.rest.app.router.add_route(i.upper(), f'/api/v2.0/{path}/', getattr(self, f'on_{i}'))
-            self.rest._openapi.add_path(path, i, operation)
+            self.rest._openapi.add_path(path, i, operation, self.service_config)
             self.__map_method_params(operation)
 
         self.middleware.logger.trace(f"add route {self.get_path()}")

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -99,7 +99,7 @@ class RESTfulAPI(object):
                     kwargs['put'] = put
                 blacklist_methods.extend(list(kwargs.values()))
 
-            service_resource = Resource(self, self.middleware, name.replace('.', '/'), **kwargs)
+            service_resource = Resource(self, self.middleware, name.replace('.', '/'), service['config'], **kwargs)
 
             """
             For CRUD services we also need a direct subresource so we can
@@ -118,7 +118,9 @@ class RESTfulAPI(object):
                 if put in self._methods:
                     kwargs['put'] = put
                 blacklist_methods.extend(list(kwargs.values()))
-                subresource = Resource(self, self.middleware, 'id/{id}', parent=service_resource, **kwargs)
+                subresource = Resource(
+                    self, self.middleware, 'id/{id}', service['config'], parent=service_resource, **kwargs
+                )
 
             for methodname, method in list(self._methods_by_service[name].items()):
                 if methodname in blacklist_methods:
@@ -140,7 +142,7 @@ class RESTfulAPI(object):
                     res_kwargs['post'] = methodname
                 else:
                     res_kwargs['get'] = methodname
-                Resource(self, self.middleware, short_methodname, parent=parent, **res_kwargs)
+                Resource(self, self.middleware, short_methodname, service['config'], parent=parent, **res_kwargs)
             await asyncio.sleep(0)  # Force context switch
 
 
@@ -341,13 +343,14 @@ class Resource(object):
     put = None
 
     def __init__(
-        self, rest, middleware, name, parent=None,
+        self, rest, middleware, name, service_config, parent=None,
         delete=None, get=None, post=None, put=None,
     ):
         self.rest = rest
         self.middleware = middleware
         self.name = name
         self.parent = parent
+        self.service_config = service_config
         self.__method_params = {}
 
         path = self.get_path()

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -242,6 +242,7 @@ class ServiceBase(type):
             'datastore_prefix': '',
             'datastore_extend': None,
             'datastore_extend_context': None,
+            'datastore_primary_key_type': 'integer',
             'event_register': True,
             'event_send': True,
             'service': None,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ce9dff3a117ce1b5979c200c417e0142361bad80
    git cherry-pick -x 016f74e3e6ad15449bd99e665286c392e4600edb

This PR fixes an issue where we rendered the acceptable type of a CRUD endpoint as `array`. For example, the endpoint
`pool/dataset/{id}/` would show that the accepted parameter type of `id` is an `array`.

Original PR: https://github.com/truenas/middleware/pull/6718