### PR TITLE
Fix r10 enclosure

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -45,7 +45,7 @@ STATUS_DESC = [
 ]
 
 M_SERIES_REGEX = re.compile(r"(ECStream|iX) 4024S([ps])")
-R_SERIES_REGEX = re.compile(r"ECStream (FS2|DSS212S[ps])")
+R_SERIES_REGEX = re.compile(r"(ECStream|iX) (FS1|FS2|DSS212S[ps])")
 R20A_REGEX = re.compile(r"SMC SC826-P")
 R50_REGEX = re.compile(r"iX eDrawer4048S([12])")
 X_SERIES_REGEX = re.compile(r"CELESTIC (P3215-O|P3217-B)")
@@ -230,8 +230,6 @@ class EnclosureService(CRUDService):
         """
         Sync enclosure of a given ZFS pool
         """
-
-        # As we are only interfacing with SES we can skip mapping enclosures or working with non-SES enclosures
 
         encs = self.__get_enclosures()
         if len(list(encs)) == 0:

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -55,6 +55,26 @@ MAPPINGS = [
             MappingSlot(1, 3, False),
         ]),
     ]),
+    ProductMapping(re.compile(r"TRUENAS-R10$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(0, 0, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(0, 8, False),
+            MappingSlot(0, 12, False),
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 5, False),
+            MappingSlot(0, 9, False),
+            MappingSlot(0, 13, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 6, False),
+            MappingSlot(0, 10, False),
+            MappingSlot(0, 14, False),
+            MappingSlot(0, 3, False),
+            MappingSlot(0, 7, False),
+            MappingSlot(0, 11, False),
+            MappingSlot(0, 15, False),
+        ]),
+    ]),
 ]
 
 
@@ -120,11 +140,15 @@ class EnclosureService(Service):
             elements.append(element)
 
         info = await self.middleware.call("system.info")
+        if '-MINI-' in ["system_product"]:
+            model = info["system_product"]
+        else:
+            model = info["system_product"].replace("TRUENAS-", "")
         return [
             {
                 "id": "mapped_enclosure_0",
                 "name": "Drive Bays",
-                "model": info["system_product"],
+                "model": model,
                 "controller": True,
                 "elements": [
                     {


### PR DESCRIPTION
Including mapping drives bays to match standard pattern(left to right then top to bottom) instead of inverse. Tested on R10 and Mini-X+ to confirm mini mapping still works