### PR TITLE
NAS-110623 / 21.08 / Add explicit route for cluster service network to kube router config

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
@@ -65,8 +65,13 @@ class KubernetesCNIService(ConfigService):
                 {
                     'bridge': 'kube-bridge',
                     'ipam': {
-                        'subnet': config['cluster_cidr'],
                         'type': 'host-local',
+                        "ranges": [[{
+                            "subnet": config['cluster_cidr'],
+                        }]],
+                        "routes": [{
+                            "dst": config['service_cidr'],
+                        }],
                     },
                     'isDefaultGateway': True,
                     'name': 'kubernetes',


### PR DESCRIPTION
This PR updates the generated "kube router config" such that it includes a route for the cluster service network to the cluster. Currently, the config only specifies the pod network and relies on the default route to route requests to the service network correctly.
The primary use case for this is that it allows users to override the default route for individual containers without breaking said container's connection to the service network.

Additionally, the config now uses the "ranges" array instead of the deprecated<sup>[[1]](https://www.cni.dev/plugins/current/ipam/host-local/#network-configuration-reference)</sup> top-level "subnet" key.
