### PR TITLE
NAS-111648 / 21.10 / fix filesystem.statfs

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -12,7 +12,6 @@ from middlewared.event import EventSource
 from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str
 from middlewared.service import private, CallError, filterable_returns, Service, job
 from middlewared.utils import filter_list
-from middlewared.utils.path import is_child
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -307,7 +307,7 @@ class FilesystemService(Service):
                 line = line.split()
                 _path = pathlib.Path(path)
                 _line_path = pathlib.Path(line[1])
-                if _path == _line_path or _path.parent == _line_path:
+                if _path == _line_path or _path.parent == _line_path or _line_path in list(_path.parents)[:-2]:
                     device = line[0]
                     mountpoint = line[1]
                     fstype = line[2]

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -1,26 +1,17 @@
 import binascii
-try:
-    from bsd import acl
-except ImportError:
-    acl = None
 import errno
 import functools
 import grp
 import os
 import pwd
-import select
 import shutil
-
+import pyinotify
 import psutil
-try:
-    import pyinotify
-except ImportError:
-    pyinotify = None
 
 from middlewared.event import EventSource
 from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str
 from middlewared.service import private, CallError, filterable_returns, Service, job
-from middlewared.utils import filter_list, osc
+from middlewared.utils import filter_list
 from middlewared.utils.path import is_child
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
@@ -396,37 +387,14 @@ class FileFollowTailEventSource(EventSource):
             self.send_event('ADDED', fields={'data': ''.join(data[-lines:])})
             f.seek(fsize)
 
-            if osc.IS_FREEBSD:
-                gen = self._follow_freebsd(f)
-            else:
-                gen = self._follow_linux(path, f)
-
-            for data in gen:
+            for data in self._follow_path(path, f):
                 self.send_event('ADDED', fields={'data': data})
 
-    def _follow_freebsd(self, f):
-        kqueue = select.kqueue()
-
-        ev = [select.kevent(
-            f.fileno(),
-            filter=select.KQ_FILTER_VNODE,
-            flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE | select.KQ_EV_CLEAR,
-            fflags=select.KQ_NOTE_DELETE | select.KQ_NOTE_EXTEND | select.KQ_NOTE_WRITE | select.KQ_NOTE_ATTRIB,
-        )]
-        kqueue.control(ev, 0, 0)
-
-        while not self._cancel_sync.is_set():
-            events = kqueue.control([], 1, 1)
-            if not events:
-                continue
-            # TODO: handle other file operations other than just extend/write
-            yield f.read()
-
-    def _follow_linux(self, path, f):
+    def _follow_path(self, path, f):
         queue = []
         watch_manager = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(watch_manager)
-        watch_manager.add_watch(path, pyinotify.IN_MODIFY, functools.partial(self._follow_linux_callback, queue, f))
+        watch_manager.add_watch(path, pyinotify.IN_MODIFY, functools.partial(self._follow_callback, queue, f))
 
         data = f.read()
         if data:
@@ -445,7 +413,7 @@ class FileFollowTailEventSource(EventSource):
 
         notifier.stop()
 
-    def _follow_linux_callback(self, queue, f, event):
+    def _follow_callback(self, queue, f, event):
         data = f.read()
         if data:
             queue.append(data)


### PR DESCRIPTION
Fix 2 issues.

1. remove unused code
2. remove unnecessarily complex `psutil.disk_partitions` for loop. Instead use `/proc/mounts` which allows us to receive any path and pull the appropriate `fstype` based on what is written in `/proc/mounts`