### PR TITLE
Optionally expand get_user_obj output to include grouplist

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -736,7 +736,8 @@ class UserService(CRUDService):
     @accepts(Dict(
         'get_user_obj',
         Str('username', default=None),
-        Int('uid', default=None)
+        Int('uid', default=None),
+        Bool('get_groups', default=False)
     ))
     @returns(Dict(
         'user_information',
@@ -746,6 +747,7 @@ class UserService(CRUDService):
         Str('pw_shell'),
         Int('pw_uid'),
         Int('pw_gid'),
+        List('grouplist'),
     ))
     async def get_user_obj(self, data):
         """
@@ -756,7 +758,7 @@ class UserService(CRUDService):
         if not data['username'] and data['uid'] is None:
             verrors.add('get_user_obj.username', 'Either "username" or "uid" must be specified')
         verrors.check()
-        return await self.middleware.call('dscache.get_uncached_user', data['username'], data['uid'])
+        return await self.middleware.call('dscache.get_uncached_user', data['username'], data['uid'], data['getgroups'])
 
     @item_method
     @accepts(

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -342,7 +342,7 @@ class DSCache(Service):
         })
         return [x['val'] for x in entries]
 
-    def get_uncached_user(self, username=None, uid=None):
+    def get_uncached_user(self, username=None, uid=None, getgroups=False):
         """
         Returns dictionary containing pwd_struct data for
         the specified user or uid. Will raise an exception
@@ -355,13 +355,15 @@ class DSCache(Service):
             u = pwd.getpwuid(uid)
         else:
             return {}
+
         return {
             'pw_name': u.pw_name,
             'pw_uid': u.pw_uid,
             'pw_gid': u.pw_gid,
             'pw_gecos': u.pw_gecos,
             'pw_dir': u.pw_dir,
-            'pw_shell': u.pw_shell
+            'pw_shell': u.pw_shell,
+            'grouplist': os.getgrouplist(u.pw_name, u.pw_gid) if getgroups else []
         }
 
     def get_uncached_group(self, groupname=None, gid=None):


### PR DESCRIPTION
There may be some situations where we want the full list
of groups of which the specified user is a member. Since
this potentially makes the call slightly more expensive,
make additional info optional and off by default