### PR TITLE
Cleanly reset AD parameters in activedirectory.leave

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1566,7 +1566,7 @@ class WBStatusThread(threading.Thread):
         self.middleware = kwargs.get('middleware')
         self.logger = self.middleware.logger
         self.finished = threading.Event()
-        self.state = 1027
+        self.state = DSStatus.FAULTED.value
 
     def parse_msg(self, data):
         if data == str(DSStatus.LEAVING.value):

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -24,8 +24,6 @@ from middlewared.plugins.directoryservices import DSStatus
 from middlewared.plugins.idmap import DSType
 import middlewared.utils.osc as osc
 
-from samba.dcerpc.messaging import MSG_WINBIND_ONLINE
-
 AD_SMBCONF_PARAMS = {
     "server role": "member server",
     "kerberos method": "secrets and keytab",
@@ -1356,7 +1354,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             'kerberos_principal': '',
             'domainname': '',
         }
-        await self.middleware.call('activedirectory.update', payload)
+        new = await self.middleware.call('activedirectory.direct_update', payload)
         await self.set_state(DSStatus['DISABLED'])
         if smb_ha_mode == 'LEGACY' and (await self.middleware.call('failover.status')) == 'MASTER':
             try:
@@ -1369,6 +1367,11 @@ class ActiveDirectoryService(TDBWrapConfigService):
             self.logger.warning("Failed to flush samba's general cache after leaving Active Directory.")
 
         await self.middleware.call('kerberos.stop')
+        await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
+        await self.synchronize(new)
+        await self.middleware.call('idmap.synchronize')
+        await self.middleware.call('service.restart', 'cifs')
         return
 
     @private
@@ -1563,7 +1566,7 @@ class WBStatusThread(threading.Thread):
         self.middleware = kwargs.get('middleware')
         self.logger = self.middleware.logger
         self.finished = threading.Event()
-        self.state = MSG_WINBIND_ONLINE
+        self.state = 1027
 
     def parse_msg(self, data):
         if data == str(DSStatus.LEAVING.value):

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -26,10 +26,10 @@ DEFAULT_AD_CONF = {
 
 class DSStatus(enum.Enum):
     DISABLED = enum.auto()
-    FAULTED = 1028 # MSG_WINBIND_OFFLINE
+    FAULTED = 1028  # MSG_WINBIND_OFFLINE
     LEAVING = enum.auto()
     JOINING = enum.auto()
-    HEALTHY = 1027 # MSG_WINBIND_ONLINE
+    HEALTHY = 1027  # MSG_WINBIND_ONLINE
 
 
 class DSType(enum.Enum):

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -11,8 +11,6 @@ from middlewared.service import Service, private, job
 from middlewared.plugins.smb import SMBCmd, SMBPath
 from middlewared.service_exception import CallError
 from middlewared.utils import run
-from samba.dcerpc.messaging import MSG_WINBIND_OFFLINE, MSG_WINBIND_ONLINE
-
 
 DEFAULT_AD_CONF = {
     "id": 1,
@@ -28,10 +26,10 @@ DEFAULT_AD_CONF = {
 
 class DSStatus(enum.Enum):
     DISABLED = enum.auto()
-    FAULTED = MSG_WINBIND_OFFLINE
+    FAULTED = 1028 # MSG_WINBIND_OFFLINE
     LEAVING = enum.auto()
     JOINING = enum.auto()
-    HEALTHY = MSG_WINBIND_ONLINE
+    HEALTHY = 1027 # MSG_WINBIND_ONLINE
 
 
 class DSType(enum.Enum):

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -600,6 +600,10 @@ def test_60_disable_activedirectory(request):
     results = PUT("/activedirectory/", payload)
     assert results.status_code == 200, results.text
 
+    disable_job = results.json()['job_id']
+    job_status = wait_on_job(disable_job, 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+
 
 def test_61_get_activedirectory_state(request):
     depends(request, ["pool_04", "ad_01", "ad_02", "ad_10"], scope="session")


### PR DESCRIPTION
Avoid calling activedirectory.stop() in activedirectory.leave().
Have AD test wait for the activedirectory.stop jobs to complete.
Avoid importing dcerpc bindings.