### PR TITLE
NAS-110251 / 21.04 / Handle case where active_media_subtype can be none

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -127,9 +127,9 @@ class RealtimeEventSource(EventSource):
 
         interfaces = self.middleware.call_sync('interface.query')
         for interface in interfaces:
-            if m := RE_BASE.match(interface['state']['active_media_subtype']):
+            if m := RE_BASE.match(interface['state']['active_media_subtype'] or ''):
                 speeds[interface['name']] = int(m.group(1)) * MEGABIT
-            elif m := RE_MBS.match(interface['state']['active_media_subtype']):
+            elif m := RE_MBS.match(interface['state']['active_media_subtype'] or ''):
                 speeds[interface['name']] = int(m.group(1)) * MEGABIT
 
         types = ['BRIDGE', 'LINK_AGGREGATION', 'VLAN']


### PR DESCRIPTION
On freebsd, we can have `active_media_subtype` as `None`.
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/middlewared/event.py", line 45, in process
    self.run()
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/reporting/events.py", line 166, in run
    'speeds': self.get_interface_speeds(),
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/reporting/events.py", line 129, in get_interface_speeds
    if m := RE_BASE.match(interface['state']['active_media_subtype']):
TypeError: expected string or bytes-like object
```