### PR TITLE
NAS-114187 / 22.02 / Add allow interfaces directive to avahi config

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -22,7 +22,7 @@
     failover_int = middleware.call_sync("failover.internal_interfaces")
     deny_interfaces.extend(failover_int)
 
-    allow_interfaces = middleare.call_sync("interface.query", [["name", "!^", "macvtap"]])
+    allow_interfaces = middleware.call_sync("interface.query", [["name", "!^", "macvtap"]])
 
     failover_status = middleware.call_sync('failover.status')
     if failover_status not in ['SINGLE', 'MASTER']:

--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf.mako
@@ -22,6 +22,8 @@
     failover_int = middleware.call_sync("failover.internal_interfaces")
     deny_interfaces.extend(failover_int)
 
+    allow_interfaces = middleare.call_sync("interface.query", [["name", "!^", "macvtap"]])
+
     failover_status = middleware.call_sync('failover.status')
     if failover_status not in ['SINGLE', 'MASTER']:
         raise FileShouldNotExist()
@@ -35,6 +37,7 @@ use-ipv6=${"yes" if ipv6_enabled else "no"}
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000
 deny-interfaces=${", ".join(deny_interfaces)}
+allow-interfaces=${", ".join([x["name"] for x in allow_interfaces])}
 disallow-other-stacks=yes
 
 [wide-area]


### PR DESCRIPTION
Deny interfaces will be interpreted before allow interfaces.
This will prevent avahi from registering veth and macvtap interfaces.