### PR TITLE
NAS-110099 / 21.04 / Make sure required crds are setup before considering k8s node to be ready

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/crd.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/crd.py
@@ -1,0 +1,19 @@
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+from .k8s import api_client
+
+
+class KubernetesCRDService(CRUDService):
+
+    class Config:
+        namespace = 'k8s.crd'
+        private = True
+
+    @filterable
+    async def query(self, filters, options):
+        async with api_client() as (api, context):
+            return filter_list(
+                [d.to_dict() for d in (await context['extensions_api'].list_custom_resource_definition()).items],
+                filters, options
+            )

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
@@ -19,6 +19,7 @@ async def api_client(context=None, api_client_kwargs=None):
         'batch_api': client.BatchV1Api(api_cl),
         'cronjob_batch_api': client.BatchV1beta1Api(api_cl),
         'custom_object_api': client.CustomObjectsApi(api_cl),
+        'extensions_api': client.ApiextensionsV1Api(api_cl),
     }
     for k in filter(lambda k: context[k], context):
         if k == 'node':

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -74,6 +74,7 @@ class KubernetesService(Service):
 
     @private
     async def ensure_k8s_crd_are_available(self):
+        retries = 5
         required_crds = [
             'volumesnapshots.snapshot.storage.k8s.io',
             'volumesnapshotcontents.snapshot.storage.k8s.io',
@@ -86,8 +87,9 @@ class KubernetesService(Service):
         ]
         while len(
             await self.middleware.call('k8s.crd.query', [['metadata.name', 'in', required_crds]])
-        ) < len(required_crds):
+        ) < len(required_crds) and retries:
             await asyncio.sleep(5)
+            retries -= 1
 
     @private
     async def post_start_internal(self):
@@ -100,9 +102,13 @@ class KubernetesService(Service):
         manifest_path = '/usr/local/share/kubernetes_manifests/zfs-operator.yaml'
         if os.path.exists(manifest_path):
             await self.middleware.call('k8s.cluster.apply_yaml_file', manifest_path)
-        await self.ensure_k8s_crd_are_available()
-        await self.middleware.call('k8s.storage_class.setup_default_storage_class')
-        await self.middleware.call('k8s.zfs.snapshotclass.setup_default_snapshot_class')
+        try:
+            await self.ensure_k8s_crd_are_available()
+            await self.middleware.call('k8s.storage_class.setup_default_storage_class')
+            await self.middleware.call('k8s.zfs.snapshotclass.setup_default_snapshot_class')
+        except Exception as e:
+            raise CallError(f'Failed to configure PV/PVCs support: {e}')
+
         await self.middleware.call(
             'k8s.node.remove_taints', [
                 k['key'] for k in (node_config['spec']['taints'] or []) if k['key'] in ('ix-svc-start', 'ix-svc-stop')


### PR DESCRIPTION
This PR fixes an issue where in some cases kubernetes can take a few seconds to create/apply the CRDs we use and this results in issues as we consider the crds to be available.