### PR TITLE
NAS-112971 / 12.0 / recreate user homedir on do_update (if needed) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -575,6 +575,7 @@ class UserService(CRUDService):
                     'uid': user['uid'],
                     'gid': group['bsdgrp_gid'],
                     'mode': user['home_mode'],
+                    'options': {'stripacl': True},
                 }).wait_sync(raise_error=True)
 
     @accepts(Int('id'), Dict('options', Bool('delete_group', default=True)))


### PR DESCRIPTION
It's possible (illogical albeit) to remove a user homedir via the CLI. If this happens, anytime an update is done to the existing user, the underlying operation can fail (depending on what was changed in the API request).

This does 2 things:

1. recreate the user homedir if it doesn't exist
2. flake8 fixes

Original PR: https://github.com/truenas/middleware/pull/7739
Jira URL: https://jira.ixsystems.com/browse/NAS-112971