### PR TITLE
NAS-112603 / 21.10 / return ntb0 on X/M series for SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -16,11 +16,7 @@ class InternalInterfaceService(Service):
         namespace = 'failover.internal_interface'
 
     def detect(self):
-
-        hardware = self.middleware.call_sync(
-            'failover.hardware'
-        )
-
+        hardware = self.middleware.call_sync('failover.hardware')
         # Return BHYVE heartbeat interface
         if hardware == 'BHYVE':
             return ['enp0s6f1']
@@ -34,10 +30,8 @@ class InternalInterfaceService(Service):
                     if ZSERIES_PCI_ID and ZSERIES_PCI_SUBSYS_ID in data:
                         return [i.split('/')[4].strip()]
 
-        # Detect X-series and M-series heartbeat interface
-        # TODO: Fix this
         if hardware in ('PUMA', 'ECHOWARP'):
-            pass
+            return ['ntb0']
 
         return []
 


### PR DESCRIPTION
`ntb` driver is working on SCALE and the interface name is hard-coded to `ntb0`.