### PR TITLE
NAS-112987 / 22.02-RC.2 / Add app metadata for helm subcharts in app operations

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -37,6 +37,18 @@ def get_action_context(release_name):
     })
 
 
+def add_context_to_configuration(config, context_dict):
+    if 'global' in config:
+        config['global'].update(context_dict)
+        config.update(context_dict)
+    else:
+        config.update({
+            'global': context_dict,
+            **context_dict
+        })
+    return config
+
+
 def get_namespace(release_name):
     return f'{CHART_NAMESPACE_PREFIX}{release_name}'
 


### PR DESCRIPTION
This commit adds changes to include app metadata for helm subcharts so that they can benefit from the metadata and adapt their changes accordingly on app operations.