### PR TITLE
NAS-112667 / 22.02 / Set default max_parallel_replication_tasks to 5 (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/replication_/config.py
+++ b/src/middlewared/middlewared/plugins/replication_/config.py
@@ -8,7 +8,7 @@ class ReplicationConfigModel(sa.Model):
     __tablename__ = "storage_replication_config"
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    max_parallel_replication_tasks = sa.Column(sa.Integer(), nullable=True, default=None)
+    max_parallel_replication_tasks = sa.Column(sa.Integer(), nullable=True, default=5)
 
 
 class ReplicationConfigService(ConfigService):


### PR DESCRIPTION
Inifinite default value seems to crash on FreeBSD (see
https://jira.ixsystems.com/browse/NAS-112667).

Also, there is a very few cases where running many replications in parallel
would benefit performance. If the network is bandwidth-limited for a single
connection, 5 parallel connections are usually enough to utilize its full capacity.

Original PR: https://github.com/truenas/middleware/pull/8121
Jira URL: https://jira.ixsystems.com/browse/NAS-112667