### PR TITLE
NAS-113073 / 22.02-RC.2 / Bypass validation in OROperator if value matches default

### DIFF
--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -987,6 +987,9 @@ class OROperator:
         return False
 
     def clean(self, value):
+        if self.has_default and value == self.default:
+            return copy.deepcopy(self.default)
+
         found = False
         final_value = value
         verrors = ValidationErrors()


### PR DESCRIPTION
There are some situations where it may make sense to allow a
default value (for instance an empty dict) where it's not
permitted in the particular individual branches of the OROperator.

So in OROperator.clean() return copy of default if value passed
in matches the default value (skipping the branches of the attribute).