### PR TITLE
Raise ValueError in cluster tests if request is invalid

### DIFF
--- a/cluster-tests/utils.py
+++ b/cluster-tests/utils.py
@@ -86,7 +86,7 @@ def make_request(_type, url, **kwargs):
     elif _type == 'delete':
         req = requests.delete
     else:
-        print(f'Invalid request type: {_type}')
+        raise ValueError(f'Invalid request type: {_type}')
 
     if not url.startswith('http://'):
         url = f'http://{CLUSTER_INFO["NODE_A_IP"]}/api/v2.0{url}'


### PR DESCRIPTION
This is just to make things clearer to test writers when
they make typos. Unfortunately, Linux / Python doesn't
have EDOOFUS for this purpose.