### PR TITLE
NAS-110724 / 21.06 / optimize certificate alert source (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/certificates.py
+++ b/src/middlewared/middlewared/alert/source/certificates.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from middlewared.alert.base import AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.alert.schedule import CrontabSchedule
 
 
 class CertificateIsExpiringAlertClass(AlertClass):
@@ -24,32 +25,11 @@ class CertificateExpiredAlertClass(AlertClass):
     text = "Certificate %(name)r has expired."
 
 
-class CertificateIsExpiringAlertSource(AlertSource):
-    async def check(self):
-        alerts = []
-
-        for cert in await self.middleware.call(
-            'certificate.query',
-            [['certificate', '!=', None]]
-        ) + await self.middleware.call('certificateauthority.query'):
-            if cert['parsed']:
-                diff = (datetime.strptime(cert['until'], '%a %b %d %H:%M:%S %Y') - datetime.utcnow()).days
-                if diff < 10:
-                    if diff >= 0:
-                        alerts.append(
-                            Alert(
-                                CertificateIsExpiringSoonAlertClass if diff <= 2 else CertificateIsExpiringAlertClass,
-                                {
-                                    'name': cert['name'],
-                                    'days': diff,
-                                },
-                                key=[cert['name']],
-                            )
-                        )
-                    else:
-                        alerts.append(Alert(CertificateExpiredAlertClass, {'name': cert['name']}, key=[cert['name']]))
-
-        return alerts
+class CertificateParsingFailedAlertClass(AlertClass):
+    category = AlertCategory.CERTIFICATES
+    level = AlertLevel.WARNING
+    title = "Certificate Parsing Failed"
+    text = "Failed to parse %(type)s %(name)r."
 
 
 class CertificateRevokedAlertClass(AlertClass):
@@ -59,84 +39,118 @@ class CertificateRevokedAlertClass(AlertClass):
     text = '%(service)s %(type)s has been revoked. Please replace the certificate immediately.'
 
 
-class CertificateRevokedAlertSource(AlertSource):
-    async def check(self):
-        alerts = []
-
-        for cert_id, service, type_c, datastore in (
-            ((await self.middleware.call('ftp.config'))['ssltls_certificate'], 'FTP', 'certificate', 'certificate'),
-            ((await self.middleware.call('s3.config'))['certificate'], 'S3', 'certificate', 'certificate'),
-            ((await self.middleware.call('webdav.config'))['certssl'], 'Webdav', 'certificate', 'certificate'),
-            (
-                (await self.middleware.call('openvpn.server.config'))['server_certificate'],
-                'OpenVPN server', 'certificate', 'certificate'
-            ),
-            (
-                (await self.middleware.call('openvpn.client.config'))['client_certificate'],
-                'OpenVPN client', 'certificate', 'certificate'
-            ),
-            (
-                (await self.middleware.call('system.general.config'))['ui_certificate']['id'],
-                'Web UI', 'certificate', 'certificate'
-            ),
-            (
-                (await self.middleware.call('system.advanced.config'))['syslog_tls_certificate'],
-                'Syslog', 'certificate', 'certificate'
-            ),
-            (
-                (await self.middleware.call('openvpn.server.config'))['root_ca'],
-                'OpenVPN server', 'root certificate authority', 'certificateauthority'
-            ),
-            (
-                (await self.middleware.call('openvpn.client.config'))['root_ca'],
-                'OpenVPN client', 'root certificate authority', 'certificateauthority'
-            )
-        ):
-            if (
-                cert_id and (
-                    await self.middleware.call(
-                        f'{datastore}.query', [
-                            ['id', '=', cert_id]
-                        ], {'get': True}
-                    )
-                )['revoked']
-            ):
-                alerts.append(Alert(CertificateRevokedAlertClass, {'service': service, 'type': type_c}))
-
-        return alerts
-
-
-class CertificateParsingFailedAlertClass(AlertClass):
-    category = AlertCategory.CERTIFICATES
-    level = AlertLevel.WARNING
-    title = "Certificate Parsing Failed"
-    text = "Failed to parse %(type)s %(name)r."
-
-
-class CertificateParsingFailedAlertSource(AlertSource):
-    async def check(self):
-        alerts = []
-
-        for cert in await self.middleware.call(
-                'certificate.query',
-                [['certificate', '!=', None]]
-        ) + await self.middleware.call('certificateauthority.query'):
-            if not cert['parsed']:
-                alerts.append(
-                    Alert(
-                        CertificateParsingFailedAlertClass,
-                        {
-                            "type": cert["cert_type"].capitalize(),
-                            "name": cert["name"],
-                        },
-                    )
-                )
-
-        return alerts
-
-
 class WebUiCertificateSetupFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    # this is consumed in nginx.conf in the etc plugin
+    # you don't have to specify the `AlertClass` verbiage
+    # of the class name when calling it
     category = AlertCategory.CERTIFICATES
     level = AlertLevel.CRITICAL
     title = "Web UI HTTPS Certificate Setup Failed"
     text = "Web UI HTTPS certificate setup failed."
+
+
+class CertificateChecksAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=0)  # every 24 hours
+    run_on_backup_node = False
+
+    async def _get_service_certs(self):
+        _type = 'certificate'
+        service_certs = [
+            {
+                'id': (await self.middleware.call('ftp.config'))['ssltls_certificate'],
+                'service': 'FTP',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('s3.config'))['certificate'],
+                'service': 'S3',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('webdav.config'))['certssl'],
+                'service': 'Webdav',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('openvpn.server.config'))['server_certificate'],
+                'service': 'OpenVPN Server',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('openvpn.client.config'))['client_certificate'],
+                'service': 'OpenVPN Client',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('system.general.config'))['ui_certificate']['id'],
+                'service': 'Web UI',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('system.advanced.config'))['syslog_tls_certificate'],
+                'service': 'Syslog',
+                'type': _type,
+            },
+        ]
+        return service_certs
+
+    async def _get_cas(self):
+        _type = 'root certificate authority'
+        ca_certs = [
+            {
+                'id': (await self.middleware.call('openvpn.server.config'))['root_ca'],
+                'service': 'Web UI',
+                'type': _type,
+            },
+            {
+                'id': (await self.middleware.call('openvpn.client.config'))['root_ca'],
+                'service': 'Syslog',
+                'type': _type,
+            },
+        ]
+        return ca_certs
+
+    async def check(self):
+        alerts = []
+        certs = await self.middleware.call('certificate.query', [['certificate', '!=', None]])
+        certs.extend(await self.middleware.call('certificateauthority.query'))
+
+        # make the sure certs have been parsed correctly
+        parsed = []
+        for cert in certs:
+            if not cert['parsed']:
+                alerts.append(Alert(
+                    CertificateParsingFailedAlertClass,
+                    {"type": cert["cert_type"].capitalize(), "name": cert["name"]},
+                ))
+            else:
+                parsed.append(cert)
+
+        if parsed:
+            revoked_certs = [i for i in await self._get_service_certs() + await self._get_cas() if i['id']]
+
+            for cert in parsed:
+                # check the parsed certificate(s) for expiration
+                if cert['cert_type'].capitalize() == 'CERTIFICATE':
+                    diff = (datetime.strptime(cert['until'], '%a %b %d %H:%M:%S %Y') - datetime.utcnow()).days
+                    if diff < 10:
+                        if diff >= 0:
+                            alerts.append(Alert(
+                                CertificateIsExpiringSoonAlertClass if diff <= 2 else CertificateIsExpiringAlertClass,
+                                {'name': cert['name'], 'days': diff}, key=[cert['name']],
+                            ))
+                        else:
+                            alerts.append(Alert(
+                                CertificateExpiredAlertClass,
+                                {'name': cert['name']}, key=[cert['name']]
+                            ))
+
+                # check the parsed certificate(s) for revocation
+                for revoked in revoked_certs:
+                    if revoked['id'] == cert['id'] and cert['revoked']:
+                        alerts.append(Alert(
+                            CertificateRevokedAlertClass,
+                            {'service': revoked['service'], 'type': revoked['type']}
+                        ))
+
+        return alerts


### PR DESCRIPTION
Anytime `certificate.query()` or `certificateauthority.query()` is made the following calls are made for *EACH* cert and/or ca: `cryptokey.load_certificate` 2x `cryptokey.load_private_key` 1x.

In the `certificates` alert source, we do not specify a schedule so it defaults to running every 60 seconds. Furthermore, between the `certificate.query()` and `certificateauthority.query()` api calls, we were calling them13 times total.

This means the formula for API calls being made every 60 seconds is `39 * n`. `n` being the number of certificates and/or cas on the system. So for 2 certificates on the system, (potentially) 78 API calls were made. That's especially painful because the `cert**.query()` api calls return quite a bit of data but they also return quite a bit of duplicate data. Part of this data is the full contents (in string form) the public/private key contents. This becomes quite a bit of data to throw around. With my change the formula for calculating API calls is `3 * n`.

My changes do a few things:

1. don't run the certificates alert source every 60 seconds but instead run it once a day (discussed w/ @sonicaj)
2. restructure the certificates alert source so that we only call `certificate.query()` and `certificateauthority.query()` once
3. this alert does not need to be run on the standby controller since on failover we reconfigure the certs and restart webUI



Original PR: https://github.com/truenas/middleware/pull/6903
Jira URL: https://jira.ixsystems.com/browse/NAS-110724