### PR TITLE
NAS-114223 / 22.02 / Do not take snapshot of docker dataset when making a backup of apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -79,18 +79,10 @@ class KubernetesService(Service):
 
         job.set_progress(95, 'Taking snapshot of ix-applications')
 
-        k8s_ds = self.middleware.call_sync(
-            'zfs.snapshot.get_instance', k8s_config['dataset'], {'extra': {'retrieve_properties': False}}
-        )
         self.middleware.call_sync(
-            'zfs.snapshot.create', {'dataset': k8s_config['dataset'], 'name': snap_name, 'recursive': False}
+            'zettarepl.create_recursive_snapshot_with_exclude', k8s_config['dataset'],
+            snap_name, [os.path.join(k8s_config['dataset'], 'docker')]
         )
-        for child_ds in k8s_ds['children']:
-            if os.path.join(k8s_config['dataset'], 'docker') == child_ds['id']:
-                continue
-            self.middleware.call_sync(
-                'zfs.snapshot.create', {'dataset': k8s_config['dataset'], 'name': snap_name, 'recursive': True}
-            )
 
         job.set_progress(100, f'Backup {name!r} complete')
 


### PR DESCRIPTION
Docker dataset is re-initialized from scratch as containers are ephemeral in kubernetes during restore. Docker zfs driver creates at least 1 dataset per layer in container/image if not more where we end up with a huge number of datasets. This change makes sure we do not take a snapshot of the docker dataset as we end up with potentially thousands of snapshots over time.