### PR TITLE
NAS-110701 / 12.0 / Remove copy-paste error from old AD LDAP code. (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -241,8 +241,6 @@ class LDAPQuery(object):
                 if self.ldap['certificate']:
                     try:
                         res = self._handle.sasl_non_interactive_bind_s('EXTERNAL')
-                        if self.ldap['verbose_logging']:
-                            self.logger.debug('Successfully bound to [%s] using client certificate.', server)
                         break
                     except Exception as e:
                         saved_simple_error = e


### PR DESCRIPTION
LDAP plugin doesn't have `verbose_logging` key. We were using this
in code related to SASL_EXTERNAL binds, which are almost never used
in typical environments.

Original PR: https://github.com/truenas/middleware/pull/6895
Jira URL: https://jira.ixsystems.com/browse/NAS-110701