### PR TITLE
NAS-111837 / 21.08 / Make sure we start nfs when user requests it

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -4,9 +4,6 @@
     config = middleware.call_sync("nfs.config")
 
     shares = middleware.call_sync("sharing.nfs.query", [["enabled", "=", True]])
-    if not shares:
-        raise FileShouldNotExist()
-
     has_nfs_principal = middleware.call_sync("kerberos.keytab.has_nfs_principal")
 
     gc = middleware.call_sync("network.configuration.config")


### PR DESCRIPTION
Right now if no nfs shares are configured and if user attempts to start NFS, it does not start as the configuration file is missing for ganesha. This leads to violation of POLA where consumer adding shares later thinks/assumes that NFS would be running but that's not the case and it needs to be started again after configuring a share.