### PR TITLE
NAS-113287 / 13.0 / Fix `Attribute` constructor arguments typos and fix the bug that made… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -428,7 +428,7 @@ class PluginService(CRUDService):
             Bool('refresh', default=False),
             Str('plugin', required=True),
             Str('branch', default=None, null=True),
-            Str('plugin_repository', emtpy=False)
+            Str('plugin_repository', empty=False)
         )
     )
     def defaults(self, options):

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -11,8 +11,8 @@ class PoolService(Service):
         Int('oid'),
         Dict(
             'pool_attach',
-            Str('target_vdev', reuired=True),
-            Str('new_disk', reuired=True),
+            Str('target_vdev', required=True),
+            Str('new_disk', required=True),
             Str('passphrase'),
         )
     )

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1253,7 +1253,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
         List('devices', default=[], items=[Patch('vmdevice_create', 'vmdevice_update', ('rm', {'name': 'vm'}))]),
         Bool('autostart', default=True),
         Str('time', enum=['LOCAL', 'UTC'], default='LOCAL'),
-        Int('shutdown_timeout', default=90, valdiators=[Range(min=5, max=300)]),
+        Int('shutdown_timeout', default=90, validators=[Range(min=5, max=300)]),
         register=True,
     ))
     async def do_create(self, data):

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -71,6 +71,9 @@ class Attribute(object):
         self.register = register
         self.hidden = hidden
 
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {', '.join(map(repr, kwargs.keys()))}")
+
     def clean(self, value):
         if value is None and self.null is False:
             raise Error(self.name, 'null not allowed')


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 1436a218c7eafa933eba8e74aa9de5574442da5a

… them possible

Original PR: https://github.com/truenas/middleware/pull/7847
Jira URL: https://jira.ixsystems.com/browse/NAS-113287