### PR TITLE
NAS-112163 / 21.10 / Properly apply default SMB acl on dataset creation

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3306,7 +3306,7 @@ class PoolDatasetService(CRUDService):
         created_ds = await self.get_instance(data['id'])
 
         if data['type'] == 'FILESYSTEM' and data['share_type'] == 'SMB' and created_ds['acltype']['value'] == "NFSV4":
-            acl_job = await self.middleware.call('pool.dataset.permission', data['id'], {'mode': None})
+            acl_job = await self.middleware.call('pool.dataset.permission', data['id'], {'options': {'set_default_acl': True}})
             await acl_job.wait()
 
         return created_ds


### PR DESCRIPTION
Underlying API behavior changed slightly. Legacy behavior for
compatibility with requests from old django UI was to apply a
default ACL if `mode` and `acl` were empty. New behavior
requires explicitly setting option
```
{'options': {'set_default_acl': True}}
```