### PR TITLE
NAS-113727 / 13.0 / Fix a deadlock situation when creating many snapshots simultaneously

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -518,6 +518,20 @@ class CRUDService(ServiceChangeMixin, Service):
         """
         return await self._get_instance(id)
 
+    @private
+    def get_instance__sync(self, id):
+        """
+        Synchronous implementation of `get_instance`.
+        """
+        instance = self.middleware.call_sync(
+            f'{self._config.namespace}.query',
+            [('id', '=', id)],
+            {'force_sql_filters': True},
+        )
+        if not instance:
+            raise ValidationError(None, f'{self._config.verbose_name} {id} does not exist', errno.ENOENT)
+        return instance[0]
+
     async def _get_instance(self, id):
         """
         Helper method to get an instance from a collection given the `id`.

--- a/src/middlewared/middlewared/utils/service/call.py
+++ b/src/middlewared/middlewared/utils/service/call.py
@@ -6,7 +6,12 @@ from middlewared.service_exception import CallError
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ServiceCallMixin"]
+__all__ = ["MethodNotFoundError", "ServiceCallMixin"]
+
+
+class MethodNotFoundError(CallError):
+    def __init__(self, method_name, service):
+        super().__init__(f'Method {method_name!r} not found in {service!r}', CallError.ENOMETHOD)
 
 
 class ServiceCallMixin:
@@ -24,6 +29,6 @@ class ServiceCallMixin:
         try:
             methodobj = getattr(serviceobj, method_name)
         except AttributeError:
-            raise CallError(f'Method {method_name!r} not found in {service!r}', CallError.ENOMETHOD)
+            raise MethodNotFoundError(method_name, service)
 
         return serviceobj, methodobj


### PR DESCRIPTION
@rick-mesta this is another candidate that might be worth including in 12.0. It prevents WebUI from hanging when many snapshots are being created simultaneously using middleware (user had 10+ cloud sync tasks using "create snapshot" option firing up at the same time).