### PR TITLE
NAS-114015 / 22.02 / Make sure we allow exporting pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1486,10 +1486,10 @@ class PoolService(CRUDService):
         be disabled before exporting the last zpool on the system.
         """
         pool = await self.get_instance(oid)
-        root_ds = await self.middleware.call('pool.dataset.get_instance', pool['name'])
-        if root_ds['locked'] and os.path.exists(root_ds['mountpoint']):
+        root_ds = await self.middleware.call('pool.dataset.query', [['id', '=', pool['name']]])
+        if root_ds and root_ds[0]['locked'] and os.path.exists(root_ds[0]['mountpoint']):
             # We should be removing immutable flag in this case if the path exists
-            await self.middleware.call('filesystem.set_immutable', False, root_ds['mountpoint'])
+            await self.middleware.call('filesystem.set_immutable', False, root_ds[0]['mountpoint'])
 
         pool_count = await self.middleware.call('pool.query', [], {'count': True})
         if pool_count == 1 and await self.middleware.call('failover.licensed'):


### PR DESCRIPTION
This commit adds changes to fix an issue where we were looking up root dataset which in the case when the pool hasn't been imported yet and only exists in database will fail. We should make sure we still allow user to remove such pools from the database.