### PR TITLE
NAS-113473 / 22.02-RC.2 / Add acls to debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
@@ -96,7 +96,13 @@ smb_func()
 		printf "\n"
 		ls -ld "${cifs_path}"
 		printf "\n"
-		midclt call filesystem.getacl "${cifs_path}" true | jq
+		acltype=$(midclt call filesystem.getacl "${cifs_path}" true | jq -r '.acltype')
+		if [ ${acltype} = "NFS4" ]
+		then
+			nfs4xdr_getfacl "${cifs_path}"
+		else
+			getfacl -n "${cifs_path}"
+		fi
 		printf "\n"
 	done
 	section_footer

--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -36,27 +36,24 @@ zfs_getacl()
 	local mp
 	local mounted
 
-	mounted=$(zfs get -H -o value mounted "${ds}")
-	if [ "${mounted}" == "-" ] || [ "${mounted}" == "no" ]; then
+	mounted=$(zfs get -H -o value mounted "${ds}" | tr -d '\n')
+	if [ "${mounted}" = "-" ] || [ "${mounted}" = "no" ]; then
 		return 0
 	fi
 
-	mp=$(zfs get -H -o value mountpoint "${ds}")
+	mp=$(zfs get -H -o value mountpoint "${ds}" | tr -d '\n')
 	echo "Mountpoint ACL: ${ds}"
 	if [ "${mp}" = "legacy" ] || [ "${mp}" = "-" ]; then
 		return 0
 	fi
 
-	if is_linux; then
-		acltype=$(midclt call filesystem.path_get_acltype "${mp}" | tr -d '\n')
-		if [ ${acltype} = "NFS4" ]; then
-			nfs4xdr_getfacl "${mp}"
-		else
-			getfacl -n "${mp}"
-		fi
+	acltype=$(zfs get -H -o value acltype "${ds}" | tr -d '\n')
+	if [ ${acltype} = "nfsv4" ]; then
+		nfs4xdr_getfacl "${mp}"
 	else
-		getfacl "${mp}"
+		getfacl -n "${mp}"
 	fi
+
 	return 0
 }
 

--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -95,10 +95,17 @@ zfs_func()
 	do
 		section_header "${s}"
 		zfs get all "${s}"
-		if is_freebsd; then
-			echo "Mountpoint ACL:"
-			mp=$(zfs get -H -o value mountpoint "${s}")
-			if [ "${mp}" != "legacy" ]; then
+		echo "Mountpoint ACL:"
+		mp=$(zfs get -H -o value mountpoint "${s}")
+		if [ "${mp}" != "legacy" ]; then
+			if is_linux; then
+				acltype=$(midclt call filesystem.getacl "${mp}" true | jq -r '.acltype')
+				if [ ${acltype} = "NFS4" ]; then
+					nfs4xdr_getfacl "${mp}"
+				else
+					getfacl -n "${mp}"
+				fi
+			else
 				getfacl "${mp}"
 			fi
 		fi


### PR DESCRIPTION
Make sure that we're grabbing ACLs from all ZFS datasets (branding aware) on SCALE. Adjust SMB output to have more human-readable text version of ACL.