### PR TITLE
NAS-114674 / 22.02.1 / 22.02 / allow variables for portal path

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -63,7 +63,7 @@ class ChartReleaseService(Service):
         cleaned_portals = {}
         for portal_type, schema in portals.items():
             t_portals = []
-            path = schema.get('path') or '/'
+            path = tag_func(schema.get('path')) or '/'
             for protocol in filter(bool, map(tag_func, schema['protocols'])):
                 for host in filter(bool, map(tag_func, schema['host'])):
                     for port in filter(bool, map(tag_func, schema['ports'])):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -63,7 +63,7 @@ class ChartReleaseService(Service):
         cleaned_portals = {}
         for portal_type, schema in portals.items():
             t_portals = []
-            path = tag_func(schema.get('path')) or '/'
+            path = tag_func(schema.get('path') or '/')
             for protocol in filter(bool, map(tag_func, schema['protocols'])):
                 for host in filter(bool, map(tag_func, schema['host'])):
                     for port in filter(bool, map(tag_func, schema['ports'])):


### PR DESCRIPTION
Currently portal path does not accept the use of variables.
This means the path cannot be formed dynamically by using kubernetes resources.

This PR also processes the path through the logic requried to use said variables, just like the other portal options

I'm not 100% sure this synax is correct, please verify!