### PR TITLE
NAS-112817 / 12.0 / prevent "wg" from being modified (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1849,7 +1849,7 @@ class InterfaceService(CRUDService):
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
-        internal_interfaces = ['lo', 'pflog', 'pfsync', 'tun', 'tap', 'epair']
+        internal_interfaces = ['wg', 'lo', 'pflog', 'pfsync', 'tun', 'tap', 'epair']
         if not await self.middleware.call('system.is_freenas'):
             internal_interfaces.extend(await self.middleware.call('failover.internal_interfaces') or [])
         internal_interfaces = tuple(internal_interfaces)


### PR DESCRIPTION
The `wg0` interface used by TrueCommand gets deleted any time a network change is made. That's no bueno. This hasn't worked since the wireguard feature was added, as far as I can tell.

Original PR: https://github.com/truenas/middleware/pull/7662
Jira URL: https://jira.ixsystems.com/browse/NAS-112817