### PR TITLE
NAS-111695 / 21.08 / Make sure we freeup unused pages in sqlite

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/connection.py
+++ b/src/middlewared/middlewared/plugins/datastore/connection.py
@@ -42,6 +42,7 @@ class DatastoreService(Service):
         self.connection = self.engine.connect()
         self.connection.connection.create_function("REGEXP", 2, regexp)
         self.connection.connection.execute("PRAGMA foreign_keys=ON")
+        self.connection.connection.execute("VACUUM")
 
     @private
     async def execute(self, *args):


### PR DESCRIPTION
This commit adds changes to make sure that we force sqlite3 to give up space which has accumulated over time by deletions of entries. What sqlite3 does is that each data which is removed from the database, sqlite3 does not use the space consumed by that payload and instead moves it to it's list of free pages and whenever more data is added it uses these free pages first and then asks for more space. However with time these free pages can consume lots of space like for a user his db size was 15 mb approx and after vacumming it got to 706K. This change uses vacuum functionality of sqlite3 to make sure that we remove such free unused pages which are in hold by sqlite3.