### PR TITLE
NAS-113608 / 22.02-RC.2 / Fix job progress statement for ctdb plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -139,7 +139,7 @@ class ClusterJob(Service):
         await self.wait_for_method(job, method, 10)
         nodes = await self.middleware.call('ctdb.general.status')
 
-        job.set_progress(50, f'Setting job status indicator for nodes {node["pnn"] for node in nodes}')
+        job.set_progress(50, f'Setting job status indicator for nodes {", ".join([node["pnn"] for node in nodes])!r}')
         for node in nodes:
             if node['this_node'] or node['pnn'] == -1:
                 continue


### PR DESCRIPTION
```
>>> nodes = [{'pnn': 'something'}]
>>> f'Setting job status indicator for nodes {node["pnn"] for node in nodes}'
'Setting job status indicator for nodes <generator object <genexpr> at 0x7f56dd4325f0>'
```