### PR TITLE
NAS-111772 / 21.08 / Fix multiple issues with krb nfs4 config in SCALE

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -7,7 +7,7 @@
     if not shares:
         raise FileShouldNotExist()
 
-    kerberos_keytabs = middleware.call_sync("kerberos.keytab.query")
+    has_nfs_principal = middleware.call_sync("kerberos.keytab.has_nfs_principal")
 
     gc = middleware.call_sync("network.configuration.config")
 
@@ -18,7 +18,7 @@
         peers = middleware.call_sync("gluster.peer.status")
 
     bindip = middleware.call_sync("nfs.bindip", config)
-    sec = middleware.call_sync("nfs.sec", config, kerberos_keytabs)
+    sec = middleware.call_sync("nfs.sec", config, has_nfs_principal)
 
     export_id = itertools.count(1)
 %>

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -208,14 +208,11 @@ class NFSService(SystemServiceService):
                     'Enabling kerberos authentication on TrueNAS HA requires '
                     'the system dataset to be located on a data pool.'
                 )
-            ad = await self.middleware.call('activedirectory.config')
             await self.middleware.call(
-                'datastore.update',
-                'directoryservice.activedirectory',
-                ad['id'],
-                {'ad_use_default_domain': True}
+                'activedirectory.direct_update',
+                {'use_default_domain': True}
             )
-            await self.middleware.call('etc.generate', 'smb')
+            await self.middleware.call('activedirectory.synchronize')
             await self.middleware.call('service.reload', 'cifs')
 
         if not new["v4"] and new["v4_v3owner"]:

--- a/src/middlewared/middlewared/plugins/nfs_/krb5.py
+++ b/src/middlewared/middlewared/plugins/nfs_/krb5.py
@@ -49,7 +49,8 @@ class NFSService(Service):
         ad['kerberos_principal'] = ''
 
         await self.middleware.call('kerberos.do_kinit', ad)
-        return await self.middleware.call('activedirectory.add_nfs_spn', ad)
+        add_spn_job = await self.middleware.call('activedirectory.add_nfs_spn', ad)
+        return await add_spn_job.wait(raise_error=True)
 
     @private
     async def add_principal_ldap(self, data):


### PR DESCRIPTION
- Only enable krb5 security when our keytab has nfs spn.

- Convert tests to examine /etc/ganesha/ganesha.conf

- Convert activedirectory.add_nfs_spn to a job since experimentation
  indicated the call may take longer than 60 seconds to complete.

- Convert active directory configuration changes in NFS plugin to
  use the direct_update method (clustering agnostic) and sync with
  registry tdb.

- Update regression test to create a ZFS dataset and NFS share
  because these are now requirements for generating NFS config.