### PR TITLE
NAS-111429 / 21.08 / fix crash in ha_permission

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1102,7 +1102,7 @@ class FailoverService(ConfigService):
 
 async def ha_permission(middleware, app):
     # Skip if session was already authenticated
-    if app.authenticated is True:
+    if app is not None and app.authenticated is True:
         return
 
     # We only care for remote connections (IPv4), in the interlink


### PR DESCRIPTION
`app` can be `None` so make sure it's not