### PR TITLE
NAS-111819 / 21.08 / Fix taking vmware-aware manual snapshots (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -397,6 +397,11 @@ class VMWareService(CRUDService):
         return self.middleware.call_sync("vmware.query", [f])
 
     @private
+    def snapshot_begin(self, dataset, recursive):
+        qs = self._dataset_get_vms(dataset, recursive)
+        return self.snapshot_proceed(dataset, qs)
+
+    @private
     def snapshot_proceed(self, dataset, qs):
         self.middleware.call_sync('network.general.will_perform_activity', 'vmware')
 


### PR DESCRIPTION
This was broken by acef89b7413859a9bbe70226139756be3551b784

Original PR: https://github.com/truenas/middleware/pull/7321
Jira URL: https://jira.ixsystems.com/browse/NAS-111819