### PR TITLE
NAS-111420 / 21.08 / Make adding default video device optional for VMs

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-02_13-13_vm_video_device.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-02_13-13_vm_video_device.py
@@ -1,0 +1,24 @@
+"""
+VM Video Device
+
+Revision ID: 4686771af68a
+Revises: 1857e74d5f11
+Create Date: 2021-02-08 13:13:42.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '4686771af68a'
+down_revision = '1857e74d5f11'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vm_vm', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ensure_display_device', sa.Boolean(), default=True, nullable=False))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -41,7 +41,7 @@ class VMSupervisor(VMSupervisorBase):
                 device_xml = device.xml()
             devices.extend(device_xml if isinstance(device_xml, (tuple, list)) else [device_xml])
 
-        if not any(isinstance(device, DISPLAY) for device in self.devices):
+        if self.vm_data['ensure_display_device'] and not any(isinstance(device, DISPLAY) for device in self.devices):
             # We should add a video device if there is no display device configured because most by
             # default if not all headless servers like ubuntu etc require it to boot
             devices.append(create_element('video'))

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -41,6 +41,7 @@ class VMModel(sa.Model):
     cpu_mode = sa.Column(sa.Text())
     cpu_model = sa.Column(sa.Text(), nullable=True)
     hide_from_msr = sa.Column(sa.Boolean(), default=False)
+    ensure_display_device = sa.Column(sa.Boolean(), default=True)
 
 
 class VMService(CRUDService, VMSupervisorMixin):
@@ -95,6 +96,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         List('devices', items=[Patch('vmdevice_create', 'vmdevice_update', ('rm', {'name': 'vm'}))]),
         Bool('autostart', default=True),
         Bool('hide_from_msr', default=False),
+        Bool('ensure_display_device', default=True),
         Str('time', enum=['LOCAL', 'UTC'], default='LOCAL'),
         Int('shutdown_timeout', default=90, valdiators=[Range(min=5, max=300)]),
         register=True,

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -116,6 +116,11 @@ class VMService(CRUDService, VMSupervisorMixin):
         `vcpus` specifies total number of CPU sockets. `cores` specifies number of cores per socket. `threads`
         specifies number of threads per core.
 
+        `ensure_display_device` when set ( the default ) will ensure that the guest always has access to a video device.
+        For headless installations like ubuntu server this is required for the guest to operate properly. However
+        for cases where consumer would like to use GPU passthrough and does not want a display device added should set
+        this to `false`.
+
         `shutdown_timeout` indicates the time in seconds the system waits for the VM to cleanly shutdown. During system
         shutdown, if the VM hasn't exited after a hardware shutdown signal has been sent by the system within
         `shutdown_timeout` seconds, system initiates poweroff for the VM to stop it.


### PR DESCRIPTION
This PR adds changes to allow adding default video device optional for VMs. Motivation for adding this device always earlier was for headless installations like ubuntu server would still require a video device to work, however when a user has passed GPU(s), some guests can be picky about the video device they would like to consume which results in GPU passthrough working for the guest but the guest not consuming the GPU for it's primary display.