### PR TITLE
NAS-111990 / 21.10 / Wait for permissions job to finish during dataset creation

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3312,7 +3312,8 @@ class PoolDatasetService(CRUDService):
         created_ds = await self.get_instance(data['id'])
 
         if data['type'] == 'FILESYSTEM' and data['share_type'] == 'SMB' and created_ds['acltype']['value'] == "NFSV4":
-            await self.middleware.call('pool.dataset.permission', data['id'], {'mode': None})
+            acl_job = await self.middleware.call('pool.dataset.permission', data['id'], {'mode': None})
+            await acl_job.wait()
 
         return created_ds
 


### PR DESCRIPTION
If we don't wait for this then a `filesystem.stat` call immediately after dataset creation may report that there is no ACL on the created SMB dataset.