### PR TITLE
NAS-111820 / 21.08 / Extend validation of ACL entry IDs

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -40,7 +40,7 @@ class ACLType(enum.Enum):
 
             if entry['tag'] in special and not self._validate_special_id(entry['id']):
                 errors.append(
-                    (idx, f"ACL entry has invalid id for tag type.", "id")
+                    (idx, "ACL entry has invalid id for tag type.", "id")
                 )
 
         return {"is_valid": len(errors) == 0, "errors": errors}

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -374,9 +374,12 @@ class FilesystemService(Service, ACLBase):
         aclcheck = ACLType.NFS4.validate(data)
         if not aclcheck['is_valid']:
             for err in aclcheck['errors']:
-                verrors.add(
-                    'filesystem_acl.dacl.{err[0]}', err[1]
-                )
+                if err[2]:
+                    v = f'filesystem_acl.dacl.{err[0]}.{err[2]}'
+                else:
+                    v = f'filesystem_acl.dacl.{err[0]}'
+
+                verrors.add( v, err[1])
 
         path_acltype = self.getacl(path)['acltype']
         if path_acltype != ACLType.NFS4.name:
@@ -545,9 +548,12 @@ class FilesystemService(Service, ACLBase):
         aclcheck = ACLType.POSIX1E.validate(data)
         if not aclcheck['is_valid']:
             for err in aclcheck['errors']:
-                verrors.add(
-                    'filesystem_acl.dacl.{err[0]}', err[1]
-                )
+                if err[2]:
+                    v = f'filesystem_acl.dacl.{err[0]}.{err[2]}'
+                else:
+                    v = f'filesystem_acl.dacl.{err[0]}'
+
+                verrors.add(v, err[1])
 
         path_acltype = self.getacl(path)['acltype']
         if path_acltype != ACLType.POSIX1E.name:

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -379,7 +379,7 @@ class FilesystemService(Service, ACLBase):
                 else:
                     v = f'filesystem_acl.dacl.{err[0]}'
 
-                verrors.add( v, err[1])
+                verrors.add(v, err[1])
 
         path_acltype = self.getacl(path)['acltype']
         if path_acltype != ACLType.NFS4.name:


### PR DESCRIPTION
Entries with tags associated with file User, Group, or Other /Everyone
may not have a numeric id set. For backwards compatibility, the
following values are permitted for these special entries: -1, null/None.