### PR TITLE
NAS-112907 / 22.02-RC.2 / Ensure that samba internal directories are owned by root

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -465,6 +465,11 @@ class SMBService(TDBWrapConfigService):
                     os.mkdir(path, p.mode())
             else:
                 os.chmod(path, p.mode())
+                owner = os.stat(path).st_uid
+                if owner != 0:
+                    self.logger.warning("%s: invalid owner [%s] for path. Correcting.",
+                                        path, owner)
+                    os.chown(path, 0, 0)
 
     @private
     async def import_conf_to_registry(self):


### PR DESCRIPTION
There have been a couple of cases of users following bad advice
and changing owner of these files. Log a warning and fix them
during SMB configure.