### PR TITLE
NAS-111758 / 21.08 / fix IndexError in network.py

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1151,7 +1151,7 @@ class InterfaceService(CRUDService):
                 'Virtual IP address', ' cannot be changed.', ' is required when configuring HA'
             ],
             'failover_group': [
-                'Failover group number', ' cannot be changed.' ' is required when configuring HA'
+                'Failover group number', ' cannot be changed.', ' is required when configuring HA'
             ],
             'mtu': ['MTU', ' cannot be changed.'],
             'ipv4_dhcp': ['DHCP', ' cannot be changed.'],


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/network.py", line 1587, in do_update
    await self._common_validation(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/network.py", line 1344, in _common_validation
    f'{str(validation_attrs[i][0]) + str(validation_attrs[i][2])}',
IndexError: list index out of range
```

is raised on HA SCALE systems when a failover group isn't provided when configuring an interface for HA