### PR TITLE
NAS-110773 / 21.08 / Fix kerberos error (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -284,7 +284,7 @@ class KerberosService(ConfigService):
                                     f"with principal [{data['kerberos_principal']}] "
                                     f"failed: {kinit.stderr.decode()}")
 
-                elif dstype == DSType.LDAP:
+                elif dstype == DSType.DS_TYPE_LDAP:
                     raise CallError(f"kinit with principal [{data['kerberos_principal']}] "
                                     f"failed: {kinit.stderr.decode()}")
             return True
@@ -292,7 +292,7 @@ class KerberosService(ConfigService):
         if dstype == DSType.DS_TYPE_ACTIVEDIRECTORY:
                 principal = f'{data["bindname"]}@{data["domainname"].upper()}'
 
-        elif dstype == DSType.LDAP:
+        elif dstype == DSType.DS_TYPE_LDAP:
                 krb_realm = await self.middleware.call(
                     'kerberos.realm.query',
                     [('id', '=', data['kerberos_realm'])],


### PR DESCRIPTION
https://jira.ixsystems.com/browse/NAS-110214
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 367, in run
    await self.future
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 403, in __run_body
    rv = await self.method(*([self] + args))
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/smb.py", line 473, in configure
    await self.middleware.call("directoryservices.initialize")
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1238, in call
    return await self._call(
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1195, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/directoryservices.py", line 416, in initialize
    await self.middleware.call('kerberos.start')
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1238, in call
    return await self._call(
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1195, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/kerberos.py", line 577, in start
    await asyncio.wait_for(self._kinit(), timeout=kinit_timeout)
  File "/usr/local/lib/python3.8/asyncio/tasks.py", line 494, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/kerberos.py", line 322, in _kinit
    await self.do_kinit(ldap)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/kerberos.py", line 273, in do_kinit
    elif dstype == DSType.LDAP:
  File "/usr/local/lib/python3.8/enum.py", line 384, in __getattr__
    raise AttributeError(name) from None
AttributeError: LDAP
```

Original PR: https://github.com/truenas/middleware/pull/6863
Jira URL: https://jira.ixsystems.com/browse/NAS-110773