### PR TITLE
NAS-112584 / 21.10 / Fix logic for path_suffix removal

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1626,8 +1626,8 @@ class SharingSMBService(SharingService):
         case user-defined takes precedence.
         """
         params = (SMBSharePreset[data["purpose"]].value)["params"].copy()
-        if data.get('home') and not params['path_suffix']:
-            params.pop('path_suffix')
+        if data.get('home'):
+            params.pop('path_suffix', None)
 
         aux = params.pop("auxsmbconf")
         data.update(params)


### PR DESCRIPTION
We want to basically substitute path_suffix provided by preset
in case share is a `home` share.