### PR TITLE
NAS-111050 / 21.08 / Fix parsing error for getfacl return with comment in ACE

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -228,6 +228,8 @@ class FilesystemService(Service, ACLBase):
         for entry in entries:
             if entry.startswith("#"):
                 continue
+
+            entry = entry.split("\t")[0]
             ace = {
                 "default": False,
                 "tag": None,


### PR DESCRIPTION
ACE comments are separated from entry by tab.