### PR TITLE
NAS-111240 / 21.08 / Add `who` string to ACL output

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -299,33 +299,33 @@ class ACLBase(ServicePartBase):
         Return ACL of a given path. This may return a POSIX1e ACL or a NFSv4 ACL. The acl type is indicated
         by the `acltype` key.
 
-        `simplified` NFSv4 - returns a shortened form of the ACL permset, POSIX1E - this is a no-op.
+        `simplified` - effect of this depends on ACL type on underlying filesystem. In the case of
+        NFSv4 ACLs simplified permissions and flags are returned for ACL entries where applicable.
+        NFSv4 errata below. In the case of POSIX1E ACls, this setting has no impact on returned ACL.
 
         `resolve_ids` - adds additional `who` key to each ACL entry, that converts the numeric id to
         a user name or group name. In the case of owner@ and group@ (NFSv4) or USER_OBJ and GROUP_OBJ
-        (POSIX1E), st_uid or st_gid will be converted from stat() return for file. In all other cases.
+        (POSIX1E), st_uid or st_gid will be converted from stat() return for file. In the case of
         MASK (POSIX1E), OTHER (POSIX1E), everyone@ (NFSv4), key `who` will be included, but set to null.
         In case of failure to resolve the id to a name, `who` will be set to null. This option should
         only be used if resolving ids to names is required.
 
         Errata about ACLType NFSv4:
 
-        `simplified` returns a shortened form of the ACL permset and flags.
+        `simplified` returns a shortened form of the ACL permset and flags where applicable. If permissions
+        have been simplified, then the `perms` object will contain only a single `BASIC` key with a string
+        describing the underlying permissions set.
 
         `TRAVERSE` sufficient rights to traverse a directory, but not read contents.
 
         `READ` sufficient rights to traverse a directory, and read file contents.
 
-        `MODIFIY` sufficient rights to traverse, read, write, and modify a file. Equivalent to modify_set.
+        `MODIFIY` sufficient rights to traverse, read, write, and modify a file.
 
         `FULL_CONTROL` all permissions.
 
         If the permisssions do not fit within one of the pre-defined simplified permissions types, then
         the full ACL entry will be returned.
-
-        An inheriting empty everyone@ ACE is appended to non-trivial ACLs in order to enforce Windows
-        expectations regarding permissions inheritance. This entry is removed from NT ACL returned
-        to SMB clients when 'ixnas' samba VFS module is enabled. We also remove it here to avoid confusion.
         """
 
     @accepts(

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -171,23 +171,6 @@ class FilesystemService(Service, ACLBase):
         return acl
 
     @private
-    def id_to_name(self, id, idtype):
-        if idtype == "GROUP":
-            try:
-                group_obj = self.middleware.call_sync("group.get_group_obj", {"gid": id})
-                name = group_obj['gr_name']
-            except Exception:
-                name = None
-        elif idtype == "USER":
-            try:
-                user_obj = self.middleware.call_sync("user.get_user_obj", {"uid": id})
-                name = user_obj['pw_name']
-            except Exception:
-                name = None
-
-        return name
-
-    @private
     def getacl_nfs4(self, path, simplified, resolve_ids):
         flags = "-jn"
 
@@ -206,11 +189,17 @@ class FilesystemService(Service, ACLBase):
         output = json.loads(getacl.stdout.decode())
         for ace in output['acl']:
             if resolve_ids and ace['id'] != -1:
-                ace['who'] = self.id_to_name(ace['id'], ace['tag'])
+                ace['who'] = self.middleware.call_sync(
+                    'idmap.id_to_name', ace['id'], ace['tag']
+                )
             elif resolve_ids and ace['tag'] == 'group@':
-                ace['who'] = self.id_to_name(output['gid'], "GROUP")
+                ace['who'] = self.middleware.call_sync(
+                    'idmap.id_to_name', output['gid'], 'GROUP'
+                )
             elif resolve_ids and ace['tag'] == 'owner@':
-                ace['who'] = self.id_to_name(output['uid'], "USER")
+                ace['who'] = self.middleware.call_sync(
+                    'idmap.id_to_name', output['uid'], 'USER'
+                )
             elif resolve_ids:
                 ace['who'] = None
 
@@ -282,12 +271,16 @@ class FilesystemService(Service, ACLBase):
             if id.isdigit():
                 ace['id'] = int(id)
                 if resolve_ids:
-                    ace['who'] = self.id_to_name(ace['id'], ace['tag'])
+                    ace['who'] = self.middleware.call_sync(
+                        'idmap.id_to_name', ace['id'], ace['tag']
+                    )
 
             elif ace['tag'] not in ['OTHER', 'MASK']:
                 if resolve_ids:
                     to_check = st.st_gid if ace['tag'] == "GROUP" else st.st_uid
-                    ace['who'] = self.id_to_name(to_check, ace['tag'])
+                    ace['who'] = self.middleware.call_sync(
+                        'idmap.id_to_name', to_check, ace['tag']
+                    )
 
                 ace['tag'] += '_OBJ'
 
@@ -303,7 +296,6 @@ class FilesystemService(Service, ACLBase):
         if not os.path.exists(path):
             raise CallError('Path not found.', errno.ENOENT)
         # Add explicit check for ACL type
-        self.logger.debug("resolve_ids: %s", resolve_ids)
         try:
             ret = self.getacl_nfs4(path, simplified, resolve_ids)
         except CallError:

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -788,7 +788,7 @@ class IdmapDomainService(CRUDService):
         if idtype == IDType.GROUP or idtype == IDType.BOTH:
             method = "group.get_group_obj"
             to_check = {"gid": id}
-            key= 'gr_name'
+            key = 'gr_name'
         elif idtype == IDType.USER:
             method = "user.get_user_obj"
             to_check = {"uid": id}
@@ -799,7 +799,7 @@ class IdmapDomainService(CRUDService):
         try:
             ret = await asyncio.wait_for(
                 self.middleware.call(method, to_check),
-                timeout = idmap_timeout
+                timeout=idmap_timeout
             )
             name = ret[key]
         except asyncio.TimeoutError:


### PR DESCRIPTION
Add optional (non-default) `resolve_ids` argument to `filesystem.getacl`
so that API users have an efficient way to get names from ACLs. This is
non-default because it exposes us to broken DNS or other environmental
issues. Should only be specified when _really_ needed.