### PR TITLE
NAS-111693 / 21.08 / fix enclosure.sync_zpool (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import glob
 import logging
 import os
@@ -242,6 +243,7 @@ class EnclosureService(CRUDService):
 
         seen_devs = []
         label2disk = {}
+        hardware = self.middleware.call_sync("truenas.get_chassis_hardware")
         for pool in pools:
             try:
                 pool = self.middleware.call_sync("zfs.pool.query", [["name", "=", pool]], {"get": True})
@@ -264,9 +266,12 @@ class EnclosureService(CRUDService):
                 if disk is None:
                     continue
 
-            # We want spares to only identify slot for Z-series
-            # See #32706
-            if self.middleware.call_sync("truenas.get_chassis_hardware").startswith("TRUENAS-Z"):
+            if hardware.startswith("TRUENAS-Z"):
+                # We want spares to have identify set on the enclosure slot for
+                # Z-series systems only see #32706 for details. Gist is that
+                # the other hardware platforms "identify" light is red which
+                # causes customer confusion because they see red and think
+                # something is wrong.
                 spare_value = "identify"
             else:
                 spare_value = "clear"
@@ -303,11 +308,14 @@ class EnclosureService(CRUDService):
                 seen_devs.append(label)
 
                 try:
-                    element = self._get_ses_slot_for_disk(disk)
-                except MatchNotFound:
-                    pass
-                else:
-                    element.device_slot_set("clear")
+                    element = encs.find_device_slot(disk)
+                    if element:
+                        element.device_slot_set("clear")
+                except AssertionError:
+                    # happens for pmem devices since those
+                    # are NVDIMM sticks internal to each
+                    # controller
+                    continue
 
         disks = []
         for label in seen_devs:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b593cc4460a86c0dfefc3b75dd4bfa416d0eb647

1. No reason to call `truenas.get_chassis_hardware` for every zpool on system so call it outside for loop.
2. `disk.label_to_disk` is abysmally slow when it has to run `geom.scan()`, instead use new `label_to_dev_disk_cache` method to essentially make this portion of the method instant.
3. `_get_ses_slot_for_disk` calls `enclosure.query` but we already enumerate the enclosures at the top of this method in the `encs` variable. Use the built-in `find_device_slot` instead to prevent unnecessary `enclosure.query` calls for every disk on every zpool.

Before changes `enclosure.sync_zpool` was taking ~5mins+ on M60 with 417 disks.
After changes `enclosure.sync_zpool` is taking ~21seconds on M60 with 417 disks.

Original PR: https://github.com/truenas/middleware/pull/7266
Jira URL: https://jira.ixsystems.com/browse/NAS-111693