### PR TITLE
NAS-114074 / 22.02 / fix regression with /etc/hosts

### DIFF
--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -7,6 +7,9 @@
 		hostname = middleware.call_sync('smb.config')['netbiosname_local'].lower()
 		domain_name = ad_config['ad_domainname'].lower()
 %>
+% if network_config['hosts']:
+${network_config['hosts']}
+% endif
 127.0.0.1	localhost
 127.0.0.1	${hostname}.${domain_name} ${hostname}
 


### PR DESCRIPTION
Need to account for the fact that "aliases" can be given in the webUI under network global configuration. We need to write these to `/etc/hosts` accordingly.