### PR TITLE
NAS-113277 / 22.02 / Improve validation for GPU isolation

### DIFF
--- a/src/middlewared/middlewared/plugins/device.py
+++ b/src/middlewared/middlewared/plugins/device.py
@@ -36,6 +36,7 @@ class DeviceService(Service):
             )]),
             Str('vendor', required=True, null=True),
             Bool('available_to_host', required=True),
+            Bool('uses_system_critical_devices', required=True),
         ),
         ]),
         Dict('disk_info', additional_attrs=True),

--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -47,7 +47,7 @@ def get_gpus():
                 'pci_slot': child['PCI_SLOT_NAME'],
                 'vm_pci_slot': f'pci_{child["PCI_SLOT_NAME"].replace(".", "_").replace(":", "_")}',
             })
-            critical = any(
+            critical |= any(
                 k in child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '').lower() for k in ('host bridge', 'memory')
             )
 


### PR DESCRIPTION
This PR adds changes to improve validation to disallow GPUs to be isolated which might have devices which are critical for the system to function. For now we have added checks to see if the device is potentially host bridge or a memory device and in that case disallowing the GPU to be isolated from the host.