### PR TITLE
NAS-110308 / 21.06 / Improve key name for gpu pci ids choices

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -281,5 +281,6 @@ class DeviceService(Service, DeviceInfoBase):
         Retrieve choices for GPU PCI ids located in the system.
         """
         return {
-            gpu['addr']['pci_slot']: gpu['addr']['pci_slot'] for gpu in await self.middleware.call('device.get_gpus')
+            gpu['description'] or gpu['vendor'] or gpu['addr']['pci_slot']: gpu['addr']['pci_slot']
+            for gpu in await self.middleware.call('device.get_gpus')
         }


### PR DESCRIPTION
This will provide us with a much more meaningful choices dictionary
```
> midclt call device.gpu_pci_ids_choices | jq .
{
  "ASPEED Technology, Inc. ASPEED Graphics Family": "0000:03:00.0",
  "NVIDIA Corporation GM107 [GeForce GTX 750 Ti]": "0000:af:00.0",
  "NVIDIA Corporation GK208B [GeForce GT 730]": "0000:d8:00.0"
}
truenas#
```