### PR TITLE
NAS-110929 / 21.08 / Allow retrieving catalog data partially

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -1,0 +1,29 @@
+import errno
+import os
+
+from middlewared.schema import accepts, Dict, Str
+from middlewared.service import CallError, Service
+
+
+class CatalogService(Service):
+
+    class Config:
+        cli_namespace = 'app.catalog'
+
+    @accepts(
+        Str('item_name'),
+        Dict(
+            'item_version_details',
+            Str('catalog', required=True),
+            Str('train', required=True),
+        )
+    )
+    def get_item_details(self, item_name, options):
+        """
+        Retrieve information of `item_name` `item_version_details.catalog` catalog item.
+        """
+        catalog = self.middleware.call_sync('catalog.get_instance', options['catalog'])
+        item_location = os.path.join(catalog['location'], options['train'], item_name)
+        if not os.path.exists(item_location):
+            raise CallError(f'Unable to locate {item_name!r} at {item_location!r}', errno=errno.ENOENT)
+        return self.middleware.call_sync('catalog.retrieve_item_details', item_location)

--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -27,6 +27,8 @@ class CatalogService(Service):
         item_location = os.path.join(catalog['location'], options['train'], item_name)
         if not os.path.exists(item_location):
             raise CallError(f'Unable to locate {item_name!r} at {item_location!r}', errno=errno.ENOENT)
+        elif not os.path.isdir(item_location):
+            raise CallError(f'{item_location!r} must be a directory')
 
         if options['cache'] and self.middleware.call_sync(
             'cache.has_key', f'catalog_{options["catalog"]}_train_details'

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -127,9 +127,10 @@ class CatalogService(Service):
         return trains
 
     @private
-    def retrieve_item_details(self, item_location, options):
+    def retrieve_item_details(self, item_location, options=None):
         item = item_location.rsplit('/', 1)[-1]
         train = item_location.rsplit('/', 2)[-2]
+        options = options or {}
         questions_context = options.get('questions_context') or self.middleware.call_sync(
             'catalog.get_normalised_questions_context'
         )

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -119,6 +119,7 @@ class CatalogService(Service):
                     'healthy': False,  # healthy means that each version the item hosts is valid and healthy
                     'healthy_error': None,  # An error string explaining why the item is not healthy
                     'versions': {},
+                    'latest_version': None,
                 }
 
                 schema = f'{train}.{item}'
@@ -137,10 +138,13 @@ class CatalogService(Service):
                 item_data.update(self.item_details(item_location, schema, questions_context))
                 unhealthy_versions = []
                 for k, v in sorted(item_data['versions'].items(), key=lambda v: parse_version(v[0]), reverse=True):
-                    if not item_data['app_readme'] and v['healthy']:
-                        item_data['app_readme'] = v['app_readme']
-                    elif not v['healthy']:
+                    if not v['healthy']:
                         unhealthy_versions.append(k)
+                    else:
+                        if not item_data['app_readme']:
+                            item_data['app_readme'] = v['app_readme']
+                        if not item_data['latest_version']:
+                            item_data['latest_version'] = k
 
                 if unhealthy_versions:
                     if train in preferred_trains:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -49,8 +49,10 @@ class CatalogService(Service):
 
         if options['cache'] and self.middleware.call_sync('cache.has_key', f'catalog_{label}_train_details'):
             orig_data = self.middleware.call_sync('cache.get', f'catalog_{label}_train_details')
+            questions_context = None if not options['retrieve_versions'] else self.middleware.call_sync(
+                'catalog.get_normalised_questions_context'
+            )
             cached_data = {}
-            questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
             for train in orig_data:
                 if not all_trains and train not in options['trains']:
                     continue
@@ -166,6 +168,7 @@ class CatalogService(Service):
             'healthy_error': None,  # An error string explaining why the item is not healthy
             'versions': {},
             'latest_version': None,
+            'latest_app_version': None,
         }
 
         schema = f'{train}.{item}'
@@ -189,6 +192,7 @@ class CatalogService(Service):
                     item_data['app_readme'] = v['app_readme']
                 if not item_data['latest_version']:
                     item_data['latest_version'] = k
+                    item_data['latest_app_version'] = v['chart_metadata'].get('appVersion')
 
         if unhealthy_versions:
             item_data['healthy_error'] = f'Errors were found with {", ".join(unhealthy_versions)} version(s)'

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -119,20 +119,19 @@ class CatalogService(Service):
 
         for train in os.listdir(location):
             if (
-                not os.path.isdir(os.path.join(location, train)) or train.startswith('.') or 
-                train in ('library', 'docs') or not VALID_TRAIN_REGEX.match(train)
+                not (all_trains or train in trains_filter) or not os.path.isdir(
+                    os.path.join(location, train)
+                ) or train.startswith('.') or train in ('library', 'docs') or not VALID_TRAIN_REGEX.match(train)
             ):
                 continue
 
             trains[train] = {}
-
-        for train in filter(
-            lambda c: (all_trains or c in trains_filter) and os.path.exists(os.path.join(location, c)),
-            trains
-        ):
             category_path = os.path.join(location, train)
             for item in filter(lambda p: os.path.isdir(os.path.join(category_path, p)), os.listdir(category_path)):
                 item_location = os.path.join(category_path, item)
+                if not os.path.isdir(item_location):
+                    continue
+
                 trains[train][item] = self.retrieve_item_details(item_location, {
                     'questions_context': questions_context,
                 })

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -60,7 +60,7 @@ class CatalogService(CRUDService):
                         'cache': extra.get('cache', True),
                         'retrieve_all_trains': extra.get('retrieve_all_trains', True),
                         'trains': extra.get('trains', []),
-                        'skip_retrieving_versions': extra.get('skip_retrieving_versions'),
+                        'retrieve_versions': extra.get('retrieve_versions', True),
                     },
                 )
             except Exception:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -56,7 +56,12 @@ class CatalogService(CRUDService):
         if extra.get('item_details'):
             try:
                 catalog['trains'] = await self.middleware.call(
-                    'catalog.items', catalog['label'], {'cache': extra.get('cache', True)},
+                    'catalog.items', catalog['label'], {
+                        'cache': extra.get('cache', True),
+                        'retrieve_all_trains': extra.get('retrieve_all_trains', True),
+                        'trains': extra.get('trains', []),
+                        'skip_retrieving_versions': extra.get('skip_retrieving_versions'),
+                    },
                 )
             except Exception:
                 # We do not want this to fail as it will block `catalog.query` otherwise. The error would


### PR DESCRIPTION
As community usage has grown, we are seeing lots of trains with a decent number of applications with decent number of versions in a catalog, this results in middleware taking considerable amount of time to reading the data and sending it to the UI. Even with caching, we get slow at json dumping/loading which impacts UI performance.

This PR intends to introduce the following changes:
1) Allow retrieving information of some specific trains only
2) Add `latest_version` key to item level payload so that consumer is able to know the latest healthy item version without going through the payload
3) Allow skipping retrieving versions of an item which helps improve performance for json dump/load operations
4) Introduce a new endpoint to retrieve version details of an item specifically without querying up everything