### PR TITLE
NAS-108723 / 12.0 / Correct NVMe capacity check in disk_resize. (by amotin)

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -225,8 +225,8 @@ nvme)
 	# Make sure we have enough capacity to not fail after delete.
 	if [ -n "${size}" ]; then
 		ucap=`nvmecontrol identify ${ctrlr} | awk '/Unallocated NVM Capacity:/ { print $4 }'`
-		osize=`nvmecontrol identify -n ${nsid} ${ctrlr} | awk '/^Size:/ { print $2}'`
-		if [ "${size}" -gt $((${ucap} / ${sector} + ${osize})) ]; then
+		ocap=`nvmecontrol identify -n ${nsid} ${ctrlr} | awk '/^NVM Capacity:/ { print $3}'`
+		if [ "${size}" -gt $(((${ucap} + ${ocap}) / ${sector})) ]; then
 			echo "Not enough capacity."
 			exit 1
 		fi


### PR DESCRIPTION
Appears for some devices NVM Capacity is not equal to Size multiplied
by sector size, but is a pretty arbitrary value.  Use it directly.

Original PR: https://github.com/truenas/middleware/pull/7167
Jira URL: https://jira.ixsystems.com/browse/NAS-108723