### PR TITLE
NAS-113286 / 22.02-RC.2 / mark primary interface on active-backup bonds

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -57,6 +57,15 @@ class LaggMixin:
         run(["ip", "link", "set", self.name, "type", "bond", "lacp_rate", value])
 
     @property
+    def primary_interface(self):
+        if self.protocol == AggregationProtocol.FAILOVER:
+            return self._sysfs_read(self.get_options_path("primary")).strip() or None
+
+    @primary_interface.setter
+    def primary_interface(self, value):
+        run(["ip", "link", "set", self.name, "type", "bond", "primary", value])
+
+    @property
     def ports(self):
         ports = []
         for port in self._sysfs_read(f"/sys/devices/virtual/net/{self.name}/bonding/slaves").split():


### PR DESCRIPTION
When an `active-backup` type bond is created on SCALE, we're not setting the `primary` interface setting. This isn't a problem because the kernel will automatically choose one, however, it's very common to want to choose which member of the `active-backup` bond is the "primary" underlying interface to be used.

This changes the interface that has a `lagg_ordernum` of 0 to be the "primary" interface which means the order in which the members are specified when creating this bond type are important.