### PR TITLE
NAS-111226 / 21.08 / Mark login password as private

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -325,7 +325,7 @@ class AuthService(Service):
 
     @cli_private
     @no_auth_required
-    @accepts(Str('username'), Str('password'), Str('otp_token', null=True, default=None))
+    @accepts(Str('username'), Str('password', private=True), Str('otp_token', null=True, default=None))
     @returns(Bool('successful_login'))
     @pass_app()
     async def login(self, app, username, password, otp_token):


### PR DESCRIPTION
Mark login password as private as when socket messages are retrieved it's possible the user login password is retrieved as it is due it not being private.