### PR TITLE
NAS-111567 / 21.10 / Improvements to middleware schema/events

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1392,6 +1392,8 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         assert event_type in ('ADDED', 'CHANGED', 'REMOVED')
 
         event_data = self.__events.get_event(name)
+        # TODO: Temporarily skip events which are CHANGED but have cleared set for validation as CHANGED
+        #  will be removed in next release and this case wouldn't be applicable
         if event_data and conf.debug_mode and event_type in ('ADDED', 'CHANGED') and 'cleared' not in kwargs:
             verrors = ValidationErrors()
             clean_and_validate_arg(verrors, event_data['returns'][0], kwargs['fields'])

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -439,7 +439,7 @@ class AlertService(Service):
 
     def _send_alert_deleted_event(self, alert):
         self.middleware.send_event("alert.list", "CHANGED", id=alert.uuid, cleared=True)
-        self.middleware.send_event("alert.list", "REMOVED", id=alert.uuid, cleared=True)
+        self.middleware.send_event("alert.list", "REMOVED", id=alert.uuid)
 
     @periodic(60)
     @private

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -439,6 +439,7 @@ class AlertService(Service):
 
     def _send_alert_deleted_event(self, alert):
         self.middleware.send_event("alert.list", "CHANGED", id=alert.uuid, cleared=True)
+        self.middleware.send_event("alert.list", "REMOVED", id=alert.uuid, cleared=True)
 
     @periodic(60)
     @private

--- a/src/middlewared/middlewared/plugins/datastore/event.py
+++ b/src/middlewared/middlewared/plugins/datastore/event.py
@@ -59,6 +59,7 @@ class DatastoreService(Service):
                 id=id,
                 cleared=True,
             )
+            await self._send_event(options, "REMOVED", id=id, cleared=True)
 
     async def _fields(self, options, row, get=True):
         query_options = {"get": get}

--- a/src/middlewared/middlewared/plugins/datastore/event.py
+++ b/src/middlewared/middlewared/plugins/datastore/event.py
@@ -59,7 +59,7 @@ class DatastoreService(Service):
                 id=id,
                 cleared=True,
             )
-            await self._send_event(options, "REMOVED", id=id, cleared=True)
+            await self._send_event(options, "REMOVED", id=id)
 
     async def _fields(self, options, row, get=True):
         query_options = {"get": get}

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1690,6 +1690,7 @@ class PoolService(CRUDService):
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
         self.middleware.send_event('pool.query', 'CHANGED', id=oid, cleared=True)
+        self.middleware.send_event('pool.query', 'REMOVED', id=oid, cleared=True)
 
     @item_method
     @accepts(Int('id'))

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1690,7 +1690,7 @@ class PoolService(CRUDService):
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
         self.middleware.send_event('pool.query', 'CHANGED', id=oid, cleared=True)
-        self.middleware.send_event('pool.query', 'REMOVED', id=oid, cleared=True)
+        self.middleware.send_event('pool.query', 'REMOVED', id=oid)
 
     @item_method
     @accepts(Int('id'))

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -204,7 +204,7 @@ async def zfs_events(middleware, data):
             )
         elif event_type == 'destroy':
             middleware.send_event('pool.dataset.query', 'CHANGED', id=ds_id, cleared=True)
-            middleware.send_event('pool.dataset.query', 'REMOVED', id=ds_id, cleared=True)
+            middleware.send_event('pool.dataset.query', 'REMOVED', id=ds_id)
 
             await middleware.call(
                 'pool.dataset.delete_encrypted_datasets_from_db', [

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -204,6 +204,7 @@ async def zfs_events(middleware, data):
             )
         elif event_type == 'destroy':
             middleware.send_event('pool.dataset.query', 'CHANGED', id=ds_id, cleared=True)
+            middleware.send_event('pool.dataset.query', 'REMOVED', id=ds_id, cleared=True)
 
             await middleware.call(
                 'pool.dataset.delete_encrypted_datasets_from_db', [

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -754,10 +754,8 @@ class Dict(Attribute):
     def resolve(self, schemas):
         for name, attr in list(self.attrs.items()):
             if not attr.resolved:
-                new_name = attr.schema_name if isinstance(attr, Patch) else name
+                new_name = name
                 self.attrs[new_name] = attr.resolve(schemas)
-                if new_name != name:
-                    self.attrs.pop(name)
         if self.register:
             schemas.add(self)
         self.resolved = True

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -754,7 +754,7 @@ class Dict(Attribute):
     def resolve(self, schemas):
         for name, attr in list(self.attrs.items()):
             if not attr.resolved:
-                new_name = attr.newname if isinstance(attr, Patch) else name
+                new_name = attr.schema_name if isinstance(attr, Patch) else name
                 self.attrs[new_name] = attr.resolve(schemas)
                 if new_name != name:
                     self.attrs.pop(name)
@@ -903,22 +903,22 @@ class Ref(object):
 
 class Patch(object):
 
-    def __init__(self, name, newname, *patches, register=False):
-        self.name = name
-        self.newname = newname
+    def __init__(self, orig_name, newname, *patches, register=False):
+        self.schema_name = orig_name
+        self.name = newname
         self.patches = list(patches)
         self.register = register
         self.resolved = False
 
     def resolve(self, schemas):
-        schema = schemas.get(self.name)
+        schema = schemas.get(self.schema_name)
         if not schema:
             raise ResolverError(f'Schema {self.name} not found')
         elif not isinstance(schema, Dict):
             raise ValueError('Patch non-dict is not allowed')
 
         schema = schema.copy()
-        schema.name = self.newname
+        schema.name = self.name
         for operation, patch in self.patches:
             if operation == 'replace':
                 # This is for convenience where it's hard sometimes to change attrs in a large dict

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -849,7 +849,9 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         )
         await self.middleware.call_hook(f'{self._config.namespace}.post_delete', rv)
         if self._config.event_send:
+            # TODO: Changed event on removal is deprecated and will be removed in next release
             self.middleware.send_event(f'{self._config.namespace}.query', 'CHANGED', id=id, cleared=True)
+            self.middleware.send_event(f'{self._config.namespace}.query', 'REMOVED', id=id, cleared=True)
         return rv
 
     @private

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -851,7 +851,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         if self._config.event_send:
             # TODO: Changed event on removal is deprecated and will be removed in next release
             self.middleware.send_event(f'{self._config.namespace}.query', 'CHANGED', id=id, cleared=True)
-            self.middleware.send_event(f'{self._config.namespace}.query', 'REMOVED', id=id, cleared=True)
+            self.middleware.send_event(f'{self._config.namespace}.query', 'REMOVED', id=id)
         return rv
 
     @private

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -431,7 +431,7 @@ class ConfigServiceMetabase(ServiceBase):
         if klass.ENTRY == NotImplementedError:
             klass.ENTRY = Dict(config_entry_key, additional_attrs=True)
 
-        config_entry_key = getattr(klass.ENTRY, 'newname' if isinstance(klass.ENTRY, Patch) else 'name')
+        config_entry_key = klass.ENTRY.name
 
         config_entry = copy.deepcopy(klass.ENTRY)
         config_entry.register = True
@@ -698,12 +698,10 @@ class CRUDServiceMetabase(ServiceBase):
             klass.ENTRY = Dict(entry_key, additional_attrs=True)
         else:
             # We would like to ensure that not all fields are required as select can filter out fields
-            if isinstance(klass.ENTRY, Patch):
-                entry_key = klass.ENTRY.newname
+            if isinstance(klass.ENTRY, (Dict, Patch)):
+                entry_key = klass.ENTRY.name
             elif isinstance(klass.ENTRY, Ref):
                 entry_key = f'{klass.ENTRY.name}_ref_entry'
-            elif isinstance(klass.ENTRY, Dict):
-                entry_key = klass.ENTRY.name
             else:
                 raise ValueError('Result entry should be Dict/Patch/Ref instance')
 
@@ -780,7 +778,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
                 f'{self._config.namespace}.query',
                 f'Sent on {self._config.namespace} changes.',
                 self._config.private,
-                returns=Ref(self.ENTRY.newname if isinstance(self.ENTRY, Patch) else self.ENTRY.name),
+                returns=Ref(self.ENTRY.name),
             )
 
     @private


### PR DESCRIPTION
This PR adds following changes:

1) Normalizes `Patch` class so that `name` points to the new name of the schema consumer wants.
2) Send a `REMOVED` event when resources are cleared/removed and deprecate sending `CHANGED` events on these instances.