### PR TITLE
NAS-112640 / 22.02-RC.1 / remove nfs alias parameter

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -100,12 +100,8 @@ EXPORT {
     % else:
     Protocols = 3, 4;
     % endif;
-    % if config["v4"] and share["aliases"]:
-    Pseudo = ${alias};
-    % elif not config["v4"] and share["aliases"]:
-    Tag = ${alias.lstrip('/')};
-    % elif config["v4"] and not share["aliases"]:
-    Pseudo = /${path.split('/')[-1]};
+    % if config["v4"]:
+    Pseudo = ${path};
     % endif;
     % if config["udp"]:
     Transports = TCP, UDP;


### PR DESCRIPTION
Changing the `Pseudo` option in the ganesha.conf (`aliases`) requires that the nfs-ganesha service be restarted. It does not allow graceful reload of the service. The ability to reload the service when this config param has been changed was added to nfs-ganesha v4.0 but it is still in development. When v4.0 of nfs-ganesha has been released as stable, we need to update to that release. The webUI has hidden the associated `Alias` box for now.

If you have NFSv4 enabled it requires a Pseudo parameter in the config so we fill it in by default if one isn't provided. Yet if you try to change this, it will break client mounts and then require a restart of the service. So for now, we just default it to the `Path` parameter which is the absolute path to the directory being shared.