### PR TITLE
NAS-113417 / 22.02-RC.1-2 / fix event that is sent when gluster vol is deleted (#7858)

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -195,7 +195,7 @@ class GlusterVolumeService(CRUDService):
             # need to unmount the FUSE mountpoint (if it exists) and
             # send the request to do the same to all other peers in
             # the TSP before we delete the volume
-            data = {'event': 'VOLUME_START', 'name': id, 'forward': True}
+            data = {'event': 'VOLUME_STOP', 'name': id, 'forward': True}
             await self.middleware.call('gluster.localevents.send', data)
             await self.middleware.call('gluster.method.run', volume.delete, args)
 


### PR DESCRIPTION
Cherry-pick of 7865d9e21edf54a74ee578de7a654c4afba79466. QE is routinely testing deleting and recreating gluster volumes so the correct event needs to be sent when this occurs.