### PR TITLE
NAS-114031 / 22.02 / Correctly use tag reference when updating chart release images

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -417,6 +417,10 @@ class ChartReleaseService(Service):
         )
         for reference in results['resources']['container_images']:
             parsed_reference = await self.middleware.call('container.image.normalize_reference', reference)
+            if parsed_reference['reference_is_digest']:
+                # There is no point in trying to update an image when we have a digest as the tag
+                continue
+
             bulk_pull_params.append([{
                 'from_image': parsed_reference['reference'].rsplit(':', 1)[0],
                 'tag': parsed_reference['tag']

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -418,7 +418,7 @@ class ChartReleaseService(Service):
         for reference in results['resources']['container_images']:
             parsed_reference = await self.middleware.call('container.image.normalize_reference', reference)
             bulk_pull_params.append([{
-                'from_image': f"{parsed_reference['registry']}/{parsed_reference['image']}",
+                'from_image': parsed_reference['reference'].rsplit(':', 1)[0],
                 'tag': parsed_reference['tag']
             }])
             parsed_references.append(parsed_reference)

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -36,6 +36,7 @@ def normalize_reference(reference: str) -> Dict:
 
     # At this point, tag should be included already – we just need to see whether this
     # tag is named or digested and respond accordingly.
+    ref_is_digest = False
     if '@' in tagged_image:
         matches = re.findall(DIGEST_RE, tagged_image)
         if not matches:
@@ -45,6 +46,7 @@ def normalize_reference(reference: str) -> Dict:
         tag_pos = tagged_image.find(tag)
         image = tagged_image[:tag_pos - 1].rsplit(':', 1)[0]
         sep = '@'
+        ref_is_digest = True
     elif ':' in tagged_image:
         image, tag = tagged_image.rsplit(':', 1)
         sep = ':'
@@ -55,4 +57,5 @@ def normalize_reference(reference: str) -> Dict:
         'tag': tag,
         'registry': registry,
         'complete_tag': f'{registry}/{image}{sep}{tag}',
+        'reference_is_digest': ref_is_digest,
     }

--- a/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
@@ -10,6 +10,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'latest',
         'registry': 'registry-1.docker.io',
         'complete_tag': 'registry-1.docker.io/library/redis:latest',
+        'reference_is_digest': False,
     }),
     ('redis:12.1', {
         'reference': 'redis:12.1',
@@ -17,6 +18,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': '12.1',
         'registry': 'registry-1.docker.io',
         'complete_tag': 'registry-1.docker.io/library/redis:12.1',
+        'reference_is_digest': False,
     }),
     ('redis:12.1', {
         'reference': 'redis:12.1',
@@ -24,6 +26,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': '12.1',
         'registry': 'registry-1.docker.io',
         'complete_tag': 'registry-1.docker.io/library/redis:12.1',
+        'reference_is_digest': False,
     }),
     ('redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546', {
         'reference': 'redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
@@ -31,6 +34,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
         'registry': 'registry-1.docker.io',
         'complete_tag': 'registry-1.docker.io/library/redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'reference_is_digest': True,
     }),
     ('redis:12.1@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546', {
         'reference': 'redis:12.1@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
@@ -38,6 +42,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
         'registry': 'registry-1.docker.io',
         'complete_tag': 'registry-1.docker.io/library/redis@sha256:54ee15a0b0d2c661d46b9bfbf55b181f9a4e7ddf8bf693eec5703dac2c0f5546',
+        'reference_is_digest': True,
     }),
     ('ghcr.io/k8s-at-home/transmission', {
         'reference': 'ghcr.io/k8s-at-home/transmission',
@@ -45,6 +50,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'latest',
         'registry': 'ghcr.io',
         'complete_tag': 'ghcr.io/k8s-at-home/transmission:latest',
+        'reference_is_digest': False,
     }),
     ('ghcr.io/k8s-at-home/transmission:v3.00', {
         'reference': 'ghcr.io/k8s-at-home/transmission:v3.00',
@@ -52,6 +58,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'v3.00',
         'registry': 'ghcr.io',
         'complete_tag': 'ghcr.io/k8s-at-home/transmission:v3.00',
+        'reference_is_digest': False,
     }),
     ('ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6', {
         'reference': 'ghcr.io/k8s-at-home/transmission:v3.00@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
@@ -59,6 +66,7 @@ from middlewared.plugins.docker_linux.utils import normalize_reference
         'tag': 'sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
         'registry': 'ghcr.io',
         'complete_tag': 'ghcr.io/k8s-at-home/transmission@sha256:355f4036c53c782df1957de0e16c63f4298f5b596ae5e621fea8f9ef02dd09e6',
+        'reference_is_digest': True,
     })
 ])
 def test_normalize_reference(reference, expected_results):


### PR DESCRIPTION
When we have a chart release consuming an image like `nextcloud:23`, if we normalize the tag, we have something like `registry-1.docker.io/library/nextcloud:23` which is how it's resolved internally by docker but the actual tag reference is still `nextcloud:23`.

To clarify, if we try to update app's images, we end up pulling  `registry-1.docker.io/library/nextcloud:23`, however the app is consuming `nextcloud:23` which is still pointing to the old image.

This PR introduces changes to not use the parsed reference but rather consume the app specified tag. It also introduces changes to not try and pull images which have digest as the tag as that doesn't help/work.