### PR TITLE
NAS-112748 / 21.10 / Safely consume state key in vm event

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -110,7 +110,7 @@ class VMService(Service, VMSupervisorMixin):
 
 async def _event_vms(middleware, event_type, args):
     vm = await middleware.call('vm.query', [['id', '=', args['id']]])
-    if not vm or vm[0]['status']['state'] != 'STOPPED' or args['state'] != 'SHUTOFF':
+    if not vm or vm[0]['status']['state'] != 'STOPPED' or args.get('state') != 'SHUTOFF':
         return
 
     asyncio.ensure_future(middleware.call('vm.teardown_guest_vmemory', args['id']))


### PR DESCRIPTION
This commit adds changes to safely consume 'state' key as it is not always present and is only present when the event is generated via libvirt events as then it fulfills a special use case.