### PR TITLE
NAS-110080 / 12.0 / fix hadetect entry point script and fix rc.freenas

### DIFF
--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -93,15 +93,15 @@ ro_sqlite()
 
 ha_hardware()
 {
-	/usr/local/bin/hadetect | jq -r '.hardware'
+	/usr/local/bin/hadetect | /usr/local/bin/jq -r '.hardware'
 }
 
 ha_node()
 {
-	/usr/local/bin/hadetect | jq -r '.node'
+	/usr/local/bin/hadetect | /usr/local/bin/jq -r '.node'
 }
 
 ha_licensed()
 {
-	/usr/local/bin/hadetect | jq -r '.licensed'
+	/usr/local/bin/hadetect | /usr/local/bin/jq -r '.licensed'
 }

--- a/src/middlewared/middlewared/scripts/hadetect.py
+++ b/src/middlewared/middlewared/scripts/hadetect.py
@@ -90,8 +90,8 @@ def main():
         # then things are really broken
         pass
 
-    return json.dumps(result)
+    print(json.dumps(result))
 
 
 if __name__ == '__main__':
-    print(main())
+    main()


### PR DESCRIPTION
- `rc.freenas` needs absolute path to `jq` utility
- for reasons that I just don't care to undertand, `print(main())` sends output to `stderr` so make it that the called function prints the data instead to send the output to `stdout`....