### PR TITLE
NAS-111738 / 21.08 / Fix regression in disabling AD service

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -576,8 +576,8 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if not old['enable'] and new['enable']:
             job = (await self.middleware.call('activedirectory.start')).id
 
-        elif new['enable'] and not old['enable']:
-            await self.stop()
+        elif not new['enable'] and old['enable']:
+            job = (await self.middleware.call('activedirectory.stop')).id
 
         elif new['enable'] and old['enable']:
             await self.middleware.call('service.restart', 'cifs')


### PR DESCRIPTION
Fix log error in do_update() method when disabling AD.
activedirectory.stop() is now a job and so return the job
id for (same behavior as starting AD).