### PR TITLE
NAS-113192 / 12.0 / fix disk.label_to_dev_disk_cache

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -83,14 +83,16 @@ class DiskService(Service, DiskInfoBase):
         label_to_dev = {}
         for label in bsd.geom.class_by_name('LABEL').xml:
             if (name := label.find('name')) is not None:
-                if (provider := label.find('provider/name')) is not None:
-                    label_to_dev[provider.text] = name.text
+                for provider in label.iterfind('provider'):
+                    if (prov := provider.find('name')) is not None:
+                        label_to_dev[prov.text] = name.text
 
         dev_to_disk = {}
         for label in bsd.geom.class_by_name('PART').xml:
             if (name := label.find('name')) is not None:
-                if (provider := label.find('provider/name')) is not None:
-                    dev_to_disk[provider.text] = name.text
+                for provider in label.iterfind('provider'):
+                    if (prov := provider.find('name')) is not None:
+                        dev_to_disk[prov.text] = name.text
 
         return {
             'label_to_dev': label_to_dev,


### PR DESCRIPTION
A disk can have multiple partitions, obviously. However, the subtly of this bug is that the inner `label.find` doesn't parse all of the `provider` elements for the given geom element. Instead use an inner `label.iterfind('provider')` to ensure we get all partitions for a given disk.

I've made the same change when parsing the `LABEL` xml information since it doesn't harm to have the same logic and it's not very well understood if labels are universally unique on a given system. This negates that undefined behavior.