### PR TITLE
NAS-113091 / 12.0 / fix services mgmt on 12

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/base_freebsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_freebsd.py
@@ -130,7 +130,7 @@ class FreeBSDStartNotify(threading.Thread):
 
 async def freebsd_service(rc, verb):
     r = await run("service", rc, verb, check=False, encoding="utf-8", stderr=subprocess.STDOUT)
-    if verb == 'forcestop' and r.returncode != 0 and f'{rc} not running?' not in r.stdout.decode().strip():
+    if verb == 'forcestop' and r.returncode != 0 and f'{rc} not running?' not in r.stdout.strip():
         # we only need to log a warning if we forcestop a service and it was actually running and
         # failed to stop....
         logger.warning("Failed to forcestop %s with code %d with error %r", rc, r.returncode, r.stdout)


### PR DESCRIPTION
When `encoding` kwarg is passed to `run` it will `decode` stderr/stdout.