### PR TITLE
NAS-111813 / 21.08 / Remove check for privatedir path in passdb_list

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -22,9 +22,6 @@ class SMBService(Service):
         local users in an AD environment. Immediately return in ldap enviornment.
         """
         pdbentries = []
-        private_dir = await self.middleware.call('smb.getparm', 'privatedir', 'global')
-        if not os.path.exists(f'{private_dir}/passdb.tdb'):
-            return pdbentries
 
         passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
         if not passdb_backend.startswith('tdbsam'):


### PR DESCRIPTION
The passdb path is now hard-coded and guaranteed to exist (doesn't differ between HA and non-HA).