### PR TITLE
NAS-112900 / 22.02-RC.2 / Prevent users from disabling mDNS if time machine is enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -285,6 +285,15 @@ class NetworkConfigurationService(ConfigService):
 
         verrors = await self.validate_general_settings(data, 'global_configuration_update')
 
+        if not srv['mdns']:
+            tm_shares = await self.middleware.call(
+                'sharing.smb.query',
+                [('timemachine', '=', True), ('enabled', '=', True)]
+            )
+            if tm_shares:
+                verrors.add('global_configuration_update.service_announcement.mdns',
+                            'NAS is configured as a time machine target. mDNS is required.')
+
         # we need to check if the `hostname_virtual` parameter changed in a couple places
         # in this method, so go ahead and set it here
         virt_hostname_changed = False

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1485,6 +1485,14 @@ class SharingSMBService(SharingService):
             verrors.add(f'{schema_name}.name',
                         'Path suffix may not contain more than two components.')
 
+        if data['timemachine'] and data['enabled']:
+            ngc = await self.middleware.call('network.configuration.config')
+            if not ngc['service_announcement']['mdns']:
+                verrors.add(
+                    f'{schema_name}.timemachine',
+                    'mDNS must be enabled in order to use an SMB share as a time machine target.'
+                )
+
         for entry in ['afp', 'timemachine']:
             if not data[entry]:
                 continue


### PR DESCRIPTION
Time machine uses _adisk._tcp. mDNS SRV record to determine
whether the target server is capable of serving as a time
machine backup target. Users should not be able to disable
mDNS if a timemachine SMB share is configured, and likewise
users should not be able to enable or create a time machine
target if mDNS is disabled.