### PR TITLE
NAS-114172 / 13.0 / optimize pool.format_disks

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -19,7 +19,7 @@ class PoolService(Service):
         disk_encryption_options = disk_encryption_options or {}
 
         swapgb = (await self.middleware.call('system.advanced.config'))['swapondrive']
-
+        zfs_part_type = await self.middleware.call('disk.get_zfs_part_type')
         enc_disks = []
         formatted = 0
 
@@ -29,9 +29,7 @@ class PoolService(Service):
             await self.middleware.call(
                 'disk.format', disk, swapgb if config['create_swap'] else 0, False,
             )
-            devname = await self.middleware.call(
-                'disk.gptid_from_part_type', disk, await self.middleware.call('disk.get_zfs_part_type')
-            )
+            devname = await self.middleware.call('disk.gptid_from_part_type', disk, zfs_part_type)
             if osc.IS_FREEBSD and disk_encryption_options.get('enc_keypath'):
                 enc_disks.append({
                     'disk': disk,

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 from middlewared.service import private, Service
-from middlewared.utils import osc
 from middlewared.utils.asyncio_ import asyncio_map
 
 
@@ -30,7 +29,7 @@ class PoolService(Service):
                 'disk.format', disk, swapgb if config['create_swap'] else 0, False,
             )
             devname = await self.middleware.call('disk.gptid_from_part_type', disk, zfs_part_type)
-            if osc.IS_FREEBSD and disk_encryption_options.get('enc_keypath'):
+            if disk_encryption_options.get('enc_keypath'):
                 enc_disks.append({
                     'disk': disk,
                     'devname': devname,
@@ -46,7 +45,7 @@ class PoolService(Service):
         job.set_progress(15, f'Formatting disks (0/{len(disks)})')
 
         pass_file = None
-        if osc.IS_FREEBSD and disk_encryption_options.get('passphrase'):
+        if disk_encryption_options.get('passphrase'):
             pass_file = await self.middleware.call('pool.create_temp_pass_file', disk_encryption_options['passphrase'])
             disk_encryption_options['passphrase_path'] = pass_file
 


### PR DESCRIPTION
Without these changes, the entire system goes catatonic and the job to format disks just stalls. Also, the OS becomes very slow to respond. I do 3 things to fix.

1. stop calling `disk.get_zfs_part_type` for each disk being formatted. Instead, just call it once and pass the result.
2. eventually `disk.format` is called which calls `device.get_disk` which calls `kern.geom.confxml` for _EACH_ disk. This is painful and causes `g_event` thread to spin a core at 100% and eventually cause the system to become very slow to respond. To make matters worse, we're only using it to get the size and sectorsize of the disk. I added `get_sectorsize_with_name` to `py-bsd` and call it instead. I also call `get_size_with_name` from `py-bsd` which already existed before these changes. This negates the entirety for calling `kern.geom.confxml` which makes this dramatically faster.
3. remove the `osc` plugin from `disk_/format.py` and `pool_/format_disks.py`