### PR TITLE
NAS-111690 / 21.08 / call enclosure.query once in disk.sync_all (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -82,6 +82,7 @@ class DiskService(Service, ServiceChangeMixin):
         seen_disks = {}
         serials = []
         changed = False
+        encs = await self.middleware.call('enclosure.query')
         for disk in (
             await self.middleware.call('datastore.query', 'storage.disk', [], {'order_by': ['disk_expiretime']})
         ):
@@ -131,7 +132,7 @@ class DiskService(Service, ServiceChangeMixin):
                 changed = True
 
             try:
-                await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'])
+                await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'], encs)
             except Exception:
                 self.middleware.logger.error('Unhandled exception in enclosure.sync_disk for %r',
                                              disk['disk_identifier'], exc_info=True)
@@ -172,7 +173,7 @@ class DiskService(Service, ServiceChangeMixin):
                     changed = True
 
                 try:
-                    await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'])
+                    await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'], encs)
                 except Exception:
                     self.middleware.logger.error('Unhandled exception in enclosure.sync_disk for %r',
                                                  disk['disk_identifier'], exc_info=True)

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -145,8 +145,11 @@ class EnclosureService(CRUDService):
 
         return await self._get_instance(id)
 
-    def _get_slot(self, slot_filter, enclosure_query=None):
-        for enclosure in self.middleware.call_sync("enclosure.query", enclosure_query or []):
+    def _get_slot(self, slot_filter, enclosure_query=None, enclosure_info=None):
+        if enclosure_info is None:
+            enclosure_info = self.middleware.call_sync("enclosure.query", enclosure_query or [])
+
+        for enclosure in enclosure_info:
             try:
                 elements = next(filter(lambda element: element["name"] == "Array Device Slot",
                                        enclosure["elements"]))["elements"]
@@ -157,8 +160,8 @@ class EnclosureService(CRUDService):
 
         raise MatchNotFound()
 
-    def _get_slot_for_disk(self, disk):
-        return self._get_slot(lambda element: element["data"]["Device"] == disk)
+    def _get_slot_for_disk(self, disk, enclosure_info=None):
+        return self._get_slot(lambda element: element["data"]["Device"] == disk, enclosure_info=enclosure_info)
 
     def _get_ses_slot(self, enclosure, element):
         if "original" in element:
@@ -203,7 +206,7 @@ class EnclosureService(CRUDService):
             raise CallError("Error setting slot status")
 
     @private
-    def sync_disk(self, id):
+    def sync_disk(self, id, enclosure_info=None):
         disk = self.middleware.call_sync(
             'disk.query',
             [['identifier', '=', id]],
@@ -211,7 +214,7 @@ class EnclosureService(CRUDService):
         )
 
         try:
-            enclosure, element = self._get_slot_for_disk(disk["name"])
+            enclosure, element = self._get_slot_for_disk(disk["name"], enclosure_info)
         except MatchNotFound:
             disk_enclosure = None
         else:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a0bc9febe4587fa89e5176581bb4c11b1df98d1a

1. Dont immediately sleep in `disk.sync_all` for 1 second without checking to see if `devd` is connected. Instead see if it's connected first and then sleep appropriately.
2. Only call `enclosure.query` once so that we don't call it N times (N being the number of disks on the system)

Original PR: https://github.com/truenas/middleware/pull/7265
Jira URL: https://jira.ixsystems.com/browse/NAS-111690