### PR TITLE
Enable DMA for ntb_transport.

### DIFF
--- a/src/freenas/debian/rules
+++ b/src/freenas/debian/rules
@@ -26,8 +26,9 @@ override_dh_auto_install:
 		cp -a etc/syslog-ng debian/truenas-files/etc/; \
 		cp -a etc/systemd debian/truenas-files/etc/; \
 		cp -a root debian/truenas-files/; \
-		cp -a usr/lib/systemd debian/truenas-files/usr/lib/; \
+		cp -a usr/lib/modprobe.d debian/truenas-files/usr/lib/; \
 		cp -a usr/lib/modules-load.d debian/truenas-files/usr/lib/; \
+		cp -a usr/lib/systemd debian/truenas-files/usr/lib/; \
 		mkdir -p debian/truenas-files/conf/base/etc; \
 	"
 

--- a/src/freenas/usr/lib/modprobe.d/truenas.conf
+++ b/src/freenas/usr/lib/modprobe.d/truenas.conf
@@ -1,0 +1,1 @@
+options ntb_transport use_dma=1

--- a/src/freenas/usr/lib/modules-load.d/truenas.conf
+++ b/src/freenas/usr/lib/modules-load.d/truenas.conf
@@ -1,1 +1,2 @@
+ioatdma
 ntb_netdev


### PR DESCRIPTION
I am not sure why it transfers only 50MB/s in PIO, but I do like
2GB/s I see in iperf3 with DMA.