### PR TITLE
NAS-111590 / 21.08 / Validate route_v4_gateway specified is accurate

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -171,6 +171,14 @@ class KubernetesService(ConfigService):
             for k2 in ('gateway', 'interface'):
                 verrors.add(f'{schema}.{k}_{k2}', f'{k}_gateway and {k}_interface must be specified together.')
 
+        if data['route_v4_gateway']:
+            gateway = ipaddress.ip_address(data['route_v4_gateway'])
+            if not any(gateway in network_cidr for network_cidr in network_cidrs):
+                verrors.add(
+                    f'{schema}.route_v4_gateway',
+                    'Specified value is not present on any network cidr in use by the system'
+                )
+
         verrors.check()
 
     @private


### PR DESCRIPTION
This commit adds changes to make sure that the gateway specified is accurate and is actually accessible by the system, as we have had cases with users trying to use 8.8.8.8 for the gateway which is obviously going to fail.