### PR TITLE
NAS-113727 / 22.02 / Fix a deadlock situation when creating many snapshots simultaneously (by themylogin)

### DIFF
--- a/docs/source/middleware/index.rst
+++ b/docs/source/middleware/index.rst
@@ -5,5 +5,6 @@ Middleware Daemon
     :maxdepth: 1
     :caption: Contents:
 
+    process_pool.rst
     jobs.rst
     plugins/index.rst

--- a/docs/source/middleware/process_pool.rst
+++ b/docs/source/middleware/process_pool.rst
@@ -1,0 +1,29 @@
+Process Pool
+############
+
+.. contents:: Table of Contents
+    :depth: 4
+
+Some python libraries (namely, `py-libzfs`) are not thread-safe. Methods that use such libraries should be executed in a
+separate process to avoid non-safe behavior.
+
+Middleware services that include these methods are marked with `process_pool = True`. All their synchronous methods are
+executed in a shared process pool:
+
+  .. literalinclude:: /../../src/middlewared/middlewared/main.py
+      :pyobject: Middleware.__init_procpool
+      :caption:
+
+Eliminating deadlocks
+*********************
+
+All asynchronous methods of process pool-powered services (including inherited ones) need to have their synchronous
+version named `{method}__sync`. The most important example is `CRUDService.get_instance__sync`.
+
+Why is this needed? Imagine we have a `ZFSSnapshot` service that uses a process pool. Let's say its `create` method
+calls `zfs.snapshot.get_instance` to return the result. That call will have to be forwarded to the main middleware
+process, which will call `zfs.snapshot.query` in the process pool. If the process pool is already exhausted, it will
+lead to a deadlock.
+
+By executing a synchronous implementation of the same method in the same process pool we eliminate **Hold and wait**
+condition and prevent deadlock situation from arising.

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -466,7 +466,7 @@ class UserService(CRUDService):
         Update attributes of an existing user.
         """
 
-        user = await self._get_instance(pk)
+        user = await self.get_instance(pk)
 
         verrors = ValidationErrors()
 
@@ -667,7 +667,7 @@ class UserService(CRUDService):
         any other user.
         """
 
-        user = await self._get_instance(pk)
+        user = await self.get_instance(pk)
 
         if user['builtin']:
             raise CallError('Cannot delete a built-in user', errno.EINVAL)
@@ -773,7 +773,7 @@ class UserService(CRUDService):
 
         e.g. Setting key="foo" value="var" will result in {"attributes": {"foo": "bar"}}
         """
-        user = await self._get_instance(pk)
+        user = await self.get_instance(pk)
 
         user['attributes'][key] = value
 
@@ -797,7 +797,7 @@ class UserService(CRUDService):
         """
         Remove user general purpose `attributes` dictionary `key`.
         """
-        user = await self._get_instance(pk)
+        user = await self.get_instance(pk)
 
         if key in user['attributes']:
             user['attributes'].pop(key)
@@ -1344,7 +1344,7 @@ class GroupService(CRUDService):
         Update attributes of an existing group.
         """
 
-        group = await self._get_instance(pk)
+        group = await self.get_instance(pk)
         groupmap_changed = False
 
         verrors = ValidationErrors()
@@ -1416,7 +1416,7 @@ class GroupService(CRUDService):
         The `delete_users` option deletes all users that have this group as their primary group.
         """
 
-        group = await self._get_instance(pk)
+        group = await self.get_instance(pk)
         if group['builtin']:
             raise CallError('A built-in group cannot be deleted.', errno.EACCES)
 

--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -282,7 +282,7 @@ class DNSAuthenticatorService(CRUDService):
             data,
         )
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int('id'),
@@ -319,7 +319,7 @@ class DNSAuthenticatorService(CRUDService):
                 ]
             }
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -332,7 +332,7 @@ class DNSAuthenticatorService(CRUDService):
             new
         )
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     async def do_delete(self, id):
         """

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -120,7 +120,7 @@ class ApiKeyService(CRUDService):
         """
         reset = data.pop("reset", False)
 
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
 
         new.update(data)
@@ -141,7 +141,7 @@ class ApiKeyService(CRUDService):
 
         await self.load_key(id)
 
-        return self._serve(await self._get_instance(id), key)
+        return self._serve(await self.get_instance(id), key)
 
     @accepts(
         Int("id")

--- a/src/middlewared/middlewared/plugins/bootenv.py
+++ b/src/middlewared/middlewared/plugins/bootenv.py
@@ -241,7 +241,7 @@ class BootEnvService(CRUDService):
         """
         Update `id` boot environment name with a new provided valid `name`.
         """
-        await self._get_instance(oid)
+        await self.get_instance(oid)
 
         verrors = ValidationErrors()
         await self._clean_be_name(verrors, 'bootenv_update', data['name'])
@@ -269,7 +269,7 @@ class BootEnvService(CRUDService):
         """
         Delete `id` boot environment. This removes the clone from the system.
         """
-        be = await self._get_instance(oid)
+        be = await self.get_instance(oid)
         try:
             await run(self.BE_TOOL, 'destroy', '-F', be['id'], encoding='utf8', check=True)
         except subprocess.CalledProcessError as cpe:

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -628,7 +628,7 @@ class CredentialsService(CRUDService):
         """
         Update Cloud Sync Credentials of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)
@@ -1165,7 +1165,7 @@ class CloudSyncService(TaskPathService):
         Aborts cloud sync task.
         """
 
-        cloud_sync = await self._get_instance(id)
+        cloud_sync = await self.get_instance(id)
 
         if cloud_sync["job"] is None:
             return False

--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -158,7 +158,7 @@ class CronJobService(CRUDService):
 
         await self.middleware.call('service.restart', 'cron')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     async def do_update(self, id, data):
         """
@@ -187,7 +187,7 @@ class CronJobService(CRUDService):
 
             await self.middleware.call('service.restart', 'cron')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     async def do_delete(self, id):
         """

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1296,7 +1296,7 @@ class CertificateService(CRUDService):
 
     @private
     async def get_domain_names(self, cert_id):
-        data = await self._get_instance(int(cert_id))
+        data = await self.get_instance(int(cert_id))
         names = [data['common']] if data['common'] else []
         names.extend(data['san'])
         return names
@@ -1555,7 +1555,7 @@ class CertificateService(CRUDService):
 
         job.set_progress(100, 'Certificate created successfully')
 
-        return await self._get_instance(pk)
+        return await self.get_instance(pk)
 
     @accepts(
         Dict(
@@ -1805,7 +1805,7 @@ class CertificateService(CRUDService):
                 ]
             }
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         # signedby is changed back to integer from a dict
         old['signedby'] = old['signedby']['id'] if old.get('signedby') else None
         if old.get('acme'):
@@ -1860,7 +1860,7 @@ class CertificateService(CRUDService):
 
         job.set_progress(90, 'Finalizing changes')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @private
     async def delete_domains_authenticator(self, auth_id):
@@ -2137,7 +2137,7 @@ class CertificateAuthorityService(CRUDService):
     @private
     async def get_serial_for_certificate(self, ca_id):
 
-        ca_data = await self._get_instance(ca_id)
+        ca_data = await self.get_instance(ca_id)
 
         if ca_data.get('signedby'):
             # Recursively call the same function for it's parent and let the function gather all serials in a chain
@@ -2176,7 +2176,7 @@ class CertificateAuthorityService(CRUDService):
                     serials.extend((await child_serials(child['id'])))
 
                 serials.extend((await cert_serials(ca_id)))
-                serials.append((await self._get_instance(ca_id))['serial'])
+                serials.append((await self.get_instance(ca_id))['serial'])
 
                 return serials
 
@@ -2187,7 +2187,7 @@ class CertificateAuthorityService(CRUDService):
 
             if not ca_signed_certs:
                 return int(
-                    (await self._get_instance(ca_id))['serial'] or 0
+                    (await self.get_instance(ca_id))['serial'] or 0
                 ) + 1
             else:
                 return max(ca_signed_certs) + 1
@@ -2320,7 +2320,7 @@ class CertificateAuthorityService(CRUDService):
 
         await self.middleware.call('service.start', 'ssl')
 
-        return await self._get_instance(pk)
+        return await self.get_instance(pk)
 
     @accepts(
         Dict(
@@ -2456,7 +2456,7 @@ class CertificateAuthorityService(CRUDService):
     )
     async def __create_intermediate_ca(self, data):
 
-        signing_cert = await self._get_instance(data['signedby'])
+        signing_cert = await self.get_instance(data['signedby'])
 
         serial = await self.get_serial_for_certificate(signing_cert['id'])
 
@@ -2575,7 +2575,7 @@ class CertificateAuthorityService(CRUDService):
             for key in ['ca_id', 'csr_cert_id']:
                 data.pop(key, None)
 
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         # signedby is changed back to integer from a dict
         old['signedby'] = old['signedby']['id'] if old.get('signedby') else None
 
@@ -2624,7 +2624,7 @@ class CertificateAuthorityService(CRUDService):
 
             await self.middleware.call('service.start', 'ssl')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     async def do_delete(self, id):
         """
@@ -2644,7 +2644,7 @@ class CertificateAuthorityService(CRUDService):
                 ]
             }
         """
-        await self._get_instance(id)
+        await self.get_instance(id)
         await self.middleware.run_in_thread(check_dependencies, self.middleware, 'CA', id)
 
         response = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -145,7 +145,7 @@ class EnclosureService(CRUDService):
                 "label": data["label"]
             })
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     def _get_slot(self, slot_filter, enclosure_query=None, enclosure_info=None):
         if enclosure_info is None:

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -84,7 +84,7 @@ class ACLTemplateService(CRUDService):
             data,
             {'prefix': self._config.datastore_prefix}
         )
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id'),
@@ -98,7 +98,7 @@ class ACLTemplateService(CRUDService):
         """
         update filesystem ACL template with `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -887,7 +887,7 @@ class IdmapDomainService(TDBWrapCRUDService):
         entries for the domain associated with the id.
         """
         if id <= 5:
-            entry = await self._get_instance(id)
+            entry = await self.get_instance(id)
             raise CallError(f'Deleting system idmap domain [{entry["name"]}] is not permitted.', errno.EPERM)
 
         ret = await self.direct_delete(id)

--- a/src/middlewared/middlewared/plugins/init_shutdown_script.py
+++ b/src/middlewared/middlewared/plugins/init_shutdown_script.py
@@ -79,13 +79,13 @@ class InitShutdownScriptService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     async def do_update(self, id, data):
         """
         Update initshutdown script task of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -101,7 +101,7 @@ class InitShutdownScriptService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        return await self._get_instance(new['id'])
+        return await self.get_instance(new['id'])
 
     async def do_delete(self, id):
         """

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -192,7 +192,7 @@ class ISCSIPortalService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(pk)
+        return await self.get_instance(pk)
 
     async def __save_listen(self, pk, new, old=None):
         """
@@ -236,7 +236,7 @@ class ISCSIPortalService(CRUDService):
         Update iSCSI Portal `id`.
         """
 
-        old = await self._get_instance(pk)
+        old = await self.get_instance(pk)
 
         new = old.copy()
         new.update(data)
@@ -259,14 +259,14 @@ class ISCSIPortalService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(pk)
+        return await self.get_instance(pk)
 
     @accepts(Int('id'))
     async def do_delete(self, id):
         """
         Delete iSCSI Portal `id`.
         """
-        await self._get_instance(id)
+        await self.get_instance(id)
         await self.middleware.call(
             'datastore.delete', 'services.iscsitargetgroups', [['iscsi_target_portalgroup', '=', id]]
         )
@@ -367,7 +367,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id'),
@@ -381,7 +381,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
         """
         Update iSCSI Authorized Access of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)
@@ -403,14 +403,14 @@ class iSCSITargetAuthCredentialService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'))
     async def do_delete(self, id):
         """
         Delete iSCSI Authorized Access of `id`.
         """
-        config = await self._get_instance(id)
+        config = await self.get_instance(id)
         if not await self.query([['tag', '=', config['tag']], ['id', '!=', id]]):
             usages = await self.is_in_use_by_portals_targets(id)
             if usages['in_use']:
@@ -580,7 +580,7 @@ class iSCSITargetExtentService(SharingService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id'),
@@ -633,7 +633,7 @@ class iSCSITargetExtentService(SharingService):
 
         If `id` iSCSI Extent's `type` was configured to FILE, `remove` can be set to remove the configured file.
         """
-        data = await self._get_instance(id)
+        data = await self.get_instance(id)
         target_to_extents = await self.middleware.call('iscsi.targetextent.query', [['extent', '=', id]])
         active_sessions = await self.middleware.call(
             'iscsi.target.active_sessions_for_targets', [t['target'] for t in target_to_extents]
@@ -955,7 +955,7 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id'),
@@ -969,7 +969,7 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
         """
         Update iSCSI initiator of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)
@@ -981,14 +981,14 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'))
     async def do_delete(self, id):
         """
         Delete iSCSI initiator of `id`.
         """
-        await self._get_instance(id)
+        await self.get_instance(id)
         result = await self.middleware.call(
             'datastore.delete', self._config.datastore, id
         )
@@ -1127,7 +1127,7 @@ class iSCSITargetService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(pk)
+        return await self.get_instance(pk)
 
     async def __save_groups(self, pk, new, old=None):
         """
@@ -1268,7 +1268,7 @@ class iSCSITargetService(CRUDService):
         """
         Update iSCSI Target of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -1293,7 +1293,7 @@ class iSCSITargetService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'), Bool('force', default=False))
     async def do_delete(self, id, force):
@@ -1302,7 +1302,7 @@ class iSCSITargetService(CRUDService):
 
         Deleting an iSCSI Target makes sure we delete all Associated Targets which use `id` iSCSI Target.
         """
-        target = await self._get_instance(id)
+        target = await self.get_instance(id)
         if await self.active_sessions_for_targets([target['id']]):
             if force:
                 self.middleware.logger.warning('Target %s is in use.', target['name'])
@@ -1408,7 +1408,7 @@ class iSCSITargetToExtentService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     def _set_null_false(name):
         def set_null_false(attr):
@@ -1429,7 +1429,7 @@ class iSCSITargetToExtentService(CRUDService):
         Update Associated Target of `id`.
         """
         verrors = ValidationErrors()
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)
@@ -1445,14 +1445,14 @@ class iSCSITargetToExtentService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'), Bool('force', default=False))
     async def do_delete(self, id, force):
         """
         Delete Associated Target of `id`.
         """
-        associated_target = await self._get_instance(id)
+        associated_target = await self.get_instance(id)
         active_sessions = await self.middleware.call(
             'iscsi.target.active_sessions_for_targets', [associated_target['target']]
         )

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -696,7 +696,7 @@ class KerberosRealmService(TDBWrapCRUDService):
         id = await super().do_create(data)
         await self.middleware.call('etc.generate', 'kerberos')
         await self.middleware.call('service.restart', 'cron')
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int('id', required=True),
@@ -712,7 +712,7 @@ class KerberosRealmService(TDBWrapCRUDService):
         domain join process in an Active Directory environment. Kerberos realm names
         are case-sensitive, but convention is to only use upper-case.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -720,7 +720,7 @@ class KerberosRealmService(TDBWrapCRUDService):
         await super().do_update(id, new)
 
         await self.middleware.call('etc.generate', 'kerberos')
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'))
     async def do_delete(self, id):
@@ -786,7 +786,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         id = await super().do_create(data)
         await self.middleware.call('etc.generate', 'kerberos')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int('id', required=True),
@@ -799,7 +799,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         """
         Update kerberos keytab by id.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -813,7 +813,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         await super().do_update(id, new)
         await self.middleware.call('etc.generate', 'kerberos')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int('id'))
     async def do_delete(self, id):

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -346,7 +346,7 @@ class KeychainCredentialService(CRUDService):
             }
         """
 
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)
@@ -384,7 +384,7 @@ class KeychainCredentialService(CRUDService):
             }
         """
 
-        instance = await self._get_instance(id)
+        instance = await self.get_instance(id)
 
         for delegate in TYPES[instance["type"]].used_by_delegates:
             delegate = delegate(self.middleware)
@@ -410,7 +410,7 @@ class KeychainCredentialService(CRUDService):
         """
         Returns list of objects that use this credential.
         """
-        instance = await self._get_instance(id)
+        instance = await self.get_instance(id)
 
         result = []
         for delegate in TYPES[instance["type"]].used_by_delegates:

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -753,7 +753,7 @@ class InterfaceService(CRUDService):
         if data.get('disable_offload_capabilities'):
             await self.middleware.call('interface.disable_capabilities', name)
 
-        return await self._get_instance(name)
+        return await self.get_instance(name)
 
     @private
     async def get_next(self, prefix, start=0):
@@ -1192,7 +1192,7 @@ class InterfaceService(CRUDService):
         """
         await self.__check_failover_disabled()
 
-        iface = await self._get_instance(oid)
+        iface = await self.get_instance(oid)
 
         new = iface.copy()
         new.update(data)
@@ -1362,7 +1362,7 @@ class InterfaceService(CRUDService):
                             f'Failed to enable capabilities for {iface["name"]} on standby storage controller: {e}'
                         )
 
-        return await self._get_instance(new['name'])
+        return await self.get_instance(new['name'])
 
     @accepts(Str('id'))
     @returns(Str('interface_id'))
@@ -1372,7 +1372,7 @@ class InterfaceService(CRUDService):
         """
         await self.__check_failover_disabled()
 
-        iface = await self._get_instance(oid)
+        iface = await self.get_instance(oid)
 
         await self.__save_datastores()
 

--- a/src/middlewared/middlewared/plugins/network_/static_routes.py
+++ b/src/middlewared/middlewared/plugins/network_/static_routes.py
@@ -48,13 +48,13 @@ class StaticRouteService(CRUDService):
 
         await self.middleware.call('service.restart', 'routing')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     async def do_update(self, id, data):
         """
         Update Static Route of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -67,7 +67,7 @@ class StaticRouteService(CRUDService):
 
         await self.middleware.call('service.restart', 'routing')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     def do_delete(self, id):
         """

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -87,7 +87,7 @@ class NTPServerService(CRUDService):
         """
         Update NTP server of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         new.update(data)

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -318,7 +318,7 @@ class ReplicationService(CRUDService):
 
         await self.middleware.call("zettarepl.update_tasks")
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(Int("id"), Patch(
         "replication_create",
@@ -368,7 +368,7 @@ class ReplicationService(CRUDService):
             }
         """
 
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
 
         new = old.copy()
         if new["ssh_credentials"]:
@@ -400,7 +400,7 @@ class ReplicationService(CRUDService):
 
         await self.middleware.call("zettarepl.update_tasks")
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int("id")
@@ -440,7 +440,7 @@ class ReplicationService(CRUDService):
         Run Replication Task of `id`.
         """
         if really_run:
-            task = await self._get_instance(id)
+            task = await self.get_instance(id)
 
             if not task["enabled"]:
                 raise CallError("Task is not enabled")

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -229,7 +229,7 @@ class RsyncModService(SharingService):
 
         await self._service_change('rsync', 'reload')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(Int('id'), Patch('rsyncmod_create', 'rsyncmod_update', ('attr', {'update': True})))
     async def do_update(self, id, data):
@@ -646,7 +646,7 @@ class RsyncTaskService(TaskPathService):
         """
         Helper method to generate the rsync command avoiding code duplication.
         """
-        rsync = await self._get_instance(id)
+        rsync = await self.get_instance(id)
         path = shlex.quote(rsync['path'])
 
         line = ['rsync']

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1205,7 +1205,7 @@ class SharingSMBService(SharingService):
         await self.middleware.call("smb.cluster_check")
         ha_mode = SMBHAMODE[(await self.middleware.call('smb.get_smb_ha_mode'))]
         if ha_mode != SMBHAMODE.CLUSTERED:
-            share = await self._get_instance(id)
+            share = await self.get_instance(id)
             result = await self.middleware.call('datastore.delete', self._config.datastore, id)
         else:
             share = await self.query([('id', '=', id)], {'get': True})

--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -376,7 +376,7 @@ class ShareSec(CRUDService):
         Update the ACL on the share specified by the numerical index `id`. Will write changes
         to both /var/db/system/samba4/share_info.tdb and the configuration file.
         """
-        old_acl = await self._get_instance(id)
+        old_acl = await self.get_instance(id)
         await self.setacl({"share_name": old_acl["share_name"], "share_acl": data["share_acl"]})
         return await self.getacl(old_acl["share_name"])
 
@@ -396,7 +396,7 @@ class ShareSec(CRUDService):
             old_acl = await self.getacl(id_or_name)
             new_acl.update({'share_name': id_or_name})
         else:
-            old_acl = await self._get_instance(int(id_or_name))
+            old_acl = await self.get_instance(int(id_or_name))
             new_acl.update({'share_name': old_acl['share_name']})
 
         await self.setacl(new_acl)

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -154,7 +154,7 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         await self.middleware.call('zettarepl.update_tasks')
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id', required=True),
@@ -203,7 +203,7 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         fixate_removal_date = data.pop('fixate_removal_date', False)
 
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
         new.update(data)
 
@@ -249,7 +249,7 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         await self.middleware.call('zettarepl.update_tasks')
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int('id'),
@@ -313,7 +313,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         """
         Execute a Periodic Snapshot Task of `id`.
         """
-        task = await self._get_instance(id)
+        task = await self.get_instance(id)
 
         if not task["enabled"]:
             raise CallError("Task is not enabled")

--- a/src/middlewared/middlewared/plugins/tunables.py
+++ b/src/middlewared/middlewared/plugins/tunables.py
@@ -92,7 +92,7 @@ class TunableService(CRUDService):
 
         await self.middleware.call('service.reload', data['type'])
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     async def do_update(self, id, data):
         """

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -98,7 +98,7 @@ class VMWareService(CRUDService):
             data
         )
 
-        return await self._get_instance(data['id'])
+        return await self.get_instance(data['id'])
 
     @accepts(
         Int('id', required=True),
@@ -108,7 +108,7 @@ class VMWareService(CRUDService):
         """
         Update VMWare snapshot of `id`.
         """
-        old = await self._get_instance(id)
+        old = await self.get_instance(id)
         new = old.copy()
 
         new.update(data)
@@ -122,7 +122,7 @@ class VMWareService(CRUDService):
             new,
         )
 
-        return await self._get_instance(id)
+        return await self.get_instance(id)
 
     @accepts(
         Int('id')

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -962,17 +962,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         return instance[0]
 
     @private
-    @accepts(
-        Any('id'),
-        Patch(
-            'query-options', 'query-options-get_instance',
-            ('edit', {
-                'name': 'force_sql_filters',
-                'method': lambda x: setattr(x, 'default', True),
-            }),
-            register=True,
-        ),
-    )
+    @accepts(Any('id'), Ref('query-options-get_instance'))
     def get_instance__sync(self, id, options):
         """
         Synchronous implementation of `get_instance`.

--- a/src/middlewared/middlewared/utils/service/call.py
+++ b/src/middlewared/middlewared/utils/service/call.py
@@ -6,7 +6,12 @@ from middlewared.service_exception import CallError
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ServiceCallMixin"]
+__all__ = ["MethodNotFoundError", "ServiceCallMixin"]
+
+
+class MethodNotFoundError(CallError):
+    def __init__(self, method_name, service):
+        super().__init__(f'Method {method_name!r} not found in {service!r}', CallError.ENOMETHOD)
 
 
 class ServiceCallMixin:
@@ -24,6 +29,6 @@ class ServiceCallMixin:
         try:
             methodobj = getattr(serviceobj, method_name)
         except AttributeError:
-            raise CallError(f'Method {method_name!r} not found in {service!r}', CallError.ENOMETHOD)
+            raise MethodNotFoundError(method_name, service)
 
         return serviceobj, methodobj

--- a/src/middlewared/middlewared/worker.py
+++ b/src/middlewared/middlewared/worker.py
@@ -10,7 +10,7 @@ from . import logger
 from .common.environ import environ_update
 from .utils.plugins import LoadPluginsMixin
 import middlewared.utils.osc as osc
-from .utils.service.call import ServiceCallMixin
+from .utils.service.call import MethodNotFoundError, ServiceCallMixin
 
 MIDDLEWARE = None
 
@@ -52,11 +52,28 @@ class FakeMiddleware(LoadPluginsMixin, ServiceCallMixin):
 
         if (
             serviceobj._config.process_pool and
-            not hasattr(method, '_job') and
-            not asyncio.iscoroutinefunction(methodobj)
+            not hasattr(method, '_job')
         ):
-            self.logger.trace('Calling %r in current process', method)
-            return methodobj(*params)
+            if asyncio.iscoroutinefunction(methodobj):
+                try:
+                    # Search for a synchronous implementation of the asynchronous method (i.e. `get_instance`).
+                    # Why is this needed? Imagine we have a `ZFSSnapshot` service that uses a process pool. Let's say
+                    # its `create` method calls `zfs.snapshot.get_instance` to return the result. That call will have
+                    # to be forwarded to the main middleware process, which will call `zfs.snapshot.query` in the
+                    # process pool. If the process pool is already exhausted, it will lead to a deadlock.
+                    # By executing a synchronous implementation of the same method in the same process pool we
+                    # eliminate `Hold and wait` condition and prevent deadlock situation from arising.
+                    _, sync_methodobj = self._method_lookup(f'{method}__sync')
+                except MethodNotFoundError:
+                    # FIXME: Make this an exception in 22.MM
+                    self.logger.warning('Service uses a process pool but has an asynchronous method: %r', method)
+                    sync_methodobj = None
+            else:
+                sync_methodobj = methodobj
+
+            if sync_methodobj is not None:
+                self.logger.trace('Calling %r in current process', method)
+                return sync_methodobj(*params)
 
         return self.client.call(method, *params, timeout=timeout, **kwargs)
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 7581b643bcf42be41716e4c9ed565a8f5b485d59

@rick-mesta this is another candidate that might be worth including in 12.0. It prevents WebUI from hanging when many snapshots are being created simultaneously using middleware (user had 10+ cloud sync tasks using "create snapshot" option firing up at the same time).

Original PR: https://github.com/truenas/middleware/pull/8101
Jira URL: https://jira.ixsystems.com/browse/NAS-113727