### PR TITLE
NAS-110400 / 21.06 / Harden k3s

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -16,7 +16,19 @@ def render(service, middleware):
             os.unlink(FLAGS_PATH)
         return
 
-    kube_controller_args = f'node-cidr-mask-size={ipaddress.ip_network(config["cluster_cidr"]).prefixlen}'
+    kube_controller_args = [
+        f'node-cidr-mask-size={ipaddress.ip_network(config["cluster_cidr"]).prefixlen}',
+        'terminated-pod-gc-threshold=5',
+    ]
+    kube_api_server_args = [
+        'service-node-port-range=9000-65535',
+        'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount,AlwaysPullImages',
+        'audit-log-path=/var/log/k3s_server_audit.log',
+        'audit-log-maxage=30',
+        'audit-log-maxbackup=10',
+        'audit-log-maxsize=100',
+        'service-account-lookup=true',
+    ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
@@ -26,5 +38,6 @@ def render(service, middleware):
             'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
             'kube-controller-manager-arg': kube_controller_args,
             'node-ip': config['node_ip'],
-            'kube-apiserver-arg': 'service-node-port-range=9000-65535',
+            'kube-apiserver-arg': kube_api_server_args,
+            'protect-kernel-defaults': True,
         }))


### PR DESCRIPTION
This commit introduces changes to harden k3s based on rancher's recommendations. We are not setting PSP ( pod security policy ) explicitly because that will prevent us from consuming host features like host network which for example is very helpful in setting up clustered minio.