### PR TITLE
NAS-112284 / 21.10 / Restart mDNS service on SMB share change for `enabled`

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -112,7 +112,10 @@ class mDNSService(object):
             ))
 
             if smb_is_running:
-                smb_shares = self.middleware.call_sync('sharing.smb.query', [('timemachine', '=', True)])
+                smb_shares = self.middleware.call_sync(
+                    'sharing.smb.query',
+                    [('timemachine', '=', True), ('enabled', '=', True), ('locked', '=', False)]
+                )
             else:
                 smb_shares = []
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1075,6 +1075,7 @@ class SharingSMBService(SharingService):
         await self.clean(new, 'sharingsmb_update', verrors, id=id)
         await self.validate(new, 'sharingsmb_update', verrors, old=old)
         await self.legacy_afp_check(new, 'sharingsmb_update', verrors)
+        check_mdns = False
 
         verrors.check()
 
@@ -1177,14 +1178,19 @@ class SharingSMBService(SharingService):
             Since the old share was not in our running configuration, we need
             to add it.
             """
+            check_mdns = True
             await self.middleware.call('sharing.smb.reg_addshare', new)
 
         elif not old_is_locked and new_is_locked:
             try:
                 await self.middleware.call('sharing.smb.reg_delshare', oldname)
+                check_mdns = True
             except Exception:
                 self.logger.warning('Failed to remove locked share [%s]',
                                     old['name'], exc_info=True)
+
+        if new['enabled'] != old['enabled']:
+            check_mdns = True
 
         if do_global_reload:
             await self.middleware.call('smb.initialize_globals')
@@ -1192,7 +1198,7 @@ class SharingSMBService(SharingService):
         else:
             await self._service_change('cifs', 'reload')
 
-        if old['timemachine'] != new['timemachine']:
+        if check_mdns or old['timemachine'] != new['timemachine']:
             await self.middleware.call('service.restart', 'mdns')
 
         return await self.get_instance(id)


### PR DESCRIPTION
If user is toggling `enabled` for share, then we may need to
re-do mDNS advertisement. Check for whether mDNS should
be running is performed in mDNS start method.