### PR TITLE
NAS-113170 / 22.02-RC.2 / properly set `source` attribute in filesystem.statfs

### DIFF
--- a/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
+++ b/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
@@ -55,7 +55,7 @@ def test_003_create_test_files(request):
     cmd += f'mkdir {LOCAL_PATH}/dir01;'
     cmd += f'touch {LOCAL_PATH}/dir01/file02'
     res = ssh_test(CLUSTER_IPS[0], cmd)
-    assert res['result'], res['output']
+    assert res['result'], res['stderr']
 
 
 @pytest.mark.parametrize('ip', CLUSTER_IPS)
@@ -419,4 +419,4 @@ def test_050_remove_test_files(request):
 
     cmd = f'rm -rf {LOCAL_PATH}'
     res = ssh_test(CLUSTER_IPS[0], cmd)
-    assert res['result'], res['output']
+    assert res['result'], res['stderr']

--- a/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
+++ b/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
@@ -7,8 +7,8 @@ from exceptions import JobTimeOut
 from pytest_dependency import depends
 from time import sleep
 
-local_path = f'/cluster/{CLUSTER_INFO["GLUSTER_VOLUME"]}/filesystem_01'
-cluster_path = f'CLUSTER:{CLUSTER_INFO["GLUSTER_VOLUME"]}/filesystem_01'
+LOCAL_PATH = f'/cluster/{CLUSTER_INFO["GLUSTER_VOLUME"]}/filesystem_01'
+CLUSTER_PATH = f'CLUSTER:{CLUSTER_INFO["GLUSTER_VOLUME"]}/filesystem_01'
 testfiles = [
     ('file01', False),
     ('dir01', True),
@@ -48,12 +48,12 @@ def test_003_create_test_files(request):
     depends(request, ['FS_BASIC_GLUSTER_VOLUME_MOUNTED'])
 
     url = f'http://{CLUSTER_IPS[0]}/api/v2.0/filesystem/mkdir/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
 
-    cmd = f'touch {local_path}/file01;'
-    cmd += f'mkdir {local_path}/dir01;'
-    cmd += f'touch {local_path}/dir01/file02'
+    cmd = f'touch {LOCAL_PATH}/file01;'
+    cmd += f'mkdir {LOCAL_PATH}/dir01;'
+    cmd += f'touch {LOCAL_PATH}/dir01/file02'
     res = ssh_test(CLUSTER_IPS[0], cmd)
     assert res['result'], res['output']
 
@@ -61,9 +61,9 @@ def test_003_create_test_files(request):
 @pytest.mark.parametrize('ip', CLUSTER_IPS)
 def test_004_filesystem_stat(ip, request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
-    
+
     for f, isdir in testfiles:
-        payload = f'{cluster_path}/{f}'
+        payload = f'{CLUSTER_PATH}/{f}'
         url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
         res = make_request('post', url, data=payload)
         assert res.status_code == 200, res.text
@@ -75,7 +75,7 @@ def test_004_filesystem_stat(ip, request):
 def test_005_filesystem_listdir(ip, request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
-    payload = {'path': f'{cluster_path}/'}
+    payload = {'path': f'{CLUSTER_PATH}/'}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -84,8 +84,8 @@ def test_005_filesystem_listdir(ip, request):
     names = [x['name'] for x in data]
     assert 'dir01' in names, data
     assert 'file01' in names, data
-    
-    payload = {'path': f'{cluster_path}/dir01'}
+
+    payload = {'path': f'{CLUSTER_PATH}/dir01'}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -99,7 +99,7 @@ def test_006_filesystem_chown_non_recursive(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "uid": 1000,
         "options": {"recursive": False}
     }
@@ -115,13 +115,13 @@ def test_006_filesystem_chown_non_recursive(request):
         assert status['state'] == 'SUCCESS', status
 
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     assert data['uid'] == 1000
-    assert data['gid'] == 0 
+    assert data['gid'] == 0
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -135,7 +135,7 @@ def test_007_filesystem_chown_recursive(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "uid": 2000,
         "options": {"recursive": True}
     }
@@ -151,13 +151,13 @@ def test_007_filesystem_chown_recursive(request):
         assert status['state'] == 'SUCCESS', status
 
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     assert data['uid'] == 2000
     assert data['gid'] == 0
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -171,7 +171,7 @@ def test_008_filesystem_reset_owner(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "uid": 0,
         "options": {"recursive": True}
     }
@@ -186,7 +186,7 @@ def test_008_filesystem_reset_owner(request):
         assert status['state'] == 'SUCCESS', status
 
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     assert data['uid'] == 0
@@ -196,7 +196,7 @@ def test_008_filesystem_reset_owner(request):
 def test_009_filesystem_setperm_nonrecursive(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "mode": "777",
         "options": {"recursive": False}
     }
@@ -214,14 +214,14 @@ def test_009_filesystem_setperm_nonrecursive(request):
     sleep(5)
 
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     mode = stat.S_IMODE(data['mode']) & ~stat.S_IFDIR
     assert data['acl'] is False
     assert f'{mode:03o}' == '777'
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -235,7 +235,7 @@ def test_009_filesystem_setperm_nonrecursive(request):
 def test_010_filesystem_setperm_recursive(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "mode": "777",
         "options": {"recursive": True}
     }
@@ -250,7 +250,7 @@ def test_010_filesystem_setperm_recursive(request):
     else:
         assert status['state'] == 'SUCCESS', status
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -265,7 +265,7 @@ def test_011_filesystem_reset_mode(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "mode": "755",
         "options": {"recursive": True}
     }
@@ -292,7 +292,7 @@ def test_012_filesystem_setacl_nonrecursive(request):
     to_set = res.json()
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "dacl": to_set,
         "acltype": "POSIX1E",
         "options": {"recursive": False}
@@ -310,12 +310,12 @@ def test_012_filesystem_setacl_nonrecursive(request):
         assert status['state'] == 'SUCCESS', status
 
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     assert data['acl'] is True
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[1]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -349,7 +349,7 @@ def test_013_filesystem_setacl_recursive(request):
     ])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "dacl": to_set,
         "acltype": "POSIX1E",
         "options": {"recursive": True}
@@ -367,12 +367,12 @@ def test_013_filesystem_setacl_recursive(request):
         assert status['state'] == 'SUCCESS', status
 
     url = f'http://{CLUSTER_IPS[0]}/api/v2.0/filesystem/stat/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
     assert data['acl'] is True
 
-    payload = {'path': cluster_path}
+    payload = {'path': CLUSTER_PATH}
     url = f'http://{CLUSTER_IPS[0]}/api/v2.0/filesystem/listdir/'
     res = make_request('post', url, data=payload)
     assert res.status_code == 200, res.text
@@ -385,7 +385,7 @@ def test_014_filesystem_reset_acl(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
     payload = {
-        "path": cluster_path,
+        "path": CLUSTER_PATH,
         "mode": "755",
         "options": {"recursive": True, "stripacl": True}
     }
@@ -406,17 +406,17 @@ def test_015_filesystem_statfs(ip, request):
     depends(request, ['FS_BASIC_GLUSTER_VOLUME_MOUNTED'])
 
     url = f'http://{ip}/api/v2.0/filesystem/statfs/'
-    res = make_request('post', url, data=cluster_path)
+    res = make_request('post', url, data=CLUSTER_PATH)
     assert res.status_code == 200, res.text
     data = res.json()
 
     assert data['fstype'] == 'fuse.glusterfs'
-    assert data['source'] == CLUSTER_INFO["GLUSTER_VOLUME"] 
+    assert data['source'] == CLUSTER_INFO['GLUSTER_VOLUME']
 
 
 def test_050_remove_test_files(request):
     depends(request, ['FS_BASIC_TEST_FILES_CREATED'])
 
-    cmd = f'rm -rf {local_path}'
+    cmd = f'rm -rf {LOCAL_PATH}'
     res = ssh_test(CLUSTER_IPS[0], cmd)
     assert res['result'], res['output']

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -366,9 +366,8 @@ class FilesystemService(Service):
             mountpoint = mountpoint.parent.absolute()
 
         # strip the `/mnt/` or `/cluster/` prefix from the mountpoint
-        me = mountpoint.parents[len(mountpoint.parents) - 2].as_posix() + '/'
-        with_me = ''
-        device = path.replace(me, with_me).strip('/')
+        device = mountpoint.as_posix().removeprefix('/mnt/')
+        device = device.removeprefix('/cluster/')
 
         # we only look for /mnt/ or /cluster/ paths and, currently,
         # those 2 paths are limited to zfs and/or fuse.glusterfs


### PR DESCRIPTION
1. flake8 fixes for `filesystem/*` cluster api tests
2. properly return the `source` attribute in `filesystem.statfs`