### PR TITLE
NAS-111988 / 21.10 / Fix groupmap synchronization

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -259,8 +259,8 @@ class SMBService(Service):
 
     @private
     async def sync_builtins(self, groupmap):
-        idmap_backend = await self.middleware.call("smb.getparm", "idmap config *:backend", "GLOBAL")
-        idmap_range = await self.middleware.call("smb.getparm", "idmap config *:range", "GLOBAL")
+        idmap_backend = await self.middleware.call("smb.getparm", "idmap config * : backend", "GLOBAL")
+        idmap_range = await self.middleware.call("smb.getparm", "idmap config * : range", "GLOBAL")
         payload = {"ADD": [{"groupmap": []}], "MOD": [{"groupmap": []}], "DEL": [{"groupmap": []}]}
         must_reload = False
 


### PR DESCRIPTION
Migration to storing global parameters in registry config resulted
in normalizing how idmap parameters were written to SMB configuration.
This commit updates checks when we set up S-1-5-32 in groupmapping.tdb
so that tdb insertion / alias creation happens as required.