### PR TITLE
NAS-113791 / 13.0 / dont forcefully run fenced on single controllers (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/fenced.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/fenced.py
@@ -100,7 +100,7 @@ async def _run_fenced_on_single_node(middleware, event_type, args):
         # in the fenced program for this scenario, however, best to
         # play it safe
         await middleware.call('failover.fenced.stop')
-        rc = await middleware.call('failover.fenced.start', {'force': True})
+        rc = await middleware.call('failover.fenced.start')
         for i in FencedExitCodes:
             if rc == i.value:
                 middleware.logger.error(f'Fenced failed to start because: {i.name}')


### PR DESCRIPTION
This causes a boot loop on HA systems that have not been licensed for HA. Each controller will think they're single controllers and then forcefully start fenced which preempts any reservations on the disks therefore causing boot loops.

Original PR: https://github.com/truenas/middleware/pull/8036
Jira URL: https://jira.ixsystems.com/browse/NAS-113791