### PR TITLE
NAS-110803 / 21.06 / Do not treat mountpoint specially

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2828,6 +2828,7 @@ class PoolDatasetService(CRUDService):
                 ('org.freenas:refquota_critical', 'refquota_critical', None),
                 ('org.truenas:managedby', 'managedby', None),
                 ('dedup', 'deduplication', str.upper),
+                ('mountpoint', None, _null),
                 ('aclmode', None, str.upper),
                 ('acltype', None, str.upper),
                 ('xattr', None, str.upper),

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2864,6 +2864,12 @@ class PoolDatasetService(CRUDService):
                 if method:
                     dataset[i]['value'] = method(dataset[i]['value'])
 
+            if 'mountpoint' in dataset:
+                # This is treated specially to keep backwards compatibility with API
+                dataset['mountpoint'] = dataset['mountpoint']['value']
+            if dataset['type'] == 'VOLUME':
+                dataset['mountpoint'] = None
+
             dataset['user_properties'] = {
                 k: v for k, v in dataset['properties'].items() if ':' in k and k not in self._internal_user_props()
             }

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -483,8 +483,7 @@ class ZFSDatasetService(CRUDService):
         datasets which does not incur the performance penalty.
 
         `query-options.extra.properties` is a list of properties which should be retrieved. If null ( by default ),
-        it would retrieve all properties, if empty, it will retrieve no property ( `mountpoint` is special in this
-        case and is controlled by `query-options.extra.mountpoint` attribute ).
+        it would retrieve all properties, if empty, it will retrieve no property.
 
         We provide 2 ways how zfs.dataset.query returns dataset's data. First is a flat structure ( default ), which
         means that all the datasets in the system are returned as separate objects which also contain all the data

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -14,23 +14,35 @@ def test__get_dataset_recursive_1():
     dataset, recursive = get_dataset_recursive(
         [
             {
-                "mountpoint": "/mnt/data",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/test",
-                        "children": []
+                        "children": [],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/test",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/test",
-                "children": []
+                "children": [],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/test",
+                    }
+                }
             }
         ],
         "/mnt/data",
     )
 
-    assert dataset["mountpoint"] == "/mnt/data"
+    assert dataset["properties"]["mountpoint"]["value"] == "/mnt/data"
     assert recursive is True
 
 
@@ -38,23 +50,35 @@ def test__get_dataset_recursive_2():
     dataset, recursive = get_dataset_recursive(
         [
             {
-                "mountpoint": "/mnt/data",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/test",
-                        "children": []
+                        "children": [],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/test",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/test",
-                "children": []
+                "children": [],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/test",
+                    }
+                }
             }
         ],
         "/mnt/data/test",
     )
 
-    assert dataset["mountpoint"] == "/mnt/data/test"
+    assert dataset["properties"]["mountpoint"]["value"] == "/mnt/data/test"
     assert recursive is False
 
 
@@ -62,23 +86,35 @@ def test__get_dataset_recursive_3():
     dataset, recursive = get_dataset_recursive(
         [
             {
-                "mountpoint": "/mnt/data",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/test",
-                        "children": []
+                        "children": [],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/test",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/test",
-                "children": []
+                "children": [],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/test",
+                    }
+                }
             }
         ],
         "/mnt/data/test2",
     )
 
-    assert dataset["mountpoint"] == "/mnt/data"
+    assert dataset["properties"]["mountpoint"]["value"] == "/mnt/data"
     assert recursive is False
 
 
@@ -86,37 +122,61 @@ def test__get_dataset_recursive_4():
     dataset, recursive = get_dataset_recursive(
         [
             {
-                "mountpoint": "/mnt/data",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/backup",
                         "children": [
                             {
-                                "mountpoint": "/mnt/data/backup/test0/test1/test2",
                                 "children": [],
+                                "properties": {
+                                    "mountpoint": {
+                                        "value": "/mnt/data/backup/test0/test1/test2",
+                                    }
+                                }
                             }
-                        ]
+                        ],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/backup",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/backup",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/backup/test0/test1/test2",
                         "children": [],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/backup/test0/test1/test2",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/backup",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/backup/test0/test1/test2",
                 "children": [],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/backup/test0/test1/test2",
+                    }
+                }
             }
         ],
         "/mnt/data/backup/test0",
     )
 
-    assert dataset["mountpoint"] == "/mnt/data/backup"
+    assert dataset["properties"]["mountpoint"]["value"] == "/mnt/data/backup"
     assert recursive is True
 
 
@@ -124,37 +184,61 @@ def test__get_dataset_recursive_5():
     dataset, recursive = get_dataset_recursive(
         [
             {
-                "mountpoint": "/mnt/data",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/backup",
                         "children": [
                             {
-                                "mountpoint": "/mnt/data/backup/test0/test1/test2",
                                 "children": [],
+                                "properties": {
+                                    "mountpoint": {
+                                        "value": "/mnt/data/backup/test0/test1/test2",
+                                    }
+                                }
                             }
-                        ]
+                        ],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/backup",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/backup",
                 "children": [
                     {
-                        "mountpoint": "/mnt/data/backup/test0/test1/test2",
                         "children": [],
+                        "properties": {
+                            "mountpoint": {
+                                "value": "/mnt/data/backup/test0/test1/test2",
+                            }
+                        }
                     }
-                ]
+                ],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/backup",
+                    }
+                }
             },
             {
-                "mountpoint": "/mnt/data/backup/test0/test1/test2",
                 "children": [],
+                "properties": {
+                    "mountpoint": {
+                        "value": "/mnt/data/backup/test0/test1/test2",
+                    }
+                }
             }
         ],
         "/mnt/data/backup/test0/test3",
     )
 
-    assert dataset["mountpoint"] == "/mnt/data/backup"
+    assert dataset["properties"]["mountpoint"]["value"] == "/mnt/data/backup"
     assert recursive is False
 
 


### PR DESCRIPTION
This PR introduces changes to make sure we are consistent in our usage wrt consuming `mountpoint` property.
Before py-libzfs used to return `mountpoint` key/value always even if it did or did not return the actual value of the property. This can be confusing and lead to errors/mistakes - the changes introduced here expect the key to not be present anymore and instead rely on the property to be retrieved explicitly and not make an implicit expectation that it's going to be there.