### PR TITLE
NAS-113034 / 22.02-RC.2 / prevent some db queries on passive

### DIFF
--- a/src/middlewared/middlewared/plugins/keyvalue.py
+++ b/src/middlewared/middlewared/plugins/keyvalue.py
@@ -50,9 +50,9 @@ class KeyValueService(Service):
                 "datastore.insert", "system.keyvalue", {"key": key, "value": json.dumps(value)}, options
             )
         else:
-            await self.middleware.call("datastore.update", "system.keyvalue", row["id"], {
-                "value": json.dumps(value)
-            })
+            await self.middleware.call(
+                "datastore.update", "system.keyvalue", row["id"], {"value": json.dumps(value)}, options
+            )
 
         return value
 

--- a/src/middlewared/middlewared/plugins/keyvalue.py
+++ b/src/middlewared/middlewared/plugins/keyvalue.py
@@ -1,5 +1,5 @@
 from middlewared.client import ejson as json
-from middlewared.schema import Any, Str, accepts
+from middlewared.schema import Any, Str, accepts, Dict
 from middlewared.service import Service
 import middlewared.sqlalchemy as sa
 
@@ -37,15 +37,18 @@ class KeyValueService(Service):
 
             raise KeyError(key)
 
-    @accepts(Str('key'), Any('value'))
-    async def set(self, key, value):
+    @accepts(
+        Str('key'),
+        Any('value'),
+        Dict('options', additional_attrs=True),
+    )
+    async def set(self, key, value, options):
         try:
             row = await self.middleware.call("datastore.query", "system.keyvalue", [["key", "=", key]], {"get": True})
         except IndexError:
-            await self.middleware.call("datastore.insert", "system.keyvalue", {
-                "key": key,
-                "value": json.dumps(value)
-            })
+            await self.middleware.call(
+                "datastore.insert", "system.keyvalue", {"key": key, "value": json.dumps(value)}, options
+            )
         else:
             await self.middleware.call("datastore.update", "system.keyvalue", row["id"], {
                 "value": json.dumps(value)
@@ -53,6 +56,9 @@ class KeyValueService(Service):
 
         return value
 
-    @accepts(Str('key'))
-    async def delete(self, key):
-        await self.middleware.call("datastore.delete", "system.keyvalue", [["key", "=", key]])
+    @accepts(
+        Str('key'),
+        Dict('options', additional_attrs=True),
+    )
+    async def delete(self, key, options):
+        await self.middleware.call("datastore.delete", "system.keyvalue", [["key", "=", key]], options)

--- a/src/middlewared/middlewared/plugins/migration.py
+++ b/src/middlewared/middlewared/plugins/migration.py
@@ -50,6 +50,6 @@ class MigrationService(Service):
                     self.middleware.logger.error("Error running migration %s", name, exc_info=True)
                     continue
 
-                await self.middleware.call("datastore.insert", "system.migration", {"name": name})
+                await self.middleware.call("datastore.insert", "system.migration", {"name": name}, {"ha_sync": False})
 
             await self.middleware.call("keyvalue.set", "run_migration", False)

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1679,7 +1679,9 @@ async def _update_birthday(middleware):
             middleware.logger.debug('Updating birthday data')
             # update db with new birthday
             settings = await middleware.call('datastore.config', 'system.settings')
-            await middleware.call('datastore.update', 'system.settings', settings['id'], {'stg_birthday': birthday})
+            await middleware.call(
+                'datastore.update', 'system.settings', settings['id'], {'stg_birthday': birthday}, {'ha_sync': False}
+            )
             break
         else:
             await asyncio.sleep(300)


### PR DESCRIPTION
We do not need to add these database operations to the `JournalSync` thread's queue to synchronize to the standby controller.