### PR TITLE
NAS-111634 / 21.10 / Correctly generate configuration for remote syslog with TLS (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-09-30_18-42_syslog_ca.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-09-30_18-42_syslog_ca.py
@@ -1,0 +1,32 @@
+"""
+Allow configuring CA for remote syslog tls connection
+
+Revision ID: 45d6f6f07b0f
+Revises: 26de83f45a9d
+Create Date: 2021-09-30 18:42:42.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '45d6f6f07b0f'
+down_revision = '26de83f45a9d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('adv_syslog_tls_certificate_authority_id', sa.Integer(), nullable=True))
+        batch_op.create_index(
+            batch_op.f('ix_system_advanced_adv_syslog_tls_certificate_authority_id'),
+            ['adv_syslog_tls_certificate_authority_id'], unique=False
+        )
+        batch_op.create_foreign_key(
+            batch_op.f('fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority'),
+            'system_certificateauthority', ['adv_syslog_tls_certificate_authority_id'], ['id']
+        )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-31_19-05_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-08-31_19-05_merge.py
@@ -1,0 +1,20 @@
+"""
+Merge
+
+Revision ID: b55d888749aa
+Revises: 8e991f9adcdf, 45d6f6f07b0f
+Create Date: 2021-08-31 19:05:57.583858+00:00
+
+"""
+revision = 'b55d888749aa'
+down_revision = ('8e991f9adcdf', '45d6f6f07b0f')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -89,6 +89,9 @@ class SystemAdvancedModel(sa.Model):
     adv_syslogserver = sa.Column(sa.String(120), default='')
     adv_syslog_transport = sa.Column(sa.String(12), default="UDP")
     adv_syslog_tls_certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
+    adv_syslog_tls_certificate_authority_id = sa.Column(
+        sa.ForeignKey('system_certificateauthority.id'), index=True, nullable=True
+    )
     adv_kmip_uid = sa.Column(sa.String(255), nullable=True, default=None)
     adv_kdump_enabled = sa.Column(sa.Boolean(), default=False)
     adv_isolated_gpu_pci_ids = sa.Column(sa.JSON(), default=[])

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -135,6 +135,7 @@ class SystemAdvancedService(ConfigService):
         Str('syslogserver'),
         Str('syslog_transport', enum=['UDP', 'TCP', 'TLS'], required=True),
         Int('syslog_tls_certificate', null=True, required=True),
+        Int('syslog_tls_certificate_authority', null=True, required=True),
         List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True),
         Str('kernel_extra_options', required=True),
         Int('id', required=True),
@@ -164,8 +165,8 @@ class SystemAdvancedService(ConfigService):
         if data.get('sysloglevel'):
             data['sysloglevel'] = data['sysloglevel'].upper()
 
-        if data['syslog_tls_certificate']:
-            data['syslog_tls_certificate'] = data['syslog_tls_certificate']['id']
+        for k in filter(lambda k: data[k], ['syslog_tls_certificate_authority', 'syslog_tls_certificate']):
+            data[k] = data[k]['id']
 
         if data['swapondrive'] and (await self.middleware.call('system.product_type')) == 'ENTERPRISE':
             data['swapondrive'] = 0
@@ -209,8 +210,23 @@ class SystemAdvancedService(ConfigService):
                     )
 
         if data['syslog_transport'] == 'TLS':
-            await self.middleware.call('certificate.cert_services_validation', data['syslog_tls_certificate'],
-                                       f'{schema}.syslog_tls_certificate')
+            if not data['syslog_tls_certificate_authority']:
+                verrors.add(
+                    f'{schema}.syslog_tls_certificate_authority', 'This is required when using TLS as syslog transport'
+                )
+            ca_cert = await self.middleware.call(
+                'certificateauthority.query', [['id', '=', data['syslog_tls_certificate_authority']]]
+            )
+            if not ca_cert:
+                verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Unable to locate specified CA')
+            elif ca_cert['revoked']:
+                verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Specified CA has been revoked')
+
+            if data['syslog_tls_certificate']:
+                verrors.extend(await self.middleware.call(
+                    'certificate.cert_services_validation', data['syslog_tls_certificate'],
+                    f'{schema}.syslog_tls_certificate', False
+                ))
 
         if data['isolated_gpu_pci_ids']:
             available = set([gpu['addr']['pci_slot'] for gpu in await self.middleware.call('device.get_gpus')])

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -219,7 +219,7 @@ class SystemAdvancedService(ConfigService):
             )
             if not ca_cert:
                 verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Unable to locate specified CA')
-            elif ca_cert['revoked']:
+            elif ca_cert[0]['revoked']:
                 verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Specified CA has been revoked')
 
             if data['syslog_tls_certificate']:
@@ -359,7 +359,8 @@ class SystemAdvancedService(ConfigService):
                 original_data['sysloglevel'].lower() != config_data['sysloglevel'].lower() or
                 original_data['syslogserver'] != config_data['syslogserver'] or
                 original_data['syslog_transport'] != config_data['syslog_transport'] or
-                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate']
+                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate'] or
+                original_data['syslog_tls_certificate_authority'] != config_data['syslog_tls_certificate_authority']
             ):
                 await self.middleware.call('service.restart', 'syslogd')
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x e3f84bb5b98166ca7618de8c3ae129aad427027e
    git cherry-pick -x 3121567f58ea93ff464ab9558465a7e13a1b7dfb
    git cherry-pick -x ec1344c864fa395845a6395c8ea040e6a2365e50

This PR introduces following changes:

1. Adds another field for configuring CA for remote syslog as that's a requirement for both mutual/without mutual TLS authentication.
2. Use the CA field for creating a symlink as the process is not valid for certificate.
3. Make specifying certificate for remote syslog with TLS optional as if the syslog server has disabled mutual TLS authentication, that is not required and just making the CA changes specified (2) are enough.

Original PR: https://github.com/truenas/middleware/pull/7437
Jira URL: https://jira.ixsystems.com/browse/NAS-111634