### PR TITLE
Load ntb_netdev module on boot.

### DIFF
--- a/src/freenas/debian/rules
+++ b/src/freenas/debian/rules
@@ -21,6 +21,7 @@ override_dh_auto_install:
 		cp -a etc/grub.d debian/truenas-files/etc/; \
 		cp etc/iso_3166_2_countries.csv debian/truenas-files/etc/; \
 		cp -a etc/logrotate.d debian/truenas-files/etc/; \
+		cp -a etc/modules debian/truenas-files/etc/; \
 		cp etc/netcli debian/truenas-files/etc/; \
 		cp etc/nsswitch.conf debian/truenas-files/etc/; \
 		cp -a etc/syslog-ng debian/truenas-files/etc/; \

--- a/src/freenas/etc/modules
+++ b/src/freenas/etc/modules
@@ -1,0 +1,1 @@
+ntb_netdev


### PR DESCRIPTION
I've fixed problem with NTB modules load order, so now this should work, providing NTB network interface on X and M-series, though on X-series it may still not work, haven't checked.  It is still not complete, using one hack, and so it is not future-compatible on protocol side, but should allow basic HA integration and testing.