### PR TITLE
NAS-110133 / 12.0 / Do not show a successful status for cloud sync that was not executed … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -1063,9 +1063,9 @@ class CloudSyncService(TaskPathService):
         """
 
         cloud_sync = await self.get_instance(id)
-        if cloud_sync['locked']:
-            await self.middleware.call('cloudsync.generate_locked_alert', id)
-            return
+        if cloud_sync["locked"]:
+            await self.middleware.call("cloudsync.generate_locked_alert", id)
+            raise CallError("Dataset is locked")
 
         await self._sync(cloud_sync, options, job)
 


### PR DESCRIPTION
…due to the dataset being locked

Original PR: https://github.com/truenas/middleware/pull/6755