### PR TITLE
NAS-112627 / 12.0 / make DiskStats not suck

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -166,7 +166,7 @@ class RealtimeEventSource(EventSource):
             'time': time.monotonic(),
             'speeds': self.get_interface_speeds(),
         }
-        self.disk_stats = DiskStats(2)
+        self.disk_stats = DiskStats()
 
         while not self._cancel.is_set():
             data = {}

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -1,20 +1,13 @@
 import itertools
-import json
 import psutil
 import re
 import struct
-import subprocess
 import time
 
-import humanfriendly
-
+import sysctl
+import netif
 from middlewared.event import EventSource
 from middlewared.plugins.reporting.iostat import DiskStats
-from middlewared.utils import osc
-
-if osc.IS_FREEBSD:
-    import sysctl
-    import netif
 
 
 MEGABIT = 131072
@@ -30,90 +23,44 @@ class RealtimeEventSource(EventSource):
     """
 
     INTERFACE_SPEEDS_CACHE_INTERLVAL = 300
-
-    disk_stats = None
+    INTERVAL = 2
 
     @staticmethod
     def get_cpu_usages(cp_diff):
-        cp_total = sum(cp_diff) or 1
         data = {}
+        cp_total = sum(cp_diff) or 1
         data['user'] = cp_diff[0] / cp_total * 100
         data['nice'] = cp_diff[1] / cp_total * 100
         data['system'] = cp_diff[2] / cp_total * 100
-        if osc.IS_FREEBSD:
-            idle = 4
-            data['interrupt'] = cp_diff[3] / cp_total * 100
-            data['idle'] = cp_diff[4] / cp_total * 100
-        elif osc.IS_LINUX:
-            idle = 3
-            data['idle'] = cp_diff[3] / cp_total * 100
-            data['iowait'] = cp_diff[4] / cp_total * 100
-            data['irq'] = cp_diff[5] / cp_total * 100
-            data['softirq'] = cp_diff[6] / cp_total * 100
-            data['steal'] = cp_diff[7] / cp_total * 100
-            data['guest'] = cp_diff[8] / cp_total * 100
-            data['guest_nice'] = cp_diff[9] / cp_total * 100
+        data['interrupt'] = cp_diff[3] / cp_total * 100
+        data['idle'] = cp_diff[4] / cp_total * 100
+
         # Usage is the sum of all but idle
         if sum(cp_diff):
+            idle = 4
             data['usage'] = ((cp_total - cp_diff[idle]) / cp_total) * 100
         else:
             data['usage'] = 0
         return data
 
     def get_memory_info(self, arc_size):
-        if osc.IS_FREEBSD:
-            page_size = int(sysctl.filter("hw.pagesize")[0].value)
-            classes = {
-                k: v if isinstance(v, int) else struct.unpack("I", v)[0] * page_size
-                for k, v in [
-                    (k, sysctl.filter(f"vm.stats.vm.v_{k}_count")[0].value)
-                    for k in ["cache", "laundry", "inactive", "active", "wire", "free"]
-                ]
-            }
-            classes["os_reserved"] = int(sysctl.filter("hw.physmem")[0].value) - sum(classes.values())
+        page_size = int(sysctl.filter("hw.pagesize")[0].value)
+        classes = {
+            k: v if isinstance(v, int) else struct.unpack("I", v)[0] * page_size
+            for k, v in [
+                (k, sysctl.filter(f"vm.stats.vm.v_{k}_count")[0].value)
+                for k in ["cache", "laundry", "inactive", "active", "wire", "free"]
+            ]
+        }
+        classes["os_reserved"] = int(sysctl.filter("hw.physmem")[0].value) - sum(classes.values())
 
-            classes["wire"] -= arc_size
-            classes["arc"] = arc_size
+        classes["wire"] -= arc_size
+        classes["arc"] = arc_size
 
-            extra = {}
+        extra = {}
 
-            sswap = psutil.swap_memory()
-            swap = {
-                "used": sswap.used,
-                "total": sswap.total,
-            }
-        else:
-            with open("/proc/meminfo") as f:
-                meminfo = {
-                    s[0]: humanfriendly.parse_size(s[1], binary=True)
-                    for s in [
-                        line.split(":", 1)
-                        for line in f.readlines()
-                    ]
-                }
-
-            classes = {}
-            classes["page_tables"] = meminfo["PageTables"]
-            classes["swap_cache"] = meminfo["SwapCached"]
-            classes["slab_cache"] = meminfo["Slab"]
-            classes["cache"] = meminfo["Cached"]
-            classes["buffers"] = meminfo["Buffers"]
-            classes["unused"] = meminfo["MemFree"]
-            classes["arc"] = arc_size
-            classes["apps"] = meminfo["MemTotal"] - sum(classes.values())
-
-            extra = {
-                "inactive": meminfo["Inactive"],
-                "committed": meminfo["Committed_AS"],
-                "active": meminfo["Active"],
-                "vmalloc_used": meminfo["VmallocUsed"],
-                "mapped": meminfo["Mapped"],
-            }
-
-            swap = {
-                "used": meminfo["SwapTotal"] - meminfo["SwapFree"],
-                "total": meminfo["SwapTotal"],
-            }
+        sswap = psutil.swap_memory()
+        swap = {"used": sswap.used, "total": sswap.total}
 
         return {
             "classes": classes,
@@ -162,38 +109,19 @@ class RealtimeEventSource(EventSource):
         cp_time_last = None
         cp_times_last = None
         last_interface_stats = {}
-        last_interface_speeds = {
-            'time': time.monotonic(),
-            'speeds': self.get_interface_speeds(),
-        }
-        self.disk_stats = DiskStats()
+        last_interface_speeds = {'time': time.monotonic(), 'speeds': self.get_interface_speeds()}
 
         while not self._cancel.is_set():
             data = {}
-
 
             # ZFS ARC Size (raw value is in Bytes)
             hits = 0
             misses = 0
             data['zfs'] = {}
-            if osc.IS_FREEBSD:
-                hits = sysctl.filter('kstat.zfs.misc.arcstats.hits')[0].value
-                misses = sysctl.filter('kstat.zfs.misc.arcstats.misses')[0].value
-                data['zfs']['arc_max_size'] = sysctl.filter('kstat.zfs.misc.arcstats.c_max')[0].value
-                data['zfs']['arc_size'] = sysctl.filter('kstat.zfs.misc.arcstats.size')[0].value
-            elif osc.IS_LINUX:
-                with open('/proc/spl/kstat/zfs/arcstats') as f:
-                    for line in f.readlines()[2:]:
-                        if line.strip():
-                            name, type, value = line.strip().split()
-                            if name == 'hits':
-                                hits = int(value)
-                            if name == 'misses':
-                                misses = int(value)
-                            if name == 'c_max':
-                                data['zfs']['arc_max_size'] = int(value)
-                            if name == 'size':
-                                data['zfs']['arc_size'] = int(value)
+            hits = sysctl.filter('kstat.zfs.misc.arcstats.hits')[0].value
+            misses = sysctl.filter('kstat.zfs.misc.arcstats.misses')[0].value
+            data['zfs']['arc_max_size'] = sysctl.filter('kstat.zfs.misc.arcstats.c_max')[0].value
+            data['zfs']['arc_size'] = sysctl.filter('kstat.zfs.misc.arcstats.size')[0].value
             total = hits + misses
             if total > 0:
                 data['zfs']['cache_hit_ratio'] = hits / total
@@ -204,34 +132,11 @@ class RealtimeEventSource(EventSource):
             data['memory'] = self.get_memory_info(data['zfs']['arc_size'])
             data['virtual_memory'] = psutil.virtual_memory()._asdict()
 
-            data['cpu'] = {}
             # Get CPU usage %
-            if osc.IS_FREEBSD:
-                num_times = 5
-                # cp_times has values for all cores
-                cp_times = sysctl.filter('kern.cp_times')[0].value
-                # cp_time is the sum of all cores
-                cp_time = sysctl.filter('kern.cp_time')[0].value
-            elif osc.IS_LINUX:
-                num_times = 10
-                with open('/proc/stat') as f:
-                    stat = f.read()
-                cp_times = []
-                cp_time = []
-                for line in stat.split('\n'):
-                    if line.startswith('cpu'):
-                        line_ints = [int(i) for i in line[5:].strip().split()]
-                        # cpu has a sum of all cpus
-                        if line[3] == ' ':
-                            cp_time = line_ints
-                        # cpuX is for each core
-                        else:
-                            cp_times += line_ints
-                    else:
-                        break
-            else:
-                cp_time = cp_times = None
-
+            data['cpu'] = {}
+            num_times = 5
+            cp_times = sysctl.filter('kern.cp_times')[0].value  # cp_times has values for all cores
+            cp_time = sysctl.filter('kern.cp_time')[0].value  # cp_time is the sum of all cores
             if cp_time and cp_times and cp_times_last:
                 # Get the difference of times between the last check and the current one
                 # cp_time has a list with user, nice, system, interrupt and idle
@@ -248,52 +153,45 @@ class RealtimeEventSource(EventSource):
 
             # CPU temperature
             data['cpu']['temperature'] = {}
-            if osc.IS_FREEBSD:
-                for i in itertools.count():
-                    v = sysctl.filter(f'dev.cpu.{i}.temperature')
-                    if not v:
-                        break
-                    data['cpu']['temperature'][i] = v[0].value
+            for i in itertools.count():
+                v = sysctl.filter(f'dev.cpu.{i}.temperature')
+                if not v:
+                    break
+                data['cpu']['temperature'][i] = v[0].value
             data['cpu']['temperature_celsius'] = {k: (v - 2732) / 10 for k, v in data['cpu']['temperature'].items()}
 
             # Interface related statistics
             if last_interface_speeds['time'] < time.monotonic() - self.INTERFACE_SPEEDS_CACHE_INTERLVAL:
-                last_interface_speeds.update({
-                    'time': time.monotonic(),
-                    'speeds': self.get_interface_speeds(),
-                })
-            if osc.IS_FREEBSD:
-                # Interface related statistics
-                data['interfaces'] = {}
-                retrieve_stat_keys = ['received_bytes', 'sent_bytes']
-                for iface in netif.list_interfaces().values():
-                    for addr in filter(lambda addr: addr.af.name.lower() == 'link', iface.addresses):
-                        addr_data = addr.__getstate__(stats=True)
-                        stats_time = time.time()
-                        data['interfaces'][iface.name] = {
-                            'speed': last_interface_speeds['speeds'].get(iface.name),
+                last_interface_speeds.update({'time': time.monotonic(), 'speeds': self.get_interface_speeds()})
+
+            data['interfaces'] = {}
+            retrieve_stat_keys = ['received_bytes', 'sent_bytes']
+            for iface in netif.list_interfaces().values():
+                for addr in filter(lambda addr: addr.af.name.lower() == 'link', iface.addresses):
+                    addr_data = addr.__getstate__(stats=True)
+                    stats_time = time.time()
+                    data['interfaces'][iface.name] = {
+                        'speed': last_interface_speeds['speeds'].get(iface.name),
+                    }
+                    for k in retrieve_stat_keys:
+                        traffic_stats = 0
+                        if last_interface_stats.get(iface.name):
+                            traffic_stats = addr_data['stats'][k] - last_interface_stats[iface.name][k]
+                            traffic_stats = int(
+                                traffic_stats / (time.time() - last_interface_stats[iface.name]['stats_time'])
+                            )
+                        details_dict = {
+                            k: addr_data['stats'][k],
+                            f'{k}_rate': traffic_stats,
                         }
-                        for k in retrieve_stat_keys:
-                            traffic_stats = 0
-                            if last_interface_stats.get(iface.name):
-                                traffic_stats = addr_data['stats'][k] - last_interface_stats[iface.name][k]
-                                traffic_stats = int(
-                                    traffic_stats / (time.time() - last_interface_stats[iface.name]['stats_time'])
-                                )
-                            details_dict = {
-                                k: addr_data['stats'][k],
-                                f'{k}_rate': traffic_stats,
-                            }
-                            data['interfaces'][iface.name].update(details_dict)
-                        last_interface_stats[iface.name] = {**data['interfaces'][iface.name], 'stats_time': stats_time}
-            data['disks'] = self.disk_stats.read()
+                        data['interfaces'][iface.name].update(details_dict)
+                    last_interface_stats[iface.name] = {**data['interfaces'][iface.name], 'stats_time': stats_time}
+
+            # Disk IO stats
+            data['disks'] = DiskStats(self.INTERVAL).read()
 
             self.send_event('ADDED', fields=data)
-            time.sleep(2)
-
-    def on_finish(self):
-        if self.disk_stats != None:
-            self.disk_stats.stop()
+            time.sleep(self.INTERVAL)
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/plugins/reporting/iostat.py
+++ b/src/middlewared/middlewared/plugins/reporting/iostat.py
@@ -1,84 +1,29 @@
-import logging
-import subprocess
-import time
-
-from middlewared.utils import start_daemon_thread
-
-logger = logging.getLogger(__name__)
+from psutil import disk_io_counters
+from statistics import mean
 
 
 class DiskStats:
-    def __init__(self, interval):
-        self.interval = interval
-        self.process = None
-        self.run = True
-        self.stats = {}
-        start_daemon_thread(target=self._read)
-
-    def _read(self):
-        while self.run:
-            try:
-                self.process = subprocess.Popen([
-                    "iostat",
-                    "-d",  # Display only device statistics.
-                    "-I",  # Display total statistics for a given time period
-                    "-w", f"{self.interval}",  # Pause `wait` seconds between each display.
-                    "-x",  # Show extended disk statistics
-                ], encoding="utf-8", errors="ignore", stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-                i = 0
-                stats = {}
-                while True:
-                    line = self.process.stdout.readline()
-                    if not line:
-                        break
-
-                    try:
-                        device, read_ops, write_ops, read_kbytes, write_kbytes, _, _, busy = line.split()
-                    except ValueError:
-                        # "extended device statistics" header
-                        i += 1
-                        if i > 2:  # Do not send first read results
-                            self.stats = stats
-                            stats = {}
-                    else:
-                        if device.startswith(("ada", "da", "nvd")):
-                            stats[device] = {
-                                "read_ops": int(float(read_ops)),
-                                "read_bytes": int(float(read_kbytes) * 1024),
-                                "write_ops": int(float(write_ops)),
-                                "write_bytes": int(float(write_kbytes) * 1024),
-                                "busy": float(busy) / self.interval,
-                            }
-            except Exception:
-                logger.error("Unhandled exception in DiskStats", exc_info=True)
-                time.sleep(self.interval)
+    def __init__(self):
+        self.disks = ('ada', 'da', 'nvd')
 
     def read(self):
-        read_ops = 0
-        read_bytes = 0
-        write_ops = 0
-        write_bytes = 0
-        busy = 0
-        count = 0
-        for disk, current in self.stats.items():
-            read_ops += current["read_ops"]
-            read_bytes += current["read_bytes"]
-            write_ops += current["write_ops"]
-            write_bytes += current["write_bytes"]
-            busy += current["busy"]
-            count += 1
+        read_ops = []
+        read_bytes = []
+        write_ops = []
+        write_bytes = []
+        busy = []
+        cur_values = disk_io_counters(perdisk=True, nowrap=True)
+        for disk, current in filter(lambda x: x[0].startswith(self.disks), cur_values.items()):
+            read_ops.append(current.read_count)
+            read_bytes.append(current.read_bytes)
+            write_ops.append(current.write_count)
+            write_bytes.append(current.write_bytes)
+            busy.append(current.busy_time)
 
         return {
-            "read_ops": read_ops,
-            "read_bytes": read_bytes,
-            "write_ops": write_ops,
-            "write_bytes": write_bytes,
-            "busy": busy / count if count else 0,
+            "read_ops": mean(read_ops),
+            "read_bytes": mean(read_bytes),
+            "write_ops": mean(write_ops),
+            "write_bytes": mean(write_bytes),
+            "busy": mean(busy)
         }
-
-    def stop(self):
-        self.run = False
-        try:
-            self.process.kill()
-        except ProcessLookupError:
-            pass

--- a/src/middlewared/middlewared/plugins/reporting/iostat.py
+++ b/src/middlewared/middlewared/plugins/reporting/iostat.py
@@ -2,24 +2,37 @@ from psutil import disk_io_counters
 
 
 class DiskStats:
-    def __init__(self, interval):
+    def __init__(self, interval, prev_data):
         self.interval = interval
+        self.prev_data = prev_data
         self.disks = ('ada', 'da', 'nvd')
 
     def read(self):
         read_ops = read_bytes = write_ops = write_bytes = busy = total_disks = 0
-        cur_values = disk_io_counters(perdisk=True, nowrap=False)
-        for disk, current in filter(lambda x: x[0].startswith(self.disks), cur_values.items()):
+        for disk, current in filter(lambda x: x[0].startswith(self.disks), disk_io_counters(perdisk=True).items()):
             read_ops += current.read_count
             read_bytes += current.read_bytes
             write_ops += current.write_count
             write_bytes += current.write_bytes
             busy += float(current.busy_time) / self.interval
+            total_disks += 1
 
-        return {
-            "read_ops": read_ops,
-            "read_bytes": read_bytes,
-            "write_ops": write_ops,
-            "write_bytes": write_bytes,
-            "busy": busy / total_disks if total_disks else 0
+        # the current cumulative data
+        curr_data = {
+            'read_ops': read_ops,
+            'read_bytes': read_bytes,
+            'write_ops': write_ops,
+            'write_bytes': write_bytes,
+            'busy': busy / total_disks if total_disks else 0
         }
+
+        # the difference between curr_data and prev_data
+        new_data = {
+            'read_ops': curr_data['read_ops'] - self.prev_data.get('read_ops', 0),
+            'read_bytes': curr_data['read_bytes'] - self.prev_data.get('read_bytes', 0),
+            'write_ops': curr_data['write_ops'] - self.prev_data.get('write_ops', 0),
+            'write_bytes': curr_data['write_bytes'] - self.prev_data.get('write_bytes', 0),
+            'busy': curr_data['busy'] - self.prev_data.get('busy', 0),
+        }
+
+        return curr_data, new_data


### PR DESCRIPTION
On an M60 with `1248` disks, these are the problems I've found:

1. The way we are calling `iostat` produces `2519` lines of text. We were parsing this every 2 seconds so we were parsing `5038` lines of text and discarding over half of it because we were calling `iostat` in a way that included the `pass` devices in the output.
2. we started a daemon thread that ran `subprocess` consistently to gather this information so we were having to read large output from child process stdout which is painful

Here is how I've fixed these problems.
1. `psutils.disk_io_counters(perdisk=True, nowrap=True)` gives us the _exact_ same values as `iostat`
2. get rid of the daemon thread
3. get rid of the child process that produces > 5k lines of text
4. no more absurd amount of text parsing

Before the changes, python had a thread that was eating 100% of a cpu core 100% of the time. Now it hardly shows in `top` output.