### PR TITLE
NAS-110712 / 12.0 / add --trace-malloc arg to middlewared

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -51,6 +51,7 @@ import traceback
 import types
 import urllib.parse
 import uuid
+import tracemalloc
 
 from . import logger
 
@@ -785,7 +786,7 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
 
     def __init__(
         self, loop_debug=False, loop_monitor=True, overlay_dirs=None, debug_level=None,
-        log_handler=None, startup_seq_path=None,
+        log_handler=None, startup_seq_path=None, trace_malloc=False,
         log_format='[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s'
     ):
         super().__init__(overlay_dirs)
@@ -797,6 +798,7 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         self.crash_reporting_semaphore = asyncio.Semaphore(value=2)
         self.loop_debug = loop_debug
         self.loop_monitor = loop_monitor
+        self.trace_malloc = trace_malloc
         self.debug_level = debug_level
         self.log_handler = log_handler
         self.log_format = log_format
@@ -848,7 +850,7 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
             setup_funcs.append((setup_plugin, mod.setup))
 
         def on_modules_loaded():
-            self._console_write(f'resolving plugins schemas')
+            self._console_write('resolving plugins schemas')
 
         self._load_plugins(
             on_module_begin=on_module_begin,
@@ -1359,6 +1361,57 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         for thread_id, stack in get_threads_stacks().items():
             self.logger.debug('Thread %d stack:\n%s', thread_id, ''.join(stack))
 
+    def _tracemalloc_start(self):
+        """
+        Run an endless loop grabbing snapshots of allocated memory using
+        the python's builtin "tracemalloc" module.
+        """
+        # set the thread name
+        osc.set_thread_name('tracemalloc_monitor')
+
+        # initalize tracemalloc
+        tracemalloc.start()
+
+        # change this to limit the number of lines
+        # showing the highest memory consumer
+        limit = 5
+
+        # how often to sleep in seconds before
+        # taking another memory snapshot
+        interval = 5
+
+        # filters for the snapshots so we can
+        # ignore modules that we don't care about
+        filters = (
+            tracemalloc.Filter(False, '<frozen importlib._bootstrap>'),
+            tracemalloc.Filter(False, '<frozen importlib._bootstrap_external>'),
+            tracemalloc.Filter(False, '<unknown>'),
+            tracemalloc.Filter(False, '*tracemalloc.py'),
+        )
+
+        # start the loop
+        prev = None
+        while True:
+            if prev is None:
+                prev = tracemalloc.take_snapshot()
+                prev = prev.filter_traces(filters)
+            else:
+                curr = tracemalloc.take_snapshot()
+                curr = curr.filter_traces(filters)
+                diff = curr.compare_to(prev, 'lineno')
+
+                prev = curr
+                curr = None
+                for idx, stat in enumerate(diff[:limit], 1):
+                    self.logger.debug(f'#{idx}: {stat}')
+
+            # print the memory used by the tracemalloc module itself
+            tm_mem = tracemalloc.get_tracemalloc_memory()
+            # add a newline at end of output to make logs more readable
+            self.logger.debug(f'Memory used by tracemalloc module: {tm_mem:.1f} KiB\n')
+
+            time.sleep(interval)
+
     async def ws_handler(self, request):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
@@ -1499,6 +1552,11 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         await web.TCPSite(runner, '0.0.0.0', 6000, reuse_address=True, reuse_port=True).start()
         await web.UnixSite(runner, '/var/run/middlewared.sock').start()
 
+        if self.trace_malloc:
+            _thr = threading.Thread(target=self._tracemalloc_start)
+            _thr.setDaemon(True)
+            _thr.start()
+
         self.logger.debug('Accepting connections')
         self._console_write('loading completed\n')
 
@@ -1553,6 +1611,7 @@ def main():
     parser.add_argument('--pidfile', '-P', action='store_true')
     parser.add_argument('--disable-loop-monitor', '-L', action='store_true')
     parser.add_argument('--loop-debug', action='store_true')
+    parser.add_argument('--trace-malloc', action='store_true')
     parser.add_argument('--overlay-dirs', '-o', action='append')
     parser.add_argument('--debug-level', choices=[
         'TRACE',
@@ -1591,6 +1650,7 @@ def main():
     Middleware(
         loop_debug=args.loop_debug,
         loop_monitor=not args.disable_loop_monitor,
+        trace_malloc=args.trace_malloc,
         overlay_dirs=args.overlay_dirs,
         debug_level=args.debug_level,
         log_handler=args.log_handler,


### PR DESCRIPTION
This allows one to start `middlewared` in the foreground and pass `--trace-malloc` as an argument to print memory allocations for the middlewared process.

This tracks memory allocations and not memory leaks. However, the idea is that you monitor the output of the logs and if you see a module continually allocate memory and never release it, then you might be able to glean some useful information or at least get pointed somewhere.

This allowed me to spot some low-hanging fruit with middlewared start-up where we were allocating significant memory unnecessarily. See https://github.com/truenas/iocage/pull/345 for details.