### PR TITLE
NAS-111081 / 21.06-BETA.1 / Fix setting default SMB ACL on dataset creation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3140,7 +3140,7 @@ class PoolDatasetService(CRUDService):
 
         created_ds = await self.get_instance(data['id'])
 
-        if data['type'] == 'FILESYSTEM' and data['share_type'] == 'SMB' and created_ds['acltype'] == "NFSV4":
+        if data['type'] == 'FILESYSTEM' and data['share_type'] == 'SMB' and created_ds['acltype']['value'] == "NFSV4":
             await self.middleware.call('pool.dataset.permission', data['id'], {'mode': None})
 
         return created_ds


### PR DESCRIPTION
check for acltype was broken.

Original PR: https://github.com/truenas/middleware/pull/7057
Jira URL: https://jira.ixsystems.com/browse/NAS-111081