### PR TITLE
NAS-111188 / 21.08 / support.new_ticket should fully consume system.debug file to prevent … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -292,6 +292,7 @@ class SupportService(ConfigService):
                             raise CallError('Debug too large to attach', errno.EFBIG)
                         tjob.pipes.input.w.write(r)
                 finally:
+                    debug_job.pipes.output.r.read()
                     tjob.pipes.input.w.close()
 
             await self.middleware.run_in_thread(copy)


### PR DESCRIPTION
…debug job running (and holding lock) forever

Original PR: https://github.com/truenas/middleware/pull/7134
Jira URL: https://jira.ixsystems.com/browse/NAS-111188