### PR TITLE
NAS-113034 / 22.02-RC.2 / less verbose about sql related logs in journal_ha

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1304,7 +1304,7 @@ class JournalSync:
                 self.journal.append(item)
             else:
                 query, params = item
-                logger.warning('Node status %s but executed SQL query: %s', self.failover_status, query)
+                logger.trace('Node status %s but executed SQL query: %s', self.failover_status, query)
 
     def _update_failover_status(self):
         self.failover_status = self.middleware.call_sync('failover.status')


### PR DESCRIPTION
This is too chatty and only muddies the `syslog/failover.log` file on systems. Bump this to `logger.trace` for now.