### PR TITLE
NAS-113628 / 22.02-RC.2 / ha_propagate = False in failover.become_passive()

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -326,7 +326,7 @@ class FailoverService(ConfigService):
             will be triggered but it will do nothing since the active will
             already have the zpool(s) imported.
         """
-        return await self.middleware.call('service.restart', 'keepalived')
+        return await self.middleware.call('service.restart', 'keepalived', {'ha_propagate': False})
 
     @accepts()
     @returns(Bool())


### PR DESCRIPTION
This was mildly infuriating because it's not obvious what was happening. When `ha_propagate = True` the `service.restart` command is sent to the other node.......

This means, on a functional HA system, calling `failover.become_passive` would trigger a failover event for the A node to become passive. At the same time B node would start the failover process but it would _ALSO_ get a request to `service.restart, keepalived` (i.e. `failover.become_passive`) which would start the process of the B node to become passive....

One of the many reasons why I opened this PR: https://github.com/truenas/middleware/pull/7887 since doing anything to the remote node should be _explicit_ and not _implicit_. That's my opinion, of course, but I digress.