### PR TITLE
NAS-111883 / 21.10 / Explicitly disable clustering in smb.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -13,7 +13,9 @@
     ctdb:registry.tdb = Yes
     kernel share modes = No
     % endif
+    clustering = No
     include = registry
     % else:
+    clustering = No
     netbiosname = TN_STANDBY
     % endif


### PR DESCRIPTION
Switching from `clustering = Yes` to `clustering = No` is
required for the parameter to be properly refreshed in the
the loadparm context on config file reload.