### PR TITLE
NAS-113138 / 22.02-RC.2 / fix SCALE bond validation

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1273,26 +1273,15 @@ class InterfaceService(CRUDService):
             if not lag_ports:
                 verrors.add(f'{schema_name}.lag_ports', 'This field cannot be empty.')
             for i, member in enumerate(lag_ports):
+                _schema = f'{schema_name}.lag_ports.{i}'
                 if member not in ifaces:
-                    verrors.add(f'{schema_name}.lag_ports.{i}', 'Not a valid interface.')
-                    continue
-                member_iface = ifaces[member]
-                if member_iface['state']['cloned']:
-                    verrors.add(
-                        f'{schema_name}.lag_ports.{i}',
-                        'Only physical interfaces are allowed to be a member of Link Aggregation.',
-                    )
+                    verrors.add(_schema, f'"{member}" is not a valid interface.')
                 elif member in lag_used:
-                    verrors.add(
-                        f'{schema_name}.lag_ports.{i}',
-                        f'Interface {member} is currently in use by {lag_used[member]}.',
-                    )
+                    verrors.add(_schema, f'Interface {member} is currently in use by {lag_used[member]}.')
+                elif member in bridge_used:
+                    verrors.add(_schema, f'Interface {member} is currently in use by {bridge_used[member]}.')
                 elif member in vlan_used:
-                    verrors.add(
-                        f'{schema_name}.lag_ports.{i}',
-                        f'Interface {member} is currently in use by {vlan_used[member]}.',
-                    )
-
+                    verrors.add(_schema, f'Interface {member} is currently in use by {vlan_used[member]}.')
         elif itype == 'VLAN':
             if 'name' in data:
                 try:


### PR DESCRIPTION
This does 2 things:

1. allow a `bond` interface to be a member of a `br` interface
2. allow a `bond` interface to be a member of another `bond` interface

These are perfectly valid network setups (albeit rare imo) so we shouldn't restrict them. See https://github.com/truenas/middleware/pull/7588 for more details.

We still enforce that a member of a `br` cannot be added as a member to a `bond` and vice versa since we write this info to the db. (We don't want the db to filled with dangling entries)