### PR TITLE
NAS-111491 / 21.10 / Tear down guest memory using libvirt events

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/events.py
+++ b/src/middlewared/middlewared/plugins/vm/events.py
@@ -60,7 +60,9 @@ class VMService(Service, LibvirtConnectionMixin):
             if vm_id.isdigit() and emit_type != 'REMOVED' and dom.name() in vms:
                 vm = vms[dom.name()]
                 vm['status']['state'] = state
-                self.middleware.send_event('vm.query', emit_type, id=int(vm_id), fields=vm)
+                self.middleware.send_event(
+                    'vm.query', emit_type, id=int(vm_id), fields=vm, state=vm_state_mapping.get(event, 'UNKNOWN')
+                )
             else:
                 self.middleware.logger.debug('Received libvirtd event with unknown domain name %s', dom.name())
 

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
@@ -102,7 +102,7 @@ class VMSupervisorBase(LibvirtConnectionMixin):
 
     def __getattribute__(self, item):
         retrieved_item = object.__getattribute__(self, item)
-        if callable(retrieved_item) and item in ('start', 'stop', 'restart', 'poweroff', 'undefine_domain', 'status'):
+        if callable(retrieved_item) and item in ('start', 'stop', 'poweroff', 'undefine_domain', 'status'):
             if not getattr(self, 'domain', None):
                 raise RuntimeError('Domain attribute not defined, please re-instantiate the VM class')
 
@@ -219,17 +219,6 @@ class VMSupervisorBase(LibvirtConnectionMixin):
         while shutdown_timeout > 0 and self.status()['state'] == 'RUNNING':
             shutdown_timeout -= 5
             time.sleep(5)
-
-    def restart(self, vm_data=None, shutdown_timeout=None):
-        self.stop(shutdown_timeout)
-
-        # We don't wait anymore because during stop we have already waited for the VM to shutdown cleanly
-        if self.status()['state'] == 'RUNNING':
-            # In case domain stopped between this time
-            with contextlib.suppress(libvirt.libvirtError):
-                self.poweroff()
-
-        self.start(vm_data)
 
     def poweroff(self):
         self._before_stopping_checks()

--- a/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_supervisor.py
@@ -69,11 +69,6 @@ class VMSupervisorMixin(LibvirtConnectionMixin):
         self._check_domain_running(vm_name)
         self.vms[vm_name].stop(shutdown_timeout)
 
-    def _restart(self, vm_name):
-        self._check_domain_running(vm_name)
-        vm = self._vm_from_name(vm_name)
-        self.vms[vm_name].restart(vm_data=vm, shutdown_timeout=vm['shutdown_timeout'])
-
     def _status(self, vm_name):
         self._check_setup_connection()
         return self.vms[vm_name].status()


### PR DESCRIPTION
This PR adds changes to tear down guest memory using libvirt events as VMs can be shutdown from the VM itself as well which means that we would not be releasing the memory allocated back if a VM is shut down that way.