### PR TITLE
NAS-111789 / 21.08 / Perform direct smb config write when updating with AD domain name

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1207,7 +1207,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
 
         if domain != workgroup:
             self.logger.debug(f'Updating SMB workgroup to match the short form of the AD domain [{domain}]')
-            await self.middleware.call('smb.update', {'workgroup': domain})
+            await self.middleware.call('smb.direct_update', {'workgroup': domain})
 
         return domain
 


### PR DESCRIPTION
Bypass more complex wrappers around SMB service when we're updating
with short-form name auto-discovered from AD. This can be relied
on to be valid and we don't want a service restart / reload at this
point of AD configuration process.