### PR TITLE
NAS-112446 / 21.10 / rewrite coredump code on SCALE

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -1,57 +1,35 @@
-import re
-
-from datetime import timedelta
-
-from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert, IntervalSchedule
-from middlewared.utils import run
-
-
-SKIP_REGEX = re.compile(r'Unit:\s+containerd.service')
+from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
 
 
 class CoreFilesArePresentAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
-    title = "Core Files Found in System Database"
+    title = "Core Files Found in System Dataset"
     text = ("Core files for the following executables were found: %(corefiles)s. Please create a ticket at "
             "https://jira.ixsystems.com/ and attach the relevant core files along with a system debug. "
             "Once the core files have been archived and attached to the ticket, they may be removed "
             "by running the following command in shell: 'rm /var/db/system/cores/*'.")
 
-    products = ("CORE", "SCALE")
+    products = ("SCALE",)
 
 
 class CoreFilesArePresentAlertSource(AlertSource):
-    dumps = {}
-    dump_error_logged = []
-    schedule = IntervalSchedule(timedelta(hours=6))
-
     products = ("SCALE",)
+    ignore = ("syslog-ng.service", "containerd.service")
 
     async def check(self):
         corefiles = []
         for coredump in filter(lambda c: c["corefile"] == "present", await self.middleware.call("system.coredumps")):
-            if coredump["exe"] == "/usr/sbin/syslog-ng" or coredump["pid"] in self.dump_error_logged:
-                continue
+            if coredump["unit"] in self.ignore:
+                # Unit: "syslog-ng.service" has been core dumping for, literally, years
+                # on freeBSD and now also on linux. The fix is non-trivial and it seems
+                # to be very specific to how we implemented our system dataset. Anyways,
+                # the crash isn't harmful so we ignore it.
 
-            if coredump["pid"] not in self.dumps:
-                cp = await run(
-                    "coredumpctl", "info", str(coredump["pid"]), check=False, encoding="utf-8", errors="ignore"
-                )
-                if cp.returncode:
-                    self.middleware.logger.debug(
-                        "Unable to retrieve coredump information of %r process", coredump["pid"]
-                    )
-                    self.dump_error_logged.append(coredump["pid"])
-                    continue
-
-                self.dumps[coredump["pid"]] = {
-                    **coredump,
-                    "happened_in_container": bool(SKIP_REGEX.findall(cp.stdout))
-                }
-
-            if self.dumps[coredump["pid"]]["happened_in_container"]:
-                # We don't want to raise an alert to user about a container which died for some reason
+                # Unit: "containerd.service" is related to k3s.
+                # users are free to run whatever they would like to in containers
+                # and we don't officially support all the apps themselves so we
+                # ignore those core dumps
                 continue
 
             corefiles.append(f"{coredump['exe']} ({coredump['time']})")

--- a/src/middlewared/middlewared/plugins/system_/coredump.py
+++ b/src/middlewared/middlewared/plugins/system_/coredump.py
@@ -14,16 +14,20 @@ class SystemService(Service):
             with journal.Reader() as reader:
                 reader.add_match(CODE_FUNC='submit_coredump')
                 for core in reader:
-                    coredumps.append({
+                    coredump = {
                         'time': core['COREDUMP_TIMESTAMP'].strftime('%c'),
                         'pid': core['COREDUMP_PID'],
                         'uid': core['COREDUMP_UID'],
                         'gid': core['COREDUMP_GID'],
                         'unit': core['COREDUMP_UNIT'],
                         'sig': core['COREDUMP_SIGNAL'],
-                        'corefile': 'present' if exists(core['COREDUMP_FILENAME']) else 'missing',
                         'exe': core['COREDUMP_EXE'],
-                    })
+                    }
+                    if isinstance(core['COREDUMP_FILENAME'], str):
+                        coredump['corefile'] = 'present' if exists(core['COREDUMP_FILENAME']) else 'missing'
+                    else:
+                        coredump['corefile'] = 'none'
+                    coredumps.append(coredump)
         except Exception:
             self.logger.warning('Failed to obtain coredump information', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/system_/coredump.py
+++ b/src/middlewared/middlewared/plugins/system_/coredump.py
@@ -1,33 +1,30 @@
-# -*- coding=utf-8 -*-
-import logging
+from os.path import exists
+from systemd import journal
 
 from middlewared.service import private, Service
-from middlewared.utils import run
-
-logger = logging.getLogger(__name__)
 
 
 class SystemService(Service):
-    @private
-    async def coredumps(self):
-        coredumps = []
-        coredumpctl = await run("coredumpctl", "list", "--no-pager", encoding="utf-8", errors="ignore", check=False)
-        if coredumpctl.returncode != 0:
-            return []
 
-        lines = coredumpctl.stdout.splitlines()
-        header = lines.pop(0)
-        exe_pos = header.find("EXE")
-        for line in lines:
-            exe = line[exe_pos:]
-            time, pid, uid, gid, sig, corefile = line[:exe_pos].rsplit(maxsplit=5)
-            coredumps.append({
-                "time": time,
-                "pid": int(pid),
-                "uid": int(uid),
-                "gid": int(gid),
-                "sig": int(sig),
-                "corefile": corefile,
-                "exe": exe,
-            })
+    @private
+    def coredumps(self):
+        coredumps = []
+
+        try:
+            with journal.Reader() as reader:
+                reader.add_match(CODE_FUNC='submit_coredump')
+                for core in reader:
+                    coredumps.append({
+                        'time': core['COREDUMP_TIMESTAMP'].strftime('%c'),
+                        'pid': core['COREDUMP_PID'],
+                        'uid': core['COREDUMP_UID'],
+                        'gid': core['COREDUMP_GID'],
+                        'unit': core['COREDUMP_UNIT'],
+                        'sig': core['COREDUMP_SIGNAL'],
+                        'corefile': 'present' if exists(core['COREDUMP_FILENAME']) else 'missing',
+                        'exe': core['COREDUMP_EXE'],
+                    })
+        except Exception:
+            self.logger.warning('Failed to obtain coredump information', exc_info=True)
+
         return coredumps


### PR DESCRIPTION
This fixes 3 primary issues:

1. we alert the end-user to open a ticket on Jira and then tell them to remove the core file once they've uploaded it to us but the interval for running this alert is every 6 hours. This means if the user removes that core file, the alert will linger in the webUI for the remainder of the interval that's left from when we last checked. This causes time to be spent on a non-issue.
2. we're calling `subprocess` and while we're doing every 6hrs, it still isn't "proper" especially since the `systemd.journal.Reader` class allows us to bypass it completely.
3. Because we're no longer using `subprocess` we no longer cache a dict of coredump information. Before this change, we were growing that dict unbounded which means, in theory, it could accumulate lots of RAM usage.

My changes allows us to check for coredumps every 60 seconds (polling alert system default) and doesn't cache anything to forgo unnecessary complexity.