### PR TITLE
NAS-111247 / 21.08 / Generate wsdd configuration file

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
@@ -1,0 +1,11 @@
+<%
+    import json
+
+    conf = {
+        "realm": middleware.call_sync('smb.getparm', 'realm', 'GLOBAL'),
+        "netbios_name": middleware.call_sync('smb.getparm', 'netbiosname', 'GLOBAL'),
+        "workgroup": middleware.call_sync('smb.getparm', 'workgroup', 'GLOBAL'),
+        "enabled": middleware.call_sync('network.configuration.config')['service_announcement']['wsd']
+    }
+%>
+${json.dumps(conf)}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -230,6 +230,9 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'local/avahi/avahi-daemon.conf', 'checkpoint': 'interface_sync'},
             {'type': 'py', 'path': 'local/avahi/avahi_services', 'checkpoint': 'interface_sync'}
         ],
+        'wsd': [
+            {'type': 'mako', 'path': 'local/wsdd.conf', 'checkpoint': 'interface_sync'},
+        ],
         'ups': [
             {'type': 'py', 'path': 'local/nut/ups_config'},
             {'type': 'mako', 'path': 'local/nut/ups.conf', 'owner': 'root', 'group': UPS_GROUP, 'mode': 0o440},

--- a/src/middlewared/middlewared/plugins/service_/services/wsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/wsd.py
@@ -4,6 +4,8 @@ from .base import SimpleService
 class WSDService(SimpleService):
     name = "wsdd"
 
+    etc = ["wsd"]
+
     freebsd_rc = "wsdd"
 
     systemd_unit = "wsdd"


### PR DESCRIPTION
Due to cluster-related changes to how SMB configuration is stored,
the global section of smb.conf is readable only by root user.
Add an etc plugin for wsdd and generate configuration file
for the daemon with required details prior to service start.