### PR TITLE
NAS-109803 / 21.06 / Ensure that domain sid component of groupmap entries updated properly (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -690,6 +690,7 @@ class SMBService(SystemServiceService):
         await self.compress(new)
 
         await self._update_service(old, new)
+        await self.middleware.call("etc.generate", "smb")
         await self.reset_smb_ha_mode()
 
         """
@@ -699,7 +700,14 @@ class SMBService(SystemServiceService):
         if old['aapl_extensions'] != new['aapl_extensions']:
             await self.apply_aapl_changes()
 
-        return await self.config()
+        new_config = await self.config()
+        if old['netbiosname_local'] != new_config['netbiosname_local']:
+            new_sid = await self.middleware.call("smb.get_system_sid")
+            await self.middleware.call("smb.set_database_sid", new_sid)
+            new_config["cifs_SID"] = new_sid
+            await self.middleware.call("smb.synchronize_group_mappings")
+
+        return new_config
 
     @private
     async def compress(self, data):

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -118,9 +118,9 @@ class SMBService(Service):
         passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
 
         if groupmap:
-            sids_fixed = await self.middleware.call('smb.fixsid', groupmap.values())
-            if not sids_fixed:
-                groupmap = []
+            groupmap_removed = await self.middleware.call('smb.fixsid', groupmap.values())
+            if groupmap_removed:
+                groupmap = {}
 
         for b in SMBBuiltin:
             entry = groupmap.get(b.value[0])


### PR DESCRIPTION
Wen Samba's netbiosname changes, the server's local SID is automatically
regenerated and reflected in Samba's passdb. Groupmap entries are not
updated in a similar way. This commit simplifies and fixes smb.fix_sid
so that the domain component of each group's SID matches our current
system SID. If it doesn't, then the group_mapping.tdb is removed and
regenerated. The system SID stored in the TrueNAS configuration database
is also updated at this time. A backgrounded groupmap synchronization
job is started when our netbios name is changed in an SMB service update.

Original PR: https://github.com/truenas/middleware/pull/6614
Jira URL: https://jira.ixsystems.com/browse/NAS-109803