### PR TITLE
Revert improper cherry-pick

### DIFF
--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -490,11 +490,7 @@ def test_32_add_krb_spn(request):
     privileges.
     """
     depends(request, ["V4_KRB_ENABLED", "ssh_password"], scope="session")
-    results = GET("/smb/")
-    assert results.status_code == 200, results.text
-    netbios_name = results.json()['netbiosname_local']
-
-    cmd = f'midclt call activedirectory.add_nfs_spn {netbios_name} {AD_DOMAIN}'
+    cmd = 'midclt call activedirectory.add_nfs_spn'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
 


### PR DESCRIPTION
A test change from master was cherry-picked into RC that should not have been cherry-picked.

reverts 2367d978b070136b00cfda9cdb7f6248d53c4d9f