### PR TITLE
NAS-110173 / 21.06 / Update he.net dyndns provider

### DIFF
--- a/src/middlewared/middlewared/plugins/dyndns.py
+++ b/src/middlewared/middlewared/plugins/dyndns.py
@@ -70,7 +70,7 @@ class DynDNSService(SystemServiceService):
             'default@zoneedit.com': 'zoneedit.com',
             'dyndns@3322.org': '3322.org',
             'ipv4@nsupdate.info': 'nsupdate.info',
-            'ipv6tb@he.net': 'he.net'
+            'dyndns@he.net': 'he.net'
         }
 
     @private


### PR DESCRIPTION
This commit updates he.net dyndns provider as we were using a deprecated value before ( https://code.aliyun.com/yaoruisheng/k2-router/commit/1a48a43822d777d321529e4d53aa5bd76337ceb9 ).