### PR TITLE
NAS-113961 / 22.02 / Move k3s/kubelet to the ix-applications pool

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/collectd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/collectd.conf.mako
@@ -163,6 +163,7 @@ LoadPlugin zfs_arc_v2
 	Mountpoint "/^\/boot/"
 	Mountpoint "/^\/mnt\/[^/]+\/ix-applications/"
 	Mountpoint "/^\/var\/db\/system/"
+	Mountpoint "/^\/var\/lib\/kubelet/"
 	FSType "tmpfs"
 	FSType "bindfs"
 	FSType "devtmpfs"

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -29,16 +29,22 @@ def render(service, middleware):
         'audit-log-maxsize=100',
         'service-account-lookup=true',
     ]
+    k3s_data_dir = os.path.join('/mnt', config['dataset'], 'k3s')
+    kubelet_args = [
+        f"root-dir={os.path.join(k3s_data_dir, 'kubelet')}",
+    ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
+    
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
             'cluster-cidr': config['cluster_cidr'],
             'service-cidr': config['service_cidr'],
             'cluster-dns': config['cluster_dns_ip'],
-            'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
+            'data-dir': k3s_data_dir,
             'kube-controller-manager-arg': kube_controller_args,
             'node-ip': config['node_ip'],
             'kube-apiserver-arg': kube_api_server_args,
+            'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
             'disable': [] if config['servicelb'] else ['servicelb'],
         }))

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -29,21 +29,16 @@ def render(service, middleware):
         'audit-log-maxsize=100',
         'service-account-lookup=true',
     ]
-    k3s_data_dir = os.path.join('/mnt', config['dataset'], 'k3s')
-    kubelet_args = [
-        f"root-dir={os.path.join(k3s_data_dir, 'kubelet')}",
-    ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
             'cluster-cidr': config['cluster_cidr'],
             'service-cidr': config['service_cidr'],
             'cluster-dns': config['cluster_dns_ip'],
-            'data-dir': k3s_data_dir,
+            'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
             'kube-controller-manager-arg': kube_controller_args,
             'node-ip': config['node_ip'],
             'kube-apiserver-arg': kube_api_server_args,
-            'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
             'disable': [] if config['servicelb'] else ['servicelb'],
         }))

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -34,7 +34,6 @@ def render(service, middleware):
         f"root-dir={os.path.join(k3s_data_dir, 'kubelet')}",
     ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
-    
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
             'cluster-cidr': config['cluster_cidr'],

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -260,7 +260,7 @@ class KubernetesService(Service):
         create_props = self.k8s_props_default()
         update_props = self.get_dataset_update_props(create_props)
         for dataset_name in await self.kubernetes_datasets(k8s_ds):
-            custom_props = self.kubernetes_datasets_custom_props(ds=dataset_name.rsplit(k8s_ds)[1])
+            custom_props = self.kubernetes_dataset_custom_props(ds=dataset_name.rsplit(k8s_ds)[1].strip('/'))
             if custom_props:
                 # got custom properties, need to re-calculate
                 # the update and create props.
@@ -307,7 +307,7 @@ class KubernetesService(Service):
         ]
 
     @private
-    def kubernetes_datasets_custom_props(self, ds: str) -> Dict:
+    def kubernetes_dataset_custom_props(self, ds: str) -> Dict:
         props = {
             'k3s/kubelet': {
                 'mountpoint': 'legacy'

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
@@ -33,6 +33,7 @@ class KubernetesService(Service):
                     'retention_policy': 'NONE',
                     'replicate': True,
                     'readonly': 'IGNORE',
+                    'exclude_mountpoint_property': False,
                 }
             )
             await migrate_job.wait()

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -19,7 +19,7 @@ class KubernetesService(SimpleService):
 
     async def unmount_kubelet_dataset(self):
         if os.path.ismount(self.kubelet_mountpoint):
-            await run('umount', '-f', self.kubelet_mountpoint, check=True)
+            await run('umount', '-f', '-R', self.kubelet_mountpoint, check=True)
 
     async def mount_kubelet_dataset(self):
         config = await self.middleware.call('kubernetes.config')

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -1,6 +1,8 @@
+import os
 import asyncio
 
 from middlewared.service import CallError
+from middlewared.utils import run
 
 from .base import SimpleService
 
@@ -9,10 +11,26 @@ class KubernetesService(SimpleService):
     name = 'kubernetes'
     etc = ['k3s']
     systemd_unit = 'k3s'
+    kubelet_mountpoint = '/var/lib/kubelet'
 
     async def clear_chart_releases_cache(self):
         await self.middleware.call('chart.release.clear_cached_chart_releases')
         await self.middleware.call('chart.release.clear_portal_cache')
+
+    async def unmount_kubelet_dataset(self):
+        if os.path.ismount(self.kubelet_mountpoint):
+            await run('umount', '-f', self.kubelet_mountpoint, check=True)
+
+    async def mount_kubelet_dataset(self):
+        config = await self.middleware.call('kubernetes.config')
+        await self.unmount_kubelet_dataset()
+        os.makedirs(self.kubelet_mountpoint, exist_ok=True)
+        await run(
+            'mount', '-t', 'zfs',
+            os.path.join(config['dataset'], 'k3s/kubelet'),
+            self.kubelet_mountpoint,
+            check=True
+        )
 
     async def before_start(self):
         try:
@@ -29,6 +47,7 @@ class KubernetesService(SimpleService):
 
             raise
 
+        await self.mount_kubelet_dataset()
         await self.clear_chart_releases_cache()
 
         for key, value in (
@@ -67,3 +86,4 @@ class KubernetesService(SimpleService):
         # This is necessary to ensure that docker umounts datasets and shuts down cleanly
         await asyncio.sleep(5)
         await self.middleware.call('k8s.cni.cleanup_cni')
+        await self.unmount_kubelet_dataset()


### PR DESCRIPTION
# Background
`/var/lib/kubelet` uses boot-pool and contributing significantly towards the reporting database.

# What does this do?
This creates a new dataset in applications pool i.e. `{pool_name}/ix-applications/k3s/kubelet` and controls its mounting / unmounting to the target i.e. `/var/lib/kubelet` in kubernetes service's lifecycle.

Tested accross:
- pool set/unset
- apps migrations to new pool (any number of times)
- start/stop k3s service
- pvc read/writes that uses `/var/lib/kubelet`