### PR TITLE
NAS-113791 / 22.02 / dont forcefully run fenced on single controllers

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/fenced.py
+++ b/src/middlewared/middlewared/plugins/failover_/fenced.py
@@ -117,7 +117,7 @@ async def hook_pool_event(middleware, *args, **kwargs):
         except CallError as e:
             middleware.logger.error('Failed to reload fenced: %r', e)
     else:
-        force = True
+        force = False
         use_zpools = True
         rc = await middleware.call('failover.fenced.start', force, use_zpools)
         if rc:


### PR DESCRIPTION
This causes a boot loop on HA systems that have not been licensed for HA. Each controller will think they're single controllers and then forcefully start fenced which preempts any reservations on the disks therefore causing boot loops.