### PR TITLE
NAS-110417 / 12.0 / Have unique serial number for certs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -801,7 +801,7 @@ class CryptoKeyService(Service):
                 not_valid_before
             ).not_valid_after(
                 not_valid_after
-            ).serial_number(options.get('serial') or 1)
+            ).serial_number(options.get('serial') or random.randint(1000, pow(2, 30)))
 
         if san:
             cert = cert.add_extension(san, False)


### PR DESCRIPTION
When creating a self generated certificate, we should have unique serial numbers. The upper limit for serial is 2^160 but in the changes i am keeping it 30 as otherwise it will just be a really long number which is hard to access and it has a low probability that we have 2 self signed certificates generated by us with same serial number.

Original PR: https://github.com/truenas/middleware/pull/6825
Jira URL: https://jira.ixsystems.com/browse/NAS-110417