### PR TITLE
NAS-111858 / 12.0 / Give a proper title to SSHLoginFailuresAlertClass

### DIFF
--- a/src/middlewared/middlewared/alert/source/ssh_login_failures.py
+++ b/src/middlewared/middlewared/alert/source/ssh_login_failures.py
@@ -65,7 +65,7 @@ def get_login_failures(now, messages):
 class SSHLoginFailuresAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
-    title = "SSH Login Failures"
+    title = "Yesterday's SSH Login Failures"
     text = "%(count)d SSH login failures:\n%(failures)s"
 
 


### PR DESCRIPTION
This was a direct port of FreeBSD's standard "security" cron job. We'll rewrite this alert in SCALE to make it more useful.