### PR TITLE
NAS-111339 / 21.08 / Add iptables rules with counters to debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
@@ -130,8 +130,8 @@ network_func()
 	ip rule list
 	section_footer
 
-	section_header "Iptables Rules (iptables-save)"
-	iptables-save
+	section_header "Iptables Rules (iptables-save -c)"
+	iptables-save -c
 	section_footer
 
 	section_header "IPVS rules (ipvsadm -L)"


### PR DESCRIPTION
This commit adds changes to add iptables rules with counters to debug. It can be helpful in situations when we want to debug if there are concerns with some iptable rule(s) and we can look up to counters to extract the information and make an analysis.