### PR TITLE
NAS-112294 / 21.10 / Add LDAP_DN attribute for middleware schema

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -13,7 +13,7 @@ import copy
 
 from ldap.controls import SimplePagedResultsControl
 from urllib.parse import urlparse
-from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Ref
+from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Ref, LDAP_DN
 from middlewared.service import job, private, TDBWrapConfigService, Service, ValidationErrors
 from middlewared.service_exception import CallError
 import middlewared.sqlalchemy as sa
@@ -142,10 +142,10 @@ class LDAPClient(Service):
         'ldap-configuration',
         List('uri_list', required=True),
         Str('bind_type', enum=['ANONYMOUS', 'PLAIN', 'GSSAPI', 'EXTERNAL'], required=True),
-        Str('basedn', required=True),
+        LDAP_DN('basedn', required=True),
         Dict(
             'credentials',
-            Str('binddn', default=''),
+            LDAP_DN('binddn', default=''),
             Str('bindpw', default='', private=True),
         ),
         Dict(
@@ -814,8 +814,8 @@ class LDAPService(TDBWrapConfigService):
     @accepts(Dict(
         'ldap_update',
         List('hostname', required=True),
-        Str('basedn', required=True),
-        Str('binddn'),
+        LDAP_DN('basedn', required=True),
+        LDAP_DN('binddn'),
         Str('bindpw', private=True),
         Bool('anonbind', default=False),
         Str('ssl', default='OFF', enum=['OFF', 'ON', 'START_TLS']),

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
@@ -1,7 +1,6 @@
 import pytest
 from mock import Mock
 
-from middlewared.service_exception import ValidationErrors
 from middlewared.schema import (
     accepts, LDAP_DN
 )
@@ -20,7 +19,7 @@ def test__schema_ldapdn(value, expected):
 
     if expected is ValueError:
         with pytest.raises(expected):
-            ldapdnnotnull(self,value)
+            ldapdnnotnull(self, value)
     else:
         assert ldapdnnotnull(self, value) == expected
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
@@ -1,0 +1,35 @@
+import pytest
+from mock import Mock
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.schema import (
+    accepts, LDAP_DN
+)
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('o=5def63d2b12d4332c706a57f,dc=jumpcloud,dc=com', 'o=5def63d2b12d4332c706a57f,dc=jumpcloud,dc=com'),
+    ('canary', ValueError),
+])
+def test__schema_ldapdn(value, expected):
+    @accepts(LDAP_DN('data', null=True))
+    def ldapdnnotnull(self, data):
+        return data
+
+    self = Mock()
+
+    if expected is ValueError:
+        with pytest.raises(expected):
+            ldapdnnotnull(self,value)
+    else:
+        assert ldapdnnotnull(self, value) == expected
+
+
+def test__schema_ldapdn_null():
+    @accepts(LDAP_DN('data', null=True))
+    def ldapdnnull(self, data):
+        return data
+
+    self = Mock()
+
+    assert ldapdnnull(self, None) is None

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import Mock
 
+from middlewared.service_exception import ValidationErrors
 from middlewared.schema import (
     accepts, LDAP_DN
 )
@@ -8,7 +9,8 @@ from middlewared.schema import (
 
 @pytest.mark.parametrize('value,expected', [
     ('o=5def63d2b12d4332c706a57f,dc=jumpcloud,dc=com', 'o=5def63d2b12d4332c706a57f,dc=jumpcloud,dc=com'),
-    ('canary', ValueError),
+    ('canary', ValidationErrors),
+    (420, ValidationErrors),
 ])
 def test__schema_ldapdn(value, expected):
     @accepts(LDAP_DN('data', null=True))
@@ -17,7 +19,7 @@ def test__schema_ldapdn(value, expected):
 
     self = Mock()
 
-    if expected is ValueError:
+    if expected is ValidationErrors:
         with pytest.raises(expected):
             ldapdnnotnull(self, value)
     else:

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -452,11 +452,14 @@ class LDAP_DN(Str):
         if value is None:
             return
 
+        verrors = ValidationErrors()
+
         try:
             dn.str2dn(value)
-        except DECODING_ERROR:
-            raise ValueError('Invalid LDAP DN specified')
+        except (TypeError, DECODING_ERROR):
+            verrors.add(self.name, "Invalid LDAP DN specified.")
 
+        verrors.check()
         return super().validate(value)
 
 

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -5,6 +5,7 @@ import textwrap
 import warnings
 from collections import defaultdict
 from datetime import datetime, time, timezone
+from ldap import dn, DECODING_ERROR
 import errno
 import inspect
 import ipaddress
@@ -441,6 +442,20 @@ class UnixPerm(Str):
 
         if mode & 0o777 != mode:
             raise ValueError('Please supply a value between 000 and 777')
+
+        return super().validate(value)
+
+
+class LDAP_DN(Str):
+
+    def validate(self, value):
+        if value is None:
+            return
+
+        try:
+            dn.str2dn(value)
+        except DECODING_ERROR:
+            raise ValueError('Invalid LDAP DN specified')
 
         return super().validate(value)
 

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -5,7 +5,7 @@ import textwrap
 import warnings
 from collections import defaultdict
 from datetime import datetime, time, timezone
-from ldap import dn, DECODING_ERROR
+from ldap import dn
 import errno
 import inspect
 import ipaddress
@@ -454,9 +454,7 @@ class LDAP_DN(Str):
 
         verrors = ValidationErrors()
 
-        try:
-            dn.str2dn(value)
-        except (TypeError, DECODING_ERROR):
+        if not dn.is_dn(value):
             verrors.add(self.name, "Invalid LDAP DN specified.")
 
         verrors.check()


### PR DESCRIPTION
libldap has str2dn function which can be used
to validate user-provided DN strings. Add new attribute
and begin to place in areas of middleware where we
accepts these from users.