### PR TITLE
Bug fix and add more security headers

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -156,6 +156,7 @@ http {
         ssl_protocols ${' '.join(general_settings['ui_httpsprotocols'])};
         ssl_prefer_server_ciphers on;
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA${"" if disabled_ciphers else "+SHA256"}:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS${disabled_ciphers};
+        add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
         ## If oscsp stapling is a must in cert extensions, we should make sure nginx respects that
         ## and handles clients accordingly.
@@ -174,10 +175,6 @@ http {
 % endif
 
         # Security Headers
-        add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Content-Security-Policy "script-src 'self' 'unsafe-inline' 'unsafe-eval';" always;
         add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
         add_header Referrer-Policy "strict-origin" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -220,10 +217,7 @@ http {
 % endif
             add_header Cache-Control "must-revalidate";
             add_header Etag "${system_version}";
-            add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header X-XSS-Protection "1; mode=block" always;
-            add_header Content-Security-Policy "script-src 'self' 'unsafe-inline' 'unsafe-eval';" always;
+            add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
             add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
             add_header Referrer-Policy "strict-origin" always;
             add_header X-Frame-Options "SAMEORIGIN" always;

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -156,7 +156,6 @@ http {
         ssl_protocols ${' '.join(general_settings['ui_httpsprotocols'])};
         ssl_prefer_server_ciphers on;
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA${"" if disabled_ciphers else "+SHA256"}:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS${disabled_ciphers};
-        add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
         ## If oscsp stapling is a must in cert extensions, we should make sure nginx respects that
         ## and handles clients accordingly.
@@ -175,8 +174,13 @@ http {
 % endif
 
         # Security Headers
-        add_header X-Content-Type-Options nosniff;
-        add_header X-XSS-Protection "1";
+        add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Content-Security-Policy "script-src 'self' 'unsafe-inline' 'unsafe-eval';" always;
+        add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
+        add_header Referrer-Policy "strict-origin" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
 
         location / {
             rewrite ^.* $scheme://$http_host/ui/ redirect;
@@ -216,6 +220,13 @@ http {
 % endif
             add_header Cache-Control "must-revalidate";
             add_header Etag "${system_version}";
+            add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Content-Security-Policy "script-src 'self' 'unsafe-inline' 'unsafe-eval';" always;
+            add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
+            add_header Referrer-Policy "strict-origin" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
         }
 
         location /websocket {

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -156,7 +156,6 @@ http {
         ssl_protocols ${' '.join(general_settings['ui_httpsprotocols'])};
         ssl_prefer_server_ciphers on;
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA${"" if disabled_ciphers else "+SHA256"}:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS${disabled_ciphers};
-        add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
         ## If oscsp stapling is a must in cert extensions, we should make sure nginx respects that
         ## and handles clients accordingly.
@@ -175,6 +174,9 @@ http {
 % endif
 
         # Security Headers
+        add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
         add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
         add_header Referrer-Policy "strict-origin" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -217,7 +219,9 @@ http {
 % endif
             add_header Cache-Control "must-revalidate";
             add_header Etag "${system_version}";
-            add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
+            add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
             add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
             add_header Referrer-Policy "strict-origin" always;
             add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
I've discovered a misconfiguration resulting in security headers not getting applied to the TrueNAS WebUI.

> NGINX configuration blocks inherit add_header directives from their enclosing blocks, so you just need to place the add_header directive in the top‑level server block. There’s one important exception: if a block includes an add_header directive itself, it does not inherit headers from enclosing blocks, and you need to redeclare all add_header directives:

Source: [Inheritance Rules for add_header Directives](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/)

I've also added some more recommended security headers. When validating with [securityheaders.com](https://securityheaders.com) you should not get an A grade (previously F due to the misconfiguration).

There is room for some more improvements though, for example hardening the CSP header where you whitelist all scripts. That will give you an A+ grade.