### PR TITLE
NAS-110712 / 21.08 / add --trace-malloc arg to middlewared (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -936,7 +936,9 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
                         delay = method._periodic.interval
 
                     method_name = f'{service_name}.{task_name}'
-                    self.logger.debug(f"Setting up periodic task {method_name} to run every {method._periodic.interval} seconds")
+                    self.logger.debug(
+                        f"Setting up periodic task {method_name} to run every {method._periodic.interval} seconds"
+                    )
 
                     self.loop.call_later(
                         delay,
@@ -1370,10 +1372,15 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         for thread_id, stack in get_threads_stacks().items():
             self.logger.debug('Thread %d stack:\n%s', thread_id, ''.join(stack))
 
-    def _tracemalloc_start(self):
+    def _tracemalloc_start(self, limit, interval):
         """
         Run an endless loop grabbing snapshots of allocated memory using
         the python's builtin "tracemalloc" module.
+
+        `limit` integer representing number of lines to print showing
+                highest memory consumer
+        `interval` integer representing the time in seconds to wait
+                before taking another memory snapshot
         """
         # set the thread name
         osc.set_thread_name('tracemalloc_monitor')
@@ -1381,13 +1388,11 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         # initalize tracemalloc
         tracemalloc.start()
 
-        # change this to limit the number of lines
-        # showing the highest memory consumer
-        limit = 5
-
-        # how often to sleep in seconds before
-        # taking another memory snapshot
-        interval = 5
+        # if given bogus numbers, default both of them respectively
+        if limit <= 0:
+            limit = 5
+        if interval <= 0:
+            interval = 5
 
         # filters for the snapshots so we can
         # ignore modules that we don't care about
@@ -1411,13 +1416,16 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
 
                 prev = curr
                 curr = None
+                stats = f'\nTop {limit} consumers:'
                 for idx, stat in enumerate(diff[:limit], 1):
-                    self.logger.debug(f'#{idx}: {stat}')
+                    stats += f'#{idx}: {stat}\n'
 
-            # print the memory used by the tracemalloc module itself
-            tm_mem = tracemalloc.get_tracemalloc_memory()
-            # add a newline at end of output to make logs more readable
-            self.logger.debug(f'Memory used by tracemalloc module: {tm_mem:.1f} KiB\n')
+                # print the memory used by the tracemalloc module itself
+                tm_mem = tracemalloc.get_tracemalloc_memory()
+                # add a newline at end of output to make logs more readable
+                stats += f'Memory used by tracemalloc module: {tm_mem:.1f} KiB\n'
+
+                self.logger.debug(stats)
 
             time.sleep(interval)
 
@@ -1573,7 +1581,9 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         await web.UnixSite(runner, '/var/run/middlewared.sock').start()
 
         if self.trace_malloc:
-            _thr = threading.Thread(target=self._tracemalloc_start)
+            limit = self.trace_malloc[0]
+            interval = self.trace_malloc[1]
+            _thr = threading.Thread(target=self._tracemalloc_start, args=(limit, interval,))
             _thr.setDaemon(True)
             _thr.start()
 
@@ -1631,7 +1641,7 @@ def main():
     parser.add_argument('--pidfile', '-P', action='store_true')
     parser.add_argument('--disable-loop-monitor', '-L', action='store_true')
     parser.add_argument('--loop-debug', action='store_true')
-    parser.add_argument('--trace-malloc', action='store_true')
+    parser.add_argument('--trace-malloc', '-tm', action='store', nargs=2, type=int, default=False)
     parser.add_argument('--overlay-dirs', '-o', action='append')
     parser.add_argument('--debug-level', choices=[
         'TRACE',


### PR DESCRIPTION
This allows one to start `middlewared` in the foreground and pass `--trace-malloc` as an argument to print memory allocations for the middlewared process.

This tracks memory allocations and not memory leaks. However, the idea is that you monitor the output of the logs and if you see a module continually allocate memory and never release it, then you might be able to glean some useful information or at least get pointed somewhere.

This allowed me to spot some low-hanging fruit with middlewared start-up where we were allocating significant memory unnecessarily. See https://github.com/truenas/iocage/pull/345 for details.

Original PR: https://github.com/truenas/middleware/pull/6896
Jira URL: https://jira.ixsystems.com/browse/NAS-110712