### PR TITLE
NAS-111124 / 12.0 / cache static info and optimize system.info on CORE

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -1496,15 +1496,20 @@ def show_ip():
 
 
 def netcli_title():
-    proc = subprocess.Popen(['dmidecode', '-s', 'system-product-name'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
-    product = proc.communicate()[0].strip()
-    proc = subprocess.Popen(['dmidecode', '-s', 'system-serial-number'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
-    serial = proc.communicate()[0].strip()
+
+    product = ''
+    serial = ''
+    version = ''
+
     try:
         with Client() as c:
+            data = c.call('system.dmidecode_info')
+            product = data['system-product-name']
+            serial = data['system-serial-number']
             version = c.call('system.version') + ' | '
     except Exception:
-        version = ''
+        pass
+
     return f'{product} | {version}{serial}'
 
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/alert/source/license_status.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/alert/source/license_status.py
@@ -6,7 +6,6 @@
 
 from collections import defaultdict
 from datetime import date, timedelta
-import subprocess
 import textwrap
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
@@ -50,12 +49,7 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         if license is None:
             return Alert(LicenseAlertClass, "Your TrueNAS has no license, contact support.")
 
-        proc = subprocess.Popen([
-            '/usr/local/sbin/dmidecode',
-            '-s', 'system-serial-number',
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
-        serial = proc.communicate()[0].split('\n', 1)[0].strip()
-
+        serial = self.middleware.call_sync('system.dmidecode_info')['system-serial-number']
         if license['system_serial'] != serial and license['system_serial_ha'] != serial:
             alerts.append(Alert(LicenseAlertClass, 'System serial does not match license.'))
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/alert/source/sensors.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/alert/source/sensors.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2020 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 import logging
 import re
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/alert/source/sensors.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/alert/source/sensors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 iXsystems, Inc.
+# Copyright (c) 2020 iXsystems, Inc.
 # All rights reserved.
 # This file is a part of TrueNAS
 # and may not be copied and/or distributed
@@ -8,7 +8,6 @@ import logging
 import re
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
-from middlewared.utils import run
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +46,8 @@ class SensorsAlertSource(AlertSource):
 
     async def check(self):
         baseboard_manufacturer = (
-            (await run(["dmidecode", "-s", "baseboard-manufacturer"], check=False)).stdout.decode(errors="ignore")
-        ).strip()
+            await self.middleware.call('system.dmidecode_info')
+        )['baseboard-manufacturer']
 
         failover_hardware = await self.middleware.call("failover.hardware")
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/sensor.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/sensor.py
@@ -16,8 +16,8 @@ class SensorService(Service):
     @filterable
     async def query(self, filters, options):
         baseboard_manufacturer = (
-            (await run(["dmidecode", "-s", "baseboard-manufacturer"], check=False)).stdout.decode(errors="ignore")
-        ).strip()
+            await self.middleware.call('system.dmidecode_info')
+        )['baseboard-manufacturer']
 
         failover_hardware = await self.middleware.call("failover.hardware")
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2020 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from datetime import datetime, timedelta
 import errno
 import json

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import socket
 import enum
 import json
 import logging
@@ -243,7 +244,7 @@ class AlertService:
 
     async def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = await self.middleware.call("system.product_name")
-        hostname = (await self.middleware.call("system.info"))["hostname"]
+        hostname = socket.gethostname()
         if not await self.middleware.call("system.is_freenas"):
             node_map = await self.middleware.call("alert.node_map")
         else:
@@ -260,7 +261,7 @@ class ThreadedAlertService(AlertService):
 
     def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = self.middleware.call_sync("system.product_name")
-        hostname = self.middleware.call_sync("system.info")["hostname"]
+        hostname = socket.gethostname()
         if not self.middleware.call_sync("system.is_freenas"):
             node_map = self.middleware.call_sync("alert.node_map")
         else:

--- a/src/middlewared/middlewared/alert/source/freenas_bmc.py
+++ b/src/middlewared/middlewared/alert/source/freenas_bmc.py
@@ -24,14 +24,11 @@ class FreeNASBMCAlertSource(ThreadedAlertSource):
     products = ("CORE",)
 
     def check_sync(self):
-        systemname = subprocess.run(
-            ["dmidecode", "-s", "system-product-name"],
-            capture_output=True, text=True,
-        ).stdout.strip()
-        boardname = subprocess.run(
-            ["dmidecode", "-s", "baseboard-product-name"],
-            capture_output=True, text=True,
-        ).stdout.strip()
+
+        data = self.middleware.call_sync('system.dmidecode_info')
+        systemname = data['system-product-name']
+        boardname = data['baseboard-product-name']
+
         if "freenas" in systemname.lower() and boardname == "C2750D4I":
             mcinfo = subprocess.run(
                 ["ipmitool", "mc", "info"],

--- a/src/middlewared/middlewared/etc_files/loader.py
+++ b/src/middlewared/middlewared/etc_files/loader.py
@@ -127,8 +127,8 @@ def generate_ha_loader_config(middleware):
 
 
 def generate_xen_loader_config(middleware):
-    proc = subprocess.run(["/usr/local/sbin/dmidecode", "-s", "system-product-name"], stdout=subprocess.PIPE)
-    if proc.returncode == 0 and proc.stdout.strip() == b"HVM domU":
+    proc = middleware.call_sync('system.dmidecode_info')['system-product-name']
+    if proc == "HVM domU":
         return ['hint.hpet.0.clock="0"']
 
     return []

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -410,11 +410,7 @@ def watchdog_config(middleware, context):
         # Bug #7337 -- blacklist AMD systems for now
         model = sysctl.filter('hw.model')
         if not model or 'AMD' not in model[0].value:
-            product = subprocess.run(
-                ['dmidecode', '-s', 'baseboard-product-name'],
-                capture_output=True,
-                errors='ignore',
-            ).stdout.split('\n')[0].strip()
+            product = middleware.call_sync('system.dmidecode_info')['baseboard-product-name']
 
             if product in ('C2750D4I', 'C2550D4I') and _bmc_watchdog_is_broken():
                 return [

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -3,7 +3,6 @@ import json
 import requests
 import simplejson
 import socket
-import subprocess
 import time
 
 from middlewared.pipe import Pipes
@@ -11,7 +10,6 @@ from middlewared.plugins.system import DEBUG_MAX_SIZE
 from middlewared.schema import Bool, Dict, Int, List, Str, accepts
 from middlewared.service import CallError, ConfigService, job, ValidationErrors
 import middlewared.sqlalchemy as sa
-from middlewared.utils import Popen
 from middlewared.utils.network import INTERNET_TIMEOUT
 from middlewared.validators import Email
 
@@ -188,7 +186,7 @@ class SupportService(ConfigService):
             required_attrs = ('type', 'username', 'password')
         else:
             required_attrs = ('phone', 'name', 'email', 'criticality', 'environment')
-            data['serial'] = (await (await Popen(['/usr/local/sbin/dmidecode', '-s', 'system-serial-number'], stdout=subprocess.PIPE)).communicate())[0].decode().split('\n')[0].upper()
+            data['serial'] = (await self.middleware.call('system.dmidecode_info'))['system-serial-number']
             license = (await self.middleware.call('system.info'))['license']
             if license:
                 data['company'] = license['customer_name']

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timezone, timedelta
 from middlewared.event import EventSource
 from middlewared.i18n import set_language
 from middlewared.logger import CrashReporting
@@ -356,7 +356,6 @@ class SystemAdvancedService(ConfigService):
 
 class SystemService(Service):
 
-    HOST_ID = None
     DMIDECODE_CACHE = {
         'ecc-memory': None,
         'baseboard-manufacturer': None,
@@ -367,9 +366,70 @@ class SystemService(Service):
         'system-version': None,
     }
 
+    CPU_INFO = {
+        'cpu_model': None,
+        'core_count': None,
+    }
+
+    MEM_INFO = {
+        'physmem_size': None,
+    }
+
+    BIRTHDAY_DATE = {
+        'date': None,
+    }
+
+    HOST_ID = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__product_type = None
+
+    @private
+    async def birthday(self):
+
+        if self.BIRTHDAY_DATE['date'] is None:
+            birth = (await self.middleware.call('datastore.config', 'system.settings'))['stg_birthday']
+            if birth != datetime(1970, 1, 1):
+                self.BIRTHDAY_DATE['date'] = birth
+
+        return self.BIRTHDAY_DATE
+
+    @private
+    async def mem_info(self):
+
+        if self.MEM_INFO['physmem_size'] is None:
+            # physmem doesn't change after boot so cache the results
+            self.MEM_INFO['physmem_size'] = psutil.virtual_memory().total
+
+        return self.MEM_INFO
+
+    @private
+    async def cpu_info(self):
+
+        """
+        CPU info doesn't change after boot so cache the results
+        """
+
+        if self.CPU_INFO['cpu_model'] is None:
+            self.CPU_INFO['cpu_model'] = osc.get_cpu_model()
+
+        if self.CPU_INFO['core_count'] is None:
+            self.CPU_INFO['core_count'] = psutil.cpu_count()
+
+        return self.CPU_INFO
+
+    @private
+    async def time_info(self):
+        uptime_seconds = time.clock_gettime(time.CLOCK_UPTIME)
+        current_time = time.time()
+
+        return {
+            'uptime_seconds': uptime_seconds,
+            'uptime': str(timedelta(seconds=uptime_seconds)),
+            'boot_time': datetime.fromtimestamp(psutil.boot_time(), timezone.utc),
+            'datetime': datetime.fromtimestamp(current_time, timezone.utc),
+        }
 
     @private
     async def dmidecode_info(self):
@@ -386,27 +446,39 @@ class SystemService(Service):
             self.DMIDECODE_CACHE['ecc-memory'] = ecc
 
         if self.DMIDECODE_CACHE['baseboard-manufacturer'] is None:
-            bm = ((await run(["dmidecode", "-s", "baseboard-manufacturer"], check=False)).stdout.decode(errors='ignore')).strip()
+            bm = (
+                (await run(["dmidecode", "-s", "baseboard-manufacturer"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['baseboard-manufacturer'] = bm
 
         if self.DMIDECODE_CACHE['baseboard-product-name'] is None:
-            bpn = ((await run(["dmidecode", "-s", "baseboard-product-name"], check=False)).stdout.decode(errors='ignore')).strip()
+            bpn = (
+                (await run(["dmidecode", "-s", "baseboard-product-name"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['baseboard-product-name'] = bpn
 
         if self.DMIDECODE_CACHE['system-manufacturer'] is None:
-            sm = ((await run(["dmidecode", "-s", "system-manufacturer"], check=False)).stdout.decode(errors='ignore')).strip()
+            sm = (
+                (await run(["dmidecode", "-s", "system-manufacturer"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['system-manufacturer'] = sm
 
         if self.DMIDECODE_CACHE['system-product-name'] is None:
-            spn = ((await run(["dmidecode", "-s", "system-product-name"], check=False)).stdout.decode(errors='ignore')).strip()
+            spn = (
+                (await run(["dmidecode", "-s", "system-product-name"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['system-product-name'] = spn
 
         if self.DMIDECODE_CACHE['system-serial-number'] is None:
-            ssn = ((await run(["dmidecode", "-s", "system-serial-number"], check=False)).stdout.decode(errors='ignore')).strip()
+            ssn = (
+                (await run(["dmidecode", "-s", "system-serial-number"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['system-serial-number'] = ssn
 
         if self.DMIDECODE_CACHE['system-version'] is None:
-            sv = ((await run(["dmidecode", "-s", "system-version"], check=False)).stdout.decode(errors='ignore')).strip()
+            sv = (
+                (await run(["dmidecode", "-s", "system-version"], check=False)).stdout.decode(errors='ignore')
+            ).strip()
             self.DMIDECODE_CACHE['system-version'] = sv
 
         return self.DMIDECODE_CACHE
@@ -625,38 +697,30 @@ class SystemService(Service):
         """
         Returns basic system information.
         """
-        uptime = (await (await Popen(
-            ['env', '-u', 'TZ', 'uptime'], stdout=subprocess.PIPE
-        )).communicate())[0].decode().split(',')
-        uptime = ', '.join([uptime[i].strip() for i in range(2)])
-
-        serial = await self._system_serial()
-
+        time_info = await self.middleware.call('system.time_info')
         dmidecode = await self.middleware.call('system.dmidecode_info')
-
-        birthday_date = (await self.middleware.call('datastore.config', 'system.settings'))['stg_birthday']
-        if birthday_date == datetime(1970, 1, 1):
-            birthday_date = None
-
+        cpu_info = await self.middleware.call('system.cpu_info')
+        mem_info = await self.middleware.call('system.mem_info')
+        birthday = await self.middleware.call('system.birthday')
         timezone_setting = (await self.middleware.call('datastore.config', 'system.settings'))['stg_timezone']
 
         return {
             'version': self.version(),
             'buildtime': await self.middleware.call('system.build_time'),
             'hostname': socket.gethostname(),
-            'physmem': psutil.virtual_memory().total,
-            'model': osc.get_cpu_model(),
-            'cores': psutil.cpu_count(logical=True),
+            'physmem': mem_info['physmem_size'],
+            'model': cpu_info['cpu_model'],
+            'cores': cpu_info['core_count'],
             'loadavg': os.getloadavg(),
-            'uptime': uptime,
-            'uptime_seconds': time.time() - psutil.boot_time(),
-            'system_serial': serial,
+            'uptime': time_info['uptime'],
+            'uptime_seconds': time_info['uptime_seconds'],
+            'system_serial': dmidecode['system-serial-number'] if dmidecode['system-serial-number'] else None,
             'system_product': dmidecode['system-product-name'] if dmidecode['system-product-name'] else None,
             'system_product_version': dmidecode['system-version'] if dmidecode['system-version'] else None,
             'license': await self.middleware.run_in_thread(self._get_license),
-            'boottime': datetime.fromtimestamp(psutil.boot_time(), timezone.utc),
-            'datetime': datetime.utcnow(),
-            'birthday': birthday_date,
+            'boottime': time_info['boot_time'],
+            'datetime': time_info['datetime'],
+            'birthday': birthday['date'],
             'timezone': timezone_setting,
             'system_manufacturer': dmidecode['system-manufacturer'] if dmidecode['system-manufacturer'] else None,
             'ecc_memory': dmidecode['ecc-memory'],
@@ -664,11 +728,7 @@ class SystemService(Service):
 
     @private
     async def is_ix_hardware(self):
-        product = (await(await Popen(
-            ['dmidecode', '-s', 'system-product-name'],
-            stdout=subprocess.PIPE,
-        )).communicate())[0].decode().strip() or None
-
+        product = (await self.middleware.call('system.info'))['system_product']
         return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))
 
     # Sync the clock
@@ -700,13 +760,6 @@ class SystemService(Service):
         if license and name in license['features']:
             return True
         return False
-
-    @private
-    async def _system_serial(self):
-
-        return (
-            await self.middleware.call('system.dmidecode_info')
-        )['system-serial-number'] or None
 
     @accepts(Dict('system-reboot', Int('delay', required=False), required=False))
     @job()
@@ -1474,39 +1527,36 @@ class SystemGeneralService(ConfigService):
 
 
 async def _update_birthday_data(middleware, birthday=None):
-    middleware.logger.debug('Synchronization/update birthday data')
-    # Check if it is exists already
-    system_obj = await middleware.call('system.info')
-    birthday_obj = system_obj['birthday']
-    if birthday_obj is not None:
-        # Already setted before.
+
+    birthday = (await middleware.call('system.info'))['birthday']
+    if birthday is not None:
+        # already been set
         return
 
-    # If it is not defined yet, it will try to define
+    # get current time and use as birthday
     if birthday is None:
         birthday = await middleware.call('system.sync_clock')
 
-    if birthday is not None:
-        # Update System Settings
+        middleware.logger.debug('Updating birthday data')
+        # update db with new birthday
         settings = await middleware.call('datastore.config', 'system.settings')
         await middleware.call('datastore.update', 'system.settings', settings['id'], {
             'stg_birthday': birthday,
         })
 
 
-# Update Birthday Date
 async def _update_birthday(middleware):
-    # Sync clock
-    middleware.logger.debug('Synchronization the clock for system birthday')
+
     birthday = None
     timeout = 3600 * 24
 
     middleware.register_hook('interface.post_sync', _update_birthday_data)
 
+    middleware.logger.debug('Waiting for clock sync to update system birthday')
     while birthday is None:
         birthday = await middleware.call('system.sync_clock')
 
-        # Wait until be able to sync the clock
+        # sleep for 1 day and try again
         if birthday is None:
             await asyncio.sleep(timeout)
 
@@ -1519,19 +1569,12 @@ async def _event_system(middleware, event_type, args):
     global SYSTEM_SHUTTING_DOWN
     if args['id'] == 'ready':
         SYSTEM_READY = True
-        if osc.IS_LINUX and os.path.exists(FIRST_INSTALL_SENTINEL):
-            cp = await run('update-grub', check=False, encoding='utf-8', errors='ignore')
-            if cp.returncode:
-                middleware.logger.error('Failed to update grub configuration: %s', cp.stderr)
-            os.unlink(FIRST_INSTALL_SENTINEL)
-
-        # Check if birthday is already setted
-        system_obj = await middleware.call('system.info')
-        birthday = system_obj['birthday']
-
-        # If it is not defined yet, it will try to define
+        # Check if birthday is already set
+        birthday = (await middleware.call('system.info'))['birthday']
         if birthday is None:
+            # try to set birthday in background
             asyncio.ensure_future(_update_birthday(middleware))
+
     if args['id'] == 'shutdown':
         SYSTEM_SHUTTING_DOWN = True
 

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -706,7 +706,7 @@ class SystemService(Service):
 
         return (
             await self.middleware.call('system.dmidecode_info')
-        )['system-serial'] or None
+        )['system-serial-number'] or None
 
     @accepts(Dict('system-reboot', Int('delay', required=False), required=False))
     @job()

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import syslog
+import socket
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import private, SystemServiceService, ValidationErrors
@@ -341,7 +342,7 @@ class UPSService(SystemServiceService):
                 # battery.runtime.low: 900
 
                 ups_name = config['identifier']
-                hostname = (await self.middleware.call('system.info'))['hostname']
+                hostname = socket.gethostname()
                 current_time = datetime.datetime.now(tz=dateutil.tz.tzlocal()).strftime('%a %b %d %H:%M:%S %Z %Y')
                 ups_subject = config['subject'].replace('%d', current_time).replace('%h', hostname)
                 body = f'NOTIFICATION: {notify_type!r}\n\nUPS: {ups_name!r}\n\n'


### PR DESCRIPTION
I profiled the middlewared process a few months ago and found lots of areas of improvement. The gist of it is that we're spending an exorbitant amount of CPU time simply retrieving static information that never changes after boot.

The details of the performance penalty for doing this can be found [here](https://github.com/truenas/middleware/pull/5474), [here](https://github.com/truenas/middleware/pull/5612), and [here](https://github.com/truenas/middleware/pull/5619). To add insult to injury, the NAS-109709 ticket has shown that 75% of the core dumps show `system.info` was on CPU at the time of the crash. The fact that it's on CPU doesn't mean it's related to the core dumps but it does show the fact that we're wasting lots of CPU time on static data that never changes.

These changes have been in SCALE for many months and they were actually supposed to be backported to TN Core "nightlies" at the time, but that was never done because of the `truenas/13.0-stable` branch creation so it was missed.

This just backports the above mentioned PR to `truenas/12.0-stable`.