### PR TITLE
NAS-113958 / 13.0 / fix issues in disk_info_freebsd.py

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -3,6 +3,8 @@ import re
 from xml.etree import ElementTree as etree
 
 import bsd
+import bsd.geom
+import bsd.disk
 import sysctl
 from middlewared.service import Service
 from .disk_info_base import DiskInfoBase

--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -85,14 +85,16 @@ class DiskService(Service, DiskInfoBase):
         label_to_dev = {}
         for label in bsd.geom.class_by_name('LABEL').xml:
             if (name := label.find('name')) is not None:
-                if (provider := label.find('provider/name')) is not None:
-                    label_to_dev[provider.text] = name.text
+                for provider in label.iterfind('provider'):
+                    if (prov := provider.find('name')) is not None:
+                        label_to_dev[prov.text] = name.text
 
         dev_to_disk = {}
         for label in bsd.geom.class_by_name('PART').xml:
             if (name := label.find('name')) is not None:
-                if (provider := label.find('provider/name')) is not None:
-                    dev_to_disk[provider.text] = name.text
+                for provider in label.iterfind('provider'):
+                    if (prov := provider.find('name')) is not None:
+                        dev_to_disk[prov.text] = name.text
 
         return {
             'label_to_dev': label_to_dev,


### PR DESCRIPTION
1. `py-bsd` is designed in a way where `bsd.geom` is the module itself so you can't `import bsd` and get to it
2. missing cherry-pick from 12 65f2d491b8e424bb691fb93dc9c5b5a4b4932b78