### PR TITLE
NAS-110047 / 21.04 / Fix TypeError: sync_interface() missing 1 required positional argumen…

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1997,7 +1997,7 @@ class InterfaceService(CRUDService):
         await self.middleware.call_hook('interface.post_sync')
 
     @private
-    async def sync_interface(self, name, options):
+    async def sync_interface(self, name, options=None):
         options = options or {}
 
         try:


### PR DESCRIPTION
…t: 'options'