### PR TITLE
NAS-111462 / 21.08 / fix license detection on r-series devices (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -81,7 +81,7 @@ class TrueNASService(Service):
 
         data = await self.middleware.call('system.dmidecode_info')
         chassis = data['system-product-name']
-        if chassis.startswith(('TRUENAS-M', 'TRUENAS-X', 'TRUENAS-Z')):
+        if chassis.startswith(('TRUENAS-M', 'TRUENAS-X', 'TRUENAS-Z', 'TRUENAS-R')):
             return chassis
         # We don't match a burned in name for a M, X or Z series.  Let's catch
         # the case where we are a M, X or Z. (shame on you production!)


### PR DESCRIPTION
Make sure the `r-series` devices are detected appropriately so license alerts aren't generated.

Original PR: https://github.com/truenas/middleware/pull/7182
Jira URL: https://jira.ixsystems.com/browse/NAS-111462