### PR TITLE
NAS-112996 / 12.0 / Bug fix and add more security headers

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -146,7 +146,6 @@ http {
         ssl_protocols ${' '.join(general_settings['ui_httpsprotocols'])};
         ssl_prefer_server_ciphers on;
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA${"" if disabled_ciphers else "+SHA256"}:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS${disabled_ciphers};
-        add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
         ## TODO: OCSP Stapling
         #ssl_stapling on;
@@ -162,8 +161,12 @@ http {
 % endif
 
         # Security Headers
-        add_header X-Content-Type-Options nosniff;
-        add_header X-XSS-Protection "1";
+        add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
+        add_header Referrer-Policy "strict-origin" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
 
         location / {
             rewrite ^.* $scheme://$http_host/ui/ redirect;
@@ -199,6 +202,12 @@ http {
 % endif
             add_header Cache-Control "must-revalidate";
             add_header Etag "${system_version}";
+            add_header Strict-Transport-Security "max-age=${63072000 if general_settings['ui_httpsredirect'] else 0}; includeSubDomains; preload" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()" always;
+            add_header Referrer-Policy "strict-origin" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
         }
 
         location /websocket {


### PR DESCRIPTION
* Bug fix and add more security headers

Add more security headers to the nginx config. Also fixes a misconfig where previously added security headers wouldn't be inherited in the /ui subpath.

* Remove some headers

Remove headers CSP, hardened STS, X-Content-Type-Options and X-XSS-Protection

* Only remove CSP after misunderstanding the comment in the PR