### PR TITLE
NAS-112971 / 22.02-RC.2 / recreate user homedir on do_update (if needed)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -654,6 +654,7 @@ class UserService(CRUDService):
                     'uid': user['uid'],
                     'gid': group['bsdgrp_gid'],
                     'mode': user['home_mode'],
+                    'options': {'stripacl': True},
                 }).wait_sync(raise_error=True)
 
     @accepts(Int('id'), Dict('options', Bool('delete_group', default=True)))


### PR DESCRIPTION
It's possible (illogical albeit) to remove a user homedir via the CLI. If this happens, anytime an update is done to the existing user, the underlying operation can fail (depending on what was changed in the API request).

This does 2 things:

1. recreate the user homedir if it doesn't exist
2. flake8 fixes