### PR TITLE
NAS-110979 / 21.08 / fix 'NoneType' object has no attribute 'call_sync'

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
@@ -33,7 +33,7 @@ class VMSupervisorMixin(LibvirtConnectionMixin):
         if self._has_domain(vm_name):
             self.vms.pop(vm_name).undefine_domain()
         else:
-            VMSupervisor(self._vm_from_name(vm_name)).undefine_domain()
+            VMSupervisor(self._vm_from_name(vm_name), self.middleware).undefine_domain()
 
     def _check_add_domain(self, vm_name):
         if not self._has_domain(vm_name):


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/vm_supervisor.py", line 36, in _undefine_domain
    VMSupervisor(self._vm_from_name(vm_name)).undefine_domain()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_base.py", line 42, in __init__
    self.update_domain()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_base.py", line 61, in update_domain
    self.__define_domain()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_base.py", line 84, in __define_domain
    vm_xml = etree.tostring(self.construct_xml()).decode()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_linux.py", line 12, in construct_xml
    'domain', type='kvm', id=str(self.vm_data['id']), attribute_dict={'children': self.get_domain_children()}
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_base.py", line 253, in get_domain_children
    self.cpu_xml(),
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor_linux.py", line 57, in cpu_xml
    cpu_model = self.middleware.call_sync('vm.cpu_model_choices').get(self.vm_data['cpu_model'])
AttributeError: 'NoneType' object has no attribute 'call_sync'