### PR TITLE
NAS-114116 / 12.0 / Make minio console port configurable (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2022-01-03_11-46_add_s3_console_bindport.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2022-01-03_11-46_add_s3_console_bindport.py
@@ -1,0 +1,26 @@
+"""
+Add s3 console bindport
+
+Revision ID: 37298ef77ee8
+Revises: 9c11f6c6f152
+Create Date: 2022-01-03 11:46:50.848183+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '37298ef77ee8'
+down_revision = '9c11f6c6f152'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_s3', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('s3_console_bindport', sa.SmallInteger(), nullable=False, server_default='9001'))
+
+
+def downgrade():
+    with op.batch_alter_table('services_s3', schema=None) as batch_op:
+        batch_op.drop_column('s3_console_bindport')

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -307,6 +307,7 @@ def s3_config(middleware, context):
     path = s3['storage_path'].replace(' ', '\\ ')
     yield f'minio_disks="{path}"'
     yield f'minio_address="{s3["bindip"]}:{s3["bindport"]}"'
+    yield f'minio_console_address="{s3["bindip"]}:{s3["console_bindport"]}"'
     yield 'minio_certs="/usr/local/etc/minio/certs"'
     minio_server_url = f'MINIO_SERVER_URL=https://{s3["tls_server_uri"]}:{s3["bindport"]} \\\n' if s3['certificate'] else ''
     browser = 'MINIO_BROWSER=off \\\n' if not s3['browser'] else ''

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -14,6 +14,7 @@ class S3Model(sa.Model):
     id = sa.Column(sa.Integer(), primary_key=True)
     s3_bindip = sa.Column(sa.String(128), default='0.0.0.0')
     s3_bindport = sa.Column(sa.SmallInteger(), default=9000)
+    s3_console_bindport = sa.Column(sa.SmallInteger(), default=9001)
     s3_access_key = sa.Column(sa.String(128), default='')
     s3_secret_key = sa.Column(sa.EncryptedText(), default='')
     s3_mode = sa.Column(sa.String(120), default="local")
@@ -52,6 +53,7 @@ class S3Service(SystemServiceService):
         's3_update',
         Str('bindip'),
         Int('bindport', validators=[Range(min=1, max=65535)]),
+        Int('console_bindport', validators=[Range(min=1, max=65535)]),
         Str('access_key', validators=[Match("^\w+$", explanation="Should only contain alphanumeric characters")],
             max_length=20),
         Str('secret_key', validators=[Match("^\w+$", explanation="Should only contain alphanumeric characters")],


### PR DESCRIPTION
>MinIO by default selects a random port for the MinIO Console on each server startup. Browser clients accessing the MinIO Server are automatically redirected to the MinIO Console on its dynamically selected port. This behavior emulates the legacy web browser behavior while reducing the the risk of a port collision on systems which were running MinIO before the embedded Console update.
>
>You can select an explicit static port by passing the minio server --console-address commandline option when starting each MinIO Server in the deployment.

ref: https://docs.min.io/minio/baremetal/console/minio-console.html#static-vs-dynamic-port-assignment


Original PR: https://github.com/truenas/middleware/pull/8082
Jira URL: https://jira.ixsystems.com/browse/NAS-114116