### PR TITLE
NAS-111210 / 21.08 / Improvements to revoking a certificate/ca

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1192,15 +1192,13 @@ class CertificateService(CRUDService):
             ))
 
             ca_chain = await self.middleware.call('certificateauthority.get_ca_chain', cert['id'])
-
-            cert['revoked_certs'] = list(filter(
-                lambda c: c['revoked_date'],
-                ca_chain
-            ))
-
-            cert['crl_path'] = os.path.join(
-                root_path, f'{cert["name"]}.crl'
-            )
+            cert.update({
+                'revoked_certs': list(filter(lambda c: c['revoked_date'], ca_chain)),
+                'crl_path': os.path.join(root_path, f'{cert["name"]}.crl'),
+                'can_be_revoked': bool(cert['privatekey']),
+            })
+        else:
+            cert['can_be_revoked'] = bool(cert['signedby'])
 
         if not os.path.exists(root_path):
             os.makedirs(root_path, 0o755, exist_ok=True)

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1947,6 +1947,11 @@ class CertificateService(CRUDService):
                     'certificate_update.revoked',
                     'A CSR cannot be marked as revoked.'
                 )
+            elif new['revoked'] and not new['can_be_revoked']:
+                verrors.add(
+                    'certificate_update.revoked',
+                    'Only certificate(s) can be revoked which have a CA present on the system'
+                )
 
             verrors.check()
 


### PR DESCRIPTION
This PR introduces following changes:

1) Adds a key to query output of ca/certs which shows if a cert/ca can be revoked. This will be useful for the UI where it can only expose the option to revoke if the cert/ca in question can actually be revoked.
2) Improves validation of revoking a cert only if it can be revoked.
3) Do not allow reversing revoking operation and raise necessary validation error(s).