### PR TITLE
NAS-110714 / 12.0 / fix memory allocation/leak issue in multipath.query()

### DIFF
--- a/src/middlewared/middlewared/plugins/multipath.py
+++ b/src/middlewared/middlewared/plugins/multipath.py
@@ -7,6 +7,9 @@ from middlewared.utils import filter_list
 
 class MultipathService(CRUDService):
 
+    class Config:
+        datastore_primary_key_type = 'string'
+
     @filterable
     def query(self, filters, options):
         """

--- a/src/middlewared/middlewared/plugins/multipath.py
+++ b/src/middlewared/middlewared/plugins/multipath.py
@@ -83,6 +83,5 @@ class MultipathService(CRUDService):
                 'status': g.find("./config/State").text,
                 'children': children,
             }),
-        else:
-            doc = None
-            return result
+
+        return result

--- a/src/middlewared/middlewared/plugins/multipath.py
+++ b/src/middlewared/middlewared/plugins/multipath.py
@@ -1,18 +1,11 @@
-try:
-    import sysctl
-except ImportError:
-    sysctl = None
+from xml.etree import ElementTree as ET
 
-from lxml import etree
-
+import sysctl
 from middlewared.service import CRUDService, filterable
-from middlewared.utils import filter_list, osc
+from middlewared.utils import filter_list
 
 
 class MultipathService(CRUDService):
-
-    class Config:
-        datastore_primary_key_type = 'string'
 
     @filterable
     def query(self, filters, options):
@@ -56,86 +49,37 @@ class MultipathService(CRUDService):
               }
             ]
         """
-
-        if osc.IS_LINUX:
-            return []
-
-        multipaths = self.__get_multipaths()
-
-        items = []
-        for mp in multipaths:
-            children = []
-            for cn in mp.consumers:
-                children.append({
-                    "type": "consumer",
-                    "name": cn.devname,
-                    "status": cn.status,
-                    "lun_id": cn.lunid,
-                })
-
-            data = {
-                "type": "root",
-                "name": mp.devname,
-                "status": mp.status,
-                "children": children,
-            }
-            items.append(data)
-
-        return filter_list(items, filters=filters or [], options=options or {})
+        return filter_list(self.__get_multipaths(), filters=filters or [], options=options or {})
 
     def __get_multipaths(self):
-        doc = etree.fromstring(sysctl.filter("kern.geom.confxml")[0].value)
-        return [
-            Multipath(doc=doc, xmlnode=geom)
-            for geom in doc.xpath("//class[name = 'MULTIPATH']/geom")
-        ]
+        doc = ET.fromstring(sysctl.filter("kern.geom.confxml")[0].value)
+        result = []
+        for g in doc.iterfind(".//class[name = 'MULTIPATH']/geom"):
+            # get gmultipath consumer information
+            children = []
+            for i in g.findall('./consumer'):
+                consumer_status = i.find('./config/State').text
+                provref = i.find('./provider').attrib['ref']
+                prov = doc.findall(f'.//provider[@id="{provref}"]')[0]
+                da_name = prov.find('./name').text
+                try:
+                    lun_id = prov.find('./config/lunid').text
+                except Exception:
+                    lun_id = ''
 
+                children.append({
+                    'type': 'consumer',
+                    'name': da_name,
+                    'status': consumer_status,
+                    'lun_id': lun_id,
+                })
 
-class Multipath(object):
-    """
-    Class representing a GEOM_MULTIPATH
-    """
-
-    @property
-    def status(self):
-        return getattr(self, "_status", "Unknown")
-
-    @status.setter
-    def status(self, value):
-        self._status = value
-
-    @property
-    def devices(self):
-        devs = []
-        for consumer in self.consumers:
-            devs.append(consumer.devname)
-        return devs
-
-    def __init__(self, doc, xmlnode):
-        self.name = xmlnode.xpath("./name")[0].text
-        self.devname = f"multipath/{self.name}"
-        self._status = xmlnode.xpath("./config/State")[0].text
-        self.consumers = []
-        for consumer in xmlnode.xpath("./consumer"):
-            status = consumer.xpath("./config/State")[0].text
-            provref = consumer.xpath("./provider/@ref")[0]
-            prov = doc.xpath(f"//provider[@id = '{provref}']")[0]
-            self.consumers.append(Consumer(status, prov))
-
-        self.__xml = xmlnode
-        self.__doc = doc
-
-    def __repr__(self):
-        return f"<Multipath:{self.name} [{','.join(self.devices)}]>"
-
-
-class Consumer(object):
-
-    def __init__(self, status, xmlnode):
-        self.status = status
-        self.devname = xmlnode.xpath("./name")[0].text
-        try:
-            self.lunid = xmlnode.xpath("./config/lunid")[0].text
-        except Exception:
-            self.lunid = ""
-        self.__xml = xmlnode
+            result.append({
+                'type': 'root',
+                'name': 'multipath/' + g.find("./name").text,
+                'status': g.find("./config/State").text,
+                'children': children,
+            }),
+        else:
+            doc = None
+            return result


### PR DESCRIPTION
For reasons that aren't very clear, `multipath.query()` is allocating (leaking) memory that is never freed in the io_thread pool. We, eventually, end up in `_ParserDictionaryContext` in `lxml`. That particular function does some fancy stuff for having a shared global dictionary per thread and "deduplicates" name entries when processing xml data. The idea is that the names of the attributes being processed in the xml document aren't going to change very often. Once everything is "cached" it doesn't grow anymore. This was added to `lxml` for the obvious speed improvements, however, it's causing us problems in our thread pool. I suspect it's because we're using daemon=True for all our threads which means the resources for said thread isn't cleaned up properly (safely) but I digress....

This leak is particularly painful because it shows up even if the user doesn't have multipath disks. The leak is actually happening by this line `doc = etree.fromstring(sysctl.filter("kern.geom.confxml")[0].value)`. Even though there are no multipath objects in the xml document and the method would return an empty `[]`, it still caused memory to be allocated that was never released back to OS.

My fix does 2 things:
1. Instead of using `lxml` in the multipath module, use the built-in xml library since we're not using anything in lxml that isn't already present in the shipped xml library with base python.
2. Get rid of the `Multipath` and `Consumer` classes. I didn't spot any modules importing these modules anywhere and, in my opinion, they made this file entirely overly complicated for no real benefit.

Also, since I'm on my soap-box, I suspect this will (hopefully) fix some of the `middlewared` core dumps that we're seeing. On _every_ _single_ core dump that I analyzed, I saw `_ParserDictionaryContext` somewhere on CPU. Either in the thread that actually crashed, or on another thread.

Finally I can confirm that by simply switching to the base `xml` library, resident memory growth on initial `middlewared` service startup reduced from growing 5-8MB per 60 seconds to not growing at all after the initial memory allocation stabilized.