### PR TITLE
NAS-113039 / 22.02-RC.2 / Properly ensure a method is decorated as accepts/private

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/interface_types.py
+++ b/src/middlewared/middlewared/plugins/interface/interface_types.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from middlewared.service import Service
+from middlewared.service import private, Service
 
 
 class InterfaceType(Enum):
@@ -16,6 +16,7 @@ class InterfaceService(Service):
     class Config:
         namespace_alias = 'interfaces'
 
+    @private
     async def type(self, iface_state):
         if iface_state['name'].startswith(('br', 'kube-bridge')):
             return InterfaceType.BRIDGE
@@ -28,6 +29,7 @@ class InterfaceService(Service):
         else:
             return InterfaceType.UNKNOWN
 
+    @private
     async def get_next_name(self, type):
         prefix = {
             InterfaceType.BRIDGE: 'br',
@@ -38,6 +40,7 @@ class InterfaceService(Service):
 
         return await self.middleware.call('interface.get_next', prefix)
 
+    @private
     async def validate_name(self, type, name):
         if type == InterfaceType.BRIDGE:
             if not (name.startswith('br') and name[2:].isdigit()):

--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -1,4 +1,4 @@
-from middlewared.service import Service
+from middlewared.service import private, Service
 
 
 class InterfaceService(Service):
@@ -6,5 +6,6 @@ class InterfaceService(Service):
     class Config:
         namespace_alias = 'interfaces'
 
+    @private
     async def internal_interfaces(self):
         return ['wg', 'lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn']

--- a/src/middlewared/middlewared/plugins/interface/lag_protocols.py
+++ b/src/middlewared/middlewared/plugins/interface/lag_protocols.py
@@ -1,4 +1,4 @@
-from middlewared.service import Service
+from middlewared.service import private, Service
 
 
 class InterfaceService(Service):
@@ -6,5 +6,6 @@ class InterfaceService(Service):
     class Config:
         namespace_alias = 'interfaces'
 
+    @private
     async def lag_supported_protocols(self):
         return ['LACP', 'FAILOVER', 'LOADBALANCE']


### PR DESCRIPTION
This commit adds changes to fix an issue where we are not decorating some endpoints as public/private which results in middleware not starting as that's a requirement.