### PR TITLE
NAS-111188 / 12.0 / support.new_ticket should fully consume system.debug file to prevent …

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -278,6 +278,7 @@ class SupportService(ConfigService):
                             raise CallError('Debug too large to attach', errno.EFBIG)
                         tjob.pipes.input.w.write(r)
                 finally:
+                    debug_job.pipes.output.r.read()
                     tjob.pipes.input.w.close()
 
             await self.middleware.run_in_thread(copy)


### PR DESCRIPTION
…debug job running (and holding lock) forever