### PR TITLE
NAS-111415 / 21.08 / Update chart.release.scale api tests

### DIFF
--- a/tests/api2/test_305_container.py
+++ b/tests/api2/test_305_container.py
@@ -236,7 +236,11 @@ def test_20_set_ix_chart_chart_release_scale_up(request):
     }
     results = POST('/chart/release/scale/', payload)
     assert results.status_code == 200, results.text
-    assert isinstance(results.json(), dict), results.text
+    job_id = results.json()
+    job_status = wait_on_job(job_id, 300)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+    results = job_status['results']['result']
+    assert isinstance(results, dict), str(job_status['results'])
 
 
 def test_21_verify_truecomand_ix_chart_pod_status_desired_is_1(request):

--- a/tests/api2/test_306_chart_release.py
+++ b/tests/api2/test_306_chart_release.py
@@ -163,7 +163,11 @@ def test_16_set_ipfs_chart_release_scale(request):
     }
     results = POST('/chart/release/scale/', payload)
     assert results.status_code == 200, results.text
-    assert isinstance(results.json(), dict), results.text
+    job_id = results.json()
+    job_status = wait_on_job(job_id, 300)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+    results = job_status['results']['result']
+    assert isinstance(results, dict), str(job_status['results'])
 
 
 def test_17_verify_ipfs_pod_status_desired_is_1(request):


### PR DESCRIPTION
This commit adds changes to update api tests to treat chart.release.scale as a job keeping in line with recent changes in the middleware.