### PR TITLE
NAS-111096 / 21.08 / Synchronously sync catalog on creation

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -1,4 +1,3 @@
-import asyncio
 import errno
 import os
 import shutil
@@ -173,10 +172,12 @@ class CatalogService(CRUDService):
         job.set_progress(60, 'Completed Validation')
 
         await self.middleware.call('datastore.insert', self._config.datastore, data)
+        job.set_progress(70, f'Successfully added {data["label"]!r} catalog')
 
-        asyncio.ensure_future(self.middleware.call('catalog.sync', data['label']))
+        job.set_progress(80, f'Syncing {data["label"]} catalog')
+        self.middleware.call('catalog.sync', data['label'])
 
-        job.set_progress(100, f'Successfully added {data["label"]!r} catalog')
+        job.set_progress(100, f'Successfully synced {data["label"]!r} catalog')
 
         return await self.get_instance(data['label'])
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -175,7 +175,7 @@ class CatalogService(CRUDService):
         job.set_progress(70, f'Successfully added {data["label"]!r} catalog')
 
         job.set_progress(80, f'Syncing {data["label"]} catalog')
-        self.middleware.call('catalog.sync', data['label'])
+        await self.middleware.call('catalog.sync', data['label'])
 
         job.set_progress(100, f'Successfully synced {data["label"]!r} catalog')
 


### PR DESCRIPTION
This commit adds changes to sync a catalog on creation synchronously as if the catalog is huge and not cached, it will mean that user would still expct it to be available instantaneously which won't be true. As catalog creation is a job, we can safely sync the catalog after inserting it into database which will ensure that the system is ready to serve the catalog.