### PR TITLE
NAS-108987 / 21.06 / Allow importing pool which is consuming complete disk

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
@@ -119,11 +119,19 @@ class DiskService(Service, DiskInfoBase):
 
     def label_to_dev(self, label, *args):
         dev = os.path.realpath(os.path.join('/dev', label)).split('/')[-1]
-        return dev if dev != label.split('/')[-1] else None
+        if dev == label and os.path.exists(os.path.join('/sys/block', label)):
+            # This is to cater for a case where `label` is a complete disk
+            # instead of something like disk/by-partuuid/some-uuid-here
+            return dev
+        else:
+            return dev if dev != label.split('/')[-1] else None
 
     def label_to_disk(self, label, *args):
         part_disk = self.label_to_dev(label)
-        return self.get_disk_from_partition(part_disk) if part_disk else None
+        if part_disk == label:
+            return label
+        else:
+            return self.get_disk_from_partition(part_disk) if part_disk else None
 
     def get_disk_from_partition(self, part_name):
         if not os.path.exists(os.path.join('/dev', part_name)):

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -369,7 +369,7 @@ class ZFSPoolService(CRUDService):
         found = False
         with libzfs.ZFS() as zfs:
             for pool in zfs.find_import(
-                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid'] if osc.IS_LINUX else None
+                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', '/dev'] if osc.IS_LINUX else None
             ):
                 if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
                     found = pool

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -11,7 +11,7 @@ from middlewared.schema import Any, Dict, Int, List, Str, Bool, accepts
 from middlewared.service import (
     CallError, CRUDService, ValidationError, ValidationErrors, filterable, job, private,
 )
-from middlewared.utils import filter_list, filter_getattrs, osc
+from middlewared.utils import filter_list, filter_getattrs
 from middlewared.validators import ReplicationSnapshotNamingSchema
 
 
@@ -369,7 +369,7 @@ class ZFSPoolService(CRUDService):
         found = False
         with libzfs.ZFS() as zfs:
             for pool in zfs.find_import(
-                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', '/dev'] if osc.IS_LINUX else None
+                cachefile=cachefile, search_paths=['/dev/disk/by-partuuid', '/dev']
             ):
                 if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
                     found = pool


### PR DESCRIPTION
This PR takes changes from https://github.com/truenas/middleware/pull/6281 ( thank you @dhiltonp for your contribution ) to allow importing pools which are consuming complete disk(s). With this change, it also corrects behavior so that middleware is able to recognize that a complete disk is being used by a pool which middleware was not able to translate before.