### PR TITLE
NAS-113034 / 13.0 / prevent some db queries on passive (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/migration.py
+++ b/src/middlewared/middlewared/plugins/migration.py
@@ -49,6 +49,6 @@ class MigrationService(Service):
                     self.middleware.logger.error("Error running migration %s", name, exc_info=True)
                     continue
 
-                await self.middleware.call("datastore.insert", "system.migration", {"name": name})
+                await self.middleware.call("datastore.insert", "system.migration", {"name": name}, {"ha_sync": False})
 
-            await self.middleware.call("keyvalue.set", "run_migration", False)
+            await self.middleware.call("keyvalue.set", "run_migration", False, {"ha_sync": False})

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1476,9 +1476,9 @@ async def _update_birthday_data(middleware, birthday=None):
         middleware.logger.debug('Updating birthday data')
         # update db with new birthday
         settings = await middleware.call('datastore.config', 'system.settings')
-        await middleware.call('datastore.update', 'system.settings', settings['id'], {
-            'stg_birthday': birthday,
-        })
+        await middleware.call(
+            'datastore.update', 'system.settings', settings['id'], {'stg_birthday': birthday}, {'ha_sync': False}
+        )
 
 
 async def _update_birthday(middleware):


### PR DESCRIPTION
We do not need to add these database operations to the `JournalSync` thread's queue to synchronize to the standby controller.

Original PR: https://github.com/truenas/middleware/pull/7842
Jira URL: https://jira.ixsystems.com/browse/NAS-113034