### PR TITLE
NAS-111822 / 21.08 / Use removexattr to remove POSIX1E ACLs

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -178,7 +178,6 @@ class FilesystemService(Service, ACLBase):
         if mode is not None:
             mode = int(mode, 8)
 
-
         if is_nfs4acl:
             self._strip_acl_nfs4(data['path'])
         else:


### PR DESCRIPTION
This make non-recursive operation do the same thing as our
recursive operations. There are some edge cases where xattr
removal and setfacl -b for POSIX1E ACLs yields different
results.