### PR TITLE
NAS-112862 / 22.02-RC.1 / Update test_032_ad_kerberos for internal API change (by anodos325)

### DIFF
--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -490,7 +490,11 @@ def test_32_add_krb_spn(request):
     privileges.
     """
     depends(request, ["V4_KRB_ENABLED", "ssh_password"], scope="session")
-    cmd = 'midclt call activedirectory.add_nfs_spn'
+    results = GET("/smb/")
+    assert results.status_code == 200, results.text
+    netbios_name = results.json()['netbiosname_local']
+
+    cmd = f'midclt call activedirectory.add_nfs_spn {netbios_name} {AD_DOMAIN}'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
 


### PR DESCRIPTION
add_nfs_spn now expects netbios name and domain name to be
provided explicitly.

Original PR: https://github.com/truenas/middleware/pull/7691
Jira URL: https://jira.ixsystems.com/browse/NAS-112862