### PR TITLE
NAS-113536 / 12.0 / Presume HEALTHY state when reinitializing directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -424,6 +424,13 @@ class DirectoryServices(Service):
             self.logger.warning("Failed to clear the SMB gencache after re-initializing "
                                 "directory services: [%s]", gencache_flush.stderr.decode())
 
+        ds_state = {
+            'activedirectory': DSStatus.HEALTHY.name if ad_enabled else DSStatus.DISABLED.name,
+            'ldap': DSStatus.HEALTHY.name if ldap_enabled else DSStatus.DISABLED.name,
+            'nis': DSStatus.DISABLED.name
+        }
+        await self.set_state(ds_state)
+
         await self.middleware.call('etc.generate', 'nss')
         if is_kerberized:
             try:


### PR DESCRIPTION
This happens during boot or node failover. Overriding the
directory service status forces nsswitch to be configured
correctly for the relevant directory service.