### PR TITLE
Fix api test 035_ad_idmap

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1023,13 +1023,10 @@ class IdmapDomainService(TDBWrapCRUDService):
                 f"{idmap_prefix} range": {"raw": f"{i['range_low']} - {i['range_high']}"}
             })
             for k, v in i['options'].items():
-                if v is True:
-                    v = "True"
-                elif v is False:
-                    v = "False"
+                backend_parameter = "realm" if k == "ldap_realm" else k
 
                 rv.update({
-                    f"{idmap_prefix} {k}": {"parsed": v},
+                    f"{idmap_prefix} {backend_parameter}": {"parsed": v},
                 })
 
         return rv

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -257,10 +257,9 @@ def test_08_test_backend_options(request, backend):
             assert res == v, f"[{k}]: {res}"
         except json.decoder.JSONDecodeError:
             res = results['output'].strip()
-            if v is True:
-                v = "Yes"
-            elif v is False:
-                v = "No"
+            if isinstance(v, bool):
+                v = str(v)
+
             assert v.casefold() == res.casefold(), f"[{k}]: {res}"
 
     if set_secret:


### PR DESCRIPTION
Due to global registry changes, all boolean values inserted
into [global] are normalized. Account for this in idmap test.

Also due to very old mistake in naming a parameter related to
idmap_rfc2307 (from FreeNAS 9 era), we need special handling
for ldap_realm -> realm.