### PR TITLE
NAS-110243 / 21.06 / Allow endpoints to specify explicit http methods

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -7,7 +7,8 @@ from middlewared.i18n import set_language
 from middlewared.logger import CrashReporting
 from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Str
 from middlewared.service import (
-    CallError, ConfigService, no_auth_required, job, pass_app, private, Service, throttle, ValidationErrors
+    CallError, ConfigService, no_auth_required, job, pass_app, private, rest_api_metadata,
+    Service, throttle, ValidationErrors
 )
 import middlewared.sqlalchemy as sa
 from middlewared.utils import Popen, run, start_daemon_thread, sw_buildtime, sw_version, osc
@@ -1470,6 +1471,7 @@ class SystemGeneralService(ConfigService):
 
         return await self.config()
 
+    @rest_api_metadata(extra_methods=['GET'])
     @accepts(Int('delay', default=3, validators=[Range(min=0)]))
     async def ui_restart(self, delay):
         """

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -142,8 +142,9 @@ class RESTfulAPI(object):
                     res_kwargs['post'] = methodname
                 else:
                     res_kwargs['get'] = methodname
-                for rest_method in (method['explicit_methods'] or []):
-                    assert rest_method in ('post', 'get')
+                for rest_method in map(str.lower, (method['extra_methods'] or [])):
+                    assert rest_method in ('get',)
+                    # Only allow get for now as that's the only use case we have for now NAS-110243
                     res_kwargs[rest_method] = methodname
 
                 Resource(self, self.middleware, short_methodname, service['config'], parent=parent, **res_kwargs)

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -142,6 +142,10 @@ class RESTfulAPI(object):
                     res_kwargs['post'] = methodname
                 else:
                     res_kwargs['get'] = methodname
+                for rest_method in (method['explicit_methods'] or []):
+                    assert rest_method in ('post', 'get')
+                    res_kwargs[rest_method] = methodname
+
                 Resource(self, self.middleware, short_methodname, service['config'], parent=parent, **res_kwargs)
             await asyncio.sleep(0)  # Force context switch
 

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -181,7 +181,7 @@ def pass_app(rest=False):
     return wrapper
 
 
-def rest_api_metadata(explicit_methods=None):
+def rest_api_metadata(extra_methods=None):
     """
     Allow having endpoints specify explicit rest methods.
 
@@ -192,7 +192,7 @@ def rest_api_metadata(explicit_methods=None):
     """
     def wrapper(fn):
         fn._rest_api_metadata = {
-            'explicit_methods': explicit_methods,
+            'extra_methods': extra_methods,
         }
         return fn
     return wrapper
@@ -1087,7 +1087,7 @@ class CoreService(Service):
                     'filterable': hasattr(method, '_filterable'),
                     'filterable_schema': None,
                     'pass_application': hasattr(method, '_pass_app'),
-                    'explicit_methods': method._rest_api_metadata['explicit_methods'] if hasattr(
+                    'extra_methods': method._rest_api_metadata['extra_methods'] if hasattr(
                         method, '_rest_api_metadata') else None,
                     'require_websocket': hasattr(method, '_pass_app') and not method._pass_app['rest'],
                     'job': hasattr(method, '_job'),


### PR DESCRIPTION
This is useful when we want to maintain backwards compatibility with endpoints which were not expecting payload before but are now and users still would like to consume them with previous method which would be GET whereas it's POST now.
