### PR TITLE
NAS-113980 / 13.0 / Update configuration to match upstream

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -353,6 +353,7 @@ class SharingSMBService(Service):
             data['vfsobjects'].append('worm')
 
         if data['streams']:
+            conf['smbd max xattr size'] = '2097152'
             data['vfsobjects'].append('streams_xattr')
 
         conf["vfs objects"] = await self.order_vfs_objects(data['vfsobjects'])


### PR DESCRIPTION
During the upstream review process, the name and default value for this
parameter changed. Set default max value for xattr up to 2MiB from
64 KiB.