### PR TITLE
NAS-111143 / 21.08 / reduce system.info calls

### DIFF
--- a/src/freenas/usr/local/sbin/hactl
+++ b/src/freenas/usr/local/sbin/hactl
@@ -1,11 +1,4 @@
 #!/usr/bin/env python3
-# -
-# Copyright (c) 2020 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 import argparse
 import os
 import sys
@@ -39,13 +32,15 @@ def main(command, quiet):
             print("Node status: Standby (Active node unreachable)")
 
         if fo_exists:
-            print(f"Node serial: {client.call('system.info')['system_serial']}{' (ACTIVE)' if ret == 'MASTER' else ''}")
+            serial = client.call('system.dmidecode_info')['system-serial-number']
+            serial += f"{' (ACTIVE)' if ret == 'MASTER' else ''}"
+            print(f"Node serial: {serial}")
             if ret != "UNKNOWN":
                 try:
-                    other_node_serial = client.call('failover.call_remote', 'system.info')['system_serial']
+                    other_serial = client.call('failover.call_remote', 'system.dmidecode_info')['system-serial-number']
                 except Exception as e:
-                    other_node_serial = f'ERROR: {e}'
-                print(f"Other node serial: {other_node_serial}{' (ACTIVE)' if ret == 'BACKUP' else ''}")
+                    other_serial = f'ERROR: {e}'
+                print(f"Other node serial: {other_serial}{' (ACTIVE)' if ret == 'BACKUP' else ''}")
 
             ret = client.call('failover.disabled_reasons')
             if 'NO_CRITICAL_INTERFACES' in ret:

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -71,7 +71,7 @@
         ssl_configuration = True
         middleware.call_sync('alert.oneshot_delete', 'WebUiCertificateSetupFailed', None)
 
-    system_version = middleware.call_sync('system.info')['version']
+    system_version = middleware.call_sync('system.version')
 
     if not any(i in general_settings['ui_httpsprotocols'] for i in ('TLSv1', 'TLSv1.1')):
         disabled_ciphers = ':!SHA1:!SHA256:!SHA384'

--- a/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
@@ -13,7 +13,7 @@
         uname = os.uname()
 
         hw_machine = uname.machine
-        hw_model = middleware.call_sync("system.info")["model"]
+        hw_model = middleware.call_sync("system.cpu_info")["cpu_model"]
         kern_ostype = uname.sysname
         kern_osrelease = uname.release
         kern_osrevision = uname.version

--- a/src/middlewared/middlewared/etc_files/motd.mako
+++ b/src/middlewared/middlewared/etc_files/motd.mako
@@ -1,5 +1,5 @@
 <%
-	buildtime = middleware.call_sync('system.info')['buildtime']
+	buildtime = middleware.call_sync('system.build_time')
 	motd = middleware.call_sync('system.advanced.config')['motd']
 %>\
 % if IS_FREEBSD:

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -556,7 +556,7 @@ class AlertService(Service):
                             support = await self.middleware.call("support.config")
                             msg = [f"* {alert.formatted}" for alert in new_hardware_alerts]
 
-                            serial = (await self.middleware.call("system.info"))["system_serial"]
+                            serial = (await self.middleware.call("system.dmidecode_info"))["system-serial-number"]
 
                             for name, verbose_name in await self.middleware.call("support.fields"):
                                 value = support[name]

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -523,8 +523,7 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.totp.TOTP(
             config['secret'], interval=config['interval'], digits=config['otp_digits']
         ).provisioning_uri(
-            f'{(await self.middleware.call("system.info"))["hostname"]}@'
-            f'{await self.middleware.call("system.product_name")}',
+            f'{socket.gethostname()}@{await self.middleware.call("system.product_name")}',
             'iXsystems'
         )
 

--- a/src/middlewared/middlewared/plugins/enclosure_/m50_plx.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/m50_plx.py
@@ -10,11 +10,12 @@ class EnclosureService(Service):
 
     @private
     def m50_plx_enclosures(self):
-        system_product = self.middleware.call_sync("system.info")["system_product"]
-        if system_product is None or not ("TRUENAS-M50" in system_product or "TRUENAS-M60" in system_product):
+        """
+        # TODO: fix on SCALE
+        product = self.middleware.call_sync("system.dmidecode_info")["system-product-name"]
+        if product is None or not ("TRUENAS-M50" in product or "TRUENAS-M60" in product):
             return []
 
-        """
         nvme_to_nvd = self.middleware.call_sync('disk.nvme_to_nvd_map')
 
         slot_to_nvd = {}

--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -61,12 +61,12 @@ MAPPINGS = [
 class EnclosureService(Service):
     @private
     async def map_enclosures(self, enclosures):
-        info = await self.middleware.call("system.info")
-        if info["system_product"]:
+        info = await self.middleware.call("system.dmidecode_info")
+        if info["system-product-name"] is not None:
             for product_mapping in MAPPINGS:
-                if product_mapping.product_re.match(info["system_product"]):
+                if product_mapping.product_re.match(info["system-product-name"]):
                     for version_mapping in product_mapping.mappings:
-                        if version_mapping.version_re.match(info["system_product_version"]):
+                        if version_mapping.version_re.match(info["system-version"]):
                             return await self._map_enclosures(enclosures, version_mapping.slots)
 
         return enclosures

--- a/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
@@ -1,10 +1,6 @@
 import re
 
 from middlewared.service import Service, private
-from middlewared.utils.osc import IS_FREEBSD
-
-if IS_FREEBSD:
-    import sysctl
 
 
 class EnclosureService(Service):
@@ -17,8 +13,10 @@ class EnclosureService(Service):
 
     @private
     def r50_nvme_enclosures(self):
-        system_product = self.middleware.call_sync("system.info")["system_product"]
-        if system_product != "TRUENAS-R50":
+        """
+        # TODO: fix on SCALE
+        product = self.middleware.call_sync("system.dmidecode_info")["system-product-name"]
+        if product != "TRUENAS-R50":
             return []
 
         nvme_to_nvd = self.middleware.call_sync('disk.nvme_to_nvd_map')
@@ -49,3 +47,5 @@ class EnclosureService(Service):
             3,
             slot_to_nvd
         )
+        """
+        return []

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -163,8 +163,8 @@ class FailoverService(ConfigService):
         # update the class attribute so that all instances
         # of this class see the correct value
         if FailoverService.HA_LICENSED is None:
-            info = self.middleware.call_sync('system.info')
-            if info['license'] and info['license']['system_serial_ha']:
+            info = self.middleware.call_sync('system.license')
+            if info is not None and info['system_serial_ha']:
                 FailoverService.HA_LICENSED = True
             else:
                 FailoverService.HA_LICENSED = False

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -89,8 +89,8 @@ class ISCSIGlobalService(SystemServiceService):
         if not await self.middleware.call('failover.licensed'):
             return False
 
-        license = (await self.middleware.call('system.info'))['license']
-        if license and 'FIBRECHANNEL' in license['features']:
+        license = await self.middleware.call('system.license')
+        if license is not None and 'FIBRECHANNEL' in license['features']:
             return True
 
         return (await self.middleware.call('iscsi.global.config'))['alua']

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -323,7 +323,7 @@ class MailService(ConfigService):
         else:
             interval = timedelta(seconds=interval)
 
-        sw_name = self.middleware.call_sync('system.info')['version'].split('-', 1)[0]
+        sw_name = self.middleware.call_sync('system.version').split('-', 1)[0]
 
         channel = message.get('channel')
         if not channel:

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -347,10 +347,10 @@ class RealtimeEventSource(EventSource):
 
     def _amd_cpu_temperature(self, amd_sensor):
         if self.AMD_SYSTEM_INFO is None:
-            self.AMD_SYSTEM_INFO = self.middleware.call_sync('system.info')
+            self.AMD_SYSTEM_INFO = self.middleware.call_sync('system.cpu_info')
 
-        cpu_model = self.AMD_SYSTEM_INFO['model']
-        core_count = self.AMD_SYSTEM_INFO['physical_cores']
+        cpu_model = self.AMD_SYSTEM_INFO['cpu_model']
+        core_count = self.AMD_SYSTEM_INFO['physical_core_count']
 
         ccds = []
         for k, v in amd_sensor.items():

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -88,7 +88,7 @@ class SupportService(ConfigService):
         if not await self.middleware.call('system.is_enterprise'):
             return False
 
-        license = (await self.middleware.call('system.info'))['license']
+        license = await self.middleware.call('system.license')
         if license is None:
             return False
 
@@ -202,7 +202,7 @@ class SupportService(ConfigService):
         else:
             required_attrs = ('phone', 'name', 'email', 'criticality', 'environment')
             data['serial'] = (await self.middleware.call('system.dmidecode_info'))['system-serial-number']
-            license = (await self.middleware.call('system.info'))['license']
+            license = await self.middleware.call('system.license')
             if license:
                 data['company'] = license['customer_name']
             else:

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -662,6 +662,10 @@ class SystemService(Service):
             return "READY"
         return "BOOTING"
 
+    @private
+    async def license(self):
+        return await self.middleware.run_in_thread(self._get_license)
+
     @staticmethod
     def _get_license():
         if not os.path.exists(LICENSE_FILE):
@@ -822,7 +826,7 @@ class SystemService(Service):
             'system_serial': dmidecode['system-serial-number'] if dmidecode['system-serial-number'] else None,
             'system_product': dmidecode['system-product-name'] if dmidecode['system-product-name'] else None,
             'system_product_version': dmidecode['system-version'] if dmidecode['system-version'] else None,
-            'license': await self.middleware.run_in_thread(self._get_license),
+            'license': await self.middleware.call('system.license'),
             'boottime': time_info['boot_time'],
             'datetime': time_info['datetime'],
             'birthday': birthday['date'],
@@ -866,7 +870,7 @@ class SystemService(Service):
             return False
         elif is_core:
             return True
-        license = await self.middleware.run_in_thread(self._get_license)
+        license = await self.middleware.call('system.license')
         if license and name in license['features']:
             return True
         return False

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -193,7 +193,7 @@ class TrueNASService(Service):
         return result
 
     async def __fetch_customer_information_immutable_data(self):
-        license = (await self.middleware.call('system.info'))['license']
+        license = await self.middleware.call('system.license')
         if license is None:
             return None
 
@@ -227,7 +227,7 @@ class TrueNASService(Service):
         await self.middleware.call('keyvalue.set', 'truenas:production', production)
 
         if not was_production and production:
-            serial = (await self.middleware.call('system.info'))["system_serial"]
+            serial = (await self.middleware.call('system.dmidecode_info'))["system-serial-number"]
             return await job.wrap(await self.middleware.call('support.new_ticket', {
                 "title": f"System has been just put into production ({serial})",
                 "body": "This system has been just put into production",

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -347,7 +347,9 @@ class UpdateService(Service):
 
         try:
             try:
-                self.middleware.call_sync('update.install_manual_impl', job, str(update_file.absolute()), dest_extracted)
+                self.middleware.call_sync(
+                    'update.install_manual_impl', job, str(update_file.absolute()), dest_extracted
+                )
             except Exception as e:
                 self.logger.debug('Applying manual update failed', exc_info=True)
                 raise CallError(str(e), errno.EFAULT)
@@ -448,7 +450,7 @@ class UpdateService(Service):
             self.logger.info('Deleting dataset %s snapshot %s', dataset, snapshot)
             subprocess.run(['zfs', 'destroy', f'{dataset}@{snapshot}'])
 
-        current_version = "-".join(self.middleware.call_sync("system.info")["version"].split("-")[1:])
+        current_version = "-".join(self.middleware.call_sync("system.version").split("-")[1:])
         snapshot = f'update--{datetime.utcnow().strftime("%Y-%m-%d-%H-%M")}--{current_version}'
         subprocess.run(['zfs', 'snapshot', f'{dataset}@{snapshot}'])
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_events_amd_cpu.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_events_amd_cpu.py
@@ -38,6 +38,6 @@ from middlewared.pytest.unit.middleware import Middleware
 ])
 def test_amd_cpu_temperature(model, core_count, reading, result):
     middleware = Middleware()
-    middleware["system.info"] = Mock(return_value={"model": model, "physical_cores": core_count})
+    middleware["system.cpu_info"] = Mock(return_value={"cpu_model": model, "physical_core_count": core_count})
     es = RealtimeEventSource(middleware, Mock(), Mock(), Mock(), Mock())
     assert es._amd_cpu_temperature(reading) == result


### PR DESCRIPTION
While I have gone through effort to optimize `system.info`, it still makes considerable API calls. We're calling `system.info` for simply parsing dmidecode information, for example. Another example is that on licensed systems, every `system.info` call actually reads from disk which can be painful. This is unnecessary and inefficient. This PR changes the callers from using `system.info` to a more appropriate method, if necessary.