### PR TITLE
NAS-113700 / 22.02 / Do not allow ipv6 for applications

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -299,7 +299,7 @@ class KubernetesService(ConfigService):
         """
         return {
             d['address']: d['address'] for d in await self.middleware.call(
-                'interface.ip_in_use', {'static': True, 'any': True}
+                'interface.ip_in_use', {'static': True, 'any': True, 'ipv6': False}
             )
         }
 


### PR DESCRIPTION
K3s does not support ipv6 right now, let's remove it from our choices as the node would not initialize otherwise.