### PR TITLE
NAS-110715 / 21.06 / Do not normalize docker tag when updating app

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -326,7 +326,7 @@ class ChartReleaseService(Service):
         """
         await self.middleware.call('kubernetes.validate_k8s_setup')
         images = [
-            {'orig_tag': tag, **(await self.middleware.call('container.image.parse_image_tag', tag))}
+            {'orig_tag': tag, 'from_image': tag.rsplit(':', 1)[0], 'tag': tag.rsplit(':', 1)[-1]}
             for tag in (await self.middleware.call(
                 'chart.release.query', [['id', '=', release_name]],
                 {'extra': {'retrieve_resources': True}, 'get': True}
@@ -336,7 +336,7 @@ class ChartReleaseService(Service):
 
         bulk_job = await self.middleware.call(
             'core.bulk', 'container.image.pull', [
-                [{'from_image': f'{image["registry"]}/{image["image"]}', 'tag': image['tag']}]
+                [{'from_image': image['from_image'], 'tag': image['tag']}]
                 for image in images
             ]
         )


### PR DESCRIPTION
This commit introduces a change to not normalize the docker tag when updating a chart release app. Motivation is a use case like where a user installs an application consuming 'minio/minio:latest' image. Now when a newer upstream image is available against the tag, we notify the user and he/she will update the app which will result in us pulling the newer image from upstream. However when we normalize the docker tag - what happens is that we during normalization add the default docker registry which results in our image name now being 'registry-1.docker.io/minio/minio'. When the app restarts after updating, docker has pulled the newer image but the tag which it shows is 'registry-1.docker.io/minio/minio:latest' instead of 'minio/minio:latest'. So in essence, the last tag is converted to the former tag whenever docker pulls images but when it consumes it, it does not normalize it which results in the former and latter pointing to different images. In this change we do not normalize and use the tag as is and trust the docker engine to do that for us.

An example:

```
truenas# docker images
REPOSITORY                                         TAG       IMAGE ID       CREATED         SIZE
registry-1.docker.io/minio/minio                   latest    8f1e47ce9c28   41 hours ago    191MB
minio/minio                                        latest    305cf2390a4e   3 weeks ago     184MB
openebs/zfs-driver                                 1.4.0     7f4e41f5c882   3 months ago    164MB
k8s.gcr.io/sig-storage/csi-snapshotter             v4.0.0    da32a49a903a   5 months ago    49.5MB
k8s.gcr.io/sig-storage/snapshot-controller         v4.0.0    f1d8a00ae690   5 months ago    46.6MB
k8s.gcr.io/sig-storage/csi-resizer                 v1.1.0    a8fe79377034   5 months ago    49.2MB
k8s.gcr.io/sig-storage/csi-provisioner             v2.1.0    e0d187f105d6   5 months ago    51.6MB
k8s.gcr.io/sig-storage/csi-node-driver-registrar   v2.1.0    ef2b13b2a066   5 months ago    19.6MB
rancher/coredns-coredns                            1.8.0     296a6d5035e2   6 months ago    42.4MB
rancher/klipper-lb                                 v0.1.2    897ce3c5fc8f   24 months ago   6.1MB
rancher/pause                                      3.1       da86e6ba6ca1   3 years ago     742kB
truenas#
```

After doing `docker pull minio/minio:latest`, we have
```
truenas# docker images
REPOSITORY                                         TAG       IMAGE ID       CREATED         SIZE
minio/minio                                        latest    8f1e47ce9c28   41 hours ago    191MB
registry-1.docker.io/minio/minio                   latest    8f1e47ce9c28   41 hours ago    191MB
minio/minio                                        <none>    305cf2390a4e   3 weeks ago     184MB
openebs/zfs-driver                                 1.4.0     7f4e41f5c882   3 months ago    164MB
k8s.gcr.io/sig-storage/csi-snapshotter             v4.0.0    da32a49a903a   5 months ago    49.5MB
k8s.gcr.io/sig-storage/snapshot-controller         v4.0.0    f1d8a00ae690   5 months ago    46.6MB
k8s.gcr.io/sig-storage/csi-resizer                 v1.1.0    a8fe79377034   5 months ago    49.2MB
k8s.gcr.io/sig-storage/csi-provisioner             v2.1.0    e0d187f105d6   5 months ago    51.6MB
k8s.gcr.io/sig-storage/csi-node-driver-registrar   v2.1.0    ef2b13b2a066   5 months ago    19.6MB
rancher/coredns-coredns                            1.8.0     296a6d5035e2   6 months ago    42.4MB
rancher/klipper-lb                                 v0.1.2    897ce3c5fc8f   24 months ago   6.1MB
rancher/pause                                      3.1       da86e6ba6ca1   3 years ago     742kB
truenas#
```