### PR TITLE
NAS-113212 / 22.02 / Set sysctl panic tunables

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -1,2 +1,5 @@
 kernel.panic = 10
 kernel.panic_on_oops = 1
+kernel.panic_on_io_nmi = 1
+kernel.panic_on_unrecovered_nmi = 1
+kernel.unknown_nmi_panic = 1


### PR DESCRIPTION
Enable kernel panic on IO, unrecovered and unknown NMIs.