### PR TITLE
NAS-111500 / 21.08 / Do not have default acltype on filesystem.setacl

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -247,7 +247,7 @@ class ACLBase(ServicePartBase):
                 Bool('autoinherit', default=False),
                 Bool('protected', default=False),
             ),
-            Str('acltype', enum=[x.name for x in ACLType], default=ACLType.NFS4.name),
+            Str('acltype', enum=[x.name for x in ACLType], null=True),
             Dict(
                 'options',
                 Bool('stripacl', default=False),


### PR DESCRIPTION
Don't set a default acltype if it's omitted from payload.
In this case, query current on-disk ACL for the given path
and use that acltype to determine which ACL private setacl
method to use. This means that path validation needs to
happen in acltype-agnostic filesystem.setacl method.