### PR TITLE
NAS-113951 / 22.02 / Tune test_filesystem__file_tail_follow__grouping timings and mark it as flaky

### DIFF
--- a/tests/api2/test_filesystem__file_tail_follow.py
+++ b/tests/api2/test_filesystem__file_tail_follow.py
@@ -14,6 +14,7 @@ reason = 'Skip for testing'
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=5)
 def test_filesystem__file_tail_follow__grouping():
     ssh("echo > /tmp/file_tail_follow.txt")
 
@@ -34,9 +35,9 @@ def test_filesystem__file_tail_follow__grouping():
         # We were sending this for 2-3 seconds so we should have received 4-6 blocks with 0.5 sec interval
         assert 4 <= len(received) <= 6, str(received)
         # All blocks should have been received uniformly in time
-        assert all(0.4 <= b2[0] - b1[0] <= 0.6 for b1, b2 in zip(received[:-1], received[1:])), str(received)
+        assert all(0.4 <= b2[0] - b1[0] <= 1.0 for b1, b2 in zip(received[:-1], received[1:])), str(received)
         # All blocks should contains more or less same amount of data
-        assert all(30 <= len(block[1].split("\n")) <= 50 for block in received[:-1]), str(received)
+        assert all(30 <= len(block[1].split("\n")) <= 60 for block in received[:-1]), str(received)
 
         # One single send
         ssh("echo finish >> /tmp/file_tail_follow.txt")


### PR DESCRIPTION
@ericbsd test runner will need to have https://pypi.org/project/pytest-rerunfailures/