### PR TITLE
NAS-112669 / 21.10 / Fix SMB config generation issues when clustered

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -12,9 +12,11 @@
     clustering = Yes
     ctdb:registry.tdb = Yes
     kernel share modes = No
-    % endif
+    include = registry
+    % else:
     clustering = No
     include = registry
+    % endif
     % else:
     clustering = No
     netbiosname = TN_STANDBY

--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -13,3 +13,11 @@ class CtdbService(SimpleService):
         # ctdb shared volume (if appropriate)
         if (await self.middleware.call('ctdb.setup.init'))['logit']:
             self.middleware.logger.error('ctdb config setup failed, check logs')
+
+    async def after_start(self):
+        await self.middleware.call('smb.reset_smb_ha_mode')
+        await self.middleware.call('etc.generate', 'smb')
+
+    async def after_stop(self):
+        await self.middleware.call('smb.reset_smb_ha_mode')
+        await self.middleware.call('etc.generate', 'smb')

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -754,8 +754,8 @@ class SMBService(TDBWrapConfigService):
                 verrors.add(f'smb_update.{i}', 'Not a valid mask')
 
         if not new['aapl_extensions']:
-            if await self.middleware.call('sharing.smb.query', [['afp', '=', True]], {'count': True}):
-                verrors.add('smb_update.aapl_extensions', 'This option must be enabled when AFP shares are present')
+            if await self.middleware.call('sharing.smb.query', [['OR', [['afp', '=', True], ['timemachine', '=', True]]]], {'count': True}):
+                verrors.add('smb_update.aapl_extensions', 'This option must be enabled when AFP  or time machine shares are present')
 
     @accepts(Dict(
         'smb_update',

--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -131,6 +131,8 @@ class SMBService(Service):
         parameters to reflect the specified smb service configuration.
         """
         to_set = {}
+        ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
+        data['clustered'] = (ha_mode == 'CLUSTERED')
         data['ds_state'] = await self.middleware.call('directoryservices.get_state')
         data['shares'] = await self.middleware.call(
             'sharing.smb.query',

--- a/src/middlewared/middlewared/plugins/smb_/registry_share.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_share.py
@@ -281,7 +281,7 @@ class SharingSMBService(Service):
         # TO_DO - need to validate whether VFS objects have been manually overridden by
         # auxiliary parameters or CLI changes (e.g. "net conf setparm").
         try:
-            conf_in['vfs_objects']["parsed"] = data["vfs objects"]["parsed"].split()
+            conf_in['vfs objects']["parsed"] = data["vfs objects"]["parsed"].split()
         except KeyError:
             conf_in["vfs objects"] = {"raw": "", "parsed": []}
 

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -44,8 +44,13 @@ class GlobalSchema(RegistrySchema):
             data_out['username map'] = {'parsed': '/etc/smbusername.map'}
 
         if ds_state['ldap'] in ['LEAVING', 'DISABLED']:
+            if data_in['clustered']:
+                passdb_backend = 'tdbsam'
+            else:
+                passdb_backend = 'tdbsam:/root/samba/private/passdb.tdb'
+
             data_out.update({
-                'passdb backend': {'parsed': 'tdbsam:/root/samba/private/passdb.tdb'},
+                'passdb backend': {'parsed': passdb_backend},
             })
         return
 

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -228,7 +228,7 @@ class ShareSchema(RegistrySchema):
         they deviate from our defaults).
         """
         vfs_objects = conf.get("vfs objects", [])
-        if "recycle" not in vfs_objects:
+        if "recycle" not in vfs_objects['parsed']:
             return False
 
         conf.pop("recycle:repository", "")
@@ -237,10 +237,10 @@ class ShareSchema(RegistrySchema):
             if conf[to_check]["parsed"]:
                 conf.pop(to_check)
 
-        if conf["recycle:directory_mode"] == "0777":
+        if conf["recycle:directory_mode"]['raw'] == "0777":
             conf.pop("recycle:directory_mode")
 
-        if conf["recycle:subdir_mode"] == "0700":
+        if conf["recycle:subdir_mode"]['raw'] == "0700":
             conf.pop("recycle:subdir_mode")
 
         return True

--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -49,7 +49,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         if dbmap:
             return dbmap[0]['dbid']
 
-        cmd = ["ctdb", "attach", name, "persistent"]
+        cmd = ["ctdb", "attach", f"{name}.tdb", "persistent"]
         attach = run(cmd, check=False)
         if attach.returncode != 0:
             raise CallError("Failed to attach backend: %s", attach.stderr.decode())


### PR DESCRIPTION
This PR addresses several issues discovered while writing regression tests:
- smb HA mode was not being updated to reflect new clustering state as ctdb started and stopped.
- typo in smb4.conf.mako resulted in some parameters being set twice.
- tdbsam path should not be altered when clustering is enabled
- newly generated persistent ctdb files weren't being properly attached