### PR TITLE
NAS-111808 / 12.0 / User serial port name instead of I/O address in grub configuration (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -12,6 +12,10 @@ def dict_factory(cursor, row):
     return d
 
 
+def get_serial_ports():
+    return {e['start']: e['name'].replace('uart', 'ttyS') for e in osc.system.serial_port_choices()}
+
+
 if __name__ == "__main__":
     conn = sqlite3.connect(FREENAS_DATABASE)
     conn.row_factory = dict_factory
@@ -30,7 +34,8 @@ if __name__ == "__main__":
         config.append(f'GRUB_SERIAL_COMMAND="serial --speed={advanced["serialspeed"]} --word=8 --parity=no --stop=1"')
         terminal.append("serial")
 
-        cmdline.append(f"console={advanced['serialport']},{advanced['serialspeed']} console=tty1")
+        port = get_serial_ports().get(advanced['serialport'], advanced['serialport'])
+        cmdline.append(f"console={port},{advanced['serialspeed']} console=tty1")
 
     config.append(f'GRUB_TERMINAL="{" ".join(terminal)}"')
     config.append(f'GRUB_CMDLINE_LINUX="{" ".join(cmdline)}"')

--- a/src/middlewared/middlewared/utils/osc/freebsd/system.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/system.py
@@ -1,5 +1,7 @@
 # -*- coding=utf-8 -*-
 import logging
+import re
+import subprocess
 import sysctl
 
 logger = logging.getLogger(__name__)
@@ -7,5 +9,22 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 
+RE_PORT = re.compile(r'([0-9a-fA-Fx]+).*\((uart[0-9])+\)')
+
+
 def get_cpu_model():
     return sysctl.filter('hw.model')[0].value
+
+
+def serial_port_choices():
+    cp = subprocess.Popen(
+        "/usr/sbin/devinfo -u | grep -A 99999 '^I/O ports:' | grep -E '*([0-9a-fA-Fx]+).*\\(uart[0-9]+\\)'",
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    stdout, stderr = cp.communicate()
+    return [
+        {
+            'name': e[1],
+            'start': e[0],
+        } for e in RE_PORT.findall(stdout.decode(errors='ignore'))
+    ]


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 0df476384478a8b1e0be51a3c150e5f56ec93aa1
    git cherry-pick -x 9661da12abade2b0375edd0e7739c357cfab25ca
    git cherry-pick -x 159c239041e1e67d5c684c1308ec47972d95d244
    git cherry-pick -x 4fd21ec31c0be4f439f273afa3cd8b6314c5135b
    git cherry-pick -x 839e2f0922e164ea3bdccb8e1df9db9806e75c54
    git cherry-pick -x 58633db64cdd7062602ca37d4796f68e7995df6b
    git cherry-pick -x f2b21fa435f7f38f742f93b14a964b1c4cd8caa7
    git cherry-pick -x bc895bb5dc1ecb47d908f0d56ac3d3fc9a742c63

This PR adds changes to use serial port name instead of serial port i/o address as with the latter console redirection does not work and we are left with a blank console with ipmi sol.

Original PR: https://github.com/truenas/middleware/pull/7345
Jira URL: https://jira.ixsystems.com/browse/NAS-111808