### PR TITLE
NAS-112875 / 22.02-RC.2 / Change timeout of non-critical services to 60secs on failover

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -553,7 +553,7 @@ class FailoverService(Service):
 
         # restart the remaining "non-critical" services
         logger.info('Restarting remaining services')
-        self.run_call('failover.events.restart_services')
+        self.run_call('failover.events.restart_services', {'critical': False, 'timeout': 60})
 
         # start any VMs (this will log errors if the vm(s) fail to start)
         self.run_call('vm.start_on_boot')


### PR DESCRIPTION
This commit adds changes to increase timeout of starting non-critical services on failover as apps can take more then 15 secs to start.