### PR TITLE
NAS-112768 / 22.02-RC.2 / Properly show UPS driver choices

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nut/ups.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nut/ups.conf.mako
@@ -1,9 +1,9 @@
 <%
 	ups_config = middleware.call_sync('ups.config')
-    driver = middleware.call_sync('ups.normalize_driver_string', ups_config['driver'])
+	driver = middleware.call_sync('ups.normalize_driver_string', ups_config['driver'])
 %>\
 [${ups_config['identifier']}]
-	driver = ${driver}
+	${driver}
 	port = ${ups_config['port']}
 	desc = "${ups_config['description'].replace('"', r'\"')}"
 	${ups_config['options']}

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -105,7 +105,8 @@ class UPSService(SystemServiceService):
         driver = driver_str.split('$')[0]
         driver = driver.split('(')[0]  # "blazer_usb (USB ID 0665:5161)"
         driver = driver.split(' or ')[0]  # "blazer_ser or blazer_usb"
-        return driver.replace(' ', '\n')  # "genericups upstype=16"
+        driver = driver.replace(' ', '\n\t')  # "genericups upstype=16"
+        return f'driver = {driver}'
 
     @accepts()
     @returns(Dict(additional_attrs=True, example={'blazer_ser$CPM-800': 'WinPower ups 2 CPM-800 (blazer_ser)'}))

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ups.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ups.py
@@ -37,3 +37,16 @@ from middlewared.plugins.ups import UPSService
 def test__services_ups_service__driver_choices(config_line, key, value):
     with patch('builtins.open', mock_open(read_data=config_line)):
         assert UPSService(Mock()).driver_choices() == {key: value}
+
+
+@pytest.mark.parametrize('driver_str,normalized', [
+    ('victronups$(various)', 'driver = victronups'),
+    ('genericups upstype=4$(various)', 'driver = genericups\n\tupstype=4'),
+    ('genericups upstype=21$(various)', 'driver = genericups\n\tupstype=21'),
+    ('genericups upstype=10$(various)', 'driver = genericups\n\tupstype=10'),
+    ('blazer_usb$Alpha 1200Sx', 'driver = blazer_usb'),
+    ('tripplite_usb$SMART500RT1U', 'driver = tripplite_usb'),
+])
+@patch('os.path.exists', lambda x: True)
+def test__services_ups_service__driver_string_normalization(driver_str, normalized):
+    assert UPSService(Mock()).normalize_driver_string(driver_str) == normalized


### PR DESCRIPTION
This PR introduces following changes:

1) Normalize ups driver choice properly when some other options are specified in driver string tab entry. This was not happening before as we weren't accounting for custom UPS options to be specified in the string.
2) If there are multiple entries against a single key, this PR adds changes to make sure we display all of those entries for user clarity.