### PR TITLE
NAS-110538 / 21.06 / Bug fixes for configuring/unconfiguring an interface

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -259,8 +259,7 @@ class InterfaceService(Service):
         name = iface.name
 
         # Interface not in database lose addresses
-        for address in iface.addresses:
-            iface.remove_address(address)
+        iface.flush()
 
         dhclient_running, dhclient_pid = self.middleware.call_sync('interface.dhclient_status', name)
         # Kill dhclient if its running for this interface

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
@@ -18,6 +18,10 @@ class AddressMixin:
     def add_address(self, address):
         self._address_op("add", address)
 
+    def flush(self):
+        # Remove all configured ip addresses
+        run(['ip', 'addr', 'flush', 'dev', self.name, 'scope', 'global'])
+
     def remove_address(self, address):
         self._address_op("del", address)
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1972,6 +1972,16 @@ class InterfaceService(CRUDService):
 
             # If there are no interfaces configured we start DHCP on all
             if not interfaces:
+                # We should unconfigure interface first before doing autoconfigure. This can be required for cases
+                # like the following:
+                # 1) Fresh install with system having 1 NIC
+                # 2) Configure static ip for the NIC leaving dhcp checked
+                # 3) Test changes
+                # 4) Do not save changes and wait for time out
+                # 5) Rollback happens where the only nic is removed from database
+                # 6) If we don't unconfigure, autoconfigure is called which is supposed to start dhclient on the
+                #    interface. However this will result in the static ip still being set.
+                await self.middleware.call('interface.unconfigure', iface, cloned_interfaces, parent_interfaces)
                 dhclient_aws.append(asyncio.ensure_future(
                     self.middleware.call('interface.autoconfigure', iface, wait_dhcp)
                 ))


### PR DESCRIPTION
This PR fixes following issues:

1) Fixes an issue where assigned static ip would remain set on the interface even after a rollback of changes. This change ensures that we have a clean slate before trying to autocofigure an interface.

2) Use ip addr flush to remove all ip addresses as using `ip addr del` failed in my setup when the system had dhcp + a static ip configured. We want to remove all configured ip addresses and `ip addr flush` does exactly that - it also saves us from repeated subprocess calls for each configured ip address.