### PR TITLE
NAS-110844 / 21.08 / Allow retrieving snapshot(s) of dataset(s) from pool.dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2786,6 +2786,10 @@ class PoolDatasetService(CRUDService):
         If no properties are desired, in that case an empty list should be sent.
 
         `query-options.extra.snapshots` can be set to retrieve snapshot(s) of dataset in question.
+
+        `query-options.extra.snapshots_recursive` can be set to retrieve snapshot(s) recursively of dataset in question.
+        If `query-options.extra.snapshots_recursive` and `query-options.extra.snapshots` are set, snapshot(s) will be
+        retrieved recursively.
         """
         # Optimization for cases in which they can be filtered at zfs.dataset.query
         zfsfilters = []
@@ -2799,6 +2803,7 @@ class PoolDatasetService(CRUDService):
         retrieve_children = extra.get('retrieve_children', True)
         props = extra.get('properties')
         snapshots = extra.get('snapshots')
+        snapshots_recursive = extra.get('snapshots_recursive')
         return filter_list(
             self.__transform(self.middleware.call_sync(
                 'zfs.dataset.query', zfsfilters, {
@@ -2807,6 +2812,7 @@ class PoolDatasetService(CRUDService):
                         'retrieve_children': retrieve_children,
                         'properties': props,
                         'snapshots': snapshots,
+                        'snapshots_recursive': snapshots_recursive,
                     }
                 }
             ), retrieve_children, internal_datasets_filters,

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2784,6 +2784,8 @@ class PoolDatasetService(CRUDService):
         `query-options.extra.properties` which when `null` ( which is the default ) will retrieve all properties
         and otherwise a list can be specified like `["type", "used", "available"]` to retrieve selective properties.
         If no properties are desired, in that case an empty list should be sent.
+
+        `query-options.extra.snapshots` can be set to retrieve snapshot(s) of dataset in question.
         """
         # Optimization for cases in which they can be filtered at zfs.dataset.query
         zfsfilters = []
@@ -2796,11 +2798,15 @@ class PoolDatasetService(CRUDService):
         extra = copy.deepcopy(options.get('extra', {}))
         retrieve_children = extra.get('retrieve_children', True)
         props = extra.get('properties')
+        snapshots = extra.get('snapshots')
         return filter_list(
             self.__transform(self.middleware.call_sync(
                 'zfs.dataset.query', zfsfilters, {
                     'extra': {
-                        'flat': extra.get('flat', True), 'retrieve_children': retrieve_children, 'properties': props,
+                        'flat': extra.get('flat', True),
+                        'retrieve_children': retrieve_children,
+                        'properties': props,
+                        'snapshots': snapshots,
                     }
                 }
             ), retrieve_children, internal_datasets_filters,

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -508,6 +508,7 @@ class ZFSDatasetService(CRUDService):
         retrieve_properties = extra.get('retrieve_properties', True)
         retrieve_children = extra.get('retrieve_children', True)
         snapshots = extra.get('snapshots')
+        snapshots_recursive = extra.get('snapshots_recursive')
         if not retrieve_properties:
             # This is a short hand version where consumer can specify that they don't want any property to
             # be retrieved
@@ -518,6 +519,7 @@ class ZFSDatasetService(CRUDService):
             # Handle `id` filter specially to avoiding getting all datasets
             kwargs = dict(
                 props=props, user_props=user_properties, snapshots=snapshots, retrieve_children=retrieve_children,
+                snapshots_recursive=snapshots_recursive,
             )
             if filters and filters[0][0] == 'id':
                 if filters[0][1] == '=':


### PR DESCRIPTION
This commit introduces changes to allow retrieving snapshots of a specific dataset in question. This will help consumer(s) avoid filtering snapshot(s) from zfs.snapshot.query and user(s) can just retrieve snapshots of a specific dataset in question easily.