### PR TITLE
NAS-113494 / 13.0 / speed up disk wiping (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -46,20 +46,17 @@ class DiskService(Service):
                 for i in range(_32):
                     # wipe first 32MB
                     os.write(f.fileno(), to_write)
-                    os.fsync(f.fileno())
 
                 # seek to 32MB before end of drive
                 os.lseek(f.fileno(), (size - (CHUNK * _32)), os.SEEK_SET)
                 for i in range(_32):
                     # wipe last 32MB
                     os.write(f.fileno(), to_write)
-                    os.fsync(f.fileno())
             else:
                 iterations = (size // CHUNK)
                 length = len(str(iterations))
                 for i in range(iterations):
                     os.write(f.fileno(), to_write)
-                    os.fsync(f.fileno())
                     data['job'].set_progress(float(f'{i / iterations:.{length}f}') * 100)
 
     @accepts(


### PR DESCRIPTION
On CORE `os.fsync` doesn't get propagated down to the disk by design so it's a NO-OP. However, on SCALE it seems to do that on some disks which makes wiping disks abysmally slow. This isn't needed in either scenario so remove it.

Original PR: https://github.com/truenas/middleware/pull/8034
Jira URL: https://jira.ixsystems.com/browse/NAS-113494