### PR TITLE
NAS-111634 / 12.0 / Correctly generate configuration for remote syslog with TLS

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-09-30_18-42_syslog_ca.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-09-30_18-42_syslog_ca.py
@@ -1,0 +1,32 @@
+"""
+Allow configuring CA for remote syslog tls connection
+
+Revision ID: 45d6f6f07b0f
+Revises: 26de83f45a9d
+Create Date: 2021-09-30 18:42:42.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '45d6f6f07b0f'
+down_revision = '26de83f45a9d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('adv_syslog_tls_certificate_authority_id', sa.Integer(), nullable=True))
+        batch_op.create_index(
+            batch_op.f('ix_system_advanced_adv_syslog_tls_certificate_authority_id'),
+            ['adv_syslog_tls_certificate_authority_id'], unique=False
+        )
+        batch_op.create_foreign_key(
+            batch_op.f('fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority'),
+            'system_certificateauthority', ['adv_syslog_tls_certificate_authority_id'], ['id']
+        )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -21,11 +21,9 @@ def generate_syslog_remote_destination(middleware, advanced_config):
 
         if advanced_config["syslog_transport"] == "TLS":
             try:
-                certificate = middleware.call_sync(
-                    "certificate.query",
-                    [
-                        ("id", "=", advanced_config["syslog_tls_certificate"]),
-                        ("revoked", "=", False),
+                certificate_authority = middleware.call_sync(
+                    "certificateauthority.query", [
+                        ("id", "=", advanced_config["syslog_tls_certificate_authority"]), ("revoked", "=", False),
                     ],
                     {"get": True}
                 )
@@ -33,18 +31,38 @@ def generate_syslog_remote_destination(middleware, advanced_config):
                 logger.warning("Syslog TLS certificate not available, skipping remote syslog destination")
                 return ""
 
+            result += f"syslog(\"{host}\" port({port}) transport(\"tls\") "
             try:
-                ca_dir = "/etc/certificates"
+                ca_dir = "/etc/certificates/CA"
                 for filename in os.listdir(ca_dir):
                     if filename.endswith(".0") and os.path.islink(os.path.join(ca_dir, filename)):
                         os.unlink(os.path.join(ca_dir, filename))
-                os.symlink(certificate["certificate_path"],
-                           os.path.join(ca_dir, "%x.0" % certificate["subject_name_hash"]))
+                os.symlink(
+                    certificate_authority["certificate_path"], os.path.join(
+                        ca_dir, "%x.0" % certificate_authority["subject_name_hash"]
+                    )
+                )
             except Exception:
-                logger.error("Error symlinking syslog certificate, skipping remote syslog destination", exc_info=True)
+                logger.error("Error symlinking syslog CA, skipping remote syslog destination", exc_info=True)
                 return ""
+            else:
+                result += f"tls(ca-dir(\"{ca_dir}\") "
 
-            result += f'syslog("{host}" port({port}) transport("tls") tls(ca-dir("{ca_dir}")));'
+            certificate = middleware.call_sync(
+                "certificate.query", [("id", "=", advanced_config["syslog_tls_certificate"])]
+            )
+            if certificate and not certificate[0]["revoked"]:
+                result += f"key-file(\"{certificate[0]['privatekey_path']}\") " \
+                          f"cert-file(\"{certificate[0]['certificate_path']}\")"
+            else:
+                msg = 'Skipping setting key-file/cert-file for remote syslog as '
+                if not certificate:
+                    msg += 'no certificate configured'
+                else:
+                    msg += 'specified certificate has been revoked'
+                logger.debug(msg)
+
+            result += "));"
         else:
             transport = advanced_config["syslog_transport"].lower()
             result += f'{transport}("{host}" port({port}) localport(514));'

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -2773,7 +2773,9 @@ class CertificateAuthorityService(CRUDService):
         # Let's make sure we don't delete a ca which is being used by any service in the system
         for service_cert_id, text in [
             ((await self.middleware.call('openvpn.server.config'))['root_ca'], 'OpenVPN Server'),
-            ((await self.middleware.call('openvpn.client.config'))['root_ca'], 'OpenVPN Client')
+            ((await self.middleware.call('openvpn.client.config'))['root_ca'], 'OpenVPN Client'),
+            ((await self.middleware.call('system.advanced.config'))['syslog_tls_certificate_authority'],
+             'Syslog TLS CA'),
         ]:
             if service_cert_id == id:
                 verrors.add(

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -87,6 +87,9 @@ class SystemAdvancedModel(sa.Model):
     adv_syslogserver = sa.Column(sa.String(120), default='')
     adv_syslog_transport = sa.Column(sa.String(12), default="UDP")
     adv_syslog_tls_certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
+    adv_syslog_tls_certificate_authority_id = sa.Column(
+        sa.ForeignKey('system_certificateauthority.id'), index=True, nullable=True
+    )
     adv_kmip_uid = sa.Column(sa.String(255), nullable=True, default=None)
 
 

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -199,7 +199,7 @@ class SystemAdvancedService(ConfigService):
             )
             if not ca_cert:
                 verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Unable to locate specified CA')
-            elif ca_cert['revoked']:
+            elif ca_cert[0]['revoked']:
                 verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Specified CA has been revoked')
 
             if data['syslog_tls_certificate']:
@@ -332,7 +332,8 @@ class SystemAdvancedService(ConfigService):
                 original_data['sysloglevel'].lower() != config_data['sysloglevel'].lower() or
                 original_data['syslogserver'] != config_data['syslogserver'] or
                 original_data['syslog_transport'] != config_data['syslog_transport'] or
-                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate']
+                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate'] or
+                original_data['syslog_tls_certificate_authority'] != config_data['syslog_tls_certificate_authority']
             ):
                 await self.middleware.call('service.restart', 'syslogd')
 


### PR DESCRIPTION
This PR introduces following changes:

1. Adds another field for configuring CA for remote syslog as that's a requirement for both mutual/without mutual TLS authentication.
2. Use the CA field for creating a symlink as the process is not valid for certificate.
3. Make specifying certificate for remote syslog with TLS optional as if the syslog server has disabled mutual TLS authentication, that is not required and just making the CA changes specified (2) are enough.