### PR TITLE
NAS-113958 / 12.0 / fix import issue in disk_info_freebsd.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -3,6 +3,8 @@ import re
 from xml.etree import ElementTree as etree
 
 import bsd
+import bsd.geom
+import bsd.disk
 import sysctl
 from middlewared.service import Service
 from .disk_info_base import DiskInfoBase


### PR DESCRIPTION
`py-bsd` is designed in a way where `bsd.geom` is the module itself so you can't `import bsd` and get to it


Original PR: https://github.com/truenas/middleware/pull/8040
Jira URL: https://jira.ixsystems.com/browse/NAS-113958