### PR TITLE
NAS-113816 / 22.02 / Fix wsdd configuration generation

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
@@ -3,7 +3,7 @@
 
     conf = {
         "realm": middleware.call_sync('smb.getparm', 'realm', 'GLOBAL'),
-        "netbios_name": middleware.call_sync('smb.getparm', 'netbiosname', 'GLOBAL'),
+        "netbios_name": middleware.call_sync('smb.getparm', 'netbios name', 'GLOBAL'),
         "workgroup": middleware.call_sync('smb.getparm', 'workgroup', 'GLOBAL'),
         "enabled": middleware.call_sync('network.configuration.config')['service_announcement']['wsd']
     }


### PR DESCRIPTION
"netbiosname" vs "netbios name". Order of parameter lookup through middleware is to (1) use libsmbconf, (2) look up in /etc/local/smb4.conf, then (3) get default through python loadparm context. Unfortunately the netbiosname->netbios name alias mapping doesn't appear to work through libsmbconf, so we fall back to the loadparm default, which is incorrect.