### PR TITLE
NAS-111406 / 12.0 / Fix for mini-3.0-xl+ 2.5 inch drive bays being swapped. (by darkfiberiru)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -64,7 +64,7 @@ MAPPINGS = [
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-XL\+$"), [
         VersionMapping(re.compile(".*"), [
-            MappingSlot(1, 4, False),
+            MappingSlot(1, 5, False),
             MappingSlot(0, 0, False),
             MappingSlot(0, 1, False),
             MappingSlot(0, 2, False),
@@ -73,7 +73,7 @@ MAPPINGS = [
             MappingSlot(0, 5, False),
             MappingSlot(0, 6, False),
             MappingSlot(0, 7, False),
-            MappingSlot(1, 3, False),
+            MappingSlot(1, 4, False),
         ]),
     ]),
     ProductMapping(re.compile(r"TRUENAS-R10$"), [


### PR DESCRIPTION
Prior to this change the side internal bay showed as slot 1(hot swap
2.5inch bay)
No UI change is needed for this fix mapping only
Confirmed against multiple systems both based opon production builds and
redbook verified builds

Original PR: https://github.com/truenas/middleware/pull/7154
Jira URL: https://jira.ixsystems.com/browse/NAS-111406