### PR TITLE
NAS-114333 / 13.0 / Expand `__[POSTCOMPILE_encrypted_provider_1` into valid SQL syntax

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/connection.py
+++ b/src/middlewared/middlewared/plugins/datastore/connection.py
@@ -54,7 +54,7 @@ class DatastoreService(Service):
         options.setdefault('ha_sync', True)
         options.setdefault('return_last_insert_rowid', False)
 
-        compiled = stmt.compile(self.engine)
+        compiled = stmt.compile(self.engine, compile_kwargs={"render_postcompile": True})
 
         sql = compiled.string
         binds = []

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
@@ -331,6 +331,20 @@ async def test__string_filters(filter, ids):
         assert [row["id"] for row in await ds.query("test.string", filter)] == ids
 
 
+@pytest.mark.asyncio
+async def test_delete_not_in():
+    async with datastore_test() as ds:
+        await ds.execute("INSERT INTO test_string VALUES (1, 'Lorem')")
+        await ds.execute("INSERT INTO test_string VALUES (2, 'Ipsum')")
+        await ds.execute("INSERT INTO test_string VALUES (3, 'dolor')")
+        await ds.execute("INSERT INTO test_string VALUES (4, 'sit')")
+        await ds.execute("INSERT INTO test_string VALUES (5, 'amer')")
+
+        await ds.delete("test_string", [["string", "nin", ["Lorem", "dolor"]]])
+
+        assert [row["id"] for row in await ds.query("test.string")] == [1, 3]
+
+
 class IntegerModel(Model):
     __tablename__ = 'test_integer'
 


### PR DESCRIPTION
SQLAlchemy includes a variant on a bound parameter known as `BindParameter.expanding`,
which is a “late evaluated” parameter that is rendered in an intermediary state when
a SQL construct is compiled, which is then further processed at statement execution
time when the actual known values are passed. “Expanding” parameters are used for
`ColumnOperators.in_()` expressions by default so that the SQL string can be safely
cached independently of the actual lists of values being passed to a particular
invocation of `ColumnOperators.in_()`.

We need to render the `IN` clause with real bound parameter symbols as we store these
statements in HA database journal and execute them in a lower-level connection that
does not support these SQLAlchemy substitutions.