### PR TITLE
NAS-112721 / 21.10 / Add API call to create directories

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -70,11 +70,11 @@ class FilesystemService(Service):
             'path': path,
             'realpath': realpath,
             'type': 'DIRECTORY',
-                'size': stat.st_size,
-                'mode': stat.st_mode,
-                'acl': False if self.acl_is_trivial(path) else True,
-                'uid': stat.st_uid,
-                'gid': stat.st_gid,
+            'size': stat.st_size,
+            'mode': stat.st_mode,
+            'acl': False if self.acl_is_trivial(path) else True,
+            'uid': stat.st_uid,
+            'gid': stat.st_gid,
         }
 
         return data


### PR DESCRIPTION
Primary use case is to expose ability to create paths inside
cluster volumes for users to share out via SMB or other 
file sharing protocols.

Return value is same as entry from filesystem.listdir.