### PR TITLE
NAS-112119 / 21.10 / deprecate custom interface options on SCALE

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -1165,14 +1165,11 @@ def create_vlan():
                     int_name=vlan_interface_name,
                     int_dhcp=False,
                     int_ipv6auto=False,
-                    int_options='up',
                 )
                 vlan_interface.save()
             else:
                 vlan_interface = qs[0]
-                if 'up' not in vlan_interface.int_options:
-                    vlan_interface.int_options += ' up'
-                    vlan_interface.save()
+                vlan_interface.save()
     except Exception:
         print(_("Failed"))
         return False

--- a/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
@@ -100,7 +100,6 @@ network_func()
 			int_vhid as 'VHID',
 			int_vip as 'VIP',
 			int_link_address as 'MAC address',
-			int_options as 'Options'
 		FROM
 			network_interfaces
 		WHERE

--- a/src/middlewared/middlewared/alembic/versions/21.MM/2021-09-17_12-16_deprecate-custom-int-options.py
+++ b/src/middlewared/middlewared/alembic/versions/21.MM/2021-09-17_12-16_deprecate-custom-int-options.py
@@ -1,0 +1,22 @@
+"""deprecate custom interface options
+
+Revision ID: df19c1a8d4ae
+Revises: b55d888749aa
+Create Date: 2021-09-17 12:16:21.819535+00:00
+
+"""
+from alembic import op
+
+revision = 'df19c1a8d4ae'
+down_revision = 'b55d888749aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
+        batch_op.drop_column('int_options')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -1,8 +1,6 @@
 import ipaddress
 import os
-import shlex
 import signal
-import subprocess
 import re
 import textwrap
 
@@ -214,16 +212,6 @@ class InterfaceService(Service):
             self.logger.debug('{}: adding {}'.format(name, addr))
             iface.add_address(addr)
 
-        # Apply interface options specified in GUI
-        if data['int_options']:
-            self.logger.info('{}: applying {}'.format(name, data['int_options']))
-            proc = subprocess.Popen(['/sbin/ifconfig', name] + shlex.split(data['int_options']),
-                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                    close_fds=True)
-            err = proc.communicate()[1].decode()
-            if err:
-                self.logger.info('{}: error applying: {}'.format(name, err))
-
         # In case there is no MTU in interface and it is currently
         # different than the default of 1500, revert it
         if not options.get('skip_mtu'):
@@ -239,7 +227,7 @@ class InterfaceService(Service):
             except Exception:
                 self.logger.warn(f'Failed to set interface {name} description', exc_info=True)
 
-        if netif.InterfaceFlags.UP not in iface.flags and 'down' not in data['int_options'].split():
+        if netif.InterfaceFlags.UP not in iface.flags:
             iface.up()
 
         # If dhclient is not running and dhcp is configured, lets start it


### PR DESCRIPTION
The custom interface options was brought over from CORE so it still uses `ifconfig` underneath the hood. SCALE uses `ip` for interface/address manipulation so the possibility of someone using this successfully on SCALE is pretty small.

Furthermore, if we do have some using this option they will need to migrate their custom interface options to use a post-init script.

The reasoning behind this is quite simple, really. Trying to parse user provided input for network specific settings is going to almost always never work right. It gets infinitely more complex because `ip` has different incantations for the same command.