### PR TITLE
NAS-110467 / 21.06 / Set k3s required sysctl's

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -10,6 +10,13 @@ class KubernetesService(SimpleService):
 
     async def before_start(self):
         await self.middleware.call('kubernetes.validate_k8s_fs_setup')
+        for key, value in (
+            ('vm.panic_on_oom', 0),
+            ('vm.overcommit_memory', 1),
+            ('kernel.panic', 10),
+            ('kernel.panic_on_oops', 1),
+        ):
+            await self.middleware.call('sysctl.set_value', key, value)
         await self.middleware.call('service.start', 'docker')
         await self._systemd_unit('cni-dhcp', 'start')
 

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info_linux.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info_linux.py
@@ -50,8 +50,8 @@ class SysctlService(Service, SysctlInfoBase):
     def get_arcstats_size(self):
         return self.get_arcstats()['size']
 
-    def set_value(self, key, value):
-        raise NotImplementedError
+    async def set_value(self, key, value):
+        await run(['sysctl', f'{key}={value}'])
 
     def write_to_file(self, path, value):
         with open(path, 'w') as f:


### PR DESCRIPTION
When hardened k3s is started, it does not set sysctl values automatically ( which it normally does for it's functioning ) and they need to be explicitly set for kubelet to work.