### PR TITLE
NAS-110915 / 21.08 / fix internal interface on SCALE HA

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -12,7 +12,6 @@ Conflicts=systemd-networkd.service
 Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=-midclt call etc.generate_checkpoint pre_interface_sync
-ExecStart=-midclt -t 60 call failover.internal_interface.pre_sync
 ExecStart=-midclt -t 120 call interface.sync true
 ExecStartPost=midclt call etc.generate_checkpoint interface_sync
 StandardOutput=null

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2044,7 +2044,7 @@ class InterfaceService(CRUDService):
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
         internal_interfaces = await self.middleware.call('interface.internal_interfaces')
-        if await self.middleware.call('failover.licensed'):
+        if await self.middleware.call('system.is_enterprise'):
             internal_interfaces.extend(await self.middleware.call('failover.internal_interfaces') or [])
         internal_interfaces = tuple(internal_interfaces)
 


### PR DESCRIPTION
There are 2 subtle issues being fixed for SCALE HA.

1. we were calling `failover.internal_interface.pre_sync` twice at boot time
2. we were only configuring the internal heartbeat interface when the system was licensed for HA which is invalid. The heartbeat has to be configured on HA _capable_ hardware.