### PR TITLE
NAS-109033 / 12.0 / Bug fix for correctly retrieving DN value from a cert (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -445,11 +445,12 @@ class CryptoKeyService(Service):
                 self.middleware.logger.error('Unable to parse extension: %s', e)
 
         dn = []
-        for k, v in obj.get_subject().get_components():
-            if k.decode() == 'subjectAltName':
-                continue
-
-            dn.append(f'{k.decode()}={v.decode()}')
+        subject = obj.get_subject()
+        for k in filter(
+            lambda k: k != 'subjectAltName' and hasattr(subject, k),
+            map(lambda v: v[0].decode(), subject.get_components())
+        ):
+            dn.append(f'{k}={getattr(subject, k)}')
 
         cert_info['DN'] = f'/{"/".join(dn)}'
 


### PR DESCRIPTION
There are cases where simple decode can fail when trying to read cert attributes. We should rely on openssl module instead to give us normalized values instead of trying to decode ourselves.

Original PR: https://github.com/truenas/middleware/pull/6298
Jira URL: https://jira.ixsystems.com/browse/NAS-109033