### PR TITLE
NAS-111936 / 21.08-BETA.1 / Use libvirt to determine how much memory a VM is consuming (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -1,9 +1,12 @@
 import errno
 
+from middlewared.schema import accepts, Int, returns
 from middlewared.service import CallError, private, Service
 
+from .vm_supervisor import VMSupervisorMixin
 
-class VMService(Service):
+
+class VMService(Service, VMSupervisorMixin):
 
     async def __set_guest_vmemory(self, memory, overcommit):
         memory_available = await self.middleware.call('vm.get_available_memory', overcommit)
@@ -53,3 +56,12 @@ class VMService(Service):
                 self.logger.warn(
                     f'Not giving back memory to ARC because new arc_max ({new_arc_max}) <= arc_min ({arc_min})'
                 )
+
+    @accepts(Int('vm_id'))
+    @returns(Int('memory_usage', description='Memory usage of a VM in bytes'))
+    def get_memory_usage(self, vm_id):
+        return self.get_memory_usage_internal(self.middleware.call('vm.get_instance', vm_id))
+
+    @private
+    def get_memory_usage_internal(self, vm):
+        return self._memory_info(vm['name'])

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -60,7 +60,7 @@ class VMService(Service, VMSupervisorMixin):
     @accepts(Int('vm_id'))
     @returns(Int('memory_usage', description='Memory usage of a VM in bytes'))
     def get_memory_usage(self, vm_id):
-        return self.get_memory_usage_internal(self.middleware.call('vm.get_instance', vm_id))
+        return self.get_memory_usage_internal(self.middleware.call_sync('vm.get_instance', vm_id))
 
     @private
     def get_memory_usage_internal(self, vm):

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
@@ -77,6 +77,10 @@ class VMSupervisorBase(LibvirtConnectionMixin):
 
         return data
 
+    def memory_usage(self):
+        # We return this in bytes
+        return self.domain.memoryStats()['actual'] * 1024
+
     def __define_domain(self):
         if self.domain:
             raise CallError(f'{self.libvirt_domain_name} domain has already been defined')

--- a/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
@@ -77,3 +77,8 @@ class VMSupervisorMixin(LibvirtConnectionMixin):
     def _status(self, vm_name):
         self._check_setup_connection()
         return self.vms[vm_name].status()
+
+    def _memory_info(self, vm_name):
+        self._check_setup_connection()
+        self._check_domain_running(vm_name)
+        return self.vms[vm_name].memory_usage()


### PR DESCRIPTION
We should use libvirt to determine how much memory a VM is consuming instead of trying to do it ourselves. With current logic, a VM memory size can sometimes go to negative with how it's being calculated which when subtracted from total actually results in addition of the vm size to memory instead of subtracting from it.

Using libvirt gives us benefit of not going into implementation specifics of how memory of a VM should be calculated and also we avoid getting into the problem stated above.

Original PR: https://github.com/truenas/middleware/pull/7369
Jira URL: https://jira.ixsystems.com/browse/NAS-111936