### PR TITLE
NAS-110894 / 21.08 / Reinitialize udev monitor on udev polling error

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/udev_events_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/udev_events_linux.py
@@ -16,14 +16,14 @@ class DeviceService(Service):
 
 
 def udev_events(middleware):
-    context = pyudev.Context()
-    monitor = pyudev.Monitor.from_netlink(context)
-    monitor.filter_by(subsystem='block')
-    monitor.filter_by(subsystem='net')
     while True:
         # We always want to keep polling udev, let's log what error we are
         # seeing and fix them accordingly as we see them
         try:
+            context = pyudev.Context()
+            monitor = pyudev.Monitor.from_netlink(context)
+            monitor.filter_by(subsystem='block')
+            monitor.filter_by(subsystem='net')
             for device in iter(monitor.poll, None):
                 middleware.call_hook_sync(
                     f'udev.{device.subsystem}', data={**dict(device), 'SYS_NAME': device.sys_name}


### PR DESCRIPTION
Observed `OSError: Error while polling fd: 28` in an infinite loop.

@rick-mesta might be worth including into 21.06-BETA.1