### PR TITLE
NAS-112666 / 22.02-RC.2 / Do not sleep in the ZFS process pool while performing a scrub

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/events.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/events.md
@@ -74,7 +74,7 @@ Event Response Example:
         "collection": "core.get_jobs",
         "id": 79,
         "fields": {
-            "id": 79, "method": "zfs.pool.scrub",
+            "id": 79, "method": "pool.scrub.scrub",
             "arguments": ["vol1", "START"], "logs_path": null,
             "logs_excerpt": null,
             "progress": {"percent": 0.001258680822502356, "description": "Scrubbing", "extra": null},

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -241,7 +241,7 @@ class BootService(Service):
         """
         Scrub on boot pool.
         """
-        subjob = await self.middleware.call('zfs.pool.scrub', BOOT_POOL_NAME)
+        subjob = await self.middleware.call('pool.scrub.scrub', BOOT_POOL_NAME)
         return await job.wrap(subjob)
 
     @accepts(

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -365,7 +365,7 @@ class PoolService(CRUDService):
         """
         pool = await self.get_instance(oid)
         return await job.wrap(
-            await self.middleware.call('zfs.pool.scrub', pool['name'], action)
+            await self.middleware.call('pool.scrub.scrub', pool['name'], action)
         )
 
     @accepts(List('types', items=[Str('type', enum=['FILESYSTEM', 'VOLUME'])], default=['FILESYSTEM', 'VOLUME']))
@@ -4475,6 +4475,40 @@ class PoolScrubService(CRUDService):
         await self.middleware.call('service.restart', 'cron')
         return response
 
+    @accepts(
+        Str('name', required=True),
+        Str('action', enum=['START', 'STOP', 'PAUSE'], default='START')
+    )
+    @job(lock=lambda i: f'{i[0]}-{i[1] if len(i) >= 2 else "START"}')
+    async def scrub(self, job, name, action):
+        """
+        Start/Stop/Pause a scrub on pool `name`.
+        """
+        await self.middleware.call('zfs.pool.scrub_action', name, action)
+
+        if action == 'START':
+            while True:
+                scrub = await self.middleware.call('zfs.pool.scrub_state', name)
+
+                if scrub['pause']:
+                    job.set_progress(100, 'Scrub paused')
+                    break
+
+                if scrub['function'] != 'SCRUB':
+                    break
+
+                if scrub['state'] == 'FINISHED':
+                    job.set_progress(100, 'Scrub finished')
+                    break
+
+                if scrub['state'] == 'CANCELED':
+                    break
+
+                if scrub['state'] == 'SCANNING':
+                    job.set_progress(scrub['percentage'], 'Scrubbing')
+
+                await asyncio.sleep(1)
+
     @accepts(Str('name'), Int('threshold', default=35))
     @returns()
     async def run(self, name, threshold):
@@ -4529,7 +4563,7 @@ class PoolScrubService(CRUDService):
             logger.debug("Pool %r last scrub %r", name, last_scrub)
             return False
 
-        await self.middleware.call('zfs.pool.scrub', pool['name'])
+        await self.middleware.call('pool.scrub.scrub', pool['name'])
         return True
 
 

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -1,8 +1,6 @@
 import copy
 import errno
 import subprocess
-import threading
-import time
 from collections import defaultdict
 from copy import deepcopy
 
@@ -304,8 +302,7 @@ class ZFSPoolService(CRUDService):
         Str('name', required=True),
         Str('action', enum=['START', 'STOP', 'PAUSE'], default='START')
     )
-    @job(lock=lambda i: f'{i[0]}-{i[1] if len(i) >= 2 else "START"}')
-    def scrub(self, job, name, action):
+    def scrub_action(self, name, action):
         """
         Start/Stop/Pause a scrub on pool `name`.
         """
@@ -330,33 +327,9 @@ class ZFSPoolService(CRUDService):
             if proc.returncode != 0:
                 raise CallError('Unable to pause scrubbing')
 
-        def watch():
-            while True:
-                with libzfs.ZFS() as zfs:
-                    scrub = zfs.get(name).scrub.__getstate__()
-
-                if scrub['pause']:
-                    job.set_progress(100, 'Scrub paused')
-                    break
-
-                if scrub['function'] != 'SCRUB':
-                    break
-
-                if scrub['state'] == 'FINISHED':
-                    job.set_progress(100, 'Scrub finished')
-                    break
-
-                if scrub['state'] == 'CANCELED':
-                    break
-
-                if scrub['state'] == 'SCANNING':
-                    job.set_progress(scrub['percentage'], 'Scrubbing')
-                time.sleep(1)
-
-        if action == 'START':
-            t = threading.Thread(target=watch, daemon=True)
-            t.start()
-            t.join()
+    def scrub_state(self, name):
+        with libzfs.ZFS() as zfs:
+            return zfs.get(name).scrub.__getstate__()
 
     @accepts()
     def find_import(self):


### PR DESCRIPTION
We only have 5 libzfs processes. We can't afford using this scarce resource
to sleep while reporting scrub progress. Instead, we move scrub job to the main
asyncio loop and only use ZFS process pool to perform start/stop operation or
query scrub status.