### PR TITLE
NAS-112850 / 22.02-RC.2 / Fix out-of-order operation in test_435

### DIFF
--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -193,12 +193,12 @@ def test_009_reset_smb():
     Remove all parameters that might turn us into
     a MacOS-style SMB server (fruit).
     """
-    payload = {"aapl_extensions": False}
-    results = PUT("/smb/", payload)
-    assert results.status_code == 200, results.text
-
     results = PUT(f'/sharing/smb/id/{SHARE_DICT["REGISTRYTEST_0"]}/',
                   {"purpose": "NO_PRESET", "timemachine": False})
+    assert results.status_code == 200, results.text
+
+    payload = {"aapl_extensions": False}
+    results = PUT("/smb/", payload)
     assert results.status_code == 200, results.text
 
 


### PR DESCRIPTION
The reset_smb operation is failing due to improvements in
validation of SMB server and share configuration. Specifically,
aapl extension support cannot be disabled if any SMB shares
are configured for time machine. This PR fixes the order
of the server configuration reset steps prior to testing auxiliary
parameter support so that time machine is disabled before disabling
aapl extension support.