### PR TITLE
NAS-112032 / 21.10 / Fix check for whether advanced flags are inherited

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -51,7 +51,7 @@ class ACLType(enum.Enum):
         if ace['flags'].get("BASIC"):
             return False
 
-        return ace['flags']['INHERITED']
+        return ace['flags'].get('INHERITED', False)
 
     def canonicalize(self, theacl):
         """


### PR DESCRIPTION
If INHERITED is missing from the flags dict passed into
the ACLType validation for NFSv4 ACL canonicalization, then
it is implicitly false.