### PR TITLE
NAS-113096 / 23.10 / Add tests for LDAP + GSSAPI

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
@@ -166,22 +166,22 @@
 
         def pam_account(self):
             min_uid = self.min_uid()
-            ldap_args = [
-                "try_first_pass",
-                "ignore_unknown_user",
-                "ignore_authinfo_unavail",
-                "no_warn",
-                f"minimum_uid={min_uid}"
-            ]
+            ldap_args = {
+                'new_authtok_reqd': 'done',
+                'ignore': 'ignore',
+                'unknown_user': 'ignore',
+                'authinfo_unavail': 'ignore',
+                'default': 'bad'
+            }
             krb5_args = ["no_warn", f"minimum_uid={min_uid}"]
 
             unix_entry = super().pam_account()
-            ldap_entry = super().pam_account(success="ok", pam_path=self.pam_ldap, pam_args=ldap_args)
+            ldap_entry = super().pam_account(success="ok", pam_path=self.pam_ldap, pam_args=[f"minimum_uid={min_uid}"], **ldap_args)
 
             entries = [unix_entry, ldap_entry]
 
             if self.is_kerberized():
-                krb5_entry = f"account\t\tsufficient\t{self.pam_krb5}\t\t{' '.join(krb5_args)}"
+                krb5_entry = f"account\t\trequired\t{self.pam_krb5}\t\t{' '.join(krb5_args)}"
                 entries.insert(1, krb5_entry)
 
             return "\n".join(entries)
@@ -198,16 +198,17 @@
                 "no_warn",
                 f"minimum_uid={min_uid}"
             ]
-            krb5_args = ["try_first_pass", "no_warn", f"minimum_uid={min_uid}"]
+            krb5_args = ["try_first_pass", f"minimum_uid={min_uid}"]
 
             unix_entry = super().pam_password(success=2)
             ldap_entry = super().pam_password(pam_path=self.pam_ldap, pam_args=ldap_args, success=1)
 
+            entries = [unix_entry, ldap_entry]
+
             if self.is_kerberized():
-                krb5_entry = super().pam_password(pam_path=self.pam_krb5, pam_args=krb5_args, success=3)
+                krb5_entry = super().pam_password(pam_path=self.pam_krb5, pam_args=krb5_args, success=3, required=)
                 entries.insert(0, krb5_entry)
 
-            entries = [unix_entry, ldap_entry]
             return "\n".join(entries)
 
     class DirectoryServicePam(DirectoryServicePamBase):

--- a/tests/api2/test_007_systemdataset.py
+++ b/tests/api2/test_007_systemdataset.py
@@ -240,7 +240,7 @@ def test_09_verify_sysds_does_not_move_after_second_pool_is_created(request, poo
 
 
 def test_10_verify_changes_to_sysds_are_forbidden_while_AD_is_running(set_ad_nameserver):
-    depends(set_ad_nameservers[0], ["second_pool"])
+    depends(set_ad_nameserver[0], ["second_pool"])
 
     with active_directory(AD_DOMAIN, ADUSERNAME, ADPASSWORD,
         netbiosname=hostname,

--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+import os
+import json
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+from assets.REST.directory_services import active_directory, ldap, override_nameservers
+from auto_config import ip, hostname, password, user
+from contextlib import contextmanager
+from functions import GET, POST, PUT, make_ws_request, wait_on_job
+from pytest_dependency import depends
+
+try:
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+except ImportError:
+    Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
+    pytestmark = pytest.mark.skip(reason=Reason)
+else:
+    from auto_config import dev_test
+    # comment pytestmark for development testing with --dev-test
+    pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
+
+@pytest.fixture(scope="module")
+def kerberos_config():
+    return {}
+
+
+@pytest.fixture(scope="module")
+def do_ad_connection(request):
+    with active_directory(
+        AD_DOMAIN,
+        ADUSERNAME,
+        ADPASSWORD,
+        netbiosname=hostname,
+    ) as ad:
+        yield (request, ad)
+
+
+@contextmanager
+def stop_activedirectory(request):
+    results = PUT("/activedirectory/", {"enable": False})
+    assert results.status_code == 200, results.text
+    job_id = results.json()['job_id']
+    job_status = wait_on_job(job_id, 180)
+    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+    try:
+        yield results.json()
+    finally:
+        results = PUT("/activedirectory/", {"enable": True})
+        assert results.status_code == 200, results.text
+        job_id = results.json()['job_id']
+        job_status = wait_on_job(job_id, 180)
+        assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+
+
+@pytest.fixture(scope="module")
+def do_ldap_connection(request):
+
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'kerberos.keytab.kerberos_principal_choices',
+        'params': [],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+
+    kerberos_principal = res['result'][0]
+
+    results = GET("/kerberos/realm/")
+    assert results.status_code == 200, results.text
+
+    realm_id = results.json()[0]['id']
+
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'kerberos._klist_test',
+        'params': [],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+    assert res['result'] is True
+
+    results = POST("/activedirectory/domain_info/", AD_DOMAIN)
+    assert results.status_code == 200, results.text
+    domain_info = results.json()
+
+    with stop_activedirectory(request) as ad:
+        res = make_ws_request(ip, {
+            'msg': 'method',
+            'method': 'kerberos.get_cred',
+            'params': [{
+                'dstype': 'DS_TYPE_LDAP',
+                'conf': {
+                    'kerberos_realm': realm_id,
+                    'kerberos_principal': kerberos_principal,
+                }
+            }],
+        })
+        error = res.get('error')
+        assert error is None, str(error)
+        cred = res['result']
+
+        res = make_ws_request(ip, {
+            'msg': 'method',
+            'method': 'kerberos.do_kinit',
+            'params': [{
+                'krb5_cred': cred,
+                'kinit-options': {
+                    'kdc_override': {
+                        'domain': AD_DOMAIN.upper(),
+                        'kdc': domain_info['KDC server']
+                    },
+                }
+            }],
+        })
+        error = res.get('error')
+        assert error is None, str(error)
+
+        with ldap(
+            domain_info['Bind Path'],
+            '', '', f'{domain_info["LDAP server name"].upper()}.',
+            has_samba_schema=False,
+            ssl="OFF",
+            kerberos_realm=realm_id,
+            kerberos_principal=kerberos_principal,
+            validate_certificates=False,
+            enable=True
+        ) as ldap_conn:
+            yield (request, ldap_conn)
+
+
+@pytest.fixture(scope="module")
+def set_ad_nameserver(request):
+    with override_nameservers(ADNameServer) as ns:
+        yield (request, ns)
+
+
+def test_01_set_nameserver_for_ad(set_ad_nameserver):
+    assert set_ad_nameserver[1]['nameserver1'] == ADNameServer
+
+
+def test_02_enabling_activedirectory(do_ad_connection):
+    results = GET('/activedirectory/started/')
+    assert results.status_code == 200, results.text
+
+
+@pytest.mark.dependency(name="SET_UP_AD_VIA_LDAP")
+def test_03_setup_and_enabling_ldap(do_ldap_connection):
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'kerberos.stop',
+        'params': [],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'kerberos.start',
+        'params': [],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'kerberos._klist_test',
+        'params': [],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+    assert res['result'] is True
+
+
+def test_04_verify_ldap_users(request):
+    depends(request, ["SET_UP_AD_VIA_LDAP"], scope="session")
+
+    results = GET('/user', payload={
+        'query-filters': [['local', '=', False]],
+        'query-options': {'extra': {"search_dscache": True}},
+    })
+    assert results.status_code == 200, results.text
+    assert len(results.json()) > 0, results.text
+
+    results = GET('/group', payload={
+        'query-filters': [['local', '=', False]],
+        'query-options': {'extra': {"search_dscache": True}},
+    })
+    assert results.status_code == 200, results.text
+    assert len(results.json()) > 0, results.text


### PR DESCRIPTION
Add regression tests for using kerberos keytabs with
LDAP plugin. Since CI infrastrucutre already has
Active Directory deployed, join the AD domain first through
libads to generate a keytab and account in AD, then
stop the AD service and use the machine account keytab for
authentication through the LDAP plugin. This provides
coverage for LDAP GSSAPI binds, and general correctness
of behavior for generating krb5.conf and keytab when
LDAP plugin is used.