### PR TITLE
NAS-114164 / 12.0 / Disable SMB1 Unix Extensions by default

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -122,6 +122,7 @@
                 'disable spoolss': 'Yes',
                 'dos filemode': 'Yes',
                 'kernel change notify': 'No',
+                'unix extensions': 'No',
                 'directory name cache size': '0',
                 'nsupdate command': '/usr/local/bin/samba-nsupdate -g',
                 'unix charset': db['cifs']['unixcharset'],
@@ -146,7 +147,7 @@
                 pc.update({'server min protocol': 'NT1'})
             else:
                 pc.update({'server min protocol': 'SMB2_02'})
-                pc.update({'unix extensions': 'No'})
+
             if db['cifs']['guest'] != "nobody":
                 try:
                     middleware.call_sync("user.get_user_obj", {"username": db['cifs']['guest']})


### PR DESCRIPTION
This still leaves open option for users to manually enable
through auxiliary parameters.