### PR TITLE
NAS-112602 / 21.10 / systemd.link file to rename ntb device on SCALE HA

### DIFF
--- a/src/freenas/etc/systemd/network/10-persistent-net.link
+++ b/src/freenas/etc/systemd/network/10-persistent-net.link
@@ -1,0 +1,5 @@
+[Match]
+Driver=ntb_netdev
+
+[Link]
+Name=ntb0


### PR DESCRIPTION
The `ntb` network device driver hard-codes the ethernet device name to `eth0` on SCALE. We can change that to `ntb0` quite easily as to not interfere with any other devices in the universe that also try to use `eth0`. This prevents us from having to probe the device after the system is booted and query for specific vendor/model/unique properties for the heartbeat interface on SCALE HA systems.

Note: this file has to exist on the filesystem when the ntb device is being loaded and brought online. Changing the name after the fact requires `down()`'ing and then `up()`'ing the device which is highly undesirable.