### PR TITLE
NAS-111462 / 12.0 / fix license detection on r-series devices

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
@@ -83,7 +83,7 @@ class TrueNASService(Service):
 
         data = await self.middleware.call('system.dmidecode_info')
         chassis = data['system-product-name']
-        if chassis.startswith(('TRUENAS-M', 'TRUENAS-X', 'TRUENAS-Z')):
+        if chassis.startswith(('TRUENAS-M', 'TRUENAS-X', 'TRUENAS-Z', 'TRUENAS-R')):
             return chassis
         # We don't match a burned in name for a M, X or Z series.  Let's catch
         # the case where we are a M, X or Z. (shame on you production!)


### PR DESCRIPTION
Make sure the `r-series` devices are detected appropriately so license alerts aren't generated.