### PR TITLE
NAS-112445 / 13.0 / Reimplement zilstat SNMP MIBs to avoid using DTrace

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -425,6 +425,13 @@ class ZpoolIoThread(threading.Thread):
             return copy.deepcopy(self.values_overall), copy.deepcopy(self.values_1s)
 
 
+def readZilOpsCount() -> int:
+    return (
+        sysctl.filter("kstat.zfs.misc.zil.zil_itx_metaslab_normal_count")[0].value +
+        sysctl.filter("kstat.zfs.misc.zil.zil_itx_metaslab_slog_count")[0].value
+    )
+
+
 class ZilstatThread(threading.Thread):
     def __init__(self, interval):
         super().__init__()
@@ -432,42 +439,15 @@ class ZilstatThread(threading.Thread):
         self.daemon = True
 
         self.interval = interval
-        self.value = {
-            "NBytes": 0,
-            "NBytespersec": 0,
-            "NMaxRate": 0,
-            "BBytes": 0,
-            "BBytespersec": 0,
-            "BMaxRate": 0,
-            "ops": 0,
-            "lteq4kb": 0,
-            "4to32kb": 0,
-            "gteq4kb": 0,
-        }
+        self.value = 0
 
     def run(self):
-        zilstatproc = subprocess.Popen(
-            ["/usr/local/bin/zilstat", str(self.interval)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            preexec_fn=os.setsid,
-        )
-        zilstatproc.stdout.readline().strip()
-        while zilstatproc.poll() is None:
-            output = zilstatproc.stdout.readline().strip().split()
-            value = {
-                "NBytes": output[0],
-                "NBytespersec": output[1],
-                "NMaxRate": output[2],
-                "BBytes": output[3],
-                "BBytespersec": output[4],
-                "BMaxRate": output[5],
-                "ops": int(output[6]),
-                "lteq4kb": output[7],
-                "4to32kb": output[8],
-                "gteq4kb": output[9],
-            }
-            self.value = value
+        previous = readZilOpsCount()
+        while True:
+            time.sleep(self.interval)
+            current = readZilOpsCount()
+            self.value = current - previous
+            previous = current
 
 
 class CpuTempThread(threading.Thread):
@@ -862,10 +842,10 @@ if __name__ == "__main__":
             zfs_l2arc_size.update(int(kstat["kstat.zfs.misc.arcstats.l2_asize"] / 1024))
 
             if zilstat_1_thread:
-                zfs_zilstat_ops1.update(zilstat_1_thread.value["ops"])
+                zfs_zilstat_ops1.update(zilstat_1_thread.value)
             if zilstat_5_thread:
-                zfs_zilstat_ops5.update(zilstat_5_thread.value["ops"])
+                zfs_zilstat_ops5.update(zilstat_5_thread.value)
             if zilstat_10_thread:
-                zfs_zilstat_ops10.update(zilstat_10_thread.value["ops"])
+                zfs_zilstat_ops10.update(zilstat_10_thread.value)
 
             last_update_at = datetime.utcnow()


### PR DESCRIPTION
The zfsZilstatOps MIBs can be implemented using OpenZFS zil kstat
counters in CORE rather than the zilstat script which relies on DTrace,
similar to how this is being reimplemented for SCALE.

Jira: NAS-112445