### PR TITLE
NAS-110319 / 21.06 / Update gpu error message

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -210,7 +210,7 @@ class SystemAdvancedService(ConfigService):
             if len(available - provided) < 1:
                 verrors.add(
                     f'{schema}.isolated_gpu_pci_ids',
-                    'A minimum of 2 GPUs are required in the host to ensure that host has at least 1 GPU available.'
+                    'A minimum of 1 GPU is required for the host to ensure it functions as desired.'
                 )
 
         return verrors, data


### PR DESCRIPTION
This commit adds changes to update outdated gpu error message explaining that the host requires at least 1 GPU to function properly.