### PR TITLE
NAS-110003 / 21.08 / Fix nsswitch.conf usage in SCALE

### DIFF
--- a/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
@@ -1,42 +1,11 @@
 #
 # nsswitch.conf(5) - name service switch configuration file
-# $FreeBSD$
 #
-<%
-        def safe_call(*args):
-            try:
-                val = middleware.call_sync(*args)
-            except:
-                val = False
-            return val
 
-        ad_enabled = safe_call('activedirectory.config')['enable']
-        ldap_enabled = safe_call('ldap.config')['enable']
-        nis_enabled = IS_FREEBSD and safe_call('nis.config')['enable']
-
-        group = ['files']
-        hosts = ['files', 'dns']
-        passwd = ['files']
-        sudoers = ['files']
-
-        if ldap_enabled:
-            group.append('ldap')
-            passwd.append('ldap')
-
-        if nis_enabled:
-            group.append('nis')
-            hosts.append('nis')
-            passwd.append('nis')
-
-        if ad_enabled:
-            group.append('winbind')
-            passwd.append('winbind')
-%>
-
-group: ${' '.join(group)}
-hosts: ${' '.join(hosts)}
+group: files winbind ldap
+hosts: files dns
 networks: files
-passwd: ${' '.join(passwd)}
+passwd: files winbind ldap
 shells: files
 services: files
 protocols: files

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -748,7 +748,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
         await self.middleware.call('idmap.synchronize')
         await self.middleware.call('service.restart', 'cifs')
         await self.middleware.call('etc.generate', 'pam')
-        await self.middleware.call('etc.generate', 'nss')
         if ret == neterr.JOINED:
             await self.set_state(DSStatus['HEALTHY'])
             await self.middleware.call('admonitor.start')
@@ -792,7 +791,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
         await self.middleware.call('service.restart', 'cifs')
         job.set_progress(40, 'Reconfiguring pam and nss.')
         await self.middleware.call('etc.generate', 'pam')
-        await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'])
         job.set_progress(60, 'clearing caches.')
         await self.middleware.call('service.stop', 'dscache')
@@ -821,7 +819,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
         enabled = (await self.config())['enable']
         await self.middleware.call('etc.generate', 'hostname')
         await self.middleware.call('etc.generate', 'pam')
-        await self.middleware.call('etc.generate', 'nss')
         await self.middleware.call('service.restart', 'cifs')
         verb = "start" if enabled else "stop"
         await self.middleware.call(f'kerberos.{verb}')

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -462,7 +462,6 @@ class DirectoryServices(Service):
             self.logger.warning("Failed to clear the SMB gencache after re-initializing "
                                 "directory services: [%s]", gencache_flush.stderr.decode())
 
-        await self.middleware.call('etc.generate', 'nss')
         if is_kerberized:
             try:
                 await self.middleware.call('kerberos.start')

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -117,6 +117,8 @@ class EtcService(Service):
         ],
         'ldap': [
             {'type': 'mako', 'path': 'local/openldap/ldap.conf'},
+            {'type': 'mako', 'path': 'local/nslcd.conf',
+                'owner': 'nslcd', 'group': 'nslcd', 'mode': 0o0400},
         ],
         'loader': [
             {'type': 'py', 'path': 'loader', 'platform': 'FreeBSD'},
@@ -131,8 +133,6 @@ class EtcService(Service):
         ],
         'nss': [
             {'type': 'mako', 'path': 'nsswitch.conf'},
-            {'type': 'mako', 'path': 'local/nslcd.conf',
-                'owner': 'nslcd', 'group': 'nslcd', 'mode': 0o0400},
         ],
         'pam': [
             {'type': 'mako', 'path': os.path.join('pam.d', f.name[:-5])}


### PR DESCRIPTION
Only generate nsswitch.conf and always include ldap and winbind
entries. This file will only be read once the first time pwd or
group modules are used and used for the life of the middlewared
process.

Move nslcd config to ldap plugin and remove extra calls to generate
nss.

Fix a couple of bugs in ldap plugin as well:
- wrong string used for checking for start_tls usage. Switch to constant
- synchronize registry regardless of whether samba schema is in payload.