### PR TITLE
NAS-113632 / 22.02-RC.2 / Ensure rid value consistency between user/group name changes

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -427,15 +427,9 @@ class SMBService(TDBWrapConfigService):
         return self.LP_CTX.get(parm)
 
     @private
-    async def get_next_rid(self):
-        next_rid = (await self.config())['next_rid']
-        if next_rid < 10000:
-            next_rid = 10000
-
-        await self.middleware.call('datastore.update', 'services.cifs', 1,
-                                   {'next_rid': next_rid + 1},
-                                   {'prefix': 'cifs_srv_'})
-        return next_rid
+    async def get_next_rid(self, objtype, id):
+        base_rid = 20000 if objtype == 'USER' else 200000
+        return base_rid + id
 
     @private
     async def setup_directories(self):

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -377,6 +377,7 @@ class SMBService(Service):
         set_to_mod = set([x for x in intersect if groupmap['local'][x]['nt_name'] != g_dict[x]['group']])
 
         to_add = [{
+            "dbid": g_dict[x]["id"],
             "gid": g_dict[x]["gid"],
             "nt_name": g_dict[x]["group"],
             "group_type_str": "local"
@@ -384,7 +385,8 @@ class SMBService(Service):
 
         if ha_mode != 'CLUSTERED':
             for m in to_add:
-                m['rid'] = await self.middleware.call('smb.get_next_rid')
+                dbid = m.pop("dbid")
+                m['rid'] = await self.middleware.call('smb.get_next_rid', 'GROUP', dbid)
 
         to_mod = [{
             "gid": g_dict[x]["gid"],

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -106,7 +106,7 @@ class SMBService(Service):
         if not entry:
             cmd = [SMBCmd.PDBEDIT.value, '-d', '0', '-a', username]
 
-            next_rid = await self.middleware.call('smb.get_next_rid')
+            next_rid = await self.middleware.call('smb.get_next_rid', 'USER', bsduser[0]['id'])
             if next_rid != -1:
                 cmd.extend(['-U', str(next_rid)])
 


### PR DESCRIPTION
Since these are used in share_info.tdb (keyed on SID value, not name or GID), it's worthwhile to ensure some consistency in database id and sids.