### PR TITLE
NAS-112581 / 21.10 / fix ssh key generation on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/ssh.py
+++ b/src/middlewared/middlewared/plugins/ssh.py
@@ -206,8 +206,16 @@ class SSHService(SystemServiceService):
     @private
     def generate_keys(self):
         self.middleware.logger.debug("Generating SSH host keys")
-        p = subprocess.run(["dpkg-reconfigure", "openssh-server"], stdout=subprocess.PIPE,
-                           stderr=subprocess.STDOUT, encoding="utf-8", errors="ignore")
+        p = subprocess.run(
+            # For each of the key types (rsa, dsa, ecdsa and ed25519) for which host keys do not exist,
+            # generate the host keys with the default key file path, an empty passphrase, default bits
+            # for the key type, and default comment.
+            ["ssh-keygen", "-A"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+            errors="ignore"
+        )
         if p.returncode != 0:
             self.middleware.logger.error("Error generating SSH host keys: %s", p.stdout)
 


### PR DESCRIPTION
Using `dpkg-reconfigure` was failing in spectacular ways.

1. `dpkg-reconfigure` is interactive so it will ask the user questions. This obviously failed since we run this during upgrades and at boot time so answering questions is not an option.
2. `dpkg-reconfigure` has an `--frontend=noninteractive` option that you can use which makes it run silently and use the default answers for said `apt` package. However, in our implementation we still have ssh keys on disk so when doing this it fails with an error of `rescue-ssh.target is a disabled or a static unit, not starting it`
3. finally, `ix-ssh-keys.service` would exit with an error so the `middlewared.service` would fail to get setup leaving the system in an unusable state.

Make this extremely simple by just calling `ssh-keygen -A`. The man pages explain it best.


>For each of the key types (rsa, dsa, ecdsa and ed25519) for which host keys do not exist, generate the host keys with the default key file path, an empty passphrase, default bits for the key type, and default comment.  If -f has also been specified, its argument is used as a prefix to the default path for the resulting host key files.
