### PR TITLE
NAS-111594 / 13.0 / improve the process for formatting disks

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -1,47 +1,76 @@
-import asyncio
 import os
-import re
-import signal
-import subprocess
+import array
+import struct
+import fcntl
 
 from middlewared.schema import accepts, Bool, Ref, Str
 from middlewared.service import job, private, Service
-from middlewared.utils import osc, Popen, run
 
 
-if osc.IS_LINUX:
-    RE_DD = re.compile(r'^(\d+).*bytes.*copied.*, ([\d\.]+)\s*(GB|MB|KB|B)/s')
-else:
-    RE_DD = re.compile(r'^(\d+) bytes transferred .*\((\d+) bytes')
+DIOCGMEDIASIZE = 0x40086481  # sys/sys/disk.h _IOR('d', 129, uint64_t)
+CHUNK = 1048576  # 1MB binary
 
 
 class DiskService(Service):
 
     @private
-    async def destroy_partitions(self, disk):
-        if osc.IS_LINUX:
-            await run(['sgdisk', '-Z', os.path.join('/dev', disk)])
-        else:
-            await run('gpart', 'destroy', '-F', f'/dev/{disk}', check=False)
-            # Wipe out the partition table by doing an additional iterate of create/destroy
-            await run('gpart', 'create', '-s', 'gpt', f'/dev/{disk}')
-            await run('gpart', 'destroy', '-F', f'/dev/{disk}')
+    def _get_size(self, handle):
+        size = None
+        try:
+            _buffer = array.array('B', range(0, 8))
+            fcntl.ioctl(handle.fileno(), DIOCGMEDIASIZE, _buffer, 1)
+            size = struct.unpack('q', _buffer)[0]
+        except Exception:
+            self.logger.error('Failed to determine size of "%s"', handle.name, exc_info=True)
+
+        return size
 
     @private
-    async def wipe_quick(self, dev, size=None):
-        # If the size is too small, lets just skip it for now.
-        # In the future we can adjust dd size
-        if size and size < 33554432:
-            return
-        await run('dd', 'if=/dev/zero', f'of=/dev/{dev}', 'bs=1M', 'count=32')
-        size = await self.middleware.call('disk.get_dev_size', dev)
-        if not size:
-            self.logger.error(f'Unable to determine size of {dev}')
-        else:
-            # This will fail when EOL is reached
-            await run(
-                'dd', 'if=/dev/zero', f'of=/dev/{dev}', 'bs=1M', f'oseek={int(size / (1024*1024)) - 32}', check=False
-            )
+    def _wipe(self, data):
+        with open(f'/dev/{data["dev"]}', 'wb') as f:
+            size = self._get_size(f)
+            if size is None or size == 0:
+                # no size means nothing else will work
+                self.logger.error('Unable to determine size of "%s"', dev)
+                return
+            elif size < 33554432 and data['mode'] == 'QUICK':
+                # we wipe the first and last 33554432 bytes (32MB) of the
+                # device when it's the "QUICK" mode so if the device is smaller
+                # than that, ignore it.
+                return
+
+            # seek to the beginning of the disk to be safe
+            os.lseek(f.fileno(), os.SEEK_SET, os.SEEK_SET)
+
+            # freeBSD 12+ changed maxphys to 1MB so if we try
+            # to write more than that at any given time then
+            # it gets chunked behind the scenes. This also allows
+            # us to save ram usage by only allocating a 1MB buffer
+            if data['mode'] in ('QUICK', 'FULL'):
+                to_write = bytearray(CHUNK).zfill(0)
+            else:
+                to_write = bytearray(os.urandom(CHUNK))
+
+            if data['mode'] == 'QUICK':
+                _32 = 32
+                for i in range(_32):
+                    # wipe first 32MB
+                    os.write(f.fileno(), to_write)
+                    os.fsync(f.fileno())
+
+                # seek to 32MB before end of drive
+                os.lseek(f.fileno(), (size - (CHUNK * _32)), os.SEEK_SET)
+                for i in range(_32):
+                    # wipe last 32MB
+                    os.write(f.fileno(), to_write)
+                    os.fsync(f.fileno())
+            else:
+                iterations = (size // CHUNK)
+                length = len(str(iterations))
+                for i in range(iterations):
+                    os.write(f.fileno(), to_write)
+                    os.fsync(f.fileno())
+                    data['job'].set_progress(float(f'{i / iterations:.{length}f}') * 100)
 
     @accepts(
         Str('dev'),
@@ -54,55 +83,11 @@ class DiskService(Service):
         """
         Performs a wipe of a disk `dev`.
         It can be of the following modes:
-          - QUICK: clean the first few and last megabytes of every partition and disk
+          - QUICK: clean the first and last 32 megabytes on `dev`
           - FULL: write whole disk with zero's
           - FULL_RANDOM: write whole disk with random bytes
         """
         await self.middleware.call('disk.swaps_remove_disks', [dev], options)
-
-        if osc.IS_FREEBSD:
-            await self.middleware.call('disk.remove_disk_from_graid', dev)
-
-        # First do a quick wipe of every partition to clean things like zfs labels
-        if mode == 'QUICK':
-            for part in await self.middleware.call('disk.list_partitions', dev):
-                await self.wipe_quick(part['name'], part['size'])
-
-        await self.middleware.call('disk.destroy_partitions', dev)
-
-        if mode == 'QUICK':
-            await self.wipe_quick(dev)
-        else:
-            size = await self.middleware.call('disk.get_dev_size', dev) or 1
-
-            proc = await Popen([
-                'dd',
-                'if=/dev/{}'.format('zero' if mode == 'FULL' else 'random'),
-                f'of=/dev/{dev}',
-                'bs=1M',
-            ], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-
-            async def dd_wait():
-                while True:
-                    if proc.returncode is not None:
-                        break
-                    os.kill(proc.pid, signal.SIGUSR1 if osc.IS_LINUX else signal.SIGINFO)
-                    await asyncio.sleep(1)
-
-            asyncio.ensure_future(dd_wait())
-
-            while True:
-                line = await proc.stderr.readline()
-                if line == b'':
-                    break
-                line = line.decode()
-                reg = RE_DD.search(line)
-                if reg:
-                    speed = float(reg.group(2)) if osc.IS_LINUX else int(reg.group(2))
-                    if osc.IS_LINUX:
-                        mapping = {'gb': 1024 * 1024 * 1024, 'mb': 1024 * 1024, 'kb': 1024, 'b': 1}
-                        speed = int(speed * mapping[reg.group(3).lower()])
-                    job.set_progress((int(reg.group(1)) / size) * 100, extra={'speed': speed})
-
-        if sync:
-            await self.middleware.call('disk.sync', dev)
+        await self.middleware.call('disk.remove_disk_from_graid', dev)
+        await self.middleware.run_in_thread(self._wipe, {'job': job, 'dev': dev, 'mode': mode})
+        await self.middleware.call('disk.sync', dev) if sync else None


### PR DESCRIPTION
This dramatically improves the process for "wiping" a disk. Before my changes, we were doing the following:
1. `dd`'ing first 32MB of disk
2. `dd`'ing any partition table offsets (if they were detected)
3. `dd`'ing the last 32MB of disk
4. `gpart destroy -f` the disk (after `dd`)
5. `gpart create -s gpt`
6. `gpart destroy -f` again...
(because of our process we were opening the underlying disk(s) many times unnecessarily)

To add insult to injury, we are doing this all using `subprocess` which is expensive and inefficient. Furthermore, there is a race between when `dd` is done and the GEOM thread goes idle before we call `gpart destroy`. See https://github.com/truenas/middleware/pull/7232 for details and work-around for the `truenas/12.0-stable` branch.

To resolve all of these issues in 1 fell swoop, I've added the ability to wipe a disk using python's native low-level `os` module. Overwriting the first and last 32MB of a disk is more than enough to remove all partition table information. There is no reason to run `gpart` related commands after this has been done. Lastly, this gets run in a native thread so, in theory, the speed at which the data gets written to disk will be as fast as the underlying disk. So, in summary, with the changes this fixes:
1. the elevated usage of `subprocess`
2. the unnecessary `dd`'ing and subsequent `gpart destroy/create` calls
3. the potential for race conditions
4. open the underlying disk only once

(added benefit of being more efficient and getting rid of regular expression usage as well)