### PR TITLE
NAS-112627 / 21.10 / make DiskStats not suck (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/iostat.py
+++ b/src/middlewared/middlewared/plugins/reporting/iostat.py
@@ -1,96 +1,53 @@
-from collections import namedtuple
-import re
-import time
-
-RE_NVME_C = re.compile(r"(nvme[0-9]+)c[0-9]+(n[0-9]+)")
-RE_NVME_P = re.compile(r"(nvme[0-9]+n[0-9]+)p[0-9]+")
-
-DiskStat = namedtuple("DiskStat", ["rd_ios", "rd_bytes", "wr_ios", "wr_bytes", "tot_ticks"])
-
-
-def get_device_disk(disk):
-    # Strip partition numbers and NVMe namespaces
-    # Disks are reported above partitions and NVMe namespaces are reported above NVMe devices
-    # They are the ones that contain corresponding device stats so we'll parse the first
-    # line we see and skip the rest (which would be zeroes)
-    if disk.startswith("nvme"):
-        disk = RE_NVME_C.sub(r"\1\2", disk)
-        disk = RE_NVME_P.sub(r"\1", disk)
-    else:
-        while disk and disk[-1].isdigit():
-            disk = disk[:-1]
-
-    return disk
+from psutil import disk_io_counters
 
 
 class DiskStats:
-    def __init__(self):
-        self.prev = None
-        self.prev_time = None
-        self.current = None
-        self.current_time = None
-        self._read()
+    def __init__(self, interval, prev_data):
+        self.interval = interval
+        self.prev_data = prev_data
+        self.ignore = ('sr', 'md', 'dm')
 
-    def _read(self):
-        with open("/proc/diskstats") as f:
-            lines = f.readlines()
+    def get_disk(self, disk):
+        if disk.startswith(self.ignore):
+            return
+        elif disk.startswith('nvme'):
+            if 'c' in disk or 'p' in disk:
+                # nvme0c0p1 or nvme0n1p1 which reports statistics but we only
+                # want the top-level namespace (i.e. nvme0n1) since it has the
+                # over-all disk statistics
+                return
+            else:
+                return disk
+        else:
+            while disk and disk[-1].isdigit():
+                disk = disk[:-1]
+            return disk
 
-        self.current = {}
-        for line in lines:
-            line = line.split()
+    def read(self):
+        read_ops = read_bytes = write_ops = write_bytes = busy = total_disks = 0
+        for disk, current in filter(lambda x: self.get_disk(x[0]) is not None, disk_io_counters(perdisk=True).items()):
+            read_ops += current.read_count
+            read_bytes += current.read_bytes
+            write_ops += current.write_count
+            busy += float(current.busy_time) / self.interval
+            total_disks += 1
 
-            disk = line[2]
-
-            if disk.startswith("loop"):
-                continue
-
-            disk = get_device_disk(disk)
-            if disk in self.current:
-                continue
-
-            # According to https://github.com/torvalds/linux/blob/7ca8cf5/include/linux/types.h#L120
-            # sectors are always 512 bytes.
-            disk_stat = DiskStat(
-                rd_ios=int(line[3]),
-                rd_bytes=int(line[5]) * 512,
-                wr_ios=int(line[7]),
-                wr_bytes=int(line[9]) * 512,
-                tot_ticks=int(line[12]),
-            )
-
-            self.current[disk] = disk_stat
-
-        self.current_time = time.monotonic()
-
-    def get(self):
-        self.prev = self.current
-        self.prev_time = self.current_time
-        self._read()
-
-        read_ops = 0
-        read_bytes = 0
-        write_ops = 0
-        write_bytes = 0
-        total_ticks = 0
-        count = 0
-        for disk, current in self.current.items():
-            prev = self.prev.get(disk)
-            if prev is None:
-                continue
-
-            read_ops += current.rd_ios - prev.rd_ios
-            read_bytes += current.rd_bytes - prev.rd_bytes
-            write_ops += current.wr_ios - prev.wr_ios
-            write_bytes += current.wr_bytes - prev.wr_bytes
-            total_ticks += current.tot_ticks - prev.tot_ticks
-            count += 1
-
-        t = self.current_time - self.prev_time
-
-        return {
-            "read_ops": int(read_ops / t),
-            "read_bytes": int(read_bytes / t),
-            "write_ops": int(write_ops / t),
-            "write_bytes": int(write_bytes / t),
-            "busy": total_ticks / count / 1000 / t,
+        # the current cumulative data
+        curr_data = {
+            'read_ops': read_ops,
+            'read_bytes': read_bytes,
+            'write_ops': write_ops,
+            'write_bytes': write_bytes,
+            'busy': busy / total_disks if total_disks else 0
         }
+
+        # the difference between curr_data and prev_data
+        new_data = {
+            'read_opts': curr_data['read_ops'] - self.prev_data.get('read_ops', 0),
+            'read_bytes': curr_data['read_bytes'] - self.prev_data.get('read_bytes', 0),
+            'write_ops': curr_data['write_ops'] - self.prev_data.get('write_ops', 0),
+            'write_bytes': curr_data['write_bytes'] - self.prev_data.get('write_bytes', 0),
+            'busy': curr_data['busy'] - self.prev_data.get('busy', 0),
+        }
+
+        return curr_data, new_data


### PR DESCRIPTION
On an M60 with `1248` disks, these are the problems I've found:

1. The way we are calling `iostat` produces `2519` lines of text. We were parsing this every 2 seconds so we were parsing `5038` lines of text and discarding over half of it because we were calling `iostat` in a way that included the `pass` devices in the output.
2. we started a daemon thread that ran `subprocess` consistently to gather this information so we were having to read large output from child process stdout which is painful

Here is how I've fixed these problems.
1. `psutils.disk_io_counters(perdisk=True, nowrap=True)` gives us the _exact_ same values as `iostat`
2. get rid of the daemon thread
3. get rid of the child process that produces > 5k lines of text
4. no more absurd amount of text parsing

Before the changes, python had a thread that was eating 100% of a cpu core 100% of the time. Now it hardly shows in `top` output.

Original PR: https://github.com/truenas/middleware/pull/7611
Jira URL: https://jira.ixsystems.com/browse/NAS-112627