### PR TITLE
NAS-110932 / 21.08 / Do not attempt to query chart releases if no pool is set

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -42,7 +42,8 @@ class ChartReleaseService(CRUDService):
         `query-options.extra.include_chart_schema` is a boolean when set will retrieve the schema being used by
         the chart release in question.
         """
-        if not await self.middleware.call('service.started', 'kubernetes'):
+        k8s_config = await self.middleware.call('kubernetes.config')
+        if not await self.middleware.call('service.started', 'kubernetes') or not k8s_config['dataset']:
             # We use filter_list here to ensure that `options` are respected, options like get: true
             return filter_list([], filters, options)
 
@@ -77,7 +78,6 @@ class ChartReleaseService(CRUDService):
 
                 update_catalog_config[catalog['label']][train] = train_data
 
-        k8s_config = await self.middleware.call('kubernetes.config')
         k8s_node_ip = await self.middleware.call('kubernetes.node_ip')
         options = options or {}
         extra = copy.deepcopy(options.get('extra', {}))


### PR DESCRIPTION
It's possible that when a user unsets pool for k8s, k8s takes some time to shut down but during this duration if chart releases are queried they'll still try to move ahead which is not desired and we should make sure we only do that when k8s is running and a pool is set in db.