### PR TITLE
NAS-111631 / 21.08 / fuse mount gluster volumes with acl support

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/fuse.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/fuse.py
@@ -106,7 +106,7 @@ class GlusterFuseService(Service):
                             raise CallError(f'Failed creating {path} with error: {e}')
 
                         local_path = Path('localhost:/').joinpath(j['name'])
-                        cmd = ['mount', '-t', 'glusterfs', str(local_path), str(path)]
+                        cmd = ['mount', '-o', 'acl', '-t', 'glusterfs', str(local_path), str(path)]
                         cp = await run(cmd, check=False)
                         if cp.returncode:
                             errmsg = cp.stderr.decode().strip()


### PR DESCRIPTION
This is, obviously, needed so ACL's can be altered on the fuse mounts in `/cluster`