### PR TITLE
NAS-113630 / 22.02 / Additional safety check on k3s initialization: secrets are not set

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/service_accounts.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/service_accounts.py
@@ -23,7 +23,7 @@ async def get_service_account(api_client, service_account_name):
     accounts = await api_client.list_service_account_for_all_namespaces(
         field_selector=f'metadata.name={service_account_name}'
     )
-    if not accounts.items or not accounts.items[0]:
+    if not accounts.items or not accounts.items[0] or not accounts.items[0].secrets:
         # We check if the item is not null because in some race conditions
         # the data we get from the api returns null which is of course not the service account we desire
         raise CallError(f'Unable to find "{service_account_name}" service account', errno=errno.ENOENT)


### PR DESCRIPTION
Additional safety check where secrets are not attached to returned service account instance resulting in:
```python
[2021/12/02 12:20:03] (ERROR) asyncio.default_exception_handler():1738 - Task exception was never retrieved
future: <Task finished name='Task-59479' coro=<Middleware.call() done, defined at /usr/lib/python3/dist-packages/middlewared/main.py:1304> exception=TypeError("'NoneType' object is not iterable")>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1310, in call
    return await self._call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1267, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/lifecycle.py", line 22, in post_start
    return await self.post_start_impl()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/lifecycle.py", line 38, in post_start_impl
    await self.post_start_internal()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/lifecycle.py", line 116, in post_start_internal
    await self.middleware.call('k8s.cni.setup_cni')
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1310, in call
    return await self._call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1267, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/cni.py", line 31, in setup_cni
    cni_config[cni] = await service_accounts.get_service_account_details(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/k8s/service_accounts.py", line 42, in get_service_account_details
    return (await get_service_account_tokens_cas(api_client, svc_account))[0]
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/k8s/service_accounts.py", line 10, in get_service_account_tokens_cas
    for secret in service_account.secrets:
TypeError: 'NoneType' object is not iterable
```
