### PR TITLE
NAS-110930 / 21.08 / Improvements to kubernetes lifecycle

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -209,9 +209,10 @@ class CatalogService(Service):
 
     @private
     async def get_normalised_questions_context(self):
+        k8s_started = await self.middleware.call('service.started', 'kubernetes')
         return {
             'nic_choices': await self.middleware.call('chart.release.nic_choices'),
-            'gpus': await self.middleware.call('k8s.gpu.available_gpus'),
+            'gpus': await self.middleware.call('k8s.gpu.available_gpus') if k8s_started else {},
             'timezones': await self.middleware.call('system.general.timezone_choices'),
             'node_ip': await self.middleware.call('kubernetes.node_ip'),
             'certificates': await self.middleware.call('chart.release.certificate_choices'),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -65,8 +65,4 @@ async def chart_release_event(middleware, event_type, args):
 async def setup(middleware):
     middleware.event_subscribe('kubernetes.events', chart_release_event)
     if await middleware.call('service.started', 'kubernetes'):
-        try:
-            await middleware.call('chart.release.refresh_events_state')
-        except Exception:
-            # Let's not make this fatal for middleware boot
-            middleware.logger.error('Failed to refresh chart release events state', exc_info=True)
+        asyncio.ensure_future(middleware.call('chart.release.refresh_events_state'))

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -305,13 +305,13 @@ class KubernetesService(ConfigService):
         """
         Returns IP used by kubernetes which kubernetes uses to allow incoming connections.
         """
-        k8s_node_config = await self.middleware.call('k8s.node.config')
         node_ip = None
-        if k8s_node_config['node_configured']:
-            node_ip = next(
-                (addr['address'] for addr in k8s_node_config['status']['addresses'] if addr['type'] == 'InternalIP'),
-                None
-            )
+        if await self.middleware.call('service.started', 'kubernetes'):
+            k8s_node_config = await self.middleware.call('k8s.node.config')
+            if k8s_node_config['node_configured']:
+                node_ip = next((
+                    addr['address'] for addr in k8s_node_config['status']['addresses'] if addr['type'] == 'InternalIP'
+                ), None)
         if not node_ip:
             node_ip = (await self.middleware.call('kubernetes.config'))['node_ip']
 


### PR DESCRIPTION
This PR introduces following changes:

1) Do not block middleware boot on restart of middleware by refreshing chart release events state as that can potentially take a few seconds depending on the catalog size
2) Do not query kubernetes api if kubernetes is not running