### PR TITLE
NAS-113967 / 22.02 / Fix `Unable to downgrade from TrueNAS-12.0-U7 to TrueNAS-12.0-U7` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -37,6 +37,8 @@ class UpdateService(Service):
 
             old_version = old_manifest["version"]
             new_version = manifest["version"]
+            if old_version == new_version:
+                raise CallError(f'You already are using {new_version}')
             if not can_update(old_version, new_version):
                 raise CallError(f'Unable to downgrade from {old_version} to {new_version}')
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 245efa2220366d8889242375710da1594ae9b5b4



Original PR: https://github.com/truenas/middleware/pull/8099
Jira URL: https://jira.ixsystems.com/browse/NAS-113967