### PR TITLE
NAS-110159 / 21.04 / Connect POSIX ACL logic to nfs4xdr_winacl

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -11,8 +11,6 @@ OS_FLAG = OS_TYPE_FREEBSD if osc.IS_FREEBSD else OS_TYPE_LINUX
 class ACLType(enum.Enum):
     NFS4 = (OS_TYPE_FREEBSD, ['tag', 'id', 'perms', 'flags', 'type'])
     POSIX1E = (OS_TYPE_FREEBSD | OS_TYPE_LINUX, ['default', 'tag', 'id', 'perms'])
-    RICH = (OS_TYPE_LINUX,)
-    SAMBA = (OS_TYPE_LINUX,)
 
     def validate(self, theacl):
         errors = []
@@ -27,10 +25,20 @@ class ACLType(enum.Enum):
         for idx, entry in enumerate(theacl['dacl']):
             extra = set(entry.keys()) - set(ace_keys)
             missing = set(ace_keys) - set(entry.keys())
-            if extra:
-                errors.append(f"ACL entry [{idx}] contains invalid extra key(s): {extra}")
-            if missing:
-                errors.append(f"ACL entry [{idx}] is missing required keys(s): {missing}")
+            if osc.IS_FREEBSD:
+                if extra:
+                    errors.append(f"ACL entry [{idx}] contains invalid extra key(s): {extra}")
+                if missing:
+                    errors.append(f"ACL entry [{idx}] is missing required keys(s): {missing}")
+            else:
+                if extra:
+                    errors.append(
+                        (idx, f"ACL entry contains invalid extra key(s): {extra}")
+                    )
+                if missing:
+                    errors.append(
+                        (idx, f"ACL entry is missing required keys(s): {missing}")
+                    )
 
         return {"is_valid": len(errors) == 0, "errors": errors}
 

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -2,8 +2,9 @@ import errno
 import os
 import subprocess
 import stat as pystat
+from pathlib import Path
 
-from middlewared.service import private, CallError, Service
+from middlewared.service import private, CallError, ValidationErrors, Service
 from middlewared.plugins.smb import SMBBuiltin
 from .acl_base import ACLBase, ACLDefault, ACLType
 
@@ -12,81 +13,101 @@ class FilesystemService(Service, ACLBase):
 
     @private
     def acltool(self, path, action, uid, gid, options):
+
+        flags = "-r"
+        flags += "x" if options.get('traverse') else ""
+        flags += "C" if options.get('do_chmod') else ""
+        flags += "P" if options.get('posixacl') else ""
+
         acltool = subprocess.run([
-            '/usr/bin/acltool',
+            '/usr/bin/nfs4xdr_winacl',
             '-a', action,
             '-O', str(uid), '-G', str(gid),
-            '-rx' if options['traverse'] else '-r',
+            flags,
             '-c', path,
             '-p', path], check=False, capture_output=True
         )
         if acltool.returncode != 0:
             raise CallError(f"acltool [{action}] on path {path} failed with error: [{acltool.stderr.decode().strip()}]")
 
-    def _common_perm_path_validate(self, path):
-        if not os.path.exists(path):
-            raise CallError(f"Path not found: {path}",
-                            errno.ENOENT)
+    def _common_perm_path_validate(self, schema, path, recursive, verrors):
+        p = Path(path)
+        if not p.is_absolute():
+            verrors.add(f'{schema}.path', 'Must be an absolute path.')
+            return
+
+        if p.is_file() and recursive:
+            verrors.add(f'{schema}.path', 'Recursive operations on a file are invalid.')
+            return
 
         if not os.path.realpath(path).startswith('/mnt/'):
-            raise CallError(f"Changing permissions on paths outside of /mnt is not permitted: {path}",
-                            errno.EPERM)
+            verrors.add(
+                f'{schema}.path',
+                f"Changing permissions on paths outside of /mnt is not permitted: {path}"
+            )
 
-        if os.path.realpath(path) in [x['path'] for x in self.middleware.call_sync('pool.query')]:
-            raise CallError(f"Changing permissions of root level dataset is not permitted: {path}",
-                            errno.EPERM)
+        elif len(p.resolve().parents) == 2:
+            verrors.add(
+                f'{schema}.path',
+                f'The specified path is a ZFS pool mountpoint "({path})" '
+            )
+
+        elif self.middleware.call_sync('pool.dataset.path_in_locked_datasets', path):
+            verrors.add(
+                f'{schema}.path',
+                'Path component for is currently encrypted and locked'
+            )
 
     def chown(self, job, data):
         job.set_progress(0, 'Preparing to change owner.')
-
-        self._common_perm_path_validate(data['path'])
+        verrors = ValidationErrors()
 
         uid = -1 if data['uid'] is None else data['uid']
         gid = -1 if data['gid'] is None else data['gid']
         options = data['options']
 
+        self._common_perm_path_validate("filesystem.chown",
+                                        data['path'],
+                                        options.get('recursive', False),
+                                        verrors)
+        verrors.check()
+
         if not options['recursive']:
             job.set_progress(100, 'Finished changing owner.')
             os.chown(data['path'], uid, gid)
-        else:
-            if uid == -1 and gid == -1:
-                return
-            job.set_progress(10, f'Recursively changing owner of {data["path"]}.')
-            # TODO: plumb in acltool to handle recursive / traverse so that we
-            # don't break mountpoints
-            # self.acltool(data['path'], 'chown', uid, gid, options)
-            if gid == -1:
-                chown = subprocess.run(['chown', '-R', str(uid), data['path']],
-                                       check=False, capture_output=True)
-            elif uid == -1:
-                chown = subprocess.run(['chgrp', '-R', str(gid), data['path']],
-                                       check=False, capture_output=True)
-            else:
-                chown = subprocess.run(['chown', '-R', f'{uid}:{gid}', data['path']],
-                                       check=False, capture_output=True)
+            return
 
-            if chown.returncode != 0:
-                raise CallError(f"Failed to chown [{data['path']}]: "
-                                f"{chown.stderr.decode()}")
+        if uid == -1 and gid == -1:
+            return
 
-            job.set_progress(100, 'Finished changing owner.')
+        job.set_progress(10, f'Recursively changing owner of {data["path"]}.')
+        options['posixacl'] = True
+        self.acltool(data['path'], 'chown', uid, gid, options)
+        job.set_progress(100, 'Finished changing owner.')
 
     def setperm(self, job, data):
         job.set_progress(0, 'Preparing to set permissions.')
         options = data['options']
         mode = data.get('mode', None)
+        verrors = ValidationErrors()
 
         uid = -1 if data['uid'] is None else data['uid']
         gid = -1 if data['gid'] is None else data['gid']
 
-        self._common_perm_path_validate(data['path'])
+        self._common_perm_path_validate("filesystem.setperm",
+                                        data['path'],
+                                        options.get('recursive', False),
+                                        verrors)
 
         acl_is_trivial = self.middleware.call_sync('filesystem.acl_is_trivial', data['path'])
         if not acl_is_trivial and not options['stripacl']:
-            raise CallError(
-                f'Non-trivial ACL present on [{data["path"]}]. Option "stripacl" required to change permission.',
-                errno.EINVAL
+            verrors.add(
+                'filesystem.setperm.mode',
+                f'Non-trivial ACL present on [{data["path"]}]. '
+                'Option "stripacl" required to change permission.',
             )
+
+        verrors.check()
 
         if mode is not None:
             mode = int(mode, 8)
@@ -108,34 +129,9 @@ class FilesystemService(Service, ACLBase):
 
         action = 'clone' if mode else 'strip'
         job.set_progress(10, f'Recursively setting permissions on {data["path"]}.')
-        if action == 'strip':
-            stripacl = subprocess.run(['setfacl', '-bR', data['path']],
-                                      check=False, capture_output=True)
-            if stripacl.returncode != 0:
-                raise CallError(f"Failed to remove POSIX1e ACL from [{data['path']}]: "
-                                f"{stripacl.stderr.decode()}")
-
-        if uid != -1 or gid != -1:
-            if gid == -1:
-                chown = subprocess.run(['chown', '-R', str(uid), data['path']],
-                                       check=False, capture_output=True)
-            elif uid == -1:
-                chown = subprocess.run(['chgrp', '-R', str(gid), data['path']],
-                                       check=False, capture_output=True)
-            else:
-                chown = subprocess.run(['chown', '-R', f'{uid}:{gid}', data['path']],
-                                       check=False, capture_output=True)
-
-            if chown.returncode != 0:
-                raise CallError(f"Failed to chown [{data['path']}]: "
-                                f"{chown.stderr.decode()}")
-
-        chmod = subprocess.run(['chmod', '-R', str(data.get('mode')), data['path']],
-                               check=False, capture_output=True)
-        if chmod.returncode != 0:
-            raise CallError(f"Failed to chmod [{data['path']}]: "
-                            f"{chmod.stderr.decode()}")
-
+        options['posixacl'] = True
+        options['do_chmod'] = True
+        self.acltool(data['path'], action, uid, gid, options)
         job.set_progress(100, 'Finished setting permissions.')
 
     async def default_acl_choices(self):
@@ -239,30 +235,27 @@ class FilesystemService(Service, ACLBase):
         raise CallError('NFSv4 ACLs are not yet implemented.', errno.ENOTSUP)
 
     @private
-    def setacl_posix1e(self, job, data):
-        job.set_progress(0, 'Preparing to set acl.')
-
-        options = data['options']
-        recursive = options.get('recursive')
-        dacl = data.get('dacl', [])
-        path = data['path']
-
-        aclcheck = ACLType.POSIX1E.validate(data)
-
-        if not aclcheck['is_valid']:
-            raise CallError(f"POSIX1e ACL is invalid: {' '.join(aclcheck['errors'])}")
-
-        stripacl = subprocess.run(['setfacl', '-bR' if recursive else '-b', path],
-                                  check=False, capture_output=True)
-        if stripacl.returncode != 0:
-            raise CallError(f"Failed to remove POSIX1e ACL from [{path}]: "
-                            f"{stripacl.stderr.decode()}")
-
-        if options['stripacl']:
-            job.set_progress(100, "Finished removing POSIX1e ACL")
-            return
-
-        job.set_progress(50, 'Reticulating splines.')
+    def gen_aclstring_posix1e(self, dacl, recursive, verrors):
+        """
+        This method iterates through provided POSIX1e ACL and
+        performs addtional validation before returning the ACL
+        string formatted for the setfacl command. In case
+        of ValidationError, None is returned.
+        """
+        has_tag = {
+            "USER_OBJ": False,
+            "GROUP_OBJ": False,
+            "OTHER": False,
+            "MASK": False,
+            "DEF_USER_OBJ": False,
+            "DEF_GROUP_OBJ": False,
+            "DEF_OTHER": False,
+            "DEF_MASK": False,
+        }
+        required_entries = ["USER_OBJ", "GROUP_OBJ", "OTHER"]
+        has_named = False
+        has_def_named = False
+        has_default = False
 
         for idx, ace in enumerate(dacl):
             if idx == 0:
@@ -273,9 +266,30 @@ class FilesystemService(Service, ACLBase):
             if ace['id'] == -1:
                 ace['id'] = ''
 
+            who = "DEF_" if ace['default'] else ""
+            who += ace['tag']
+            duplicate_who = has_tag.get(who)
+
+            if duplicate_who is True:
+                verrors.add(
+                    'filesystem.setacl.dacl.{idx}',
+                    f'More than one {"default" if ace["default"] else ""} '
+                    f'{ace["tag"]} entry is not permitted'
+                )
+
+            elif duplicate_who is False:
+                has_tag[who] = True
+
+            if ace['tag'] in ["USER", "GROUP"]:
+                if ace['default']:
+                    has_def_named = True
+                else:
+                    has_named = True
+
             ace['tag'] = ace['tag'].rstrip('_OBJ').lower()
 
             if ace['default']:
+                has_default = True
                 aclstring += "default:"
 
             aclstring += f"{ace['tag']}:{ace['id']}:"
@@ -283,11 +297,99 @@ class FilesystemService(Service, ACLBase):
             aclstring += 'w' if ace['perms']['WRITE'] else '-'
             aclstring += 'x' if ace['perms']['EXECUTE'] else '-'
 
-        setacl = subprocess.run(['setfacl', '-mR' if recursive else '-m', aclstring, path],
-                                check=False, capture_output=True)
-        if setacl.returncode != 0:
-            return CallError(f'Failed to set ACL on path [{path}]: ',
-                             f'{setacl.stderr.decode()}')
+        if has_named and not has_tag['MASK']:
+            verrors.add(
+                'filesystem.setacl.dacl',
+                'Named (user or group) POSIX ACL entries '
+                'require a mask entry to be present in the ACL.'
+            )
+
+        elif has_def_named and not has_tag['DEF_MASK']:
+            verrors.add(
+                'filesystem.setacl.dacl',
+                'Named default (user or group) POSIX ACL entries '
+                'require a default mask entry to be present in the ACL.'
+            )
+
+        if recursive and not has_default:
+            verrors.add(
+                'filesystem.setacl.dacl',
+                'Default ACL entries are required in order to apply '
+                'ACL recursively.'
+            )
+
+        for entry in required_entries:
+            if not has_tag[entry]:
+                verrors.add(
+                    'filesystem.setacl.dacl',
+                    f'Presence of [{entry}] entry is required.'
+                )
+
+            if has_default and not has_tag[f"DEF_{entry}"]:
+                verrors.add(
+                    'filesystem.setacl.dacl',
+                    f'Presence of default [{entry}] entry is required.'
+                )
+
+        return aclstring
+
+    @private
+    def setacl_posix1e(self, job, data):
+        job.set_progress(0, 'Preparing to set acl.')
+        verrors = ValidationErrors()
+        options = data['options']
+        recursive = options.get('recursive', False)
+        do_strip = options.get('stripacl', False)
+        dacl = data.get('dacl', [])
+        path = data['path']
+        uid = -1 if not data.get('uid') else data['uid']
+        gid = -1 if not data.get('gid') else data['gid']
+
+        self._common_perm_path_validate("filesystem.setacl",
+                                        path, recursive,
+                                        verrors)
+
+        aclcheck = ACLType.POSIX1E.validate(data)
+        if not aclcheck['is_valid']:
+            for err in aclcheck['errors']:
+                verrors.add(
+                    'filesystem.setacl.dacl.{err[0]}', err[1]
+                )
+
+        if do_strip and dacl:
+            verrors.add(
+                'filesystem.setacl.dacl',
+                'Simulatenously setting and removing ACL from path is invalid.'
+            )
+
+        if not do_strip:
+            aclstring = self.gen_aclstring_posix1e(dacl, recursive, verrors)
+
+        verrors.check()
+
+        stripacl = subprocess.run(['setfacl', '-b', path],
+                                  check=False, capture_output=True)
+        if stripacl.returncode != 0:
+            raise CallError(f"Failed to remove POSIX1e ACL from [{path}]: "
+                            f"{stripacl.stderr.decode()}")
+
+        job.set_progress(50, 'Setting POSIX1e ACL.')
+
+        if not do_strip:
+            setacl = subprocess.run(['setfacl', '-m', aclstring, path],
+                                    check=False, capture_output=True)
+            if setacl.returncode != 0:
+                raise CallError(f'Failed to set ACL [{aclstring}] on path [{path}]: '
+                                f'{setacl.stderr.decode()}')
+
+        if not recursive:
+            job.set_progress(100, 'Finished setting POSIX1e ACL.')
+            return
+
+        options['posixacl'] = True
+        self.acltool(data['path'],
+                     'clone' if not do_strip else 'strip',
+                     uid, gid, options)
 
         job.set_progress(100, 'Finished setting POSIX1e ACL.')
 


### PR DESCRIPTION
This commit brings in proper behavior for recursively applying POSIX ACLs and also adds no-xdev capabilities for associated permissions changes.

Since this more-or-less finishes POSIX ACL implementation, more thorough validation is being added with this commit.