### PR TITLE
NAS-113308 / 22.02-RC.2 / fix race with netif.create_interface and netif.list_interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -1,8 +1,6 @@
-# -*- coding=utf-8 -*-
 import json
 import logging
-
-import middlewared.plugins.interface.netif_linux.interface as interface
+from pyroute2 import NDB
 
 from .utils import run
 
@@ -12,12 +10,8 @@ __all__ = ["create_bridge", "BridgeMixin"]
 
 
 def create_bridge(name):
-    cmd = [
-        "ip", "link", "add", name, "type", "bridge",
-        "stp_state", "1"  # enable stp by default 1 == on 0 == off
-    ]
-    run(cmd)
-    interface.Interface(name).up()
+    with NDB(log='off') as ndb:
+        ndb.interfaces.create(ifname=name, kind="bridge").set("br_stp_state", 1).set("state", "up").commit()
 
 
 class BridgeMixin:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -10,7 +10,7 @@ __all__ = ["create_bridge", "BridgeMixin"]
 
 
 def create_bridge(name):
-    with NDB(log='off') as ndb:
+    with NDB(log="off") as ndb:
         ndb.interfaces.create(ifname=name, kind="bridge").set("br_stp_state", 1).set("state", "up").commit()
 
 

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 import pathlib
+from pyroute2 import NDB
 
 import middlewared.plugins.interface.netif_linux.interface as interface
 from .utils import run
@@ -17,8 +18,8 @@ class AggregationProtocol(enum.Enum):
 
 
 def create_lagg(name):
-    run(["ip", "link", "add", name, "type", "bond"])
-    interface.Interface(name).up()
+    with NDB(log="off") as ndb:
+        ndb.interfaces.create(ifname=name, kind="bond").set("state", "up").commit()
 
 
 class LaggMixin:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pyroute2 import NDB
 
 from .bridge import create_bridge

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,6 +1,6 @@
-# -*- coding=utf-8 -*-
 import logging
 import os
+from pyroute2 import NDB
 
 from .bridge import create_bridge
 from .interface import Interface, CLONED_PREFIXES
@@ -38,6 +38,5 @@ def get_interface(name):
 
 
 def list_interfaces():
-    return {name: Interface(name)
-            for name in os.listdir("/sys/class/net")
-            if os.path.isdir(os.path.join("/sys/class/net", name))}
+    with NDB(log="off") as ndb:
+        return {i.ifname: Interface(i.ifname) for i in ndb.interfaces}


### PR DESCRIPTION
Because we're using `subprocess` to create and list interfaces there exists a potential for a race between the time we create an interface and the time we try to retrieve that interface. To make matters worse, if an empty vlan is created and its parent is a physical interface then on boot when we create the vlan interface we will get a `KeyError` when we try to retrieve that interface which prevents the parent interface from ever coming up. If other interfaces are dependent on that physical interface to come up, then the entire network is down until someone manually brings that physical interface up. To fix all of these scenarios I've made it so that all virtual interfaces (`vlan`, `bond`, `br`) get created using `pyroute2.NDB` which actually monitors and waits for state synchronization. This means the `.commit()` will not return until the interface has actually been created and all necessary parameters have been applied.

I also change `list_interfaces` to use `pyroute2.NDB` as well.