### PR TITLE
NAS-111814 / 21.10 / Do not report coredumps generated by apps in containers

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -1,6 +1,12 @@
+import re
+
 from datetime import timedelta
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert, IntervalSchedule
+from middlewared.utils import run
+
+
+SKIP_REGEX = re.compile(r'Unit:\s+containerd.service')
 
 
 class CoreFilesArePresentAlertClass(AlertClass):
@@ -16,18 +22,37 @@ class CoreFilesArePresentAlertClass(AlertClass):
 
 
 class CoreFilesArePresentAlertSource(AlertSource):
+    dumps = {}
     schedule = IntervalSchedule(timedelta(minutes=5))
 
     products = ("SCALE",)
 
     async def check(self):
         corefiles = []
-        for coredump in await self.middleware.call("system.coredumps"):
-            if coredump["corefile"] == "present":
-                if coredump["exe"] == "/usr/sbin/syslog-ng":
+        for coredump in filter(lambda c: c["corefile"] == "present", await self.middleware.call("system.coredumps")):
+            if coredump["exe"] == "/usr/sbin/syslog-ng":
+                continue
+
+            if coredump["pid"] not in self.dumps:
+                cp = await run(
+                    "coredumpctl", "info", str(coredump["pid"]), check=False, encoding="utf-8", errors="ignore"
+                )
+                if cp.returncode:
+                    self.middleware.logger.debug(
+                        "Unable to retrieve coredump information of %r process", coredump["pid"]
+                    )
                     continue
 
-                corefiles.append(f"{coredump['exe']} ({coredump['time']})")
+                self.dumps[coredump["pid"]] = {
+                    **coredump,
+                    "happened_in_container": bool(SKIP_REGEX.findall(cp.stdout))
+                }
+
+            if self.dumps[coredump["pid"]]["happened_in_container"]:
+                # We don't want to raise an alert to user about a container which died for some reason
+                continue
+
+            corefiles.append(f"{coredump['exe']} ({coredump['time']})")
 
         if corefiles:
             return Alert(CoreFilesArePresentAlertClass, {"corefiles": ', '.join(corefiles)})

--- a/src/middlewared/middlewared/plugins/system_/coredump.py
+++ b/src/middlewared/middlewared/plugins/system_/coredump.py
@@ -1,10 +1,13 @@
 # -*- coding=utf-8 -*-
 import logging
+import re
 
 from middlewared.service import private, Service
 from middlewared.utils import run
 
 logger = logging.getLogger(__name__)
+
+SKIP_REGEX = re.compile(r'Unit:\s+containerd.service')
 
 
 class SystemService(Service):
@@ -21,6 +24,15 @@ class SystemService(Service):
         for line in lines:
             exe = line[exe_pos:]
             time, pid, uid, gid, sig, corefile = line[:exe_pos].rsplit(maxsplit=5)
+            cp = await run("coredumpctl", "info", pid, check=False, encoding="utf-8", errors="ignore")
+            if cp.returncode:
+                self.logger.debug("Unable to retrieve coredump information of %r process", pid)
+                continue
+
+            if SKIP_REGEX.findall(cp.stdout):
+                # We don't want to raise an alert to user about a container which died for some reason
+                continue
+
             coredumps.append({
                 "time": time,
                 "pid": int(pid),

--- a/src/middlewared/middlewared/plugins/system_/coredump.py
+++ b/src/middlewared/middlewared/plugins/system_/coredump.py
@@ -1,13 +1,10 @@
 # -*- coding=utf-8 -*-
 import logging
-import re
 
 from middlewared.service import private, Service
 from middlewared.utils import run
 
 logger = logging.getLogger(__name__)
-
-SKIP_REGEX = re.compile(r'Unit:\s+containerd.service')
 
 
 class SystemService(Service):
@@ -24,15 +21,6 @@ class SystemService(Service):
         for line in lines:
             exe = line[exe_pos:]
             time, pid, uid, gid, sig, corefile = line[:exe_pos].rsplit(maxsplit=5)
-            cp = await run("coredumpctl", "info", pid, check=False, encoding="utf-8", errors="ignore")
-            if cp.returncode:
-                self.logger.debug("Unable to retrieve coredump information of %r process", pid)
-                continue
-
-            if SKIP_REGEX.findall(cp.stdout):
-                # We don't want to raise an alert to user about a container which died for some reason
-                continue
-
             coredumps.append({
                 "time": time,
                 "pid": int(pid),


### PR DESCRIPTION
This commit adds changes to not report coredumps generated by any specific app in a container as users are free to run whatever they would like to in containers and we don't officially support all the apps themselves.