### PR TITLE
NAS-112666 / 13.0 / Do not sleep in the ZFS process pool while performing a scrub (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/events.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/events.md
@@ -64,7 +64,7 @@ Event Response Example:
         "collection": "core.get_jobs",
         "id": 79,
         "fields": {
-            "id": 79, "method": "zfs.pool.scrub",
+            "id": 79, "method": "pool.scrub.scrub",
             "arguments": ["vol1", "START"], "logs_path": null,
             "logs_excerpt": null,
             "progress": {"percent": 0.001258680822502356, "description": "Scrubbing", "extra": null},

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -147,7 +147,7 @@ class BootService(Service):
         """
         Scrub on boot pool.
         """
-        subjob = await self.middleware.call('zfs.pool.scrub', BOOT_POOL_NAME)
+        subjob = await self.middleware.call('pool.scrub.scrub', BOOT_POOL_NAME)
         return await job.wrap(subjob)
 
     @accepts(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c50cc9c74f06da0fe5dbc3d6cdc2c1467c6dfd56

We only have 5 libzfs processes. We can't afford using this scarce resource
to sleep while reporting scrub progress. Instead, we move scrub job to the main
asyncio loop and only use ZFS process pool to perform start/stop operation or
query scrub status.

Original PR: https://github.com/truenas/middleware/pull/7790
Jira URL: https://jira.ixsystems.com/browse/NAS-112666