### PR TITLE
NAS-113870 / 22.02 / fix some of SCALE HA related alerts

### DIFF
--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -1,14 +1,4 @@
-# Copyright (c) 2015 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
-import logging
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
-
-logger = logging.getLogger(__name__)
 
 
 class EnclosureUnhealthyAlertClass(AlertClass):
@@ -16,8 +6,7 @@ class EnclosureUnhealthyAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Enclosure Status Is Not Healthy"
     text = "Enclosure %d (%s): %s is %s (%s)."
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class EnclosureHealthyAlertClass(AlertClass):
@@ -25,12 +14,11 @@ class EnclosureHealthyAlertClass(AlertClass):
     level = AlertLevel.INFO
     title = "Enclosure Status Is Healthy"
     text = "Enclosure %d (%s): is healthy."
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class EnclosureStatusAlertSource(AlertSource):
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -14,7 +14,7 @@ class DisksAreNotPresentOnBackupNodeAlertClass(AlertClass):
         "Disks with serial %(serials)s present on active storage controller but missing on standby storage controller."
     )
 
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class DisksAreNotPresentOnMasterNodeAlertClass(AlertClass):
@@ -25,11 +25,11 @@ class DisksAreNotPresentOnMasterNodeAlertClass(AlertClass):
         "Disks with serial %(serials)s present on standby storage controller but missing on active storage controller."
     )
 
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class FailoverDisksAlertSource(AlertSource):
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_ip.py
+++ b/src/middlewared/middlewared/alert/source/failover_ip.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2018 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 
 
@@ -13,12 +7,11 @@ class FailoverIpAlertClass(AlertClass):
     title = "Network Interface Is Marked Critical for Failover, but Is Missing Required IP Address"
     text = ("Network interface %(interface)s is marked critical for failover, but is missing following required "
             "IP addresses: %(addresses)s")
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class FailoverIpAlertSource(AlertSource):
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
     async def check(self):
         interfaces = await self.middleware.call("datastore.query", "network.interfaces")

--- a/src/middlewared/middlewared/alert/source/failover_sync.py
+++ b/src/middlewared/middlewared/alert/source/failover_sync.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2015 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from middlewared.alert.base import (
     Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel, OneShotAlertClass
 )
@@ -18,8 +12,7 @@ class FailoverSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
         "controller. Use Sync to Peer on the System/Failover page to "
         "perform a manual sync."
     )
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class FailoverKeysSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
@@ -32,8 +25,7 @@ class FailoverKeysSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
         "The automatic synchronization of encryption passphrases with the standby "
         "controller has failed. Please go to System > Failover and manually sync to peer."
     )
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class FailoverKMIPKeysSyncFailedAlertClass(AlertClass, OneShotAlertClass):
@@ -46,8 +38,7 @@ class FailoverKMIPKeysSyncFailedAlertClass(AlertClass, OneShotAlertClass):
         "The automatic synchronization of KMIP keys with the standby "
         "controller has failed due to %(error)s. Please go to System > Failover and manually sync to peer."
     )
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
     async def create(self, args):
         return Alert(FailoverKMIPKeysSyncFailedAlertClass, args)

--- a/src/middlewared/middlewared/alert/source/ix.py
+++ b/src/middlewared/middlewared/alert/source/ix.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2017 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 
 
@@ -13,11 +7,11 @@ class IxAlertClass(AlertClass):
     title = "iXsystems alert"
     text = "%s"
 
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class IxAlertSource(AlertSource):
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
     run_on_backup_node = False
 
     async def check(self):

--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -19,8 +19,7 @@ class LicenseAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "TrueNAS License Issue"
     text = "%s"
-
-    products = ("ENTERPRISE", "SCALE_ENTERPRISE")
+    products = ("SCALE_ENTERPRISE",)
 
 
 class LicenseIsExpiringAlertClass(AlertClass):
@@ -28,8 +27,7 @@ class LicenseIsExpiringAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "TrueNAS License Is Expiring"
     text = "%s"
-
-    products = ("ENTERPRISE", "SCALE_ENTERPRISE")
+    products = ("SCALE_ENTERPRISE",)
 
 
 class LicenseHasExpiredAlertClass(AlertClass):
@@ -37,12 +35,11 @@ class LicenseHasExpiredAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "TrueNAS License Has Expired"
     text = "%s"
-
-    products = ("ENTERPRISE", "SCALE_ENTERPRISE")
+    products = ("SCALE_ENTERPRISE",)
 
 
 class LicenseStatusAlertSource(ThreadedAlertSource):
-    products = ("ENTERPRISE", "SCALE_ENTERPRISE")
+    products = ("SCALE_ENTERPRISE",)
     run_on_backup_node = False
 
     def check_sync(self):

--- a/src/middlewared/middlewared/alert/source/sata_dom_wear.py
+++ b/src/middlewared/middlewared/alert/source/sata_dom_wear.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2019 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from datetime import timedelta
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, IntervalSchedule
@@ -14,8 +8,7 @@ class SATADOMWearWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "SATA DOM Lifetime: Less Than 20% Left"
     text = "%(lifetime)d%% of lifetime left on SATA DOM %(disk)s."
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class SATADOMWearCriticalAlertClass(AlertClass):
@@ -23,8 +16,7 @@ class SATADOMWearCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "SATA DOM Lifetime: Less Than 10% Left"
     text = "%(lifetime)d%% of lifetime left on SATA DOM %(disk)s."
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class SATADOMWearAlertSource(AlertSource):

--- a/src/middlewared/middlewared/alert/source/sensors.py
+++ b/src/middlewared/middlewared/alert/source/sensors.py
@@ -1,15 +1,6 @@
-# Copyright (c) 2020 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
-import logging
 import re
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
-
-logger = logging.getLogger(__name__)
 
 RE_CPUTEMP = re.compile(r'^cpu.*temp$', re.I)
 RE_SYSFAN = re.compile(r'^sys_fan\d+$', re.I)
@@ -28,8 +19,7 @@ class SensorAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Sensor Value Is Outside of Working Range"
     text = "Sensor %(name)s is %(relative)s %(level)s value: %(value)d %(description)s"
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class PowerSupplyAlertClass(AlertClass):
@@ -37,8 +27,7 @@ class PowerSupplyAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Power Supply Failed"
     text = "Power supply %(number)s failed: %(errors)s."
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
 
 class SensorsAlertSource(AlertSource):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -602,7 +602,7 @@ class AlertService(Service):
         product_type = await self.middleware.call("alert.product_type")
         run_on_backup_node = False
         run_failover_related = False
-        if product_type == "ENTERPRISE":
+        if product_type == "SCALE_ENTERPRISE":
             if await self.middleware.call("failover.licensed"):
                 if await self.middleware.call("failover.node") == "B":
                     master_node = "B"

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -488,11 +488,9 @@ class DiskService(CRUDService):
         This runs on boot to properly configure all power management options
         (Advanced Power Management and IDLE) for all disks.
         """
-        # Do not run power management on ENTERPRISE
-        if await self.middleware.call('system.product_type') == 'ENTERPRISE':
-            return
-        for disk in await self.middleware.call('disk.query'):
-            await self.middleware.call('disk.power_management', disk['name'], disk)
+        if await self.middleware.call('system.product_type') != 'SCALE_ENTERPRISE':
+            for disk in await self.middleware.call('disk.query'):
+                await self.middleware.call('disk.power_management', disk['name'], disk)
 
     @private
     async def power_management(self, dev, disk=None):

--- a/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
+++ b/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
@@ -48,13 +48,6 @@ class DetectVirtualIpStates(Service):
         return masters, backups
 
     async def get_states(self, interfaces=None):
-
-        """
-        The `inits` list is not used on SCALE_ENTERPRISE but
-        is kept here to provide backwards compatibility with
-        ENTERPRISE API.
-        """
-
         masters, backups, inits = [], [], []
 
         if interfaces is None:

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -183,7 +183,7 @@ class InterfaceService(CRUDService):
             i['int_interface']: i
             for i in self.middleware.call_sync('datastore.query', 'network.interfaces')
         }
-        ha_hardware = self.middleware.call_sync('system.product_type') in ('ENTERPRISE', 'SCALE_ENTERPRISE')
+        ha_hardware = self.middleware.call_sync('system.product_type') == 'SCALE_ENTERPRISE'
         if ha_hardware:
             internal_ifaces = self.middleware.call_sync('failover.internal_interfaces')
         for name, iface in netif.list_interfaces().items():

--- a/src/middlewared/middlewared/plugins/network_/global.py
+++ b/src/middlewared/middlewared/plugins/network_/global.py
@@ -82,9 +82,8 @@ class NetworkConfigurationService(ConfigService):
 
     @private
     def network_config_extend(self, data):
-
         # hostname_local will be used when the hostname of the current machine
-        # needs to be used so it works with either TrueNAS CORE or ENTERPRISE
+        # needs to be used so it works with either TrueNAS SCALE or SCALE_ENTERPRISE
         data['hostname_local'] = data['hostname']
 
         if not self.middleware.call_sync('system.is_enterprise'):

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -544,7 +544,7 @@ class SystemService(Service):
 
     @private
     async def is_enterprise(self):
-        return await self.middleware.call('system.product_type') in ['ENTERPRISE', 'SCALE_ENTERPRISE']
+        return await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE'
 
     @private
     async def hostname(self):
@@ -705,7 +705,7 @@ class SystemService(Service):
         self.middleware.call_sync('etc.generate', 'rc')
 
         SystemService.PRODUCT_TYPE = None
-        if self.middleware.call_sync('system.product_type') == 'ENTERPRISE':
+        if self.middleware.call_sync('system.is_enterprise'):
             Path('/data/truenas-eula-pending').touch(exist_ok=True)
         self.middleware.run_coroutine(
             self.middleware.call_hook('system.post_license_update', prev_product_type=prev_product_type), wait=False,
@@ -1801,7 +1801,7 @@ async def firstboot(middleware):
         # we do not want the clone to have the file in it.
         os.unlink(FIRST_INSTALL_SENTINEL)
 
-        if await middleware.call('system.product_type') == 'ENTERPRISE':
+        if await middleware.call('system.is_enterprise'):
             config = await middleware.call('datastore.config', 'system.advanced')
             await middleware.call('datastore.update', 'system.advanced', config['id'], {'adv_autotune': True})
 

--- a/src/middlewared/middlewared/plugins/tunables.py
+++ b/src/middlewared/middlewared/plugins/tunables.py
@@ -78,11 +78,6 @@ class TunableService(CRUDService):
 
         `type` for SCALE should be one of the following:
         1) SYSCTL     -     Configure `var` for sysctl(8)
-
-        `type` for CORE/ENTERPRISE should be one of the following:
-        1) LOADER     -     Configure `var` for loader(8)
-        2) RC         -     Configure `var` for rc(8)
-        3) SYSCTL     -     Configure `var` for sysctl(8)
         """
         await self.clean(data, 'tunable_create')
         await self.validate(data, 'tunable_create')


### PR DESCRIPTION
While SCALE HA doesn't have a public release date, yet, QE is still doing low-hanging fruit API tests with each release. Plumbing in the HA alerts would be nice to catch any new issues so we can work on them sooner rather than later. Some of the alerts I didn't touch because they're still written with CORE in-mind and will require further changes.