### PR TITLE
NAS-112420 / 21.10 / allow valid bridge configuration on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1243,7 +1243,6 @@ class InterfaceService(CRUDService):
                             f'{schema_name}.{k}',
                             f'Interface in use by {lag_name}. {str(v[0]) + str(v[1])}'
                         )
-
         elif itype == 'BRIDGE':
             if 'name' in data:
                 try:
@@ -1268,11 +1267,6 @@ class InterfaceService(CRUDService):
                     verrors.add(
                         f'{schema_name}.bridge_members.{i}',
                         f'Interface {member} is currently in use by {lag_used[member]}.',
-                    )
-                elif member in vlan_used:
-                    verrors.add(
-                        f'{schema_name}.bridge_members.{i}',
-                        f'Interface {member} is currently in use by {vlan_used[member]}.',
                     )
         elif itype == 'LINK_AGGREGATION':
             if 'name' in data:


### PR DESCRIPTION
It's perfectly valid to have an interface, that has a vlan on top of it, be added to the bridge on SCALE.