### PR TITLE
DOCS-1960 / 20.04 / Change the sleep of test 31 to 5 seccond in api2/test_306_chart_release.py

### DIFF
--- a/tests/api2/test_306_chart_release.py
+++ b/tests/api2/test_306_chart_release.py
@@ -333,7 +333,7 @@ def test_31_set_custom_catalog_for_testing_update():
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict), results.text
     # the sleep is needed or /catalog/items is not ready on time.
-    time.sleep(2)
+    time.sleep(5)
 
 
 @pytest.mark.parametrize('key', list(updatechart_catalog.keys()))


### PR DESCRIPTION
This gives more time to the system to get the repository before test 35 starts running.