### PR TITLE
NAS-110396 / 21.06 / Correctly retrieve host path volumes

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -339,7 +339,7 @@ class ChartReleaseService(CRUDService):
     async def host_path_volumes(self, pods):
         host_path_volumes = []
         for pod in pods:
-            for volume in filter(lambda v: v.get('host_path'), pod['spec']['volumes']):
+            for volume in filter(lambda v: v.get('host_path'), pod['spec']['volumes'] or []):
                 host_path_volumes.append(copy.deepcopy(volume))
         return host_path_volumes
 


### PR DESCRIPTION
In some cases k8s api can retrieve a null value for volumes key. This commit addresses that case.