### PR TITLE
NAS-111444 / 21.08 / Improvements to Chart Release(s) event handling

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -603,6 +603,7 @@ class ChartReleaseService(CRUDService):
 
         job.set_progress(90, 'Syncing secrets for chart release')
         await self.middleware.call('chart.release.sync_secrets_for_release', chart_release)
+        await self.middleware.call('chart.release.refresh_events_state', chart_release)
 
         job.set_progress(100, 'Update completed for chart release')
         return await self.get_instance(chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -1,10 +1,9 @@
 import asyncio
 import collections
-import copy
-import functools
 
 from middlewared.schema import Dict, List, Str, returns
 from middlewared.service import accepts, private, Service
+from middlewared.utils.itertools import infinite_multiplier_generator
 
 from .utils import get_chart_release_from_namespace, get_namespace, is_ix_namespace
 
@@ -16,7 +15,6 @@ LOCKS = collections.defaultdict(asyncio.Lock)
 class ChartReleaseService(Service):
 
     CHART_RELEASES = {}
-    MAX_SECONDS = 1024
 
     class Config:
         namespace = 'chart.release'
@@ -60,16 +58,6 @@ class ChartReleaseService(Service):
                 }
 
     @private
-    @functools.cache
-    def get_queue(self):
-        iterable = []
-        cur = 2
-        while cur <= self.MAX_SECONDS:
-            iterable.append(cur)
-            cur *= 2
-        return iterable
-
-    @private
     async def remove_chart_release_from_events_state(self, chart_release_name):
         async with LOCKS[chart_release_name]:
             ChartReleaseService.CHART_RELEASES.pop(chart_release_name, None)
@@ -108,8 +96,7 @@ class ChartReleaseService(Service):
 
     @private
     async def poll_chart_release_status(self, name):
-        queue = copy.deepcopy(self.get_queue())
-        while True:
+        for sleep_sec in infinite_multiplier_generator(2, 1024, 2):
             async with LOCKS[name]:
                 release_data = self.CHART_RELEASES.get(name)
                 if not release_data or not release_data['poll']:
@@ -120,7 +107,7 @@ class ChartReleaseService(Service):
                     release_data['poll'] = False
                     break
 
-            await asyncio.sleep(queue.pop(0) if queue else self.MAX_SECONDS)
+            await asyncio.sleep(sleep_sec)
 
 
 async def chart_release_event(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -59,20 +59,21 @@ class ChartReleaseService(Service):
     async def handle_k8s_event(self, k8s_event):
         name = get_chart_release_from_namespace(k8s_event['involved_object']['namespace'])
         async with LOCKS[name]:
-            chart_release = await self.middleware.call(
-                'chart.release.query', [['id', '=', name]], {'extra': {'history': True}}
-            )
-            if not chart_release:
+            if name not in self.CHART_RELEASES:
                 # It's possible the chart release got deleted
                 return
-            else:
-                chart_release = chart_release[0]
 
-            if chart_release['status'] != self.CHART_RELEASES.get(name, {}).get('status'):
+            status = await self.middleware.call('chart.release.pod_status', name)
+            if status['status'] != self.CHART_RELEASES[name]['status']:
                 # raise event
-                self.middleware.send_event('chart.release.query', 'CHANGED', id=name, fields=chart_release)
-
-            ChartReleaseService.CHART_RELEASES[name] = chart_release
+                ChartReleaseService.CHART_RELEASES[name].update({
+                    'status': status['status'],
+                    'pod_status': {
+                        'desired': status['desired'],
+                        'available': status['available'],
+                    }
+                })
+                self.middleware.send_event('chart.release.query', 'CHANGED', id=name, fields=self.CHART_RELEASES[name])
 
 
 async def chart_release_event(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -202,6 +202,9 @@ class ChartReleaseService(Service):
             for r_data in await self.middleware.call(
                 f'k8s.{resource.name.lower()}.query', [['metadata.namespace', '=', get_namespace(release_name)]],
             ):
+                # Detail about ready_replicas/replicas
+                # https://stackoverflow.com/questions/66317251/couldnt-understand-availablereplicas-
+                # readyreplicas-unavailablereplicas-in-dep
                 status.update({
                     'available': (r_data['status']['ready_replicas'] or 0),
                     'desired': (r_data['status']['replicas'] or 0),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
@@ -127,6 +127,7 @@ class ChartReleaseService(Service):
             ] + command, check=False,
         )
         await self.middleware.call('chart.release.sync_secrets_for_release', release_name)
+        await self.middleware.call('chart.release.refresh_events_state', release_name)
 
         # Helm rollback is a bit tricky, it utilizes rollout functionality of kubernetes and rolls back the
         # resources to specified version. However in this process, if the rollback is to fail for any reason, it's

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -254,6 +254,7 @@ class ChartReleaseService(Service):
         job.set_progress(60, 'Upgrading chart release version')
 
         await self.middleware.call('chart.release.helm_action', release_name, chart_path, config, 'upgrade')
+        await self.middleware.call('chart.release.refresh_events_state', release_name)
 
     @private
     def upgrade_values(self, release, new_version_path):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
@@ -26,11 +26,12 @@ class KubernetesDeploymentService(CRUDService):
                 func = functools.partial(context['apps_api'].list_deployment_for_all_namespaces)
 
             deployments = [d.to_dict() for d in (await func()).items]
-            events = await self.middleware.call(
-                'kubernetes.get_events_of_resource_type', 'Deployment', [d['metadata']['uid'] for d in deployments]
-            )
-            for deployment in deployments:
-                deployment['events'] = events[deployment['metadata']['uid']]
+            if options['extra'].get('events'):
+                events = await self.middleware.call(
+                    'kubernetes.get_events_of_resource_type', 'Deployment', [d['metadata']['uid'] for d in deployments]
+                )
+                for deployment in deployments:
+                    deployment['events'] = events[deployment['metadata']['uid']]
 
         return filter_list(deployments, filters, options)
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
@@ -18,9 +18,7 @@ class KubernetesDeploymentService(CRUDService):
     @filterable
     async def query(self, filters, options):
         async with api_client() as (api, context):
-            if len(filters) == 1 and len(filters[0]) == 3 and all(
-                a == d for a, d in zip(filters[0][:2], ['metadata.namespace', '='])
-            ):
+            if len(filters) == 1 and len(filters[0]) == 3 and list(filters[0])[:2] == ['metadata.namespace', '=']:
                 func = functools.partial(context['apps_api'].list_namespaced_deployment, namespace=filters[0][2])
             else:
                 func = functools.partial(context['apps_api'].list_deployment_for_all_namespaces)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/deployments.py
@@ -1,3 +1,5 @@
+import functools
+
 from kubernetes_asyncio import client
 
 from middlewared.schema import Dict, Ref, Str
@@ -16,7 +18,14 @@ class KubernetesDeploymentService(CRUDService):
     @filterable
     async def query(self, filters, options):
         async with api_client() as (api, context):
-            deployments = [d.to_dict() for d in (await context['apps_api'].list_deployment_for_all_namespaces()).items]
+            if len(filters) == 1 and len(filters[0]) == 3 and all(
+                a == d for a, d in zip(filters[0][:2], ['metadata.namespace', '='])
+            ):
+                func = functools.partial(context['apps_api'].list_namespaced_deployment, namespace=filters[0][2])
+            else:
+                func = functools.partial(context['apps_api'].list_deployment_for_all_namespaces)
+
+            deployments = [d.to_dict() for d in (await func()).items]
             events = await self.middleware.call(
                 'kubernetes.get_events_of_resource_type', 'Deployment', [d['metadata']['uid'] for d in deployments]
             )

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
@@ -24,12 +24,12 @@ class KubernetesPodService(CRUDService):
         kwargs = {k: v for k, v in [('label_selector', label_selector)] if v}
         async with api_client() as (api, context):
             pods = [d.to_dict() for d in (await context['core_api'].list_pod_for_all_namespaces(**kwargs)).items]
-            events = await self.middleware.call(
-                'kubernetes.get_events_of_resource_type', 'Pod', [p['metadata']['uid'] for p in pods]
-            )
-
-            for pod in pods:
-                pod['events'] = events[pod['metadata']['uid']]
+            if options['extra'].get('events'):
+                events = await self.middleware.call(
+                    'kubernetes.get_events_of_resource_type', 'Pod', [p['metadata']['uid'] for p in pods]
+                )
+                for pod in pods:
+                    pod['events'] = events[pod['metadata']['uid']]
 
         return filter_list(pods, filters, options)
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/secrets.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/secrets.py
@@ -22,9 +22,7 @@ class KubernetesSecretService(CRUDService):
         label_selector = options.get('extra', {}).get('label_selector')
         kwargs = {k: v for k, v in [('label_selector', label_selector)] if v}
         async with api_client() as (api, context):
-            if len(filters) == 1 and len(filters[0]) == 3 and all(
-                a == d for a, d in zip(filters[0][:2], ['metadata.namespace', '='])
-            ):
+            if len(filters) == 1 and len(filters[0]) == 3 and list(filters[0])[:2] == ['metadata.namespace', '=']:
                 func = functools.partial(context['core_api'].list_namespaced_secret, namespace=filters[0][2], **kwargs)
             else:
                 func = functools.partial(context['core_api'].list_secret_for_all_namespaces, **kwargs)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/statefulsets.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/statefulsets.py
@@ -18,9 +18,7 @@ class KubernetesStatefulsetService(CRUDService):
     @filterable
     async def query(self, filters, options):
         async with api_client() as (api, context):
-            if len(filters) == 1 and len(filters[0]) == 3 and all(
-                a == d for a, d in zip(filters[0][:2], ['metadata.namespace', '='])
-            ):
+            if len(filters) == 1 and len(filters[0]) == 3 and list(filters[0])[:2] == ['metadata.namespace', '=']:
                 func = functools.partial(context['apps_api'].list_namespaced_stateful_set, namespace=filters[0][2])
             else:
                 func = functools.partial(context['apps_api'].list_stateful_set_for_all_namespaces)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/statefulsets.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/statefulsets.py
@@ -26,11 +26,13 @@ class KubernetesStatefulsetService(CRUDService):
                 func = functools.partial(context['apps_api'].list_stateful_set_for_all_namespaces)
 
             stateful_sets = [d.to_dict() for d in (await func()).items]
-            events = await self.middleware.call(
-                'kubernetes.get_events_of_resource_type', 'StatefulSet', [s['metadata']['uid'] for s in stateful_sets]
-            )
-            for stateful_set in stateful_sets:
-                stateful_set['events'] = events[stateful_set['metadata']['uid']]
+            if options['extra'].get('events'):
+                events = await self.middleware.call(
+                    'kubernetes.get_events_of_resource_type', 'StatefulSet',
+                    [s['metadata']['uid'] for s in stateful_sets]
+                )
+                for stateful_set in stateful_sets:
+                    stateful_set['events'] = events[stateful_set['metadata']['uid']]
 
         return filter_list(stateful_sets, filters, options)
 

--- a/src/middlewared/middlewared/utils/itertools.py
+++ b/src/middlewared/middlewared/utils/itertools.py
@@ -1,0 +1,7 @@
+def infinite_multiplier_generator(multiplier, max_value, initial_value):
+    cur = initial_value
+    while True:
+        yield cur
+        next_val = cur * multiplier
+        if next_val <= max_value:
+            cur = next_val


### PR DESCRIPTION
This PR introduces following changes:

1) If an app was abusive in the sense that it consistently crashed or for other various reasons was emitting constant events, middleware was not able to cope with the flow of the events as `chart.release.query` is an expensive call and lots of events happening ended up slowing down middleware. With the current changes this has been addressed and optimized to only retrieve what we want which is basically monitoring updated status of the application.
2) If an app had probes defined, when the probe considered the pod/deployment to be ready, kubernetes would not be emitting an event in this case which resulted in UI constantly saying `DEPLOYING` for the said application. The same is true when there are multiple init containers defined and the startup can take some time but we get an asynchronous event from kubernetes after container start where it does not really wait for the container / pod to be up, this results in the same `DEPLOYING` problem. This PR handles this by polling kubernetes API at intervals until the `DEPLOYING` status changes. We would poll in intervals `2, 4, 8, 16, 32, 64, 128, 256, 512, 1024` - so after 2 seconds, we would try 4 then 8 then 16 and so on. The last try would happen at 1024 seconds since the event ( the large gap is to allow large images to be pulled ).
3) Improves performance querying for k8s resources in a specified namespace.
4) Optionally return each resource individual events.
5) Fixes a potential race condition where we might try to access cached chart release when it has been deleted already.