### PR TITLE
NAS-111769 / 12.0 / fix disk identification with vmware nvme disks

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/identify_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/identify_freebsd.py
@@ -108,7 +108,20 @@ class DiskService(Service, DiskIdentifyBase):
             else:
                 xml = geom.class_by_name('DISK').xml
 
-            _ident, _lunid = value.split('_')
+            info = value.split('_')
+            info_len = len(info)
+            if info_len < 2:
+                # nothing to do return
+                return
+            elif info_len == 2:
+                _ident = info[0]
+                _lunid = info[1]
+            else:
+                # vmware nvme disks look like `VMware NVME_0000_a9d1a9a7feaf1d66000c296f092d9204`
+                # so we need to account for it
+                _lunid = info[-1]
+                _ident = info[:-info_len].rstrip('_')
+
             found_ident = xml.find(f'.//provider/config[ident = "{_ident}"]/../../name')
             if found_ident is not None:
                 found_lunid = xml.find(f'.//provider/config[lunid = "{_lunid}"]/../../name')


### PR DESCRIPTION
When CORE is running as a VM in VMware and NVMe disks are provided to the VM, the disks have more than 1 `_` delimiter which is causing us to raise a `ValueError: too many values to unpack (expected 2)`. This fixes that particular scenario, and hopefully more, if we get a disk that has more than 1 `_` in the string passed to us.