### PR TITLE
NAS-110794 / 21.06 / Inherit special_small_blocks by default

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3135,6 +3135,7 @@ class PoolDatasetService(CRUDService):
         ('edit', _add_inherit('readonly')),
         ('edit', _add_inherit('recordsize')),
         ('edit', _add_inherit('snapdir')),
+        ('edit', _add_inherit('special_small_blocks')),
         ('add', Inheritable('quota_warning', value=Int('quota_warning', validators=[Range(0, 100)]))),
         ('add', Inheritable('quota_critical', value=Int('quota_critical', validators=[Range(0, 100)]))),
         ('add', Inheritable('refquota_warning', value=Int('refquota_warning', validators=[Range(0, 100)]))),


### PR DESCRIPTION
Users would expect that special_small_blocks on child datasets inherit the setting of their parent, just like compression.
Not having this inherited leads to costly mistakes, requiring completely rewriting the data to get the smallblocks loaded into the metadata device.

Note:
While the UI isn't able to show "inherited" it does show inherited small block values when set.
However: We might want to also use a dropdown for small-block sizes, as the same limitations apply as for recordsizes (power of 2)