### PR TITLE
NAS-113795 / 22.02 / refactor network_alias table

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-12-20_20-37_fix_network_alias.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-12-20_20-37_fix_network_alias.py
@@ -1,0 +1,128 @@
+"""fix network_alias table
+
+Revision ID: 6e41203881b2
+Revises: a3f3b07bb1aa
+Create Date: 2021-12-20 20:37:29.496586+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from ipaddress import ip_interface
+
+
+# revision identifiers, used by Alembic.
+revision = '6e41203881b2'
+down_revision = 'a3f3b07bb1aa'
+branch_labels = None
+depends_on = None
+
+
+def pull_out_entries(rows):
+    a_addresses = set()
+    b_addresses = set()
+    vips = set()
+    for row in rows:
+        if row['alias_v4address']:
+            # v4address column always has the netmask bit
+            a_addresses.add(ip_interface(f'{row["alias_v4address"]}/{row["alias_v4netmaskbit"]}'))
+        elif row['alias_v6address']:
+            # v6address column always has the netmask bit
+            a_addresses.add(ip_interface(f'{row["alias_v6address"]}/{row["alias_v6netmaskbit"]}'))
+        elif row['alias_vip']:
+            vips.add(ip_interface(row['alias_vip']))
+        elif row['alias_vipv6address']:
+            vips.add(ip_interface(row['alias_vipv6address']))
+        elif row['alias_v4address_b']:
+            # on 12, netmask bit is written to db for _b address
+            netmask = row['alias_v4netmaskbit'] if row['alias_v4netmaskbit'] else 32
+            b_addresses.add(ip_interface(f'{row["alias_v4address_b"]}/{netmask}'))
+        elif row['alias_v6address_b']:
+            # on 12, IPv6 on HA systems isn't supported but it is on scale
+            # but to be safe, we'll check to see if we're lucky and got the
+            # prefix length
+            netmask = row['alias_v6netmaskbit'] if row['alias_v6netmaskbit'] else 128
+            b_addresses.add(ip_interface(f'{row["alias_v6address_b"]}/{netmask}'))
+
+    return a_addresses, b_addresses, vips
+
+
+def combine_entries(iface_id, a_addresses, b_addresses, vips):
+    new_aliases = []
+    new_alias = {
+        'alias_interface_id': iface_id,
+        'alias_address': '',
+        'alias_address_b': '',
+        'alias_netmask': 32,
+        'alias_version': 4,
+        'alias_vip': '',
+    }
+    for a_addr in a_addresses:
+        alias = new_alias.copy()
+
+        # controller A addresses
+        alias['alias_address'] = str(a_addr.ip)
+        alias['alias_netmask'] = int(a_addr.compressed.split('/')[-1])
+        alias['alias_version'] = a_addr.ip.version
+
+        # controller B addresses
+        for b_addr in b_addresses:
+            if b_addr.ip in a_addr.network:
+                alias['alias_address_b'] = str(b_addr.ip)
+                break
+
+        # controller VIP addresses
+        for v_addr in vips:
+            if v_addr.ip in a_addr.network:
+                alias['alias_vip'] = str(b_addr.ip)
+                break
+
+        # save the result
+        new_aliases.append(alias)
+
+    return new_aliases
+
+
+def drop_and_create_new_table():
+    op.drop_table('network_alias')
+
+    op.create_table(
+        'network_alias',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('alias_interface_id', sa.Integer(), nullable=True),
+        sa.Column('alias_address', sa.String(length=45), nullable=True),
+        sa.Column('alias_version', sa.Integer(), nullable=False),
+        sa.Column('alias_netmask', sa.Integer(), nullable=False),
+        sa.Column('alias_address_b', sa.String(length=45), nullable=False),
+        sa.Column('alias_vip', sa.String(length=45), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['alias_interface_id'],
+            ['network_interfaces.id'],
+            name=op.f('fk_network_alias_alias_interface_id_network_interfaces'),
+            ondelete='CASCADE'
+        ),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_network_alias')),
+        sqlite_autoincrement=True
+    )
+    with op.batch_alter_table('network_alias', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_network_alias_alias_interface_id'), ['alias_interface_id'], unique=False)
+
+
+def upgrade():
+    con = op.get_bind()
+    for iface_id, in con.execute('SELECT id from network_interfaces').fetchall():
+        rows = con.execute(f'SELECT * FROM network_alias WHERE alias_interface_id = {iface_id}').fetchall()
+        a_addresses, b_addresses, vips = pull_out_entries(rows)
+        new_aliases = combine_entries(iface_id, a_addresses, b_addresses, vips)
+
+    drop_and_create_new_table()
+
+    # now write our new values to newly created table
+    for new_alias in new_aliases:
+        alias = dict(new_alias)
+        columns = tuple(alias.keys())
+        values = tuple(alias.values())
+        con.execute(f'INSERT INTO network_alias {columns} VALUES {values}')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-12-20_20-37_fix_network_alias.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-12-20_20-37_fix_network_alias.py
@@ -109,6 +109,7 @@ def drop_and_create_new_table():
 
 def upgrade():
     con = op.get_bind()
+    new_aliases = []
     for iface_id, in con.execute('SELECT id from network_interfaces').fetchall():
         rows = con.execute(f'SELECT * FROM network_alias WHERE alias_interface_id = {iface_id}').fetchall()
         a_addresses, b_addresses, vips = pull_out_entries(rows)

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -75,23 +75,21 @@ class InterfaceService(Service):
                 has_ipv6 = True
 
         # configure VRRP
-        has_vip = data.get('int_vip', '')
-        if has_vip:
-            vip_data = {
-                'address': data['int_vip'],
+        vip = data.get('int_vip', '')
+        if vip:
+            addrs_database.add(self.alias_to_addr({
+                'address': vip,
                 'netmask': '32',
-            }
+            }))
 
-        has_vipv6 = data.get('int_vipv6address', '')
-        if has_vipv6:
-            vip_data = {
-                'address': data['int_vipv6address'],
+        vipv6 = data.get('int_vipv6address', '')
+        if vipv6:
+            addrs_database.add(self.alias_to_addr({
+                'address': vipv6,
                 'netmask': '128',
-            }
+            }))
 
-        if has_vip or has_vipv6:
-            addrs_database.add(self.alias_to_addr(vip_data))
-
+        alias_vips = []
         for alias in aliases:
             if alias[alias_field]:
                 addrs_database.add(self.alias_to_addr({
@@ -100,8 +98,10 @@ class InterfaceService(Service):
                 }))
 
             if alias['alias_vip']:
+                alias_vip = alias['alias_vip']
+                alias_vips.append(alias_vip)
                 addrs_database.add(self.alias_to_addr({
-                    'address': alias['alias_vip'],
+                    'address': alias_vip,
                     'netmask': '32' if alias['alias_version'] == 4 else '128',
                 }))
 
@@ -123,10 +123,11 @@ class InterfaceService(Service):
 
         # Remove addresses configured and not in database
         for addr in addrs_configured:
-            # keepalived service is responsible for deleting the VIP
-            if str(addr.address) in (has_vip, has_vipv6):
+            address = str(addr.address)
+            # keepalived service is responsible for deleting the VIP(s)
+            if address in (vip, vipv6) or address in alias_vips:
                 continue
-            if has_ipv6 and str(addr.address).startswith('fe80::'):
+            if vipv6 and address.startswith('fe80::'):
                 continue
             if addr not in addrs_database:
                 self.logger.debug('{}: removing {}'.format(name, addr))
@@ -135,7 +136,7 @@ class InterfaceService(Service):
                 self.logger.debug('{}: removing possible valid_lft and preferred_lft on {}'.format(name, addr))
                 iface.replace_address(addr)
 
-        if has_vip or has_vipv6:
+        if vip or vipv6 or alias_vips:
             if not self.middleware.call_sync('service.started', 'keepalived'):
                 self.middleware.call_sync('service.start', 'keepalived')
             else:
@@ -144,8 +145,9 @@ class InterfaceService(Service):
 
         # Add addresses in database and not configured
         for addr in (addrs_database - addrs_configured):
-            # keepalived service is responsible for adding the VIP
-            if str(addr.address) in (has_vip, has_vipv6):
+            address = str(addr.address)
+            # keepalived service is responsible for adding the VIP(s)
+            if address in (vip, vipv6) or address in alias_vips:
                 continue
             self.logger.debug('{}: adding {}'.format(name, addr))
             iface.add_address(addr)

--- a/src/middlewared/middlewared/plugins/interface/listen.py
+++ b/src/middlewared/middlewared/plugins/interface/listen.py
@@ -72,11 +72,9 @@ class InterfaceService(Service):
                 addresses.add(interface[k])
                 addresses.add(interface[f"{k}_b"])
         for alias in datastores["alias"]:
-            for k in ["alias_v4address", "alias_v6address"]:
-                addresses.add(alias[k])
-                addresses.add(alias[f"{k}_b"])
+            addresses.add(alias["alias_address"])
+            addresses.add(alias["alias_address_b"])
             addresses.add(alias["alias_vip"])
-            addresses.add(alias["alias_vipv6address"])
         addresses.discard("")
         return addresses
 

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -98,11 +98,9 @@ class ISCSIPortalService(CRUDService):
             ]):
                 choices[i['int_vip']] = f'{i["int_ipv4address"]}/{i["int_ipv4address_b"]}'
 
-            for i in await self.middleware.call('datastore.query', 'network.Alias', [
-                ('alias_vip', 'nin', [None, '']),
-            ]):
-                choices[i['alias_vip']] = f'{i["alias_v4address"]}/{i["alias_v4address_b"]}'
-
+            filters = [('alias_vip', 'nin', [None, ''])]
+            for i in await self.middleware.call('datastore.query', 'network.Alias', filters):
+                choices[i['alias_vip']] = f'{i["alias_address"]}/{i["alias_netmask"]}'
         else:
             for i in await self.middleware.call('interface.query'):
                 for alias in i.get('failover_virtual_aliases') or []:

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1,9 +1,9 @@
 import asyncio
 import contextlib
 import ipaddress
-import itertools
 import socket
 from collections import defaultdict
+from itertools import zip_longest
 
 import middlewared.sqlalchemy as sa
 from middlewared.service import CallError, CRUDService, filterable, pass_app, private
@@ -21,14 +21,11 @@ class NetworkAliasModel(sa.Model):
 
     id = sa.Column(sa.Integer(), primary_key=True)
     alias_interface_id = sa.Column(sa.Integer(), sa.ForeignKey('network_interfaces.id', ondelete='CASCADE'), index=True)
-    alias_v4address = sa.Column(sa.String(42), default='')
-    alias_v4netmaskbit = sa.Column(sa.String(3), default='')
-    alias_v6address = sa.Column(sa.String(45), default='')
-    alias_v6netmaskbit = sa.Column(sa.String(3), default='')
+    alias_address = sa.Column(sa.String(42), default='')
+    alias_version = sa.Column(sa.Integer())
+    alias_netmask = sa.Column(sa.Integer())
+    alias_address_b = sa.Column(sa.String(42), default='')
     alias_vip = sa.Column(sa.String(42), default='')
-    alias_vipv6address = sa.Column(sa.String(45), default='')
-    alias_v4address_b = sa.Column(sa.String(42), default='')
-    alias_v6address_b = sa.Column(sa.String(45), default='')
 
 
 class NetworkBridgeModel(sa.Model):
@@ -361,46 +358,27 @@ class InterfaceService(CRUDService):
                     'netmask': int(config['int_v6netmaskbit']),
                 })
 
-        for alias in self.middleware.call_sync(
-            'datastore.query', 'network.alias', [('alias_interface', '=', config['id'])]
-        ):
-
-            if alias['alias_v4address']:
+        filters = [('alias_interface', '=', config['id'])]
+        for alias in self.middleware.call_sync('datastore.query', 'network.alias', filters):
+            _type = 'INET' if alias['alias_version'] == 4 else 'INET6'
+            if alias['alias_address']:
                 iface['aliases'].append({
-                    'type': 'INET',
-                    'address': alias['alias_v4address'],
-                    'netmask': int(alias['alias_v4netmaskbit']),
-                })
-            if alias['alias_v6address']:
-                iface['aliases'].append({
-                    'type': 'INET6',
-                    'address': alias['alias_v6address'],
-                    'netmask': int(alias['alias_v6netmaskbit']),
+                    'type': _type,
+                    'address': alias['alias_address'],
+                    'netmask': alias['alias_netmask'],
                 })
             if ha_hardware:
-                if alias['alias_v4address_b']:
+                if alias['alias_address_b']:
                     iface['failover_aliases'].append({
-                        'type': 'INET',
-                        'address': alias['alias_v4address_b'],
-                        'netmask': int(alias['alias_v4netmaskbit']),
-                    })
-                if alias['alias_v6address_b']:
-                    iface['failover_aliases'].append({
-                        'type': 'INET6',
-                        'address': alias['alias_v6address_b'],
-                        'netmask': int(alias['alias_v6netmaskbit']),
+                        'type': _type,
+                        'address': alias['alias_address_b'],
+                        'netmask': alias['alias_netmask'],
                     })
                 if alias['alias_vip']:
                     iface['failover_virtual_aliases'].append({
-                        'type': 'INET',
+                        'type': _type,
                         'address': alias['alias_vip'],
-                        'netmask': 32,
-                    })
-                if alias['alias_vipv6address']:
-                    iface['failover_virtual_aliases'].append({
-                        'type': 'INET6',
-                        'address': alias['alias_vipv6address'],
-                        'netmask': 128,
+                        'netmask': 32 if _type == 'INET' else 128,
                     })
 
         return iface
@@ -1079,15 +1057,18 @@ class InterfaceService(CRUDService):
         )
         yield interface_id
 
-        for alias in aliases.values():
+        for alias in aliases:
+            alias['interface'] = interface_id
             await self.middleware.call(
-                'datastore.insert',
-                'network.alias',
-                dict(interface=interface_id, **alias),
-                {'prefix': 'alias_'},
+                'datastore.insert', 'network.alias', dict(interface=interface_id, **alias), {'prefix': 'alias_'}
             )
 
     def __convert_aliases_to_datastore(self, data):
+        da = data['aliases']
+        dfa = data.get('failover_aliases', [])
+        dfva = data.get('failover_virtual_aliases', [])
+
+        aliases = []
         iface = {
             'ipv4address': '',
             'ipv4address_b': '',
@@ -1096,61 +1077,45 @@ class InterfaceService(CRUDService):
             'ipv6address_b': '',
             'v6netmaskbit': '',
             'vip': '',
-            'vipv6address': '',
+            'vipv6address': ''
         }
-        aliases = {}
-        for field, i in itertools.chain(
-            map(lambda x: ('A', x), data['aliases']),
-            map(lambda x: ('B', x), data.get('failover_aliases') or []),
-            map(lambda x: ('V', x), data.get('failover_virtual_aliases') or []),
-        ):
-            try:
-                ipaddr = ipaddress.ip_interface(f'{i["address"]}/{i["netmask"]}')
-            except KeyError:
-                # this is expected since the `netmask` key in `failover_aliases`
-                # or `failover_virtual_aliases` isn't required via the public API.
-                # The db doesn't have a netmask column for the standby IP or for
-                # the virtual IP so we hardcode those values behind the scene.
-                ipaddr = ipaddress.ip_interface(i["address"])
+        for idx, (a, fa, fva) in enumerate(zip_longest(da, dfa, dfva, fillvalue={})):
+            netmask = a['netmask']
+            ipa = a['address']
+            ipb = fa.get('address', '')
+            ipv = fva.get('address', '')
 
-            netfield = None
-            iface_ip = True
-            if ipaddr.version == 4:
-                if field == 'A':
-                    iface_addrfield = 'ipv4address'
-                    alias_addrfield = 'v4address'
-                    netfield = 'v4netmaskbit'
-                elif field == 'B':
-                    iface_addrfield = 'ipv4address_b'
-                    alias_addrfield = 'v4address_b'
+            version = ipaddress.ip_interface(ipa).version
+            if idx == 0:
+                # first IP address is always written to `network_interface` table
+                if version == 4:
+                    a_key = 'ipv4address'
+                    b_key = 'ipv4address_b'
+                    v_key = 'vip'
+                    net_key = 'v4netmaskbit'
                 else:
-                    alias_addrfield = iface_addrfield = 'vip'
-                if iface.get(iface_addrfield) or data.get('ipv4_dhcp'):
-                    iface_ip = False
-            else:
-                if field == 'A':
-                    iface_addrfield = 'ipv6address'
-                    alias_addrfield = 'v6address'
-                    netfield = 'v6netmaskbit'
-                elif field == 'B':
-                    iface_addrfield = 'ipv6address_b'
-                    alias_addrfield = 'v6address_b'
-                else:
-                    alias_addrfield = iface_addrfield = 'vipv6address'
-                if iface.get(iface_addrfield) or data.get('ipv6_auto'):
-                    iface_ip = False
+                    a_key = 'ipv6address'
+                    b_key = 'ipv6address_b'
+                    v_key = 'vipv6address'
+                    net_key = 'v6netmaskbit'
 
-            if iface_ip:
-                iface[iface_addrfield] = str(ipaddr.ip)
-                if netfield:
-                    iface[netfield] = ipaddr.network.prefixlen
+                # fill out info
+                iface[a_key] = ipa
+                iface[b_key] = ipb
+                iface[v_key] = ipv
+                iface[net_key] = netmask
             else:
-                cidr = f'{i["address"]}/{i["netmask"]}'
-                aliases[cidr] = {
-                    alias_addrfield: str(ipaddr.ip),
-                }
-                if netfield:
-                    aliases[cidr][netfield] = ipaddr.network.prefixlen
+                # this means it's the 2nd (or more) ip address
+                # on a singular interface so we need to write
+                # this entry to the alias table
+                aliases.append({
+                    'address': ipa,
+                    'address_b': ipb,
+                    'netmask': netmask,
+                    'version': version,
+                    'vip': ipv,
+                })
+
         return iface, aliases
 
     async def __set_lag_ports(self, lag_id, lag_ports):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -21,11 +21,11 @@ class NetworkAliasModel(sa.Model):
 
     id = sa.Column(sa.Integer(), primary_key=True)
     alias_interface_id = sa.Column(sa.Integer(), sa.ForeignKey('network_interfaces.id', ondelete='CASCADE'), index=True)
-    alias_address = sa.Column(sa.String(42), default='')
+    alias_address = sa.Column(sa.String(45), default='')
     alias_version = sa.Column(sa.Integer())
     alias_netmask = sa.Column(sa.Integer())
-    alias_address_b = sa.Column(sa.String(42), default='')
-    alias_vip = sa.Column(sa.String(42), default='')
+    alias_address_b = sa.Column(sa.String(45), default='')
+    alias_vip = sa.Column(sa.String(45), default='')
 
 
 class NetworkBridgeModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1225,7 +1225,6 @@ class InterfaceService(CRUDService):
                     'datastore.query', 'network.interfaces', [('id', '=', interface_id)]
                 ))[0]
             else:
-                interface_attrs, aliases = self.convert_aliases_to_datastore(new)
                 config = config[0]
                 if config['int_interface'] != new['name']:
                     await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1046,7 +1046,7 @@ class InterfaceService(CRUDService):
         }
 
     async def __create_interface_datastore(self, data, attrs):
-        interface_attrs, aliases = self.__convert_aliases_to_datastore(data)
+        interface_attrs, aliases = self.convert_aliases_to_datastore(data)
         interface_attrs.update(attrs)
 
         interface_id = await self.middleware.call(
@@ -1063,7 +1063,8 @@ class InterfaceService(CRUDService):
                 'datastore.insert', 'network.alias', dict(interface=interface_id, **alias), {'prefix': 'alias_'}
             )
 
-    def __convert_aliases_to_datastore(self, data):
+    @private
+    def convert_aliases_to_datastore(self, data):
         da = data['aliases']
         dfa = data.get('failover_aliases', [])
         dfva = data.get('failover_virtual_aliases', [])
@@ -1224,7 +1225,7 @@ class InterfaceService(CRUDService):
                     'datastore.query', 'network.interfaces', [('id', '=', interface_id)]
                 ))[0]
             else:
-                interface_attrs, aliases = self.__convert_aliases_to_datastore(new)
+                interface_attrs, aliases = self.convert_aliases_to_datastore(new)
                 config = config[0]
                 if config['int_interface'] != new['name']:
                     await self.middleware.call(
@@ -1291,7 +1292,7 @@ class InterfaceService(CRUDService):
                 if config['int_pass']:
                     new['failover_pass'] = config['int_pass']
 
-                interface_attrs, new_aliases = self.__convert_aliases_to_datastore(new)
+                interface_attrs, new_aliases = self.convert_aliases_to_datastore(new)
                 await self.middleware.call(
                     'datastore.update', 'network.interfaces', config['id'],
                     dict(**(await self.__convert_interface_datastore(new)), **interface_attrs),

--- a/src/middlewared/middlewared/pytest/unit/plugins/network/test_convert_aliases_to_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/network/test_convert_aliases_to_datastore.py
@@ -1,0 +1,414 @@
+import pytest
+from unittest.mock import Mock
+
+from middlewared.plugins.network import InterfaceService
+
+OBJ = InterfaceService(Mock())
+
+
+non_ha_with_1_v4ip = (
+    {
+        'aliases': [
+            {
+                'address': '1.1.1.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+        ]
+    },
+    (
+        {
+            'ipv4address': '1.1.1.1',
+            'ipv4address_b': '',
+            'v4netmaskbit': 24,
+            'ipv6address': '',
+            'ipv6address_b': '',
+            'v6netmaskbit': '',
+            'vip': '',
+            'vipv6address': '',
+        },
+        []
+    )
+)
+
+non_ha_with_1_v6ip = (
+    {
+        'aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+        ]
+    },
+    (
+        {
+            'ipv4address': '',
+            'ipv4address_b': '',
+            'v4netmaskbit': '',
+            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
+            'ipv6address_b': '',
+            'v6netmaskbit': 64,
+            'vip': '',
+            'vipv6address': '',
+        },
+        []
+    )
+)
+
+non_ha_with_2_v4ips = (
+    {
+        'aliases': [
+            {
+                'address': '1.1.1.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+            {
+                'address': '2.2.2.2',
+                'type': 'INET',
+                'netmask': 24,
+            },
+        ]
+    },
+    (
+        {
+            'ipv4address': '1.1.1.1',
+            'ipv4address_b': '',
+            'v4netmaskbit': 24,
+            'ipv6address': '',
+            'ipv6address_b': '',
+            'v6netmaskbit': '',
+            'vip': '',
+            'vipv6address': '',
+        },
+        [{
+            'address': '2.2.2.2',
+            'address_b': '',
+            'netmask': 24,
+            'version': 4,
+            'vip': '',
+        }]
+    )
+)
+
+non_ha_with_2_v6ips = (
+    {
+        'aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+            {
+                'address': 'aaaa:bbbb:cccc:eeee::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+        ]
+    },
+    (
+        {
+            'ipv4address': '',
+            'ipv4address_b': '',
+            'v4netmaskbit': '',
+            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
+            'ipv6address_b': '',
+            'v6netmaskbit': 64,
+            'vip': '',
+            'vipv6address': '',
+        },
+        [{
+            'address': 'aaaa:bbbb:cccc:eeee::1',
+            'address_b': '',
+            'netmask': 64,
+            'version': 6,
+            'vip': '',
+        }]
+    )
+)
+
+non_ha_with_2_mixed_ips = (
+    {
+        'aliases': [
+            {
+                'address': '1.1.1.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+        ]
+    },
+    (
+        {
+            'ipv4address': '1.1.1.1',
+            'ipv4address_b': '',
+            'v4netmaskbit': 24,
+            'ipv6address': '',
+            'ipv6address_b': '',
+            'v6netmaskbit': '',
+            'vip': '',
+            'vipv6address': '',
+        },
+        [{
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            'address_b': '',
+            'netmask': 64,
+            'version': 6,
+            'vip': '',
+        }]
+    )
+)
+
+ha_with_1_v4ip = (
+    {
+        'aliases': [{
+            'address': '1.1.1.1',
+            'type': 'INET',
+            'netmask': 24,
+        }],
+        'failover_aliases': [{
+            'address': '1.1.1.2',
+            'type': 'INET',
+        }],
+        'failover_virtual_aliases': [{
+            'address': '1.1.1.3',
+            'type': 'INET',
+        }],
+    },
+    (
+        {
+            'ipv4address': '1.1.1.1',
+            'ipv4address_b': '1.1.1.2',
+            'v4netmaskbit': 24,
+            'ipv6address': '',
+            'ipv6address_b': '',
+            'v6netmaskbit': '',
+            'vip': '1.1.1.3',
+            'vipv6address': '',
+        },
+        []
+    )
+)
+
+ha_with_1_v6ip = (
+    {
+        'aliases': [{
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            'type': 'INET6',
+            'netmask': 64,
+        }],
+        'failover_aliases': [{
+            'address': 'aaaa:bbbb:cccc:dddd::2',
+            'type': 'INET6',
+        }],
+        'failover_virtual_aliases': [{
+            'address': 'aaaa:bbbb:cccc:dddd::3',
+            'type': 'INET6',
+        }],
+    },
+    (
+        {
+            'ipv4address': '',
+            'ipv4address_b': '',
+            'v4netmaskbit': '',
+            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
+            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'v6netmaskbit': 64,
+            'vip': '',
+            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+        },
+        []
+    )
+)
+
+ha_with_2_v4ips = (
+    {
+        'aliases': [
+            {
+                'address': '1.1.1.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+            {
+                'address': '2.2.2.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+        ],
+        'failover_aliases': [
+            {
+                'address': '1.1.1.2',
+                'type': 'INET',
+            },
+            {
+                'address': '2.2.2.2',
+                'type': 'INET',
+            },
+        ],
+        'failover_virtual_aliases': [
+            {
+                'address': '1.1.1.3',
+                'type': 'INET',
+            },
+            {
+                'address': '2.2.2.3',
+                'type': 'INET'
+            },
+        ],
+    },
+    (
+        {
+            'ipv4address': '1.1.1.1',
+            'ipv4address_b': '1.1.1.2',
+            'v4netmaskbit': 24,
+            'ipv6address': '',
+            'ipv6address_b': '',
+            'v6netmaskbit': '',
+            'vip': '1.1.1.3',
+            'vipv6address': '',
+        },
+        [{
+            'address': '2.2.2.1',
+            'address_b': '2.2.2.2',
+            'netmask': 24,
+            'version': 4,
+            'vip': '2.2.2.3'
+        }]
+    )
+)
+
+
+ha_with_2_v6ips = (
+    {
+        'aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+            {
+                'address': 'aaaa:bbbb:3333:eeee::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+        ],
+        'failover_aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::2',
+                'type': 'INET6',
+            },
+            {
+                'address': 'aaaa:bbbb:3333:eeee::2',
+                'type': 'INET6',
+            },
+        ],
+        'failover_virtual_aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::3',
+                'type': 'INET6',
+            },
+            {
+                'address': 'aaaa:bbbb:3333:eeee::3',
+                'type': 'INET6',
+            },
+        ],
+    },
+    (
+        {
+            'ipv4address': '',
+            'ipv4address_b': '',
+            'v4netmaskbit': '',
+            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
+            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'v6netmaskbit': 64,
+            'vip': '',
+            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+        },
+        [{
+            'address': 'aaaa:bbbb:3333:eeee::1',
+            'address_b': 'aaaa:bbbb:3333:eeee::2',
+            'netmask': 64,
+            'version': 6,
+            'vip': 'aaaa:bbbb:3333:eeee::3'
+        }]
+    )
+)
+
+ha_with_2_mixed_ips = (
+    {
+        'aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::1',
+                'type': 'INET6',
+                'netmask': 64,
+            },
+            {
+                'address': '1.1.1.1',
+                'type': 'INET',
+                'netmask': 24,
+            },
+        ],
+        'failover_aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::2',
+                'type': 'INET6',
+            },
+            {
+                'address': '1.1.1.2',
+                'type': 'INET',
+            },
+        ],
+        'failover_virtual_aliases': [
+            {
+                'address': 'aaaa:bbbb:cccc:dddd::3',
+                'type': 'INET6',
+            },
+            {
+                'address': '1.1.1.3',
+                'type': 'INET',
+            },
+        ],
+    },
+    (
+        {
+            'ipv4address': '',
+            'ipv4address_b': '',
+            'v4netmaskbit': '',
+            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
+            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'v6netmaskbit': 64,
+            'vip': '',
+            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+        },
+        [{
+            'address': '1.1.1.1',
+            'address_b': '1.1.1.2',
+            'netmask': 24,
+            'version': 4,
+            'vip': '1.1.1.3'
+        }]
+    )
+)
+
+
+@pytest.mark.parametrize('data, result', [
+    non_ha_with_1_v4ip,
+    non_ha_with_1_v6ip,
+    non_ha_with_2_v4ips,
+    non_ha_with_2_v6ips,
+    non_ha_with_2_mixed_ips,
+    ha_with_1_v4ip,
+    ha_with_1_v6ip,
+    ha_with_2_v4ips,
+    ha_with_2_v6ips,
+    ha_with_2_mixed_ips
+])
+def test_convert_aliases_to_datastore(data, result):
+    iface, aliases = OBJ.convert_aliases_to_datastore(data)
+    assert iface == result[0]
+    assert aliases == result[1]


### PR DESCRIPTION
This fixes many problems:
1. as far back as I can glean from git history we have been incorrectly writing to the `network_alias` table on an HA system. If 2+ ip addresses are added to an interface, then we create a _separate_ entry for each controller IP and the VIP in the `network_alias` table (so 3 total entries in `network_alias` for every IP added to an interface) instead of making it 1 singular table entry in the db. I've written a migration script to fix this.
2. we designed the `network_alias` table to store an IPv4 _and_ an IPV6 address on a singular table entry. This made the backend logic overly complex and prone to many failure scenarios. Furthermore, it has never worked because of the issue I describe in step # 1. In the migration script, I'm redoing the `network_alias` table so that we do not store a v4 and/or a v6 entry in the table. Instead, there is an `alias_version` column which will be `4` or `6` respectively to represent the IP version. I've further simplified the columns in the `network_alias` table to make logic vastly simpler.
3. it's possible to have a `int_ipv4address` _AND_ an `int_ipv6address` entry in the `network_interfaces` table for an interface. However, we weren't properly handling this logic in `interface/configure.py` so I've resolved that problem.
4. `network_alias` table on SCALE HA systems were just ignored completely in `interface/configure.py` so I've fixed this issue
5. because of all these changes, it fixes a `KeyError` crash on SCALE HA when adding a 2nd (or more) ip to an interface

Finally, I've added changes so that `convert_aliases_to_datastores` can be unit tested and written the associated unit tests.  I'd much rather not have this situation happen again 😄 