### PR TITLE
NAS-110433 / 12.0 / Restart mdns after installing a plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -302,6 +302,8 @@ class PluginService(CRUDService):
             'branch': branch,
         })
 
+        self.middleware.call_sync('service.restart', 'mdns')
+
         new_plugin = self.middleware.call_sync('plugin._get_instance', jail_name)
         new_plugin['install_notes'] = install_notes.strip()
 


### PR DESCRIPTION
We should restart mdns after a jail is started following https://github.com/truenas/middleware/pull/6587.