### PR TITLE
NAS-111997 / 21.08-BETA.1 / Properly retrieve registry config and ACLs in SMB debug (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
@@ -118,8 +118,8 @@ smb_func()
 	section_header "net getdomainsid"
 	net getdomainsid
 	section_footer
-	section_header "net --json groupmap list"
-	net --json groupmap list | jq
+	section_header "middleware groupmap list"
+	midclt call smb.groupmap_list | jq
 	section_footer
 
 	section_header "net status sessions"

--- a/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
@@ -79,30 +79,24 @@ smb_func()
 	sc "${SMBCONF}"
 	section_footer
 
-	section_header "${SMBSHARECONF}"
-	net conf list
+	section_header "GLOBAL configuration"
+	net conf showshare global
 	section_footer
-
-	local IFS="|"
 
 	#
 	#	Dump SMB shares
 	#
 	section_header "SMB Shares & Permissions"
-	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
-	SELECT
-		cifs_path,
-		cifs_name
-	FROM
-		sharing_cifs_share
-	ORDER BY
-		-id
-	" | while read -r cifs_path cifs_name
-	do
+	SHARES=$(midclt call sharing.smb.query)
+	echo ${SHARES} | jq -c '.[]' | while read i; do
+		cifs_path=$(echo ${i} | jq -r '.path')
+		cifs_name=$(echo ${i} | jq -r '.name')
 		section_header "${cifs_name}:${cifs_path}"
+		net conf showshare ${cifs_name}
+		printf "\n"
 		ls -ld "${cifs_path}"
 		printf "\n"
-		getfacl "${cifs_path}"
+		midclt call filesystem.getacl "${cifs_path}" true | jq
 		printf "\n"
 	done
 	section_footer
@@ -124,8 +118,8 @@ smb_func()
 	section_header "net getdomainsid"
 	net getdomainsid
 	section_footer
-	section_header "net groupmap list"
-	net groupmap list | head -50
+	section_header "net --json groupmap list"
+	net --json groupmap list | jq
 	section_footer
 
 	section_header "net status sessions"

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -228,6 +228,10 @@ class SMBService(Service):
         list of SIDS to be removed. SID is necessary and sufficient for groupmap removal.
         """
         rv = {"builtins": {}, "local": {}, "local_builtins": {}, "invalid": []}
+        passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
+        if not passdb_backend.startswith('tdbsam'):
+            return rv
+
         localsid = await self.middleware.call('smb.get_system_sid')
         if localsid is None:
             raise CallError("Unable to retrieve local system SID. Group mapping failure.")


### PR DESCRIPTION
`getfacl` is not ACLtype-agnostic. Parse sharing.smb.query output
and use `filesystem.getacl` to retrieve share ACL.

Original PR: https://github.com/truenas/middleware/pull/7400
Jira URL: https://jira.ixsystems.com/browse/NAS-111997