### PR TITLE
NAS-113892 / 22.02 / Improve feedback on manual SMART test for nvme disks

### DIFF
--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -377,17 +377,22 @@ class SMARTTestService(CRUDService):
                 'Please specify at least one disk.'
             )
         else:
-            disks_choices = await self.disk_choices(True)
+            supported_disks = await self.disk_choices(True)
             devices = await self.middleware.call('device.get_storage_devices_topology')
-
+            valid_disks = [
+                disk['identifier']
+                for disk in await self.middleware.call('disk.query', [
+                    ('identifier', 'in', [disk['identifier'] for disk in disks])
+                ], {'force_sql_filters': True})
+            ]
             for index, disk in enumerate(disks):
-                if current_disk := disks_choices.get(disk['identifier']):
+                if current_disk := supported_disks.get(disk['identifier']):
                     test_disks_list.append({
                         'disk': current_disk['name'],
                         **disk
                     })
                 else:
-                    if await self.middleware.call('disk.query', [('identifier', '=', disk['identifier'])]):
+                    if disk['identifier'] in valid_disks:
                         verrors.add(
                             f'disks.{index}.identifier',
                             f'{disk["identifier"]} does not support S.M.A.R.T test.'

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -387,10 +387,16 @@ class SMARTTestService(CRUDService):
                         **disk
                     })
                 else:
-                    verrors.add(
-                        f'disks.{index}.identifier',
-                        f'{disk["identifier"]} is not valid. Please provide a valid disk identifier.'
-                    )
+                    if await self.middleware.call('disk.query', [('identifier', '=', disk['identifier'])]):
+                        verrors.add(
+                            f'disks.{index}.identifier',
+                            f'{disk["identifier"]} does not support S.M.A.R.T test.'
+                        )
+                    else:
+                        verrors.add(
+                            f'disks.{index}.identifier',
+                            f'{disk["identifier"]} is not valid. Please provide a valid disk identifier.'
+                        )
                     continue
 
                 if current_disk['name'] is None:


### PR DESCRIPTION
```
❯ midclt call -job smart.test.manual_test '[{"identifier": "{serial}xxx", "type": "SHORT"}]'
[EINVAL] disks.0.identifier: {serial}xxx is an nvme disk. We do not support S.M.A.R.T test for nvme disks.
```