### PR TITLE
NAS-111176 / 21.08 / fix writing watchdog alert file on SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event_linux.py
+++ b/src/middlewared/middlewared/plugins/failover_/event_linux.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 import time
 import contextlib
 import shutil
@@ -641,8 +642,8 @@ class FailoverService(Service):
         # So if we panic here, middleware will check for this file and send an appropriate email.
         # ticket 39114
         with contextlib.suppress(Exception):
-            with open(self.WATCHDOG_ALERT_FILE, 'w') as f:
-                f.write(int(time.time()))
+            with open(self.WATCHDOG_ALERT_FILE, 'wb') as f:
+                f.write(int(time.time()).to_bytes(4, sys.byteorder))
                 f.flush()  # be sure it goes straight to disk
                 os.fsync(f.fileno())  # be EXTRA sure it goes straight to disk
 


### PR DESCRIPTION
Two problems fixed:

1. I was opening the file in `w` mode but passing an `int` object to `f.write()` which expected a `str` object so the file was created but it was empty
2. This alert file is read in `unscheduled_reboot_alert.py` and it expects it to be a binary string of 4 bytes in native byte order