### PR TITLE
NAS-113468 / 22.02-RC.2 / Only run nscd when LDAP is enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -271,8 +271,8 @@ class DSCacheService(PseudoServiceBase):
     name = "dscache"
 
     async def start(self):
-        ad_enabled = (await self.middleware.call('activedirectory.config'))['enable']
-        if not ad_enabled:
+        ldap_enabled = (await self.middleware.call('ldap.config'))['enable']
+        if ldap_enabled:
             await systemd_unit("nscd", "restart")
         else:
             await systemd_unit("nscd", "stop")


### PR DESCRIPTION
nscd can conflict with winbindd cache on standalone servers.
Winbindd in this case is required for proper handling of
BUILTIN / well-known SIDs.