### PR TITLE
NAS-109849 / 21.06 / prevent failover log spam when remote node goes offline (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -80,6 +80,17 @@ class TruenasNodeSessionManagerCredentials(SessionManagerCredentials):
     pass
 
 
+class UnableToDetermineOSVersion(Exception):
+
+    """
+    Raised in JournalSync thread when we're unable
+    to detect the remote node's OS version.
+    (i.e. if remote node goes down (upgrade/reboot, etc)
+    """
+    pass
+
+
+
 class OSVersionMismatch(Exception):
 
     """
@@ -1385,8 +1396,11 @@ class JournalSync:
 
             self.journal.clear()
 
-        if not self._os_versions_match():
-            if self.journal:
+        if self.journal:
+            os_ver_match = self._os_versions_match()
+            if os_ver_match is None:
+                raise UnableToDetermineOSVersion()
+            elif not os_ver_match:
                 raise OSVersionMismatch()
 
         had_journal_items = bool(self.journal)
@@ -1479,7 +1493,14 @@ class JournalSync:
         except Exception:
             return False
 
-        return loc == rem
+        if rem is None:
+            # happens when other node goes offline
+            # (reboot/upgrade etc, etc) the log message
+            # is a little misleading in this scenario
+            # so make it a little better
+            return
+        else:
+            return loc == rem
 
 
 def hook_datastore_execute_write(middleware, sql, params):
@@ -1505,9 +1526,17 @@ def journal_sync(middleware):
             while True:
                 journal_sync.process()
                 alert = True
+        except UnableToDetermineOSVersion:
+            if alert:
+                logger.warning(
+                    'Unable to determine remote node OS version. Not syncing journal'
+                )
+                alert = False
         except OSVersionMismatch:
             if alert:
-                logger.warning('OS version does not match remote node. Not syncing journal')
+                logger.warning(
+                    'OS version does not match remote node. Not syncing journal'
+                )
                 alert = False
         except Exception:
             logger.warning('Failed to sync journal', exc_info=True)

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
@@ -197,6 +197,15 @@ class RemoteClient(object):
         if self._remote_os_version is None:
             try:
                 self._remote_os_version = self.client.call('system.version')
+            except AttributeError:
+                # happens when other node goes offline
+                # (upgrade, reboot, etc) self.client gets
+                # set to None which is expected. However,
+                # the JournalSync thread calls this method
+                # every 5 seconds which is particularly
+                # painful on m-series devices since those
+                # systems can take upwards of 15mins to reboot.
+                pass
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
@@ -194,18 +194,9 @@ class RemoteClient(object):
 
     def get_remote_os_version(self):
 
-        if self._remote_os_version is None:
+        if self.client is not None and self._remote_os_version is None:
             try:
                 self._remote_os_version = self.client.call('system.version')
-            except AttributeError:
-                # happens when other node goes offline
-                # (upgrade, reboot, etc) self.client gets
-                # set to None which is expected. However,
-                # the JournalSync thread calls this method
-                # every 5 seconds which is particularly
-                # painful on m-series devices since those
-                # systems can take upwards of 15mins to reboot.
-                pass
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 


### PR DESCRIPTION
- m-series devices can take upwards of 15mins to reboot so spamming `exc_info` every 5 seconds for 15mins (or more depending on what the state of the node is in that's offline) is too noisy and does nothing but muddy the log file
- clarify the verbiage when the `JournalSync` thread is sync'ing db queries to the other node.

Original PR: https://github.com/truenas/middleware/pull/6637