### PR TITLE
Include INTELLIGENT_TIERING as available S3 storage class

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -33,8 +33,8 @@ class S3RcloneRemote(BaseRcloneRemote):
     task_schema = [
         Str("encryption", title="Server-Side Encryption", enum=[None, "AES256"], default=None, null=True),
         Str("storage_class", title="The storage class to use", enum=["", "STANDARD", "REDUCED_REDUNDANCY",
-                                                                     "STANDARD_IA", "ONEZONE_IA", "GLACIER",
-                                                                     "DEEP_ARCHIVE"]),
+                                                                     "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING",
+                                                                     "GLACIER", "DEEP_ARCHIVE"]),
     ]
 
     def _get_client(self, credentials):


### PR DESCRIPTION
`INTELLIGENT_TIERING` currently not available as a selectable storage class for Cloud Sync Tasks. PR is for making it available for selection.

S3 API Docs: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax
S3 Storage Class Docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html

