### PR TITLE
NAS-111856 / 12.0 / Fix ups reporting when running in slave mode

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/plugins_freebsd.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins_freebsd.py
@@ -212,11 +212,16 @@ class UPSBase(object):
 
     plugin = 'nut'
 
-    def get_identifiers(self):
+    @property
+    def _base_path(self):
         ups_config = self.middleware.call_sync('ups.config')
-        ups_identifier = ups_config['identifier']
         if ups_config['mode'] == 'SLAVE':
-            self._base_path = os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
+            return os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
+        else:
+            return super()._base_path
+
+    def get_identifiers(self):
+        ups_identifier = self.middleware.call_sync('ups.config')['identifier']
 
         if all(os.path.exists(os.path.join(self._base_path, f'{self.plugin}-{ups_identifier}', f'{_type}.rrd'))
                for _type, dsname, transform, in self.rrd_types):

--- a/src/middlewared/middlewared/plugins/reporting/plugins_freebsd.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins_freebsd.py
@@ -3,7 +3,7 @@ import os
 import re
 import sysctl
 
-from .rrd_utils import RRDBase
+from .rrd_utils import RRDBase, RRD_BASE_DIR_PATH
 
 
 RE_DISK = re.compile(r'^[a-z]+[0-9]+$')
@@ -213,7 +213,10 @@ class UPSBase(object):
     plugin = 'nut'
 
     def get_identifiers(self):
-        ups_identifier = self.middleware.call_sync('ups.config')['identifier']
+        ups_config = self.middleware.call_sync('ups.config')
+        ups_identifier = ups_config['identifier']
+        if ups_config['mode'] == 'SLAVE':
+            self._base_path = os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
 
         if all(os.path.exists(os.path.join(self._base_path, f'{self.plugin}-{ups_identifier}', f'{_type}.rrd'))
                for _type, dsname, transform, in self.rrd_types):

--- a/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
@@ -59,8 +59,14 @@ class RRDBase(object, metaclass=RRDMeta):
 
     def __init__(self, middleware):
         self.middleware = middleware
-        self._base_path = RRD_BASE_PATH
-        self.base_path = os.path.join(self._base_path, self.plugin)
+
+    @property
+    def _base_path(self):
+        return RRD_BASE_PATH
+
+    @property
+    def base_path(self):
+        return os.path.join(self._base_path, self.plugin)
 
     def __repr__(self):
         return f'<RRD:{self.plugin}>'

--- a/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
@@ -11,7 +11,8 @@ import humanfriendly
 from middlewared.service_exception import CallError, ErrnoMixin
 
 
-RRD_BASE_PATH = '/var/db/collectd/rrd/localhost'
+RRD_BASE_DIR_PATH = '/var/db/collectd/rrd'
+RRD_BASE_PATH = os.path.join(RRD_BASE_DIR_PATH, 'localhost')
 RE_COLON = re.compile('(.+):(.+)$')
 RE_LAST_UPDATE = re.compile(r'last_update = (\d+)')
 RE_NAME = re.compile(r'(%name_(\d+)%)')


### PR DESCRIPTION
This commit fixes an issue when we would not be showing reporting for UPS when it was running in slave mode because collectd stores ups logs in a different directory when it's running in slave mode.