### PR TITLE
NAS-111612 / 12.0 / Wait for lagg interface to properly become active

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -1,3 +1,5 @@
+import time
+
 from middlewared.service import Service
 
 from .netif import netif
@@ -61,3 +63,11 @@ class InterfaceService(Service):
                 continue
             parent_interfaces.append(port[0])
             port_iface.up()
+
+        interval = 10
+        while iface.link_state != netif.InterfaceLinkState.LINK_STATE_UP and interval > 0:
+            time.sleep(2)
+            interval -= 2
+
+        if iface.link_state != netif.InterfaceLinkState.LINK_STATE_UP:
+            self.logger.error('Timed out waiting for %r interface link state to become active', name)


### PR DESCRIPTION
This commit adds changes to wait for lagg interface to actually become active before we try moving on starting services which might be relying on the lagg interface. We add a grace period of 10 seconds for that to happen and if it doesn't till then, we move on logging that it wasn't active as there can be cases where that never happens.