### PR TITLE
NAS-113861 / 23.10 / SQLAlchemy 1.4 compatibility

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/connection.py
+++ b/src/middlewared/middlewared/plugins/datastore/connection.py
@@ -54,7 +54,7 @@ class DatastoreService(Service):
         options.setdefault('ha_sync', True)
         options.setdefault('return_last_insert_rowid', False)
 
-        compiled = stmt.compile(self.engine)
+        compiled = stmt.compile(self.engine, compile_kwargs={"render_postcompile": True})
 
         sql = compiled.string
         binds = []

--- a/src/middlewared/middlewared/plugins/datastore/schema.py
+++ b/src/middlewared/middlewared/plugins/datastore/schema.py
@@ -30,7 +30,7 @@ class SchemaMixin:
             return table.c[f'{name}_id']
 
     def _get_relationships(self, table):
-        for model in Model._decl_class_registry.values():
+        for model in Model.registry._class_registry.values():
             if hasattr(model, "__tablename__") and model.__tablename__ == table.name:
                 break
         else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
@@ -331,6 +331,20 @@ async def test__string_filters(filter, ids):
         assert [row["id"] for row in await ds.query("test.string", filter)] == ids
 
 
+@pytest.mark.asyncio
+async def test_delete_not_in():
+    async with datastore_test() as ds:
+        await ds.execute("INSERT INTO test_string VALUES (1, 'Lorem')")
+        await ds.execute("INSERT INTO test_string VALUES (2, 'Ipsum')")
+        await ds.execute("INSERT INTO test_string VALUES (3, 'dolor')")
+        await ds.execute("INSERT INTO test_string VALUES (4, 'sit')")
+        await ds.execute("INSERT INTO test_string VALUES (5, 'amer')")
+
+        await ds.delete("test_string", [["string", "nin", ["Lorem", "dolor"]]])
+
+        assert [row["id"] for row in await ds.query("test.string")] == [1, 3]
+
+
 class IntegerModel(Model):
     __tablename__ = 'test_integer'
 

--- a/src/middlewared/middlewared/sqlalchemy.py
+++ b/src/middlewared/middlewared/sqlalchemy.py
@@ -28,12 +28,16 @@ Model.metadata.naming_convention = {
 
 
 class Column(_Column):
+    inherit_cache = True
+
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("nullable", False)
         super().__init__(*args, **kwargs)
 
 
 class EncryptedText(UserDefinedType):
+    cache_ok = True
+
     def get_col_spec(self, **kw):
         return "TEXT"
 
@@ -57,6 +61,8 @@ class EncryptedText(UserDefinedType):
 
 
 class JSON(UserDefinedType):
+    cache_ok = True
+
     def __init__(self, type=dict, encrypted=False):
         self.type = type
         self.encrypted = encrypted
@@ -92,6 +98,8 @@ class JSON(UserDefinedType):
 
 
 class MultiSelectField(UserDefinedType):
+    cache_ok = True
+
     def get_col_spec(self, **kw):
         return "TEXT"
 
@@ -118,6 +126,8 @@ class MultiSelectField(UserDefinedType):
 
 
 class Time(UserDefinedType):
+    cache_ok = True
+
     def get_col_spec(self, **kw):
         return "TIME"
 


### PR DESCRIPTION
These changes are incompatible with SQLAlchemy 1.3. TrueNAS SCALE uses SQLAlchemy 1.3, TrueNAS CORE 13 uses SQLAlchemy 1.4. This ticket should be merged once we update TrueNAS SCALE to the distribution that ships SQLAlchemy 1.4.