### PR TITLE
NAS-112447 / 21.10 / fix HA network validation

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1319,9 +1319,9 @@ class InterfaceService(CRUDService):
                         'VLAN MTU cannot be bigger than parent interface.',
                     )
 
-        aliases = data.get('aliases', [])
-        aliases.extend(data.get('failover_aliases', []))
-        aliases.extend(data.get('failover_virtual_aliases', []))
+        aliases = data.get('aliases', []).copy()
+        aliases.extend(data.get('failover_aliases', []).copy())
+        aliases.extend(data.get('failover_virtual_aliases', []).copy())
         mtu = data.get('mtu')
         if mtu and mtu < 1280 and any(i['type'] == 'INET6' for i in aliases):
             # we set the minimum MTU to 68 for IPv4 (per https://tools.ietf.org/html/rfc791)


### PR DESCRIPTION
Shame on me! Python is supposed to protect you from the nefarious situations that `C` inflicts upon its victims so often.

`aliases = data.get('aliases'` creates a "reference" (pointer) to the `aliases` list in `data` and then I subsequently `.extend(` it so on line 1351 we trigger a `ValidationError` 🤦 

Create a shallow `.copy()` of these items to prevent said scenario.