### PR TITLE
NAS-112817 / 22.02-RC.1 / prevent "wg" from being modified

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/info_linux.py
+++ b/src/middlewared/middlewared/plugins/interface/info_linux.py
@@ -9,4 +9,4 @@ class InterfaceService(Service, InterfaceInfoBase):
         namespace_alias = 'interfaces'
 
     async def internal_interfaces(self):
-        return ['lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn']
+        return ['wg', 'lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn']


### PR DESCRIPTION
The `wg0` interface used by TrueCommand gets deleted any time a network change is made. That's no bueno. This hasn't worked since the wireguard feature was added, as far as I can tell.