### PR TITLE
NAS-113987 / 22.02 / Performance improvement(s) when querying chart releases

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -613,6 +613,8 @@ class ChartReleaseService(CRUDService):
             if cp.returncode:
                 raise CallError(f'Failed to {tn_action} chart release: {stderr.decode()}')
 
+        self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)
+
     @accepts(Str('release_name'))
     @returns(ENTRY)
     @job(lock=lambda args: f'chart_release_redeploy_{args[0]}')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -160,11 +160,17 @@ class ChartReleaseService(CRUDService):
                 {'port': p['node_port'], 'protocol': p['protocol']} for p in node_port_svc['spec']['ports']
             ])
 
-        storage_mapping = await self.middleware.call('chart.release.get_workload_storage_details')
+        if get_resources:
+            storage_mapping = await self.middleware.call('chart.release.get_workload_storage_details')
+
         resources_mapping = await self.middleware.call('chart.release.get_resources_with_workload_mapping', {
             'resource_events': extra.get('resource_events', False),
             'resource_filters': resources_filters,
-            'resources': [r.name for r in Resources],
+            'resources': [
+                r.name for r in (
+                    Resources if get_resources else [Resources.POD, Resources.DEPLOYMENT, Resources.STATEFULSET]
+                )
+            ],
         })
         resources = resources_mapping['resources']
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -160,24 +160,7 @@ class ChartReleaseService(CRUDService):
                 {'port': p['node_port'], 'protocol': p['protocol']} for p in node_port_svc['spec']['ports']
             ])
 
-        storage_classes = collections.defaultdict(lambda: None)
-        for storage_class in await self.middleware.call('k8s.storage_class.query'):
-            storage_classes[storage_class['metadata']['name']] = storage_class
-
-        persistent_volumes = collections.defaultdict(list)
-
-        # If the chart release was consuming any PV's, they would have to be manually removed from k8s database
-        # because of chart release reclaim policy being retain
-        for pv in await self.middleware.call(
-            'k8s.pv.query', [[
-                'spec.csi.volume_attributes.openebs\\.io/poolname', '^',
-                f'{os.path.join(k8s_config["dataset"], "releases")}/'
-            ]]
-        ):
-            dataset = pv['spec']['csi']['volume_attributes']['openebs.io/poolname']
-            rl = dataset.split('/', 4)
-            if len(rl) > 4:
-                persistent_volumes[rl[3]].append(pv)
+        storage_mapping = await self.middleware.call('chart.release.get_workload_storage_details')
 
         resources = {r.value: collections.defaultdict(list) for r in Resources}
         workload_status = collections.defaultdict(lambda: {'desired': 0, 'available': 0})
@@ -233,8 +216,8 @@ class ChartReleaseService(CRUDService):
             })
 
             release_resources = {
-                'storage_class': storage_classes[get_storage_class_name(name)],
-                'persistent_volumes': persistent_volumes[name],
+                'storage_class': storage_mapping['storage_classes'][get_storage_class_name(name)],
+                'persistent_volumes': storage_mapping['persistent_volumes'][name],
                 'host_path_volumes': await self.host_path_volumes(itertools.chain(
                     *[resources[getattr(Resources, k).value][name] for k in ('DEPLOYMENT', 'STATEFULSET')]
                 )),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -1,4 +1,3 @@
-import base64
 import collections
 import copy
 import errno
@@ -13,7 +12,7 @@ from pkg_resources import parse_version
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str, returns
 from middlewared.service import CallError, CRUDService, filterable, job, private
-from middlewared.utils import filter_list, get
+from middlewared.utils import filter_list
 from middlewared.validators import Match
 
 from .utils import (
@@ -341,81 +340,6 @@ class ChartReleaseService(CRUDService):
         else:
             app_version = release_data['chart_metadata'].get('appVersion')
         return app_version
-
-    @private
-    def retrieve_portals_for_chart_release(self, release_data, node_ip=None):
-        questions_yaml_path = os.path.join(
-            release_data['path'], 'charts', release_data['chart_metadata']['version'], 'questions.yaml'
-        )
-        if not os.path.exists(questions_yaml_path):
-            return {}
-
-        with open(questions_yaml_path, 'r') as f:
-            portals = yaml.safe_load(f.read()).get('portals') or {}
-
-        if not portals:
-            return portals
-
-        if not node_ip:
-            node_ip = self.middleware.call_sync('kubernetes.node_ip')
-
-        def tag_func(key):
-            return self.parse_tag(release_data, key, node_ip)
-
-        cleaned_portals = {}
-        for portal_type, schema in portals.items():
-            t_portals = []
-            path = schema.get('path') or '/'
-            for protocol in filter(bool, map(tag_func, schema['protocols'])):
-                for host in filter(bool, map(tag_func, schema['host'])):
-                    for port in filter(bool, map(tag_func, schema['ports'])):
-                        t_portals.append(f'{protocol}://{host}:{port}{path}')
-
-            cleaned_portals[portal_type] = t_portals
-
-        return cleaned_portals
-
-    @private
-    def parse_tag(self, release_data, tag, node_ip):
-        tag = self.parse_k8s_resource_tag(release_data, tag)
-        if not tag:
-            return
-        if tag == '$node_ip':
-            return node_ip
-        elif tag.startswith('$variable-'):
-            return get(release_data['config'], tag[len('$variable-'):])
-
-        return tag
-
-    @private
-    def parse_k8s_resource_tag(self, release_data, tag):
-        # Format expected here is "$kubernetes-resource_RESOURCE-TYPE_RESOURCE-NAME_KEY-NAME"
-        if not tag.startswith('$kubernetes-resource'):
-            return tag
-
-        if tag.count('_') < 3:
-            return
-
-        _, resource_type, resource_name, key = tag.split('_', 3)
-        if resource_type not in ('configmap', 'secret'):
-            return
-
-        resource = self.middleware.call_sync(
-            f'k8s.{resource_type}.query', [
-                ['metadata.namespace', '=', release_data['namespace']], ['metadata.name', '=', resource_name]
-            ]
-        )
-        if not resource or 'data' not in resource[0] or not isinstance(resource[0]['data'].get(key), (int, str)):
-            # Chart creator did not create the resource or we have a malformed
-            # secret/configmap, nothing we can do on this end
-            return
-        else:
-            value = resource[0]['data'][key]
-
-        if resource_type == 'secret':
-            value = base64.b64decode(value)
-
-        return str(value)
 
     @private
     async def host_path_volumes(self, resources):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -566,6 +566,7 @@ class ChartReleaseService(CRUDService):
         await self.post_remove_tasks(release_name, job)
 
         await self.middleware.call('chart.release.remove_chart_release_from_events_state', release_name)
+        await self.middleware.call('chart.release.clear_chart_release_portal_cache', release_name)
         await self.middleware.call('alert.oneshot_delete', 'ChartReleaseUpdate', release_name)
 
         job.set_progress(100, f'{release_name!r} chart release deleted')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -1,0 +1,87 @@
+import base64
+import os
+import yaml
+
+from middlewared.service import private, Service
+from middlewared.utils import get
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    def retrieve_portals_for_chart_release(self, release_data, node_ip=None):
+        questions_yaml_path = os.path.join(
+            release_data['path'], 'charts', release_data['chart_metadata']['version'], 'questions.yaml'
+        )
+        if not os.path.exists(questions_yaml_path):
+            return {}
+
+        with open(questions_yaml_path, 'r') as f:
+            portals = yaml.safe_load(f.read()).get('portals') or {}
+
+        if not portals:
+            return portals
+
+        if not node_ip:
+            node_ip = self.middleware.call_sync('kubernetes.node_ip')
+
+        def tag_func(key):
+            return self.parse_tag(release_data, key, node_ip)
+
+        cleaned_portals = {}
+        for portal_type, schema in portals.items():
+            t_portals = []
+            path = schema.get('path') or '/'
+            for protocol in filter(bool, map(tag_func, schema['protocols'])):
+                for host in filter(bool, map(tag_func, schema['host'])):
+                    for port in filter(bool, map(tag_func, schema['ports'])):
+                        t_portals.append(f'{protocol}://{host}:{port}{path}')
+
+            cleaned_portals[portal_type] = t_portals
+
+        return cleaned_portals
+
+    @private
+    def parse_tag(self, release_data, tag, node_ip):
+        tag = self.parse_k8s_resource_tag(release_data, tag)
+        if not tag:
+            return
+        if tag == '$node_ip':
+            return node_ip
+        elif tag.startswith('$variable-'):
+            return get(release_data['config'], tag[len('$variable-'):])
+
+        return tag
+
+    @private
+    def parse_k8s_resource_tag(self, release_data, tag):
+        # Format expected here is "$kubernetes-resource_RESOURCE-TYPE_RESOURCE-NAME_KEY-NAME"
+        if not tag.startswith('$kubernetes-resource'):
+            return tag
+
+        if tag.count('_') < 3:
+            return
+
+        _, resource_type, resource_name, key = tag.split('_', 3)
+        if resource_type not in ('configmap', 'secret'):
+            return
+
+        resource = self.middleware.call_sync(
+            f'k8s.{resource_type}.query', [
+                ['metadata.namespace', '=', release_data['namespace']], ['metadata.name', '=', resource_name]
+            ]
+        )
+        if not resource or 'data' not in resource[0] or not isinstance(resource[0]['data'].get(key), (int, str)):
+            # Chart creator did not create the resource or we have a malformed
+            # secret/configmap, nothing we can do on this end
+            return
+        else:
+            value = resource[0]['data'][key]
+
+        if resource_type == 'secret':
+            value = base64.b64decode(value)
+
+        return str(value)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
@@ -164,6 +164,7 @@ class ChartReleaseService(Service):
         await self.middleware.call(
             'chart.release.scale_release_internal', release['resources'], None, scale_stats['before_scale'], True,
         )
+        await self.middleware.call('chart.release.clear_chart_release_portal_cache', release_name)
 
         job.set_progress(100, 'Rollback complete for chart release')
 

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -10,6 +10,10 @@ class KubernetesService(SimpleService):
     etc = ['k3s']
     systemd_unit = 'k3s'
 
+    async def clear_chart_releases_cache(self):
+        await self.middleware.call('chart.release.clear_cached_chart_releases')
+        await self.middleware.call('chart.release.clear_portal_cache')
+
     async def before_start(self):
         try:
             await self.middleware.call('kubernetes.validate_k8s_fs_setup')
@@ -24,6 +28,8 @@ class KubernetesService(SimpleService):
                 await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
             raise
+
+        await self.clear_chart_releases_cache()
 
         for key, value in (
             ('vm.panic_on_oom', 0),
@@ -53,7 +59,7 @@ class KubernetesService(SimpleService):
     async def before_stop(self):
         await self.middleware.call('k8s.node.add_taints', [{'key': 'ix-svc-stop', 'effect': 'NoExecute'}])
         await asyncio.sleep(10)
-        await self.middleware.call('chart.release.clear_cached_chart_releases')
+        await self.clear_chart_releases_cache()
         await self.middleware.call('kubernetes.remove_iptables_rules')
 
     async def after_stop(self):


### PR DESCRIPTION
This PR adds following changes:
1. Cache normalized portals to avoid querying up data from disk each time we want to list installed apps as with large number of disks, the time to do this increases dramatically. With just this change alone and having 20 apps with reasonable number of web portals, it used to take 20 secs before approximately and after caching, this gets us to 2 secs almost.
2. Do not unnecessarily retrieve data of all resources and only do that for resources where it's absolutely required.

With these changes we are approximately at 0.8-1.1 seconds for listing 20 installed apps from approximately 20 secs.