### PR TITLE
Address issues in ctdb public ip generation

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -15,6 +15,7 @@ class CtdbService(SimpleService):
             self.middleware.logger.error('ctdb config setup failed, check logs')
 
     async def after_start(self):
+        await self.middleware.call('ctdb.setup.public_ip_file')
         await self.middleware.call('smb.reset_smb_ha_mode')
         await self.middleware.call('etc.generate', 'smb')
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -284,7 +284,7 @@ class SMBService(TDBWrapConfigService):
         ha_mode = await self.get_smb_ha_mode()
 
         if ha_mode == 'CLUSTERED':
-            for i in await self.middleware.call('ctdb.public.ips.query'):
+            for i in await self.middleware.call('ctdb.general.ips'):
                 choices[i['public_ip']] = i['public_ip']
 
             return choices


### PR DESCRIPTION
Each node in the cluster must have its own unique public IP
address file. The reasoning for this is as follows:
- Some cluster nodes may have different interface names
- Some cluster nodes may have different networks available
- Internal ctdb setup of public ips will fail if it encounters an interface
   that doesn't exist on the server

The public addresses files determine which nodes are available
to take over a given IP address. With this in mind, each particular
node should be able to view and configure the overall pool of
floating IP addresses. This means that the public_addresses
must be:
- unique per node
- located in the ctdb_shared_volume

To achieve this separate files are generated for each node
with the suffix `_<pnn>` where `pnn` is the ctdb node number.
During ctdb configuration each node will symlink `/etc/ctdb/public_addresses`
to its own public addresses file in the ctdb shared volume.

This redesign required changes to the public API for
`ctdb.public.ips` in the following ways:

`create` and `update` methods have a mandatory `pnn` field specifying
the node to which the change will apply.

`query` method return is changed so that results are constructed as
follows. List of nodes are obtained through `ctdb listnodes`.
Then `configured_ips` object is constructed through reading contents
of the public_addresses file. Then `active_ips` object is constructed
by parsing output of `ctdb ip`.

This change requires us to fail hard on `ctdb.public.ips.query` if the
cluster node is unhealthy, which required shifting the generation
of the public ips file / symlink to after the ctdb service starts. Since
multiple API calls may require knowledge of our node's `pnn`, add
an optimized function to retrieve this. `pnn` value won't change
in a healthy and properly administered server so caching this value
should be fine for the duration of middleware process's lifetime.