### PR TITLE
NAS-111427 / 21.08 / Bug fix for catalog item migration handling

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -210,6 +210,7 @@ class ChartReleaseService(Service):
         await self.middleware.call('catalog.version_supported_error_check', catalog_item)
 
         config = await self.middleware.call('chart.release.upgrade_values', release, catalog_item['location'])
+        release_orig['config'] = config
 
         # We will be performing validation for values specified. Why we want to allow user to specify values here
         # is because the upgraded catalog item version might have different schema which potentially means that


### PR DESCRIPTION
This commit fixes an issue where when a migration is applied, we should assume the migration applied configuration as the old one but instead we are still considering the old configuration ( before migration one ) as the old one which can result in issues when validation takes place. For example if a field is non editable for the user, but the dev wants to change the field's value, the standard way would be to add a migration changing the value before upgrade happens and hence validation/upgrade would consume the migrated configuration but without this change validation would consume old configuration which would fail for editable field or other cases.