### PR TITLE
NAS-114018 / 22.02 / Initialize nss_winbind to use /var/empty as homedir

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -141,7 +141,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             home_share = await self.middleware.call('sharing.smb.reg_showshare', 'homes')
             home_path = home_share['parameters']['path']['raw']
         except MatchNotFound:
-            home_path = 'home'
+            home_path = '/var/empty'
 
         data_out['template homedir'] = {"parsed": f'{home_path}'}
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -530,6 +530,18 @@ class SMBService(TDBWrapConfigService):
 
         await self.middleware.call('idmap.synchronize')
 
+        """
+        Since some NSS modules will default to setting home directory to /var/empty,
+        verify that this path is immutable during setup for SMB service (prior to
+        initializing directory services).
+        """
+        try:
+            is_immutable = await self.middleware.call('filesystem.is_immutable', '/var/empty')
+            if not is_immutable:
+                await self.middleware.call('filesystem.set_immutable', True, '/var/empty')
+        except Exception:
+            self.logger.warning("Failed to set immutable flag on /var/empty", exc_info=True)
+
         job.set_progress(30, 'Setting up server SID.')
         await self.middleware.call('smb.set_sid', data['cifs_SID'])
 


### PR DESCRIPTION
Default in samba is to use /home/%D/%U for the 
template homedir in nss_winbind, but this carries risk of
writing data on boot device and accordingly risk of data
loss if said device fails. This PR adds a validation
step during SMB server setup (directory services setup actually)
where we ensure that immutable flag is set on /var/empty.
This is as a backstop to prevent accidental writes to this
path when it is used as a default by NSS modules.