### PR TITLE
NAS-113702 / 22.02 / improve pool.import_pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1433,6 +1433,7 @@ class PoolService(CRUDService):
                             await delegate.toggle(attachments, True)
             await self.middleware.call('keyvalue.delete', key)
 
+        asyncio.ensure_future(self.middleware.call('service.restart', 'collectd')
         await self.middleware.call_hook('pool.post_import', {'passphrase': data.get('passphrase'), **pool})
         await self.middleware.call('pool.dataset.sync_db_keys', pool['name'])
         self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1388,13 +1388,10 @@ class PoolService(CRUDService):
             raise CallError(err, errno.EEXIST)
 
         # import zpool
-        try:
-            opts = {'altroot': '/mnt', 'cachefile': ZPOOL_CACHE_FILE}
-            any_host = True
-            use_cachefile = None
-            await self.middleware.call('zfs.pool.import_pool', guid, opts, any_host, use_cachefile, new_name)
-        except Exception as e:
-            raise CallError(f'Failed importing pool with guid "{guid}" with error {e}')
+        opts = {'altroot': '/mnt', 'cachefile': ZPOOL_CACHE_FILE}
+        any_host = True
+        use_cachefile = None
+        await self.middleware.call('zfs.pool.import_pool', guid, opts, any_host, use_cachefile, new_name)
 
         # get the zpool name
         if not new_name:

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -365,12 +365,13 @@ class ZFSPoolService(CRUDService):
                 raise CallError(f'Pool {name_or_guid} not found.', errno.ENOENT)
 
             missing_log = options.pop('missing_log', False)
+            pool_name = new_name or found.name
             try:
-                zfs.import_pool(found, new_name or found.name, options, missing_log=missing_log, any_host=any_host)
+                zfs.import_pool(found, pool_name, options, missing_log=missing_log, any_host=any_host)
             except libzfs.ZFSException as e:
                 # We only log if some datasets failed to mount after pool import
                 if e.code != libzfs.Error.MOUNTFAILED:
-                    raise
+                    raise CallError(f'Failed to import {pool_name!r} pool: {e}', e.code)
                 else:
                     self.logger.error(
                         'Failed to mount datasets after importing "%s" pool: %s', name_or_guid, str(e), exc_info=True

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -8,7 +8,7 @@ import libzfs
 
 from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Str
 from middlewared.service import (
-    CallError, CRUDService, ValidationError, ValidationErrors, filterable, job, private,
+    CallError, CRUDService, ValidationErrors, filterable, job, private,
 )
 from middlewared.utils import filter_list, filter_getattrs
 from middlewared.validators import Match, ReplicationSnapshotNamingSchema
@@ -546,6 +546,14 @@ class ZFSDatasetService(CRUDService):
                 ds_name = None
 
         return ds_name
+
+    def child_dataset_names(self, path):
+        # return child datasets given a dataset `path`.
+        try:
+            with libzfs.ZFS() as zfs:
+                return [child.name for child in zfs.get_dataset_by_path(path).children]
+        except libzfs.ZFSException:
+            return []
 
     def get_quota(self, ds, quota_type):
         if quota_type == 'dataset':

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -88,6 +88,11 @@ class ZFSPoolService(CRUDService):
                 pools = [i.__getstate__(**state_kwargs) for i in zfs.pools]
         return filter_list(pools, filters, options)
 
+    def query_imported_fast(self):
+        # the equivalent of running `zpool list -H -o guid,name` from cli
+        with libzfs.ZFS() as zfs:
+            return {str(i.guid): i.name for i in zfs.pools}
+
     @accepts(
         Dict(
             'zfspool_create',

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -90,8 +90,11 @@ class ZFSPoolService(CRUDService):
 
     def query_imported_fast(self):
         # the equivalent of running `zpool list -H -o guid,name` from cli
-        with libzfs.ZFS() as zfs:
-            return {str(i.guid): i.name for i in zfs.pools}
+        try:
+            with libzfs.ZFS() as zfs:
+                return {str(i.guid): i.name for i in zfs.pools}
+        except libzfs.ZFSException as e:
+            raise CallError(f'Failed listing imported pools with error: {e}')
 
     @accepts(
         Dict(
@@ -554,8 +557,11 @@ class ZFSDatasetService(CRUDService):
 
     def child_dataset_names(self, path):
         # return child datasets given a dataset `path`.
-        with libzfs.ZFS() as zfs:
-            return [child.name for child in zfs.get_dataset_by_path(path).children]
+        try:
+            with libzfs.ZFS() as zfs:
+                return [child.name for child in zfs.get_dataset_by_path(path).children]
+        except libzfs.ZFSException as e:
+            raise CallError(f'Failed retrieving child datsets for {path} with error {e}')
 
     def get_quota(self, ds, quota_type):
         if quota_type == 'dataset':

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -554,11 +554,8 @@ class ZFSDatasetService(CRUDService):
 
     def child_dataset_names(self, path):
         # return child datasets given a dataset `path`.
-        try:
-            with libzfs.ZFS() as zfs:
-                return [child.name for child in zfs.get_dataset_by_path(path).children]
-        except libzfs.ZFSException:
-            return []
+        with libzfs.ZFS() as zfs:
+            return [child.name for child in zfs.get_dataset_by_path(path).children]
 
     def get_quota(self, ds, quota_type):
         if quota_type == 'dataset':


### PR DESCRIPTION
Preparing for the changes needed to support the zpool cachefile, I've decided to clean this method up a bit. Numerous issues found and fixed.

1. `passphrase` schema attribute is deprecated and not supported on SCALE (used for GELI pools)
2. because of this, `job` object can have `pipes` kwarg removed and the associated logic inside the method
3. we were calling `zfs.pool.find_import` and then calling `zfs.pool.import_pool`. The latter method calls `zfs.pool.find_import` so we were calling it twice for no real benefit.
4. we were calling `pool.query` twice when it can be limited to only being called once
5. we were calling `service.reload, disk` and `self.restart_services()` when the latter method also called `service.reload, disk`. I removed the calls to `service.reload, disk` and the call to `self.restart_services()` because both of those methods are a no-op on SCALE.
6. When recursively resetting the `mountpoint` property, `zfs.dataset.query` returned object has nested `children` keys that list the child datasets recursively for every top-level dataset. This is unneeded so I've introduced a new method `zfs.dataset.child_dataset_names` that returns only the top-level dataset's name given a path and nothing more.
7. clean up the code and remove CORE related logic