### PR TITLE
NAS-112467 / 12.0 / fix TypeError crash in enclosure plugin on 12

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -425,7 +425,7 @@ class Enclosure(object):
     def __init__(self, num, data, stat, product):
         self.num = num
         self.stat = stat
-        self.product = product
+        self.product = product if product else ''
         self.devname = f"ses{num}"
         self.encname = ""
         self.encid = ""


### PR DESCRIPTION
`product` cannot be `None` because we use built-in `str` methods on that variable as well as pass it to `re`'s various methods.  This specific use-case crashed at `MINI_REGEX.match(...` with a `TypeError: expected string or bytes-like object`.

So when we instantiate an `Enclosure` class, we'll make sure the `self.product` variable is initiated to an empty string always.