### PR TITLE
NAS-114130 / 22.02 / Correctly recognize wg/macvtap interfaces as cloned interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -1,5 +1,7 @@
 from middlewared.service import private, Service
 
+from .netif import netif
+
 
 class InterfaceService(Service):
 
@@ -8,6 +10,4 @@ class InterfaceService(Service):
 
     @private
     async def internal_interfaces(self):
-        return [
-            'wg', 'lo', 'tun', 'tap', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn', 'macvtap',
-        ]
+        return netif.INTERNAL_INTERFACES

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["Interface"]
 
 CLONED_PREFIXES = [
-    'lo', 'tun', 'tap', 'br', 'vlan', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy', 'vnet', 'openvpn',
+    'lo', 'tun', 'tap', 'br', 'vlan', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy', 'vnet', 'openvpn', 'wg',
 ]
 
 

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -5,7 +5,7 @@ from .address import AddressFamily, AddressMixin
 from .bridge import BridgeMixin
 from .bits import InterfaceFlags, InterfaceLinkState
 from .lagg import LaggMixin
-from .utils import bitmask_to_set, run
+from .utils import bitmask_to_set, INTERNAL_INTERFACES, run
 from .vlan import VlanMixin
 from .vrrp import VrrpMixin
 from .ethernet_settings import EthernetHardwareSettings
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["Interface"]
 
-CLONED_PREFIXES = [
-    'lo', 'tun', 'tap', 'br', 'vlan', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy', 'vnet', 'openvpn', 'wg',
-]
+CLONED_PREFIXES = ["br", "vlan", "bond"] + INTERNAL_INTERFACES
 
 
 class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
@@ -4,7 +4,12 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["bitmask_to_set", "run"]
+__all__ = ["bitmask_to_set", "INTERNAL_INTERFACES", "run"]
+
+
+INTERNAL_INTERFACES = [
+    "wg", "lo", "tun", "tap", "docker", "veth", "kube-bridge", "kube-dummy-if", "vnet", "openvpn", "macvtap",
+]
 
 
 def bitmask_to_set(n, enumeration):


### PR DESCRIPTION
This PR adds changes to recognize wg/macvtap interfaces as cloned interfaces and also normalize the internal interfaces usages to avoid duplication.