### PR TITLE
NAS-112471 / 12.0 / correctly retrieve parent dataset in pool.py

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3186,7 +3186,7 @@ class PoolDatasetService(CRUDService):
 
         parent = await self.middleware.call(
             'zfs.dataset.query',
-            [('id', '=', data['name'].rsplit('/')[0])],
+            [('id', '=', data['name'].rsplit('/', 1)[0])],
             {'extra': {'recursive': False}},
         )
 


### PR DESCRIPTION
As far as I can tell, this has never queried for the parent dataset properly. It's been broken since at least 2018 in `12.0-stable` but was fixed in commit 71cc23e2f4cbb1d2acdcc0b7e70fb141dab94b5a in the `master` repo in 2020 but never backported to this repo.