### PR TITLE
NAS-112856 / 22.02-RC.2 / Use setserial for retrieving serial port address

### DIFF
--- a/src/middlewared/middlewared/utils/osc/linux/system.py
+++ b/src/middlewared/middlewared/utils/osc/linux/system.py
@@ -10,8 +10,7 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 RE_CPU_MODEL = re.compile(r'^model name\s*:\s*(.*)', flags=re.M)
-RE_SERIAL = re.compile(r'state.*=\s*(\w*).*io (.*)-(\w*)\n.*', re.S | re.A)
-RE_UART_TYPE = re.compile(r'is a\s*(\w+)')
+RE_PORT_UART = re.compile(r'at\s*(\w*).*is a\s*(\w+)')
 
 
 def get_cpu_model():
@@ -30,7 +29,6 @@ def serial_port_choices():
             'drivername': 'uart',
             'description': None,
             'start': None,
-            'size': None,
         }
         tty_sys_path = os.path.join('/sys/class/tty', tty)
         dev_path = os.path.join(tty_sys_path, 'device')
@@ -45,20 +43,23 @@ def serial_port_choices():
             ['setserial', '-b', os.path.join('/dev', tty)], stderr=subprocess.DEVNULL, stdout=subprocess.PIPE
         )
         stdout, stderr = cp.communicate()
-        if not cp.returncode and stdout:
-            reg = RE_UART_TYPE.search(stdout.decode())
-            if reg:
-                serial_dev['description'] = reg.group(1)
-        if not serial_dev['description']:
+        if cp.returncode or not stdout:
             continue
-        with open(os.path.join(tty_sys_path, 'device/resources'), 'r') as f:
-            reg = RE_SERIAL.search(f.read())
-            if reg:
-                if reg.group(1).strip() != 'active':
-                    continue
-                serial_dev['start'] = reg.group(2)
-                serial_dev['size'] = (int(reg.group(3), 16) - int(reg.group(2), 16)) + 1
-        with open(os.path.join(tty_sys_path, 'device/firmware_node/path'), 'r') as f:
+
+        entry = RE_PORT_UART.findall(stdout.decode(errors='ignore'))
+        if not entry:
+            continue
+
+        serial_dev.update({
+            'start': hex(int(entry[0][0], 16)),
+            'description': entry[0][1],
+        })
+
+        path_file = os.path.join(tty_sys_path, 'device/firmware_node/path')
+        if not os.path.exists(path_file):
+            continue
+
+        with open(path_file, 'r') as f:
             serial_dev['location'] = f'handle={f.read().strip()}'
         serial_dev['name'] = tty
         devices.append(serial_dev)


### PR DESCRIPTION
We recently saw a reporter for whome a configuration file which we were relying on to exist didn't exist and resulted in failed migration. This commit adds changes to not rely on this and instead use setserial. It also removes size from the payload as that's not used anywhere.