### PR TITLE
NAS-111572 / 21.08 / Bug fix for ix-postinit

### DIFF
--- a/debian/debian/ix-postinit.service
+++ b/debian/debian/ix-postinit.service
@@ -6,7 +6,7 @@ After=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=midclt call core.notify_postinit
+ExecStartPre=-midclt call core.notify_postinit
 ExecStart=midclt call -job initshutdownscript.execute_init_tasks POSTINIT
 StandardOutput=null
 StandardError=null


### PR DESCRIPTION
This commit fixes an issue where inittasks were not executed as for oneshot service only 1 execstart command is registered.