### PR TITLE
NAS-113382 / 22.02-RC.2 / increase timeout from 5 to 30

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -67,7 +67,7 @@ class GlusterLocalEventsService(Service):
         async with aiohttp.ClientSession() as sess:
             status = reason = None
             try:
-                res = await sess.post(LOCAL_WEBHOOK_URL, headers=headers, json=data, timeout=5)
+                res = await sess.post(LOCAL_WEBHOOK_URL, headers=headers, json=data, timeout=30)
             except asyncio.exceptions.TimeoutError:
                 status = 500
                 reason = 'Timed out waiting for a response'


### PR DESCRIPTION
We're hitting this timeout internally on our cluster infrastructure when QE begins series of tests. 30 seconds fixes their problems.