### PR TITLE
NAS-112375 / 12.0 / groupmap - handle case of duplicate gid entries (#7539)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -236,18 +236,23 @@ class SMBService(Service):
 
         for g in gm['groupmap']:
             gid = g['gid']
+            key = 'invalid'
             if gid == -1:
-                rv['invalid'].append(g['sid'])
+                rv[key].append(g['sid'])
                 continue
 
             if g['sid'].startswith("S-1-5-32"):
-                rv['builtins'][gid] = g
+                key = 'builtins'
             elif g['sid'].startswith(localsid) and g['gid'] in (544, 546):
-                rv['local_builtins'][gid] = g
+                key = 'local_builtins'
             elif g['sid'].startswith(localsid):
-                rv['local'][gid] = g
-            else:
+                key = 'local'
+
+            if key == 'invalid' or rv[key].get(gid):
                 rv['invalid'].append(g['sid'])
+                continue
+
+            rv[key][gid] = g
 
         rv["localsid"] = localsid
         return rv


### PR DESCRIPTION
If group_mapping.tdb contains a duplicate gid entries,
then append second entry to `invalid` list to be deleted
during batch OPs. Also ensure that we always have entry
for S-1-5-32-545.