### PR TITLE
NAS-113452 / 22.02-RC.2 / correctly identify fstype in filesystem.statfs

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/stat_x.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/stat_x.py
@@ -1,0 +1,99 @@
+import os
+import ctypes
+
+AT_STATX_SYNC_AS_STAT = 0x0000  # Do what stat() does
+AT_FDCWD = -100  # special fd value meaning no FD
+
+
+class Mask(ctypes.c_uint):
+    TYPE = 0x00000001  # stx_mode & S_IFMT
+    MODE = 0x00000002  # stx_mode & ~S_IFMT
+    NLINK = 0x00000004  # stx_nlink
+    UID = 0x00000008  # stx_uid
+    GID = 0x00000010  # stx_gid
+    ATIME = 0x00000020  # stx_atime
+    MTIME = 0x00000040  # stx_mtime
+    CTIME = 0x00000080  # stx_ctime
+    INO = 0x00000100  # stx_ino
+    SIZE = 0x00000200  # stx_size
+    BLOCKS = 0x00000400  # stx_blocks
+    BASIC_STATS = 0x000007FF  # info in normal stat struct
+
+    # Extensions
+    BTIME = 0x00000800  # stx_btime
+    MNT_ID = 0x00001000  # stx_mnt_id
+    ALL = 0x00000FFF  # All supported flags
+    _RESERVED = 0x80000000  # Reserved for future struct statx expansion
+
+
+class StructStatxTimestamp(ctypes.Structure):
+    _fields_ = [
+        ("tv_sec", ctypes.c_uint64),
+        ("tv_nsec", ctypes.c_uint32),
+        ("__reserved", ctypes.c_uint32),
+    ]
+
+
+class StructStatx(ctypes.Structure):
+    _fields_ = [
+        # 0x00
+        ("stx_mask", Mask),
+        ("stx_blksize", ctypes.c_uint32),
+        ("stx_attributes", ctypes.c_uint64),
+
+        # 0x10
+        ("stx_nlink", ctypes.c_uint32),
+        ("stx_uid", ctypes.c_uint32),
+        ("stx_gid", ctypes.c_uint32),
+        ("stx_mode", ctypes.c_uint16),
+        ("__spare0", ctypes.c_uint16 * 1),
+
+        # 0x20
+        ("stx_ino", ctypes.c_uint64),
+        ("stx_size", ctypes.c_uint64),
+        ("stx_blocks", ctypes.c_uint64),
+        ("stx_attributes_mask", ctypes.c_uint64),
+
+        # 0x40
+        ("stx_atime", StructStatxTimestamp),
+        ("stx_btime", StructStatxTimestamp),
+        ("stx_ctime", StructStatxTimestamp),
+        ("stx_mtime", StructStatxTimestamp),
+
+        # 0x80
+        ("stx_rdev_major", ctypes.c_uint32),
+        ("stx_rdev_minor", ctypes.c_uint32),
+        ("stx_dev_major", ctypes.c_uint32),
+        ("stx_dev_minor", ctypes.c_uint32),
+
+        # 0x90
+        ("stx_mnt_id", ctypes.c_uint64),
+        ("__spare2", ctypes.c_uint64),
+
+        # 0xa0 (Spare space)
+        ("__spare3", ctypes.c_uint64 * 12),
+    ]
+
+
+def statx(path):
+    fd = AT_FDCWD
+    flags = AT_STATX_SYNC_AS_STAT
+    mask = Mask.BASIC_STATS | Mask.BTIME
+    path = path.encode() if isinstance(path, str) else path
+
+    _libc = ctypes.CDLL('libc.so.6', use_errno=True)
+    _func = _libc.statx
+    _func.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_uint,
+        ctypes.POINTER(StructStatx)
+    )
+    data = StructStatx()
+    result = _func(fd, path, flags, mask, ctypes.byref(data))
+    if result < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    else:
+        return data

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -8,8 +8,8 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import POST
-from auto_config import dev_test
+from functions import POST, SSH_TEST
+from auto_config import dev_test, pool_name, ip, user, password
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 group = 'root'
@@ -58,3 +58,42 @@ def test_03_get_filesystem_stat_(path):
     assert results.json()['user'] == 'root', results.text
     assert results.json()['group'] == group, results.text
     assert results.json()['acl'] is False, results.text
+
+
+@pytest.mark.parametrize('pool', pool_name)
+def test_04_test_filesystem_statfs_fstype(pool):
+    # test zfs fstype first
+    parent_path = f'/mnt/{pool_name}'
+    results = POST('/filesystem/statfs/', parent_path)
+    assert results.status_code == 200, results.text
+    data = results.json()
+    assert data, results.text
+    assert data['fstype'] == 'zfs', data['fstype']
+
+    # mount nested tmpfs entry and make sure statfs
+    # returns `tmpfs` as the fstype
+    # mkdir
+    nested_path = f'{parent_path}/tmpfs'
+    cmd1 = f'mkdir -p {nested_path}'
+    results = SSH_TEST(cmd1, user, password, ip)
+    assert results['result'] is True, results['output']
+
+    # mount tmpfs
+    cmd2 = f'mount -t tmpfs -o size=10M tmpfstest {nested_path}'
+    results = SSH_TEST(cmd2, user, password, ip)
+    assert results['result'] is True, results['output']
+
+    # test fstype
+    results = POST('/filesystem/statfs/', nested_path)
+    assert results.status_code == 200, results.text
+    data = results.json()
+    assert data, results.text
+    assert data['fstype'] == 'tmpfs', data['fstype']
+
+    # cleanup
+    cmd3 = f'umount {nested_path}'
+    results = SSH_TEST(cmd3, user, password, ip)
+    assert results['result'] is True, results['output']
+    cmd4 = f'rmdir {nested_path}'
+    results = SSH_TEST(cmd4, user, password, ip)
+    assert results['result'] is True, results['output']


### PR DESCRIPTION
Strangely, python on linux doesn't have a native method for `statx` in the `os` module so I've added our own. Uses `ctypes` and is written so we can add a more involved wrapper around it (if needed) but the use case for this PR is as simple as possible since we only need to get the `stx_dev_major:stx_dev_minor` values for the given path and then find it in `/proc/self/mountinfo`.