### PR TITLE
NAS-113281 / 22.02-RC.2 / only run ssh.save_keys when necessary

### DIFF
--- a/src/middlewared/middlewared/plugins/ssh.py
+++ b/src/middlewared/middlewared/plugins/ssh.py
@@ -231,7 +231,7 @@ class SSHService(SystemServiceService):
                         update[column] = data
 
         if update:
-            self.middleware.call_sync('datastore.update', 'services.ssh', old['id'], update)
+            self.middleware.call_sync('datastore.update', 'services.ssh', old['id'], update, {'ha_sync': False})
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/ssh.py
+++ b/src/middlewared/middlewared/plugins/ssh.py
@@ -222,15 +222,16 @@ class SSHService(SystemServiceService):
     @private
     def save_keys(self):
         update = {}
+        old = self.middleware.call_sync('datastore.query', 'services_ssh', [], {'get': True})
         for path, column in self.keys:
             if os.path.exists(path):
                 with open(path, "rb") as f:
                     data = base64.b64encode(f.read()).decode("ascii")
+                    if data != old[column]:
+                        update[column] = data
 
-                update[column] = data
-
-        old = self.middleware.call_sync('ssh.config')
-        self.middleware.call_sync('datastore.update', 'services.ssh', old['id'], update)
+        if update:
+            self.middleware.call_sync('datastore.update', 'services.ssh', old['id'], update)
 
 
 async def setup(middleware):


### PR DESCRIPTION
No reason to update the database with a huge amount of `ascii` text if none of the keys have changed.