### PR TITLE
NAS-110401 / 12.0 / Fix regression in service restart after pool decryption

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/pool_/encryption_freebsd.py
@@ -291,7 +291,7 @@ class PoolService(Service):
 
         await self.middleware.call('pool.sync_encrypted', oid)
 
-        to_restart = list(set(options['services_restart']) | {'system_datasets', 'disk'} - {'jails', 'vms'})
+        to_restart = [[i] for i in set(options['services_restart']) | {'system_datasets', 'disk'} - {'jails', 'vms'}]
         restart_job = await self.middleware.call('core.bulk', 'service.restart', to_restart)
         statuses = await restart_job.wait()
         for idx, srv_status in enumerate(statuses):


### PR DESCRIPTION
Commit 8a0935dbfaef0d43a246f2a94adf5887a97aa19e 
introduced a regression in restart services after pool unlock.

Basically, refactoring / applying a cherrypick of fix from master introduced a
regression whereby we were sending a list of service names to
to be restarted to the core.bulk rather than a list of lists.