### PR TITLE
NAS-112351 / 22.02-RC.2 / Retrieve data for all non-ONLINE disks in pool status alert (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -508,7 +508,7 @@ class PoolService(CRUDService):
                 guid = x.get('guid')
                 if guid is not None:
                     unavail_disk = None
-                    if x.get('status') == 'UNAVAIL':
+                    if x.get('status') != 'ONLINE':
                         unavail_disk = self.middleware.call_sync('disk.disk_by_zfs_guid', guid)
                     x['unavail_disk'] = unavail_disk
 


### PR DESCRIPTION
Besides being UNAVAIL, they can also be FAULTED, etc.

Original PR: https://github.com/truenas/middleware/pull/7726
Jira URL: https://jira.ixsystems.com/browse/NAS-112351