### PR TITLE
NAS-111126 / 21.08 / update license status on failover.sync_to_peer

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -41,7 +41,6 @@ class UnableToDetermineOSVersion(Exception):
     pass
 
 
-
 class OSVersionMismatch(Exception):
 
     """
@@ -371,6 +370,13 @@ class FailoverService(ConfigService):
 
         self.middleware.call_sync(
             'failover.call_remote', 'core.call_hook', ['config.on_upload', [FREENAS_DATABASE]],
+        )
+
+        # need to make sure the license information is updated on the standby node since
+        # it's cached in memory
+        _prev = self.middleware.call_sync('system.product_type')
+        self.middleware.call_sync(
+            'failover.call_remote', 'core.call_hook', ['system.post_license_update', [_prev]]
         )
 
         if options['reboot']:


### PR DESCRIPTION
We cache whether or not the system is licensed for HA functionality. However, the cache is potentially invalidated when a system is licensed for HA the _first_ time. Without these changes, the standby controller will still show `failover.licensed == False` after uploading a HA license on the active node. This was missed because our HA API tests actually reboot both nodes before running the tests.