### PR TITLE
NAS-112728 / 12.0 / Add check for permissions on /var/db/system/samba4/winbindd_privileged (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -86,6 +86,7 @@ class SMBPath(enum.Enum):
     LOCKDIR = ('/var/run/samba4', '/var/run/samba-lock', 0o755, True)
     LOGDIR = ('/var/log/samba4', '/var/log/samba4', 0o755, True)
     IPCSHARE = ('/var/tmp', '/tmp', 0o1777, True)
+    WINBINDD_PRIVILEGED = ('/var/db/system/samba4/winbindd_privileged', '/var/db/system/samba4/winbindd_privileged', 0o750, True)
 
     def platform(self):
         return self.value[1] if osc.IS_LINUX else self.value[0]


### PR DESCRIPTION
Incorrect permissions on this directory will prevent winbindd
from starting.

Original PR: https://github.com/truenas/middleware/pull/7699
Jira URL: https://jira.ixsystems.com/browse/NAS-112728