### PR TITLE
NAS-113797 / 22.02-RC.2 / prevent duplicate vlan entries in db (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/interface_types.py
+++ b/src/middlewared/middlewared/plugins/interface/interface_types.py
@@ -30,17 +30,6 @@ class InterfaceService(Service):
             return InterfaceType.UNKNOWN
 
     @private
-    async def get_next_name(self, type):
-        prefix = {
-            InterfaceType.BRIDGE: 'br',
-            InterfaceType.LINK_AGGREGATION: 'bond',
-        }.get(type)
-        if prefix is None:
-            raise ValueError(type)
-
-        return await self.middleware.call('interface.get_next', prefix)
-
-    @private
     async def validate_name(self, type, name):
         if type == InterfaceType.BRIDGE:
             if not (name.startswith('br') and name[2:].isdigit()):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1059,8 +1059,7 @@ class InterfaceService(CRUDService):
 
         interface_id = None
         if data['type'] == 'BRIDGE':
-            # For bridge we want to start with 2 because bridge0/bridge1 may have been used for VM.
-            name = data.get('name') or await self.middleware.call('interface.get_next_name', InterfaceType.BRIDGE)
+            name = data.get('name') or await self.middleware.call('interface.get_next', 'br')
             try:
                 async for i in self.__create_interface_datastore(data, {
                     'interface': name,
@@ -1080,8 +1079,7 @@ class InterfaceService(CRUDService):
                         )
                 raise
         elif data['type'] == 'LINK_AGGREGATION':
-            name = data.get('name') or await self.middleware.call('interface.get_next_name',
-                                                                  InterfaceType.LINK_AGGREGATION)
+            name = data.get('name') or await self.middleware.call('interface.get_next', 'bond')
             lag_id = None
             lagports_ids = []
             try:
@@ -1118,7 +1116,7 @@ class InterfaceService(CRUDService):
                         )
                 raise
         elif data['type'] == 'VLAN':
-            name = data.get('name') or f'vlan{data["vlan_tag"]}'
+            name = data.get('name') or await self.middleware.call('interface.get_next', 'vlan')
             try:
                 async for i in self.__create_interface_datastore(data, {
                     'interface': name,

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_interface.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_interface.py
@@ -179,7 +179,6 @@ async def test__interfaces_service__create_lagg():
     m = Middleware()
     m['interface.query'] = Mock(return_value=INTERFACES)
     m['interface.lag_supported_protocols'] = Mock(return_value=['LACP'])
-    m['interface.get_next_name'] = Mock()
     m['interface.validate_name'] = Mock()
     m['datastore.query'] = Mock(return_value=[])
     m['datastore.insert'] = Mock(return_value=5)


### PR DESCRIPTION
If a name is not provided when creating a vlan, then we use the `vlan_tag` attribute as the name of the interface. This causes multiple issues. Below is a scenario:

1. create `vlan` with no name and give it a tag of 100
2. create another `vlan` with no name and give it a tag of 100

This does 2 things:
1. overwrites the original vlan entry in `network_interfaces` table with whatever information was provided in step # 2 above. (This is undefined behavior because a `do_update` call should be made in this specific scenario)
2. a duplicate entry will be made to `network_vlan` table

To remedy both of these problems, I'm using the `interface.get_next` method which is what `br` and `bond` interfaces use to generate their names. There should be no functional change.

While I'm here, I've removed the unnecessary `interface.get_next_name` method since it provides no benefit. Instead use the `interface.get_next` method for all the virtual interface types.

Original PR: https://github.com/truenas/middleware/pull/7984
Jira URL: https://jira.ixsystems.com/browse/NAS-113797