### PR TITLE
NAS-113776 / 12.0 / Fix TLS certificate issue on Minio web console

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
@@ -1,0 +1,57 @@
+"""Add tls_server_uri to s3 config
+
+Revision ID: 9c11f6c6f152
+Revises: fee786dfe121
+Create Date: 2021-12-22 12:59:17.737066+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from OpenSSL import crypto
+
+# revision identifiers, used by Alembic.
+revision = '9c11f6c6f152'
+down_revision = 'fee786dfe121'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_s3', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('s3_tls_server_uri', sa.String(length=128), nullable=True))
+
+    # Try to get tls_server_uri in following order:
+    # 1. SAN from certificate
+    # 2. Common name from certificate
+    # 3. Fallback to localhost
+    conn = op.get_bind()
+    if s3_conf := conn.execute("SELECT s3_certificate_id FROM services_s3 WHERE s3_certificate_id IS NOT NULL").fetchone():
+        if cert_data := conn.execute("SELECT cert_certificate FROM system_certificate WHERE id = :cert_id", cert_id=s3_conf[0]).fetchone():
+            s3_tls_server_uri = 'localhost'
+            try:
+                cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_data[0])
+                cert_cn = cert.get_subject().CN
+                cert_san = []
+                for ext in filter(lambda e: e.get_short_name().decode() != 'UNDEF', (
+                    map(lambda i: cert.get_extension(i), range(cert.get_extension_count()))
+                    if isinstance(cert, crypto.X509)
+                    else cert.get_extensions()
+                )):
+                    if 'subjectAltName' == ext.get_short_name().decode():
+                        cert_san = [s.strip() for s in ext.__str__().split(',') if s]
+                if cert_san:
+                    s3_tls_server_uri = cert_san[0].split(':')[-1].strip()
+                elif cert_cn:
+                    s3_tls_server_uri = cert_cn
+            except Exception:
+                pass
+
+            conn.execute(
+                "UPDATE services_s3 SET s3_tls_server_uri = :s3_tls_server_uri",
+                s3_tls_server_uri=s3_tls_server_uri
+            )
+
+
+def downgrade():
+    with op.batch_alter_table('services_s3', schema=None) as batch_op:
+        batch_op.drop_column('s3_tls_server_uri')

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -308,11 +308,13 @@ def s3_config(middleware, context):
     yield f'minio_disks="{path}"'
     yield f'minio_address="{s3["bindip"]}:{s3["bindport"]}"'
     yield 'minio_certs="/usr/local/etc/minio/certs"'
+    minio_server_url = f'MINIO_SERVER_URL=https://{s3["tls_server_uri"]}:{s3["bindport"]} \\\n' if s3['certificate'] else ''
     browser = 'MINIO_BROWSER=off \\\n' if not s3['browser'] else ''
     yield (
         'minio_env="\\\n'
         f'MINIO_ACCESS_KEY={s3["access_key"]} \\\n'
         f'MINIO_SECRET_KEY={s3["secret_key"]} \\\n'
+        f'{minio_server_url}'
         f'{browser}'
         '"'
     )

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -20,6 +20,7 @@ class S3Model(sa.Model):
     s3_disks = sa.Column(sa.String(255), default='')
     s3_certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
     s3_browser = sa.Column(sa.Boolean(), default=True)
+    s3_tls_server_uri = sa.Column(sa.String(128), nullable=True)
 
 
 class S3Service(SystemServiceService):
@@ -58,6 +59,7 @@ class S3Service(SystemServiceService):
         Bool('browser'),
         Str('storage_path'),
         Int('certificate', null=True),
+        Str('tls_server_uri', null=True),
         update=True,
     ))
     async def do_update(self, data):
@@ -112,6 +114,12 @@ class S3Service(SystemServiceService):
             verrors.extend((await self.middleware.call(
                 'certificate.cert_services_validation', new['certificate'], 's3_update.certificate', False
             )))
+
+        if new['certificate'] and not new['tls_server_uri']:
+            verrors.add(
+                's3_update.tls_server_uri',
+                'Please provide at least one SAN or CN(i.e. Common Name) from the attached certificate.'
+            )
 
         if new['bindip'] not in await self.bindip_choices():
             verrors.add('s3_update.bindip', 'Please provide a valid ip address')


### PR DESCRIPTION
We need to set `MINIO_SERVER_URL` in order to fix TLS issue with minio web console.

ref: https://docs.min.io/minio/baremetal/reference/minio-server/minio-server.html#envvar.MINIO_SERVER_URL
> MINIO_SERVER_URL may be necessary if the MinIO Server TLS certificates do not contain any IP Subject Alternative Names (SAN). Specifically, the Console uses the MinIO Server IP address by default. If the Server TLS does not contain that IP address, then the Console cannot validate the TLS connection.

With self-signed cert configured:
<img width="1350" alt="Screen Shot 2021-12-22 at 8 49 11 PM" src="https://user-images.githubusercontent.com/7848408/147150507-887e91e3-6db9-49c8-91e7-5b7e31b4530b.png">
