### PR TITLE
NAS-113052 / 22.02-RC.2 / Do not toggle attachments when importing pools on boot

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1852,7 +1852,9 @@ class PoolService(CRUDService):
                         'Failed to inherit mountpoints for %s', pool['name'], exc_info=True,
                     )
 
-                unlock_job = self.middleware.call_sync('pool.dataset.unlock', pool['name'], {'recursive': True})
+                unlock_job = self.middleware.call_sync(
+                    'pool.dataset.unlock', pool['name'], {'recursive': True, 'toggle_attachments': False}
+                )
                 unlock_job.wait_sync()
                 if unlock_job.error or unlock_job.result['failed']:
                     failed = ', '.join(unlock_job.result['failed']) if not unlock_job.error else ''


### PR DESCRIPTION
This commit fixes an issue where we were trying to restart the services at boot when importing pools which was not okay as the system was not in ready state at the time and can cause various failures.