### PR TITLE
NAS-114360 / 22.02 / Correctly retrieve bus attribute for disk

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -170,7 +170,8 @@ class DeviceService(Service, DeviceInfoBase):
                 else:
                     disk['lunid'] = disk_data['wwn'].lstrip('0x')
 
-            disk['bus'] = disk_data['tran'].upper()
+            if disk_data['tran']:
+                disk['bus'] = disk_data['tran'].upper()
 
         if not disk['size'] and os.path.exists(os.path.join(disk_sys_path, 'size')):
             with open(os.path.join(disk_sys_path, 'size'), 'r') as f:


### PR DESCRIPTION
This commit fixes an issue where if 'tran' is null, we are not able to retrieve disk details.
```
❯ midclt call device.get_disk vda | jq
'NoneType' object has no attribute 'upper'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 160, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self,
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1292, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1192, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/device_info_linux.py", line 99, in get_disk
    return self.get_disk_details(block_device, disk, self.retrieve_disks_data())
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/device_info_linux.py", line 173, in get_disk_details
    disk['bus'] = disk_data['tran'].upper()
AttributeError: 'NoneType' object has no attribute 'upper'

❯
```