### PR TITLE
NAS-110128 / 21.04 / use failover.sendfile in failover.sync_to_peer

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -464,7 +464,8 @@ class FailoverService(ConfigService):
         # Journal thread will see that this is special value and will clear journal.
         sql_queue.put(None)
 
-        self.send_small_file(FREENAS_DATABASE, FREENAS_DATABASE + '.sync')
+        token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
+        self.middleware.call_sync('failover.sendfile', token, FREENAS_DATABASE, FREENAS_DATABASE + '.sync')
         self.middleware.call_sync('failover.call_remote', 'failover.receive_database')
 
     @private


### PR DESCRIPTION
`send_small_file` ended up calling `filesystem.file_receive` which has a `max_length` attribute that is limited to 2MB. We're seeing databases grow above 2MB in size on enterprise customer systems. Whether or not that's expected is undetermined at this time. However, use `failover.sendfile` to send the database to the other side to completely forgo this situation entirely.