### PR TITLE
NAS-110034 / 21.04 / Correct pam_oath.so path

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/sshd_linux.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/sshd_linux.mako
@@ -13,7 +13,7 @@ account    required     pam_nologin.so
 # access limits that are hard to express in sshd_config.
 # account  required     pam_access.so
 % if twofactor_enabled:
-auth    required    /usr/lib/security/pam_oath.so    usersfile=/etc/users.oath    window=${twofactor_auth['window']}
+auth    required    pam_oath.so    usersfile=/etc/users.oath    window=${twofactor_auth['window']}
 % endif
 
 # Standard Un*x authorization.


### PR DESCRIPTION
This commit fixes an issue where we do not point out complete path of pam_oath.so as it has recently changed and it's better to address it directly.