### PR TITLE
NAS-111938 / 21.10 / Create idmap service to wrap around winbind

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -579,7 +579,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             job = (await self.middleware.call('activedirectory.stop')).id
 
         elif new['enable'] and old['enable']:
-            await self.middleware.call('service.restart', 'cifs')
+            await self.middleware.call('service.restart', 'idmap')
 
         ret.update({'job_id': job})
         return ret

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1050,3 +1050,4 @@ class IdmapDomainService(TDBWrapCRUDService):
         to_check = (await self.middleware.call('smb.reg_globals'))['idmap']
         diff = await self.diff_conf_and_registry(idmaps, to_check)
         await self.middleware.call('sharing.smb.apply_conf_diff', 'GLOBAL', diff)
+        await self.middleware.call('service.restart', 'idmap')

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -27,6 +27,7 @@ from .keepalived import KeepalivedService
 from .glusterd import GlusterdService
 from .glustereventsd import GlusterEventsdService
 from .ctdb import CtdbService
+from .idmap import IdmapService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
@@ -84,6 +85,7 @@ all_services = [
     ActiveDirectoryService,
     LdapService,
     NisService,
+    IdmapService,
     CollectDService,
     RRDCacheDService,
     LibvirtdService,

--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -35,7 +35,6 @@ class CIFSService(SimpleService):
                     return
 
             await self._systemd_unit("smbd", "start")
-            await self._systemd_unit("winbind", "start")
         if announce["netbios"]:
             if osc.IS_FREEBSD:
                 await self._freebsd_service("nmbd", "start", force=True)
@@ -64,7 +63,6 @@ class CIFSService(SimpleService):
             await self._freebsd_service("wsdd", "stop", force=True)
         if osc.IS_LINUX:
             await self._systemd_unit("smbd", "stop")
-            await self._systemd_unit("winbind", "stop")
             await self._systemd_unit("nmbd", "stop")
             await self._systemd_unit("wsdd", "stop")
 

--- a/src/middlewared/middlewared/plugins/service_/services/idmap.py
+++ b/src/middlewared/middlewared/plugins/service_/services/idmap.py
@@ -1,0 +1,15 @@
+from .base import SimpleService
+
+
+class IdmapService(SimpleService):
+    name = "idmap"
+    reloadable = True
+    restartable = True
+
+    systemd_unit = "winbind"
+
+    async def restart(self):
+        return await self._systemd_unit("winbind", "restart")
+
+    async def reload(self):
+        return await self._systemd_unit("winbind", "reload")


### PR DESCRIPTION
Avoid touching winbindd unless it's absolutely necessary. NetBIOS names and workgroups cannot be changed while AD is
enabled and so we should be protected from having inconsistent config on winbindd and smbd.