### PR TITLE
NAS-111011 / 21.08 / Wait for vdev removal after a device is removed from zfs pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1248,6 +1248,9 @@ class PoolService(CRUDService):
             raise verrors
 
         await self.middleware.call('zfs.pool.remove', pool['name'], found[1]['guid'])
+        # We would like to wait not for the removal to actually complete for cases where the removal might not
+        # be synchronous like removing top level vdevs except for slog and l2arc
+        await self.middleware.call('zfs.pool.wait', pool['name'], 'REMOVE')
 
         if found[1]['type'] != 'DISK':
             disk_paths = [d['path'] for d in found[1]['children']]

--- a/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
@@ -1,0 +1,30 @@
+import libzfs
+
+from middlewared.schema import accepts, Dict, Str
+from middlewared.service import CallError, Service
+
+
+POOL_ACTIVITY_TYPES = [a.name for a in libzfs.ZpoolWaitActivity]
+
+
+class ZFSPoolService(Service):
+
+    class Config:
+        namespace = 'zfs.pool'
+        private = True
+        process_pool = True
+
+    @accepts(
+        Str('pool_name'),
+        Dict(
+            'options',
+            Str('activity_type', enum=POOL_ACTIVITY_TYPES, required=True),
+        )
+    )
+    def wait(self, pool_name, options):
+        try:
+            with libzfs.ZFS() as zfs:
+                pool = zfs.get(pool_name)
+                pool.wait(options['activity_type'])
+        except libzfs.ZFSException as e:
+            raise CallError(str(e))


### PR DESCRIPTION
This PR adds changes to wait for a vdev to be removed before moving on to wiping disks. This is required for cases where we have top level vdevs being removed and `zpool remove` is not a synchronous operation in this context which results in middleware trying to wipe disks while removal of vdev is still in place.