### PR TITLE
NAS-111238 / 21.08 / interface capabilities (known as features) on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/ethernet_settings.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/ethernet_settings.py
@@ -1,0 +1,107 @@
+from logging import getLogger
+from pyroute2.ethtool import Ethtool
+from pyroute2.ethtool.ioctl import NotSupportedError
+
+
+logger = getLogger(__name__)
+
+
+class EthernetHardwareSettings:
+
+    def __init__(self, interface):
+        self._name = interface
+        self._eth = Ethtool()
+        self._caps = self.__capabilities__()
+        self._media = self.__mediainfo__()
+
+    def __capabilities__(self):
+        result = {'enabled': [], 'disabled': [], 'supported': []}
+        try:
+            for i in self._eth.get_features(self._name):
+                for feature, value in i.items():
+                    if value.enable:
+                        result['enabled'].append(feature)
+                    else:
+                        result['disabled'].append(feature)
+                    result['supported'].append(feature)
+        except Exception:
+            logger.error('Failed to get capabilities for %s', self._name, exc_info=True)
+
+        return result
+
+    @property
+    def enabled_capabilities(self):
+        return self._caps['enabled']
+
+    @property
+    def disabled_capabilties(self):
+        return self._caps['disabled']
+
+    @property
+    def supported_capabilities(self):
+        return self._caps['supported']
+
+    def __mediainfo__(self):
+        result = {
+            'media_type': '',
+            'media_subtype': '',
+            'active_media_type': '',
+            'active_media_subtype': '',
+            'supported_media': [],
+        }
+
+        try:
+            attrs = self._eth.get_link_mode(self._name)
+            mst = 'Unknown'
+            if attrs.speed is not None:
+                # looks like 1000Mb/s, 10000Mb/s, etc
+                mst = f'{attrs.speed}Mb/s'
+
+            # looks like ("Unknown Twisted Pair" OR "1000Mb/s Twisted Pair" etc
+            mst = f'{mst} {self._eth.get_link_info(self._name).port}'
+
+            # fill out the results
+            result['media_type'] = 'Ethernet'
+            result['media_subtype'] = 'autoselect' if attrs.autoneg else mst
+            result['active_media_type'] = 'Ethernet'
+            result['active_media_subtype'] = mst  # just matches media_subtype...gross
+            result['supported_media'].extend(attrs.supported_modes)
+        except NotSupportedError:
+            # saw this on a VM running inside xen where the
+            # nic driver being used doesnt report any type
+            # of media info (ethtool binary didnt report anything either)
+            # so ignore these errors
+            pass
+        except Exception:
+            logger.error('Failed to get media info for %s', self._name, exc_info=True)
+
+        return result
+
+    @property
+    def media_type(self):
+        return self._media['media_type']
+
+    @property
+    def media_subtype(self):
+        return self._media['media_subtype']
+
+    @property
+    def active_media_type(self):
+        return self._media['active_media_type']
+
+    @property
+    def active_media_subtype(self):
+        return self._media['active_media_subtype']
+
+    @property
+    def supported_media(self):
+        return self._media['supported_media']
+
+    def close(self):
+        self._eth.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -1,5 +1,4 @@
 import logging
-import subprocess
 from pyroute2 import NDB
 
 from .address import AddressFamily, AddressMixin
@@ -9,6 +8,7 @@ from .lagg import LaggMixin
 from .utils import bitmask_to_set, run
 from .vlan import VlanMixin
 from .vrrp import VrrpMixin
+from .ethernet_settings import EthernetHardwareSettings
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +77,6 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         pass
 
     @property
-    def capabilities(self):
-        return set()
-
-    @property
     def link_state(self):
         operstate = self._read("operstate")
 
@@ -96,7 +92,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         except IndexError:
             return None
 
-    def __getstate__(self, address_stats=False, media=False, vrrp_config=None):
+    def __getstate__(self, address_stats=False, vrrp_config=None):
         state = {
             'name': self.name,
             'orig_name': self.orig_name,
@@ -105,7 +101,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             'cloned': self.cloned,
             'flags': [i.name for i in self.flags],
             'nd6_flags': [i.name for i in self.nd6_flags],
-            'capabilities': [i.name for i in self.capabilities],
+            'capabilities': [],
             'link_state': self.link_state.name,
             'media_type': '',
             'media_subtype': '',
@@ -118,26 +114,15 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             'vrrp_config': vrrp_config,
         }
 
-        if media:
-            p = subprocess.run(["ethtool", self.name], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                               encoding="utf-8", errors="ignore")
-            if p.returncode == 0:
-                ethtool = {
-                    k.strip(): v.strip()
-                    for k, v in map(lambda s: s.split(":", 1), [line for line in p.stdout.splitlines() if ":" in line])
-                }
-                if "Speed" in ethtool:
-                    bits = [ethtool["Speed"]]
-                    if "Port" in ethtool:
-                        bits.append(ethtool["Port"])
-                    media_subtype = " ".join(bits)
-
-                    state.update({
-                        "media_type": "Ethernet",
-                        "media_subtype": "autoselect" if ethtool.get("Auto-negotiation") == "on" else media_subtype,
-                        "active_media_type": "Ethernet",
-                        "active_media_subtype": media_subtype,
-                    })
+        with EthernetHardwareSettings(self.name) as dev:
+            state.update({
+                'capabilities': dev.enabled_capabilities,
+                'supported_media': dev.supported_media,
+                'media_type': dev.media_type,
+                'media_subtype': dev.media_subtype,
+                'active_media_type': dev.active_media_type,
+                'active_media_subtype': dev.active_media_subtype,
+            })
 
         if self.name.startswith('bond'):
             state.update({

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -531,12 +531,9 @@ class InterfaceService(CRUDService):
             if ha_hardware and name in internal_ifaces:
                 continue
             iface_extend_kwargs = {}
-            if osc.IS_LINUX:
-                iface_extend_kwargs = dict(media=True)
-
-                if ha_hardware:
-                    vrrp_config = self.middleware.call_sync('interfaces.vrrp_config', name)
-                    iface_extend_kwargs.update(dict(vrrp_config=vrrp_config))
+            if ha_hardware:
+                vrrp_config = self.middleware.call_sync('interfaces.vrrp_config', name)
+                iface_extend_kwargs.update(dict(vrrp_config=vrrp_config))
             try:
                 data[name] = self.iface_extend(iface.__getstate__(**iface_extend_kwargs), configs, ha_hardware)
             except OSError:


### PR DESCRIPTION
Add `capabilities` to SCALE. While I'm here get rid of `subprocess`'ing out to `ethtool` to get media information. `pyroute2.ethtool` provides API backed by native ioctl that gets the information for us. Also, allows us to fill in the `supported_media` attribute as well.