### PR TITLE
NAS-112619 / 12.0 / Fix groupmap synchronization

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -417,6 +417,7 @@
                     'netbios name': f"{db['gc']['hostname_virtual']}_STANDBY",
                     'logging': 'file'
                 }
+                add_idmap_params(stub_config, db)
                 return stub_config
 
             add_general_params(pc, db)

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -360,6 +360,7 @@ class SMBService(Service):
         to_add = [{
             "gid": g_dict[x]["gid"],
             "nt_name": g_dict[x]["group"],
+            "rid": await self.middleware.call('smb.get_next_rid'),
             "group_type_str": "local"
         } for x in set_to_add]
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -180,7 +180,9 @@ class SMBService(Service):
         conflict. Winbindd will regenerate the removed ones as-needed.
         """
         must_reload = False
-        tdb_handle = tdb.open(f"{SMBPath.STATEDIR.platform()}/winbindd_idmap.tdb")
+        idmap_file = f"{SMBPath.STATEDIR.platform()}/winbindd_idmap.tdb"
+        tdb_flags = os.O_CREAT | os.O_RDWR
+        tdb_handle = tdb.Tdb(idmap_file, 0, tdb.DEFAULT, tdb_flags, 0o755)
 
         try:
             group_hwm_bytes = tdb_handle.get(b'GROUP HWM\00')


### PR DESCRIPTION
Due to API changes, we now need full idmap config in passive
controller smb4.conf file. We also need to ensure that
RID counter for passdb and groupmap operations is same.