### PR TITLE
NAS-114248 / 22.02 / Selectively handle auth header in docker client

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/client.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/client.py
@@ -52,7 +52,8 @@ def parse_auth_header(header: str):
     if len(parts) > 1:
         for part in parts[1].split(','):
             key, value = part.split('=')
-            results[adapter[key]] = value.strip('"')
+            if key in adapter:
+                results[adapter[key]] = value.strip('"')
     return results
 
 


### PR DESCRIPTION
This commit adds changes to tackle unexpected values in auth header and only tackle/consume information which is of interest to us.
```
[2022/01/11 09:38:11] (ERROR) asyncio.default_exception_handler():1738 - Task exception was never retrieved
future: <Task finished name='Task-7372' coro=<Middleware.call() done, defined at /usr/lib/python3/dist-packages/middlewared/main.py:1318> exception=KeyError('error')>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1324, in call
    return await self._call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1281, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/update_alerts.py", line 32, in check_update
    await self.check_update_for_image(tag, image)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/update_alerts.py", line 59, in check_update_for_image
    self.IMAGE_CACHE[tag] = await self.compare_id_digests(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/update_alerts.py", line 77, in compare_id_digests
    repo_digest = await self._get_repo_digest(registry, image_str, tag_str)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/client.py", line 136, in _get_repo_digest
    response = await self._get_manifest_response(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/client.py", line 109, in _get_manifest_response
    auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
  File "/usr/lib/python3/dist-packages/middlewared/plugins/docker_linux/client.py", line 55, in parse_auth_header
    results[adapter[key]] = value.strip('"')
KeyError: 'error'
```