### PR TITLE
NAS-113359 / 22.02-RC.2 / Minio service deletes bucket metadata on startup

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/minio/configure.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/configure.py
@@ -42,18 +42,10 @@ def render_certificates(s3, middleware):
         os.chmod(minio_privatekey, 0o600)
 
 
-def configure_minio_sys_dir(s3):
-    storage_path = s3['storage_path']
-    # Create storage path if it does not exist
-    os.makedirs(storage_path, exist_ok=True)
-    minio_dir = os.path.join(storage_path, '.minio.sys')
-    shutil.rmtree(minio_dir, ignore_errors=True)
-
-
-def render(service, middleware):
+def render(__, middleware):
     s3 = middleware.call_sync('s3.config')
     if not s3['storage_path']:
         return
 
-    configure_minio_sys_dir(s3)
+    os.makedirs(s3['storage_path'], exist_ok=True)
     render_certificates(s3, middleware)


### PR DESCRIPTION
The solution was to upgrade to newer Minio version as data is no longer encrypted through user's configured secrets from `RELEASE.2021-04-22T15-44-28Z` onwards:

ref: https://github.com/minio/minio/blob/master/docs/kms/IAM.md#kms-iamconfig-encryption
> After release `RELEASE.2021-04-22T15-44-28Z` onwards, MinIO will use the KMS provided keys to encrypt the IAM data instead of the cluster root credentials. If the KMS is not enabled, MinIO will store the IAM data as plain text in its backend.
---
Minio upgrade part @ https://github.com/truenas/minio/pull/2

I have carried backwards compatibility tests on this new minio version @ https://github.com/Qubad786/minio-lab. I have also done the same by installing new minio binary into the scale and the results align with expectations.