### PR TITLE
NAS-111720 / 12.0 / fix numerous issues with disk.sync_all

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -142,6 +142,20 @@ class EnclosureService(CRUDService):
 
         return await self._get_instance(id)
 
+    @private
+    def build_slot_for_disks_dict(self, enclosure_info=None):
+        if enclosure_info is None:
+            enclosure_info = self.middleware.call_sync('enclosure.query')
+
+        results = {}
+        for enc in enclosure_info:
+            slots = next(filter(lambda x: x["name"] == "Array Device Slot", enc["elements"]))["elements"]
+            results.update({
+                j["slot"] * 1000 + enc["number"]: j["data"]["Device"] or None for j in slots
+            })
+
+        return results
+
     def _get_slot(self, slot_filter, enclosure_query=None, enclosure_info=None):
         if enclosure_info is None:
             enclosure_info = self.middleware.call_sync("enclosure.query", enclosure_query or [])

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -142,10 +142,8 @@ class EnclosureService(CRUDService):
 
         return await self._get_instance(id)
 
-    @private
-    def build_slot_for_disks_dict(self, enclosure_info=None):
-        if enclosure_info is None:
-            enclosure_info = self.middleware.call_sync('enclosure.query')
+    async def _build_slot_for_disks_dict(self):
+        enclosure_info = await self.middleware.call('enclosure.query')
 
         results = {}
         for enc in enclosure_info:
@@ -215,6 +213,18 @@ class EnclosureService(CRUDService):
         ses_slot = self._get_ses_slot(enclosure, element)
         if not ses_slot.device_slot_set(status.lower()):
             raise CallError("Error setting slot status")
+
+    @private
+    async def sync_disks(self):
+        curr_slot_info = await self._build_slot_for_disks_dict()
+        for db_entry in await self.middleware.call('datastore.query', 'storage.disk'):
+            for curr_slot, curr_disk in curr_slot_info.items():
+                if db_entry['disk_name'] == curr_disk and db_entry['disk_enclosure_slot'] != curr_slot:
+                    await self.middleware.call(
+                        'datastore.update', 'storage.disk',
+                        db_entry['disk_identifier'],
+                        {'disk_enclosure_slot': curr_slot},
+                    )
 
     @private
     def sync_disk(self, id, enclosure_info=None):

--- a/src/middlewared/middlewared/plugins/disk_/identify_base.py
+++ b/src/middlewared/middlewared/plugins/disk_/identify_base.py
@@ -1,6 +1,6 @@
 import re
 
-from middlewared.schema import accepts, Dict, Str
+from middlewared.schema import accepts, Dict, Str, Bool, Any
 from middlewared.service import private, ServicePartBase
 
 
@@ -29,6 +29,10 @@ class DiskIdentifyBase(ServicePartBase):
         """
 
     @private
-    @accepts(Str('identifier'), Dict('disks', additional_attrs=True))
-    def identifier_to_device(self, ident, disks=None):
+    @accepts(
+        Str('identifier'),
+        Bool('geom_scan'),
+        Any('geom_xml'),
+    )
+    def identifier_to_device(self, ident, geom_scan=True, geom_xml=None):
         raise NotImplementedError()

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -1,7 +1,7 @@
 import asyncio
-
 from datetime import datetime, timedelta
 
+from bsd import geom
 from middlewared.schema import accepts, Str
 from middlewared.service import job, private, Service, ServiceChangeMixin
 
@@ -16,21 +16,19 @@ class DiskService(Service, ServiceChangeMixin):
         """
         Syncs a disk `name` with the database cache.
         """
-        if (
-            not await self.middleware.call('system.is_freenas') and
-            await self.middleware.call('failover.licensed') and
-            await self.middleware.call('failover.status') == 'BACKUP'
-        ):
-            return
+        if await self.middleware.call('failover.licensed'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                return
 
         # Do not sync geom classes like multipath/hast/etc
         if name.find('/') != -1:
             return
 
         disks = await self.middleware.call('device.get_disks')
-        # Abort if the disk is not recognized as an available disk
         if name not in disks:
+            # return early if the disk is not recognized as an available disk
             return
+
         ident = await self.middleware.call('disk.device_to_identifier', name, disks)
         qs = await self.middleware.call(
             'datastore.query', 'storage.disk', [('disk_identifier', '=', ident)], {'order_by': ['disk_expiretime']}
@@ -83,30 +81,31 @@ class DiskService(Service, ServiceChangeMixin):
                 self.logger.warning('Starting disk.sync_all when devd is not connected yet')
 
         sys_disks = await self.middleware.call('device.get_disks')
+        geom_xml = geom.class_by_name('DISK').xml
 
-        # output logging information to middlewared.log in case we sync disks
-        # when not all the disks have been resolved
-        log_info = {
-            ok: {
-                ik: iv for ik, iv in ov.items() if ik in ('name', 'ident', 'lunid', 'serial')
-            } for ok, ov in sys_disks.items()
-        }
-        self.logger.info('Found disks: %r', log_info)
+        if len(sys_disks) <= 25:
+            # output logging information to middlewared.log in case we sync disks
+            # when not all the disks have been resolved
+            log_info = {
+                ok: {
+                    ik: iv for ik, iv in ov.items() if ik in ('name', 'ident', 'lunid', 'serial')
+                } for ok, ov in sys_disks.items()
+            }
+            self.logger.info('Found disks: %r', log_info)
 
         seen_disks = {}
         serials = []
         changed = False
-        encs = await self.middleware.call('enclosure.query')
         for disk in (
             await self.middleware.call('datastore.query', 'storage.disk', [], {'order_by': ['disk_expiretime']})
         ):
             original_disk = disk.copy()
 
-            name = await self.middleware.call('disk.identifier_to_device', disk['disk_identifier'], sys_disks)
+            name = await self.middleware.call('disk.identifier_to_device', disk['disk_identifier'], False, geom_xml)
             if (
                     not name or
                     name in seen_disks or
-                    await self.middleware.call('disk.device_to_identifier', name) != disk['disk_identifier']
+                    await self.middleware.call('disk.device_to_identifier', name, sys_disks) != disk['disk_identifier']
             ):
                 # If we cant translate the identifier to a device, give up
                 # If name has already been seen once then we are probably
@@ -149,8 +148,6 @@ class DiskService(Service, ServiceChangeMixin):
                 await self.middleware.call('datastore.update', 'storage.disk', disk['disk_identifier'], disk)
                 changed = True
 
-            await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'], encs)
-
             seen_disks[name] = disk
 
         for name in sys_disks:
@@ -186,7 +183,16 @@ class DiskService(Service, ServiceChangeMixin):
                     await self.middleware.call('datastore.insert', 'storage.disk', disk)
                     changed = True
 
-                await self.middleware.call('enclosure.sync_disk', disk['disk_identifier'], encs)
+        # now we need to check the enclosure mapping db info for each disk
+        # to make sure it matches up with reality
+        curr_slot_info = await self.middleware.call('enclosure.query')
+        curr_slot_info = await self.middleware.call('enclosure.build_slot_for_disks_dict', curr_slot_info)
+        for db_entry in await self.middleware.call('datastore.query', 'storage.disk'):
+            for curr_slot, curr_disk in curr_slot_info.items():
+                if db_entry['disk_name'] == curr_disk and db_entry['disk_enclosure_slot'] != curr_slot:
+                    await self.middleware.call(
+                        'datastore.update', 'storage.disk', db_entry['disk_identifier'], {'disk_enclosure_slot': curr_slot}
+                    )
 
         if changed:
             await self.middleware.call('disk.restart_services_after_sync')


### PR DESCRIPTION
`disk.sync_all`, in my humble opinion, needs to be scrapped and rewritten. It's almost impossible to follow (at least for me) and it's terribly inefficient.

Problems discovered:
1. for each disk we called `geom.scan()` 3 times (maybe more)
2. after `geom.scan` we followed up that with a bunch of more `geom.*` module calls.
3. we subprocess'ed out for the enclosures for every disk
4. we then iterated over every enclosure's slot for every disk
5. we call `disk.query` multiple times per disk
6. we call `datastore.query storage.disk` multiple times per disk
7. `device.identifier_to_device` accepted a `disks` keyword, which as far as I can tell, was supposed to be used to "speed" that method up and yet, the keyword argument was completely ignored and overwritten when you called that method
8. `device.device_to_identifier` accepts a `disks` keyword as well, but it was never working because we ran `disk.get('name')` instead of `disk.get(name)` (Notice the single-quotes around the `name` variable)

I really want to scrap it and rewrite it but alas time rules indiscriminately so here's what I've done to keep changes as minimal as possible.

1. stop calling geom.scan and geom* related api calls more than once for every disk. Instead call it once outside the for loop and pass it around to the various methods appropriately.
2. make the `device.identifier_to_device` accept said geom xml instantiation from a caller
3. fix `device.device_to_identifier` method to properly `.get(name)` so it's not a NO-OP
4. Nested deep down in `disk.identifier_to_device` there was a chance to crash on a `'NoneType' object has no attribute 'split'` so fix that while I'm here
5. generate a very manageable dictionary of the disks to slots outside the for loop and then once we're done updating the database for all the disks, check the enclosure slot information all at once.

Before my changes, on an M60 HA with 417 disks (and no other changes) `disk.sync_all` took ~6.5hrs....

After my changes, on an M60 HA with 417 disks `disk.sync_all` takes ~30 seconds

While I'm still not happy with 30 seconds, it will have to do for now.