### PR TITLE
NAS-111173 / 21.08 / add system.hostname endpoint and change callers to use it

### DIFF
--- a/src/freenas/etc/find_alias_for_smtplib.py
+++ b/src/freenas/etc/find_alias_for_smtplib.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import requests
-import socket
 import sys
 import syslog
 
@@ -55,7 +54,7 @@ def do_sendmail(msg, to_addrs=None, parse_recipients=False):
         margs['extra_headers'] = dict(em)
         margs['extra_headers'].update({
             'X-Mailer': sw_name,
-            f'X-{sw_name}-Host': socket.gethostname(),
+            f'X-{sw_name}-Host': c.call('system.hostname'),
             'To': ', '.join(to_addrs_repl),
         })
         margs['subject'] = em.get('Subject')

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-import socket
 import enum
 import json
 import logging
@@ -250,7 +249,7 @@ class AlertService:
 
     async def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = await self.middleware.call("system.product_name")
-        hostname = socket.gethostname()
+        hostname = await self.middleware.call("system.hostname")
         if await self.middleware.call("system.is_enterprise"):
             node_map = await self.middleware.call("alert.node_map")
         else:
@@ -273,7 +272,7 @@ class ThreadedAlertService(AlertService):
 
     def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = self.middleware.call_sync("system.product_name")
-        hostname = socket.gethostname()
+        hostname = self.middleware.call_sync("system.hostname")
         if self.middleware.call_sync("system.is_enterprise"):
             node_map = self.middleware.call_sync("alert.node_map")
         else:

--- a/src/middlewared/middlewared/alert/source/quota.py
+++ b/src/middlewared/middlewared/alert/source/quota.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 import logging
 import os
-import socket
 
 try:
     from bsd import getmntinfo
@@ -47,8 +46,10 @@ class QuotaAlertSource(ThreadedAlertSource):
                 except (KeyError, ValueError):
                     d[k] = default
 
+        # call this outside the for loop since we don't need to check
+        # for every dataset that could be potentially be out of quota...
+        hostname = self.middleware.call_sync("system.hostname")
         datasets = sorted(datasets, key=lambda ds: ds["name"])
-
         for dataset in datasets:
             for quota_property in ["quota", "refquota"]:
                 try:
@@ -90,8 +91,6 @@ class QuotaAlertSource(ThreadedAlertSource):
                     continue
 
                 quota_name = quota_property[0].upper() + quota_property[1:]
-
-                hostname = socket.gethostname()
                 args = {
                     "name": quota_name,
                     "dataset": dataset["name"],

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -523,7 +523,7 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.totp.TOTP(
             config['secret'], interval=config['interval'], digits=config['otp_digits']
         ).provisioning_uri(
-            f'{socket.gethostname()}@{await self.middleware.call("system.product_name")}',
+            f'{await self.middleware.call("system.hostname")}@{await self.middleware.call("system.product_name")}',
             'iXsystems'
         )
 

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -21,7 +21,6 @@ import json
 import os
 import pickle
 import smtplib
-import socket
 import syslog
 
 
@@ -406,9 +405,14 @@ class MailService(ConfigService):
             msg['Cc'] = ', '.join(message.get('cc'))
         msg['Date'] = formatdate()
 
-        local_hostname = socket.gethostname()
+        local_hostname = self.middleware.call_sync('system.hostname')
 
-        msg['Message-ID'] = "<%s-%s.%s@%s>" % (sw_name.lower(), datetime.utcnow().strftime("%Y%m%d.%H%M%S.%f"), base64.urlsafe_b64encode(os.urandom(3)), local_hostname)
+        msg['Message-ID'] = "<%s-%s.%s@%s>" % (
+            sw_name.lower(),
+            datetime.utcnow().strftime("%Y%m%d.%H%M%S.%f"),
+            base64.urlsafe_b64encode(os.urandom(3)),
+            local_hostname
+        )
 
         extra_headers = message.get('extra_headers') or {}
         for key, val in list(extra_headers.items()):
@@ -463,7 +467,7 @@ class MailService(ConfigService):
         self.middleware.call_sync('network.general.will_perform_activity', 'mail')
 
         if local_hostname is None:
-            local_hostname = socket.gethostname()
+            local_hostname = self.middleware.call_sync('system.hostname')
 
         if not config['outgoingserver'] or not config['port']:
             # See NOTE below.

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -2,7 +2,6 @@ import errno
 import json
 import requests
 import simplejson
-import socket
 import time
 
 from middlewared.pipe import Pipes
@@ -263,7 +262,7 @@ class SupportService(ConfigService):
                 debug_name = 'debug-{}.tar'.format(time.strftime('%Y%m%d%H%M%S'))
             else:
                 debug_name = 'debug-{}-{}.txz'.format(
-                    socket.gethostname().split('.')[0],
+                    (await self.middleware.call('system.hostname')).split('.')[0],
                     time.strftime('%Y%m%d%H%M%S'),
                 )
 

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -606,6 +606,10 @@ class SystemService(Service):
     async def is_enterprise(self):
         return await self.middleware.call('system.product_type') in ['ENTERPRISE', 'SCALE_ENTERPRISE']
 
+    @private
+    async def hostname(self):
+        return socket.gethostname()
+
     @no_auth_required
     @accepts()
     @returns(Str('product_name'))
@@ -827,7 +831,7 @@ class SystemService(Service):
         return {
             'version': self.version(),
             'buildtime': await self.middleware.call('system.build_time'),
-            'hostname': socket.gethostname(),
+            'hostname': await self.middleware.call('system.hostname'),
             'physmem': mem_info['physmem_size'],
             'model': cpu_info['cpu_model'],
             'cores': cpu_info['core_count'],

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -1,5 +1,4 @@
 import asyncio
-import socket
 
 from middlewared.service import CallError, job, private, Service
 
@@ -148,7 +147,7 @@ class TruecommandService(Service, TruecommandAPIMixin):
             'action': 'add-truecommand-wg-key',
             'apikey': config['api_key'],
             'nas_pubkey': config['wg_public_key'],
-            'hostname': socket.gethostname(),
+            'hostname': await self.middleware.call('system.hostname'),
             'sysversion': await self.middleware.call('system.version'),
         })
 

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -7,7 +7,6 @@ import io
 import os
 import re
 import syslog
-import socket
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, returns, Str
 from middlewared.service import private, SystemServiceService, ValidationErrors
@@ -351,7 +350,7 @@ class UPSService(SystemServiceService):
                 # battery.runtime.low: 900
 
                 ups_name = config['identifier']
-                hostname = socket.gethostname()
+                hostname = await self.middleware.call('system.hostname')
                 current_time = datetime.datetime.now(tz=dateutil.tz.tzlocal()).strftime('%a %b %d %H:%M:%S %Z %Y')
                 ups_subject = config['subject'].replace('%d', current_time).replace('%h', hostname)
                 body = f'NOTIFICATION: {notify_type!r}\n\nUPS: {ups_name!r}\n\n'


### PR DESCRIPTION
We're `import socket` in multiple modules and call `socket.gethostname()`. This is minor code cleanup to make a `system.hostname` endpoint and change all the callers to use it instead.