### PR TITLE
NAS-110393 / 21.06 / Only add extra arguments if specified

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -451,7 +451,8 @@ class Resource(object):
 
     def _filterable_args(self, req):
         filters = []
-        options = {'extra': {}}
+        extra_args = {}
+        options = {}
         for key, val in list(req.query.items()):
             if '__' in key:
                 field, op = key.split('__', 1)
@@ -476,7 +477,7 @@ class Resource(object):
                 continue
             elif key.startswith('extra.'):
                 key = key[len('extra.'):]
-                options['extra'][key] = normalize_query_parameter(val)
+                extra_args[key] = normalize_query_parameter(val)
                 continue
 
             op_map = {
@@ -500,6 +501,9 @@ class Resource(object):
             elif val.lower() == 'null':
                 val = None
             filters.append((field, op, val))
+
+        if extra_args:
+            options['extra'] = extra_args
 
         return [filters, options] if filters or options else []
 


### PR DESCRIPTION
This commit fixes an issue where we allowed specifying request body for get methods but with recent changes where we allowed to specify extra arguments as query parameters, specifying empty extra arguments resulted in get implementation assuming that query parameters had been specified which resulted in request body being ignored which is a change of behaviour.