### PR TITLE
NAS-111719 / 21.10 / Add safeguards to prevent usage of FreeBSD VFS objects on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1324,7 +1324,7 @@ class SharingSMBService(SharingService):
                     'are not permitted.'
                 )
 
-            if kv[0].strip() == "vfs objects":
+            if kv[0].strip() == 'vfs objects':
                 for i in kv[1].split():
                     if i in freebsd_vfs_objects:
                         verrors.add(


### PR DESCRIPTION
There are two parts to this:
1) we raise ValidationError if user tries to create or update share with
   invalid VFS objects for SCALE. This should prevent new damage.
2) We refuse to add shares that already have invalid parameters to
   our SMB server configuration.