### PR TITLE
NAS-111564 / 21.08 / Correct vm.query event payload to match vm_entry schema

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/events.py
+++ b/src/middlewared/middlewared/plugins/vm/events.py
@@ -56,8 +56,11 @@ class VMService(Service, LibvirtConnectionMixin):
                 state = 'UNKNOWN'
 
             vm_id = dom.name().split('_')[0]
-            if vm_id.isdigit():
-                self.middleware.send_event('vm.query', emit_type, id=int(vm_id), fields={'state': state})
+            # We do not send an event on removed because that would already be done by vm.delete
+            if vm_id.isdigit() and emit_type != 'REMOVED' and dom.name() in vms:
+                vm = vms[dom.name()]
+                vm['status']['state'] = state
+                self.middleware.send_event('vm.query', emit_type, id=int(vm_id), fields=vm)
             else:
                 self.middleware.logger.debug('Received libvirtd event with unknown domain name %s', dom.name())
 

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -628,7 +628,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
                 f'{self._config.namespace}.query',
                 f'Sent on {self._config.namespace} changes.',
                 self._config.private,
-                returns=Ref(self.ENTRY.name),
+                returns=Ref(self.ENTRY.newname if isinstance(self.ENTRY, Patch) else self.ENTRY.name),
             )
 
     @private


### PR DESCRIPTION
This PR fixes following issues:

1) Correctly refer to the CRUD entry schema for query events.
2) Correct vm.query event payload structure.