### PR TITLE
NAS-111179 / 21.10 / improve gathering DMI information

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -53,7 +53,6 @@ FIRST_INSTALL_SENTINEL = '/data/first-boot'
 LICENSE_FILE = '/data/license'
 
 RE_KDUMP_CONFIGURED = re.compile(r'current state\s*:\s*(ready to kdump)', flags=re.M)
-RE_ECC_MEMORY = re.compile(r'Error Correction Type:\s*(.*ECC.*)')
 
 DEBUG_MAX_SIZE = 30
 

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -400,16 +400,6 @@ class SystemAdvancedService(ConfigService):
 
 class SystemService(Service):
 
-    DMIDECODE_CACHE = {
-        'ecc-memory': None,
-        'baseboard-manufacturer': None,
-        'baseboard-product-name': None,
-        'system-manufacturer': None,
-        'system-product-name': None,
-        'system-serial-number': None,
-        'system-version': None,
-    }
-
     CPU_INFO = {
         'cpu_model': None,
         'core_count': None,
@@ -485,57 +475,6 @@ class SystemService(Service):
             'boot_time': datetime.fromtimestamp((current_time - uptime_seconds), timezone.utc),
             'datetime': datetime.fromtimestamp(current_time, timezone.utc),
         }
-
-    @private
-    async def dmidecode_info(self):
-        """
-        dmidecode data is mostly static so cache the results
-        """
-
-        if self.DMIDECODE_CACHE['ecc-memory'] is None:
-            # https://superuser.com/questions/893560/how-do-i-tell-if-my-memory-is-ecc-or-non-ecc/893569#893569
-            # After discussing with nap, we determined that checking -t 17 did not work well with some systems,
-            # so we check -t 16 now only to see if it reports ECC memory
-            ecc = bool(RE_ECC_MEMORY.findall((await run(['dmidecode', '-t', '16'])).stdout.decode(errors='ignore')))
-            self.DMIDECODE_CACHE['ecc-memory'] = ecc
-
-        if self.DMIDECODE_CACHE['baseboard-manufacturer'] is None:
-            bm = (
-                (await run(['dmidecode', '-s', 'baseboard-manufacturer'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['baseboard-manufacturer'] = bm
-
-        if self.DMIDECODE_CACHE['baseboard-product-name'] is None:
-            bpn = (
-                (await run(['dmidecode', '-s', 'baseboard-product-name'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['baseboard-product-name'] = bpn
-
-        if self.DMIDECODE_CACHE['system-manufacturer'] is None:
-            sm = (
-                (await run(['dmidecode', '-s', 'system-manufacturer'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['system-manufacturer'] = sm
-
-        if self.DMIDECODE_CACHE['system-product-name'] is None:
-            spn = (
-                (await run(['dmidecode', '-s', 'system-product-name'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['system-product-name'] = spn
-
-        if self.DMIDECODE_CACHE['system-serial-number'] is None:
-            ssn = (
-                (await run(['dmidecode', '-s', 'system-serial-number'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['system-serial-number'] = ssn
-
-        if self.DMIDECODE_CACHE['system-version'] is None:
-            sv = (
-                (await run(['dmidecode', '-s', 'system-version'], check=False)).stdout.decode(errors='ignore')
-            ).strip()
-            self.DMIDECODE_CACHE['system-version'] = sv
-
-        return self.DMIDECODE_CACHE
 
     @no_auth_required
     @accepts()
@@ -829,8 +768,7 @@ class SystemService(Service):
 
     @private
     async def is_ix_hardware(self):
-        dmidecode = await self.middleware.call('system.dmidecode_info')
-        product = dmidecode['system-product-name']
+        product = (await self.middleware.call('system.dmidecode_info'))['system-product-name']
         return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))
 
     @private

--- a/src/middlewared/middlewared/plugins/system_/dmi.py
+++ b/src/middlewared/middlewared/plugins/system_/dmi.py
@@ -1,0 +1,61 @@
+import subprocess
+
+from middlewared.service import private, Service
+
+
+class SystemService(Service):
+    # DMI information is mostly static so cache it
+    CACHE = {
+        'ecc-memory': None,
+        'baseboard-manufacturer': None,
+        'baseboard-product-name': None,
+        'system-manufacturer': None,
+        'system-product-name': None,
+        'system-serial-number': None,
+        'system-version': None,
+    }
+
+    @private
+    def dmidecode_info(self):
+        if all(v is None for k, v in SystemService.CACHE.items()):
+            cp = subprocess.run(['dmidecode', '-t', '1,2,16'], encoding='utf8', capture_output=True)
+            self._parse_dmi(cp.stdout.splitlines())
+
+        return SystemService.CACHE
+
+    @private
+    def _parse_dmi(self, lines):
+        for line in lines:
+            if '# No SMBIOS nor DMI entry point found' in line:
+                # means no DMI information available so fill out cache
+                # with empty values so we don't continually try to fill it
+                # (which defeats the entire purpose of having a cache)
+                SystemService.CACHE = {i: '' for i in SystemService.CACHE}
+                break
+
+            if 'DMI type 1,' in line:
+                _type = 'SYSINFO'
+            if 'DMI type 2,' in line:
+                _type = 'BBINFO'
+
+            if not line or ':' not in line:
+                # "sections" are separated by the category name and then
+                # a newline so ignore those lines
+                continue
+
+            sect, val = [i.strip() for i in line.split(':')]
+            if sect == 'Manufacturer':
+                SystemService.CACHE['system-manufacturer' if _type == 'SYSINFO' else 'baseboard-manufacturer'] = val
+            elif sect == 'Product Name':
+                SystemService.CACHE['system-product-name' if _type == 'SYSINFO' else 'baseboard-product-name'] = val
+            elif sect == 'Serial Number' and _type == 'SYSINFO':
+                SystemService.CACHE['system-serial-number'] = val
+            elif sect == 'Version' and _type == 'SYSINFO':
+                SystemService.CACHE['system-version'] = val
+            elif sect == 'Error Correction Type':
+                SystemService.CACHE['ecc-memory'] = 'ECC' in val
+                # we break the for loop here since "16" is the last section
+                # that gets processed and dmidecode always list the data in
+                # the same order as requested (1,2,16) and "Error Correction Type"
+                # doesn't appear in any of the other sections
+                break

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -1,0 +1,90 @@
+from middlewared.plugins.system_.dmi import SystemService
+from middlewared.service import Service
+
+
+full_dmi = ("""
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.2.1 present.
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+        Manufacturer: iXsystems
+        Product Name: TRUENAS-M60
+        Version: 0123456789
+        Serial Number: A1-111111
+        UUID: 00000000-0000-0000-0000-3cecef5ee7d6
+        Wake-up Type: Power Switch
+        SKU Number: To be filled by O.E.M.
+        Family: To be filled by O.E.M.
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Supermicro
+        Product Name: X11SPH-nCTPF
+        Version: 1.01
+        Serial Number: 0000000000000
+        Asset Tag: To be filled by O.E.M.
+        Features:
+                Board is a hosting board
+                Board is replaceable
+        Location In Chassis: To be filled by O.E.M.
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+Handle 0x0024, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: System Board Or Motherboard
+        Use: System Memory
+        Error Correction Type: Single-bit ECC
+        Maximum Capacity: 2304 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 4
+
+Handle 0x002C, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: System Board Or Motherboard
+        Use: System Memory
+        Error Correction Type: Single-bit ECC
+        Maximum Capacity: 2304 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 4
+
+""").splitlines()
+
+no_dmi = ("""
+# dmidecode 3.2
+Scanning /dev/mem for entry point.
+# No SMBIOS nor DMI entry point found, sorry.
+""").splitlines()
+
+
+def test__full_dmi_parse():
+    expected_result = {
+        'ecc-memory': True,
+        'baseboard-manufacturer': 'Supermicro',
+        'baseboard-product-name': 'X11SPH-nCTPF',
+        'system-manufacturer': 'iXsystems',
+        'system-product-name': 'TRUENAS-M60',
+        'system-serial-number': 'A1-111111',
+        'system-version': '0123456789',
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(full_dmi)
+    assert obj.CACHE == expected_result
+
+
+def test__no_dmi_parse():
+    expected_result = {
+        'ecc-memory': '',
+        'baseboard-manufacturer': '',
+        'baseboard-product-name': '',
+        'system-manufacturer': '',
+        'system-product-name': '',
+        'system-serial-number': '',
+        'system-version': '',
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(no_dmi)
+    assert obj.CACHE == expected_result


### PR DESCRIPTION
On `middlewared` service start up or at boot time, 7 subprocess'es run back-to-back to fill out the DMI information. This does not scale well when the system is very busy. `dmidecode` allows you to specify all  the "types" at once so we can gather this information via 1 subprocess which is a 7x improvement in that respect. Furthermore, separate the dmi related methods to their own module in `system_/dmi.py`.