### PR TITLE
NAS-111973 / 12.0 / Bug fix for s3 service

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-08-26_13-25_s3_bindip.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-08-26_13-25_s3_bindip.py
@@ -1,0 +1,24 @@
+"""
+Normalize s3 bindip
+
+Revision ID: 26de83f45a9d
+Revises: 2e2c8b0e787b
+Create Date: 2021-08-26 13:25:29.872200+00:00
+
+"""
+from alembic import op
+
+
+revision = '26de83f45a9d'
+down_revision = '2e2c8b0e787b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute("UPDATE services_s3 SET s3_bindip = '0.0.0.0' WHERE s3_bindip = ''")
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -12,7 +12,7 @@ class S3Model(sa.Model):
     __tablename__ = 'services_s3'
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    s3_bindip = sa.Column(sa.String(128))
+    s3_bindip = sa.Column(sa.String(128), default='0.0.0.0')
     s3_bindport = sa.Column(sa.SmallInteger(), default=9000)
     s3_access_key = sa.Column(sa.String(128), default='')
     s3_secret_key = sa.Column(sa.EncryptedText(), default='')


### PR DESCRIPTION
This PR introduces the following change:

It normalizes s3 bindip to a reasonable default value if no ip is configured at the moment, this could result in unexpected behavior when we were deleting/removing dataset which was being used by s3 service. The specific scenario in question is using having configured s3 service but with bindip not set which points out to missing validation for bindip, however the validation is in place now in stable branch.

We still have delete operation fatal for s3 attachment if we are not able to unset storage path while the dataset is being removed as if that's not fatal, this will result us in creating the path even if it does not exist which would result in unexpected behavior.
