### PR TITLE
Update avahi DEV_INFO service model payload

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -15,6 +15,7 @@ class DevType(enum.Enum):
     AIRPORT = 'AirPort'
     APPLETV = 'AppleTv1,1'
     MACPRO = 'MacPro'
+    MACPRORACK = 'MacPro7,1@ECOLOR=226,226,224'
     RACKMAC = 'RackMac'
     TIMECAPSULE = 'TimeCapsule6,106'
     XSERVE = 'Xserve'
@@ -102,7 +103,7 @@ class mDNSService(object):
 
         txtrecord = {}
         if self.service == 'DEV_INFO':
-            txtrecord['model'] = DevType.RACKMAC
+            txtrecord['model'] = DevType.MACPRORACK
             return (txtrecord, [AvahiConst.AVAHI_IF_UNSPEC])
 
         if self.service == 'ADISK':


### PR DESCRIPTION
macOS Big Sur and later dropped support for "RackMac" sidebar icon in Finder. This PR updated the model field to use the new Mac Pro rack instead.

Before:
<img width="137" alt="Screen Shot 2022-01-17 at 10 47 30 PM" src="https://user-images.githubusercontent.com/1725664/149885011-1b460161-46c9-4ea8-8333-4f02364e524f.png">


After:
<img width="136" alt="Screen Shot 2022-01-17 at 10 46 25 PM" src="https://user-images.githubusercontent.com/1725664/149884839-e4a353b0-994e-4b9d-96a7-274821cf9e07.png">

