### PR TITLE
NAS-110350 / 21.06 / Increase crash kernel memory size

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -37,8 +37,11 @@ if __name__ == "__main__":
         #
         # We should test this on systems with higher memory as there are contradicting
         # docs - https://www.suse.com/support/kb/doc/?id=000016171
+        # With our custom kernel, having 256MB RAM as base is not enough.
+        # In my tests it worked with having 400MB as base RAM.
+        # TODO: Let's please see what we can do to bring this down on the kernel side perhaps
         current_mem = psutil.virtual_memory().total / 1024
-        cmdline.append(f"crashkernel={256 + math.ceil(current_mem / 16 / 1024 / 1024)}M")
+        cmdline.append(f"crashkernel={400 + math.ceil(current_mem / 16 / 1024 / 1024)}M")
 
     config.append(f'GRUB_TERMINAL="{" ".join(terminal)}"')
     config.append(f'GRUB_CMDLINE_LINUX="{" ".join(cmdline)}"')


### PR DESCRIPTION
With our custom kernel, kdump is not working and in case of a kernel crash, the crash kernel runs out of memory. We have had a user running into this and i was easily able to reproduce as well. When the crash kernel runs out of memory, system does not reboot and gets stuck so it needs to be manually restarted. We should however investigate how we can bring the memory size down, maybe looking at some configuration knobs for the kernel.