### PR TITLE
NAS-109935 / 21.06 / Add ref to validate container images

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/features.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/features.py
@@ -14,6 +14,7 @@ SUPPORTED_FEATURES = {
     'definitions/gpuConfiguration',
     'definitions/timezone',
     'definitions/nodeIP',
+    'validations/containerImage',
     'validations/nodePort',
 }
 


### PR DESCRIPTION
This PR adds changes to introduce a `ref` attribute which can be used to validate if a container image exists. We do this by querying up the docker registry and trying to retrieve the image's digest information.