### PR TITLE
NAS-111305 / 21.08 / raise collectd partition threshold to 1.5GB

### DIFF
--- a/src/middlewared/middlewared/alert/source/reporting_db.py
+++ b/src/middlewared/middlewared/alert/source/reporting_db.py
@@ -1,26 +1,32 @@
-import humanfriendly
-import psutil
+import shutil
+from humanfriendly import format_size
 
-from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource, UnavailableException
+from middlewared.alert.base import (AlertClass, AlertCategory, AlertLevel,
+                                    Alert, ThreadedAlertSource, UnavailableException)
 
 
 class ReportingDbAlertClass(AlertClass):
     category = AlertCategory.REPORTING
     level = AlertLevel.WARNING
-    title = 'Reporting Database Size Is Larger than 1 GiB'
-    text = 'Reporting database size (%s) is larger than 1 GiB.'
+    title = 'Reporting Database Size Exceeds Threshold'
+    text = 'Reporting database used size %(used)s is larger than %(threshold)s.'
 
 
 class ReportingDbAlertSource(ThreadedAlertSource):
     def check_sync(self):
-        rrd_size_alert_threshold = 1073741824
+        rrd_size_alert_threshold = 1610611911  # bytes
 
         try:
-            used = psutil.disk_usage('/var/db/collectd/rrd').used
+            used = shutil.disk_usage('/var/db/collectd/rrd').used
         except FileNotFoundError:
             raise UnavailableException()
 
         if used > rrd_size_alert_threshold:
-            return Alert(ReportingDbAlertClass,
-                         args=humanfriendly.format_size(used),
-                         key=None)
+            # zfs list reports in kibi/mebi/gibi(bytes) but
+            # format_size() calculates in kilo/mega/giga by default
+            # so the report that we send the user needs to match
+            # up with what zfs list reports as to not confuse anyone
+            used = format_size(used, binary=True)
+            threshold = format_size(rrd_size_alert_threshold, binary=True)
+
+            return Alert(ReportingDbAlertClass, {'used': used, 'threshold': threshold})


### PR DESCRIPTION
This fixes a few things.

1. raise the upper threshold for the collectd partition to 1.5GB from 1GB
2. `zfs list` reports in kibi/mebi/gibi etc but we were reporting in kilo/mega/giga so if the end-user was to get a notice saying the rrd database size was 1.61GB in size, `zfs list` reports it as 1.5G. So I format the end-user facing number to what zfs reports to not confuse anyone
3. replace `psutil` with `shutil` as to remove dependency on 3rd party python module (there is no functionality change with this)
4. fix up the `text` verbiage of this alert to make it a little more readable