### PR TITLE
NAS-110127 / 12.0 / bump max_length in filesystem.file_receive

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -240,7 +240,7 @@ class FilesystemService(Service):
     @private
     @accepts(
         Str('path'),
-        Str('content', max_length=2048000),
+        Str('content', max_length=5242880),  # 5MB
         Dict(
             'options',
             Bool('append', default=False),


### PR DESCRIPTION
We're starting to see customer enterprise systems have larger than 2MB sized databases. Investigation is on-going to understand if that's expected. For the immediate future, bump this to 5MB since this method isn't writing to the database and the `Str` class has this max_length imposed because it's expected anything using the `Str` class is writing to the db.