### PR TITLE
NAS-111505 / 21.08 / Add support for fuse-mounted paths to filesystem plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -8,6 +8,7 @@ class FuseConfig(enum.Enum):
     the gluster volumes locally.
     """
     FUSE_PATH_BASE = '/cluster'
+    FUSE_PATH_SUBST = 'CLUSTER:'
 
 
 class CTDBConfig(enum.Enum):

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -23,7 +23,7 @@ from middlewared.service import private, CallError, filterable_returns, Service,
 from middlewared.utils import filter_list, osc
 from middlewared.utils.path import is_child
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
+from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 
 
 class FilesystemService(Service):
@@ -43,7 +43,7 @@ class FilesystemService(Service):
         if not is_mounted:
             raise CallError(f'{gluster_volume}: cluster volume is not mounted.', errno.ENXIO)
 
-        cluster_path = path.replace('CLUSTER:', '/cluster/')
+        cluster_path = path.replace(FuseConfig.FUSE_PATH_SUBST.value, f'{FuseConfig.FUSE_PATH_BASE.value}/')
         return cluster_path
 
     @accepts(Str('path', required=True), Ref('query-filters'), Ref('query-options'))

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -31,7 +31,12 @@ class FilesystemService(Service):
     class Config:
         cli_namespace = 'storage.filesystem'
 
+    @private
     def resolve_cluster_path(self, path):
+        """
+        Convert a "CLUSTER:"-prefixed path to an absolute path
+        on the server.
+        """
         if not path.startswith(FuseConfig.FUSE_PATH_SUBST.value):
             return path
 
@@ -62,6 +67,11 @@ class FilesystemService(Service):
     def listdir(self, path, filters, options):
         """
         Get the contents of a directory.
+
+        Paths on clustered volumes may be specifed with the path prefix
+        `CLUSTER:<volume name>`. For example, to list directories
+        in the directory 'data' in the clustered volume `smb01`, the
+        path should be specified as `CLUSTER:smb01/data`.
 
         Each entry of the list consists of:
           name(str): name of the file
@@ -132,6 +142,11 @@ class FilesystemService(Service):
     def stat(self, path):
         """
         Return the filesystem stat(2) for a given `path`.
+
+        Paths on clustered volumes may be specifed with the path prefix
+        `CLUSTER:<volume name>`. For example, to list directories
+        in the directory 'data' in the clustered volume `smb01`, the
+        path should be specified as `CLUSTER:smb01/data`.
         """
         path = self.resolve_cluster_path(path)
         try:
@@ -325,8 +340,12 @@ class FilesystemService(Service):
     def acl_is_trivial(self, path):
         """
         Returns True if the ACL can be fully expressed as a file mode without losing
-        any access rules, or if the path does not support NFSv4 ACLs (for example
-        a path on a tmpfs filesystem).
+        any access rules.
+
+        Paths on clustered volumes may be specifed with the path prefix
+        `CLUSTER:<volume name>`. For example, to list directories
+        in the directory 'data' in the clustered volume `smb01`, the
+        path should be specified as `CLUSTER:smb01/data`.
         """
         path = self.resolve_cluster_path(path)
         if not os.path.exists(path):

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -32,7 +32,7 @@ class FilesystemService(Service):
         cli_namespace = 'storage.filesystem'
 
     def resolve_cluster_path(self, path):
-        if not path.startswith('CLUSTER:'):
+        if not path.startswith(FuseConfig.FUSE_PATH_SUBST.value):
             return path
 
         gluster_volume = path[8:].split("/")[0]
@@ -94,7 +94,7 @@ class FilesystemService(Service):
 
             data = {
                 'name': entry.name,
-                'path': entry.path.replace('/cluster/', 'CLUSTER:'),
+                'path': entry.path.replace(f'{FuseConfig.FUSE_PATH_BASE.value}/', FuseConfig.FUSE_PATH_SUBST.value),
                 'realpath': os.path.realpath(entry.path) if etype == 'SYMLINK' else entry.path,
                 'type': etype,
             }

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -263,6 +263,11 @@ class ACLBase(ServicePartBase):
         Set ACL of a given path. Takes the following parameters:
         `path` full path to directory or file.
 
+        Paths on clustered volumes may be specifed with the path prefix
+        `CLUSTER:<volume name>`. For example, to list directories
+        in the directory 'data' in the clustered volume `smb01`, the
+        path should be specified as `CLUSTER:smb01/data`.
+
         `dacl` ACL entries. Formatting depends on the underlying `acltype`. NFS4ACL requires
         NFSv4 entries. POSIX1e requires POSIX1e entries.
 
@@ -375,7 +380,12 @@ class ACLBase(ServicePartBase):
     @job(lock="perm_change")
     def setperm(self, job, data):
         """
-        Remove extended ACL from specified path.
+        Set unix permissions on given `path`.
+
+        Paths on clustered volumes may be specifed with the path prefix
+        `CLUSTER:<volume name>`. For example, to list directories
+        in the directory 'data' in the clustered volume `smb01`, the
+        path should be specified as `CLUSTER:smb01/data`.
 
         If `mode` is specified then the mode will be applied to the
         path and files and subdirectories depending on which `options` are

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from middlewared.service import private, CallError, ValidationErrors, Service
 from middlewared.plugins.smb import SMBBuiltin
+from middlewared.plugins.cluster_linux.utils import FuseConfig
 from .acl_base import ACLBase, ACLDefault, ACLType
 
 
@@ -32,7 +33,7 @@ class FilesystemService(Service, ACLBase):
             raise CallError(f"acltool [{action}] on path {path} failed with error: [{acltool.stderr.decode().strip()}]")
 
     def _common_perm_path_validate(self, schema, data, verrors):
-        is_cluster = data['path'].startswith('CLUSTER')
+        is_cluster = data['path'].startswith('FuseConfig.FUSE_PATH_SUBST.value')
         try:
             data['path'] = self.middleware.call_sync('filesystem.resolve_cluster_path', data['path'])
         except CallError as e:

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -33,7 +33,7 @@ class FilesystemService(Service, ACLBase):
             raise CallError(f"acltool [{action}] on path {path} failed with error: [{acltool.stderr.decode().strip()}]")
 
     def _common_perm_path_validate(self, schema, data, verrors):
-        is_cluster = data['path'].startswith('FuseConfig.FUSE_PATH_SUBST.value')
+        is_cluster = data['path'].startswith(FuseConfig.FUSE_PATH_SUBST.value)
         try:
             data['path'] = self.middleware.call_sync('filesystem.resolve_cluster_path', data['path'])
         except CallError as e:


### PR DESCRIPTION
Paths that have prefix "CLUSTER:" receive special handling in
filesystem plugin. Rather than evaluating a normal path under
/mnt, checks are performed under /cluster. CallError is raised
with errno ENXIO if the gluster volume is not mounted.

This allows modification of permissions on mounted gluster volumes.
Explicitly prevent filesystem access to ctdb shared volume to
prevent alterations that may break clustering. In this case
raise CallError with errno EPERM.

Sample path:
`CLUSTER:smb01/data`
Which resolves to /data inside the smb01 volume.