### PR TITLE
NAS-111511 / 21.08 / automatic configuration of ctdb clustering daemon

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -17,6 +17,7 @@ class AllowedEvents(enum.Enum):
     EVENTS = (
         'VOLUME_START',
         'VOLUME_STOP',
+        'CTDB_START',
     )
 
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -14,11 +14,11 @@ LOCAL_WEBHOOK_URL = GlusterConfig.LOCAL_WEBHOOK_URL.value
 
 
 class AllowedEvents(enum.Enum):
-    EVENTS = (
-        'VOLUME_START',
-        'VOLUME_STOP',
-        'CTDB_START',
-    )
+    VOLUME_START = 'VOLUME_START'
+    VOLUME_STOP = 'VOLUME_STOP'
+    CTDB_START = 'CTDB_START'
+    CTDB_STOP = 'CTDB_STOP'
+    SMB_STOP = 'SMB_STOP'
 
 
 class GlusterLocalEventsService(Service):
@@ -32,7 +32,7 @@ class GlusterLocalEventsService(Service):
     @private
     async def validate(self, data):
         verrors = ValidationErrors()
-        allowed = AllowedEvents.EVENTS.value
+        allowed = [i.value for i in AllowedEvents]
 
         if data['event'] not in allowed:
             verrors.add(

--- a/src/middlewared/middlewared/plugins/gluster_linux/peer.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/peer.py
@@ -68,6 +68,9 @@ class GlusterPeerService(CRUDService):
 
         `hostname` String representing an IP(v4/v6) address or DNS name
         """
+        # we need to verify that we can resolve the hostname to an IP address
+        # or clustering, in general, is going to fail in spectacular ways
+        await self.middleware.call('cluster.utils.resolve_hostnames', [data['hostname']])
 
         await self.middleware.call('gluster.method.run', peer.attach, {'args': (data['hostname'],)})
         return await self.middleware.call('gluster.peer.query', [('hostname', '=', data['hostname'])])

--- a/src/middlewared/middlewared/webhooks/cluster_events.py
+++ b/src/middlewared/middlewared/webhooks/cluster_events.py
@@ -20,9 +20,15 @@ class ClusterEventsApplication(object):
                 method = 'gluster.fuse.mount'
             elif event == 'VOLUME_STOP':
                 method = 'gluster.fuse.umount'
+            elif event == 'CTDB_START':
+                method = ('service.start', 'ctdb')
 
             if method is not None:
-                await self.middleware.call(method, {'name': name})
+                if event.startswith('VOLUME'):
+                    await self.middleware.call(method, {'name': name})
+                elif event.startswith('CTDB'):
+                    await self.middleware.call(method[0], method[1])
+
                 if data.pop('forward', False):
                     # means the request originated from localhost
                     # so we need to forward it out to the other

--- a/src/middlewared/middlewared/webhooks/cluster_events.py
+++ b/src/middlewared/middlewared/webhooks/cluster_events.py
@@ -22,11 +22,15 @@ class ClusterEventsApplication(object):
                 method = 'gluster.fuse.umount'
             elif event == 'CTDB_START':
                 method = ('service.start', 'ctdb')
+            elif event == 'CTDB_STOP':
+                method = ('service.stop', 'ctdb')
+            elif event == 'SMB_STOP':
+                method = ('service.stop', 'cifs')
 
             if method is not None:
                 if event.startswith('VOLUME'):
                     await self.middleware.call(method, {'name': name})
-                elif event.startswith('CTDB'):
+                elif event.startswith(('CTDB', 'SMB')):
                     await self.middleware.call(method[0], method[1])
 
                 if data.pop('forward', False):


### PR DESCRIPTION
SMB active-active sharing is approaching some form of stability so this is the next set of logic that needs to be added. This does a few things.

1. add an async dns resolver
2. we have to resolve hostname(s) (if they're provided) for the gluster peers since if we're unable to resolve the IP address then clustering, in general, will fail in spectacular ways.
3. once we get to the point where the ctdb shared volume is started, we FUSE mount it locally, and then use the gluster peers ip addresses as the private ips for the ctdb daemon. This is the minimal amount of config needed to ensure active-active smb shares will work.
4. finally, we send a request to all peers in the TSP to start the ctdb daemon