### PR TITLE
NAS-112628 / 21.10 / Adjust site-specific kerberos info for API usage change

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1278,11 +1278,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             if len(servers) == 1:
                 return None
 
-        return {
-            'kdc': ' '.join(kdc),
-            'admin_server': ' '.join(admin_server),
-            'kpasswd_server': ' '.join(kpasswd)
-        }
+        return {'kdc': kdc, 'admin_server': admin_server, 'kpasswd_server': kpasswd}
 
     @private
     def set_kerberos_servers(self, ad=None):
@@ -1295,7 +1291,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                 ad['kerberos_realm'],
                 site_indexed_kerberos_servers
             )
-            self.middleware.call_sync('etc.generate', 'kerberos')
 
     @private
     async def set_ntp_servers(self):


### PR DESCRIPTION
We've switched from datastore.update to using kerberos.update
for inserting site-specific kerberos changes. This means
we need to submit list rather than string.