### PR TITLE
NAS-112017 / 21.10 / Check allocatable gpu's instead of seeing capacity for k8s

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -94,7 +94,7 @@ class KubernetesGPUService(Service):
             return {}
 
         return {
-            k: v for k, v in node_config['status']['capacity'].items()
+            k: v for k, v in node_config['status']['allocatable'].items()
             if k.endswith('/gpu') or k.startswith('gpu.intel')
         }
 


### PR DESCRIPTION
This commit adds changes to use the figure provided by allocatable stats instead of the ones specified by capacity as if a GPU is old but the device plugin supports it but it is lacking some feature and can't be consumed, it would show up in capacity but in allocatable it would be 0 which is what reflects reality from user perspective wrt consumption.