### PR TITLE
NAS-112352 / 21.10 / fix IPv4 broadcast assignment on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
@@ -36,7 +36,15 @@ class AddressMixin:
         if isinstance(address.address, ipaddress.IPv6Address):
             netmask = ipv6_netmask_to_prefixlen(netmask)
 
-        run(["ip", "addr", op, f"{address.address}/{netmask}", "dev", self.name])
+        cmd = ["ip", "addr", op, f"{address.address}/{netmask}"]
+        if op == 'add':
+            # make sure we tell linux to assign proper broadcast address
+            # when adding an IPv4 address to an interface
+            # (doesn't apply to IPv6)
+            cmd.extend(["brd", "+"]) if ':' not in f'{address.address}' else None
+        cmd.exnted(["dev", self.name])
+
+        run(cmd)
 
     @property
     def addresses(self):


### PR DESCRIPTION
When adding an address if the `brd +` isn't specified then the IP address is assigned to an interface with a broadcast address of `0.0.0.0` which is undesired. This doesn't apply to IPv6 addresses.