### PR TITLE
NAS-110986 / 21.08 / Properly keep vm cache in sync

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/connection.py
+++ b/src/middlewared/middlewared/plugins/vm/connection.py
@@ -24,7 +24,7 @@ class LibvirtConnectionMixin:
         except libvirt.libvirtError as e:
             raise CallError(f'Failed to close libvirt connection: {e}')
         else:
-            self.LIBVIRT_CONNECTION = None
+            LibvirtConnectionMixin.LIBVIRT_CONNECTION = None
 
     def _is_connection_alive(self):
         with contextlib.suppress(libvirt.libvirtError):

--- a/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
@@ -24,14 +24,15 @@ class VMSupervisorMixin(LibvirtConnectionMixin):
         self.vms[new['name']] = vm
 
     def _clear(self):
-        self.vms = {}
+        VMSupervisorMixin.vms = {}
 
     def _vm_from_name(self, vm_name):
         return self.middleware.call_sync('vm.query', [['name', '=', vm_name]], {'get': True})
 
     def _undefine_domain(self, vm_name):
-        if self._has_domain(vm_name):
-            self.vms.pop(vm_name).undefine_domain()
+        domain = self.vms.pop(vm_name, None)
+        if domain and domain.domain:
+            domain.undefine_domain()
         else:
             VMSupervisor(self._vm_from_name(vm_name), self.middleware).undefine_domain()
 


### PR DESCRIPTION
This commit fixes a bug where different instances of supervisor mixin initialized their own instance of vms cache when all vms were deleted which resulted in buggy behavior when vms were created again and different service parts had different vms cache.