### PR TITLE
NAS-112295 / 21.10 / call pytest instead of pytest-3

### DIFF
--- a/cluster-tests/run-cluster-tests.py
+++ b/cluster-tests/run-cluster-tests.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 import pathlib
 import subprocess
 
@@ -55,7 +54,7 @@ def setup_api_results_dir():
 
 
 def setup_pytest_command(args, results_path):
-    cmd = [f'pytest-{sys.version_info.major}', '-v', '-rfesp', f'--junit-xml={results_path}']
+    cmd = ['pytest', '-v', '-rfesp', f'--junit-xml={results_path}']
 
     # pytest is clever enough to search the "tests" subdirectory
     # and look at the argument that is passed and figure out if


### PR DESCRIPTION
The builder that runs the cluster tests installs `pytest` via `pip` instead of `apt` so the binary is `pytest` instead of `pytest-3`.