### PR TITLE
NAS-111087 / 21.08 / Do not read/validate all catalog item versions

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -130,7 +130,6 @@ class CatalogService(Service):
         options = options or {}
         all_trains = options.get('all_trains', True)
         trains_filter = options.get('trains', [])
-        retrieve_versions = options.get('retrieve_versions', True)
         questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
         unhealthy_apps = set()
         if options.get('alert') and options.get('label'):
@@ -155,9 +154,8 @@ class CatalogService(Service):
 
                 trains[train][item] = self.retrieve_item_details(item_location, {
                     'questions_context': questions_context,
+                    'retrieve_versions': options.get('retrieve_versions', True),
                 })
-                if not retrieve_versions:
-                    trains[train][item].pop('versions')
                 if train in preferred_trains and not trains[train][item]['healthy']:
                     unhealthy_apps.add(f'{item} ({train} train)')
 
@@ -178,6 +176,7 @@ class CatalogService(Service):
         questions_context = options.get('questions_context') or self.middleware.call_sync(
             'catalog.get_normalised_questions_context'
         )
+        retrieve_versions = options.get('retrieve_versions', True)
         item_data = {
             'name': item,
             'categories': [],
@@ -200,9 +199,14 @@ class CatalogService(Service):
                 item_data['healthy_error'] += f'{verror[0]}: {verror[1]}'
 
             # If the item format is not valid - there is no point descending any further into versions
+            if not retrieve_versions:
+                item_data.pop('versions')
             return item_data
 
-        item_data.update(self.item_details(item_location, schema, questions_context))
+        item_data.update(self.item_details(item_location, schema, {
+            'retrieve_latest_version': not retrieve_versions,
+            'questions_context': questions_context,
+        }))
         unhealthy_versions = []
         for k, v in sorted(item_data['versions'].items(), key=lambda v: parse_version(v[0]), reverse=True):
             if not v['healthy']:
@@ -222,13 +226,17 @@ class CatalogService(Service):
             item_data['healthy_error'] = f'Errors were found with {", ".join(unhealthy_versions)} version(s)'
         else:
             item_data['healthy'] = True
+        if not retrieve_versions:
+            item_data.pop('versions')
 
         return item_data
 
     @private
-    def item_details(self, item_path, schema, questions_context):
+    def item_details(self, item_path, schema, options):
         # Each directory under item path represents a version of the item and we need to retrieve details
         # for each version available under the item
+        questions_context = options['questions_context']
+        retrieve_latest_version = options.get('retrieve_latest_version')
         item_data = {'versions': {}}
         with open(os.path.join(item_path, 'item.yaml'), 'r') as f:
             item_data.update(yaml.safe_load(f.read()))
@@ -264,6 +272,8 @@ class CatalogService(Service):
                 'healthy': True,
                 **self.item_version_details(version_details['location'], questions_context)
             })
+            if retrieve_latest_version:
+                break
 
         return item_data
 


### PR DESCRIPTION
This commit adds changes to not read/validate every catalog item versions if user at the end does not want versions. In this case, we just read the latest healthy one and update the item metadata accordingly.