### PR TITLE
NAS-111794 / 21.08 / Move static nsswitch.conf to base install

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -3,6 +3,7 @@
 mkdir -p /var/trash
 for file in \
     /etc/default/inadyn \
+    /etc/nsswitch.conf \
     /lib/systemd/system/smartmontools.service
 do
     dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"

--- a/src/freenas/debian/rules
+++ b/src/freenas/debian/rules
@@ -22,6 +22,7 @@ override_dh_auto_install:
 		cp etc/iso_3166_2_countries.csv debian/truenas-files/etc/; \
 		cp -a etc/logrotate.d debian/truenas-files/etc/; \
 		cp etc/netcli debian/truenas-files/etc/; \
+		cp etc/nsswitch.conf debian/truenas-files/etc/; \
 		cp -a etc/syslog-ng debian/truenas-files/etc/; \
 		cp -a etc/systemd debian/truenas-files/etc/; \
 		cp -a usr/lib/systemd debian/truenas-files/usr/lib/; \

--- a/src/freenas/etc/nsswitch.conf
+++ b/src/freenas/etc/nsswitch.conf
@@ -10,4 +10,4 @@ shells: files
 services: files
 protocols: files
 rpc: files
-sudoers: files 
+sudoers: files

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1376,7 +1376,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
 
         await self.middleware.call('kerberos.stop')
         await self.middleware.call('etc.generate', 'pam')
-        await self.middleware.call('etc.generate', 'nss')
         await self.synchronize(new)
         await self.middleware.call('idmap.synchronize')
         await self.middleware.call('service.restart', 'cifs')

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -131,9 +131,6 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'default/nfs-common', 'platform': 'Linux'},
             {'type': 'mako', 'path': 'ganesha/ganesha.conf', 'platform': 'Linux', 'checkpoint': 'pool_import'},
         ],
-        'nss': [
-            {'type': 'mako', 'path': 'nsswitch.conf'},
-        ],
         'pam': [
             {'type': 'mako', 'path': os.path.join('pam.d', f.name[:-5])}
             for f in PAM_FILES


### PR DESCRIPTION
There's no need to generate this in middleware and we must
ensure that it's configured before middleware starts.