### PR TITLE
NAS-11305 / 22.02-RC.2 / Fix/refactor reference parsing for image throughout the services

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/client.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/client.py
@@ -58,7 +58,8 @@ class DockerClientMixin:
             f'https://{registry}/v2/{image}/manifests/{tag}', headers=headers, mode=mode
         )
         if raise_error and response['error']:
-            raise CallError(f'Unable to retrieve latest image digest for {f"{image}:{tag}"!r}: {response["error"]}')
+            raise CallError(f"Unable to retrieve latest image digest for registry={registry} "
+                            f"image={image} tag={tag}: {response['error']}")
 
         return response
 
@@ -66,6 +67,8 @@ class DockerClientMixin:
     async def get_manifest_call_headers(self, registry, image, headers):
         if registry == DEFAULT_DOCKER_REGISTRY:
             headers['Authorization'] = f'Bearer {await self._get_token(image)}'
+        else:
+            headers['Authorization'] = f'Bearer {await self._get_token(f"{registry}/{image}")}'
         return headers
 
     async def _get_latest_digest(self, registry, image, tag):

--- a/src/middlewared/middlewared/plugins/docker_linux/client.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/client.py
@@ -2,14 +2,58 @@ import aiohttp
 import aiohttp.client_exceptions
 import async_timeout
 import asyncio
+import urllib
 
 from middlewared.service import CallError, private
 
 from .utils import DEFAULT_DOCKER_REGISTRY, DOCKER_CONTENT_DIGEST_HEADER
 
 
-DOCKER_REGISTRY_AUTH_BASE = 'https://auth.docker.io'
+DOCKER_AUTH_HEADER = 'WWW-Authenticate'
+DOCKER_AUTH_URL = 'https://auth.docker.io/token'
 DOCKER_AUTH_SERVICE = 'registry.docker.io'
+DOCKER_MANIFEST_SCHEMA_V1 = 'application/vnd.docker.distribution.manifest.v1+json'
+DOCKER_MANIFEST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.v2+json'
+DOCKER_MANIFEST_LIST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.list.v2+json'
+
+
+def parse_digest_from_schema(response):
+    """
+    Parses out the digest according to schemas specs:
+    https://docs.docker.com/registry/spec/manifest-v2-1/
+    """
+    media_type = response['response']['mediaType']
+    if media_type == DOCKER_MANIFEST_SCHEMA_V2:
+        return response['response']['config']['digest']
+    elif media_type == DOCKER_MANIFEST_LIST_SCHEMA_V2:
+        if (manifests := response['response']['manifests']):
+            return manifests[0]['digest']
+
+
+def parse_auth_header(header: str):
+    """
+    Parses header in format below:
+    'Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="redis:pull"'
+
+    Returns:
+        {
+            'auth_url': 'https://ghcr.io/token',
+            'service': 'ghcr.io',
+            'scope': 'redis:pull'
+        }
+    """
+    adapter = {
+        'realm': 'auth_url',
+        'service': 'service',
+        'scope': 'scope',
+    }
+    results = {}
+    parts = header.split()
+    if len(parts) > 1:
+        for part in parts[1].split(','):
+            key, value = part.split('=')
+            results[adapter[key]] = value.strip('"')
+    return results
 
 
 class DockerClientMixin:
@@ -28,7 +72,7 @@ class DockerClientMixin:
         except asyncio.TimeoutError:
             response['error'] = f'Unable to connect with {url} in {timeout} seconds.'
         except aiohttp.ClientResponseError as e:
-            response['error'] = str(e)
+            response['error'] = e
         else:
             response['response_obj'] = req
             if req.status != 200:
@@ -44,19 +88,29 @@ class DockerClientMixin:
                     response['error'] = f'Unable to parse response: {e}'
         return response
 
-    async def _get_token(self, image):
-        response = await self._api_call(
-            f'{DOCKER_REGISTRY_AUTH_BASE}/token?service={DOCKER_AUTH_SERVICE}&scope=repository:{image}:pull'
-        )
+    async def _get_token(self, scope, auth_url=DOCKER_AUTH_URL, service=DOCKER_AUTH_SERVICE):
+        query_params = urllib.parse.urlencode({
+            'service': service,
+            'scope': scope,
+        })
+        response = await self._api_call(f'{auth_url}?{query_params}')
         if response['error']:
-            raise CallError(f'Unable to retrieve token for {image!r}: {response["error"]}')
+            raise CallError(f'Unable to retrieve token for {scope!r}: {response["error"]}')
 
         return response['response']['token']
 
     async def _get_manifest_response(self, registry, image, tag, headers, mode, raise_error):
-        response = await self._api_call(
-            f'https://{registry}/v2/{image}/manifests/{tag}', headers=headers, mode=mode
-        )
+        manifest_url = f'https://{registry}/v2/{image}/manifests/{tag}'
+        # 1) try getting manifest
+        response = await self._api_call(manifest_url, headers=headers, mode=mode)
+        if (error := response['error']) and isinstance(error, aiohttp.ClientResponseError):
+            if error.status == 401:
+                # 2) try to get token from manifest api call's response headers
+                auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
+                headers['Authorization'] = f'Bearer {await self._get_token(**auth_data)}'
+                # 3) Redo the manifest call with updated token
+                response = await self._api_call(manifest_url, headers=headers, mode=mode)
+
         if raise_error and response['error']:
             raise CallError(f"Unable to retrieve latest image digest for registry={registry} "
                             f"image={image} tag={tag}: {response['error']}")
@@ -66,26 +120,24 @@ class DockerClientMixin:
     @private
     async def get_manifest_call_headers(self, registry, image, headers):
         if registry == DEFAULT_DOCKER_REGISTRY:
-            headers['Authorization'] = f'Bearer {await self._get_token(image)}'
-        else:
-            headers['Authorization'] = f'Bearer {await self._get_token(f"{registry}/{image}")}'
+            headers['Authorization'] = f'Bearer {await self._get_token(scope=f"repository:{image}:pull")}'
         return headers
 
     async def _get_latest_digest(self, registry, image, tag):
+        headers = await self.get_manifest_call_headers(registry, image, {
+            'Accept': DOCKER_MANIFEST_SCHEMA_V2,
+        })
         response = await self._get_manifest_response(
-            registry, image, tag, await self.get_manifest_call_headers(registry, image, {
-                'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
-            }), 'get', True
+            registry, image, tag, headers, 'get', True
         )
-
-        return response['response']['config']['digest']
+        return parse_digest_from_schema(response)
 
     async def _get_repo_digest(self, registry, image, tag):
         response = await self._get_manifest_response(
             registry, image, tag, await self.get_manifest_call_headers(registry, image, {
-                'Accept': 'application/vnd.docker.distribution.manifest.v2+json, '
-                          'application/vnd.docker.distribution.manifest.list.v2+json, '
-                          'application/vnd.docker.distribution.manifest.v1+json',
+                'Accept': (f'{DOCKER_MANIFEST_SCHEMA_V2}, '
+                           f'{DOCKER_MANIFEST_LIST_SCHEMA_V2}, '
+                           f'{DOCKER_MANIFEST_SCHEMA_V1}')
             }), 'head', False
         )
         if not response['error']:

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -1,5 +1,60 @@
+import re
+from typing import Dict
+
+from middlewared.service import CallError
+
+# Default values
 DEFAULT_DOCKER_IMAGES_LIST_PATH = '/usr/local/share/docker_images/image-list.txt'
 DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
 DEFAULT_DOCKER_REPO = 'library'
 DEFAULT_DOCKER_TAG = 'latest'
 DOCKER_CONTENT_DIGEST_HEADER = 'Docker-Content-Digest'
+
+# Taken from OCI: https://github.com/opencontainers/go-digest/blob/master/digest.go#L63
+DIGEST_RE = r"[a-z0-9]+(?:[.+_-])*:[a-zA-Z0-9=_-]+"
+
+
+def normalize_reference(reference: str) -> Dict:
+    """
+    Parses the reference for image, tag and repository.
+
+    Most of the logic has been used from docker engine to make sure we follow the same rules/practices
+    for normalising the image name / tag
+    """
+    registry_idx = reference.find('/')
+    if registry_idx == -1 or (not any(c in reference[:registry_idx] for c in ('.', ':')) and reference[:registry_idx] != 'localhost'):
+        registry, tagged_image = DEFAULT_DOCKER_REGISTRY, reference
+    else:
+        registry, tagged_image = reference[:registry_idx], reference[registry_idx + 1:]
+
+    if '/' not in tagged_image:
+        tagged_image = f'{DEFAULT_DOCKER_REPO}/{tagged_image}'
+
+    # if image is not tagged, use default value.
+    if ':' not in tagged_image:
+        tagged_image += f':{DEFAULT_DOCKER_TAG}'
+
+    # At this point, tag should be included already – we just need to see whether this
+    # tag is named or digested and respond accordingly.
+    if '@' in tagged_image:
+        matches = re.findall(DIGEST_RE, tagged_image)
+        if not matches:
+            raise CallError(f'Invalid reference format: {tagged_image}')
+
+        tag = matches[-1]
+        tag_pos = tagged_image.find(tag)
+        image = tagged_image[:tag_pos - 1].rsplit(':', 1)[0]
+        sep = '@'
+    elif ':' in tagged_image:
+        image, tag = tagged_image.rsplit(':', 1)
+        sep = ':'
+    else:
+        raise CallError(f'Unable to parse the reference: {reference}')
+
+    return {
+        'reference': reference,
+        'image': image,
+        'tag': tag,
+        'registry': registry,
+        'complete_tag': f'{registry}/{image}{sep}{tag}',
+    }

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -48,8 +48,6 @@ def normalize_reference(reference: str) -> Dict:
     elif ':' in tagged_image:
         image, tag = tagged_image.rsplit(':', 1)
         sep = ':'
-    else:
-        raise CallError(f'Unable to parse the reference: {reference}')
 
     return {
         'reference': reference,

--- a/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
@@ -1,0 +1,66 @@
+import pytest
+
+from middlewared.plugins.docker_linux.utils import normalize_reference
+
+
+@pytest.mark.parametrize("reference,expected_results", [
+    ('redis', {
+        'reference': 'redis',
+        'image': 'library/redis',
+        'tag': 'latest',
+        'registry': 'registry-1.docker.io',
+        'complete_tag': 'registry-1.docker.io/library/redis:latest',
+    }),
+    ('redis:12.1', {
+        'reference': 'redis:12.1',
+        'image': 'library/redis',
+        'tag': '12.1',
+        'registry': 'registry-1.docker.io',
+        'complete_tag': 'registry-1.docker.io/library/redis:12.1',
+    }),
+    ('redis:12.1', {
+        'reference': 'redis:12.1',
+        'image': 'library/redis',
+        'tag': '12.1',
+        'registry': 'registry-1.docker.io',
+        'complete_tag': 'registry-1.docker.io/library/redis:12.1',
+    }),
+    ('redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546', {
+        'reference': 'redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'image': 'library/redis',
+        'tag': 'sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'registry': 'registry-1.docker.io',
+        'complete_tag': 'registry-1.docker.io/library/redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+    }),
+    ('redis:12.1@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546', {
+        'reference': 'redis:12.1@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'image': 'library/redis',
+        'tag': 'sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'registry': 'registry-1.docker.io',
+        'complete_tag': 'registry-1.docker.io/library/redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+    }),
+    ('ghcr.io/k8s-at-home/transmission', {
+        'reference': 'ghcr.io/k8s-at-home/transmission',
+        'image': 'k8s-at-home/transmission',
+        'tag': 'latest',
+        'registry': 'ghcr.io',
+        'complete_tag': 'ghcr.io/k8s-at-home/transmission:latest',
+    }),
+    ('ghcr.io/k8s-at-home/transmission:v3.00', {
+        'reference': 'ghcr.io/k8s-at-home/transmission:v3.00',
+        'image': 'k8s-at-home/transmission',
+        'tag': 'v3.00',
+        'registry': 'ghcr.io',
+        'complete_tag': 'ghcr.io/k8s-at-home/transmission:v3.00',
+    }),
+    ('ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6', {
+        'reference': 'ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
+        'image': 'k8s-at-home/transmission',
+        'tag': 'sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
+        'registry': 'ghcr.io',
+        'complete_tag': 'ghcr.io/k8s-at-home/transmission@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
+    })
+])
+def test_normalize_reference(reference, expected_results):
+    actual_results = normalize_reference(reference)
+    assert actual_results == expected_results


### PR DESCRIPTION
## This PR contains:
- `normailize_reference` util based-on researching the docker/cli
- Utilize where-ever we're parsing out registry, image, tag/digest information out of reference

I think, the scope of this PR went larger than the ticket assigned as soon as I dig deeper – I found out that `retrieve_image_digest` was also unable to parse out tag information from digest based reference. So, I did these updates in way that they would be re-used easily and provide us with central means to normalize the images/references.

## Examples
```bash
# Example parsing the digest would be like:
❯ midclt call container.image.normalize_reference 'ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6' | jq
{
  "reference": "ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6",
  "image": "k8s-at-home/transmission",
  "tag": "sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6",
  "registry": "ghcr.io",
  "complete_tag": "ghcr.io/k8s-at-home/transmission@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6"
}

# Example digest retrieval given: image, tagged image, digested image and tagged+digested image
❯ midclt call container.image.retrieve_image_digest 'redis'
sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546

❯ midclt call container.image.retrieve_image_digest 'redis:latest'
sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546

❯ midclt call container.image.retrieve_image_digest 'redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546'
sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546

❯ midclt call container.image.retrieve_image_digest 'redis:latest@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546'
sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546

# Example bulk pull container images
❯ midclt call -job chart.release.pull_container_images trans '{"redeploy": false}'
Status: (none)
Total Progress: [########################################] 100.00%
{"ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6": "Updated image"}
```