### PR TITLE
NAS-111269 / 21.08 / Rework directory services user cache backend

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1484,7 +1484,9 @@ class ActiveDirectoryService(ConfigService):
 
     @private
     async def get_cache(self):
-        return await self.middleware.call('dscache.entries', self._config.namespace)
+        users = await self.middleware.call('dscache.entries', self._config.namespace.upper(), 'USER')
+        groups = await self.middleware.call('dscache.entries', self._config.namespace.upper(), 'GROUP')
+        return {"USERS": users, "GROUPS": groups}
 
 
 class WBStatusThread(threading.Thread):

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1315,6 +1315,20 @@ class ActiveDirectoryService(ConfigService):
         self.logger.debug("Successfully left domain: %s", ad['domainname'])
 
     @private
+    def get_gencache_sid(self, tdb_key):
+        gencache = tdb.Tdb('/tmp/gencache.tdb', 0, tdb.DEFAULT, os.O_RDONLY)
+        try:
+            tdb_val = gencache.get(tdb_key)
+        finally:
+            gencache.close()
+
+        decoded_sid = tdb_val[8:-5].decode()
+        if decoded_sid == '-':
+            return None
+
+        return decoded_sid
+
+    @private
     @job(lock='fill_ad_cache')
     def fill_cache(self, job, force=False):
         """
@@ -1329,10 +1343,6 @@ class ActiveDirectoryService(ConfigService):
         may be revised in the future, but we want to keep things as simple as possible
         here since the list of entries numbers perhaps in the tens of thousands.
         """
-        if self.middleware.call_sync('cache.has_key', 'AD_cache') and not force:
-            raise CallError('AD cache already exists. Refusing to generate cache.')
-
-        self.middleware.call_sync('cache.pop', 'AD_cache')
         ad = self.middleware.call_sync('activedirectory.config')
         smb = self.middleware.call_sync('smb.config')
         id_type_both_backends = [
@@ -1361,9 +1371,7 @@ class ActiveDirectoryService(ConfigService):
         local_groups = {}
         local_users.update({x['uid']: x for x in self.middleware.call_sync('user.query')})
         local_users.update({x['gid']: x for x in self.middleware.call_sync('group.query')})
-        cache_data = {'users': {}, 'groups': {}}
         configured_domains = self.middleware.call_sync('idmap.query')
-        user_next_index = group_next_index = 300000000
         for d in configured_domains:
             if d['name'] == 'DS_TYPE_ACTIVEDIRECTORY':
                 known_domains.append({
@@ -1385,6 +1393,11 @@ class ActiveDirectoryService(ConfigService):
             if prefix != b'IDMAP/UID2SID' and prefix != b'IDMAP/GID2SID':
                 continue
 
+            sid = self.get_gencache_sid(key)
+            if sid is None:
+                return
+
+            rid = int(sid.rsplit("-", 1)[1])
             line = key.decode()
             if line.startswith('IDMAP/UID2SID'):
                 # tdb keys are terminated with \x00, this must be sliced off before converting to int
@@ -1404,8 +1417,8 @@ class ActiveDirectoryService(ConfigService):
                         """
                         try:
                             user_data = pwd.getpwuid(cached_uid)
-                            cache_data['users'].update({user_data.pw_name: {
-                                'id': user_next_index,
+                            entry = {
+                                'id': 100000 + d['low_id'] + rid,
                                 'uid': user_data.pw_uid,
                                 'username': user_data.pw_name,
                                 'unixhash': None,
@@ -1427,8 +1440,8 @@ class ActiveDirectoryService(ConfigService):
                                 'sshpubkey': None,
                                 'local': False,
                                 'id_type_both': d['id_type_both']
-                            }})
-                            user_next_index += 1
+                            }
+                            self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
                             break
                         except KeyError:
                             break
@@ -1453,8 +1466,8 @@ class ActiveDirectoryService(ConfigService):
                         except KeyError:
                             break
 
-                        cache_data['groups'].update({group_data.gr_name: {
-                            'id': group_next_index,
+                        entry = {
+                            'id': 100000 + d['low_id'] + rid,
                             'gid': group_data.gr_gid,
                             'name': group_data.gr_name,
                             'group': group_data.gr_name,
@@ -1465,33 +1478,13 @@ class ActiveDirectoryService(ConfigService):
                             'users': [],
                             'local': False,
                             'id_type_both': d['id_type_both']
-                        }})
-                        group_next_index += 1
+                        }
+                        self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)
                         break
-
-        if not cache_data.get('users'):
-            return
-        sorted_cache = {}
-        sorted_cache['users'] = dict(sorted(cache_data['users'].items()))
-        sorted_cache['groups'] = dict(sorted(cache_data['groups'].items()))
-
-        self.middleware.call_sync('cache.put', 'AD_cache', sorted_cache)
-        self.middleware.call_sync('dscache.backup')
 
     @private
     async def get_cache(self):
-        """
-        Returns cached AD user and group information. If proactive caching is enabled
-        then this will contain all AD users and groups, otherwise it contains the
-        users and groups that were present in the winbindd cache when the cache was
-        last filled. The cache expires and is refilled every 24 hours, or can be
-        manually refreshed by calling fill_cache(True).
-        """
-        if not await self.middleware.call('cache.has_key', 'AD_cache'):
-            await self.middleware.call('activedirectory.fill_cache')
-            self.logger.debug('cache fill is in progress.')
-            return {'users': {}, 'groups': {}}
-        return await self.middleware.call('cache.get', 'AD_cache')
+        return await self.middleware.call('dscache.entries', self._config.namespace)
 
 
 class WBStatusThread(threading.Thread):

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -1,13 +1,15 @@
-from middlewared.schema import Any, Str, accepts, Int
+from middlewared.schema import Any, Str, Ref, Int, Dict, Bool, accepts
 from middlewared.service import Service, private, job
 from middlewared.utils import filter_list, osc
+from middlewared.service_exception import CallError, MatchNotFound
 
 from collections import namedtuple
 import time
-import pickle
 import pwd
 import grp
 import os
+import tdb
+import json
 
 
 class CacheService(Service):
@@ -94,6 +96,93 @@ class DSCache(Service):
     class Config:
         private = True
 
+    @accepts(
+        Str('directory_service', required=True, enum=["ACTIVEDIRECTORY", "LDAP"]),
+        Str('idtype', enum=['USER', 'GROUP'], required=True),
+        Dict('cache_entry', additional_attrs=True),
+    )
+    async def insert(self, ds, idtype, entry):
+        if idtype == "GROUP":
+            id_key = "gid"
+            name_key = "name"
+        else:
+            id_key = "uid"
+            name_key = "username"
+
+        ops = [
+            {"action": "SET", "key": f'ID_{entry[id_key]}', "val": entry},
+            {"action": "SET", "key": f'NAME_{entry[name_key]}', "val": entry}
+        ]
+        await self.middleware.call(
+            'tdb.batch_ops',
+            f'{ds.lower()}_{idtype.lower()}',
+            ops
+        )
+        return True
+
+    @accepts(
+        Str('directory_service', required=True, enum=["ACTIVEDIRECTORY", "LDAP"]),
+        Dict('principal_info',
+            Str('idtype', enum=['USER', 'GROUP']),
+            Str('who'),
+            Int('id'),
+        ),
+        Dict('options', Bool('synthesize', default=False))
+    )
+    async def retrieve(self, ds, data, options):
+        who_str = data.get('who')
+        who_id = data.get('id')
+        if who_str is None and who_id is None:
+            raise CallError("`who` or `id` entry is required to uniquely "
+                            "identify the entry to be retrieved.")
+
+        tdb_name = f'{ds}_{data["idtype"].lower()}'
+        prefix = "NAME" if who_str else "ID"
+        tdb_key = f'{prefix}_{who_str if who_str else who_id}'
+
+        try:
+            entry = await self.middleware.call("tdb.fetch", tdb_name, tdb_key)
+        except MatchNotFound:
+            entry = None
+
+        if not entry and options['synthesize']:
+            """
+            if cache lacks entry, create one from passwd / grp info,
+            insert into cache and return synthesized value.
+            get_uncached_* will raise KeyError if NSS lookup fails.
+            """
+            try:
+                if data['idtype'] == 'USER':
+                    pwdobj = await self.middleware.call('dscache.get_uncached_user',
+                                                        who_str, who_id)
+                    entry = await self.middleware.call('idmap.synthetic_user',
+                                                       ds, pwdobj)
+                else:
+                    grpobj = await self.middleware.call('dscache.get_uncached_group',
+                                                        who_str, who_id)
+                    entry = await self.middleware.call('idmap.synthetic_group',
+                                                       ds, grpobj)
+                await self.insert(ds, data['idtype'], entry)
+            except KeyError:
+                entry = None
+
+        elif not entry:
+            raise KeyError(who_str if who_str else who_id)
+
+        return entry
+
+    @accepts(
+        Str('ds', required=True, enum=["ACTIVEDIRECTORY", "LDAP"]),
+        Str('idtype', required=True, enum=["USER", "GROUP"]),
+    )
+    async def entries(self, ds, idtype):
+        entries = await self.middleware.call(
+            'tdb.entries',
+            f'{ds.lower()}_{idtype.lower()}',
+            [('key', '^', 'ID')]
+        )
+        return [x['val'] for x in entries]
+
     def get_uncached_user(self, username=None, uid=None):
         """
         Returns dictionary containing pwd_struct data for
@@ -135,80 +224,52 @@ class DSCache(Service):
             'gr_mem': g.gr_mem
         }
 
-    def initialize(self):
-        dstypes = [('activedirectory', 'AD'), ('ldap', 'LDAP')]
-        if osc.IS_FREEBSD:
-            dstypes.append(('nis', 'NIS'))
 
-        for ds in dstypes:
-            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
-                try:
-                    with open(f'/var/db/system/.{ds[1]}_cache_backup', 'rb') as f:
-                        pickled_cache = pickle.load(f)
-                    self.middleware.call_sync('cache.put', f'{ds[1]}_cache', pickled_cache)
-                except FileNotFoundError:
-                    self.logger.debug('User cache file for [%s] is not present.', ds[0])
-
-    def backup(self):
-        dstypes = [('activedirectory', 'AD'), ('ldap', 'LDAP')]
-        if osc.IS_FREEBSD:
-            dstypes.append(('nis', 'NIS'))
-
-        for ds in dstypes:
-            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
-                try:
-                    ds_cache = self.middleware.call_sync('cache.get', f'{ds[1]}_cache')
-                    with open(f'/var/db/system/.{ds[1]}_cache_backup', 'wb') as f:
-                        pickle.dump(ds_cache, f)
-                except KeyError:
-                    self.logger.debug('No cache exists for directory service [%s].', ds[0])
-
-    async def query(self, objtype='USERS', filters=None, options=None):
+    @accepts(
+        Str('objtype', enum=['USERS', 'GROUPS'], default='USERS'),
+        Ref('query-filters'),
+        Ref('query-options'),
+    )
+    async def query(self, objtype, filters, options):
         """
         Query User / Group cache with `query-filters` and `query-options`.
 
         `objtype`: 'USERS' or 'GROUPS'
-
-        Each directory service, when enabled, will generate a user and group cache using its
-        respective 'fill_cache' method (ex: ldap.fill_cache). The cache entry is formatted
-        as follows:
-
-        The cache can be refreshed by calliing 'dscache.refresh'. The actual cache fill
-        will run in the background (potentially for a long time). The exact duration of the
-        fill process depends factors such as number of users and groups, and network
-        performance. In environments with a large number of users (over a few thousand),
-        administrators may consider disabling caching. In the case of active directory,
-        the dscache will continue to be filled using entries from samba's gencache (the end
-        result in this case will be that only users and groups actively accessing the share
-        will be populated in UI dropdowns). In the case of other directory services, the
-        users and groups will simply not appear in query results (UI features).
-
         """
         res = []
         ds_state = await self.middleware.call('directoryservices.get_state')
+        enabled_ds = None
 
-        is_name_check = bool(filters and len(filters) == 1 and filters[0][0] in ['username', 'groupname'])
+        is_name_check = bool(filters and len(filters) == 1 and filters[0][0] in ['username', 'name'])
+        is_id_check = bool(filters and len(filters) == 1 and filters[0][0] in ['uid', 'gid'])
 
         res.extend((await self.middleware.call(f'{objtype.lower()[:-1]}.query', filters, options)))
 
         for dstype, state in ds_state.items():
             if state != 'DISABLED':
-                """
-                Avoid iteration here if possible.  Use keys if single filter "=" and x in x=y is a
-                username or groupname.
-                """
-                if is_name_check and filters[0][1] == '=':
-                    cache = (await self.middleware.call(f'{dstype}.get_cache'))[objtype.lower()]
-                    name = filters[0][2]
-                    return [cache.get(name)] if cache.get(name) else []
+                enabled_ds = dstype
+                break
 
-                else:
-                    res.extend(filter_list(
-                        list((await self.middleware.call(f'{dstype}.get_cache'))[objtype.lower()].values()),
-                        filters,
-                        options
-                    ))
+        if not enabled_ds:
+            return res
 
+        if is_name_check and filters[0][1] == '=':
+            entry = await self.retrieve(enabled_ds, {
+                'idtype': objtype[:-1],
+                'who': filters[0][2],
+            }, {'synthensize': True})
+            return [entry] if entry else []
+
+        if is_id_check and filters[0][1] == '=':
+            entry = await self.retrieve(enabled_ds, {
+                'idtype': objtype[:-1],
+                'id': filters[0][2],
+            }, {'synthesize': True})
+            return [entry] if entry else []
+
+        entries = await self.entries(enabled_ds.upper(), objtype[:-1])
+        entries_by_id = sorted(entries, key=lambda i: i['id'])
+        res.extend(filter_list(entries_by_id, filters, options))
         return res
 
     @job(lock="dscache_refresh")
@@ -217,37 +278,13 @@ class DSCache(Service):
         This is called from a cronjob every 24 hours and when a user clicks on the
         UI button to 'rebuild directory service cache'.
         """
-        available_ds = ['activedirectory', 'ldap']
-        if osc.IS_FREEBSD:
-            available_ds.append('nis')
+        for ds in ['activedirectory', 'ldap']:
+            await self.middleware.call('tdb.wipe', f'{ds}_user')
+            await self.middleware.call('tdb.wipe', f'{ds}_group')
 
-        for ds in available_ds:
             ds_state = await self.middleware.call(f'{ds}.get_state')
+
             if ds_state == 'HEALTHY':
                 await job.wrap(await self.middleware.call(f'{ds}.fill_cache', True))
             elif ds_state != 'DISABLED':
                 self.logger.debug('Unable to refresh [%s] cache, state is: %s' % (ds, ds_state))
-            else:
-                if ds == 'activedirectory':
-                    backup_path = "/var/db/system/.AD_cache"
-                elif ds == 'ldap':
-                    backup_path = "/var/db/system/.LDAP_cache"
-                else:
-                    backup_path = "/var/db/system/.NIS_cache"
-                try:
-                    os.unlink(backup_path)
-                except FileNotFoundError:
-                    pass
-                except Exception:
-                    self.logger.error("Failed to remove directory service cache backup [%s].",
-                                      backup_path, exc_info=True)
-
-        await self.middleware.call('dscache.backup')
-
-
-async def setup(middleware):
-    """
-    During initial boot, we need to wait for the system dataset to be imported.
-    """
-    if await middleware.call('system.ready'):
-        await middleware.call('dscache.initialize')

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -1,15 +1,12 @@
 from middlewared.schema import Any, Str, Ref, Int, Dict, Bool, accepts
 from middlewared.service import Service, private, job
-from middlewared.utils import filter_list, osc
+from middlewared.utils import filter_list
 from middlewared.service_exception import CallError, MatchNotFound
 
 from collections import namedtuple
 import time
 import pwd
 import grp
-import os
-import tdb
-import json
 
 
 class CacheService(Service):
@@ -122,7 +119,8 @@ class DSCache(Service):
 
     @accepts(
         Str('directory_service', required=True, enum=["ACTIVEDIRECTORY", "LDAP"]),
-        Dict('principal_info',
+        Dict(
+            'principal_info',
             Str('idtype', enum=['USER', 'GROUP']),
             Str('who'),
             Int('id'),
@@ -223,7 +221,6 @@ class DSCache(Service):
             'gr_gid': g.gr_gid,
             'gr_mem': g.gr_mem
         }
-
 
     @accepts(
         Str('objtype', enum=['USERS', 'GROUPS'], default='USERS'),

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -251,6 +251,10 @@ class DSCache(Service):
             return res
 
         if is_name_check and filters[0][1] == '=':
+            # exists in local sqlite database, return results
+            if res:
+                return res
+
             entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
                 'who': filters[0][2],
@@ -258,6 +262,10 @@ class DSCache(Service):
             return [entry] if entry else []
 
         if is_id_check and filters[0][1] == '=':
+            # exists in local sqlite database, return results
+            if res:
+                return res
+
             entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
                 'id': filters[0][2],

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -134,7 +134,7 @@ class DSCache(Service):
             raise CallError("`who` or `id` entry is required to uniquely "
                             "identify the entry to be retrieved.")
 
-        tdb_name = f'{ds}_{data["idtype"].lower()}'
+        tdb_name = f'{ds.lower()}_{data["idtype"].lower()}'
         prefix = "NAME" if who_str else "ID"
         tdb_key = f'{prefix}_{who_str if who_str else who_id}'
 
@@ -154,12 +154,12 @@ class DSCache(Service):
                     pwdobj = await self.middleware.call('dscache.get_uncached_user',
                                                         who_str, who_id)
                     entry = await self.middleware.call('idmap.synthetic_user',
-                                                       ds, pwdobj)
+                                                       ds.lower(), pwdobj)
                 else:
                     grpobj = await self.middleware.call('dscache.get_uncached_group',
                                                         who_str, who_id)
                     entry = await self.middleware.call('idmap.synthetic_group',
-                                                       ds, grpobj)
+                                                       ds.lower(), grpobj)
                 await self.insert(ds, data['idtype'], entry)
             except KeyError:
                 entry = None
@@ -251,14 +251,14 @@ class DSCache(Service):
             return res
 
         if is_name_check and filters[0][1] == '=':
-            entry = await self.retrieve(enabled_ds, {
+            entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
                 'who': filters[0][2],
             }, {'synthensize': True})
             return [entry] if entry else []
 
         if is_id_check and filters[0][1] == '=':
-            entry = await self.retrieve(enabled_ds, {
+            entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
                 'id': filters[0][2],
             }, {'synthesize': True})

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -901,9 +901,9 @@ class IdmapDomainService(CRUDService):
         }
 
     @private
-    async def sythetic_group(self, ds, grp):
-        idmap_info = self.get_idmap_info(ds, group['gr_gid'])
-        sid = await self.unixid_to_sid({"id": group['gr_gid'], "id_type": "GROUPR"})
+    async def synthetic_group(self, ds, grp):
+        idmap_info = await self.get_idmap_info(ds, grp['gr_gid'])
+        sid = await self.unixid_to_sid({"id": grp['gr_gid'], "id_type": "GROUP"})
         rid = int(sid.rsplit('-', 1)[1])
         return {
             'id': 100000 + idmap_info[0] + rid,

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -849,3 +849,72 @@ class IdmapDomainService(CRUDService):
             return None
 
         return wb.stdout.decode().strip()
+
+    @private
+    async def get_idmap_info(self, ds, id):
+        low_range = None
+        id_type_both = False
+        domains = await self.query()
+
+        for d in domains:
+            if ds == 'activedirectory' and d['name'] == 'DS_TYPE_LDAP':
+                continue
+
+            if ds == 'ldap' and d['name'] != 'DS_TYPE_LDAP':
+                continue
+
+            if id in range(d['range_low'], d['range_high']):
+                low_range = d['range_low']
+                id_type_both = d['idmap_backend'] in ['AUTORID', 'RID']
+                break
+
+        return (low_range, id_type_both)
+
+    @private
+    async def synthetic_user(self, ds, passwd):
+        idmap_info = await self.get_idmap_info(ds, passwd['pw_uid'])
+        sid = await self.unixid_to_sid({"id": passwd['pw_uid'], "id_type": "USER"})
+        rid = int(sid.rsplit('-', 1)[1])
+        return {
+            'id': 100000 + idmap_info[0] + rid,
+            'uid': passwd['pw_uid'],
+            'username': passwd['pw_name'],
+            'unixhash': None,
+            'smbhash': None,
+            'group': {},
+            'home': '',
+            'shell': '',
+            'full_name': passwd['pw_gecos'],
+            'builtin': False,
+            'email': '',
+            'password_disabled': False,
+            'locked': False,
+            'sudo': False,
+            'sudo_nopasswd': False,
+            'sudo_commands': [],
+            'microsoft_account': False,
+            'attributes': {},
+            'groups': [],
+            'sshpubkey': None,
+            'local': False,
+            'id_type_both': idmap_info[1],
+        }
+
+    @private
+    async def sythetic_group(self, ds, grp):
+        idmap_info = self.get_idmap_info(ds, group['gr_gid'])
+        sid = await self.unixid_to_sid({"id": group['gr_gid'], "id_type": "GROUPR"})
+        rid = int(sid.rsplit('-', 1)[1])
+        return {
+            'id': 100000 + idmap_info[0] + rid,
+            'gid': grp['gr_gid'],
+            'name': grp['gr_name'],
+            'group': grp['gr_name'],
+            'builtin': False,
+            'sudo': False,
+            'sudo_nopasswd': False,
+            'sudo_commands': [],
+            'users': [],
+            'local': False,
+            'id_type_both': idmap_info[1],
+        }

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1067,4 +1067,6 @@ class LDAPService(ConfigService):
 
     @private
     async def get_cache(self):
-        return await self.middleware.call('dscache.entries', self._config.namespace)
+        users = await self.middleware.call('dscache.entries', self._config.namespace.upper(), 'USER')
+        groups = await self.middleware.call('dscache.entries', self._config.namespace.upper(), 'GROUP')
+        return {"USERS": users, "GROUPS": groups}

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -345,7 +345,6 @@ class SystemDatasetService(ConfigService):
             # The following should be backgrounded since they may be quite
             # long-running.
             await self.middleware.call('smb.configure', False)
-            await self.middleware.call('dscache.initialize')
 
         return config
 

--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -1,0 +1,163 @@
+from middlewared.service import Service, private
+from middlewared.schema import accepts, Bool, Dict, Ref, List, Str
+from middlewared.service_exception import CallError, MatchNotFound
+from middlewared.utils import filter_list
+from .connection import TDBMixin, TDBPath
+
+import os
+import json
+import errno
+
+from contextlib import closing
+
+
+class TDBService(Service, TDBMixin):
+
+    handles = {}
+
+    class Config:
+        private = True
+
+    @private
+    def get_connection(self, name, options):
+        existing = self.handles.get('name')
+
+        if existing:
+            if options != existing['options']:
+                raise CallError(f'{name}: Internal Error - tdb options mismatch', errno.EINVAL)
+            if existing['handle']:
+                return existing['handle']
+
+        else:
+            self.handles[name] = {'options': options.copy()}
+
+        handle = self._get_handle(name, options)
+        return handle
+
+    @accepts(
+        Str('name', required=True),
+        Str('key', required=True),
+        Dict('data', required=True, additional_attrs=True),
+        Dict(
+            'tdb-options',
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'INTERNAL'], default='PERSISTENT'),
+            Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
+            Bool('mmap', default=True),
+            Bool('clustered', default=False),
+        )
+    )
+    def store(self, name, tdb_key, data, options):
+        handle = self.get_connection(name, options)
+        tdb_val = json.dumps(data)
+
+        with closing(handle) as tdb_handle:
+            self._set(tdb_handle, tdb_key, tdb_val)
+
+    @accepts(
+        Str('name', required=True),
+        Str('key', required=True),
+        Dict(
+            'tdb-options',
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'INTERNAL'], default='PERSISTENT'),
+            Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
+            Bool('mmap', default=True),
+            Bool('clustered', default=False),
+        )
+    )
+    def fetch(self, name, tdb_key, options):
+        handle = self.get_connection(name, options)
+
+        with closing(handle) as tdb_handle:
+            tdb_val = self._get(tdb_handle, tdb_key)
+
+        if tdb_val is None:
+            raise MatchNotFound(tdb_key)
+
+        data = json.loads(tdb_val)
+        return data
+
+    @accepts(
+        Str('name', required=True),
+        Ref('query-filters'),
+        Ref('query-options'),
+        Dict(
+            'tdb_options',
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'INTERNAL'], default='PERSISTENT'),
+            Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
+            Bool('mmap', default=True),
+            Bool('clustered', default=False),
+        )
+    )
+    def entries(self, name, filters, options, tdb_options):
+        def append_entries(tdb_key, tdb_data, outlist):
+            if tdb_data is None:
+                return True
+
+            entry = json.loads(tdb_data)
+            outlist.append({"key": tdb_key, "val": entry})
+            return True
+
+        output = []
+        handle = self.get_connection(name, tdb_options)
+
+        with closing(handle) as tdb_handle:
+            self._traverse(tdb_handle, append_entries, output)
+
+        return filter_list(output, filters, options)
+
+    @accepts(
+        Str('name', required=True),
+        List('ops', required=True),
+        Dict(
+            'tdb-options',
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'INTERNAL'], default='PERSISTENT'),
+            Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
+            Bool('mmap', default=True),
+        )
+    )
+    def batch_ops(self, name, ops, options):
+        handle = self.get_connection(name, options)
+        output = []
+
+        with closing(handle) as tdb_handle:
+            self._transaction(tdb_handle, 'START')
+            try:
+                for op in ops:
+                    if op["action"] == "SET":
+                        tdb_val = json.dumps(op["val"])
+                        self._set(tdb_handle, op["key"], tdb_val)
+                    if op["action"] == "DEL":
+                        self._rem(tdb_handle, op["key"])
+                    if op["action"] == "GET":
+                        tdb_val = self._get(tdb_handle, op["key"])
+                        output.append(json.loads(tdb_val))
+                self._transaction(tdb_handle, "COMMIT")
+            except Exception:
+                self._transaction(tdb_handle, "CANCEL")
+                raise
+
+        return output
+
+    @accepts(
+        Str('name', required=True),
+        Dict(
+            'tdb_options',
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'INTERNAL'], default='PERSISTENT'),
+            Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
+            Bool('mmap', default=True),
+            Bool('clustered', default=False),
+        )
+    )
+    def wipe(self, name, options):
+        handle = self.get_connection(name, options)
+        with closing(handle) as tdb_handle:
+            self._wipe(tdb_handle)
+
+    @private
+    async def setup(self):
+        for p in TDBPath:
+            os.makedirs(p.value, mode=0o700, exist_ok=True)
+
+
+async def setup(middleware):
+    await middleware.call("tdb.setup")

--- a/src/middlewared/middlewared/plugins/tdb/connection.py
+++ b/src/middlewared/middlewared/plugins/tdb/connection.py
@@ -1,0 +1,67 @@
+import tdb
+import os
+import enum
+
+
+class TDBPath(enum.Enum):
+    VOLATILE = '/var/run/tdb/volatile'
+    PERSISTENT = '/root/tdb/persistent'
+
+
+class TDBMixin:
+    def _get_handle(self, name, options):
+        tdb_type = options.get('backend', 'PERSISTENT')
+        tdb_flags = tdb.DEFAULT
+        open_flags = os.O_CREAT | os.O_RDWR
+        open_mode = 0o600
+
+        if tdb_type == 'INTERNAL':
+            tdb_flags |= tdb.INTERNAL
+
+        if not options.get('mmap', True):
+            tdb_flags |= tdb.NOMMAP
+
+        if not tdb_flags & tdb.INTERNAL:
+            name = f'{TDBPath[tdb_type].value}/{name}.tdb'
+
+        handle = tdb.Tdb(name, 0, tdb_flags, open_flags, open_mode)
+        return handle
+
+    def _close_handle(self, tdb_handle):
+        tdb_handle.close()
+
+    def _get(self, tdb_handle, key):
+        tdb_key = key.encode()
+        tdb_val = tdb_handle.get(tdb_key)
+        return tdb_val.decode() if tdb_val else None
+
+    def _set(self, tdb_handle, key, val):
+        tdb_key = key.encode()
+        tdb_val = val.encode()
+        tdb_handle.store(tdb_key, tdb_val)
+
+    def _rem(self, tdb_handle, key):
+        tdb_key = key.encode()
+        tdb_handle.delete(tdb_key)
+
+    def _traverse(self, tdb_handle, fn, private_data):
+        ok = True
+        for i in tdb_handle.keys():
+            tdb_key = i.decode()
+            tdb_val = self._get(tdb_handle, tdb_key)
+            ok = fn(tdb_key, tdb_val, private_data)
+            if not ok:
+                break
+
+        return ok
+
+    def _wipe(self, tdb_handle):
+        tdb_handle.clear()
+
+    def _transaction(self, tdb_handle, verb):
+        if verb == 'START':
+            tdb_handle.transaction_start()
+        elif verb == 'CANCEL':
+            tdb_handle.transaction_cancel()
+        elif verb == 'COMMIT':
+            tdb_handle.transaction_commit()


### PR DESCRIPTION
Switch to using tdb files for the directory services cache.
This simplifies some interactions with the cache (retrieval
while building it out) and also makes persistence simpler.

Rework backend behavior so that if API user specifies an
explict id or name, and only has one filter doing this,
then on cache lookup failure, we directly query nss for
user or group, create a synthetic result, insert into cache
and return it to API user. This requires having deterministic
method of generating fake "id" keys for directory services
users. Algorithm used is to take low-range of idmap backend,
add the rid value of the user/group to it, and add a default offset
of 100,000. This should avoid collisions with ids assigned from
sqlite (in a sane environment, 100K users or groups won't have
been added to the server). RID values in AD increment as well and
so this algorithm ensures that no `id` keys are ever re-used.