### PR TITLE
NAS-111399 / 21.08 / fix NDB() instantiation

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -1,6 +1,6 @@
 import logging
 import subprocess
-import pyroute2
+from pyroute2 import NDB
 
 from .address import AddressFamily, AddressMixin
 from .bridge import BridgeMixin
@@ -157,11 +157,13 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         return state
 
     def up(self):
-        with pyroute2.NDB().interfaces[self.name] as i:
-            # this context manager waits until the interface
-            # is up and "ready" before exiting
-            i['state'] = 'up'
+        with NDB(log='off') as ndb:
+            with ndb.interfaces[self.name] as dev:
+                # this context manager waits until the interface
+                # is up and "ready" before exiting
+                dev['state'] = 'up'
 
     def down(self):
-        with pyroute2.NDB().interfaces[self.name] as i:
-            i['state'] = 'down'
+        with NDB(log='off') as ndb:
+            with ndb.interfaces[self.name] as dev:
+                dev['state'] = 'down'


### PR DESCRIPTION
A few issues.

- `with pyroute2.NDB().interfaces...` opened a netlink socket and left it dangling every time an interface was up/down'ed
- NDB() is absurdly chatty (even only logging errors) and instantiating this class actually starts a thread which monitors kernel network events and will log lots of messages (repeatedly) to middlewared.log
- `service.start/stop kubernetes` is causing a golang core dump (unrelated problem upstream) however it showed these problems

Fix this by:
- use outer `NDB()` class context manager so that the associated threads from the class are properly cleaned up
- user inner `ndb.interface` context manager so that the up() or down() operation is properly committed and waited on