### PR TITLE
NAS-111808 / 21.10 / User serial port name instead of I/O address in grub configuration

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -7,9 +7,19 @@ from middlewared.utils.db import query_config_table
 
 
 def get_serial_ports():
-    return {
-        v: k.replace('uart', 'ttyS') if osc.IS_FREEBSD else k for k, v in osc.system.serial_port_choices().items()
-    }
+    choices = osc.system.serial_port_choices()
+    if osc.IS_FREEBSD:
+        return {v: k.replace('uart', 'ttyS') for k, v in choices.items()}
+    else:
+        options = {}
+        # We also add i/o address to the dict here because when users are upgrading and their db still references to
+        # i/o address instead of port name, we won't be generating a valid configuration which is not desired
+        for k, v in choices.items():
+            options.update({
+                k: k,
+                v: k,
+            })
+        return options
 
 
 if __name__ == "__main__":

--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -7,19 +7,7 @@ from middlewared.utils.db import query_config_table
 
 
 def get_serial_ports():
-    choices = osc.system.serial_port_choices()
-    if osc.IS_FREEBSD:
-        return {v: k.replace('uart', 'ttyS') for k, v in choices.items()}
-    else:
-        options = {}
-        # We also add i/o address to the dict here because when users are upgrading and their db still references to
-        # i/o address instead of port name, we won't be generating a valid configuration which is not desired
-        for k, v in choices.items():
-            options.update({
-                k: k,
-                v: k,
-            })
-        return options
+    return {e['start']: e['name'].replace('uart', 'ttyS') for e in osc.system.serial_port_choices()}
 
 
 if __name__ == "__main__":

--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -6,6 +6,12 @@ from middlewared.utils import osc
 from middlewared.utils.db import query_config_table
 
 
+def get_serial_ports():
+    return {
+        v: k.replace('uart', 'ttyS') if osc.IS_FREEBSD else k for k, v in osc.system.serial_port_choices().items()
+    }
+
+
 if __name__ == "__main__":
     advanced = query_config_table("system_advanced", prefix="adv_")
     kernel_extra_args = advanced.get('kernel_extra_options') or ''
@@ -24,8 +30,8 @@ if __name__ == "__main__":
     if advanced["serialconsole"]:
         config.append(f'GRUB_SERIAL_COMMAND="serial --speed={advanced["serialspeed"]} --word=8 --parity=no --stop=1"')
         terminal.append("serial")
-
-        cmdline.append(f"console={advanced['serialport']},{advanced['serialspeed']} console=tty1")
+        port = get_serial_ports().get(advanced['serialport'], advanced['serialport'])
+        cmdline.append(f"console={port},{advanced['serialspeed']} console=tty1")
 
     if advanced.get("kdump_enabled"):
         # (memory in kb) / 16 / 1024 / 1024

--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-20_17-20_serial_ports.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-20_17-20_serial_ports.py
@@ -19,13 +19,13 @@ depends_on = None
 
 def upgrade():
     conn = op.get_bind()
-    io_choices = {v: k for k, v in osc.system.serial_port_choices().items()}
+    io_choices = {e['start']: e['name'] for e in osc.system.serial_port_choices()}
     sys_config = [dict(row) for row in conn.execute("SELECT * FROM system_advanced").fetchall()]
     if not sys_config:
         return
 
     sys_config = sys_config[0]
-    if sys_config['adv_serialport'] not in io_choices and not sys_config['adv_serialport'].startswith('ttyS'):
+    if sys_config['adv_serialport'] not in io_choices:
         new_val = 'ttyS0'
     else:
         new_val = io_choices[sys_config['adv_serialport']]

--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-20_17-20_serial_ports.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-20_17-20_serial_ports.py
@@ -1,0 +1,37 @@
+"""
+User serial port(s) name instead of I/O address
+
+Revision ID: 725b7264abe6
+Revises: 29abd3dce632
+Create Date: 2021-20-08 17:20:42.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from middlewared.utils import osc
+
+
+revision = '725b7264abe6'
+down_revision = '29abd3dce632'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    io_choices = {v: k for k, v in osc.system.serial_port_choices().items()}
+    sys_config = [dict(row) for row in conn.execute("SELECT * FROM system_advanced").fetchall()]
+    if not sys_config:
+        return
+
+    sys_config = sys_config[0]
+    if sys_config['adv_serialport'] not in io_choices and not sys_config['adv_serialport'].startswith('ttyS'):
+        new_val = 'ttyS0'
+    else:
+        new_val = io_choices[sys_config['adv_serialport']]
+
+    conn.execute("UPDATE system_advanced SET adv_serialport = ? WHERE id = ?", (new_val, sys_config['id']))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -68,7 +68,7 @@ class SystemAdvancedModel(sa.Model):
     id = sa.Column(sa.Integer(), primary_key=True)
     adv_consolemenu = sa.Column(sa.Boolean(), default=False)
     adv_serialconsole = sa.Column(sa.Boolean(), default=False)
-    adv_serialport = sa.Column(sa.String(120), default="0x2f8")
+    adv_serialport = sa.Column(sa.String(120), default="ttyS0")
     adv_serialspeed = sa.Column(sa.String(120), default="9600")
     adv_powerdaemon = sa.Column(sa.Boolean(), default=False)
     adv_swapondrive = sa.Column(sa.Integer(), default=2)

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -139,12 +139,12 @@ class SystemAdvancedService(ConfigService):
 
     @accepts()
     @returns(Dict('serial_port_choices', additional_attrs=True))
-    def serial_port_choices(self):
+    async def serial_port_choices(self):
         """
         Get available choices for `serialport`.
         """
-        ports = {k: k for k in osc.system.serial_port_choices()}
-        if not ports or self.middleware.call_sync('system.advanced.config')['serialport'] == 'ttyS0':
+        ports = {e['name']: e['name'] for e in await self.middleware.call('device.get_info', 'SERIAL')}
+        if not ports or (await self.middleware.call('system.advanced.config'))['serialport'] == 'ttyS0':
             # We should always add ttyS0 if ports is false or current value is the default one in db
             # i.e ttyS0
             ports['ttyS0'] = 'ttyS0'
@@ -183,7 +183,7 @@ class SystemAdvancedService(ConfigService):
                     f'{schema}.serialport',
                     'Please specify a serial port when serial console option is checked'
                 )
-            elif serial_choice not in await self.middleware.call('system.advanced.serial_port_choices'):
+            elif serial_choice not in await self.serial_port_choices():
                 verrors.add(
                     f'{schema}.serialport',
                     'Serial port specified has not been identified by the system'

--- a/src/middlewared/middlewared/utils/device.py
+++ b/src/middlewared/middlewared/utils/device.py
@@ -1,0 +1,4 @@
+import subprocess
+
+
+

--- a/src/middlewared/middlewared/utils/device.py
+++ b/src/middlewared/middlewared/utils/device.py
@@ -1,4 +1,0 @@
-import subprocess
-
-
-

--- a/src/middlewared/middlewared/utils/osc/freebsd/system.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/system.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 
-PORT_REGEX = re.compile(r'([0-9a-fA-Fx]+).*\((uart[0-9])+\)')
+RE_PORT = re.compile(r'([0-9a-fA-Fx]+).*\((uart[0-9])+\)')
 
 
 def get_cpu_model():
@@ -22,4 +22,4 @@ def serial_port_choices():
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
     stdout, stderr = cp.communicate()
-    return {e[1]: e[0] for e in PORT_REGEX.findall(stdout.decode(errors='ignore'))}
+    return {e[1]: e[0] for e in RE_PORT.findall(stdout.decode(errors='ignore'))}

--- a/src/middlewared/middlewared/utils/osc/freebsd/system.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/system.py
@@ -1,5 +1,7 @@
 # -*- coding=utf-8 -*-
 import logging
+import re
+import subprocess
 import sysctl
 
 logger = logging.getLogger(__name__)
@@ -7,5 +9,17 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 
+PORT_REGEX = re.compile(r'([0-9a-fA-Fx]+).*\((uart[0-9])+\)')
+
+
 def get_cpu_model():
     return sysctl.filter('hw.model')[0].value
+
+
+def serial_port_choices():
+    cp = subprocess.Popen(
+        "/usr/sbin/devinfo -u | grep -A 99999 '^I/O ports:' | grep -E '*([0-9a-fA-Fx]+).*\\(uart[0-9]+\\)'",
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    stdout, stderr = cp.communicate()
+    return {e[1]: e[0] for e in PORT_REGEX.findall(stdout.decode(errors='ignore'))}

--- a/src/middlewared/middlewared/utils/osc/freebsd/system.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/system.py
@@ -22,4 +22,9 @@ def serial_port_choices():
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
     stdout, stderr = cp.communicate()
-    return {e[1]: e[0] for e in RE_PORT.findall(stdout.decode(errors='ignore'))}
+    return [
+        {
+            'name': e[1],
+            'start': e[0],
+        } for e in RE_PORT.findall(stdout.decode(errors='ignore'))
+    ]

--- a/src/middlewared/middlewared/utils/osc/linux/system.py
+++ b/src/middlewared/middlewared/utils/osc/linux/system.py
@@ -1,5 +1,7 @@
 # -*- coding=utf-8 -*-
+import glob
 import logging
+import os
 import re
 import subprocess
 
@@ -8,7 +10,8 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 RE_CPU_MODEL = re.compile(r'^model name\s*:\s*(.*)', flags=re.M)
-RE_PORT = re.compile(r'(ttyS\d+) at I/O (\S+)')
+RE_SERIAL = re.compile(r'state.*=\s*(\w*).*io (.*)-(\w*)\n.*', re.S | re.A)
+RE_UART_TYPE = re.compile(r'is a\s*(\w+)')
 
 
 def get_cpu_model():
@@ -18,6 +21,45 @@ def get_cpu_model():
 
 
 def serial_port_choices():
-    cp = subprocess.Popen('dmesg | grep ttyS', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    stdout, stderr = cp.communicate()
-    return {e[0]: e[1] for e in RE_PORT.findall(stdout.decode(errors='ignore'))}
+    devices = []
+    for tty in map(lambda t: os.path.basename(t), glob.glob('/dev/ttyS*')):
+        # We want to filter out platform based serial devices here
+        serial_dev = {
+            'name': None,
+            'location': None,
+            'drivername': 'uart',
+            'description': None,
+            'start': None,
+            'size': None,
+        }
+        tty_sys_path = os.path.join('/sys/class/tty', tty)
+        dev_path = os.path.join(tty_sys_path, 'device')
+        if (
+            os.path.exists(dev_path) and os.path.basename(
+                os.path.realpath(os.path.join(dev_path, 'subsystem'))
+            ) == 'platform'
+        ) or not os.path.exists(dev_path):
+            continue
+
+        cp = subprocess.Popen(
+            ['setserial', '-b', os.path.join('/dev', tty)], stderr=subprocess.DEVNULL, stdout=subprocess.PIPE
+        )
+        stdout, stderr = cp.communicate()
+        if not cp.returncode and stdout:
+            reg = RE_UART_TYPE.search(stdout.decode())
+            if reg:
+                serial_dev['description'] = reg.group(1)
+        if not serial_dev['description']:
+            continue
+        with open(os.path.join(tty_sys_path, 'device/resources'), 'r') as f:
+            reg = RE_SERIAL.search(f.read())
+            if reg:
+                if reg.group(1).strip() != 'active':
+                    continue
+                serial_dev['start'] = reg.group(2)
+                serial_dev['size'] = (int(reg.group(3), 16) - int(reg.group(2), 16)) + 1
+        with open(os.path.join(tty_sys_path, 'device/firmware_node/path'), 'r') as f:
+            serial_dev['location'] = f'handle={f.read().strip()}'
+        serial_dev['name'] = tty
+        devices.append(serial_dev)
+    return devices

--- a/src/middlewared/middlewared/utils/osc/linux/system.py
+++ b/src/middlewared/middlewared/utils/osc/linux/system.py
@@ -1,15 +1,23 @@
 # -*- coding=utf-8 -*-
 import logging
 import re
+import subprocess
 
 logger = logging.getLogger(__name__)
 
 __all__ = ['get_cpu_model']
 
 RE_CPU_MODEL = re.compile(r'^model name\s*:\s*(.*)', flags=re.M)
+RE_PORT = re.compile(r'(ttyS\d+) at I/O (\S+)')
 
 
 def get_cpu_model():
     with open('/proc/cpuinfo', 'r') as f:
         model = RE_CPU_MODEL.search(f.read())
         return model.group(1) if model else None
+
+
+def serial_port_choices():
+    cp = subprocess.Popen('dmesg | grep ttyS', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    stdout, stderr = cp.communicate()
+    return {e[0]: e[1] for e in RE_PORT.findall(stdout.decode(errors='ignore'))}


### PR DESCRIPTION
This PR adds changes to use serial port name instead of serial port i/o address as with the latter console redirection does not work and we are left with a blank console with ipmi sol.