### PR TITLE
NAS-106539 / 12.0 / Copy over profile(4) localbase/etc to reflect with upstream changes

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -24,6 +24,12 @@ copy_templates()
 		if [ "$nfile" = "/etc/login.conf" ] ; then
 			cap_mkdb /etc/login.conf
 		fi
+
+		# We copy profile file to /usr/local/etc to reflect with upstream changes
+		# https://forums.freebsd.org/threads/what-happened-to-etc-profile.78406/
+		if [ "$nfile" = "/etc/profile" -a -f "$nfile" ]; then
+			cp "$nfile" "/usr/local$nfile"
+		fi
 	done
 }
 


### PR DESCRIPTION
This commit adds changes to copy over profile(4) to localbase/etc as bash reads the login initialization changes from there now with recent changes introduced to freebsd upstream last year ( https://forums.freebsd.org/threads/what-happened-to-etc-profile.78406/ ).
