### PR TITLE
`ssh-rsa` was excluded from default `PubkeyAcceptedAlgorithms`. Isn't…

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/ssh/sshd_config
+++ b/src/middlewared/middlewared/etc_files/local/ssh/sshd_config
@@ -84,6 +84,7 @@ PasswordAuthentication yes
 GSSAPIAuthentication yes
 % endif
 PubkeyAuthentication yes
+PubkeyAcceptedAlgorithms +ssh-rsa
 ${ssh_config['options']}
 % if twofactor_enabled:
 # These are forced to be enabled with 2FA


### PR DESCRIPTION
… it a little bit premature?