### PR TITLE
NAS-112156 / 21.10 / add more unit tests for dmidecode edge cases

### DIFF
--- a/src/middlewared/middlewared/plugins/system_/dmi.py
+++ b/src/middlewared/middlewared/plugins/system_/dmi.py
@@ -25,14 +25,8 @@ class SystemService(Service):
 
     @private
     def _parse_dmi(self, lines):
+        SystemService.CACHE = {i: '' for i in SystemService.CACHE}
         for line in lines:
-            if '# No SMBIOS nor DMI entry point found' in line:
-                # means no DMI information available so fill out cache
-                # with empty values so we don't continually try to fill it
-                # (which defeats the entire purpose of having a cache)
-                SystemService.CACHE = {i: '' for i in SystemService.CACHE}
-                break
-
             if 'DMI type 1,' in line:
                 _type = 'SYSINFO'
             if 'DMI type 2,' in line:

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -53,14 +53,101 @@ Physical Memory Array
 
 """).splitlines()
 
-no_dmi = ("""
-# dmidecode 3.2
-Scanning /dev/mem for entry point.
-# No SMBIOS nor DMI entry point found, sorry.
+missing_dmi = []
+
+missing_dmi_type1 = ("""
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Supermicro
+        Product Name: X11SPH-nCTPF
+        Version: 1.01
+        Serial Number: 0000000000000
+        Asset Tag: To be filled by O.E.M.
+        Features:
+                Board is a hosting board
+                Board is replaceable
+        Location In Chassis: To be filled by O.E.M.
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+Handle 0x1000, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: Other
+        Use: System Memory
+        Error Correction Type: Multi-bit ECC
+        Maximum Capacity: 8 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 1
+
+""").splitlines()
+
+missing_dmi_type2 = ("""
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+        Manufacturer: QEMU
+        Product Name: Standard PC (Q35 + ICH9, 2009)
+        Version: pc-q35-5.2
+        Serial Number: Not Specified
+        UUID: 236ce080-e87b-4d21-b9dd-3e43b8fb58dd
+        Wake-up Type: Power Switch
+        SKU Number: Not Specified
+        Family: Not Specified
+
+Handle 0x1000, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: Other
+        Use: System Memory
+        Error Correction Type: Multi-bit ECC
+        Maximum Capacity: 8 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 1
+
+""").splitlines()
+
+missing_dmi_type16 = ("""
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+
+Handle 0x0100, DMI type 1, 27 bytes
+System Information
+        Manufacturer: QEMU
+        Product Name: Standard PC (Q35 + ICH9, 2009)
+        Version: pc-q35-5.2
+        Serial Number: Not Specified
+        UUID: 236ce080-e87b-4d21-b9dd-3e43b8fb58dd
+        Wake-up Type: Power Switch
+        SKU Number: Not Specified
+        Family: Not Specified
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Supermicro
+        Product Name: X11SPH-nCTPF
+        Version: 1.01
+        Serial Number: 0000000000000
+        Asset Tag: To be filled by O.E.M.
+        Features:
+                Board is a hosting board
+                Board is replaceable
+        Location In Chassis: To be filled by O.E.M.
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
 """).splitlines()
 
 
-def test__full_dmi_parse():
+def test__full_dmi():
     expected_result = {
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
@@ -75,7 +162,7 @@ def test__full_dmi_parse():
     assert obj.CACHE == expected_result
 
 
-def test__no_dmi_parse():
+def test__missing_dmi():
     expected_result = {
         'ecc-memory': '',
         'baseboard-manufacturer': '',
@@ -86,5 +173,50 @@ def test__no_dmi_parse():
         'system-version': '',
     }
     obj = SystemService(Service)
-    obj._parse_dmi(no_dmi)
+    obj._parse_dmi(missing_dmi)
+    assert obj.CACHE == expected_result
+
+
+def test__missing_dmi_type1():
+    expected_result = {
+        'ecc-memory': True,
+        'baseboard-manufacturer': 'Supermicro',
+        'baseboard-product-name': 'X11SPH-nCTPF',
+        'system-manufacturer': '',
+        'system-product-name': '',
+        'system-serial-number': '',
+        'system-version': '',
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(missing_dmi_type1)
+    assert obj.CACHE == expected_result
+
+
+def test__missing_dmi_type2():
+    expected_result = {
+        'ecc-memory': True,
+        'baseboard-manufacturer': '',
+        'baseboard-product-name': '',
+        'system-manufacturer': 'QEMU',
+        'system-product-name': 'Standard PC (Q35 + ICH9, 2009)',
+        'system-serial-number': 'Not Specified',
+        'system-version': 'pc-q35-5.2',
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(missing_dmi_type2)
+    assert obj.CACHE == expected_result
+
+
+def test__missing_dmi_type16():
+    expected_result = {
+        'ecc-memory': '',
+        'baseboard-manufacturer': 'Supermicro',
+        'baseboard-product-name': 'X11SPH-nCTPF',
+        'system-manufacturer': 'QEMU',
+        'system-product-name': 'Standard PC (Q35 + ICH9, 2009)',
+        'system-serial-number': 'Not Specified',
+        'system-version': 'pc-q35-5.2',
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(missing_dmi_type16)
     assert obj.CACHE == expected_result


### PR DESCRIPTION
Setting up SCALE cluster and writing unit tests, I noticed that `dmidecode` omits certain information (at least inside a KVM vm). Fix the logic in `dmi.py` and add more unit tests to account for this scenario.

Also, unified the unit test names.