### PR TITLE
NAS-111683 / 21.08 / Fix smb plugin issues causing test_435_smb_registry failures

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -71,5 +71,8 @@ class CIFSService(SimpleService):
     async def after_stop(self):
         await self.middleware.call("service.reload", "mdns")
 
+    async def before_reload(self):
+        await self.middleware.call("sharing.smb.sync_registry")
+
     async def after_reload(self):
         await self.middleware.call("service.reload", "mdns")

--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -131,6 +131,7 @@ class SMBService(Service):
         parameters to reflect the specified smb service configuration.
         """
         to_set = {}
+        data['ds_state'] = await self.middleware.call('directoryservices.get_state')
         gs = GlobalSchema()
         gs.convert_schema_to_registry(data, to_set)
 

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -21,6 +21,12 @@ class GlobalSchema(RegistrySchema):
             'printcap name': {'parsed': '/dev/null'},
             'restrict anonymous': {'parsed': 2},
         })
+
+        ds_state = data_in.pop('ds_state')
+        if ds_state['ldap'] in ['LEAVING', 'DISABLED']:
+            data_out.update({
+                'passdb backend': {'parsed': 'tdbsam:/root/samba/private/passdb.tdb'},
+            })
         return
 
     def smb_proto_transform(entry, conf):

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -53,7 +53,7 @@ class ShareSchema(RegistrySchema):
         def order_vfs_objects(vfs_objects, is_clustered, purpose):
             vfs_objects_special = ('catia', 'zfs_space', 'fruit', 'streams_xattr', 'shadow_copy_zfs',
                                    'noacl', 'ixnas', 'acl_xattr', 'zfsacl', 'nfs4acl_xattr',
-                                   'glusterfs', 'crossrename', 'recycle', 'zfs_core', 'aio_fbsd', 'io_uring')
+                                   'glusterfs', 'crossrename', 'winmsa', 'recycle', 'zfs_core', 'aio_fbsd', 'io_uring')
 
             cluster_safe_objects = ['catia', 'fruit', 'streams_xattr', 'acl_xattr', 'recycle', 'glusterfs', 'io_ring']
 
@@ -127,17 +127,19 @@ class ShareSchema(RegistrySchema):
                 """
                 if auxparam.strip() == "vfs objects":
                     vfsobjects = val.strip().split()
-                    if data_in['fruit_enableed']:
+                    if data_in['fruit_enabled']:
                         vfsobjects.append('fruit')
                     if data_in['shadowcopy']:
                         vfsobjects.append('shadow_copy_zfs')
-                    data_out['vfs objects'] = {"parsed": order_vfs_objects(vfsobjects, is_clustered)}
+                    data_out['vfs objects'] = {"parsed": order_vfs_objects(vfsobjects, is_clustered, None)}
                 else:
                     data_out[auxparam.strip()] = {"raw": val.strip()}
 
             except Exception:
-                self.logger.debug("[%s] contains invalid auxiliary parameter: [%s]",
-                                  data_in['auxsmbconf'], param)
+                self.middleware.logger.debug(
+                    "[%s] contains invalid auxiliary parameter: [%s]",
+                    data_in['auxsmbconf'], param
+                )
 
         self._normalize_config(data_out)
         return

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -51,7 +51,7 @@ SAMPLE_AUX = [
     '### VFS OBJECTS (shadow_copy2 not included if no periodic snaps, so do it manually)', '',
     '# Include recycle, crossrename, and exclude readonly, as share=RW', '',
     '#vfs objects = zfs_space zfsacl winmsa streams_xattr recycle shadow_copy2 crossrename aio_pthread', '',
-    'vfs objects = zfs_space zfsacl winmsa streams_xattr recycle crossrename aio_pthread', '',
+    'vfs objects = aio_pthread zfs_space streams_xattr shadow_copy_zfs zfsacl crossrename winmsa recycle', '',
     '# testing without shadow_copy2', '',
     'valid users = MY_ACCOUNT @ALLOWED_USERS',
     'invalid users = root anonymous guest',


### PR DESCRIPTION
- resync registry shares during smb.reload method to ensure consistency
between config and registry

- pass directory services state into function that generates global
SMB configuration (so that we set an appropriate passdb backend path)

- fix a couple of typos in share configuration parsing.

- update registry test to account for fact that we now sort vfs
objects that are provided in auxiliary parameters prior to applying to
smb.conf

- ensure that winmsa is moved towards end of vfs objects list if it's added
(not at head).