### PR TITLE
NAS-110798 / 21.08 / Allow stopping specific workloads before taking snapshot on app upgrade

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -166,14 +166,14 @@ class ChartReleaseService(Service):
                 )
 
     @private
-    async def wait_for_pods_to_terminate(self, namespace):
+    async def wait_for_pods_to_terminate(self, namespace, extra_filters=None):
         # wait for release to uninstall properly, helm right now does not support a flag for this but
         # a feature request is open in the community https://github.com/helm/helm/issues/2378
         while await self.middleware.call(
             'k8s.pod.query', [
                 ['metadata.namespace', '=', namespace],
                 ['status.phase', 'in', ['Running', 'Pending']],
-            ]
+            ] + (extra_filters or [])
         ):
             await asyncio.sleep(5)
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -60,3 +60,13 @@ def get_storage_class_name(release):
 
 def get_network_attachment_definition_name(release, count):
     return f'ix-{release}-{count}'
+
+
+SCALEABLE_RESOURCES = [
+    Resources.DEPLOYMENT,
+    Resources.STATEFULSET,
+]
+SCALE_DOWN_ANNOTATION = {
+    'key': 'ix\\.upgrade\\.scale\\.down\\.workload',
+    'value': ['true', '1'],
+}

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/replicaset.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/replicaset.py
@@ -1,0 +1,20 @@
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+from .k8s import api_client
+
+
+class KubernetesReplicaSetService(CRUDService):
+
+    class Config:
+        namespace = 'k8s.replicaset'
+        private = True
+
+    @filterable
+    async def query(self, filters, options):
+        async with api_client() as (api, context):
+            replica_sets = [
+                d.to_dict() for d in (await context['apps_api'].list_replica_set_for_all_namespaces()).items
+            ]
+
+        return filter_list(replica_sets, filters, options)


### PR DESCRIPTION
This PR introduces changes to allow stopping specific workloads which have a certain annotation specified on app upgrade before snapshot is taken. This is helpful for cases where we are dealing with upgrades of databases which should be stopped ideally before we take a snapshot for integrity protection.