### PR TITLE
NAS-110067 / 21.06 / Normalise docker data-root path

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker.py
+++ b/src/middlewared/middlewared/etc_files/docker.py
@@ -39,9 +39,10 @@ def render(service, middleware):
     subprocess.run(['systemctl', 'daemon-reload'], capture_output=True, check=True)
 
     os.makedirs('/etc/docker', exist_ok=True)
+    data_root = os.path.join('/mnt', config['dataset'], 'docker')
     with open('/etc/docker/daemon.json', 'w') as f:
         f.write(json.dumps({
-            'data-root': os.path.join('/mnt', config['dataset'], 'docker'),
+            'data-root': data_root.replace(' ', r'\ '),
             'exec-opts': ['native.cgroupdriver=cgroupfs'],
             'iptables': False,
             'bridge': 'none',


### PR DESCRIPTION
This commit adds changes to escape spaces in data-root path as docker fails to start. An upstream issue has been made ( https://github.com/moby/moby/issues/42260 ) as we should not have to escape the path in json.