### PR TITLE
NAS-112810 / 22.02-RC.1 / Fix issue with RID collision on creating new passdb users

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -47,7 +47,7 @@ class GlobalSchema(RegistrySchema):
             if data_in['clustered']:
                 passdb_backend = 'tdbsam'
             else:
-                passdb_backend = 'tdbsam:/root/samba/private/passdb.tdb'
+                passdb_backend = 'tdbsam:/var/run/samba-cache/passdb.tdb'
 
             data_out.update({
                 'passdb backend': {'parsed': passdb_backend},


### PR DESCRIPTION
When pdb_default_create_user() in souce3/passdb in samba
creates a new passdb entry, it automatically allocates
generates a new SID for user based on nex_rid counter in
passdb.tdb. Middleware keeps its own RID counter to
ensure consistency between user and group RIDs across
updates. Unfortunately, the passdb's next_rid function
is not aware of manually allocated SIDs and so it's
possible to generate a collision during new RID allocation
and have it fail with STATUS_OBJECT_NAME_COLLISION even
if `pdbedit` command specifies exact RID to use for
new entry. This is because in this case the new passdb
entry is generated with an auto-incremented RID and then
updated to have the specified SID/RID.

To address this issue, this PR introduces the following
changes:
1) passdb.tdb is shifted to a tmpfs filesystem, which
   will reset the next_rid counter and also provide
   performance improvement compared to potentially slow
   boot medium. The information used to populate the
   passdb entry is already stored in our sqlite database.

2) bump up low end of middleware's next_rid so that new
   RIDs allocated will be a minimum of 10000, which will
   avoid passdb-allocated RIDs (start at 1000).