### PR TITLE
NAS-113460 / 13.0 / Shift order nsswitch generation in LDAP plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -984,7 +984,6 @@ class LDAPService(ConfigService):
             await self.middleware.call('kerberos.start')
 
         await self.middleware.call('etc.generate', 'rc')
-        await self.middleware.call('etc.generate', 'nss')
         await self.middleware.call('etc.generate', 'ldap')
         await self.middleware.call('etc.generate', 'pam')
 
@@ -1000,6 +999,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('smb.set_passdb_backend', 'ldapsam')
 
         await self.set_state(DSStatus['HEALTHY'])
+        await self.middleware.call('etc.generate', 'nss')
         await self.middleware.call('ldap.fill_cache')
 
     @private


### PR DESCRIPTION
nsswitch.conf generation needs to happen after we set the service
state to HEALTHY. This ensures that ldap is added to the passwd
and group entries.

Original PR: https://github.com/truenas/middleware/pull/7899
Jira URL: https://jira.ixsystems.com/browse/NAS-113460