### PR TITLE
NAS-112978 / 22.02-RC.2 / Add ability to query ntp peers

### DIFF
--- a/src/middlewared/middlewared/alert/source/ntp.py
+++ b/src/middlewared/middlewared/alert/source/ntp.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 
 from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource
@@ -7,8 +8,8 @@ from middlewared.alert.schedule import IntervalSchedule
 class NTPHealthCheckAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
-    title = "Excessive NTP server offset"
-    text = "NTP health check failed: %(reason)s"
+    title = "NTP Health Check Failed"
+    text = "NTP health check failed - %(reason)s"
 
 
 class NTPHealthCheckAlertSource(AlertSource):
@@ -16,6 +17,10 @@ class NTPHealthCheckAlertSource(AlertSource):
     run_on_backup_node = False
 
     async def check(self):
+        uptime_seconds = time.clock_gettime(time.CLOCK_MONOTONIC_RAW)
+        if uptime_seconds < 300:
+            return
+
         try:
             peers = await self.middleware.call("system.ntpserver.peers")
         except Exception:

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -146,6 +146,10 @@ class NTPServerService(CRUDService):
             return when
 
         peers = []
+
+        if not self.middleware.call_sync('system.ready'):
+            return peers
+
         resp = subprocess.run(['ntpq', '-np'], capture_output=True)
         if resp.returncode != 0 or resp.stderr:
             raise CallError(resp.stderr.decode().strip())


### PR DESCRIPTION
Also add alerts for the following situations:
(1) our offset with current peer is excessively large (> 5 minutes)
(2) we have connections to NTP servers, but for whatever reason do
not have a peer relation with any (perhaps all REJECTED).

Lack of results from system.ntpserver.peers API call is not
treated as an error condition at this point.