### PR TITLE
NAS-110039 / 21.04 / Ignore encoding errors in stdout/stderr

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -100,7 +100,8 @@ class DeviceService(Service, DeviceInfoBase):
         disks_cp = subprocess.run(
             ['lsblk', '-OJdb'],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            errors="ignore"
         )
         if not disks_cp.returncode:
             try:

--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -101,7 +101,7 @@ class DeviceService(Service, DeviceInfoBase):
             ['lsblk', '-OJdb'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            errors="ignore"
+            errors='ignore'
         )
         if not disks_cp.returncode:
             try:


### PR DESCRIPTION
When calling lsblk apparently disks can have non utf-8 data in at least labels and potentially more spots. By adding error=ignore to subprocess.run we can decode stdout earlier and toss junk data instead of causing exception on decoding it during json.loads later. Maybe needed in other spots in middlewared