### PR TITLE
Do not ignore SSH_TEST commant stderr

### DIFF
--- a/tests/api2/test_012_api_key.py
+++ b/tests/api2/test_012_api_key.py
@@ -34,7 +34,7 @@ def test_root_api_key_websocket(request):
     with api_key([]) as key:
         cmd = f"sudo -u testuser midclt -u ws://{ip}/websocket --api-key {key} call system.info"
         results = SSH_TEST(cmd, user, password, ip)
-        assert results['result'] is True, str(results['output'])
+        assert results['result'] is True, f'out: {results["output"]}, err: {results["stderr"]}'
         assert 'uptime' in str(results['output'])
 
 
@@ -44,7 +44,7 @@ def test_allowed_api_key_websocket(request):
     with api_key([{"method": "CALL", "resource": "system.info"}]) as key:
         cmd = f"sudo -u testuser midclt -u ws://{ip}/websocket --api-key {key} call system.info"
         results = SSH_TEST(cmd, user, password, ip)
-        assert results['result'] is True, str(results['output'])
+        assert results['result'] is True, f'out: {results["output"]}, err: {results["stderr"]}'
         assert 'uptime' in str(results['output'])
 
 

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -92,12 +92,13 @@ def SSH_TEST(command, username, passwrd, host):
         f"{username}@{host}",
         command
     ]
-    process = run(cmd, stdout=PIPE, universal_newlines=True)
+    process = run(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     output = process.stdout
+    stderr = process.stderr
     if process.returncode != 0:
-        return {'result': False, 'output': output}
+        return {'result': False, 'output': output, 'stderr': stderr}
     else:
-        return {'result': True, 'output': output}
+        return {'result': True, 'output': output, 'stderr': stderr}
 
 
 def send_file(file, destination, username, passwrd, host):


### PR DESCRIPTION
It can contain a lot of interesting information that might end up being extremely useful
in investigating test failures.