### PR TITLE
NAS-113275 / 22.02-RC.2 / Exclude internal interfaces from avahi config

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -21,6 +21,10 @@
     deny_interfaces = middleware.call_sync("interface.internal_interfaces")
     failover_int = middleware.call_sync("failover.internal_interfaces")
     deny_interfaces.extend(failover_int)
+
+    failover_status = middleware.call_sync('failover.status')
+    if failover_status not in ['SINGLE', 'MASTER']:
+        raise FileShouldNotExist()
 %>
 
 [server]

--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -18,9 +18,8 @@
 
     ipv6_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': False, 'ipv6': True}))
 
+    deny_interfaces = middleware.call_sync("interface.internal_interfaces")
     failover_int = middleware.call_sync("failover.internal_interfaces")
-
-    deny_interfaces = ['lo']
     deny_interfaces.extend(failover_int)
 %>
 


### PR DESCRIPTION
Binding avahi to kubernetes bridge and other internal interfaces
can cause erratic mDNS behavior.