### PR TITLE
NAS-110656 / 21.06 / Update logic to determine if a pci device is a gpu

### DIFF
--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -15,7 +15,15 @@ def get_gpus():
         raise CallError(f'Unable to list available gpus: {stderr.decode()}')
 
     gpus = []
-    gpu_slots = [line.strip() for line in stdout.decode().splitlines() if 'VGA compatible controller' in line]
+    gpu_slots = [
+        line.strip()
+        for line in stdout.decode().splitlines() if any(
+            k in line for k in (
+                'VGA compatible controller',
+                'Display controller',
+            )
+        )
+    ]
     for gpu_line in gpu_slots:
         addr = gpu_line.split()[0]
         addr_re = RE_PCI_ADDR.match(addr)


### PR DESCRIPTION
For a user who is using a BMC board, he sees GPU being presented/declared to the system differently. This commit adds changes to account for such behaviours and make sure that we consider this pci device as a valid gpu entry.