### PR TITLE
NAS-111360 / 21.08 / Add ipsets to debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
@@ -138,6 +138,10 @@ network_func()
 	ipvsadm -L
 	section_footer
 
+	section_header "IPSET rules (ipset --list)"
+	ipset --list
+	section_footer
+
 	section_header "ARP entries (arp -an)"
 	arp -an
 	section_footer


### PR DESCRIPTION
This commit adds changes to add ipsets to debug which can be helpful in debugging k8s networking issues.