### PR TITLE
NAS-110963 / 21.08 / Fix test failures for User account and SMB datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -22,7 +22,7 @@ import stat
 import time
 from pathlib import Path
 
-SKEL_PATH = '/usr/share/skel/'
+SKEL_PATH = '/etc/skel/'
 
 
 def pw_checkname(verrors, attribute, name):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3033,6 +3033,8 @@ class PoolDatasetService(CRUDService):
 
         if data['share_type'] == 'SMB':
             data['casesensitivity'] = 'INSENSITIVE'
+            data['acltype'] = 'NFSV4'
+            data['aclmode'] = 'RESTRICTED'
 
         if parent_ds['locked']:
             verrors.add(


### PR DESCRIPTION
Fix skel directory path and switch SMB preset to use
NFSv4 ACLs with aclmode == restricted