### PR TITLE
NAS-111395 / 21.08 / Add support for policy based routing for kubernetes

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -233,3 +233,23 @@ class RoutingTable:
             kwargs[key] = value
 
         ip.route(op, **kwargs)
+
+
+class RuleTable:
+
+    @property
+    def rules(self):
+        rules = []
+        tables = {t.table_id: t for t in RoutingTable().routing_tables.values()}
+        for rule in ip.get_rules():
+            attrs = dict(rule['attrs'])
+            if not all(k in attrs for k in ('FRA_TABLE', 'FRA_PRIORITY')):
+                continue
+
+            rules.append({
+                'table': tables[attrs['FRA_TABLE']],
+                'priority': attrs['FRA_PRIORITY'],
+                'source_addr': attrs.get('FRA_SRC'),
+            })
+
+        return rules

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -14,7 +14,7 @@ from .address.types import AddressFamily
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["Route", "RouteFlags", "RoutingTable", "RouteTable", "IPRoute"]
+__all__ = ["Route", "RouteFlags", "RoutingTable", "RouteTable", "IPRoute", "RuleTable"]
 
 DEFAULT_TABLE_ID = 254  # This is the default table named as "main" and most of what we do happens here
 ip = IPRoute()
@@ -262,3 +262,6 @@ class RuleTable:
 
     def delete_rule(self, priority):
         ip.rule('delete', priority=priority)
+
+    def rule_exists(self, priority):
+        return any(priority == rule['priority'] for rule in self.rules)

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -253,3 +253,12 @@ class RuleTable:
             })
 
         return rules
+
+    def add_rule(self, table_id, priority, source_addr=None):
+        kwargs = {'table': table_id, 'priority': priority}
+        if source_addr:
+            kwargs['src'] = source_addr
+        ip.rule('add', **kwargs)
+
+    def delete_rule(self, priority):
+        ip.rule('delete', priority=priority)

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -241,7 +241,7 @@ class RuleTable:
     def rules(self):
         rules = []
         tables = {t.table_id: t for t in RoutingTable().routing_tables.values()}
-        for rule in ip.get_rules():
+        for rule in filter(lambda r: r.get('attrs'), ip.get_rules()):
             attrs = dict(rule['attrs'])
             if not all(k in attrs for k in ('FRA_TABLE', 'FRA_PRIORITY')):
                 continue

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -75,6 +75,14 @@ class RouteTable:
         self.table_id = table_id
         self.table_name = table_name
 
+    def create(self):
+        with open("/etc/iproute2/rt_tables", "a+") as f:
+            f.write(f'{self.table_id} {self.table_name}\n')
+
+    @property
+    def exists(self):
+        return self.table_name in RoutingTable().routing_tables
+
     @property
     def is_reserved(self):
         return self.table_id in (255, 254, 253, 0)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
@@ -122,7 +122,10 @@ class KubernetesCNIService(ConfigService):
         cp = subprocess.Popen(['kube-router', '--cleanup-config'], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
         stderr = cp.communicate()[1]
         if cp.returncode:
-            raise CallError(f'Failed to cleanup kube-router configuration: {stderr.decode()}')
+            # Let's log the error as to why kube-router was not able to clean up ipvs bits
+            # TODO: We should raise an exception but right now this is broken upstream and raising an exception
+            #  here means we won't be cleaning/flushing the locally configured routes adding to the issue
+            self.logger.error('Failed to cleanup kube-router configuration: %r', stderr.decode())
 
         tables = netif.RoutingTable().routing_tables
         for t_name in filter(lambda t: t in tables, ('kube-router', 'kube-router-dsr')):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
@@ -42,6 +42,11 @@ class KubernetesCNIService(ConfigService):
         route_table = netif.RouteTable(KUBEROUTER_TABLE_ID, KUBEROUTER_TABLE_NAME)
         if not route_table.exists:
             route_table.create()
+        # We will add a rule now to forward pod traffic to the kube-router table
+        # so that user can make use of policy based routing
+        rule_table = netif.RuleTable()
+        if not rule_table.rule_exists(KUBEROUTER_RULE_PRIORITY):
+            rule_table.add_rule(KUBEROUTER_TABLE_ID, KUBEROUTER_RULE_PRIORITY, kube_config['cluster_cidr'])
 
         await self.middleware.call('service.start', 'kuberouter')
         await self.middleware.call('k8s.cni.add_user_route_to_kube_router_table')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -4,6 +4,9 @@ import os
 BACKUP_NAME_PREFIX = 'ix-applications-backup-'
 KUBECONFIG_FILE = '/etc/rancher/k3s/k3s.yaml'
 KUBERNETES_WORKER_NODE_PASSWORD = 'e3d26cefbdf2f81eff5181e68a02372f'
+KUBEROUTER_RULE_PRIORITY = 32764
+KUBEROUTER_TABLE_ID = 77
+KUBEROUTER_TABLE_NAME = 'kube-router'
 MIGRATION_NAMING_SCHEMA = 'ix-app-migrate-%Y-%m-%d_%H-%M'
 NODE_NAME = 'ix-truenas'
 OPENEBS_ZFS_GROUP_NAME = 'zfs.openebs.io'


### PR DESCRIPTION
This PR adds changes to add support for policy based routing for kubernetes. This was being provided before by kube-router itself when we were using overlay for pod networking but it was disabled due to another issue https://github.com/truenas/kube-router/pull/4 where due to ip in ip tunneling packets with fragmentation bit unset could potentially get dropped. Talking upstream about it, kube-router dev advised that server/clients should make sure that they conform to PMTU and kube-router should allow such connections, however with latest version from upstream the issue mentioned could still easily be reproduced with `curl`.

This PR adds following changes to be specific:
1) We have a bug upstream where routes are not properly cleaned, we don't make cleaning that fatal as other routes which are to be cleaned by us cannot be cleaned - so temporarily making the call non fatal.
2) Do not wait for `kube-router` table to be created and create it ourselves if it does not exist.
3) Add a rule to make sure that pod traffic gives preference to the rule(s) defined in `kube-router` table to enforce policy based routing.
4) Properly cleanup custom rule(s) added.
5) Add ability to add/remove/query ip rules.