### PR TITLE
NAS-112998 / 22.02-RC.2 / Make sure we don't iterate over none object

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
@@ -27,7 +27,7 @@ class KubernetesPodService(CRUDService):
         async with api_client() as (api, context):
             pods = [
                 d.to_dict() for d in (await context['core_api'].list_pod_for_all_namespaces(**kwargs)).items
-                if force_all_pods or not any(o.kind == 'DaemonSet' for o in d.metadata.owner_references)
+                if force_all_pods or not any(o.kind == 'DaemonSet' for o in (d.metadata.owner_references or []))
             ]
             if options['extra'].get('events'):
                 events = await self.middleware.call(


### PR DESCRIPTION
This commit adds changes to account for the fact that owner_references can sometimes be null as well instead of being an empty list, so we handle that usage appropriately