### PR TITLE
NAS-111656 / 21.08 / fix KeyError and NotImplementedError in network.py

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1615,13 +1615,10 @@ class InterfaceService(CRUDService):
             verrors, 'interface_update', new, iface['type'], update=iface
         )
         licensed = await self.middleware.call('failover.licensed')
-        if licensed and iface.get('disable_offload_capabilities') != new.get('disable_offload_capabilities'):
-            if not new['disable_offload_capabilities']:
-                if iface['name'] in await self.middleware.call('interface.to_disable_evil_nic_capabilities', False):
-                    verrors.add(
-                        'interface_update.disable_offload_capabilities',
-                        f'Capabilities for {oid} cannot be enabled as there are VM(s) which need them disabled.'
-                    )
+        if licensed:
+            if new.get('ipv4_dhcp') or new.get('ipv6_auto'):
+                verrors.add('interface_update.dhcp', 'Enabling DHCPv4/v6 on HA systems is unsupported.')
+
         verrors.check()
 
         await self.__save_datastores()


### PR DESCRIPTION
Problems:
- updating an interface and enabling DHCPv4/v6 produced a `KeyError` further down in the failover validation on HA systems.
- updating an interface with specific parameters on SCALE HA systems will raise a `NotImplementedError`

Fixes:
- when updating an interface on an HA system, if DHCPv4 or IPv6 autoconfig is enabled then raise a validation error appropriately
- remove the logic that calls the method that will raise `NotImplementedError` since the method doesn't exist on SCALE and further testing for SCALE HA systems needs to be done. The behavior with this change, is that it's a NO-OP and ignored.