### PR TITLE
NAS-112883 / 22.02-RC.2 / fix SCALE HA API tests

### DIFF
--- a/tests/api2/test_006_fenced.py
+++ b/tests/api2/test_006_fenced.py
@@ -1,0 +1,27 @@
+import pytest
+import sys
+from pytest_dependency import depends
+from os import getcwd, environ
+apifolder = getcwd()
+sys.path.append(apifolder)
+
+from functions import make_ws_request
+from auto_config import ha, dev_test
+
+pytestmark = pytest.mark.skipif(not ha or dev_test, reason='Only applicable to HA')
+IP = environ.get('controller1_ip')
+assert IP, 'Need controller 1 IP before this will work'
+
+
+@pytest.mark.dependency(name='FORCE_START_FENCED')
+def test_01_force_start_fenced():
+    payload = {'msg': 'method', 'method': 'failover.fenced.start', 'params': [True]}
+    res = make_ws_request(IP, payload)
+    assert res['result'] == 0, res
+
+
+def test_02_verify_fenced_is_running(request):
+    depends(request, ['FORCE_START_FENCED'])
+    payload = {'msg': 'method', 'method': 'failover.fenced.run_info', 'params': []}
+    res = make_ws_request(IP, payload)
+    assert res['result']['running'], res

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -4,12 +4,16 @@
 # License: BSD
 
 import requests
-from auto_config import api_url, user, password
 import json
 import os
+import re
+import websocket
+import uuid
 from subprocess import run, Popen, PIPE
 from time import sleep
-import re
+
+from auto_config import api_url, user, password
+
 
 if "controller1_ip" in os.environ:
     controller1_ip = os.environ["controller1_ip"]
@@ -256,3 +260,22 @@ def wait_on_job(job_id, max_timeout):
         if timeout >= max_timeout:
             return {'state': 'TIMEOUT', 'results': job_results.json()[0]}
         timeout += 5
+
+
+def make_ws_request(ip, payload):
+    # create connection
+    ws = websocket.create_connection(f'ws://{ip}:80/websocket')
+
+    # setup features
+    ws.send(json.dumps({'msg': 'connect', 'version': '1', 'support': ['1'], 'features': []}))
+    ws.recv()
+
+    # login
+    id = str(uuid.uuid4())
+    ws.send(json.dumps({'id': id, 'msg': 'method', 'method': 'auth.login', 'params': list(authentication)}))
+    ws.recv()
+
+    # return the request
+    payload.update({'id': id})
+    ws.send(json.dumps(payload))
+    return json.loads(ws.recv())


### PR DESCRIPTION
SCALE HA API tests should never work without this. If they were, it was because of pure luck. When the VM is initially setup, the disks used for zpool configuration have to be reserved via `fenced`. If a previous API run completed, a different set of scsi pr keys are left on the disks. While this shouldn't matter (since those keys are never updated), the way we run API tests now it does. To fix the problem, ensure the current instance of the HA VM has reserved the disks before trying to do anything with them.

1. create `make_ws_request` function so private API endpoints can be used (needed for fenced endpoints)
2. touch-up the ordering of imports
3. add `test_006_fenced.py` that should only run with HA api tests