### PR TITLE
NAS-111175 / 21.08 / add xmit_hash_policy and lacpdu_rate for lagg interfaces

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-29_add_xmit_hash_policy_and_lacpdu_rate.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-06-29_add_xmit_hash_policy_and_lacpdu_rate.py
@@ -1,0 +1,25 @@
+"""add xmit_hash_policy and lacpdu_rate
+
+Revision ID: c02971570fb0
+Revises: 1fd17693941f
+Create Date: 2021-06-29 15:45:54.309469+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'c02971570fb0'
+down_revision = '1fd17693941f'
+
+
+def upgrade():
+    with op.batch_alter_table('network_lagginterface', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('lagg_lacpdu_rate', sa.String(length=4), nullable=True))
+        batch_op.add_column(sa.Column('lagg_xmit_hash_policy', sa.String(length=8), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('network_lagginterface', schema=None) as batch_op:
+        batch_op.drop_column('lagg_xmit_hash_policy')
+        batch_op.drop_column('lagg_lacpdu_rate')

--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -11,16 +11,16 @@ class InterfaceService(Service):
     @private
     def lag_setup(self, lagg, members, disable_capabilities, parent_interfaces, sync_interface_opts):
         name = lagg['lagg_interface']['int_interface']
-        self.logger.info('Setting up {}'.format(name))
+        self.logger.info('Setting up %s', name)
 
         try:
             iface = netif.get_interface(name)
         except KeyError:
             iface = None
         else:
-            first_port = next(iter(iface.ports))
+            first_port = next(iter(iface.ports), None)
             if first_port is None or first_port[0] != members[0]['lagg_physnic']:
-                self.logger.info('Destroying existing %s as its first port has changed', name)
+                self.logger.info('Destroying %s because its first port has changed', name)
                 netif.destroy_interface(name)
                 iface = None
 
@@ -28,13 +28,50 @@ class InterfaceService(Service):
             netif.create_interface(name)
             iface = netif.get_interface(name)
 
+        # FIXME: this will fail on SCALE since we don't even have
+        # a "disable_capabilities" method
+        """
         if disable_capabilities:
             self.middleware.call_sync('interface.disable_capabilities', name)
+        """
 
+        info = {'protocol': None, 'xmit_hash_policy': None, 'lacpdu_rate': None}
         protocol = getattr(netif.AggregationProtocol, lagg['lagg_protocol'].upper())
         if iface.protocol != protocol:
-            self.logger.info('{}: changing protocol to {}'.format(name, protocol))
-            iface.protocol = protocol
+            info['protocol'] = protocol
+
+        xmit_hash = lagg['lagg_xmit_hash_policy']
+        if iface.xmit_hash_policy != xmit_hash:
+            info['xmit_hash_policy'] = xmit_hash
+
+        lacpdu_rate = lagg['lagg_lacpdu_rate']
+        if iface.lacpdu_rate != lacpdu_rate:
+            info['lacpdu_rate'] = lacpdu_rate
+
+        if any(i is not None for i in info.values()):
+            # means one of the lagg options changed or is being
+            # setup for the first time so we have to down the
+            # interface before performing any of the actions
+            iface.down()
+
+            if info['protocol'] is not None:
+                # we _always_ have to start with the protocol
+                # information first since it deletes members
+                # (if any) of the current lagg and then changes
+                # the protocol
+                self.logger.info('Changing protocol on %r to %s', name, info['protocol'].name)
+                iface.protocol = info['protocol']
+
+            if info['xmit_hash_policy'] is not None:
+                self.logger.info('Changing xmit_hash_policy on %r to %s', name, info['xmit_hash_policy'])
+                iface.xmit_hash_policy = info['xmit_hash_policy']
+
+            if info['lacpdu_rate'] is not None:
+                self.logger.info('Changing lacpdu_rate on %r to %s', name, info['lacpdu_rate'])
+                iface.lacpdu_rate = info['lacpdu_rate']
+
+            # be sure and bring the lagg back up after making changes
+            iface.up()
 
         members_database = []
         members_configured = {p[0] for p in iface.ports}
@@ -58,7 +95,8 @@ class InterfaceService(Service):
             try:
                 port_iface = netif.get_interface(port[0])
             except KeyError:
-                self.logger.warn('Could not find {} from {}'.format(port[0], name))
+                self.logger.warning('Could not find %s from %s', port[0], name)
                 continue
+
             parent_interfaces.append(port[0])
             port_iface.up()

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -142,7 +142,9 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         if self.name.startswith('bond'):
             state.update({
                 'protocol': self.protocol.name,
-                'ports': [{'name': p, 'flags': [x.name for x in f]} for p, f in self.ports]
+                'ports': [{'name': p, 'flags': [x.name for x in f]} for p, f in self.ports],
+                'xmit_hash_policy': self.xmit_hash_policy,
+                'lacpdu_rate': self.lacpdu_rate,
             })
 
         if self.name.startswith('vlan'):

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -1,9 +1,8 @@
-# -*- coding=utf-8 -*-
 import enum
 import logging
+import pathlib
 
 import middlewared.plugins.interface.netif_linux.interface as interface
-
 from .utils import run
 
 logger = logging.getLogger(__name__)
@@ -23,6 +22,7 @@ def create_lagg(name):
 
 
 class LaggMixin:
+
     @property
     def protocol(self):
         value = self._sysfs_read(f"/sys/devices/virtual/net/{self.name}/bonding/mode").split()[0]
@@ -30,22 +30,41 @@ class LaggMixin:
             if protocol.value == value:
                 return protocol
 
-        return None
-
     @protocol.setter
     def protocol(self, value):
-        run(["ip", "link", "set", self.name, "down"])
         for port in self.ports:
             self.delete_port(port[0])
         run(["ip", "link", "set", self.name, "type", "bond", "mode", value.value])
-        run(["ip", "link", "set", self.name, "up"])
+
+    @property
+    def xmit_hash_policy(self):
+        if self.protocol in (AggregationProtocol.LACP, AggregationProtocol.LOADBALANCE):
+            # this option only applies to 802.3ad and/or balance-xor
+            return self._sysfs_read(self.get_options_path("xmit_hash_policy")).split()[0]
+
+    @xmit_hash_policy.setter
+    def xmit_hash_policy(self, value):
+        run(["ip", "link", "set", self.name, "type", "bond", "xmit_hash_policy", value])
+
+    @property
+    def lacpdu_rate(self):
+        if self.protocol == AggregationProtocol.LACP:
+            # this option only applies to 802.3ad
+            return self._sysfs_read(self.get_options_path("lacp_rate")).split()[0]
+
+    @lacpdu_rate.setter
+    def lacpdu_rate(self, value):
+        run(["ip", "link", "set", self.name, "type", "bond", "lacp_rate", value])
 
     @property
     def ports(self):
-        return [
-            (port, set())
-            for port in self._sysfs_read(f"/sys/devices/virtual/net/{self.name}/bonding/slaves").split()
-        ]
+        ports = []
+        for port in self._sysfs_read(f"/sys/devices/virtual/net/{self.name}/bonding/slaves").split():
+            ports.append((port, set()))
+        return ports
+
+    def get_options_path(self, value):
+        return str(pathlib.Path(f"/sys/class/net/{self.name}/bonding/").joinpath(value))
 
     def add_port(self, name):
         interface.Interface(name).down()


### PR DESCRIPTION
While I'm in this horribly messy code, fix a few issues.

1. we were calling `next(iter(iface.port))` without specifying a default to the `next()` function so it could raise a `StopIteration` in an edge-case which causes a nasty `asyncio` warning
2. `lag_setup` method was written in a way that would force me to `down()` and `up()` the interface for any of the 2 newly added options (if they were specified). This is bad but more importantly, some switches will detect this as "link flaps" and actually disable the associated switch port(s). Change this so when a lagg is setup for the first time and/or updated, only take it down as necessary.
3. `disable_capabilities` was kept for API backwards capability and while it's `False` always on SCALE, if someone were to specify it as `True` via the API manually, then we would fail because that method doesn't even exist on SCALE.
4. This also fixes a race condition with `attach_interface` and a udev event. Since we were `down()`'ing and then `up()'ing` the interface the moment we changed the protocol, `attach_interface` would call `interface.query()` which would run `__getstate__` and `self.protocol.name` would return `'NoneType' object has no attrbute 'name'` because the protocol had not been set by the time the udev event was triggered.
5. various flake8 fixes and general code clean up