### PR TITLE
NAS-111885 / 21.10 / Update check_user method to allow checking passwords of other users

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -283,8 +283,6 @@ class AuthService(Service):
         """
         Verify username and password
         """
-        if username != 'root':
-            return False
         try:
             user = await self.middleware.call('datastore.query', 'account.bsdusers',
                                               [('bsdusr_username', '=', username)], {'get': True})

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -281,6 +281,15 @@ class AuthService(Service):
     @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
     async def check_user(self, username, password):
         """
+        Verify username and password (this will only validate root user's password and
+        would return `false` for any other user)
+        """
+        return False if username != 'root' else await self.check_password(username, password)
+
+    @accepts(Str('username'), Str('password'))
+    @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
+    async def check_password(self, username, password):
+        """
         Verify username and password
         """
         try:


### PR DESCRIPTION
This commit adds a change to check_user method adapting it so that it can be used for other users as well for checking if a specified password is accurate/correct against the specified username.