### PR TITLE
NAS-111674 / 21.08 / only eventsd.delete if glustereventsd is running

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
@@ -208,4 +208,5 @@ class GlusterEventsdService(Service):
         # implementation is very much broken so now we remove
         # localhost api endpoint (it if it's there)
         data = {'url': LOCAL_WEBHOOK_URL}
-        self.middleware.call_sync('gluster.eventsd.delete', data)
+        if self.middleware.call_sync('service.started', 'glustereventsd'):
+            self.middleware.call_sync('gluster.eventsd.delete', data)


### PR DESCRIPTION
When we call `eventsd.init` need to make sure the daemon is running or it will give a spurious error message that isn't really helpful.