### PR TITLE
NAS-109961 / 21.04 / Do not start collectd immediately during boot because it can hang

### DIFF
--- a/src/freenas/etc/systemd/system/collectd.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/collectd.service.d/override.conf
@@ -1,0 +1,5 @@
+# collectd hangs on some systems if being started during boot
+# Hard to repeat and does not happen under strace so let's just sleep until upstream fixes it
+# https://jira.ixsystems.com/browse/NAS-109961
+[Service]
+ExecStartPre=/usr/bin/sh -c 'if [ ! -f /tmp/collectd-boot ]; then touch /tmp/collectd-boot; sleep 10; fi'


### PR DESCRIPTION
It happened only for Rehaf Yosaf, I was only able to repeat it once out of many attempts. Also yesterday I've seen one indirect evidence of this happening in an unrelated user debug  If I trace it, it does not hang. Harmless sleep is the only sane option IMO.