### PR TITLE
NAS-113424 / 22.02 / add failsafe middlewared.log

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -147,7 +147,7 @@ fi
 echo "** 96%: Compressing System Logs"
 tar -chf - -C /var --exclude=log/journal --exclude=log/faillog --exclude=log/lastlog --exclude=log/sysstat log | tar -C $dir -xf -
 if [ -f "/tmp/failsafe_middlewared.log" ]; then
-	cp "/tmp/failsafe_middlewared.log" "$dir"
+	cp "/tmp/failsafe_middlewared*" "$dir"
 fi
 
 echo "** 97%: Compressing Debug Files"

--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -146,6 +146,10 @@ fi
 
 echo "** 96%: Compressing System Logs"
 tar -chf - -C /var --exclude=log/journal --exclude=log/faillog --exclude=log/lastlog --exclude=log/sysstat log | tar -C $dir -xf -
+if [ -f "/tmp/failsafe_middlewared.log" ]; then
+	cp "/tmp/failsafe_middlewared.log" "$dir"
+fi
+
 echo "** 97%: Compressing Debug Files"
 tar -chf - -C /var/tmp fndebug | tar -C $dir -xf -
 if [ "${limit}" != "-1" ] ; then

--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -32,7 +32,7 @@ logging.getLogger('pyroute2.ndb').setLevel(logging.ERROR)
 logging.getLogger('kubernetes_asyncio.client.rest').setLevel(logging.WARN)
 logging.getLogger('kubernetes_asyncio.config.kube_config').setLevel(logging.WARN)
 
-FAILSAFE = '/tmp/failsafe_middlewared.log'
+FAILSAFE_LOGFILE = '/tmp/failsafe_middlewared.log'
 LOGFILE = '/var/log/middlewared.log'
 ZETTAREPL_LOGFILE = '/var/log/zettarepl.log'
 FAILOVER_LOGFILE = '/root/syslog/failover.log'
@@ -247,7 +247,7 @@ class Logger(object):
                 'failsafe': {
                     'level': 'DEBUG',
                     'class': 'logging.handlers.RotatingFileHandler',
-                    'filename': FAILSAFE,
+                    'filename': FAILSAFE_LOGFILE,
                     'mode': 'a',
                     'maxBytes': 10485760,
                     'backupCount': 5,
@@ -310,7 +310,7 @@ class Logger(object):
         # Make sure various log files are not readable by everybody.
         # umask could be another approach but chmod was chosen so
         # it affects existing installs.
-        for i in (FAILSAFE, LOGFILE, ZETTAREPL_LOGFILE):
+        for i in (FAILSAFE_LOGFILE, LOGFILE, ZETTAREPL_LOGFILE):
             try:
                 os.chmod(i, 0o640)
             except OSError:


### PR DESCRIPTION
The idea is to have a logging handler for `middlewared` service that does not get touched by `stop_logging` or `reconfigure_logging` etc. This can be valuable when system dataset migration/move fails, and logging is now "broken" and you can't track down which log file is being used by the currently running process.