### PR TITLE
NAS-111370 / 21.08 / Increase timeout to start k3s service

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -22,7 +22,7 @@ class KubernetesService(SimpleService):
 
     async def _start_linux(self):
         await super()._start_linux()
-        timeout = 20
+        timeout = 40
         # First time when k8s is started, it takes a bit more time to initialise itself properly
         # and we need to have sleep here so that after start is called post_start is not dismissed
         while timeout > 0:


### PR DESCRIPTION
This commit adds changes to increase timeout to start k3s service. First time k3s is initialized it takes some time before it's systemd unit actually reports that it's active and 20secs was good enough - however Kris was running into issues on a 4gb ram / 1 core vm and there the timeout of 40 secs works. This is less then ideal for waiting as ideally the systemd unit file should not be doing this but that's an upstream issue ( will be creating an issue about it upstream ).