### PR TITLE
NAS-111390 / 12.0 / Enclosure Management fix for R20A. (by darkfiberiru)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -96,7 +96,7 @@ MAPPINGS = [
             MappingSlot(0, 15, False),
         ]),
     ]),
-    ProductMapping(re.compile(r"TRUENAS-R20A?$"), [
+    ProductMapping(re.compile(r"TRUENAS-R20$"), [
         VersionMapping(re.compile(".*"), [
             MappingSlot(2, 0, False),
             MappingSlot(2, 1, False),
@@ -110,6 +110,24 @@ MAPPINGS = [
             MappingSlot(2, 9, False),
             MappingSlot(2, 10, False),
             MappingSlot(2, 11, False),
+            MappingSlot(0, 0, False),
+            MappingSlot(0, 1, False),
+        ]),
+    ]),
+    ProductMapping(re.compile(r"TRUENAS-R20A$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(2, 2, False),
+            MappingSlot(2, 5, False),
+            MappingSlot(2, 8, False),
+            MappingSlot(2, 11, False),
+            MappingSlot(2, 1, False),
+            MappingSlot(2, 4, False),
+            MappingSlot(2, 7, False),
+            MappingSlot(2, 10, False),
+            MappingSlot(2, 0, False),
+            MappingSlot(2, 3, False),
+            MappingSlot(2, 6, False),
+            MappingSlot(2, 9, False),
             MappingSlot(0, 0, False),
             MappingSlot(0, 1, False),
         ]),


### PR DESCRIPTION
System has weird drive mapping top to bottom then left to right naturally
Needs correspondending UI change to map drives Left to Right and top to
bottom as is standard(same as r20)

Original PR: https://github.com/truenas/middleware/pull/7144
Jira URL: https://jira.ixsystems.com/browse/NAS-111390