### PR TITLE
NAS-111228 / 21.08 / Permit sysdataset move during boot if AD enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -140,8 +140,9 @@ class SystemDatasetService(ConfigService):
 
         verrors = ValidationErrors()
         if new['pool'] != config['pool']:
-            ad_enabled = (await self.middleware.call('activedirectory.get_state')) != 'DISABLED'
-            if ad_enabled:
+            system_ready = await self.middleware.call('system.ready')
+            ad_enabled = (await self.middleware.call('activedirectory.get_state')) in ['HEALTHY', 'FAULTED']
+            if system_ready and ad_enabled:
                 verrors.add(
                     'sysdataset_update.pool',
                     'System dataset location may not be moved while the Active Directory service is enabled.',


### PR DESCRIPTION
Raising an exception at this point will cause systemdataset
setup to fail, which is generally a bad thing. During boot
there will be no active SMB sessions and so potential impact
is minimal.