### PR TITLE
NAS-110373 / 21.06 / Add system configured timezone as default in catalogs

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -207,6 +207,7 @@ class CatalogService(Service):
             'node_ip': await self.middleware.call('kubernetes.node_ip'),
             'certificates': await self.middleware.call('chart.release.certificate_choices'),
             'certificate_authorities': await self.middleware.call('chart.release.certificate_authority_choices'),
+            'system.general.config': await self.middleware.call('system.general.config'),
         }
 
     @private
@@ -249,7 +250,10 @@ class CatalogService(Service):
                         }
                     })
             elif ref == 'definitions/timezone':
-                data['enum'] = [{'value': t, 'description': f'{t!r} timezone'} for t in context['timezones']]
+                data.update({
+                    'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in context['timezones']],
+                    'default': context['system.general.config']['timezone']
+                })
             elif ref == 'definitions/nodeIP':
                 data['default'] = context['node_ip']
             elif ref == 'definitions/certificate':


### PR DESCRIPTION
This commit adds changes to add system configured timezone as a default timezone if a catalog item utilizes the timezone feature. This helps the user with moving on to the next question easily instead of finding the correct timezone in the long list of timezones.