### PR TITLE
NAS-112490 / 21.10 / Account for difference in Linux / FreeBSD in AD homedir creation

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf.mako
@@ -64,6 +64,9 @@
                     base_homedir = f"{share['path']}/{db['cifs']['workgroup']}"
                     if not pc[share["name"]].get('ixnas:zfs_auto_home_dir'):
                         make_homedir(base_homedir)
+                        st = os.stat(share['path'])
+                        os.chown(base_homedir, -1, st.st_gid)
+
                 elif is_home_share:
                     pc[share["name"]].update({"path": f'{share["path"]}/%U'})
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1220,21 +1220,22 @@ class SharingSMBService(SharingService):
             share = await self.query([('id', '=', id)], {'get': True})
             result = id
 
+        share_name = 'homes' if share['home'] else share['name']
         share_list = await self.middleware.call('sharing.smb.reg_listshares')
-        if share['name'] in share_list:
-            await self.close_share(share['name'])
+        if share_name in share_list:
+            await self.close_share(share_name)
             try:
-                await self.middleware.call('smb.sharesec._delete', share['name'] if not share['home'] else 'homes')
+                await self.middleware.call('smb.sharesec._delete', share_name)
             except Exception:
-                self.logger.debug('Failed to delete share ACL for [%s].', share['name'], exc_info=True)
+                self.logger.debug('Failed to delete share ACL for [%s].', share_name, exc_info=True)
 
             try:
-                await self.middleware.call('sharing.smb.reg_delshare',
-                                           share['name'] if not share['home'] else 'homes')
+                await self.middleware.call('sharing.smb.reg_delshare', share_name)
+
             except MatchNotFound:
                 pass
             except Exception:
-                self.logger.warn('Failed to remove registry entry for [%s].', share['name'], exc_info=True)
+                self.logger.warn('Failed to remove registry entry for [%s].', share_name, exc_info=True)
 
         if share['timemachine']:
             await self.middleware.call('service.restart', 'mdns')


### PR DESCRIPTION
When automatically creating directory for domain for homedir, copy
group from parent directory. FreeBSD preserves group in this situation,
but Linux does not. Child directories created by pam_mkhomedir should
do the right thing because nss_winbind will set AD users up with
domain users as primary group in most relevant situations.