### PR TITLE
NAS-111422 / 21.08 / fix issues in enclosure.sync_zpool (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -264,13 +264,6 @@ class EnclosureService(CRUDService):
                 if disk is None:
                     continue
 
-                try:
-                    element = self._get_ses_slot_for_disk(disk)
-                except MatchNotFound:
-                    pass
-                else:
-                    element.device_slot_set("fault")
-
             # We want spares to only identify slot for Z-series
             # See #32706
             if self.middleware.call_sync("truenas.get_chassis_hardware").startswith("TRUENAS-Z"):
@@ -279,26 +272,25 @@ class EnclosureService(CRUDService):
                 spare_value = "clear"
 
             for node in pool["groups"]["spare"]:
-                for vdev in node["children"]:
-                    for dev in vdev["children"]:
-                        if dev["path"] is None:
-                            continue
+                if node["path"] is None:
+                    continue
 
-                        label = dev["path"].replace("/dev/", "")
-                        disk = label2disk.get(label)
+                label = node["path"].replace("/dev/", "")
+                disk = label2disk.get(label)
+                if disk is None:
+                    continue
 
-                        if disk is None:
-                            continue
+                if node["status"] != "AVAIL":
+                    # when a hot-spare gets automatically attached to a zpool
+                    # its status is reported as "UNAVAIL"
+                    continue
 
-                        if dev["status"] != "AVAIL":
-                            continue
+                seen_devs.append(node["path"])
 
-                        seen_devs.append(dev["path"])
-
-                        element = encs.find_device_slot(disk)
-                        if element:
-                            self.logger.debug(f"{spare_value}ing bay slot for %r", disk)
-                            element.device_slot_set(spare_value)
+                element = encs.find_device_slot(disk)
+                if element:
+                    self.logger.debug(f"{spare_value}ing bay slot for %r", disk)
+                    element.device_slot_set(spare_value)
 
             """
             Go through all devs in the pool


### PR DESCRIPTION
Historically speaking, this is old cold that has been here since the legacy webUI. However, we're handling the situation incorrectly. This will turn the fault light on for spare hard drives when they get attached to a zpool when a data disk becomes unavailable.

We turn the `fault` light on for _all_ disks on the zpool and then subsequently `clear` them out based on what type of zfs disk they are at the end of the `zpool_sync` method. This doesn't make a lot of sense to me but in the interest of not making incredibly intrusive changes I've fixed 2 problems.

1. stop turning the `fault` light on by default (this is legacy code that makes 0 sense)
2. we were iterating over the spare devices incorrectly which means the z-series devices will no longer have the spare drives `identify` light turned on by default on 12 which is a regression compared to 11.3

While I'm here, go ahead and document the fact that when a hot-spare is auto-attached to a zpool it's status is reported as `UNAVAIL`

Original PR: https://github.com/truenas/middleware/pull/7180
Jira URL: https://jira.ixsystems.com/browse/NAS-111422