### PR TITLE
NAS-110394 / 21.06 / Allow specifying extra kernel arguments

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import math
-import json
 import psutil
 
 from middlewared.utils import osc
@@ -9,7 +8,7 @@ from middlewared.utils.db import query_config_table
 
 if __name__ == "__main__":
     advanced = query_config_table("system_advanced", prefix="adv_")
-    kernel_extra_args = ' '.join(json.loads(advanced.get('kernel_extra_options') or []))
+    kernel_extra_args = advanced.get('kernel_extra_options') or ''
 
     # We need to allow tpm in grub as sedutil-cli requires it
     # TODO: Please remove kernel flag to use cgroups v1 when nvidia device plugin starts working
@@ -17,7 +16,7 @@ if __name__ == "__main__":
     config = [
         'GRUB_DISTRIBUTOR="TrueNAS Scale"',
         'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1 systemd.unified_cgroup_hierarchy=0 amd_iommu=on iommu=pt '
-        f'kvm_amd.npt=1 kvm_amd.avic=1 intel_iommu=on{f" {kernel_extra_args}"if kernel_extra_args else ""}"',
+        f'kvm_amd.npt=1 kvm_amd.avic=1 intel_iommu=on{f" {kernel_extra_args}" if kernel_extra_args else ""}"',
     ]
 
     terminal = ["console"]

--- a/src/middlewared/middlewared/alembic/versions/12.1/2021-04-27_01-05_grub_extra_args.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2021-04-27_01-05_grub_extra_args.py
@@ -1,0 +1,29 @@
+"""
+GRUB linux extra arguments
+
+Revision ID: 9372814239d7
+Revises: e6aa9844e0c4
+Create Date: 2021-04-27 01:15:42.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '9372814239d7'
+down_revision = 'e6aa9844e0c4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('adv_kernel_extra_options', sa.TEXT(), nullable=True))
+
+    op.execute("UPDATE system_advanced SET adv_kernel_extra_options = '[]'")
+
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.alter_column('adv_kernel_extra_options', existing_type=sa.TEXT(), nullable=False)
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/12.1/2021-04-27_01-05_grub_extra_args.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2021-04-27_01-05_grub_extra_args.py
@@ -17,12 +17,9 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('system_advanced', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('adv_kernel_extra_options', sa.TEXT(), nullable=True))
-
-    op.execute("UPDATE system_advanced SET adv_kernel_extra_options = '[]'")
-
-    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
-        batch_op.alter_column('adv_kernel_extra_options', existing_type=sa.TEXT(), nullable=False)
+        batch_op.add_column(
+            sa.Column('adv_kernel_extra_options', sa.TEXT(), server_default='', nullable=False)
+        )
 
 
 def downgrade():

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -247,7 +247,7 @@ class SystemAdvancedService(ConfigService):
             Str('syslog_transport', enum=['UDP', 'TCP', 'TLS']),
             Int('syslog_tls_certificate', null=True),
             List('isolated_gpu_pci_ids', items=[Str('pci_id')]),
-            List('kernel_extra_options', items=[Str('pci_id')]),
+            List('kernel_extra_options', items=[Str('extra_option')]),
             update=True
         )
     )

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -93,6 +93,7 @@ class SystemAdvancedModel(sa.Model):
     adv_kmip_uid = sa.Column(sa.String(255), nullable=True, default=None)
     adv_kdump_enabled = sa.Column(sa.Boolean(), default=False)
     adv_isolated_gpu_pci_ids = sa.Column(sa.JSON(), default=[])
+    adv_kernel_extra_options = sa.Column(sa.JSON(), default=[])
 
 
 class SystemAdvancedService(ConfigService):
@@ -246,6 +247,7 @@ class SystemAdvancedService(ConfigService):
             Str('syslog_transport', enum=['UDP', 'TCP', 'TLS']),
             Int('syslog_tls_certificate', null=True),
             List('isolated_gpu_pci_ids', items=[Str('pci_id')]),
+            List('kernel_extra_options', items=[Str('pci_id')]),
             update=True
         )
     )

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -365,8 +365,11 @@ class SystemAdvancedService(ConfigService):
                 await self.middleware.call('etc.generate', 'kdump')
                 await self.middleware.call('etc.generate', 'grub')
 
-            if osc.IS_LINUX and original_data['isolated_gpu_pci_ids'] != config_data['isolated_gpu_pci_ids']:
-                await self.middleware.call('boot.update_initramfs')
+            if osc.IS_LINUX:
+                if original_data['isolated_gpu_pci_ids'] != config_data['isolated_gpu_pci_ids']:
+                    await self.middleware.call('boot.update_initramfs')
+                if original_data['kernel_extra_options'] != config_data['kernel_extra_options']:
+                    await self.middleware.call('etc.generate', 'grub')
 
         if consolemsg is not None:
             await self.middleware.call('system.general.update', {'ui_consolemsg': consolemsg})


### PR DESCRIPTION
This PR adds changes to allow specifying extra kernel arguments. This is helpful when users are using hardware which requires custom arguments to the kernel, for example we have had a user for whom `poweroff` does not work even on stock debian unless a custom parameter is specified.