### PR TITLE
fix importing zpools with trailing whitespace

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
@@ -1,5 +1,6 @@
 from lockfile import LockFile, AlreadyLocked
 from collections import defaultdict
+from shlex import quote
 import multiprocessing
 import os
 import subprocess
@@ -532,11 +533,9 @@ class FailoverService(Service):
                 p = multiprocessing.Process(target=os.system("""dtrace -qn 'zfs-dbgmsg{printf("\r                            \r%s", stringof(arg0))}' > /dev/console &"""))
                 p.start()
                 for volume in fobj['volumes']:
-                    logger.warning('Importing %s', volume)
+                    logger.warning('Importing %r', volume)
                     # TODO: try to import using cachefile and then fallback without if it fails
-                    error, output = run('zpool import -o cachefile=none -m -R /mnt -f {}'.format(
-                        volume,
-                    ), stderr=True)
+                    error, output = run(f'zpool import -o cachefile=none -m -R /mnt -f {quote(volume)}', stderr=True)
                     if error:
                         logger.error('Failed to import %s: %s', volume, output)
                         open(FAILED_FILE, 'w').close()


### PR DESCRIPTION
ZFS allows trailing whitespace for zpool names. A horrible design decision, in my opinion, but the fact remains is that it's allowed. We see zpools with trailing whitespace as an accident more than anything. When this happens, on failover, the zpool fails to import because we're not escaping special characters correctly.

`def run()` in `failover_/event.py` uses `subprocess.Popen` with the `shell=True` which means it's our responsibility to escape anything. This changes uses the `shlex.quote` method to escape the zpool name when we go to import the zpool on failover.