### PR TITLE
NAS-113561 / 22.02-RC.2 / fix fstype parsing in filesystem.statfs

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -381,9 +381,8 @@ class FilesystemService(Service):
             # OR
             # "129 26 0:50 / /mnt/data rw,noatime shared:72 - zfs data rw,xattr,posixacl"
             for line in f:
-                fline = line.split()
-                if len(fline) >= 3 and fline[2] == maj_min:
-                    fstype = line[line.find('-'):].split()[1]
+                if line.find(maj_min) != -1:
+                    fstype = line.rsplit(' - ')[1].split()[0]
                     break
 
         return {


### PR DESCRIPTION
ZFS has very few restrictions on what you can name a filesystem which means this parsing fails when a dataset has a hyphen in the name. `/proc/self/mountinfo` always has the sequence ` - ` as the separator before the filesystem type for the given mountpoint so use `rsplit`.