### PR TITLE
NAS-111854 / 21.08 / Expand blacklist of SMB auxiliary parameters

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1285,6 +1285,7 @@ class SharingSMBService(SharingService):
             'state directory',
             'private directory',
             'lock directory',
+            'lock dir',
             'config backend',
             'private dir',
             'log level',
@@ -1292,6 +1293,7 @@ class SharingSMBService(SharingService):
             'clustering',
             'ctdb socket',
             'socket options',
+            'include',
         ]
         for entry in data.splitlines():
             if entry == '' or entry.startswith(('#', ';')):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1284,6 +1284,8 @@ class SharingSMBService(SharingService):
         aux_blacklist = [
             'state directory',
             'private directory',
+            'lock directory',
+            'config backend',
             'private dir',
             'log level',
             'cache directory',


### PR DESCRIPTION
Since we are now using registry backend for global parameters
we need to disallow "lock directory" and "config backend"
parameters as auxiliary parameters. If we don't, then
attempts to set GLOBAL section will fail with
SBC_ERR_INVALID_PARAM.