### PR TITLE
NAS-110141 / 21.06 / Wait for changes to txt records to propagate

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/base.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/base.py
@@ -1,9 +1,12 @@
+import time
+
 from middlewared.service import CallError
 
 
 class Authenticator:
 
     NAME = NotImplementedError
+    PROPAGATION_DELAY = NotImplementedError
     SCHEMA = NotImplementedError
 
     def __init__(self, attributes):
@@ -19,12 +22,17 @@ class Authenticator:
 
     def perform(self, domain, validation_name, validation_content):
         try:
-            self._perform(domain, validation_name, validation_content)
+            perform_ret = self._perform(domain, validation_name, validation_content)
         except Exception as e:
             raise CallError(f'Failed to perform {self.NAME} challenge for {domain!r} domain: {e}')
+        else:
+            self.wait_for_records_to_propagate(perform_ret)
 
     def _perform(self, domain, validation_name, validation_content):
         raise NotImplementedError
+
+    def wait_for_records_to_propagate(self, perform_ret):
+        time.sleep(self.PROPAGATION_DELAY)
 
     def cleanup(self, domain, validation_name, validation_content):
         try:

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class CloudFlareAuthenticator(Authenticator):
 
     NAME = 'cloudflare'
+    PROPAGATION_DELAY = 60
     SCHEMA = Dict(
         'cloudflare',
         Str('cloudflare_email', empty=False, null=True, title='Cloudflare Email'),

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/route53.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/route53.py
@@ -34,8 +34,9 @@ class Route53Authenticator(Authenticator):
         pass
 
     def _perform(self, domain, validation_name, validation_content):
-        resp_change_info = self._change_txt_record('UPSERT', validation_name, validation_content)
+        return self._change_txt_record('UPSERT', validation_name, validation_content)
 
+    def wait_for_records_to_propagate(self, resp_change_info):
         """
         Wait for a change to be propagated to all Route53 DNS servers.
         https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetChange.html


### PR DESCRIPTION
This commit adds changes to wait for each record to propagate before telling CA that the records can be validated. The behaviour is keeping in line with how certbot operates where there's a custom delay for each provider supported. ( For reference - https://github.com/certbot/certbot/blob/32247b3c89cb44b87f764a21e6deda9168431dec/certbot/certbot/plugins/dns_common.py#L63 )