### PR TITLE
NAS-113075 / 22.02-RC.2 / Only adjust "ldap ssl" parameter in idmap backend if AD enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1141,7 +1141,7 @@ class IdmapDomainService(TDBWrapCRUDService):
                 })
 
         if ad_enabled:
-           rv['ldap ssl'] = {'parsed': 'off' if disable_ldap_starttls else 'start tls'}
+            rv['ldap ssl'] = {'parsed': 'off' if disable_ldap_starttls else 'start tls'}
 
         return rv
 


### PR DESCRIPTION
If LDAP plugin is enabled then use `ssl` parameter from that
plugin via ldap.start rather than the idmap `ssl` settings.

In AD case, use the idmap settings. This carries it's own
issues because the SMB LDAP client has global ssl settings,
but having separate idmap domains with different SSL settings
(starttls vs ldaps) is a quite obscure edge case.