### PR TITLE
NAS-111526 / 21.10 / Ensure that avahi is started on boot

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -19,6 +19,9 @@
     ipv6_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': False, 'ipv6': True}))
 
     failover_int = middleware.call_sync("failover.internal_interfaces")
+
+    deny_interfaces = ['lo']
+    deny_interfaces.extend(failover_int)
 %>
 
 [server]
@@ -28,12 +31,8 @@ use-ipv6=${"yes" if ipv6_enabled else "no"}
 %endif
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000
-% if IS_FREEBSD:
-enable-dbus=no
-% endif
-%if failover_int:
-deny-interfaces=${", ".join(failover_int)}
-%endif
+deny-interfaces=${", ".join(deny_interfaces)}
+disallow-other-stacks=yes
 
 [wide-area]
 enable-wide-area=yes

--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -182,7 +182,7 @@ class mDNSService(object):
                         iindex.append(socket.if_nametoindex(intobj['name']))
                     except OSError:
                         self.logger.debug('Failed to determine interface index for [%s], service [%s]',
-                                          iface, service, exc_info=True)
+                                          intobj['name'], service, exc_info=True)
 
                     break
 

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -224,8 +224,8 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'motd'}
         ],
         'mdns': [
-            {'type': 'mako', 'path': 'local/avahi/avahi-daemon.conf', 'checkpoint': 'interface_sync'},
-            {'type': 'py', 'path': 'local/avahi/avahi_services', 'checkpoint': 'interface_sync'}
+            {'type': 'mako', 'path': 'local/avahi/avahi-daemon.conf', 'checkpoint': None},
+            {'type': 'py', 'path': 'local/avahi/avahi_services', 'checkpoint': None}
         ],
         'wsd': [
             {'type': 'mako', 'path': 'local/wsdd.conf', 'checkpoint': 'interface_sync'},

--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -1,7 +1,9 @@
-async def interface_post_sync(middleware):
-    if await middleware.call('system.ready'):
-        await middleware.call('etc.generate', 'mdns')
+async def __event_system_ready(middleware, event_type, args):
+
+    if args['id'] == 'ready':
+        # start method for service checks whether mDNS is enabled
+        await middleware.call("service.start", "mdns")
 
 
-def setup(middleware):
-    middleware.register_hook('interface.post_sync', interface_post_sync)
+async def setup(middleware):
+    middleware.event_subscribe('system', __event_system_ready)

--- a/src/middlewared/middlewared/plugins/service_/services/mdns.py
+++ b/src/middlewared/middlewared/plugins/service_/services/mdns.py
@@ -17,11 +17,13 @@ class MDNSService(SimpleService):
         if not announce["mdns"]:
             return
 
-        return await super().start()
+        return await self._systemd_unit("avahi-daemon", "start")
 
     async def reload(self):
         announce = (await self.middleware.call("network.configuration.config"))["service_announcement"]
         if not announce["mdns"]:
             return
 
-        return await super().reload()
+        state = await self.get_state()
+        cmd = "reload" if state.running else "start"
+        return await self._systemd_unit("avahi-daemon", cmd)

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -111,14 +111,12 @@ class HttpService(PseudoServiceBase):
     reloadable = True
 
     async def restart(self):
-        await self.middleware.call("service.reload", "mdns")
         if osc.IS_FREEBSD:
             await freebsd_service("nginx", "restart")
         if osc.IS_LINUX:
             await systemd_unit("nginx", "restart")
 
     async def reload(self):
-        await self.middleware.call("service.reload", "mdns")
         if osc.IS_FREEBSD:
             await freebsd_service("nginx", "reload")
         if osc.IS_LINUX:

--- a/src/middlewared/middlewared/plugins/service_/services/ssh.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ssh.py
@@ -13,14 +13,8 @@ class SSHService(SimpleService):
 
     systemd_unit = "ssh"
 
-    async def before_start(self):
-        await self.middleware.call("service.reload", "mdns")
-
     async def after_start(self):
         await self.middleware.call("ssh.save_keys")
-
-    async def before_reload(self):
-        await self.middleware.call("service.reload", "mdns")
 
     async def after_reload(self):
         await self.middleware.call("ssh.save_keys")


### PR DESCRIPTION
Start the avahi-daemon only after system is ready.
Remove SRV records for services that don't rely on mDNS.
Keep HTTP SRV record
Prevent avahi from binding to loopback