### PR TITLE
NAS-110032 / 12.0 / make fallback to ix-netif work

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -12,8 +12,6 @@
 
 _interface_config()
 {
-	local failover_status="" failover_licensed=0
-
 	local saved_ifs="${IFS}"
 	local IFS=\|
 	local interface_id interface dodhcp ipv4addr ipv4netmask doipv6auto ipv6addr ipv6netmask options
@@ -43,8 +41,8 @@ _interface_config()
 	local configure_ifaces=1
 	if ! is_freenas; then
 
-		if [ "$(ha_mode)" = "MANUAL" ]; then
-			if [ ${failover_licensed} -eq 1 ]; then
+		if [ "$(ha_hardware)" = "MANUAL" ]; then
+			if [ "$(ha_licensed)" = "true" ]; then
 				configure_ifaces=0
 				echo "# Unable to determine HA hardware and node, skipping interfaces configuration" | tee /dev/console
 			fi
@@ -61,6 +59,7 @@ _interface_config()
 			carp2_skew="20"
 			internal_ip="169.254.10.2"
 		else
+			configure_ifaces=0
 			echo "# Could not determine system node"
 		fi
 
@@ -139,7 +138,7 @@ _interface_config()
 			else
 				int_passopt=""
 			fi
-			if [ "${failover_status}" = "MASTER" ]; then
+			if [ "$(/usr/local/bin/midclt call failover.status)" = "MASTER" ]; then
 				carp1_skew="1"
 			fi
 			echo -n "ifconfig_${interface}_alias0=\"inet vhid ${int_vhid} advskew ${carp1_skew}${int_passopt} alias ${int_vip}/32"

--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -90,3 +90,18 @@ ro_sqlite()
 	cp ${FREENAS_CONFIG} ${ret}
 	echo ${ret}
 }
+
+ha_hardware()
+{
+	/usr/local/bin/hadetect | jq -r '.hardware'
+}
+
+ha_node()
+{
+	/usr/local/bin/hadetect | jq -r '.node'
+}
+
+ha_licensed()
+{
+	/usr/local/bin/hadetect | jq -r '.licensed'
+}

--- a/src/middlewared/middlewared/scripts/hadetect.py
+++ b/src/middlewared/middlewared/scripts/hadetect.py
@@ -1,16 +1,97 @@
-#!/usr/bin/env python
-import importlib
+#!/usr/bin/env python3
 
-spec = importlib.util.spec_from_file_location(
-    'failover', '/usr/local/lib/middlewared_truenas/plugins/failover.py',
-)
-failover = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(failover)
+import subprocess
+import re
+import json
+import glob
+
+from licenselib.license import License
+
+GETENCSTAT = '/usr/sbin/getencstat'
+ZSERIES = 'SD_9GV12P1J_12R6K4'
+XSERIES = 'Enclosure Name: CELESTIC (P3215-O|P3217-B)'
+MSERIES = 'Enclosure Name: (ECStream|iX) 4024S([ps])'
+LICENSE = '/data/license'
 
 
 def main():
-    print(':'.join(str(i) for i in failover.FailoverService._ha_mode()))
+    result = {'hardware': 'MANUAL', 'node': '', 'licensed': False}
+    try:
+        for enclosure in glob.iglob('/dev/ses*'):
+            # grab the getencstat output
+            cp = subprocess.run(
+                [GETENCSTAT, '-V', enclosure],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if cp.stdout:
+                encstat = cp.stdout.decode('utf8', 'ignore').strip()
+                if re.search(ZSERIES, encstat, re.M):
+                    # echostream (Z-series)
+                    result['hardware'] = 'ECHOSTREAM'
+
+                    # now get node position
+                    node = re.search(r"3U20D-Encl-([AB])", encstat, re.M)
+                    if node:
+                        result['node'] = node.group(1)
+                        break
+
+                elif re.search(XSERIES, encstat, re.M):
+                    # puma (X-series)
+                    result['hardware'] = 'PUMA'
+
+                    # now get node position
+                    smp = subprocess.run(
+                        ['/sbin/camcontrol', 'smpphylist', enclosure, '-q'],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    if smp.stdout:
+                        smp = smp.stdout.decode('utf8', 'ignore').strip()
+
+                        regA = re.search(
+                            'ESCE A_(5[0-9A-F]{15})', encstat, re.M
+                        )
+                        if regA:
+                            addr = hex(int(regA.group(1), 16) - 1)
+                            if addr in smp:
+                                result['node'] = 'A'
+                                break
+                        regB = re.search(
+                            'ESCE B_(5[0-9A-F]{15})', encstat, re.M
+                        )
+                        if regB:
+                            addr = hex(int(regB.group(1), 16) - 1)
+                            if addr in smp:
+                                result['node'] = 'B'
+                                break
+                else:
+                    reg = re.search(MSERIES, encstat, re.M)
+                    if reg:
+                        # echowarp (M-series)
+                        result['hardware'] = 'ECHOWARP'
+
+                        # now get node position
+                        if reg.group(2) == 'p':
+                            result['node'] = 'A'
+                            break
+                        elif reg.group(2) == 's':
+                            result['node'] = 'B'
+                            break
+
+        # check if this system is licensed for HA
+        with open(LICENSE, 'r') as f:
+            if License.load(f.read().strip('\n')).system_serial_ha:
+                result['licensed'] = True
+
+    except Exception:
+        # this script is called as a fallback mechanism in
+        # ix-netif rc script so if any type of error occurs
+        # then things are really broken
+        pass
+
+    return json.dumps(result)
 
 
 if __name__ == '__main__':
-    main()
+    print(main())


### PR DESCRIPTION
It's come to my attention that we've had multiple customers fail the upgrade from 11.3 to 12.0 on their HA systems. This was able to be reproduced in-house. Upon investigation of the internal system, I found that `interface.sync` failed so we failed back to using `ix-netif` rc script but that failed because the `ha_*` related rc routines in `rc.freenas` have been removed in 12. This commit does the following:

- fix `hadetect.py` to work since it was broken in the first place
- make `hadetect.py` standalone and not require middlewared to be running
- add `ha_hardware`, `ha_node`, and `ha_licensed` to `rc.freenas` to be used by `ix-netif`
- fix multiple issues in `ix-netif` rc script