### PR TITLE
NAS-110343 / 21.06 / Properly set hostname in scale

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -11,6 +11,7 @@ Conflicts=systemd-networkd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=-midclt call etc.generate_checkpoint pre_interface_sync
 ExecStart=-midclt -t 60 call failover.internal_interface.pre_sync
 ExecStart=-midclt -t 120 call interface.sync true
 ExecStartPost=midclt call etc.generate_checkpoint interface_sync

--- a/src/middlewared/middlewared/etc_files/hostname.py
+++ b/src/middlewared/middlewared/etc_files/hostname.py
@@ -1,14 +1,20 @@
 import logging
+import subprocess
 
-from middlewared.utils import run
+from middlewared.service import CallError
 
 logger = logging.getLogger(__name__)
 
 
-async def render(service, middleware):
-    config = await middleware.call("network.configuration.config")
-    hostname = f"{config['hostname_local']}.{config['domain']}"
-    with open('/etc/hostname', 'w') as f:
+def render(service, middleware):
+    config = middleware.call_sync("network.configuration.config")
+    hostname = config['hostname_local']
+    if config['domain']:
+        hostname += f'.{config["domain"]}'
+    with open("/etc/hostname", "w") as f:
         f.write(hostname)
 
-    await run(["hostname", hostname])
+    cp = subprocess.Popen(["hostname", hostname], stderr=subprocess.PIPE, stdout=subprocess.DEVNULL)
+    stderr = cp.communicate()[1]
+    if cp.returncode:
+        raise CallError(f'Failed to set hostname: {stderr.decode()}')

--- a/src/middlewared/middlewared/etc_files/hostname.py
+++ b/src/middlewared/middlewared/etc_files/hostname.py
@@ -7,4 +7,8 @@ logger = logging.getLogger(__name__)
 
 async def render(service, middleware):
     config = await middleware.call("network.configuration.config")
-    await run(["hostname", f'{config["hostname_local"]}.{config["domain"]}'])
+    hostname = f"{config['hostname_local']}.{config['domain']}"
+    with open('/etc/hostname', 'w') as f:
+        f.write(hostname)
+
+    await run(["hostname", hostname])

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -277,7 +277,7 @@ class EtcService(Service):
         ],
         'hostname': [
             {'type': 'mako', 'path': 'hosts'},
-            {'type': 'py', 'path': 'hostname', 'platform': 'Linux'},
+            {'type': 'py', 'path': 'hostname', 'platform': 'Linux', 'checkpoint': 'pre_interface_sync'},
         ],
         'ssh': [
             {'type': 'mako', 'path': 'local/ssh/sshd_config', 'checkpoint': 'interface_sync'},
@@ -339,7 +339,7 @@ class EtcService(Service):
     }
     LOCKS = defaultdict(asyncio.Lock)
 
-    checkpoints = ['initial', 'interface_sync', 'post_init', 'pool_import']
+    checkpoints = ['initial', 'interface_sync', 'post_init', 'pool_import', 'pre_interface_sync']
 
     class Config:
         private = True


### PR DESCRIPTION
On first boot, contents of `/etc/hostname` contain the host name of the builder where the iso was generated on. What happens is that when the system boots and interfaces are synced, `hostname --all-fqdn` reports the old hostname as well because it has already been advertised in the network. We should be setting the new/correct hostname on fresh install / upgrade before syncing network to ensure correct hostname is advertised.