### PR TITLE
NAS-110931 / 21.08 / Raise multus log level

### DIFF
--- a/src/middlewared/middlewared/etc_files/cni/multus.py
+++ b/src/middlewared/middlewared/etc_files/cni/multus.py
@@ -13,7 +13,7 @@ def render(service, middleware):
             'cniVersion': '0.3.1',
             'name': 'multus-cni-network',
             'type': 'multus',
-            'logLevel': 'debug',
+            'logLevel': 'error',
             'LogFile': '/var/log/multus.log',
             'kubeconfig': '/etc/cni/net.d/multus.d/multus.kubeconfig',
             'delegates': [middleware.call_sync('k8s.cni.kube_router_config')]


### PR DESCRIPTION
This commit adds changes to raise multus log level as with debug mode we have a huge log file for multus with data which is most probably never going to be used.