### PR TITLE
NAS-110192 / 21.06 / Add normalized vm pci id to device.get_gpus

### DIFF
--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -39,7 +39,7 @@ def get_gpus():
                 {
                     'pci_id': child['PCI_ID'],
                     'pci_slot': child['PCI_SLOT_NAME'],
-
+                    'vm_pci_slot': f'pci_{child["PCI_SLOT_NAME"].replace(".", "_").replace(":", "_")}',
                 }
                 for child in gpu_dev.parent.children if 'PCI_SLOT_NAME' in child and 'PCI_ID' in child
             ],


### PR DESCRIPTION
This commit adds changes to add a normalized vm pci slot id which UI can consume for easily retrieving information about a GPU which VM plugin will accept where we rely on libvirt to provide us with normalized pci slot ids.