### PR TITLE
NAS-112468 / 21.10 / Update middleware for samba changes in 4.15

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -131,6 +131,7 @@ class GlobalSchema(RegistrySchema):
         RegObj("unixcharset", "unix charset", "UTF8"),
         RegObj("syslog", "syslog only", False),
         RegObj("localmaster", "local master", False),
+        RegObj("multichannel", "server multi channel support", True),
         RegObj("loglevel", "log level", "MINIMUM",
                smbconf_parser=log_level_transform, schema_parser=set_log_level),
         RegObj("guest", "guest account", "nobody"),

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -352,7 +352,7 @@ class ShareSchema(RegistrySchema):
 
         data_out['vfs objects']['parsed'].append("streams_xattr")
         if not data_in.get("cluster_volname"):
-            data_out['smbd:max_xattr_size'] = {"parsed": 2097152}
+            data_out['smbd max xattr size'] = {"parsed": 2097152}
 
         if data_in['fruit_enabled']:
             data_out["fruit:metadata"] = {"parsed": "stream"}


### PR DESCRIPTION
CLI tools use different args for kerberos-related methods.

Multichannel support is now default in samba. Plumb though
our schema 'multichannel' parameter. Disabled by default, currently
raises ValidationError (until we have satisfactory testing in place).

My max xattr size parameter was accepted upstream with slightly different
implementation. Adjust parameter name accordingly.