### PR TITLE
NAS-110009 / 21.04 / use correct logrorate size

### DIFF
--- a/src/freenas/etc/logrotate.d/syslog-ng-truenas
+++ b/src/freenas/etc/logrotate.d/syslog-ng-truenas
@@ -1,7 +1,7 @@
 /var/log/syslog
 {
 	rotate 3
-	size 10m
+	size 10M
 	missingok
 	notifempty
 	delaycompress
@@ -26,7 +26,7 @@
 /var/log/error
 {
 	rotate 3
-	size 10m
+	size 10M
 	missingok
 	notifempty
 	compress


### PR DESCRIPTION
https://linux.die.net/man/8/logrotate
Log files are rotated only if they grow bigger then size bytes. If size
is followed by k, the size is assumed to be in kilobytes. If the M is
used, the size is in megabytes, and if G is used, the size is in
gigabytes. So size 100, size 100k, size 100M and size 100Gare all
valid.

This should fix this issue i have on `TrueNAS-SCALE-21.02-ALPHA.1`
`Apr 03 13:35:02 truenas.local logrotate[3719176]: error: syslog-ng-truenas:3 unknown unit 'm'`