### PR TITLE
NAS-112861 / 22.02-RC.2 / fix enclosure drive mapping on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosure_linux.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosure_linux.py
@@ -13,10 +13,10 @@ class EnclosureService(Service):
     @private
     def list_ses_enclosures(self):
         try:
-            return [
+            return sorted([
                 os.path.join("/dev/bsg", enc)
                 for enc in os.listdir("/sys/class/enclosure")
-            ]
+            ])
         except FileNotFoundError:
             return []
 


### PR DESCRIPTION
On SCALE, for the `R40`, the enclosures are listed as `/dev/bsg/0:0:24:0` and `/dev/bsg/0:0:49:0`. During testing we were mapping drives `0-24` to `/dev/bsg/0:0:49:0` and drives `25-48` to `/dev/bsg/0:0:24:0`.

The only reason why this was occurring is because `enclosure.list_ses_enclosures` is returning `[/dev/bsg/0:0:49:0, /dev/bsg/0:0:24:0]`.

In `enclosure.get_ses_enclosures` I `sorted` the `enclosure.list_ses_enclosures` output to work-around this problem.
