### PR TITLE
NAS-110374 / 21.06 / Retrieve questions context if not specified

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -168,7 +168,9 @@ class CatalogService(Service):
         return item_data
 
     @private
-    def item_version_details(self, version_path, questions_context):
+    def item_version_details(self, version_path, questions_context=None):
+        if not questions_context:
+            questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
         version_data = {'location': version_path, 'required_features': set()}
         for key, filename, parser in (
             ('chart_metadata', 'Chart.yaml', yaml.safe_load),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -84,6 +84,10 @@ class ChartReleaseService(CRUDService):
         retrieve_schema = extra.get('include_chart_schema')
         get_resources = extra.get('retrieve_resources')
         get_history = extra.get('history')
+        if retrieve_schema:
+            questions_context = await self.middleware.call('catalog.get_normalised_questions_context')
+        else:
+            questions_context = None
 
         if filters and len(filters) == 1 and filters[0][:2] == ['id', '=']:
             extra['namespace_filter'] = ['metadata.namespace', '=', f'{CHART_NAMESPACE_PREFIX}{filters[0][-1]}']
@@ -236,7 +240,7 @@ class ChartReleaseService(CRUDService):
                 chart_path = os.path.join(release_data['path'], 'charts', release_data['chart_metadata']['version'])
                 if os.path.exists(chart_path):
                     release_data['chart_schema'] = await self.middleware.call(
-                        'catalog.item_version_details', chart_path
+                        'catalog.item_version_details', chart_path, questions_context
                     )
                 else:
                     release_data['chart_schema'] = None


### PR DESCRIPTION
We should retrieve questions context if not explicitly specified and if querying chart releases with their existing schema, speed up retrieval by using cached questions context.