### PR TITLE
NAS-111633 / 21.08 / Bug fix for creating a zvol

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3176,7 +3176,9 @@ class PoolDatasetService(CRUDService):
 
         parent_ds = parent_ds[0]
         mountpoint = os.path.join('/mnt', data['name'])
-        if data.get('acltype', 'INHERIT') == 'INHERIT' and len(data['name'].split('/')) == 2:
+        if data['type'] == 'FILESYSTEM' and data.get('acltype', 'INHERIT') == 'INHERIT' and len(
+            data['name'].split('/')
+        ) == 2:
             data['acltype'] = 'POSIX'
 
         if os.path.exists(mountpoint):


### PR DESCRIPTION
Fixes
```
middlewared.service_exception.CallError: [EFAULT] Failed to create dataset: 'acltype' does not apply to datasets of this type
```