### PR TITLE
NAS-110095 / 21.06 / Make sure we correctly retrieve active containers status

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -22,7 +22,7 @@ class ChartReleaseService(Service):
         choices = {}
         for pod in release['resources']['pods']:
             choices[pod['metadata']['name']] = []
-            for container in pod['status']['container_statuses']:
+            for container in (pod['status']['container_statuses'] or []):
                 choices[pod['metadata']['name']].append(container['name'])
 
         return choices


### PR DESCRIPTION
This commit fixes an issue where we were not able to retrieve pod/container choices because api was not giving an empty list if there weren't any containers.
```
[2021/04/07 11:12:52] (WARNING) application.call_method():174 - Exception while calling chart.release.pod_console_choices(*['plex'])
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 138, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self,
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1196, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1001, in nf
    return await f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/resources.py", line 38, in pod_console_choices
    return await self.retrieve_pod_with_containers(release_name)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/resources.py", line 25, in retrieve_pod_with_containers
    for container in pod['status']['container_statuses']:
TypeError: 'NoneType' object is not iterable
```