### PR TITLE
NAS-113425 / 22.02.1 / fix SCALE HA failovers

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -262,7 +262,7 @@ class SystemDatasetService(ConfigService):
         if config['pool'] != boot_pool and not await self.middleware.call(
             'pool.query', [('name', '=', config['pool'])]
         ):
-            self.middleware.logger.debug('Pool %r does not exist, moving system dataset to another pool',
+            self.logger.debug('Pool %r does not exist, moving system dataset to another pool',
                                          config['pool'])
             job = await self.middleware.call('systemdataset.update', {
                 'pool': None, 'pool_exclude': exclude_pool,
@@ -276,7 +276,7 @@ class SystemDatasetService(ConfigService):
         # to put it on.
         if not config['pool_set']:
             if pool := await self._query_pool_for_system_dataset(exclude_pool):
-                self.middleware.logger.debug('System dataset pool was not set, moving it to first available pool %r',
+                self.logger.debug('System dataset pool was not set, moving it to first available pool %r',
                                              pool['name'])
                 job = await self.middleware.call('systemdataset.update', {'pool': pool['name']})
                 await job.wait()
@@ -288,7 +288,7 @@ class SystemDatasetService(ConfigService):
                                              {'extra': {'retrieve_children': False}})
         if not dataset or dataset[0]['locked']:
             # Pool is not mounted (e.g. HA node B), temporary set up system dataset on the boot pool
-            self.middleware.logger.debug(
+            self.logger.debug(
                 'Root dataset for pool %r is not available, temporarily setting up system dataset on boot pool',
                 config['pool'],
             )
@@ -300,7 +300,7 @@ class SystemDatasetService(ConfigService):
             if p.mountpoint == SYSDATASET_PATH:
                 mounted_pool = p.device.split('/')[0]
         if mounted_pool and mounted_pool != config['pool']:
-            self.middleware.logger.debug('Abandoning dataset on %r in favor of %r', mounted_pool, config['pool'])
+            self.logger.debug('Abandoning dataset on %r in favor of %r', mounted_pool, config['pool'])
             async with self._release_system_dataset():
                 await self.__umount(mounted_pool, config['uuid'])
                 await self.__setup_datasets(config['pool'], config['uuid'])

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -493,8 +493,8 @@ class SystemDatasetService(ConfigService):
             restart.insert(0, 'glusterd')
         if await self.middleware.call('service.started_or_enabled', 'webdav'):
             restart.append('webdav')
-        for service in ['open-vm-tools']:
-            restart.append(service)
+        if await self.middleware.call('service.started', 'open-vm-tools'):
+            restart.append('open-vm-tools')
         if await self.middleware.call('service.started', 'idmap'):
             restart.append('idmap')
 


### PR DESCRIPTION
Gather round, all, for another story of complete despair that ends with triumph...kind of?? The `sysdataset` plugin is an absolute nightmare to troubleshoot because it calls a method `core.stop_logging` which stops all forms of logging being done by the `middlewared` service. This is an unfortunate reality (and necessity) but it causes a precarious (or hysterical depending on the person troubleshooting the problem) situation where depending on the ole "printf"'ing form of troubleshooting doesn't work. To make matters worse, we use the STONITH method for our HA product which means 1 of the nodes will actually hard reset itself. With whaling and gnashing of teeth, I ended up having to implement a "failsafe" log that `middlewared` service opened up and logged to that would not get touched via `core.stop_logging`. Once this was in place, 3 problems presented themselves.

Problems found:
1. `umount -f` randomly failed with `target is busy` even though `lsof` showed 0 open files for said partition
2. we are stopping services, setting up new system dataset dirs for mounting, starting services _BEFORE_ mounting the zfs partitions
3. we're always stopping and starting `open-vm-tools` service even if it isn't running

Fixes implemented:
1. call the `__mount()` method inside the scope of the `_release_system_dataset()` context manager
2. `umount -f` is a no-op in our use-case because the `-f` flag is for non-responsive _NFS_ mountpoints so I've changed this to use the `-l` flag but only for HA systems since on a failover event, if the zpool can't be exported in 5 seconds we will violently reboot the node. Quoting the man page entry `Lazy unmount.  Detach the filesystem from the file hierarchy now, and clean up all references to this filesystem as soon as it is not  busy anymore.`
3. handle the `open-vm-tools` service appropriately

Further "problems" "fixed":
1. flake8
2. replace `self.middleware.logger` entries with `self.logger` entries since the former is deprecated and not recommended to be used.