### PR TITLE
NAS-114092 / 22.02 / use /proc for tracking processes using a path

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/track_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/track_processes.py
@@ -1,0 +1,37 @@
+import os
+import contextlib
+
+from middlewared.service import CRUDService, private
+
+
+class PoolDatasetService(CRUDService):
+
+    @private
+    def processes_using_paths(self, paths):
+        include_devs = []
+        for path in paths:
+            try:
+                include_devs.append(os.stat(path).st_dev)
+            except FileNotFoundError:
+                continue
+
+        result = []
+        if include_devs:
+            for pid in os.listdir('/proc'):
+                if not pid.isdigit() or int(pid) == os.getpid():
+                    continue
+
+                with contextlib.suppress(FileNotFoundError):
+                    # FileNotFoundError for when a process is killed/exits
+                    # while we're iterating
+                    for f in os.listdir(f'/proc/{pid}/fd'):
+                        if os.stat(f'/proc/{pid}/fd/{f}').st_dev in include_devs:
+                            with open(f'/proc/{pid}/status') as status:
+                                name = status.readline().split('\t', 1)[1].strip()
+                                if svc := self.middleware.call_sync('service.identify_process', name):
+                                    result.append({'pid': pid, 'name': name, 'service': svc})
+                                else:
+                                    with open(f'/proc/{pid}/cmdline') as cmd:
+                                        cmdline = cmd.read().replace('\u0000', ' ').strip()
+                                        result.append({'pid': pid, 'name': name, 'cmdline': cmdline})
+        return result

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -1,0 +1,25 @@
+import sys
+import os
+sys.path.append(os.getcwd())
+
+from functions import POST, make_ws_request
+from auto_config import pool_name, ip
+from middlewared.test.integration.utils import ssh
+
+TEST_DATASET = f'{pool_name}/testing_processes'
+
+
+def test_01_create_dataset():
+    results = POST('/pool/dataset', {'name': TEST_DATASET})
+    assert results.status_code == 200, results.text
+
+
+def test_02_open_path_and_check_proc():
+    path = f'/mnt/{TEST_DATASET}'
+    test_file = f'{path}/test_file'
+    open_pid = ssh(f'python -c "import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)" & echo $!')
+    assert open_pid.isdigit()
+
+    payload = {'msg': 'method', 'method': 'pool.dataset.processes_using_paths', 'params': list(path)}
+    res = make_ws_request(ip, payload)
+    assert int(res[0]['pid']) == int(open_pid), res

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -1,25 +1,37 @@
 import sys
 import os
+import time
 sys.path.append(os.getcwd())
 
-from functions import POST, make_ws_request
-from auto_config import pool_name, ip
+from functions import make_ws_request
+from auto_config import ip
 from middlewared.test.integration.utils import ssh
+from middlewared.test.integration.assets.pool import dataset
 
-TEST_DATASET = f'{pool_name}/testing_processes'
-
-
-def test_01_create_dataset():
-    results = POST('/pool/dataset', {'name': TEST_DATASET})
-    assert results.status_code == 200, results.text
+TEST_DATASET = 'testing_processes'
 
 
-def test_02_open_path_and_check_proc():
-    path = f'/mnt/{TEST_DATASET}'
-    test_file = f'{path}/test_file'
-    open_pid = ssh(f'python -c "import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)" & echo $!')
-    assert open_pid.isdigit()
+def test__open_path_and_check_proc():
+    with dataset(TEST_DATASET) as ds:
+        opened = False
+        try:
+            path = f'/mnt/{ds}'
+            test_file = f'{path}/test_file'
+            cmdline = f'python -c "import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)" & echo $!'
+            open_pid = ssh(cmdline)
+            assert open_pid.isdigit(), open_pid
+            opened = True
 
-    payload = {'msg': 'method', 'method': 'pool.dataset.processes_using_paths', 'params': list(path)}
-    res = make_ws_request(ip, payload)
-    assert int(res[0]['pid']) == int(open_pid), res
+            # spinning up python interpreter could take some time on busy system so sleep
+            # for a couple seconds to give it time
+            time.sleep(2)
+
+            # have to use websocket since the method being called is private
+            payload = {'msg': 'method', 'method': 'pool.dataset.processes_using_paths', 'params': list(path)}
+            res = make_ws_request(ip, payload)
+            assert len(res) == 1, res
+            assert int(res[0]['pid']) == int(open_pid), res
+            assert res[0]['cmdline'] == cmdline, res
+        finally:
+            if opened:
+                ssh(f'kill -9 {open_pid}')


### PR DESCRIPTION
There should be no functional change. This does essentially the same as what lsof does but instead gets the information directly from `/proc`. This gets rid of subprocessing to `lsof` which is causing 100% cpu usage on certain systems. Also gets rid of a call to `psutil`.