### PR TITLE
NAS-113194 / 22.02-RC.2 / fix usb device information on SCALE in debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
@@ -60,8 +60,8 @@ hardware_linux()
 	lspci -vvvD
 	section_footer
 
-	section_header "usb-devices"
-	usb-devices
+	section_header "USB device information"
+	cat /sys/kernel/debug/usb/devices
 	section_footer
 
 	section_header "dmidecode"


### PR DESCRIPTION
`usb-devices` binary just prints the information in `/sys/kernel/debug/usb/devices` so instead of installing any more tools in the base image, just `cat` that file.