### PR TITLE
Ignore files and some folders in trains folder

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -68,8 +68,11 @@ class CatalogService(Service):
 
         for train in filter(lambda c: os.path.exists(os.path.join(location, c)), trains):
             category_path = os.path.join(location, train)
+            
             for item in filter(lambda p: os.path.isdir(os.path.join(category_path, p)), os.listdir(category_path)):
                 item_location = os.path.join(category_path, item)
+                if (not os.path.isdir(item_location) or train.startswith('.')):
+                    continue
                 trains[train][item] = item_data = {
                     'name': item,
                     'categories': [],


### PR DESCRIPTION
As an addition to:
https://github.com/truenas/catalog_validation/pull/19

Currently a train folder can only contain folder and no files.
However: it would be nice ignoring files in the train folder completely, because they are totally irrelevant.