### PR TITLE
NAS-113744 / 12.0 / prevent endless loop in hook_setup_ha on CORE (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1662,7 +1662,7 @@ async def hook_setup_ha(middleware, *args, **kwargs):
     if not await middleware.call('failover.licensed'):
         return
 
-    if not await middleware.call('interface.query', [('failover_vhid', '!=', [])]):
+    if not await middleware.call('interface.query', [('failover_vhid', '!=', None)]):
         return
 
     if not await middleware.call('pool.query'):


### PR DESCRIPTION
The exact same issue was resolved in master with commit f0aee3d339e but it, mistakenly, was assumed to also apply to CORE (when it did not).

Long-story kept short, SCALE HA does not require `failover_vhid` but CORE HA does. The backport to CORE introduced the bug that the original commit set out to resolve....

Revert back to using `failover_vhid != None` since the master commit was not backported properly and even then, doesn't apply to CORE HA.

Original PR: https://github.com/truenas/middleware/pull/7962
Jira URL: https://jira.ixsystems.com/browse/NAS-113744