### PR TITLE
NAS-111050 / 21.06-BETA.1 / Fix parsing error for getfacl return with comment in ACE (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -228,6 +228,8 @@ class FilesystemService(Service, ACLBase):
         for entry in entries:
             if entry.startswith("#"):
                 continue
+
+            entry = entry.split("\t")[0]
             ace = {
                 "default": False,
                 "tag": None,


### PR DESCRIPTION
ACE comments are separated from entry by tab.

Original PR: https://github.com/truenas/middleware/pull/7038
Jira URL: https://jira.ixsystems.com/browse/NAS-111050