### PR TITLE
NAS-110779 / 12.0 / Consistently retrieve boot time (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -622,7 +622,7 @@ class SystemService(Service):
             'system_product': product,
             'system_product_version': product_version,
             'license': await self.middleware.run_in_thread(self._get_license),
-            'boottime': datetime.fromtimestamp(psutil.boot_time()),
+            'boottime': datetime.fromtimestamp(psutil.boot_time(), timezone.utc),
             'datetime': datetime.utcnow(),
             'birthday': birthday_date,
             'timezone': timezone_setting,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e406f2758bec6f8e0b54254ece068ae6bf2197b2

This commit fixes an issue where we were not normalizing the datetime object.

Original PR: https://github.com/truenas/middleware/pull/6917
Jira URL: https://jira.ixsystems.com/browse/NAS-110779