### PR TITLE
NAS-111132 / 21.08 / Fix r10 enclosures

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -39,7 +39,7 @@ STATUS_DESC = [
 ]
 
 M_SERIES_REGEX = re.compile(r"(ECStream|iX) 4024S([ps])")
-R_SERIES_REGEX = re.compile(r"ECStream (FS2|DSS212S[ps])")
+R_SERIES_REGEX = re.compile(r"(ECStream|iX) (FS1|FS2|DSS212S[ps])")
 R20A_REGEX = re.compile(r"SMC SC826-P")
 R50_REGEX = re.compile(r"iX eDrawer4048S([12])")
 X_SERIES_REGEX = re.compile(r"CELESTIC (P3215-O|P3217-B)")
@@ -227,8 +227,6 @@ class EnclosureService(CRUDService):
         """
         Sync enclosure of a given ZFS pool
         """
-
-        # As we are only interfacing with SES we can skip mapping enclosures or working with non-SES enclosures
 
         encs = self.__get_enclosures()
         if len(list(encs)) == 0:

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -544,7 +544,6 @@ class Enclosure(object):
             self.model = self.system_info["system_product"]
             self.controller = True
 
-
     def _parse_raw_value(self, value):
         newvalue = 0
         for i, v in enumerate(value.split(' ')):

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -45,6 +45,7 @@ R50_REGEX = re.compile(r"iX eDrawer4048S([12])")
 X_SERIES_REGEX = re.compile(r"CELESTIC (P3215-O|P3217-B)")
 ES24_REGEX = re.compile(r"(ECStream|iX) 4024J")
 ES24F_REGEX = re.compile(r"(ECStream|iX) 2024J([ps])")
+MINI_REGEX = re.compile(r"(TRUE|FREE)NAS-MINI")
 
 
 class EnclosureLabelModel(sa.Model):
@@ -536,6 +537,13 @@ class Enclosure(object):
             self.model = "ES24F"
         elif self.encname.startswith("CELESTIC X2012"):
             self.model = "ES12"
+        elif (
+            self.encname == "AHCI SGPIO Enclosure 2.00" and
+            MINI_REGEX.match(self.system_info["system_product"])
+        ):
+            self.model = self.system_info["system_product"]
+            self.controller = True
+
 
     def _parse_raw_value(self, value):
         newvalue = 0

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -139,16 +139,11 @@ class EnclosureService(Service):
 
             elements.append(element)
 
-        info = await self.middleware.call("system.info")
-        if '-MINI-' in info["system_product"]:
-            model = info["system_product"]
-        else:
-            model = info["system_product"].replace("TRUENAS-", "")
-        return [
+        mapped = [
             {
                 "id": "mapped_enclosure_0",
                 "name": "Drive Bays",
-                "model": model,
+                "model": enclosures[0].model,
                 "controller": True,
                 "elements": [
                     {
@@ -161,3 +156,8 @@ class EnclosureService(Service):
                 ],
             }
         ]
+        #Add shelves back in
+        for enclosure in enclosures:
+            if enclosure.controller == false:
+                mapped.append(enclosure)
+        return mapped

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -143,7 +143,7 @@ class EnclosureService(Service):
             {
                 "id": "mapped_enclosure_0",
                 "name": "Drive Bays",
-                "model": enclosures[0].model,
+                "model": enclosures[0]['model'],
                 "controller": True,
                 "elements": [
                     {
@@ -161,7 +161,7 @@ class EnclosureService(Service):
         # ability to support expansion shelves, then we need to add them
         # back in here so drive identification works
         for enclosure in enclosures:
-            if enclosure.controller == false:
+            if enclosure['controller'] == False:
                 mapped.append(enclosure)
 
         return mapped

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -55,6 +55,26 @@ MAPPINGS = [
             MappingSlot(1, 3, False),
         ]),
     ]),
+    ProductMapping(re.compile(r"TRUENAS-R10$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(0, 0, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(0, 8, False),
+            MappingSlot(0, 12, False),
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 5, False),
+            MappingSlot(0, 9, False),
+            MappingSlot(0, 13, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 6, False),
+            MappingSlot(0, 10, False),
+            MappingSlot(0, 14, False),
+            MappingSlot(0, 3, False),
+            MappingSlot(0, 7, False),
+            MappingSlot(0, 11, False),
+            MappingSlot(0, 15, False),
+        ]),
+    ]),
 ]
 
 
@@ -120,11 +140,15 @@ class EnclosureService(Service):
             elements.append(element)
 
         info = await self.middleware.call("system.info")
+        if '-MINI-' in info["system_product"]:
+            model = info["system_product"]
+        else:
+            model = info["system_product"].replace("TRUENAS-", "")
         return [
             {
                 "id": "mapped_enclosure_0",
                 "name": "Drive Bays",
-                "model": info["system_product"],
+                "model": model,
                 "controller": True,
                 "elements": [
                     {

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -143,7 +143,7 @@ class EnclosureService(Service):
             {
                 "id": "mapped_enclosure_0",
                 "name": "Drive Bays",
-                "model": enclosures[0]['model'],
+                "model": enclosures[0]["model"],
                 "controller": True,
                 "elements": [
                     {
@@ -161,7 +161,7 @@ class EnclosureService(Service):
         # ability to support expansion shelves, then we need to add them
         # back in here so drive identification works
         for enclosure in enclosures:
-            if enclosure['controller'] == False:
+            if not enclosure["controller"]:
                 mapped.append(enclosure)
 
         return mapped

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -156,8 +156,12 @@ class EnclosureService(Service):
                 ],
             }
         ]
-        #Add shelves back in
+
+        # if we have future products that need to be mapped and/or have the
+        # ability to support expansion shelves, then we need to add them
+        # back in here so drive identification works
         for enclosure in enclosures:
             if enclosure.controller == false:
                 mapped.append(enclosure)
+
         return mapped


### PR DESCRIPTION
For iX branded hardware, it's expected that the drive mapping matches a standard pattern (left to right, then top to bottom). The R10 has the inverse of this, however, we have never had to map anything other than TrueNAS-Mini's. This fixes and improves a few things. This was tested on R10 and Mini-X+ to confirm mini mapping still works.

1. update r-series regex to catch R10 model
2. add a `MINI_REGEX` so that the `self.model` in `class Enclosure` doesn't interfere with R10 product mapping
3. future-proof the code by adding back the expansion shelf information to the product mapping