### PR TITLE
NAS-111039 / 21.06-BETA.1 / Remove strict check for path existence in AFP validation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1078,7 +1078,7 @@ class SharingSMBService(SharingService):
 
     @private
     async def legacy_afp_check(self, data, schema, verrors):
-        to_check = Path(data['path']).resolve(strict=True)
+        to_check = Path(data['path']).resolve(strict=False)
         legacy_afp = await self.query([
             ("afp", "=", True),
             ("enabled", "=", True),


### PR DESCRIPTION
SMB share API currently allows creating directories by passing
assing non-existent paths to the sharing.smb.create endpoint.

Original PR: https://github.com/truenas/middleware/pull/7034
Jira URL: https://jira.ixsystems.com/browse/NAS-111039