### PR TITLE
NAS-111317 / 21.08 / fix traceback when creating bond type interfaces on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -141,7 +141,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
 
         if self.name.startswith('bond'):
             state.update({
-                'protocol': self.protocol.name,
+                'protocol': self.protocol.name if self.protocol is not None else self.protocol,
                 'ports': [{'name': p, 'flags': [x.name for x in f]} for p, f in self.ports],
                 'xmit_hash_policy': self.xmit_hash_policy,
                 'lacpdu_rate': self.lacpdu_rate,

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from .bridge import create_bridge
-from .interface import Interface
+from .interface import Interface, CLONED_PREFIXES
 from .lagg import AggregationProtocol, create_lagg
 from .utils import run
 from .vlan import create_vlan
@@ -11,7 +11,7 @@ from .vlan import create_vlan
 logger = logging.getLogger(__name__)
 
 __all__ = ["AggregationProtocol", "create_vlan", "create_interface", "destroy_interface", "get_interface",
-           "list_interfaces"]
+           "list_interfaces", "CLONED_PREFIXES"]
 
 
 def create_interface(name):


### PR DESCRIPTION
This fixes a race when adding bond type interfaces. In some situations, when adding a bond, a udevd event would be generated as expected. The race occurs between `interface.query()` calling `__getstate__()` and the time it takes to setup the lagg. In the failure condition, `__getstate__()` would set `protocol: self.protocol.name` but `self.protocol` would be `None` in this situation causing a `AttributeError: 'NoneType' object has no attribute 'name'`. While I'm here I've done some research and I've found that this method was added back in 2018 [here](https://github.com/truenas/middleware/pull/1368/files) which also fixes a race condition when adding laggs on freeBSD. I've made the following changes based on historical research as well as local testing.

1. remove the unused TN CORE code
2. import `CLONED_PREFIXES` since it's relevant to SCALE and use it in the `udevd_ifnet_hook` function so we can return earlier on the udevd event which saves us from the race condition mentioned above.
3. `epair` is a TN CORE only interface
4. fix `self.logger.info` call in `sync_interface` to be Sentry friendly
5. add docstring to `udevd_ifnet_hook`
6. do not crash `interface.query` in `__getstate__` when trying to set `protocol` information