### PR TITLE
NAS-111216 / 21.08 / Move passdb.tdb to path outside of system dataset

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -223,6 +223,7 @@
             that the openldap server have the Samba LDAP schema extensions.
             """
             if db['role'] == "ad_member":
+                pc.update({'passdb backend': 'tdbsam:/root/samba/private/passdb.tdb'})
                 pc.update({
                     'server role': 'member server',
                     'kerberos method': 'secrets and keytab',
@@ -268,6 +269,7 @@
                 })
 
             elif db['role'] == "standalone":
+                pc.update({'passdb backend': 'tdbsam:/root/samba/private/passdb.tdb'})
                 pc.update({'server role': 'standalone'})
                 pc.update({'workgroup': db['cifs']['workgroup'].upper()})
 


### PR DESCRIPTION
Python bindings used in middleware will open handle on passdb.tdb
preventing system dataset move in some cases. Switch to using
path under /root. At future time we can evaluate using tmpfs as
we re-sync this file on boot.