### PR TITLE
NAS-114327 / 22.02.1 / Give admins more insight into SMB connections to NAS

### DIFF
--- a/src/middlewared/middlewared/alert/source/smb.py
+++ b/src/middlewared/middlewared/alert/source/smb.py
@@ -1,0 +1,70 @@
+import time
+from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource
+from middlewared.alert.schedule import CrontabSchedule
+
+
+async def generate_alert_text(auth_log):
+    alert_text = [
+        f'{x["Authentication"]["clientAccount"]}: {x["Authentication"]["remoteAddress"]}' for x in auth_log
+    ]
+    return alert_text
+
+
+class SMBLegacyProtocolAlertClass(AlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.NOTICE
+    title = "SMB1 connections to TrueNAS server have been performed in last 24 hours"
+    text = "The following clients have established SMB1 sessions: %(err)s."
+
+
+class NTLMv1AuthenticationAlertClass(AlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "NTLMv1 authentication has been attempted in the last 24 hours"
+    text = "The following clients have attempted NTLMv1 authentication: %(err)s"
+
+
+class SMBLegacyProtocolAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=1)  # every 24 hours
+    run_on_backup_node = False
+
+    async def check(self):
+        if not await self.middleware.call('service.started', 'cifs'):
+            return
+
+        now = time.time()
+        auth_log = await self.middleware.call('smb.status', 'AUTH_LOG', [
+            ["timestamp_tval.tv_sec", ">", now - 86400],
+            ["Authentication.serviceDescription", "=", "SMB"],
+        ])
+
+        return Alert(
+            SMBLegacyProtocolAlertClass,
+            {'err': ', '.join(await generate_alert_text(auth_log))},
+            key=None
+        )
+
+
+class NTLMv1AuthenticationAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=0)  # every 24 hours
+    run_on_backup_node = False
+
+    async def check(self):
+        if not await self.middleware.call('service.started', 'cifs'):
+            return
+
+        smb_conf = await self.middleware.call('smb.config')
+        if smb_conf['ntlmv1_auth']:
+            return
+
+        now = time.time()
+        auth_log = await self.middleware.call('smb.status', 'AUTH_LOG', [
+            ["timestamp_tval.tv_sec", ">", now - 86400],
+            ["Authentication.passwordType", "=", "NTLMv1"]
+        ])
+
+        return Alert(
+            NTLMv1AuthenticationAlertClass,
+            {'err': ', '.join(await generate_alert_text(auth_log))},
+            key=None
+        )

--- a/src/middlewared/middlewared/alert/source/smb.py
+++ b/src/middlewared/middlewared/alert/source/smb.py
@@ -20,7 +20,7 @@ def generate_alert_text(auth_log):
         }
         alert_text[k] = entry
 
-    return [str(x) for x in alert_text.values()]
+    return [f"{entry['client']} at {entry['address']} ({entry['cnt']} times)" for entry in alert_text.values()]
 
 
 class SMBLegacyProtocolAlertClass(AlertClass):


### PR DESCRIPTION
Modern SMB clients shouldn't be using NTLMv1 for authentication,
but I'm increasingly seeing this on the forums (and users not
being aware that their Windows computer's security settings
have somehow been downgraded). This has also happened for
customers as well. Alerting on NTLMv1 generally will help
possibly avoid a support call / debugging session.

At some point in time in the future, SMB1 will be deprecated
in Samba. We can start generating running logs of SMB1 clients
in notice alerts to nag users to start looking into upgrading
legacy clients.