### PR TITLE
NAS-112531 / 21.10 / Alter behavior of restrict_pam key for AD plugin

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
@@ -41,7 +41,11 @@
             return 'ActiveDirectory'
 
         def enabled(self):
-            return self.safe_call('activedirectory.config')['enable']
+            config = self.safe_call('activedirectory.config')
+            if config['restrict_pam']:
+                return False
+
+            return config['enable']
 
         def pam_auth(self):
             module = self.pam_winbind

--- a/src/middlewared/middlewared/etc_files/security/pam_winbind.conf.mako
+++ b/src/middlewared/middlewared/etc_files/security/pam_winbind.conf.mako
@@ -9,9 +9,6 @@
     ad = middleware.call_sync('activedirectory.config')
 %>
 [global]
-%if ad['restrict_pam']:
-require_membership_of = S-1-5-32-544
-%endif
 %if ad['verbose_logging']:
 debug = yes
 %else:


### PR DESCRIPTION
Originally restrict_pam limited to members of S-1-5-32-544,
but due to certain limitations in pam_winbind it is probably
more useful to provide users with ability to entirely disable
pam integration rather than trying to split hairs here.