### PR TITLE
NAS-112903 / 22.02-RC.2 / correctly start/stop VrrpFifoThread on SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/vrrp_events_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events_linux.py
@@ -1,39 +1,87 @@
-import os
-import time
+from os import mkfifo
+from prctl import set_name
+from threading import Thread
+from time import sleep
+from asyncio import ensure_future
 
-from middlewared.utils import start_daemon_thread
 
-VRRP_FIFO_FILE = '/var/run/vrrpd.fifo'
-TIMEOUT = 2
 VRRP_THREAD = None
 
 
-def vrrp_fifo_listen(middleware):
+class VrrpFifoThread(Thread):
 
-    # create the fifo, ignoring if it already exists
-    try:
-        os.mkfifo(VRRP_FIFO_FILE)
-    except FileExistsError:
-        pass
+    def __init__(self, *args, **kwargs):
+        super(VrrpFifoThread, self).__init__()
+        self._retry_timeout = 2  # timeout in seconds before retrying to connect to FIFO
+        self._vrrp_file = '/var/run/vrrpd.fifo'
+        self.middleware = kwargs.get('middleware')
+        self.logger = self.middleware.logger
+        self.shutdown_line = '--SHUTDOWN--\n'
 
-    while True:
+    def shutdown(self):
+        with open(self._vrrp_file, 'w') as f:
+            f.write(self.shutdown_line)
+
+    def create_fifo(self):
         try:
-            with open(VRRP_FIFO_FILE) as f:
-                middleware.logger.info('vrrp fifo connection established')
-                # all vrrp messages are terminated with a newline
-                for line in f:
-                    middleware.call_hook_sync('vrrp.fifo', data=line)
+            mkfifo(self._vrrp_file)
+        except FileExistsError:
+            pass
         except Exception:
-            middleware.logger.error('vrrp fifo connection not established, retrying')
-            # sleep for `TIMEOUT` before trying to open FIFO and send event again
-            time.sleep(TIMEOUT)
+            raise
+
+    def run(self):
+        set_name('vrrp_fifo_thread')
+        try:
+            self.create_fifo()
+        except Exception:
+            self.logger.error('FATAL: Unable to create VRRP fifo.', exc_info=True)
+            return
+
+        log_it = True
+        while True:
+            try:
+                with open(self._vrrp_file) as f:
+                    self.logger.info('vrrp fifo connection established')
+                    for line in f:
+                        if line == self.shutdown_line:
+                            return
+                        else:
+                            self.middleware.call_hook_sync('vrrp.fifo', data=line)
+            except Exception:
+                if log_it:
+                    self.logger.warning(
+                        'vrrp fifo connection not established, retrying every %d seconds',
+                        self._retry_timeout,
+                        exc_info=True
+                    )
+                    log_it = False
+                    sleep(self._retry_timeout)
+
+
+async def _event_system(middleware, *args, **kwargs):
+    global VRRP_THREAD
+    try:
+        shutting_down = args[1]['id'] == 'shutdown'
+    except (IndexError, KeyError):
+        shutting_down = False
+
+    licensed = await middleware.call('failover.licensed')
+    if licensed and (VRRP_THREAD is None or not VRRP_THREAD.is_alive()):
+        # if this is a system that is being licensed for HA for the
+        # first time (without being rebooted) then we need to make
+        # sure we start this.
+        VRRP_THREAD = VrrpFifoThread(middleware=middleware)
+        VRRP_THREAD.start()
+    elif (VRRP_THREAD is not None and VRRP_THREAD.is_alive()) and not licensed or shutting_down:
+        # maybe the system is being downgraded to non-HA
+        # (this is rare but still need to handle it) or
+        # system is being restarted/shutdown etc
+        await middleware.run_in_thread(VRRP_THREAD.shutdown)
+        VRRP_THREAD = None
 
 
 async def setup(middleware):
-
-    global VRRP_THREAD
-
-    # only run on licensed systems
-    if await middleware.call('failover.licensed'):
-        if VRRP_THREAD is None:
-            VRRP_THREAD = start_daemon_thread(target=vrrp_fifo_listen, args=(middleware,))
+    ensure_future(_event_system(middleware))  # start thread on middlewared service start/restart
+    middleware.register_hook('system', _event_system)  # catch shutdown event and clean up thread
+    middleware.register_hook('system.post_license_update', _event_system)  # catch license change

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1927,4 +1927,4 @@ async def setup(middleware):
     if osc.IS_LINUX:
         await middleware.call('sysctl.set_zvol_volmode', 2)
 
-    middleware.register_hook('system.post_license_update', hook_license_update, sync=False)
+    middleware.register_hook('system.post_license_update', hook_license_update)


### PR DESCRIPTION
Need to make sure this thread is started in 3 different scenarios.

1. HA system is booted for first time and subsequently licensed for HA (without reboot)
2. `middlewared` service is restarted (without reboot)
3. system is rebooted

In the above scenarios, it's imperative that we make sure we start this thread on _BOTH_ controllers since it's 100% responsible for processing failover events. I achieve this by 2 hooks `system` and `system.post_license_update`.