### PR TITLE
NAS-111795 / 21.10 / Bug fix for fix_unique migration

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-05-10_13-52_fix_unique.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-05-10_13-52_fix_unique.py
@@ -20,7 +20,7 @@ depends_on = None
 
 def ensure_unique_string(conn, table, column):
     values = set()
-    for row in conn.execute(f"SELECT * FROM {table}").fetchall():
+    for row in map(dict, conn.execute(f"SELECT * FROM {table}").fetchall()):
         if row[column] is not None:
             update = False
             if row[column] in values:


### PR DESCRIPTION
Row proxy object's values cannot be changed, so we should convert it to a dict for temporary changes instead.