### PR TITLE
NAS-111570 / 21.08 / Wait when adding/removing iptables rules

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -53,6 +53,7 @@ class KubernetesService(SimpleService):
     async def before_stop(self):
         await self.middleware.call('k8s.node.add_taints', [{'key': 'ix-svc-stop', 'effect': 'NoExecute'}])
         await asyncio.sleep(10)
+        await self.middleware.call('kubernetes.remove_iptables_rules')
 
     async def after_stop(self):
         await self._systemd_unit('kube-router', 'stop')
@@ -61,4 +62,3 @@ class KubernetesService(SimpleService):
         # This is necessary to ensure that docker umounts datasets and shuts down cleanly
         await asyncio.sleep(5)
         await self.middleware.call('k8s.cni.cleanup_cni')
-        await self.middleware.call('kubernetes.remove_iptables_rules')


### PR DESCRIPTION
This PR fixes following issues:
1) Wait when adding/deleting iptables rules as another app might be holding the xtables-lock
2) Do not continue adding iptables rules if we are unable to add even one
3) Remove drop iptables rule first and then proceed to the accept ones
4) Remove iptables rules before stopping k3s as if user is using wildcard ip address for k8s, k8s would be selecting a node ip on it's own and after k8s has stopped we can't determine which ip was chosen by k8s.