### PR TITLE
NAS-113737 / 22.02 / filter top-level /mnt non-mounts in filesystem.listdir

### DIFF
--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -122,3 +122,17 @@ def test_05_set_immutable_flag_on_path(pool):
             result = results.json()
             assert isinstance(result, bool) is True, results.text
             assert result == flag_set, 'Immutable flag is still not set' if flag_set else 'Immutable flag is still set'
+
+
+def test_06_test_filesystem_listdir_exclude_non_mounts():
+    # create a random directory at top-level of '/mnt'
+    mnt = '/mnt/'
+    randir = 'random_dir'
+    path = mnt + randir
+
+    with directory(path) as _:
+        # now call filesystem.listdir specifying '/mnt' as path
+        # and ensure `randir` is not in the output
+        results = POST('/filesystem/listdir/', {'path': mnt})
+        assert results.status_code == 200, results.text
+        assert not any(i['name'] == randir for i in results.json()), f'{randir} should not be listed'


### PR DESCRIPTION
Various failure conditions can leave the top-level directory in `/mnt` after the zpool is exported (or sometimes fails to export). The webUI calls this method to list the paths available when configuring a share for the various sharing services. To account for this and prevent the end-user from pointing a share to a directory that isn't associated to a zpool mountpoint, filter them in`filesystem.listdir`.