### PR TITLE
NAS-110666 / 12.0 / Run top in non-interactive mode

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
@@ -102,8 +102,8 @@ system_func()
 		vmstat -ia
 		section_footer
 
-		section_header "top -SHIwz -d 2"
-		top -SHIwz -d 2
+		section_header "top -SHInwz -d 2"
+		top -SHInwz -d 2
 		section_footer
 
 		section_header "procstat -akk"


### PR DESCRIPTION
When run without TERM set, top fails to correctly configure its line
width, causing the process list lines to be blank.

Invoke in non-interactive mode to force line_width to 1024.

Jira: NAS-110666