### PR TITLE
NAS-112259 / 12.0 / Backport groupmap fixes

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -353,7 +353,8 @@ class UserService(CRUDService):
         await self.middleware.call('service.reload', 'user')
 
         if data['smb']:
-            await self.middleware.call('smb.synchronize_passdb')
+            gm_job = await self.middleware.call('smb.synchronize_passdb')
+            await gm_job.wait()
 
         if os.path.exists(data['home']):
             for f in os.listdir(SKEL_PATH):
@@ -543,7 +544,8 @@ class UserService(CRUDService):
 
         await self.middleware.call('service.reload', 'user')
         if user['smb'] and must_change_pdb_entry:
-            await self.middleware.call('smb.synchronize_passdb')
+            gm_job = await self.middleware.call('smb.synchronize_passdb')
+            await gm_job.wait()
 
         return pk
 
@@ -1102,7 +1104,8 @@ class GroupService(CRUDService):
             await self.middleware.call('service.reload', 'user')
 
         if data['smb']:
-            await self.middleware.call('smb.synchronize_group_mappings')
+            gm_job = await self.middleware.call('smb.synchronize_group_mappings')
+            await gm_job.wait()
 
         return pk
 
@@ -1158,7 +1161,8 @@ class GroupService(CRUDService):
         await self.middleware.call('service.reload', 'user')
 
         if groupmap_changed:
-            await self.middleware.call('smb.synchronize_group_mappings')
+            gm_job = await self.middleware.call('smb.synchronize_group_mappings')
+            await gm_job.wait()
 
         return pk
 
@@ -1171,14 +1175,12 @@ class GroupService(CRUDService):
         """
 
         group = await self._get_instance(pk)
-        if group['smb']:
-            await self.middleware.call('smb.synchronize_group_mappings')
-
         if group['builtin']:
             raise CallError('A built-in group cannot be deleted.', errno.EACCES)
 
         nogroup = await self.middleware.call('datastore.query', 'account.bsdgroups', [('group', '=', 'nogroup')],
                                              {'prefix': 'bsdgrp_', 'get': True})
+
         for i in await self.middleware.call('datastore.query', 'account.bsdusers', [('group', '=', group['id'])],
                                             {'prefix': 'bsdusr_'}):
             if options['delete_users']:
@@ -1188,6 +1190,10 @@ class GroupService(CRUDService):
                                            {'prefix': 'bsdusr_'})
 
         await self.middleware.call('datastore.delete', 'account.bsdgroups', pk)
+
+        if group['smb']:
+            gm_job = await self.middleware.call('smb.synchronize_group_mappings')
+            await gm_job.wait()
 
         await self.middleware.call('service.reload', 'user')
 

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -217,11 +217,15 @@ class IdmapDomainService(CRUDService):
         return (low_range, high_range)
 
     @private
-    async def remove_winbind_idmap_tdb(self):
+    async def snapshot_samba4_dataset(self):
         sysdataset = (await self.middleware.call('systemdataset.config'))['basename']
         ts = str(datetime.datetime.now(datetime.timezone.utc).timestamp())[:10]
         await self.middleware.call('zfs.snapshot.create', {'dataset': f'{sysdataset}/samba4',
                                                            'name': f'wbc-{ts}'})
+
+    @private
+    async def remove_winbind_idmap_tdb(self):
+        await self.snapshot_samba4_dataset()
         try:
             os.remove('/var/db/system/samba4/winbindd_idmap.tdb')
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -66,6 +66,13 @@ class SMBBuiltin(enum.Enum):
     def sids():
         return [x.value[1] for x in SMBBuiltin]
 
+    def by_rid(rid):
+        for x in SMBBuiltin:
+            if x.value[1].endswith(str(rid)):
+                return x
+
+        return None
+
 
 class SMBPath(enum.Enum):
     GLOBALCONF = ('/usr/local/etc/smb4.conf', '/etc/smb4.conf', 0o755, False)

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -255,8 +255,8 @@ class SMBService(Service):
 
     @private
     async def sync_builtins(self, groupmap):
-        idmap_backend = await self.middleware.call("smb.getparm", "idmap config *:backend", "GLOBAL")
-        idmap_range = await self.middleware.call("smb.getparm", "idmap config *:range", "GLOBAL")
+        idmap_backend = await self.middleware.call("smb.getparm", "idmap config * : backend", "GLOBAL")
+        idmap_range = await self.middleware.call("smb.getparm", "idmap config * : range", "GLOBAL")
         payload = {"ADD": [{"groupmap": []}], "MOD": [{"groupmap": []}], "DEL": [{"groupmap": []}]}
         must_reload = False
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -85,12 +85,12 @@ class SMBService(Service):
         async def add_to_payload(payload, alias, key, members):
             idx = next((i for i, x in enumerate(payload[key]) if x["alias"] == alias), None)
             if not idx:
-                payload["ADDMEM"].append({
+                payload[key].append({
                     "alias": alias,
                     "members": members,
                 })
             else:
-                payload["ADDMEM"][idx]["members"].append(members)
+                payload[key][idx]["members"].append(members)
 
         if diff.get("ADDMEM"):
             await add_to_payload(payload, alias, "ADDMEM", diff["ADDMEM"])
@@ -142,7 +142,7 @@ class SMBService(Service):
                                                  {'groupname': admin_group})
             admin_sid = await self.middleware.call(
                 'idmap.unixid_to_sid',
-                {"id_type": "GROUP", "id": grp_obj["gid"]}
+                {"id_type": "GROUP", "id": grp_obj["gr_gid"]}
             )
             if admin_sid:
                 expected.append(admin_sid)

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -345,15 +345,24 @@ class SMBService(Service):
 
         groups = await self.middleware.call('group.query', [('builtin', '=', False), ('smb', '=', True)])
         g_dict = {x["gid"]: x for x in groups}
+        intersect = set(g_dict.keys()).intersection(set(groupmap["local"].keys()))
 
         set_to_add = set(g_dict.keys()) - set(groupmap["local"].keys())
         set_to_del = set(groupmap["local"].keys()) - set(g_dict.keys())
+        set_to_mod = set([x for x in intersect if groupmap['local'][x]['nt_name'] != g_dict[x]['group']])
 
         to_add = [{
             "gid": g_dict[x]["gid"],
             "nt_name": g_dict[x]["group"],
             "group_type_str": "local"
         } for x in set_to_add]
+
+        to_mod = [{
+            "gid": g_dict[x]["gid"],
+            "nt_name": g_dict[x]["group"],
+            "sid": groupmap["local"][x]["sid"],
+            "group_type_str": "local"
+        } for x in set_to_mod]
 
         to_del = [{
             "sid": groupmap["local"][x]["sid"]
@@ -376,6 +385,9 @@ class SMBService(Service):
 
         if to_add:
             payload["ADD"] = [{"groupmap": to_add}]
+
+        if to_mod:
+            payload["MOD"] = [{"groupmap": to_mod}]
 
         if to_del:
             payload["DEL"] = [{"groupmap": to_del}]

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -152,7 +152,6 @@ class SMBService(Service):
 
         # Users should only have local users and domain users
         users = await self.groupmap_listmem("S-1-5-32-545")
-        expected = [groupmap['local_builtins'][545]['sid']]
         if domain_sid:
             expected.append(f'{domain_sid}-513')
 
@@ -243,7 +242,7 @@ class SMBService(Service):
 
             if g['sid'].startswith("S-1-5-32"):
                 rv['builtins'][gid] = g
-            elif g['sid'].startswith(localsid) and g['gid'] in range(544, 547):
+            elif g['sid'].startswith(localsid) and g['gid'] in (544, 546):
                 rv['local_builtins'][gid] = g
             elif g['sid'].startswith(localsid):
                 rv['local'][gid] = g
@@ -270,7 +269,7 @@ class SMBService(Service):
         low_range = int(idmap_range.split("-")[0].strip())
         sid_lookup = {x["sid"]: x for x in groupmap.values()}
 
-        for b in SMBBuiltin:
+        for b in (SMBBuiltin.ADMINISTRATORS, SMBBuiltin.GUESTS):
             sid = b.value[1]
             rid = int(sid.split('-')[-1])
             gid = low_range + (rid - 544)
@@ -345,6 +344,8 @@ class SMBService(Service):
 
         groups = await self.middleware.call('group.query', [('builtin', '=', False), ('smb', '=', True)])
         g_dict = {x["gid"]: x for x in groups}
+        g_dict[545] = await self.middleware.call('group.query', [('gid', '=', 545)], {'get': True})
+
         intersect = set(g_dict.keys()).intersection(set(groupmap["local"].keys()))
 
         set_to_add = set(g_dict.keys()) - set(groupmap["local"].keys())
@@ -371,7 +372,7 @@ class SMBService(Service):
         for sid in groupmap['invalid']:
             to_del.append({"sid": sid})
 
-        for gid in range(544, 547):
+        for gid in (544, 546):
             if not groupmap["local_builtins"].get(gid):
                 builtin = SMBBuiltin.by_rid(gid)
                 rid = 512 + (gid - 544)

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -4,9 +4,14 @@ from middlewared.utils import run
 from middlewared.plugins.smb import SMBCmd, SMBBuiltin, SMBPath
 
 import os
-import re
+import json
+import tdb
+import struct
 
-RE_NETGROUPMAP = re.compile(r"^(?P<ntgroup>.+) \((?P<SID>S-[0-9\-]+)\) -> (?P<unixgroup>.+)$")
+# This follows JSON output version for net_groupmap.c
+# Output format may change between this and final version accepted
+# upstream, but Samba project has standardized on following version format
+GROUPMAP_JSON_VERSION = {"major": 0, "minor": 1}
 
 
 class SMBService(Service):
@@ -15,134 +20,370 @@ class SMBService(Service):
         service = 'cifs'
         service_verb = 'restart'
 
-    @private
-    async def groupmap_list(self):
-        groupmap = {}
-        out = await run([SMBCmd.NET.value, 'groupmap', 'list'], check=False)
-        if out.returncode != 0:
-            raise CallError(f'groupmap list failed with error {out.stderr.decode()}')
-        for line in (out.stdout.decode()).splitlines():
-            m = RE_NETGROUPMAP.match(line)
-            if m:
-                entry = m.groupdict()
-                groupmap[entry['unixgroup']] = entry
-
-        return groupmap
-
-    @private
-    async def add_builtin_group(self, group):
-        unixgroup = group
-        ntgroup = group[8:].capitalize()
-        sid = SMBBuiltin[ntgroup.upper()].value[1]
-        gm_add = await run([
-            SMBCmd.NET.value, '-d', '0', 'groupmap', 'add', f'sid={sid}',
-            'type=builtin', f'unixgroup={unixgroup}', f'ntgroup={ntgroup}'],
-            check=False
-        )
-        if gm_add.returncode != 0:
-            raise CallError(
-                f'Failed to generate groupmap for [{group}]: ({gm_add.stderr.decode()})'
-            )
-
-    @private
-    async def groupmap_add(self, group, passdb_backend=None):
-        """
-        Map Unix group to NT group. This is required for group members to be
-        able to access the SMB share. Name collisions with well-known and
-        builtin groups must be avoided. Mapping groups with the same
-        names as users should also be avoided.
-        """
-        if passdb_backend is None:
-            passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
-
-        if passdb_backend != 'tdbsam':
+    async def json_check_version(self, version):
+        if version == GROUPMAP_JSON_VERSION:
             return
 
-        if group in SMBBuiltin.unix_groups():
-            return await self.add_builtin_group(group)
-
-        disallowed_list = ['USERS', 'ADMINISTRATORS', 'GUESTS']
-        existing_groupmap = await self.groupmap_list()
-
-        if existing_groupmap.get(group):
-            self.logger.debug('Setting group map for %s is not permitted. '
-                              'Entry already exists.', group)
-            return False
-
-        if group.upper() in disallowed_list:
-            self.logger.debug('Setting group map for %s is not permitted. '
-                              'Entry mirrors existing builtin groupmap.', group)
-            return False
-
-        next_rid = str(await self.middleware.call("smb.get_next_rid"))
-        gm_add = await run(
-            [SMBCmd.NET.value, '-d', '0', 'groupmap', 'add', 'type=local', f'rid={next_rid}', f'unixgroup={group}', f'ntgroup={group}'],
-            check=False
+        raise CallError(
+            "Unexpected JSON version returned from Samba utils: "
+            f"[{version}]. Expected version was: [{GROUPMAP_JSON_VERSION}]. "
+            "Behavior is undefined with a version mismatch and so refusing "
+            "to perform groupmap operation. Please file a bug report at "
+            "jira.ixsystems.com with this traceback."
         )
-        if gm_add.returncode != 0:
+
+    async def groupmap_listmem(self, sid):
+        payload = json.dumps({"alias": sid})
+        lm = await run([
+            SMBCmd.NET.value, "--json", "groupmap", "listmem", payload
+        ], check=False)
+
+        # Command will return ENOENT when fails with STATUS_NO_SUCH_ALIAS
+        if lm.returncode == 2:
+            return []
+        elif lm.returncode != 0:
+            raise CallError(f"Failed to list membership of alias [{sid}]: "
+                            f"{lm.stderr.decode()}")
+
+        output = json.loads(lm.stdout.decode())
+        await self.json_check_version(output['version'])
+
+        return [x["sid"] for x in output['members']]
+
+    async def groupmap_addmem(self, alias, member):
+        payload = f'data={json.dumps({"alias": alias, "member": member})}'
+        am = await run([
+            SMBCmd.NET.value, "--json", "groupmap", "addmem", payload,
+        ], check=False)
+        if am.returncode != 0:
             raise CallError(
-                f'Failed to generate groupmap for [{group}]: ({gm_add.stderr.decode()})'
+                f"Failed to add [{member}] to [{alias}]: {am.stderr.decode()}"
             )
 
     @private
-    async def groupmap_delete(self, data):
-        ntgroup = data.get("ntgroup")
-        sid = data.get("sid")
-        if not ntgroup and not sid:
-            raise CallError("ntgroup or sid is required")
+    async def diff_membership(self, actual, expected):
+        """
+        Generate a diff between expected members of an alias vs
+        actual members. This is used for batch operation to add
+        or remove memberships. Since these memberships affect
+        how nss_winbind generates passwd entries, and also rights
+        evaluation in samba (for instance when a non-owner tries
+        to change ownership of a file), it is important that
+        we have no unexpected entries here.
+        """
+        out = {"ADDMEM": [], "DELMEM": []}
 
-        if ntgroup:
-            target = f"ntgroup={ntgroup}"
-        elif sid:
-            if sid.startswith("S-1-5-32"):
-                self.logger.debug("Refusing to delete group mapping for BUILTIN group: %s", sid)
-                return
+        actual_set = set(actual)
+        expected_set = set(expected)
 
-            target = f"sid={sid}"
+        out["ADDMEM"] = [{"sid": x} for x in expected_set - actual_set]
+        out["DELMEM"] = [{"sid": x} for x in actual_set - expected_set]
 
-        gm_delete = await run(
-            [SMBCmd.NET.value, '-d' '0', 'groupmap', 'delete', target], check=False
-        )
+        return out
 
-        if gm_delete.returncode != 0:
-            self.logger.debug(f'Failed to delete groupmap for [{target}]: ({gm_delete.stderr.decode()})')
+    async def update_payload_with_diff(self, payload, alias, diff, ad):
+        async def add_to_payload(payload, alias, key, members):
+            idx = next((i for i, x in enumerate(payload[key]) if x["alias"] == alias), None)
+            if not idx:
+                payload["ADDMEM"].append({
+                    "alias": alias,
+                    "members": members,
+                })
+            else:
+                payload["ADDMEM"][idx]["members"].append(members)
+
+        if diff.get("ADDMEM"):
+            await add_to_payload(payload, alias, "ADDMEM", diff["ADDMEM"])
+
+        """
+        If AD is FAULTED or in process of joining or leaving AD,
+        then we may not have an accurate picture of what should be
+        in the alias member list. In this case, defer member removal
+        until next groupmap synchronization.
+        """
+        if ad in ["HEALTHY", "DISABLED"] and diff.get("DELMEM"):
+            await add_to_payload(payload, alias, "DELMEM", diff["DELMEM"])
+
+        return
+
+    @private
+    async def sync_foreign_groups(self):
+        """
+        Domain Users, and Domain Admins must have S-1-5-32-545 and S-1-5-32-544
+        added to their respective Unix tokens for correct behavior in AD domain.
+        These are added by making them foreign members in the group_mapping for
+        the repsective alias. This membership is generated during samba startup
+        when newly creating these groups (if they don't exist), but can get
+        lost, resulting in unexpected / erratic permissions behavior.
+        """
+        domain_sid = None
+        payload = {"ADDMEM": [], "DELMEM": []}
+        # second groupmap listing is to ensure we have accurate / current info.
+        groupmap = await self.groupmap_list()
+        admin_group = (await self.middleware.call('smb.config'))['admin_group']
+
+        ad_state = await self.middleware.call('activedirectory.get_state')
+        if ad_state == 'HEALTHY':
+            domain_info = await self.middleware.call('idmap.domain_info',
+                                                     'DS_TYPE_ACTIVEDIRECTORY')
+            domain_sid = domain_info['sid']
+
+        """
+        Administrators should only have local and domain admins, and a user-
+        designated "admin group" (if specified).
+        """
+        admins = await self.groupmap_listmem("S-1-5-32-544")
+        expected = [groupmap['local_builtins'][544]['sid']]
+        if domain_sid:
+            expected.append(f'{domain_sid}-512')
+
+        if admin_group:
+            grp_obj = await self.middleware.call('group.get_group_obj',
+                                                 {'groupname': admin_group})
+            admin_sid = await self.middleware.call(
+                'idmap.unixid_to_sid',
+                {"id_type": "GROUP", "id": grp_obj["gid"]}
+            )
+            if admin_sid:
+                expected.append(admin_sid)
+
+        diff = await self.diff_membership(admins, expected)
+        await self.update_payload_with_diff(payload, "S-1-5-32-544", diff, ad_state)
+
+        # Users should only have local users and domain users
+        users = await self.groupmap_listmem("S-1-5-32-545")
+        expected = [groupmap['local_builtins'][545]['sid']]
+        if domain_sid:
+            expected.append(f'{domain_sid}-513')
+
+        diff = await self.diff_membership(users, expected)
+        await self.update_payload_with_diff(payload, "S-1-5-32-545", diff, ad_state)
+
+        guests = await self.groupmap_listmem("S-1-5-32-546")
+        expected = [
+            groupmap['local_builtins'][546]['sid'],
+            f'{groupmap["localsid"]}-501'
+        ]
+        if domain_sid:
+            expected.append(f'{domain_sid}-514')
+
+        diff = await self.diff_membership(guests, expected)
+        await self.update_payload_with_diff(payload, "S-1-5-32-546", diff, ad_state)
+
+        await self.batch_groupmap(payload)
+
+    @private
+    def validate_groupmap_hwm(self, low_range):
+        """
+        Middleware forces allocation of GIDs for Users, Groups, and Administrators
+        to be deterministic with the default idmap backend. Bump up the idmap_tdb
+        high-water mark to avoid conflicts with these and remove any mappings that
+        conflict. Winbindd will regenerate the removed ones as-needed.
+        """
+        must_reload = False
+        tdb_handle = tdb.open(f"{SMBPath.STATEDIR.platform()}/winbindd_idmap.tdb")
+
+        try:
+            group_hwm_bytes = tdb_handle.get(b'GROUP HWM\00')
+            hwm = struct.unpack("<L", group_hwm_bytes)[0]
+            if hwm < low_range + 2:
+                tdb_handle.transaction_start()
+                new_hwm_bytes = struct.pack("<L", group_hwm_bytes)
+                tdb_handle.store(b'GROUP HWM\00', new_hwm_bytes)
+                tdb_handle.transaction_commit()
+                self.middleware.call_sync('idmap.snapshot_samba4_dataset')
+                must_reload = True
+
+            for key in tdb_handle.keys():
+                if key[:3] == b'GID' and int(key.decode()[4:-3]) < (low_range + 2):
+                    reverse = tdb_handle.get(key)
+                    tdb_handle.transaction_start()
+                    tdb_handle.delete(key)
+                    tdb_handle.delete(reverse)
+                    tdb_handle.transaction_commit()
+                    if not must_reload:
+                        self.middleware.call_sync('idmap.snapshot_samba4_dataset')
+                    must_reload = True
+
+        except Exception as e:
+            self.logger.warning("TDB maintenace failed: %s", e)
+
+        finally:
+            tdb_handle.close()
+
+        return must_reload
+
+    @private
+    async def groupmap_list(self):
+        """
+        Convert JSON groupmap output to dict to get O(1) lookups by `gid`
+
+        Separate out the groupmap output into builtins, locals, and invalid entries.
+        Invalid entries are ones that aren't from our domain, or are mapped to gid -1.
+        Latter occurs when group mapping is lost. In case of invalid entries, we store
+        list of SIDS to be removed. SID is necessary and sufficient for groupmap removal.
+        """
+        rv = {"builtins": {}, "local": {}, "local_builtins": {}, "invalid": []}
+        localsid = await self.middleware.call('smb.get_system_sid')
+        if localsid is None:
+            raise CallError("Unable to retrieve local system SID. Group mapping failure.")
+
+        out = await run([SMBCmd.NET.value, '--json', 'groupmap', 'list', '{"verbose": true}'], check=False)
+        if out.returncode != 0:
+            raise CallError(f'groupmap list failed with error {out.stderr.decode()}')
+
+        gm = json.loads(out.stdout.decode())
+        await self.json_check_version(gm['version'])
+
+        for g in gm['groupmap']:
+            gid = g['gid']
+            if gid == -1:
+                rv['invalid'].append(g['sid'])
+                continue
+
+            if g['sid'].startswith("S-1-5-32"):
+                rv['builtins'][gid] = g
+            elif g['sid'].startswith(localsid) and g['gid'] in range(544, 547):
+                rv['local_builtins'][gid] = g
+            elif g['sid'].startswith(localsid):
+                rv['local'][gid] = g
+            else:
+                rv['invalid'].append(g['sid'])
+
+        rv["localsid"] = localsid
+        return rv
+
+    @private
+    async def sync_builtins(self, groupmap):
+        idmap_backend = await self.middleware.call("smb.getparm", "idmap config *:backend", "GLOBAL")
+        idmap_range = await self.middleware.call("smb.getparm", "idmap config *:range", "GLOBAL")
+        payload = {"ADD": [{"groupmap": []}], "MOD": [{"groupmap": []}], "DEL": [{"groupmap": []}]}
+        must_reload = False
+
+        if idmap_backend != "tdb":
+            """
+            idmap_autorid and potentially other allocating idmap backends may be used for
+            the default domain. We do not want to touch how these are allocated.
+            """
+            return must_reload
+
+        low_range = int(idmap_range.split("-")[0].strip())
+        sid_lookup = {x["sid"]: x for x in groupmap.values()}
+
+        for b in SMBBuiltin:
+            sid = b.value[1]
+            rid = int(sid.split('-')[-1])
+            gid = low_range + (rid - 544)
+            entry = sid_lookup.get(sid, None)
+            if entry and entry['gid'] == gid:
+                # Value is correct, nothing to do.
+                continue
+
+            # If group type is incorrect, it entry must be deleted before re-adding.
+            elif entry and entry['gid'] != gid and entry['group_type_int'] != 4:
+                payload['DEL'][0]['groupmap'].append({
+                    'sid': str(sid),
+                })
+                payload['ADD'][0]['groupmap'].append({
+                    'sid': str(sid),
+                    'gid': gid,
+                    'group_type_str': 'local',
+                    'nt_name': b.value[0][8:].capitalize()
+                })
+            elif entry and entry['gid'] != gid:
+                payload['MOD'][0]['groupmap'].append({
+                    'sid': str(sid),
+                    'gid': gid,
+                    'group_type_str': 'local',
+                    'nt_name': b.value[0][8:].capitalize()
+                })
+            else:
+                payload['ADD'][0]['groupmap'].append({
+                    'sid': str(sid),
+                    'gid': gid,
+                    'group_type_str': 'local',
+                    'nt_name': b.value[0][8:].capitalize()
+                })
+
+        await self.batch_groupmap(payload)
+        if (await self.middleware.call('smb.validate_groupmap_hwm', low_range)):
+            must_reload = True
+
+        return must_reload
+
+    @private
+    async def batch_groupmap(self, data):
+        for op in ["ADD", "MOD", "DEL"]:
+            if data.get(op) is not None and len(data[op]) == 0:
+                data.pop(op)
+
+        payload = json.dumps(data)
+        out = await run([SMBCmd.NET.value, '--json', 'groupmap', 'batch', payload], check=False)
+        if out.returncode != 0:
+            raise CallError(f'Batch operation for [{data}] failed with error {out.stderr.decode()}')
 
     @private
     @job(lock="groupmap_sync")
     async def synchronize_group_mappings(self, job):
+        """
+        This method does the following:
+        1) prepares payload for a batch groupmap operation. These are added to two arrays:
+           "to_add" and "to_del". Missing entries are added, invalid entries are deleted.
+        2) we synchronize S-1-5-32-544, S-1-5-32-545, and S-1-5-32-546 separately
+        3) we add any required group mappings for the SIDs in (2) above.
+        4) we flush various caches if required.
+        """
+        payload = {}
+        to_add = []
+        to_del = []
+
         if await self.middleware.call('ldap.get_state') != "DISABLED":
             return
 
         groupmap = await self.groupmap_list()
         must_remove_cache = False
-        passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
-
-        if groupmap:
-            groupmap_removed = await self.middleware.call('smb.fixsid', groupmap.values())
-            if groupmap_removed:
-                groupmap = {}
-
-        for b in SMBBuiltin:
-            entry = groupmap.get(b.value[0])
-            if b.name == 'ADMINISTRATORS':
-                if len(await self.middleware.call('group.query', [('gid', '=', 544)])) > 1:
-                    # Creating an SMB administrators mapping for a duplicate ID is potentially a security issue.
-                    self.logger.warn("Multiple groups have GID 544, switching allocation method for "
-                                     "SMB Administrators [S-1-5-32-544] to internal winbind method.")
-                    continue
-
-            if not entry:
-                stale_entry = list(filter(lambda x: b.name.lower().capitalize() == x['ntgroup'], groupmap.values()))
-                if stale_entry:
-                    must_remove_cache = True
-                    await self.groupmap_delete({"ntgroup": b.name.lower().capitalize()})
-
-                await self.groupmap_add(b.value[0], passdb_backend)
 
         groups = await self.middleware.call('group.query', [('builtin', '=', False), ('smb', '=', True)])
-        for g in groups:
-            if not groupmap.get(g['group']):
-                await self.groupmap_add(g['group'], passdb_backend)
+        g_dict = {x["gid"]: x for x in groups}
+
+        set_to_add = set(g_dict.keys()) - set(groupmap["local"].keys())
+        set_to_del = set(groupmap["local"].keys()) - set(g_dict.keys())
+
+        to_add = [{
+            "gid": g_dict[x]["gid"],
+            "nt_name": g_dict[x]["group"],
+            "group_type_str": "local"
+        } for x in set_to_add]
+
+        to_del = [{
+            "sid": groupmap["local"][x]["sid"]
+        } for x in set_to_del]
+
+        for sid in groupmap['invalid']:
+            to_del.append({"sid": sid})
+
+        for gid in range(544, 547):
+            if not groupmap["local_builtins"].get(gid):
+                builtin = SMBBuiltin.by_rid(gid)
+                rid = 512 + (gid - 544)
+                sid = f'{groupmap["localsid"]}-{rid}'
+                to_add.append({
+                    "gid": gid,
+                    "nt_name": f"local_{builtin.name.lower()}",
+                    "group_type_str": "local",
+                    "sid": sid,
+                })
+
+        if to_add:
+            payload["ADD"] = [{"groupmap": to_add}]
+
+        if to_del:
+            payload["DEL"] = [{"groupmap": to_del}]
+
+        await self.middleware.call('smb.fixsid')
+        must_remove_cache = await self.sync_builtins(groupmap['builtins'])
+        await self.batch_groupmap(payload)
+        await self.sync_foreign_groups()
 
         if must_remove_cache:
             if os.path.exists(f'{SMBPath.STATEDIR.platform()}/winbindd_cache.tdb'):

--- a/tests/api2/group.py
+++ b/tests/api2/group.py
@@ -139,8 +139,9 @@ def test_18_check_groupmap_added():
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
     if results['result'] is True:
-        groupmap = (json.loads(results['output'])).get('newgroup')
-        assert groupmap is not None, results['output']
+        groupmap = json.loads(results['output'])
+        local_maps = groupmap['local'].values()
+        assert len(local_maps) != 0, results['output']
 
 
 # Delete the group
@@ -192,8 +193,9 @@ def test_24_check_groupmap_added(request):
     assert results['result'] is True, results['output']
     global groupmap
     if results['result'] is True:
-        groupmap = (json.loads(results['output'])).get('smbgroup')
-        assert groupmap is not None, results['output']
+        groupmap = json.loads(results['output'])
+        local_maps = groupmap['local'].values()
+        assert len(local_maps) != 0, results['output']
 
 
 def test_25_test_name_change_smb_group(request):
@@ -205,20 +207,27 @@ def test_25_test_name_change_smb_group(request):
     assert results.status_code == 200, results.text
 
 
-def test_26_old_groupmap_removed_after_name_change(request):
+def test_26_groupmap_entry_nt_name_change(request):
     """
-    "net groupmap list" does not show group mappings for unix groups that no
-    longer exist. For this reason, we must use tdbdump to verify that the old
-    SID entry has been properly removed. Stale groupmap entries may cause
-    difficult-to-diagnose group mapping issues.
     """
-    depends(request, ["SMB_GROUP_CREATED"])
-    cmd = 'tdbdump /var/db/system/samba4/group_mapping.tdb'
+    depends(request, ["SMB_GROUP_CREATED", "ssh_password"], scope="session")
+    cmd = 'midclt call smb.groupmap_list'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
+    gm = None
+
+    for groupmap_entry in groupmap['local'].values():
+        if groupmap_entry['nt_name'] == 'smbgroup':
+            gm = groupmap_entry
+            break
+
     if results['result'] is True:
-        for entry in results['output'].splitlines():
-            assert groupmap['SID'] not in entry, entry
+        new = json.loads(results['output'])
+        old_sid = gm['sid']
+        new_entry = new['local'].get(str(gm['gid']))
+        assert new_entry, results['output']
+        assert old_sid == new_entry['sid'], results['output']
+        assert gm['nt_name'] != new_entry['nt_name'], results['output']
 
 
 def test_27_new_groupmap_added_after_name_change(request):
@@ -231,8 +240,9 @@ def test_27_new_groupmap_added_after_name_change(request):
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
     if results['result'] is True:
-        groupmap = (json.loads(results['output'])).get('newsmbgroup')
-        assert groupmap is not None, results['output']
+        groupmap = json.loads(results['output'])
+        local_maps = groupmap['local'].values()
+        assert len(local_maps) != 0, results['output']
 
 
 def test_28_convert_smb_group_to_non_smb(request):


### PR DESCRIPTION
*Background*
In a Windows / AD environment, all objects are identified by
SID. SIDs for user / group objects take the form
`S-1-5-21-<domain>-<rid>`

The <domain> component for a SID will vary depending on
whether the account is a local one or one from an external domain.
A domain sid is of the form `S-1-5-21-<domain>`, and every
TrueNAS server has a unique domain sid, which is randomly
generated by samba libraries when it is first needed.

Each relative id (rid) uniquely identifies an object in the domain.
Certain rids are present in every domain. Of particular note
for this commit are the following:

```
S-1-5-21-<domain>-501 - Guest
S-1-5-21-<domain>-512 - Domain Admins
S-1-5-21-<domain>-513 - Domain Users
S-1-5-21-<domain>-514 - Domain Guests
```

In addition to domain (S-1-5-21) sids, every Windows computer
and Samba server has sids that are identical on every machine
that are prefixed with S-1-5-32 (built-in groups). Of particular note
for this commit are the following:
```
S-1-5-32-544 - Adminstrators
S-1-5-32-545 - Users
S-1-5-32-546 - Guests
```

Since Unix-like servers use uids / gids (xids) to identify users and
groups rather than sids, sids must be mapped into xids and vice-versa.
This task falls on Samba's passdb, groupdb, and winbindd's idmapping
facilities.

During samba startup, if samba's groupdb lacks entries for
Administrators, Users, and Guests, then they will be automatically
added by allocating new gids for each of them from winbindd's idmap
backend that has been configured to provide mappings for built-in
sids. This allocation increments the xid high-water mark in
winbindd_idmap.tdb, (but does not write the explicit mapping in
the key-value store) and then writes the explicit mapping in
group_mapping.tdb.

Windows has the concept of nested groups. Groups in Windows may
have members that are either users or groups. Accordingly, each
groupmap entry in group_mapping.tdb may have zero or more
foreign memberships in it. The following is a sample tdb entry:

```
{
key(23) = "UNIXGROUP/S-1-5-32-546\00"
data(32) = "\83J]\05\04\00\00\00Guests\00Local Unix group\00"
}
{
key(54) = "MEMBEROF/S-1-5-21-944110568-1438105595-1944063070-514\00"
data(13) = "S-1-5-32-546\00"
}
```

In this case, S-1-5-32-546 is mapped to gid 90,000,002 and has
a foreign member of S-1-5-21-944110568-1438105595-1944063070-514.

During the domain-join process, libads adds domain sids as members
of the above built-in groups:
```
S-1-5-21-<new domain>-512 --> S-1-5-32-544
S-1-5-21-<new domain>-513 --> S-1-5-32-545
S-1-5-21-<new domain>-514 --> S-1-5-32-546
```

Which means that when nss_winbind generates a passwd struct for
a domain user, BUILTIN\Users is added to the grouplist with the
gid listed in the group_mapping.tdb.

*Problem*
There are various situations that can occur where original
mapping for builtins is lost or remapped to different ids
foreign memberships are lost, or id collisions are generated
with other groups allocated in winbindd_idmap.tdb.

Although these built-in groups are not exposed via middleware and
the webui, they are exposed via the SMB protocol and Samba's
RPC endpoints. The most common reason for them to be used is
when robocopy is used to migrate data from a Windows share on
Windows server where the system administrator is using
built-in groups rather than AD groups to share data.

*Impact*
Impact of potential indetermenancy with the mapping potentially
profound. User tokens may be generated with incorrect ids,
and filesystem ACLs may cease to grant expected access.
If foreign group membership is dropped, then built-in groups
will not appear in passwd entries for AD and local users.

*Resolution*
When built-in groups are handled by idmap_tdb (default),
ensure that Administrators, Users, and Guests are mapped
explicitly to the lowest three gids in the range that is
specified for the default domain (*). Use newly-added
json-based batch operations for groupmap to achieve this.
net_groupmap text variant does not allow direct manipulation
of gids in the groupmap file, which creates a chicken-and-egg
problem for mapping built-ins explicitly when there is no
corresponding winbindd_idmap.tdb entry.

Adjust high-water-mark in idmap_tdb to never allocate gids
in this reserved area.

Ensure that local builtin_users, builtin_admins, builtin_guests
groups are mapped to the respective local domain (TrueNAS)
domain users, domain admins, domain guests SIDs.

Ensure that foreign mappings for Administrators, Users, and Guests
always exist.