### PR TITLE
NAS-113698 / 22.02-RC.2 / Added some sleeps in ad_idmap test 8 (by ericbsd)

### DIFF
--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -14,6 +14,7 @@ from functions import PUT, POST, GET, DELETE, SSH_TEST, wait_on_job
 from auto_config import ip, hostname, password, user
 from base64 import b64decode
 from pytest_dependency import depends
+from time import sleep
 
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
@@ -21,9 +22,7 @@ try:
         LDAPBASEDN,
         LDAPBINDDN,
         LDAPBINDPASSWORD,
-        LDAPHOSTNAME,
-        LDAPUSER,
-        LDAPPASSWORD
+        LDAPHOSTNAME
     )
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
@@ -172,6 +171,7 @@ def test_08_test_backend_options(request, backend):
     if not payload['options']:
         payload.pop('options')
 
+    sleep(2.5)
     results = PUT("/idmap/id/1/", payload)
     assert results.status_code == 200, f'payload: {payload}, results: {results.text}'
 
@@ -307,6 +307,7 @@ def test_08_test_backend_options(request, backend):
             decoded_sec = b64decode(stored_sec).rstrip(b'\x00').decode()
             assert secret == decoded_sec, stored_sec
 
+    sleep(2.5)
     # reset idmap backend to RID to ensure that winbindd is running
     payload = {
         "name": "DS_TYPE_ACTIVEDIRECTORY",


### PR DESCRIPTION
This is to avoid restarting systemd service more then 5 time per 10 second which is the default limit.

Original PR: https://github.com/truenas/middleware/pull/7997
Jira URL: https://jira.ixsystems.com/browse/NAS-113698