### PR TITLE
NAS-111715 / 21.08 / Add global parameter handling for guest access

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -132,6 +132,7 @@ class SMBService(Service):
         """
         to_set = {}
         data['ds_state'] = await self.middleware.call('directoryservices.get_state')
+        data['shares'] = await self.middleware.call('sharing.smb.query')
         gs = GlobalSchema()
         gs.convert_schema_to_registry(data, to_set)
 


### PR DESCRIPTION
Conversion to global registry backend caused us to drop a couple
of parameters related to legacy guest SMB share access. Add them
back in with a comment about what guest-related changes we make.