### PR TITLE
NAS-113433 / 22.02 / ignore CallError in get_remote_os_version

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -192,6 +192,9 @@ class RemoteClient(object):
         if self.client is not None and self._remote_os_version is None:
             try:
                 self._remote_os_version = self.client.call('system.version')
+            except CallError:
+                # ignore CallErrors since they're being caught in self.client.call
+                pass
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 


### PR DESCRIPTION
`RemoteClient.call` already does the hard work of catching the expected exceptions on the p2p connection. This ignores `CallError` in `get_remote_os_version` and logs an exception for anything else.