### PR TITLE
NAS-112871 / 22.02-RC.2 / Do not retrieve user properties when updating/setting props on k8s datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -256,6 +256,7 @@ class KubernetesService(Service):
                     'extra': {
                         'properties': list(update_props),
                         'retrieve_children': False,
+                        'user_properties': False,
                     }
                 }
             )


### PR DESCRIPTION
This commit adds changes to not take into account any user properties when configuring k8s datasets as they are not being used by us and will result in failure when we operate on properties below.