### PR TITLE
NAS-113585 / 22.02-RC.2 / add missing_log to zfs.pool.import_pool SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -440,19 +440,16 @@ class FailoverService(Service):
         job.set_progress(None, description='IMPORTING')
 
         failed = []
+        options = {'altroot': '/mnt', 'missing_log': True}
+        any_host = True
+        cachefile = self.ZPOOL_CACHE_FILE
+        new_name = None
         for vol in fobj['volumes']:
             logger.info('Importing %s', vol['name'])
 
             # import the zpool(s)
             try:
-                self.run_call(
-                    'zfs.pool.import_pool',
-                    vol['guid'],
-                    {
-                        'altroot': '/mnt',
-                        'cachefile': self.ZPOOL_CACHE_FILE,
-                    }
-                )
+                self.run_call('zfs.pool.import_pool', vol['guid'], options, any_host, cachefile, new_name)
             except Exception as e:
                 vol['error'] = str(e)
                 failed.append(vol)


### PR DESCRIPTION
m-series devices use pmem devices for SLOG. These can, sometimes, be inadvertently wiped/destroyed etc. This is not a fatal event and should not prevent failover from working (if there is only a singular zpool).

This change fixes 2 problems:

1. add the `missing_log` kwarg so that the zpool will be imported if the SLOG is missing
2. `cachefile` was not being sent to the API correctly so it wasn't actually being used