### PR TITLE
NAS-111102 / 21.08 / Improve handling of large catalogs

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -31,6 +31,7 @@ class CatalogService(Service):
         Dict('versions', required=True, additional_attrs=True),
         Str('latest_version', required=True, null=True),
         Str('latest_app_version', required=True, null=True),
+        Str('latest_human_version', required=True, null=True),
         Str('icon_url', required=True, null=True),
     ))
     def get_item_details(self, item_name, options):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -202,7 +202,7 @@ class CatalogService(Service):
             item = item_key.removesuffix(f'_{train}')
             item_location = os.path.join(location, train, item)
             job.set_progress(
-                ((index / total_items) * (90 - 10)) + 10,
+                int((index / total_items) * 80) + 10,
                 f'Retrieving information of {item!r} item from {train!r} train'
             )
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -78,7 +78,8 @@ class CatalogService(Service):
         of desired trains in a catalog. If `options.retrieve_all_trains` is set, it has precedence over `options.train`.
 
         `options.retrieve_versions` can be unset to skip retrieving version details of each catalog item. This
-        can help in cases to optimize performance.
+        can help in cases to optimize performance. Retrieving versions would be deprecated in the next major
+        release from this endpoint.
         """
         catalog = self.middleware.call_sync('catalog.get_instance', label)
         all_trains = options['retrieve_all_trains']

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -222,6 +222,7 @@ class CatalogService(CRUDService):
 
         job.set_progress(80, f'Syncing {data["label"]} catalog')
         sync_job = await self.middleware.call('catalog.sync', data['label'])
+        await sync_job.wait()
         if sync_job.error:
             raise CallError(f'Catalog was added successfully but failed to sync: {sync_job.error}')
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -78,7 +78,9 @@ class CatalogService(CRUDService):
             'item_sync_params': await self.middleware.call(
                 'catalog.sync_items_params'
             ) if extra.get('item_details') else None,
-            'all_jobs': await self.middleware.call('core.get_jobs') if extra.get('item_details') else [],
+            'all_jobs': await self.middleware.call(
+                'core.get_jobs', [['method', '=', 'catalog.items']]
+            ) if extra.get('item_details') else [],
         }
 
     @private
@@ -125,7 +127,6 @@ class CatalogService(CRUDService):
             # data has not been retrieved as well due to this
             caching_job = filter_list(
                 context['all_jobs'], [
-                    ['method', '=', 'catalog.items'],
                     ['arguments', '=', [catalog['id'], context['item_sync_params']]]
                 ]
             )

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -70,10 +70,11 @@ class CatalogService(CRUDService):
             try:
                 catalog['trains'] = await self.middleware.call(
                     'catalog.items', catalog['label'], {
-                        'cache': extra.get('cache', True),
+                        'cache': True,
+                        'cache_only': await self.official_catalog_label() != catalog['label'],
                         'retrieve_all_trains': extra.get('retrieve_all_trains', True),
                         'trains': extra.get('trains', []),
-                        'retrieve_versions': extra.get('retrieve_versions', True),
+                        'retrieve_versions': extra.get('retrieve_versions', False),
                     },
                 )
             except Exception:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -176,7 +176,9 @@ class CatalogService(CRUDService):
         job.set_progress(70, f'Successfully added {data["label"]!r} catalog')
 
         job.set_progress(80, f'Syncing {data["label"]} catalog')
-        await self.middleware.call('catalog.sync', data['label'])
+        sync_job = await self.middleware.call('catalog.sync', data['label'])
+        if sync_job.error:
+            raise CallError(f'Catalog was added successfully but failed to sync: {sync_job.error}')
 
         job.set_progress(100, f'Successfully synced {data["label"]!r} catalog')
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -159,7 +159,7 @@ class CatalogService(CRUDService):
                 await self.middleware.call('catalog.update_git_repository', {**data, 'location': path}, True)
                 await self.middleware.call('catalog.validate_catalog_from_path', path)
                 await self.common_validation(
-                    {'trains': await self.middleware.call('catalog.get_trains', path)}, 'catalog_create', data
+                    {'trains': await self.middleware.call('catalog.retrieve_train_names', path)}, 'catalog_create', data
                 )
             except CallError as e:
                 verrors.add('catalog_create.label', f'Failed to validate catalog: {e}')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -107,9 +107,7 @@ class ChartReleaseService(CRUDService):
             return filter_list([], filters, options)
 
         update_catalog_config = {}
-        catalogs = await self.middleware.call(
-            'catalog.query', [], {'extra': {'item_details': True, 'retrieve_versions': False}}
-        )
+        catalogs = await self.middleware.call('catalog.query', [], {'extra': {'item_details': True}})
         container_images = {}
         for image in await self.middleware.call('container.image.query'):
             for tag in image['repo_tags']:

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -123,7 +123,7 @@ class ChartReleaseService(CRUDService):
                     app_version = catalog['trains'][train][catalog_item]['latest_app_version'] or '0.0.0'
                     train_data[catalog_item] = {
                         'chart_version': parse_version(max_version),
-                        'app_version': parse_version(app_version),
+                        'app_version': app_version,
                     }
 
                 update_catalog_config[catalog['label']][train] = train_data

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -456,9 +456,10 @@ class ChartReleaseService(CRUDService):
                 'chart.release.get_latest_version_from_item_versions', item_details['versions']
             )
 
-        if version not in catalog['trains'][data['train']][data['item']]['versions']:
+        if version not in item_details['versions']:
             raise CallError(f'Unable to locate "{data["version"]}" catalog item version.', errno=errno.ENOENT)
 
+        item_details = item_details['versions'][version]
         await self.middleware.call('catalog.version_supported_error_check', item_details)
 
         k8s_config = await self.middleware.call('kubernetes.config')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -138,7 +138,7 @@ class ChartReleaseService(Service):
         ),
         Str('latest_version'),
         Str('latest_human_version'),
-        Str('changelog', max_length=5000),
+        Str('changelog', max_length=None, null=True),
     ))
     def upgrade_summary(self, release_name, options):
         """

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -321,14 +321,11 @@ class ChartReleaseService(Service):
 
     @private
     async def chart_release_update_check(self, catalog_item, application):
-        available_versions = [
-            parse_version(version) for version, data in catalog_item['versions'].items() if data['healthy']
-        ]
-        if not available_versions:
+        latest_version = catalog_item['latest_version']
+        if not latest_version:
             return
 
-        available_versions.sort(reverse=True)
-        if available_versions[0] > parse_version(application['chart_metadata']['version']):
+        if parse_version(latest_version) > parse_version(application['chart_metadata']['version']):
             await self.middleware.call('alert.oneshot_create', 'ChartReleaseUpdate', application)
         else:
             await self.middleware.call('alert.oneshot_delete', 'ChartReleaseUpdate', application['id'])

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2049,7 +2049,7 @@ class PoolDatasetService(CRUDService):
         Str('name', required=True),
         Str('pool', required=True),
         Bool('encrypted'),
-        Bool('encryption_root', null=True),
+        Str('encryption_root', null=True),
         Bool('key_loaded', null=True),
         List('children', required=True),
         Dict('user_properties', additional_attrs=True, required=True),


### PR DESCRIPTION
This PR introduces following changes:

1) Make `catalog.items` a job as reading large catalog(s) can potentially take quite a few minutes.
2) Properly report progress when reading large catalog(s) with `catalog.items` so that consumer(s) can have a clear estimate.
3) Only retrieve cached content of catalog item(s) from `catalog.query`. Motivation for this change is that querying catalog(s) should be fast whereas reading a single large catalog can potentially take quite some time. However, `OFFICIAL` catalog is treated specially where we try to use cache but if the content's not been cached yet, we will read it from disk. This is with the assumption that `OFFICIAL` catalog would not go into thousands of item version(s) which is what which takes lots of time to read.
4) Do not retrieve catalog item versions with `catalog.query` as catalog(s) with thousand(s) of catalog items would increase the payload which can increase the time to load/dump the catalog version(s) data.
5) Make `catalog.sync` a job as it does 2 functions, one is updating the git repository and the second is calling `catalog.items` and both can take potentially quite some time to complete.

With these changes, UI can load catalog(s) faster and for catalog(s) which are still being synced, UI would report progress for them that they are being synced and display them when they are.