### PR TITLE
NAS-110600 / 21.06 / Correctly retrieve s3 attachment

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/minio/configure.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/configure.py
@@ -44,11 +44,16 @@ def render_certificates(s3, middleware):
 
 def configure_minio_sys_dir(s3):
     storage_path = s3['storage_path']
+    # Create storage path if it does not exist
+    os.makedirs(storage_path, exist_ok=True)
     minio_dir = os.path.join(storage_path, '.minio.sys')
     shutil.rmtree(minio_dir, ignore_errors=True)
 
 
 def render(service, middleware):
     s3 = middleware.call_sync('s3.config')
+    if not s3['storage_path']:
+        return
+
     configure_minio_sys_dir(s3)
     render_certificates(s3, middleware)

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -13,7 +13,7 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
         results = []
 
         s3_config = await self.middleware.call('s3.config')
-        if not s3_config['storage_path']:
+        if not s3_config['storage_path'] or not os.path.exists(s3_config['storage_path']):
             return results
         else:
             s3_ds = await self.middleware.call('zfs.dataset.path_to_dataset', s3_config['storage_path'])


### PR DESCRIPTION
This commit fixes an issue if s3 path did not exist for some reason ( got deleted or was an old path ), retrieving s3 attachments would error out as the path would not exist. Secondly, if the path does not exist but has been configured - we create the path before starting the s3 service.