### PR TITLE
NAS-113120 / 22.02-RC.2 / fix cluster API tests

### DIFF
--- a/cluster-tests/helpers.py
+++ b/cluster-tests/helpers.py
@@ -1,5 +1,11 @@
 import contextlib
+from time import sleep
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from protocols import SMB
+
+from config import CLUSTER_IPS
+from utils import make_request
+
 
 def get_bool(parm):
     if isinstance(parm, bool):
@@ -13,6 +19,33 @@ def get_bool(parm):
         raise ValueError(parm)
 
     return bool(parm)
+
+
+def ctdb_healthy(timeout=0):
+    """
+    In parallel, check if all nodes in the cluster are healthy. This will "wait"
+    `timeout` seconds before giving up and returning.
+    """
+    if timeout > 60:
+        timeout = 60  # limit to 60 for now
+    sleep_timeout = 2
+
+    with ThreadPoolExecutor() as exc:
+        urls = [f'http://{ip}/api/v2.0/ctdb/general/healthy' for ip in CLUSTER_IPS]
+        while True:
+            futures = {exc.submit(make_request, 'get', url): url for url in urls}
+
+            results = {}
+            for fut in as_completed(futures):
+                results[futures[fut]] = fut.result().json()
+
+            rc = all(v is True for k, v in results.items())
+            if timeout <= 0 or rc:
+                # no timeout provided, expired timeout, or cluster is healthy
+                return rc
+            else:
+                sleep(sleep_timeout)
+                timeout -= sleep_timeout
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This does a few things:

1. make `init_gluster` actually wait (30 seconds) for ctdb to become healthy
2. make `init_gluster` add the ctdb public ips to the cluster
3. remove unnecessary code in the `directoryservices` tests since they were checking if ctdb is healthy (this should be done at cluster initialization now)
4. fix a few `flake8` issues