### PR TITLE
NAS-112939 / 22.02-RC.2 / Fix cluster tests

### DIFF
--- a/cluster-tests/init_gluster.py
+++ b/cluster-tests/init_gluster.py
@@ -80,7 +80,7 @@ def add_peers():
     # use casefold() for purpose of hostname validation sense case does not matter
     # but the resolvable names on the network might not match _exactly_ with what
     # was given to us in the config (i.e. DNS1.HOSTNAME.BLAH == DNS1.hostname.BLAH)
-    assert set([i['hostname'].casefold() for i in ans.json()]) == set([i.casefold() for i HOSTNAMES]), ans.json()
+    assert set([i['hostname'].casefold() for i in ans.json()]) == set([i.casefold() for i in HOSTNAMES]), ans.json()
 
 
 def add_jwt_secret():

--- a/cluster-tests/tests/smb/001_sharing_smb.py
+++ b/cluster-tests/tests/smb/001_sharing_smb.py
@@ -1,7 +1,7 @@
 import pytest
 
 from config import CLUSTER_INFO, CLUSTER_IPS
-from utils import make_request, make_ws_request
+from utils import make_request, ssh_test, make_ws_request
 from pytest_dependency import depends
 from helpers import get_bool
 
@@ -449,6 +449,10 @@ def test_030_delete_smb_share(request):
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/sharing/smb/id/{smb_share_id}'
     res = make_request('delete', url)
     assert res.status_code == 200, res.text
+
+    cmd = f'rm -rf /cluster/{CLUSTER_INFO["GLUSTER_VOLUME"]}/smb_share_01'
+    res = ssh_test(CLUSTER_IPS[0], cmd)
+    assert res['result'], res['output']
 
 
 @pytest.mark.parametrize('ip', CLUSTER_IPS)

--- a/cluster-tests/utils.py
+++ b/cluster-tests/utils.py
@@ -96,7 +96,7 @@ def make_request(_type, url, **kwargs):
 
 def _run_ssh_cmd(host, action, **kwargs):
     cmd = [
-        'sshpass' '-p', AUTH[1],
+        'sshpass', '-p', AUTH[1],
         'ssh' if action == 'test' else 'scp',
         '-o', 'StrictHostKeyChecking=no',
         '-o', 'UserKnownHostsFile=/dev/null',
@@ -119,7 +119,7 @@ def _run_ssh_cmd(host, action, **kwargs):
 
 
 def ssh_test(host, cmd):
-    return _run_ssh_cmd(host, 'test', cmd=cmd})
+    return _run_ssh_cmd(host, 'test', cmd=cmd)
 
 
 def ssh_get(host, _file, _dst):


### PR DESCRIPTION
Address a couple of typos preventing tests from running.
Remove SMB share directory after SMB test completes