### PR TITLE
NAS-112167 / 21.10 / Do not generate username map unless required

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smbusername.map.mako
+++ b/src/middlewared/middlewared/etc_files/local/smbusername.map.mako
@@ -11,10 +11,10 @@
         ('email', '!=', None),
         ('email', '!=', ''),
     ])
+    if not users:
+        raise FileShouldNotExist()
 
 %>
-% if users:
 % for user in users:
 ${user['username']} = ${user['email']}
 % endfor
-% endif

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -942,6 +942,10 @@ class UserService(CRUDService):
                     'Please provide a valid value for home_mode attribute'
                 )
 
+        if data.get('microsoft_account') and not data.get('email'):
+            verrors.add(f'{schema}.microsoft_account',
+                        'The Microsoft Account feature requires an email address.')
+
         if 'groups' in data:
             groups = data.get('groups') or []
             if groups and len(groups) > 64:


### PR DESCRIPTION
Raise FileShouldNotExist() if there will be no users in it.
Also add validation to account plugin to ensure we have
an email address before allowing users to populate.