### PR TITLE
NAS-113268 / 22.02-RC.2 / Mark macvtapX as an internal interface

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -8,4 +8,6 @@ class InterfaceService(Service):
 
     @private
     async def internal_interfaces(self):
-        return ['wg', 'lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn']
+        return [
+            'wg', 'lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn', 'macvtap',
+        ]


### PR DESCRIPTION
We should not try to configure/unconfigure macvtap as interfaces as they are internal interfaces and managed by us.