### PR TITLE
NAS-110887 / 21.06-BETA.1 / enable STP by default when creating bridges on SCALE (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -12,7 +12,11 @@ __all__ = ["create_bridge", "BridgeMixin"]
 
 
 def create_bridge(name):
-    run(["ip", "link", "add", name, "type", "bridge"])
+    cmd = [
+        "ip", "link", "add", name, "type", "bridge",
+        "stp_state", "1"  # enable stp by default 1 == on 0 == off
+    ]
+    run(cmd)
     interface.Interface(name).up()
 
 


### PR DESCRIPTION
FreeBSD bridges have STP/RSTP enabled by default for obvious reasons. Mirror the behavior on SCALE.

Original PR: https://github.com/truenas/middleware/pull/6945
Jira URL: https://jira.ixsystems.com/browse/NAS-110887