### PR TITLE
NAS-111494 / 21.08 / fix runtest.py

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -111,7 +111,7 @@ digit = ''.join(random.choices(string.digits, k=2))
 hostname = f'test{digit}'
 domain = f'test{digit}.nb.ixsystems.com'
 
-cfg_content = f"""#!/usr/bin/env python3.6
+cfg_content = f"""#!/usr/bin/env python{version}
 
 user = "root"
 password = "{passwd}"
@@ -153,15 +153,14 @@ cfg_file.writelines(f'sshKey = "{Key}"\n')
 cfg_file.close()
 
 
-call(
-    [
-        f"pytest-{version}",
-        "-v",
-        "--junitxml",
-        'results/api_v2_tests_result.xml',
-        f"api2/{testName}"
-    ]
-)
+call([
+    f"pytest-{version}",
+    "-v",
+    "-o", "junit_family=xunit2",
+    "--junitxml",
+    'results/api_v2_tests_result.xml',
+    f"api2/{testName}"
+])
 
 # get useful logs
 artifacts = f"{workdir}/artifacts/"


### PR DESCRIPTION
Fix 2 issues:
- dont make the `runtest.py` helper script dependent on `python3.6` use the `version` variable which is defined at the top of the file that already takes care of getting the currently installed python version.
- fix a `DeprecationWarning` from `pytest` script

```
/usr/lib/python3/dist-packages/_pytest/junitxml.py:446
  /usr/lib/python3/dist-packages/_pytest/junitxml.py:446: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0. See:
    https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2