### PR TITLE
NAS-111019 / 22.02-RC.2 / Allow Kubernetes ServiceLB to be turned off

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-11-09_22-08_add_servicelb_toggle.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-11-09_22-08_add_servicelb_toggle.py
@@ -1,0 +1,25 @@
+"""add servicelb toggle
+
+Revision ID: daec6faa9589
+Revises: 91b71800c7fe
+Create Date: 2021-11-09 22:08:27.526805+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'daec6faa9589'
+down_revision = '91b71800c7fe'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('servicelb', sa.Boolean(), default=True, nullable=False))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -40,4 +40,5 @@ def render(service, middleware):
             'node-ip': config['node_ip'],
             'kube-apiserver-arg': kube_api_server_args,
             'protect-kernel-defaults': True,
+            'disable': [] if config['servicelb'] else ['servicelb'],
         }))

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -25,6 +25,7 @@ class KubernetesModel(sa.Model):
     node_ip = sa.Column(sa.String(128), default='0.0.0.0')
     cni_config = sa.Column(sa.JSON(type=dict), default={})
     configure_gpus = sa.Column(sa.Boolean(), default=True, nullable=False)
+    servicelb = sa.Column(sa.Boolean(), default=True, nullable=False)
 
 
 class KubernetesService(ConfigService):
@@ -36,6 +37,7 @@ class KubernetesService(ConfigService):
 
     ENTRY = Dict(
         'kubernetes_entry',
+        Bool('servicelb', required=True),
         Bool('configure_gpus', required=True),
         Str('pool', required=True, null=True),
         IPAddr('cluster_cidr', required=True, cidr=True, empty=True),
@@ -223,6 +225,12 @@ class KubernetesService(ConfigService):
         """
         `pool` must be a valid ZFS pool configured in the system. Kubernetes service will initialise the pool by
         creating datasets under `pool_name/ix-applications`.
+
+        `configure_gpus` is a boolean to enable or disable to prevent automatically loading any GPU Support
+        into kubernetes. This includes not loading any daemonsets for Intel and NVIDIA support.
+
+        `servicelb` is a boolean to enable or disable the integrated k3s Service Loadbalancer called "Klipper".
+        This can be set to disabled to enable the user to run another LoadBalancer or no LoadBalancer at all.
 
         `cluster_cidr` is the CIDR to be used for default NAT network between workloads.
 


### PR DESCRIPTION
NAS-111019 originally aims to add MetalLB by iX systems.

**However, I've come across a few caveats:**
- It would limit users to still only be able to use either of the 2 loadbalancers
- MetalLB also includes a lot of options that are not likely to be included (such as prometheus metrics support), where users actually do want to customise their setup

**Considering:**
- Loadbalancers are also easily rolled out as Apps
- We already have a solid solution for Apps
- iX already leaves it to the communityto build Ingresses as Apps as well

I've come to the conclusion that the simplest and cleanest solution would be to just allow users to turn off the  ServiceLB "Klipper" LoadBalancer. I've done initial research and this can cleanly be done, without complete reinstallation of k3s. (aka: Hotswap is fully supported).

This PR Adds a simple hook in the middleware to disable it. The PR aims to be as simple as possible, to prevent needless overcomplication.

**Possible Bugs/Risks/Problems**
- It basically only tells k3s to not install (or remove) the LoadBalancer deployment. The default loadbalancer works mostly by adding seperate pods to each HelmChart/Service, which get removed and that's (basically) it. It's also used by a LOT of k3s users worldwide. Hence the chance this will cause _technical_ issues is practically zero, if implemented correctly.
- As this is just the middleware "backend" portion, the chances of this causing a significant support requirement, are also quite minimal. Users using this as-is (by manually toggling the flag), would not be many and relatively experienced.
- Even if this would cause an issue, the issue would be limited to there not being a loadbalancer deployed, which would not affect the official Apps at all, as those do not use the loadbalancer type service.

**Consequences for the End user**
As requested by @sonicaj here a short list of what happens to the end-user when they disable the build-in LoadBalancer:
- `SVCLB` pods will not spawn
- Services with type "LoadBalancer", will not automatically get an external IP/Port assigned:
![image](https://user-images.githubusercontent.com/7613738/141090090-aef88363-21bd-4809-984f-b94e9e992cc0.png)
- Users can still manually set an ExternalIP on a service with type "LoadBalancer" to open on the host:
![image](https://user-images.githubusercontent.com/7613738/141090454-7fd183e7-9076-4c58-8777-dd667bd186d7.png)
(this will NOT open that port cluster wide, like ServiceLB does, only on the local node like NodePort)
- Users will still be able to install Apps
- Users will still be able to connect to Apps internally

**Performed tests:**
- Manually checked if the add "disable" list in config.yaml would, in fact, disable the loadbalancer (Correct)
- Checked if the added Python scripting does, in fact, result in the loadbalancer being disabled in config.yaml
- Created a UI PR (https://github.com/truenas/webui/pull/6104) and tested if that did, in fact, cause the loadbalancer to be disabled in config.yaml

In all cases where the loadbalancer is disabled, it, in fact, does not spawn any svclb pods as expected:
![image](https://user-images.githubusercontent.com/7613738/141020678-b5336283-85aa-4e40-9c77-353aa63eae26.png)

In case anyone wants to test how this would work, an example MetalLB App is available in the TrueCharts Incubator Train:
![image](https://user-images.githubusercontent.com/7613738/141169994-d798540d-58a6-443e-8325-de9c8f437d79.png)

![image](https://user-images.githubusercontent.com/7613738/141170058-0dede3ca-33b0-4997-8d02-efa7ab549a3c.png)
