### PR TITLE
NAS-114122 / 22.02 / Performance improvements for querying chart releases

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -579,6 +579,14 @@ class ChartReleaseService(CRUDService):
             args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
 
         action = tn_action if tn_action == 'install' else 'upgrade'
+        if action == 'upgrade':
+            # We only keep history of max 5 upgrades
+            # We input 6 here because helm considers app setting modifications as upgrades as well
+            # which means that if an app setting is even just modified and is not an upgrade in scale terms
+            # we will essentially only be keeping 4 major upgrades revision history. With 6, we temporarily have 6
+            # secrets for the app but that gets sorted out asap after the upgrade action when we sync secrets and
+            # we end up with 5 revision secrets max per app
+            args.insert(0, '--history-max=6')
 
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(yaml.dump(config))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
@@ -30,7 +30,7 @@ class ChartReleaseService(Service):
 
         release_secrets = defaultdict(lambda: dict({'releases': [], 'history': {}}))
         secrets = self.middleware.call_sync(
-            'k8s.secret.query', [['type', '=', 'helm.sh/release.v1'], namespace_filter]
+            'k8s.secret.query', [namespace_filter], {'extra': {'field_selector': 'type=helm.sh/release.v1'}}
         )
         official_catalog_label = self.middleware.call_sync('catalog.official_catalog_label')
         for release_secret in secrets:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/secrets.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/secrets.py
@@ -19,8 +19,10 @@ class KubernetesSecretService(CRUDService):
     @filterable
     async def query(self, filters, options):
         options = options or {}
-        label_selector = options.get('extra', {}).get('label_selector')
-        kwargs = {k: v for k, v in [('label_selector', label_selector)] if v}
+        extra = options.get('extra', {})
+        label_selector = extra.get('label_selector')
+        field_selector = extra.get('field_selector')
+        kwargs = {k: v for k, v in [('label_selector', label_selector), ('field_selector', field_selector)] if v}
         async with api_client() as (api, context):
             if len(filters) == 1 and len(filters[0]) == 3 and list(filters[0])[:2] == ['metadata.namespace', '=']:
                 func = functools.partial(context['core_api'].list_namespaced_secret, namespace=filters[0][2], **kwargs)


### PR DESCRIPTION
This PR adds following changes:

1. Keep last 5 version upgrades history for apps instead of 10 ( the helm default ). Motivation behind this change is that each revision in an app is a secret entry by helm. So if a user has 25 apps with 10 revisions history - we end up with just 250 secrets for the apps helm secrets alone. K8s client without any middleware takes approximately 1.8 secs to list down these secrets and with middleware we get around 4 secs. Discussing this with the community, it was advised 3-5 is a good number for revision history which we should keep for each app - reducing this by half improves the performance by half for such users who have been using apps for a long time and have been upgrading it continuously filling 10 revision history limit.
2. Kubernetes API does not provide us to with a mechanism to do extensive filtering/matching at k8s level but only filter out exact field name matches or do filtering for labels. We were earlier filtering type field at middleware which is relatively more expensive then doing it with k8s - we now do field level filtering at k8s level for secrets.