### PR TITLE
Prevent creating SMB shares on paths that aren't clustered or ZFS

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1461,6 +1461,10 @@ class SharingSMBService(SharingService):
 
         if data['path']:
             await self.validate_path_field(data, schema_name, verrors, bypass=bypass)
+            if not data['cluster_volname']:
+                fstype = (await self.middleware.call('filesystem.statfs', data['path']))['fstype']
+                if fstype != 'zfs':
+                    verrors.add(f'{schema_name}.path', f'{fstype}: path is not a ZFS dataset')
         elif not data['home']:
             verrors.add(f'{schema_name}.path', 'This field is required.')
         else:


### PR DESCRIPTION
Users mounting and sharing ext3/4/other filesystems under /mnt
and sharing via SMB is not really a supportable behavior.