### PR TITLE
NAS-113131 / 12.0 / fix zfs.pool.get_disks

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/disks_freebsd.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks_freebsd.py
@@ -21,10 +21,15 @@ class ZFSPoolService(Service, PoolDiskServiceBase):
         pool_disks = []
         cache = self.middleware.call_sync('disk.label_to_dev_disk_cache')
         for disk in disks:
+            found_disk = None
             found_label = cache['label_to_dev'].get(disk)
             if found_label:
                 found_disk = cache['dev_to_disk'].get(found_label)
-                if found_disk:
-                    pool_disks.append(found_disk)
+            else:
+                # maybe the disk for this zpool doesn't have a label (freenas-boot/boot-pool)
+                # we still need to try and find the raw disk
+                found_disk = cache['dev_to_disk'].get(disk)
+
+            pool_disks.append(found_disk) if found_disk else None
 
         return pool_disks


### PR DESCRIPTION
Given a zpool we're not guaranteed the underlying disks are recognized by gptid labels. Sometimes it's the zfs partition label on the raw disk. `boot-pool` is an example of this so we need to make sure we try to find the raw disk given a partition label (`ada0p2`).