### PR TITLE
NAS-112107 / 21.10 / Add endpoint clarifying why virtualization is not supported

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/info_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/info_linux.py
@@ -29,6 +29,21 @@ class VMService(Service):
         return cp.returncode == 0
 
     @accepts()
+    @returns(Dict(
+        Bool('supported', required=True),
+        Str('error', null=True, required=True),
+    ))
+    async def virtualization_details(self):
+        """
+        Retrieve details if virtualization is supported on the system and in case why it's not supported if it isn't.
+        """
+        cp = await run(['kvm-ok'], check=False)
+        return {
+            'supported': cp.returncode == 0,
+            'error': None if cp.returncode == 0 else cp.stdout.decode(),
+        }
+
+    @accepts()
     @returns(Int())
     async def maximum_supported_vcpus(self):
         """

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -47,7 +47,7 @@ class VMService(Service, VMSupervisorMixin):
 
     @private
     def initialize_vms(self, timeout=30):
-        if self.middleware.call_sync('vm.query'):
+        if self.middleware.call_sync('vm.query') and self.middleware.call_sync('vm.supports_virtualization'):
             self.setup_libvirt_connection(timeout)
         else:
             return


### PR DESCRIPTION
This PR adds changes to improve the UI experience where if virtualization cannot be used, we report that to the user appropriately and also do a best effort of clarifying why that is the case so he/she can address it.