### PR TITLE
NAS-111762 / 21.08 / Remove Samba passdb binding from middleware

### DIFF
--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -98,7 +98,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Dict('value', required=True, additional_attrs=True),
         Dict(
             'tdb-options',
-            Str('backend', enum=['PERSISTENT', 'VOLATILE'], default='PERSISTENT'),
+            Str('backend', enum=['PERSISTENT', 'VOLATILE', 'CUSTOM'], default='PERSISTENT'),
             Str('tdb_type', enum=['BASIC', 'CRUD', 'CONFIG'], default='BASIC'),
             Str('data_type', enum=['JSON', 'STRING', 'BYTES'], default='JSON'),
             Bool('cluster', default=False),
@@ -140,7 +140,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         elif data['tdb-options']['data_type'] == 'STRING':
             data = tdb_val
         elif data['tdb-options']['data_type'] == 'BYTES':
-            data = b64encode(tdb_val)
+            data = b64encode(tdb_val).decode()
 
         return data
 
@@ -306,6 +306,9 @@ class TDBService(Service, TDBMixin, SchemaMixin):
     @private
     async def setup(self):
         for p in TDBPath:
+            if TDBPath.CUSTOM:
+                continue
+
             os.makedirs(p.value, mode=0o700, exist_ok=True)
 
 

--- a/src/middlewared/middlewared/plugins/tdb/connection.py
+++ b/src/middlewared/middlewared/plugins/tdb/connection.py
@@ -13,7 +13,6 @@ class TDBMixin:
 
     def _get(self, tdb_handle, key):
         tdb_val = tdb_handle.get(key)
-
         return tdb_val if tdb_val else None
 
     def _set(self, tdb_handle, key, val):

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -30,7 +30,7 @@ class TDBWrap(object):
     def get(self, key):
         tdb_key = key.encode()
         if self.options['data_type'] == 'BYTES':
-            tdb_key +=  b"\x00"
+            tdb_key += b"\x00"
 
         tdb_val = self.hdl.get(tdb_key)
         if self.options['data_type'] == 'BYTES':
@@ -44,7 +44,7 @@ class TDBWrap(object):
     def store(self, key, val):
         tdb_key = key.encode()
         if self.options['data_type'] == 'BYTES':
-            tdb_key +=  b"\x00"
+            tdb_key += b"\x00"
 
         tdb_val = val.encode()
 
@@ -53,7 +53,7 @@ class TDBWrap(object):
     def delete(self, key):
         tdb_key = key.encode()
         if self.options['data_type'] == 'BYTES':
-            tdb_key +=  b"\x00"
+            tdb_key += b"\x00"
 
         self.hdl.delete(tdb_key)
 

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -11,6 +11,7 @@ from middlewared.service_exception import CallError
 class TDBPath(enum.Enum):
     VOLATILE = '/var/run/tdb/volatile'
     PERSISTENT = '/root/tdb/persistent'
+    CUSTOM = ''
 
 
 class TDBWrap(object):
@@ -28,20 +29,31 @@ class TDBWrap(object):
 
     def get(self, key):
         tdb_key = key.encode()
+        if self.options['data_type'] == 'BYTES':
+            tdb_key +=  b"\x00"
 
         tdb_val = self.hdl.get(tdb_key)
-        tdb_val = tdb_val.decode()
+        if self.options['data_type'] == 'BYTES':
+            return tdb_val
+
+        if tdb_val is not None:
+            tdb_val = tdb_val.decode()
 
         return tdb_val
 
     def store(self, key, val):
         tdb_key = key.encode()
+        if self.options['data_type'] == 'BYTES':
+            tdb_key +=  b"\x00"
+
         tdb_val = val.encode()
 
         self.hdl.store(tdb_key, tdb_val)
 
     def delete(self, key):
         tdb_key = key.encode()
+        if self.options['data_type'] == 'BYTES':
+            tdb_key +=  b"\x00"
 
         self.hdl.delete(tdb_key)
 
@@ -87,7 +99,7 @@ class TDBWrap(object):
         open_flags = os.O_CREAT | os.O_RDWR
         open_mode = 0o600
 
-        if not tdb_flags & tdb.INTERNAL:
+        if tdb_type != 'CUSTOM':
             name = f'{TDBPath[tdb_type].value}/{name}.tdb'
 
         self.hdl = tdb.Tdb(name, 0, tdb_flags, open_flags, open_mode)


### PR DESCRIPTION
In some cases middleware can keep a passdb handle open. Since we
now have proper wrapping for tdb operations, we can just directly
retrieve the info we need from a copy of passdb.tdb.