### PR TITLE
NAS-112849 / 22.02-RC.2 / Wait for activedirectory.leave to complete in QE tests

### DIFF
--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -387,6 +387,8 @@ def test_36_leave_activedirectory(request):
     }
     results = POST("/activedirectory/leave/", payload)
     assert results.status_code == 200, results.text
+    job_status = wait_on_job(results.json(), 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_37_verify_activedirectory_leave_do_not_leak_password_in_middleware_log(request):
@@ -577,6 +579,8 @@ def test_59_leave_activedirectory(request):
     }
     results = POST("/activedirectory/leave/", payload)
     assert results.status_code == 200, results.text
+    job_status = wait_on_job(results.json(), 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_60_verify_activedirectory_leave_do_not_leak_password_in_middleware_log(request):

--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -604,6 +604,8 @@ def test_39_leave_activedirectory(request):
     }
     results = POST("/activedirectory/leave/", payload)
     assert results.status_code == 200, results.text
+    job_status = wait_on_job(results.json(), 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_40_verify_activedirectory_live_do_not_leak_password_in_middleware_log(request):

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -417,6 +417,8 @@ def test_17_leave_activedirectory(request):
     }
     results = POST("/activedirectory/leave/", payload)
     assert results.status_code == 200, results.text
+    job_status = wait_on_job(results.json(), 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_18_verify_activedirectory_leave_do_not_leak_password_in_middleware_log(request):

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -336,6 +336,8 @@ def test_39_leave_activedirectory(request):
     }
     results = POST("/activedirectory/leave/", payload)
     assert results.status_code == 200, results.text
+    job_status = wait_on_job(results.json(), 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_41_remove_site(request):


### PR DESCRIPTION
During testing it was determined that AD leave can take more than
60 seconds in some environments (or when server is clustered), and
so the method was converted to a middleware job. Fix API tests
to also wait for the job to complete.