### PR TITLE
NAS-112577 / 21.10 / prevent hook_setup_ha endless loop on HA systems

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1429,7 +1429,7 @@ async def hook_setup_ha(middleware, *args, **kwargs):
     if not await middleware.call('failover.licensed'):
         return
 
-    if not await middleware.call('interface.query', [('failover_virtual_aliases', '!=', None)]):
+    if not await middleware.call('interface.query', [('failover_virtual_aliases', '!=', [])]):
         return
 
     if not await middleware.call('pool.query'):


### PR DESCRIPTION
Gather round for a tale about a series of unfortunate events.  Back in 2018 a commit (33dee08d77a53962891177fee68c146ea442fc7c) was made to add a `hook` so that certain methods could be triggered under certain circumstances. Unfortunately, a subtle typo exposed a rather rare but excruciating endless loop. The perpetrator is `hook_setup_ha`. Let me try to explain the scenario...

1. have an HA system and both controllers be online and functional (no configuration except for it to be licensed for HA)
2. DHCP configured on network to hand an address out to _both_ controllers

In the above scenario, DHCP will hand an address out to both controllers as expected. If you log into 1 of the controllers and create a zpool, the series of events is as follows:

1. `pool.do_create` calls hook `post_create_or_update`
2. `post_create_or_update` calls `hook_setup_ha`
3. `hook_setup_ha` (in this scenario) calls `'interface.query', [('failover_virtual_aliases', '!=', None)]` which *NEVER* evaluates to `True` because that attribute is not a `NoneType`. It's a list `[]` and while the `failover_virtual_aliases` represents the VIP on an HA system and in this scenario there isn't one, this call returns information because DHCP has assigned an IP address to the interface.
4. so moving on, `hook_setup_ha` gets to the point where it calls `failover.call_remote interface.sync`
5. `interface.sync` calls `interface.unconfigure` and removes the IP addresses from all interfaces since there are no interfaces written to the database (as expected)
6. `interface.sync` then calls `interface.autoconfigure` (which enables DHCP on the interface it just unconfigured)
7. DHCP hands an address to the interface
8. `interface.sync` ends up calling `interface.post_sync`
9. `interface.post_sync` ends up calling `hook_setup_ha`

So when we call `failover.call_remote interface.sync` because of the typo `'interface.query', [('failover_virtual_aliases', '!=', None)]`,  it actually (in a non-obvious, extremely "round about" way) ends up calling `failover.call_remote interface.sync` from the remote node.

So now both nodes are calling `failover.call_remote interface.sync` in an endless loop.