### PR TITLE
NAS-115948 / 22.12 / pare down acltype options to ones that ZFS returns

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2941,7 +2941,7 @@ class PoolDatasetService(CRUDService):
         ]), has_default=False),
         Inheritable(Str('casesensitivity', enum=['SENSITIVE', 'INSENSITIVE', 'MIXED']), has_default=False),
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
-        Inheritable(Str('acltype', enum=['OFF', 'NOACL', 'NFSV4', 'NFS4ACL', 'POSIX', 'POSIXACL']), has_default=False),
+        Inheritable(Str('acltype', enum=['OFF', 'NFSV4', 'POSIX']), has_default=False),
         Str('share_type', default='GENERIC', enum=['GENERIC', 'SMB']),
         Inheritable(Str('xattr', enum=['ON', 'SA'])),
         Ref('encryption_options'),


### PR DESCRIPTION
Some of these names were left around for backwards-compatibility.
I think we should probably axe them.