### PR TITLE
NAS-111556 / 21.08 / Bug fix for iptables getting out of sync

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -72,8 +72,11 @@ class KubernetesService(Service):
             # Even if user selects 0.0.0.0, k8s is going to auto select a node ip in this case
             return []
 
+        # https://unix.stackexchange.com/questions/591113/iptables-inserts-duplicate-
+        # rules-when-name-localhost-is-used-instead-of-127-0-0
+        # We don't use localhost name directly because it adds duplicate entries
         return [
-            ['INPUT', '-p', 'tcp', '-s', f'{node_ip},localhost', '--dport', '6443', '-j', 'ACCEPT'],
+            ['INPUT', '-p', 'tcp', '-s', f'{node_ip},127.0.0.1', '--dport', '6443', '-j', 'ACCEPT'],
             ['INPUT', '-p', 'tcp', '--dport', '6443', '-j', 'DROP'],
         ]
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -76,8 +76,14 @@ class KubernetesService(Service):
         # rules-when-name-localhost-is-used-instead-of-127-0-0
         # We don't use localhost name directly because it adds duplicate entries
         return [
-            ['INPUT', '-p', 'tcp', '-s', f'{node_ip},127.0.0.1', '--dport', '6443', '-j', 'ACCEPT'],
-            ['INPUT', '-p', 'tcp', '--dport', '6443', '-j', 'DROP'],
+            [
+                'INPUT', '-p', 'tcp', '-s', f'{node_ip},127.0.0.1', '--dport', '6443', '-j', 'ACCEPT', '-m', 'comment',
+                '--comment', 'iX Custom Rule to allow access to k8s cluster from internal TrueNAS connections'
+            ],
+            [
+                'INPUT', '-p', 'tcp', '--dport', '6443', '-j', 'DROP', '-m', 'comment', '--comment',
+                'iX Custom Rule to drop connection requests to k8s cluster from external sources'
+            ],
         ]
 
     @private


### PR DESCRIPTION
This PR addresses following issues:

1) Sometimes we were seeing that rules which allow internal traffic to be passed to k8s cluster being removed from INPUT chain. The suspect here is kube-router which probably due to some weird race condition is responsible for the removal ( I have not been able to narrow down the exact cause yet as the issue is random but definitely happens ). There are 2 ways to remove an iptable rules from a chain, one is to specify the complete spec of the rule and the other is to remove it by rule number in the chain. Kube-router from the inspection of the source i have done so far uses the former method to remove rules, this PR adds changes to get around that by adding a ix specific comment to the iptable rule spec which means that kube-router would not be able to remove the rule.
2) We had duplicate localhost rules being created, this PR fixes that issue as well.