### PR TITLE
NAS-111337 / 21.08 / prevent race with dhclient and up/down'ing interfaces

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -6,7 +6,7 @@ import sys
 
 import sentry_sdk
 
-from .utils import osc, sw_version, sw_version_is_stable
+from .utils import sw_version, sw_version_is_stable
 
 
 # markdown debug is also considered useless
@@ -25,10 +25,11 @@ logging.getLogger('git.cmd').setLevel(logging.WARN)
 logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 # registered 'pbkdf2_sha256' handler: <class 'passlib.handlers.pbkdf2.pbkdf2_sha256'>
 logging.getLogger('passlib.registry').setLevel(logging.INFO)
-if osc.IS_LINUX:
-    # It logs each call made to the k8s api server when in debug mode, so we set the level to warn
-    logging.getLogger('kubernetes_asyncio.client.rest').setLevel(logging.WARN)
-    logging.getLogger('kubernetes_asyncio.config.kube_config').setLevel(logging.WARN)
+# dont need internal debug messages from pyroute2.ndb
+logging.getLogger('pyroute2.ndb').setLevel(logging.WARN)
+# It logs each call made to the k8s api server when in debug mode, so we set the level to warn
+logging.getLogger('kubernetes_asyncio.client.rest').setLevel(logging.WARN)
+logging.getLogger('kubernetes_asyncio.config.kube_config').setLevel(logging.WARN)
 
 LOGFILE = '/var/log/middlewared.log'
 ZETTAREPL_LOGFILE = '/var/log/zettarepl.log'
@@ -58,8 +59,10 @@ class CrashReporting(object):
         else:
             self.sentinel_file_path = '/data/.crashreporting_disabled'
         self.logger = logging.getLogger('middlewared.logger.CrashReporting')
+        url = 'https://11101daa5d5643fba21020af71900475:d60cd246ba684afbadd479653de2c216@sentry.ixsystems.com/2'
+        query = '?timeout=3'
         sentry_sdk.init(
-            'https://11101daa5d5643fba21020af71900475:d60cd246ba684afbadd479653de2c216@sentry.ixsystems.com/2?timeout=3',
+            url + query,
             release=sw_version(),
             integrations=[],
             default_integrations=False,

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -1,6 +1,6 @@
-# -*- coding=utf-8 -*-
 import logging
 import subprocess
+import pyroute2
 
 from .address import AddressFamily, AddressMixin
 from .bridge import BridgeMixin
@@ -157,7 +157,11 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         return state
 
     def up(self):
-        run(["ip", "link", "set", self.name, "up"])
+        with pyroute2.NDB().interface[self.name] as i:
+            # this context manager waits until the interface
+            # is up and "ready" before exiting
+            i['state'] = 'up'
 
     def down(self):
-        run(["ip", "link", "set", self.name, "down"])
+        with pyroute2.NDB().interface[self.name] as i:
+            i['state'] = 'down'


### PR DESCRIPTION
Before this change, we subprocess out and just run `ip link set <dev> up` which doesn't wait for the link to become "ready". This causes a race condition between downing and then subsequently uping the interface and then starting a background asyncio task to start `dhclient` for said interface.

Use `pyroute2.NDB` class to up/down an interface since it actually waits for the interface to become ready.

On a side note, this fixes a long-standing `pyroute2.netlink.exceptions.NetlinkError` traceback in the `RouteService` class in middlewared.