### PR TITLE
DOCS-2793 / 12.0-U6.1 / Adding 5 second after the second ISCSI mount

### DIFF
--- a/tests/api2/iscsi.py
+++ b/tests/api2/iscsi.py
@@ -385,6 +385,7 @@ def test_35_waiting_for_iscsi_connection_before_grabbing_device_name(request):
             assert True
             break
         sleep(1)
+    sleep(5)
 
 
 @bsd_host_cfg


### PR DESCRIPTION
This fixes the race condition seen with ENTERPRISE HA trying to mount iscsi a second time.