### PR TITLE
NAS-111204 / 21.08 / Make scaling workloads a job

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
@@ -109,10 +109,10 @@ class ChartReleaseService(Service):
 
         # TODO: Upstream helm does not have ability to force stop a release, until we have that ability
         #  let's just try to do a best effort to scale down scaleable workloads and then scale them back up
-        scale_stats = await self.middleware.call('chart.release.scale', release_name, {'replica_count': 0})
         job.set_progress(45, 'Scaling down workloads')
-
-        await self.middleware.call('chart.release.wait_for_pods_to_terminate', release['namespace'])
+        scale_stats = await (
+            await self.middleware.call('chart.release.scale', release_name, {'replica_count': 0})
+        ).wait(raise_error=True)
 
         job.set_progress(50, 'Rolling back chart release')
 


### PR DESCRIPTION
This commit adds changes to make scaling workloads a job as it can take time to actually create/destroy pods and returning immediately gives the impression that workloads have already been scaled to desired replica counts which is not true as they have just been registered by k8s to be scaled to the desired replica count.