### PR TITLE
NAS-110703 / 21.08 / Allow user to explicitly disable gpu integration with kubernetes

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-10_11-30_configure_gpus_k8s.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-10_11-30_configure_gpus_k8s.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('configure_gpus', sa.Boolean(), default=False, nullable=False))
+        batch_op.add_column(sa.Column('configure_gpus', sa.Boolean(), default=True, nullable=False))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-10_11-30_configure_gpus_k8s.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-10_11-30_configure_gpus_k8s.py
@@ -1,0 +1,25 @@
+"""
+Add field to configure gpus for k8s
+
+Revision ID: 737912c7a9c1
+Revises: bd637e18fb0b
+Create Date: 2021-06-10 11:30:28.702007+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '737912c7a9c1'
+down_revision = 'bd637e18fb0b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('configure_gpus', sa.Boolean(), default=False, nullable=False))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -36,6 +36,7 @@ class KubernetesService(ConfigService):
 
     ENTRY = Dict(
         'kubernetes_entry',
+        Bool('configure_gpus', required=True),
         Str('pool', required=True, null=True),
         IPAddr('cluster_cidr', required=True, cidr=True, empty=True),
         IPAddr('service_cidr', required=True, cidr=True, empty=True),
@@ -187,7 +188,6 @@ class KubernetesService(ConfigService):
     @accepts(
         Patch(
             'kubernetes_entry', 'kubernetes_update',
-            ('add', Bool('configure_gpus')),
             ('add', Bool('migrate_applications')),
             ('rm', {'name': 'id'}),
             ('rm', {'name': 'dataset'}),

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -24,6 +24,7 @@ class KubernetesModel(sa.Model):
     route_v6_gateway = sa.Column(sa.String(128), nullable=True)
     node_ip = sa.Column(sa.String(128), default='0.0.0.0')
     cni_config = sa.Column(sa.JSON(type=dict), default={})
+    configure_gpus = sa.Column(sa.Boolean(), default=True, nullable=False)
 
 
 class KubernetesService(ConfigService):
@@ -186,6 +187,7 @@ class KubernetesService(ConfigService):
     @accepts(
         Patch(
             'kubernetes_entry', 'kubernetes_update',
+            ('add', Bool('configure_gpus')),
             ('add', Bool('migrate_applications')),
             ('rm', {'name': 'id'}),
             ('rm', {'name': 'dataset'}),


### PR DESCRIPTION
This PR adds changes to allow user(s) to explicitly disable gpu support for k8s as in some cases when user is consuming old graphic cards which are not supported by the upstream driver plugins, we see erroneous logging.