### PR TITLE
NAS-110853 / 13.0 / Download single dataset encryption key as a json file (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2200,8 +2200,8 @@ class PoolDatasetService(CRUDService):
     @job(lock='dataset_export_keys', pipes=['output'], check_pipes=False)
     def export_key(self, job, id, download):
         """
-        Export own encryption key for dataset `id`. If `download` is `true`, key will be downloaded as a text file,
-        otherwise it will be returned as string.
+        Export own encryption key for dataset `id`. If `download` is `true`, key will be downloaded in a json file
+        where the same file can be used to unlock the dataset, otherwise it will be returned as string.
 
         Please refer to websocket documentation for downloading the file.
         """
@@ -2217,7 +2217,7 @@ class PoolDatasetService(CRUDService):
         key = keys[id]
 
         if download:
-            job.pipes.output.w.write(key.encode())
+            job.pipes.output.w.write(json.dumps({id: key}).encode())
         else:
             return key
 


### PR DESCRIPTION
This commit adds changes to download encryption key of a single dataset as a json file because otherwise the same file cannot be used when we are unlocking the dataset which becomes confusing and is misleading.

Original PR: https://github.com/truenas/middleware/pull/7972
Jira URL: https://jira.ixsystems.com/browse/NAS-110853