### PR TITLE
NAS-110671 / 21.06-BETA.1 / prevent unlimited WAITING cron jobs (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -209,7 +209,7 @@ class CronJobService(CRUDService):
         Int('id'),
         Bool('skip_disabled', default=False),
     )
-    @job(lock=lambda args: f'cron_job_run_{args[0]}', logs=True)
+    @job(lock=lambda args: f'cron_job_run_{args[0]}', logs=True, lock_queue_size=1)
     def run(self, job, id, skip_disabled):
         """
         Job to run cronjob task of `id`.


### PR DESCRIPTION
This prevents a scenario where the list of `Job` objects grows without bounds.

Take the following scneario:
1. create cronjob entry that never exits
2. make it run every 1 second indefinitely
3. middlewared will build a list of `WAITING` objects which, over time, eats memory and uses high CPU

Original PR: https://github.com/truenas/middleware/pull/6971
Jira URL: https://jira.ixsystems.com/browse/NAS-110671