### PR TITLE
NAS-111702 / 21.10 / Fix microsoft_account feature

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -416,6 +416,10 @@ class UserService(CRUDService):
         if data['smb']:
             gm_job = await self.middleware.call('smb.synchronize_passdb')
             await gm_job.wait()
+            if data.get('microsoft_account'):
+                has_username_map = await self.middleware.call('smb.getparm', 'username map', 'GLOBAL')
+                if not has_username_map:
+                    await self.middleware.call('smb.initialize_globals')
 
         if os.path.isdir(SKEL_PATH) and os.path.exists(data['home']):
             for f in os.listdir(SKEL_PATH):
@@ -608,6 +612,11 @@ class UserService(CRUDService):
         if user['smb'] and must_change_pdb_entry:
             gm_job = await self.middleware.call('smb.synchronize_passdb')
             await gm_job.wait()
+
+        if user.get('microsoft_account'):
+            has_username_map = await self.middleware.call('smb.getparm', 'username map', 'GLOBAL')
+            if not has_username_map:
+                await self.middleware.call('smb.initialize_globals')
 
         return pk
 

--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -133,6 +133,11 @@ class SMBService(Service):
         to_set = {}
         data['ds_state'] = await self.middleware.call('directoryservices.get_state')
         data['shares'] = await self.middleware.call('sharing.smb.query')
+        data['ms_accounts'] = await self.middleware.call(
+            'user.query',
+            [('microsoft_account', '=', True), ('locked', '=', False)],
+            {'count': True}
+        )
         gs = GlobalSchema()
         gs.convert_schema_to_registry(data, to_set)
 

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -14,6 +14,7 @@ class GlobalSchema(RegistrySchema):
     def convert_schema_to_registry(self, data_in, data_out):
         super().convert_schema_to_registry(data_in, data_out)
         shares = data_in.pop('shares')
+        ms_accounts = data_in.pop('ms_accounts')
 
         """
         When guest access permitted on any share:
@@ -36,6 +37,9 @@ class GlobalSchema(RegistrySchema):
             data_out['map to guest'] = {'parsed': 'Bad User'}
 
         ds_state = data_in.pop('ds_state')
+        if ms_accounts and ds_state['activedirectory'] == 'DISABLED':
+            data_out['username map'] = {'parsed': '/etc/smbusername.map'}
+
         if ds_state['ldap'] in ['LEAVING', 'DISABLED']:
             data_out.update({
                 'passdb backend': {'parsed': 'tdbsam:/root/samba/private/passdb.tdb'},


### PR DESCRIPTION
By default home editions of Windows will attempt to authenticate
to SMB shares using the user's microsoft account (email address
name). In legacy versions of FreeNAS the decision was made to
create a username mapping for samba to map a user's email address
to the account name. This simplifies particular edge cases
where Windows appears to "forget" the stored credentials for an
SMB server and attempts to authenticate using the "microsoft
account" credentials. During migration to a different smb.conf
backend, this behavior was broken. The mapping file was still
being created, but the smb.conf parameter to use it was not
added. We really don't want this parameter / file to be added
unilaterally. In early TrueNAS 11.3 releases it was observed
that these mappings / lookups in some cases could cause
failures to look up AD users, hence the restriction to the
case of servers that aren't joined to AD. At some future
point in time, this feature should be re-evaluated and possibly
removed.