### PR TITLE
NAS-111744 / 21.08 / Fix SSHd IPV6 link local ListenAddress

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/ssh/sshd_config.mako
+++ b/src/middlewared/middlewared/etc_files/local/ssh/sshd_config.mako
@@ -1,5 +1,6 @@
 <%
 	import os
+	import ipaddress
 
 	ssh_config = middleware.call_sync('ssh.config')
 	if not os.path.exists('/root/.ssh'):
@@ -16,7 +17,10 @@
 	for iface in ifaces:
 		for alias in iface.get('state', {}).get('aliases', []):
 			if alias.get('type') in ('INET', 'INET6') and alias.get('address'):
-				bind_ifaces.append(alias['address'])
+				if ipaddress.ip_address(alias['address']).is_link_local:
+					bind_ifaces.append(f"{alias['address']}%{iface['name']}")
+				else:
+					bind_ifaces.append(alias['address'])
 
 	if bind_ifaces:
 		bind_ifaces.insert(0, '127.0.0.1')


### PR DESCRIPTION
[Jira link](https://jira.ixsystems.com/browse/NAS-109095) - not sure why it was closed as this issue still persists

If SSH is restricted to listen on specific interface(s) and those interfaces are configured for IPv6 then for a IPv6 link local address the interface name must also be appended to the address.