### PR TITLE
NAS-111283 / 12.0 / Bug fix for recommending zvol blocksize (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3750,7 +3750,7 @@ class PoolDatasetService(CRUDService):
             if disks > maxdisks:
                 maxdisks = disks
 
-        return f'{max(16, min(128, 2 ** ((maxdisks * 8) - 1).bit_length()))}'
+        return f'{max(16, min(128, 2 ** ((maxdisks * 8) - 1).bit_length()))}K'
 
     @item_method
     @accepts(Str('id', required=True))


### PR DESCRIPTION
This commit fixes an issue where we are not sending 'K' suffix with the recommended blocksize which we were doing before.

Original PR: https://github.com/truenas/middleware/pull/7108
Jira URL: https://jira.ixsystems.com/browse/NAS-111283