### PR TITLE
NAS-110376 / 21.06 / Clear old update alerts on kubernetes status change

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -352,3 +352,8 @@ class ChartReleaseService(Service):
             await job.wrap(await self.middleware.call('chart.release.redeploy', release_name))
 
         return results
+
+    @private
+    async def clear_update_alerts_for_all_chart_releases(self):
+        for chart_release in await self.middleware.call('chart.release.query'):
+            await self.middleware.call('alert.oneshot_delete', 'ChartReleaseUpdate', chart_release['id'])

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -234,6 +234,7 @@ class KubernetesService(ConfigService):
             job.set_progress(40, 'Migration complete for ix-applications dataset')
 
         if len(set(old_config.items()) ^ set(config.items())) > 0:
+            await self.middleware.call('chart.release.clear_update_alerts_for_all_chart_releases')
             config['cni_config'] = {}
             await self.middleware.call('datastore.update', self._config.datastore, old_config['id'], config)
             await self.middleware.call('kubernetes.status_change')


### PR DESCRIPTION
This commit adds changes to clear chart release update alerts when kubernetes status changes, this can be using a different pool or re-initializing kubernetes or perhaps just a configuration change. In either case it's fine as when kubernetes starts, the alerts are re-generated based on current chart release's status.