### PR TITLE
NAS-114250 / 13.0 / fix creating zpools on 13

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -83,14 +83,15 @@ class DiskService(Service, DiskInfoBase):
 
     def label_to_dev_disk_cache(self):
         label_to_dev = {}
-        for label in bsd.geom.class_by_name('LABEL').xml:
+        xml = self.middleware.call('geom.cache.get_xml')
+        for label in xml.iterfind('.//class[name="LABEL"]/geom'):
             if (name := label.find('name')) is not None:
                 for provider in label.iterfind('provider'):
                     if (prov := provider.find('name')) is not None:
                         label_to_dev[prov.text] = name.text
 
         dev_to_disk = {}
-        for label in bsd.geom.class_by_name('PART').xml:
+        for label in xml.iterfind('.//class[name="PART"]/geom'):
             if (name := label.find('name')) is not None:
                 for provider in label.iterfind('provider'):
                     if (prov := provider.find('name')) is not None:

--- a/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
@@ -322,7 +322,7 @@ class DiskService(Service, DiskEncryptionBase):
 
     @private
     def geli_clear(self, dev):
-        dev = f'{dev.removeprefix("/dev/")}.removesuffix(".eli")'
+        dev = f'{dev.removeprefix("/dev/").removesuffix(".eli")}'
         if os.path.exists(f'{dev}.eli'):
             # the .eli device should already be detached before clear can be run on it
             raise CallError(f'Unable to geli clear {dev!r} because {dev}.eli exists')

--- a/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
@@ -68,12 +68,12 @@ class DiskService(Service, DiskEncryptionBase):
 
     @private
     def geli_attach_single(self, dev, key, passphrase=None, skip_existing=False):
-        if skip_existing or not os.path.exists(f'/dev/{dev}.eli'):
+        if skip_existing or not os.path.exists(f'{dev}.eli'):
             cp = subprocess.run(
                 ['geli', 'attach'] + (['-j', passphrase] if passphrase else ['-p']) + ['-k', key, dev],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            if cp.stderr or not os.path.exists(f'/dev/{dev}.eli'):
+            if cp.stderr or not os.path.exists(f'{dev}.eli'):
                 raise CallError(f'Unable to geli attach {dev}: {cp.stderr.decode()}')
         else:
             self.logger.debug(f'{dev} already attached')

--- a/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
@@ -318,13 +318,16 @@ class DiskService(Service, DiskEncryptionBase):
 
         cp = subprocess.run(['geli', 'detach', dev], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if cp.returncode != 0:
-            raise CallError(f'Unable to geli detach {dev}: {cp.stderr.decode()}')
+            raise CallError(f'Unable to geli detach {dev!r}: {cp.stderr.decode()}')
 
     @private
     def geli_clear(self, dev):
-        cp = subprocess.run(
-            ['geli', 'clear', dev], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
+        dev = f'{dev.removeprefix("/dev/")}.removesuffix(".eli")'
+        if os.path.exists(f'{dev}.eli'):
+            # the .eli device should already be detached before clear can be run on it
+            raise CallError(f'Unable to geli clear {dev!r} because {dev}.eli exists')
+
+        cp = subprocess.run(['geli', 'clear', dev], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if cp.returncode != 0:
             raise CallError(f'Unable to geli clear {dev}: {cp.stderr.decode()}')
 

--- a/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
@@ -312,11 +312,11 @@ class DiskService(Service, DiskEncryptionBase):
 
     @private
     def geli_detach_single(self, dev):
-        if not os.path.exists(f'/dev/{dev.replace(".eli", "")}.eli'):
+        dev = f'{dev.removeprefix("/dev/").removesuffix(".eli")}.eli'
+        if not os.path.exists(dev):
             return
-        cp = subprocess.run(
-            ['geli', 'detach', dev], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
+
+        cp = subprocess.run(['geli', 'detach', dev], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if cp.returncode != 0:
             raise CallError(f'Unable to geli detach {dev}: {cp.stderr.decode()}')
 

--- a/src/middlewared/middlewared/plugins/geom.py
+++ b/src/middlewared/middlewared/plugins/geom.py
@@ -48,7 +48,7 @@ class GeomCache(Service):
             if class_name in self.CLASSES:
                 return self.XML.find(f'.//class[name="{class_name}"]')
 
-    def invalidate_cache(self):
+    def invalidate(self):
         self.middleware.call_sync('geom.cache.fill')
 
     def remove_disk(self, disk):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1644,7 +1644,7 @@ class PoolService(CRUDService):
                     wipe_job = await self.middleware.call('disk.wipe', disk, 'QUICK', False, {'configure_swap': False})
                     await wipe_job.wait()
                     if wipe_job.error:
-                        self.logger.warn(f'Failed to wipe disk {disk}: {wipe_job.error}')
+                        self.logger.warning('Failed to wipe disk %r: %r', disk, wipe_job.error)
                 await asyncio_map(unlabel, disks, limit=16)
 
             await self.middleware.call('disk.sync_all')

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -846,7 +846,7 @@ class PoolService(CRUDService):
 
         if disks:
             await self.middleware.call('pool.format_disks', job, disks, enc_options)
-            await self.middleware.call('geom.invalidate.cache')
+            await self.middleware.call('geom.cache.invalidate')
             vdevs, enc_disks = await self.middleware.call(
                 'pool.convert_topology_to_vdevs', data['topology'], enc_options
             )
@@ -962,7 +962,7 @@ class PoolService(CRUDService):
         geli = enc_options and bool(enc_options.get('enc_keypath'))
         vdevs = []
         enc_disks = []
-        xml = await self.middleware.call('geom.get_xml')
+        xml = await self.middleware.call('geom.cache.get_xml')
         zfs_part = await self.middleware.call('disk.get_zfs_part_type')
         for vdev_type in topology:
             for vdev_info in topology[vdev_type]:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -670,10 +670,6 @@ class PoolService(CRUDService):
         # format the disks (GELI encryption is ignored on create requests since it was deprecated)
         await self.middleware.call('pool.format_disks', job, disks)
 
-        # now we need to invalidate in-memory cache of disk info
-        # since we just formatted disks and wrote fresh gptid lables
-        await self.middleware.call('geom.cache.invalidate')
-
         options = {
             'feature@lz4_compress': 'enabled',
             'altroot': '/mnt',
@@ -846,7 +842,6 @@ class PoolService(CRUDService):
 
         if disks:
             await self.middleware.call('pool.format_disks', job, disks)
-            await self.middleware.call('geom.cache.invalidate')
             vdevs, enc_disks = await self.middleware.call(
                 'pool.convert_topology_to_vdevs', data['topology'], enc_options
             )

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -651,7 +651,7 @@ class PoolService(CRUDService):
 
         await self.__common_validation(verrors, data, 'pool_create')
         disks = await self.middleware.call('pool.mark_disks_for_swap', data['topology'])
-        disks_cache = await self.middleware.call('disk.check_disks_availability', verrors, list(disks), 'pool_create')
+        await self.middleware.call('disk.check_disks_availability', verrors, list(disks), 'pool_create')
         verrors.check()
 
         log_disks = sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])
@@ -742,9 +742,6 @@ class PoolService(CRUDService):
             encrypted_dataset_pk = await self.middleware.call(
                 'pool.dataset.insert_or_update_encrypted_record', encrypted_dataset_data
             )
-
-            if osc.IS_FREEBSD:
-                await self.middleware.call('pool.save_encrypteddisks', pool_id, formatted_disks, disks_cache)
 
             await self.middleware.call(
                 'datastore.insert',

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -2,7 +2,6 @@ import asyncio
 
 from middlewared.schema import accepts, Dict, Int, Str
 from middlewared.service import CallError, job, Service, ValidationErrors
-from middlewared.utils import osc
 
 
 class PoolService(Service):
@@ -26,11 +25,12 @@ class PoolService(Service):
         is the STRIPED disk GUID which will be converted to mirror. If `target_vdev` is mirror, it will be converted
         into a n-way mirror.
         """
-        pool = await self.middleware.call('pool.get_instance', oid)
+        pool = await self.get_instance(oid)
         verrors = ValidationErrors()
         if not pool['is_decrypted']:
             verrors.add('oid', 'Pool must be unlocked for this action.')
             verrors.check()
+
         topology = pool['topology']
         topology_type = vdev = None
         for i in topology:
@@ -44,6 +44,7 @@ class PoolService(Service):
         else:
             verrors.add('pool_attach.target_vdev', 'Unable to locate VDEV')
             verrors.check()
+
         if topology_type in ('cache', 'spares'):
             verrors.add('pool_attach.target_vdev', f'Attaching disks to {topology_type} not allowed.')
         elif topology_type == 'data':
@@ -51,45 +52,50 @@ class PoolService(Service):
             if vdev['type'] not in ('DISK', 'MIRROR'):
                 verrors.add('pool_attach.target_vdev', f'Attaching disk to {vdev["type"]} vdev is not allowed.')
 
-        if osc.IS_FREEBSD and pool['encrypt'] == 2:
+        if pool['encrypt'] == 2:
             if not options.get('passphrase'):
                 verrors.add('pool_attach.passphrase', 'Passphrase is required for encrypted pool.')
             elif not await self.middleware.call('disk.geli_testkey', pool, options['passphrase']):
                 verrors.add('pool_attach.passphrase', 'Passphrase is not valid.')
 
-        if osc.IS_LINUX and options.get('passphrase'):
-            verrors.add(
-                'pool_attach.passphrase',
-                'This field is not valid on this platform.'
-            )
-
         # Let's validate new disk now
         await self.middleware.call('disk.check_disks_availability', verrors, [options['new_disk']], 'pool_attach')
         verrors.check()
 
-        guid = vdev['guid'] if vdev['type'] == 'DISK' else vdev['children'][0]['guid']
-        disks = {options['new_disk']: {'create_swap': topology_type == 'data', 'vdev': []}}
-        enc_disks = await self.middleware.call(
+        disks = {options['new_disk']: {'create_swap': topology_type == 'data'}}
+        await self.middleware.call(
             'pool.format_disks', job, disks,
             {'enc_keypath': pool['encryptkey_path'], 'passphrase': options.get('passphrase')}
         )
 
-        devname = disks[options['new_disk']]['vdev'][0]
+        # just formatted and encrypted the disk so have to invalidate
+        # the in-memory cache of disk info
+        await self.middleware.call('geom.cache.invalidate')
+
+        devname = await self.middleware.call(
+            'disk.gptid_from_part_type',
+            options['new_disk'],
+            await self.middleware.call('disk.get_zfs_part_type')
+        )
+        if pool['encrypt'] > 0:
+            devname = f'/dev/{devname}.eli'
+
+        guid = vdev['guid'] if vdev['type'] == 'DISK' else vdev['children'][0]['guid']
         extend_job = await self.middleware.call('zfs.pool.extend', pool['name'], None, [
             {'target': guid, 'type': 'DISK', 'path': devname}
         ])
         try:
             await job.wrap(extend_job)
         except CallError:
-            if osc.IS_FREEBSD and pool['encrypt'] > 0:
+            if pool['encrypt'] > 0:
                 try:
                     # If replace has failed lets detach geli to not keep disk busy
                     await self.middleware.call('disk.geli_detach_single', devname)
                 except Exception:
-                    self.logger.warn(f'Failed to geli detach {devname}', exc_info=True)
+                    self.logger.warning('Failed to geli detach %r', devname, exc_info=True)
             raise
 
-        if osc.IS_FREEBSD:
-            disk = await self.middleware.call('disk.query', [['devname', '=', options['new_disk']]], {'get': True})
-            await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})
+        enc_disks = {'disk': options['new_disk'], 'devname': devname}
+        disk = await self.middleware.call('disk.query', [['devname', '=', options['new_disk']]], {'get': True})
+        await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})
         asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))

--- a/src/middlewared/middlewared/plugins/pool_/encrypt_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/encrypt_disks.py
@@ -1,0 +1,61 @@
+import os
+from tempfile import NamedTemporaryFile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from middlewared.service import private, Service
+
+
+class PoolService(Service):
+
+    @private
+    def encrypt_disks(self, job, disks, options):
+        """
+        This GELI encrypts all the disks in `disks`.
+        NOTE: this is only called on pool.update since GELI was deprecated
+        for all newly created zpools.
+        """
+        # we do not allow the creation of new GELI based zpools, however,
+        # we still have to support users who created them before we deprecated
+        # the parameters in the API. This is here for those users.
+        total_disks = len(disks)
+        pass_file = None
+        if options.get('passphrase'):
+            # called when attaching disks to a GELI encrypted zpool
+            with NamedTemporaryFile(mode='w+', dir='/tmp', delete=False) as p:
+                os.chmod(p.name, 0o600)
+                p.write(options['passphrase'])
+                p.flush()
+                options['passphrase_path'] = pass_file = p.name
+
+        with ThreadPoolExecutor(max_workers=16) as exc:
+            # The called methods `subprocess` out many times for each disk
+            # so this is painful on systems with large amount of disks.
+            # This is, unfortunately, the best we can really do right now
+            # without implementing gpart code natively in python.
+            # (cython or ctypes wrapper maybe???)
+            futures = [
+                exc.submit(
+                    self.middleware.call_sync(
+                        'disk.encrypt', i['devname'].replace('.eli', ''),
+                        options['enc_keypath'], options.get('passphrase_path')
+                    )
+                )
+                for i in disks
+            ]
+            try:
+                for idx, fut in enumerate(as_completed(futures), start=1):
+                    try:
+                        fut.result()
+                    except TypeError:
+                        # `disk.encrypt` returns a str type which isn't callable
+                        # however, it's return data isn't needed so the TypeError
+                        # is expected
+                        job.set_progress(25, f'Encrypted disk {idx} of {total_disks!r}')
+            finally:
+                try:
+                    os.unlink(pass_file)
+                except (TypeError, FileNotFoundError):
+                    # TypeError if pass_file = None
+                    # FileNotFoundError to be "proper" in case
+                    # something else removes that file before we do
+                    pass

--- a/src/middlewared/middlewared/plugins/pool_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/pool_/encryption_freebsd.py
@@ -27,7 +27,7 @@ class PoolService(Service):
                     {
                         'volume': pool_id,
                         'disk': disks_cache[enc_disk['disk']]['identifier'],
-                        'provider': enc_disk['devname'],
+                        'provider': enc_disk['devname'].removeprefix('/dev/'),
                     },
                     {'prefix': 'encrypted_'},
                 )

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -1,5 +1,3 @@
-import os
-from tempfile import NamedTemporaryFile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from middlewared.service import private, Service
@@ -8,19 +6,16 @@ from middlewared.service import private, Service
 class PoolService(Service):
 
     @private
-    def format_disks(self, job, disks, options=None):
+    def format_disks(self, job, disks):
         """
         This does a few things:
             1. wipes the disks (max of 16 in parallel using native threads)
             2. formats the disks with a freebsd-zfs partition label
             3. formats the disks with a freebsd-swap partition lable (if necessary)
-            4. encrypts disks (only on update method and on existing GELI pools)
         """
         self.middleware.call_sync('disk.sed_unlock_all')  # unlock any SED drives
         swapgb = self.middleware.call_sync('system.advanced.config')['swapondrive']
         total_disks = len(disks)
-        options = options or {}
-
         with ThreadPoolExecutor(max_workers=16) as exc:
             # The called methods `subprocess` out many times for each disk
             # so this is painful on systems with large amount of disks.
@@ -38,35 +33,3 @@ class PoolService(Service):
                     # `disk.format` returns None which isn't callable
                     # so this exception is expected and means it's complete
                     job.set_progress(15, f'Formatted disk {idx} of {total_disks}')
-
-            # we do not allow the creation of new GELI based zpools, however,
-            # we still have to support users who created them before we deprecated
-            # the parameters in the API. This is here for those users.
-            if options.get('enc_keypath'):
-                pass_file = None
-                if options.get('passphrase'):
-                    # called when attaching disks to a GELI encrypted zpool
-                    with NamedTemporaryFile(mode='w+', dir='/tmp', delete=False) as p:
-                        os.chmod(p.name, 0o600)
-                        p.write(options['passphrase'])
-                        p.flush()
-                        options['passphrase_path'] = pass_file = p.name
-
-                futures = [exc.submit(
-                    self.middleware.call_sync(
-                        'disk.encrypt', k, options['enc_keypath'], options.get('passphrase_path'))
-                    )
-                    for k in disks
-                ]
-                try:
-                    for idx, fut in enumerate(as_completed(futures), start=1):
-                        fut.result()
-                        job.set_progress(25, f'Encrypted disk {idx} of {total_disks!r}')
-                finally:
-                    try:
-                        os.unlink(pass_file)
-                    except (TypeError, FileNotFoundError):
-                        # TypeError if pass_file = None
-                        # FileNotFoundError to be "proper" in case
-                        # something else removes that file before we do
-                        pass

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -1,75 +1,72 @@
 import os
-import tempfile
+from tempfile import NamedTemporaryFile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from middlewared.service import private, Service
-from middlewared.utils.asyncio_ import asyncio_map
 
 
 class PoolService(Service):
 
     @private
-    async def format_disks(self, job, disks, disk_encryption_options=None):
+    def format_disks(self, job, disks, options=None):
         """
-        Format all disks, putting all freebsd-zfs partitions created
-        into their respective vdevs and encrypting disks if specified for FreeBSD.
+        This does a few things:
+            1. wipes the disks (max of 16 in parallel using native threads)
+            2. formats the disks with a freebsd-zfs partition label
+            3. formats the disks with a freebsd-swap partition lable (if necessary)
+            4. encrypts disks (only on update method and on existing GELI pools)
         """
-        # Make sure all SED disks are unlocked
-        await self.middleware.call('disk.sed_unlock_all')
-        disk_encryption_options = disk_encryption_options or {}
+        self.middleware.call_sync('disk.sed_unlock_all')  # unlock any SED drives
+        swapgb = self.middleware.call_sync('system.advanced.config')['swapondrive']
+        total_disks = len(disks)
+        options = options or {}
 
-        swapgb = (await self.middleware.call('system.advanced.config'))['swapondrive']
-        zfs_part_type = await self.middleware.call('disk.get_zfs_part_type')
-        enc_disks = []
-        formatted = 0
+        with ThreadPoolExecutor(max_workers=16) as exc:
+            # The called methods `subprocess` out many times for each disk
+            # so this is painful on systems with large amount of disks.
+            # This is, unfortunately, the best we can really do right now
+            # without implementing gpart code natively in python.
+            # (cython or ctypes wrapper maybe???)
+            futures = [exc.submit(
+                self.middleware.call_sync('disk.format', k, swapgb if v['create_swap'] else 0, False))
+                for k, v in disks.items()
+            ]
+            for idx, fut in enumerate(as_completed(futures), start=1):
+                try:
+                    fut.result()
+                except TypeError:
+                    # `disk.format` returns None which isn't callable
+                    # so this exception is expected and means it's complete
+                    job.set_progress(15, f'Formatted disk {idx} of {total_disks}')
 
-        async def format_disk(arg):
-            nonlocal enc_disks, formatted
-            disk, config = arg
-            await self.middleware.call(
-                'disk.format', disk, swapgb if config['create_swap'] else 0, False,
-            )
-            devname = await self.middleware.call('disk.gptid_from_part_type', disk, zfs_part_type)
-            if disk_encryption_options.get('enc_keypath'):
-                enc_disks.append({
-                    'disk': disk,
-                    'devname': devname,
-                })
-                devname = await self.middleware.call(
-                    'disk.encrypt', devname, disk_encryption_options['enc_keypath'],
-                    disk_encryption_options.get('passphrase_path')
-                )
-            formatted += 1
-            job.set_progress(15, f'Formatting disks ({formatted}/{len(disks)})')
-            config['vdev'].append(f'/dev/{devname}')
+            # we do not allow the creation of new GELI based zpools, however,
+            # we still have to support users who created them before we deprecated
+            # the parameters in the API. This is here for those users.
+            if options.get('enc_keypath'):
+                pass_file = None
+                if options.get('passphrase'):
+                    # called when attaching disks to a GELI encrypted zpool
+                    with NamedTemporaryFile(mode='w+', dir='/tmp', delete=False) as p:
+                        os.chmod(p.name, 0o600)
+                        p.write(options['passphrase'])
+                        p.flush()
+                        options['passphrase_path'] = pass_file = p.name
 
-        job.set_progress(15, f'Formatting disks (0/{len(disks)})')
-
-        pass_file = None
-        if disk_encryption_options.get('passphrase'):
-            pass_file = await self.middleware.call('pool.create_temp_pass_file', disk_encryption_options['passphrase'])
-            disk_encryption_options['passphrase_path'] = pass_file
-
-        try:
-            await asyncio_map(format_disk, disks.items(), limit=16)
-        finally:
-            if pass_file:
-                await self.middleware.call('pool.destroy_temp_pass_file', pass_file)
-
-        await self.middleware.call('disk.sync_all')
-
-        return enc_disks
-
-    @private
-    def create_temp_pass_file(self, content):
-        passf = tempfile.NamedTemporaryFile(mode='w+', dir='/tmp/', delete=False)
-        os.chmod(passf.name, 0o600)
-        passf.write(content)
-        passf.flush()
-        pass_file = passf.name
-        passf.close()
-        return pass_file
-
-    @private
-    def destroy_temp_pass_file(self, path):
-        if os.path.exists(path):
-            os.unlink(path)
+                futures = [exc.submit(
+                    self.middleware.call_sync(
+                        'disk.encrypt', k, options['enc_keypath'], options.get('passphrase_path'))
+                    )
+                    for k in disks
+                ]
+                try:
+                    for idx, fut in enumerate(as_completed(futures), start=1):
+                        fut.result()
+                        job.set_progress(25, f'Encrypted disk {idx} of {total_disks!r}')
+                finally:
+                    try:
+                        os.unlink(pass_file)
+                    except (TypeError, FileNotFoundError):
+                        # TypeError if pass_file = None
+                        # FileNotFoundError to be "proper" in case
+                        # something else removes that file before we do
+                        pass

--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -3,8 +3,7 @@ import errno
 import os
 
 from middlewared.schema import accepts, Bool, Dict, Int, Str
-from middlewared.service import CallError, item_method, job, Service, ValidationErrors
-from middlewared.utils import osc
+from middlewared.service import item_method, job, Service, ValidationErrors
 
 
 class PoolService(Service):
@@ -41,42 +40,30 @@ class PoolService(Service):
                 }]
             }
         """
-        pool = await self.middleware.call('pool.get_instance', oid)
+        pool = await self.get_instance(oid)
 
         verrors = ValidationErrors()
 
         unused_disks = await self.middleware.call('disk.get_unused')
         disk = list(filter(lambda x: x['identifier'] == options['disk'], unused_disks))
         if not disk:
-            verrors.add('options.disk', 'Disk not found.', errno.ENOENT)
+            verrors.add('options.disk', f'Disk {options["disk"]!r} not found.', errno.ENOENT)
         else:
             disk = disk[0]
 
             if not options['force'] and not await self.middleware.call('disk.check_clean', disk['devname']):
                 verrors.add('options.force', 'Disk is not clean, partitions were found.')
 
-        if osc.IS_FREEBSD and pool['encrypt'] == 2:
+        if pool['encrypt'] == 2:
             if not options.get('passphrase'):
                 verrors.add('options.passphrase', 'Passphrase is required for encrypted pool.')
-            elif not await self.middleware.call(
-                'disk.geli_testkey', pool, options['passphrase']
-            ):
+            elif not await self.middleware.call('disk.geli_testkey', pool, options['passphrase']):
                 verrors.add('options.passphrase', 'Passphrase is not valid.')
 
-        if osc.IS_LINUX and options.get('passphrase'):
-            verrors.add(
-                'options.passphrase', 'This field is not valid on this platform.'
-            )
-
         found = await self.middleware.call('pool.find_disk_from_topology', options['label'], pool)
-
         if not found:
             verrors.add('options.label', f'Label {options["label"]} not found.', errno.ENOENT)
-
-        if verrors:
-            raise verrors
-
-        create_swap = found[0] in ('data', 'spare')
+        verrors.check()
 
         swap_disks = [disk['devname']]
         # If the disk we are replacing is still available, remove it from swap as well
@@ -88,14 +75,16 @@ class PoolService(Service):
                 swap_disks.append(from_disk)
 
         await self.middleware.call('disk.swaps_remove_disks', swap_disks)
-
-        vdev = []
-        enc_disks = await self.middleware.call(
-            'pool.format_disks', job, {disk['devname']: {'vdev': vdev, 'create_swap': create_swap}},
+        await self.middleware.call(
+            'pool.format_disks', job, {disk['devname']: {'create_swap': found[0] in ('data', 'spare')}},
             {'enc_keypath': pool['encryptkey_path'], 'passphrase': options.get('passphrase')},
         )
+        await self.middleware.call('geom.cache.invalidate')
 
-        new_devname = vdev[0].replace('/dev/', '')
+        zfs_part = await self.middleware.call('disk.get_zfs_part_type')
+        new_devname = await self.middleware.call('disk.gptid_from_part_type', disk['devname'], zfs_part)
+        if pool['encrypt'] > 0:
+            new_devname = f'{new_devname}.eli'
 
         job.set_progress(30, 'Replacing disk')
         try:
@@ -111,21 +100,20 @@ class PoolService(Service):
                 if vdev['status'] not in ('ONLINE', 'DEGRADED'):
                     await self.middleware.call('zfs.pool.detach', pool['name'], options['label'])
             except Exception:
-                self.logger.warn('Failed to detach device', exc_info=True)
-        except Exception as e:
-            if osc.IS_FREEBSD:
-                try:
-                    # If replace has failed lets detach geli to not keep disk busy
-                    await self.middleware.call('disk.geli_detach_single', new_devname)
-                except Exception:
-                    self.logger.warn(f'Failed to geli detach {new_devname}', exc_info=True)
-            raise e
+                self.logger.warning('Failed to detach device', exc_info=True)
+        except Exception:
+            try:
+                # If replace has failed lets detach geli to not keep disk busy
+                await self.middleware.call('disk.geli_detach_single', new_devname)
+            except Exception:
+                self.logger.warning('Failed to geli detach %r', new_devname, exc_info=True)
+            raise
         finally:
             # Needs to happen even if replace failed to put back disk that had been
             # removed from swap prior to replacement
             asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
 
-        if osc.IS_FREEBSD:
-            await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})
+        enc_disks = {'disk': disk['devname'], 'devname': f'/dev/{new_devname}'}
+        await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})
 
         return True


### PR DESCRIPTION
I _really_ tried to keep the changes here as minimal as possible. These changes are also part of the massive PR against 13 that I filed awhile ago but ended up closing in favor of breaking up the commits into smaller chunks.

Anyways, I've broken all of these commits up into small chunks so they can be followed easily enough without getting lost in all the changes.

Without these changes, on hardware that QE gave me access to, creating a zpool via the webUI on 13 never completes and the OS goes into a semi-catatonic state with `g_event` thread spinning a cpu core at 100% indefinitely. This occurs because `disk.format` calls `disk.gptid_from_part_type` for _EVERY_ disk that gets formatted. This ends up calling `kern.geom.confxml` which is expensive and painful. We do this just to get the `gptid` label that was put on the disk. To make matters worse, we did this in parallel up to a max of 16 times. On a system with 100's of hard drives, you can see how this will never scale or work properly.

My changes fix this design problem by simply formatting the disks in their entirety. Once the formatting has been done, I only call `kern.geom.confxml` once afterwards.

The unfortunate reality is that I had to touch a bunch of surrounding methods because they were all designed for this specific flow control. Also, we still support updating GELI encrypted zpools. I tested the GELI related methods and found quite a few other bugs so I went ahead and fixed those. The biggest one being that on `pool.export` `geli detach` and then `geli clear` raced with `disk.format` if you exported the zpool and chose the option to destroy the zpool. We don't need to run `disk.format` on disks that were geli encrypted because we run `geli clear` which wipes the metadata from the disks. `disk.format` does nothing in this scenario. I also found that when attaching/detaching/decrypting geli providers, we weren't passing the correct arguments to the CLI so I've normalized the device names in their respective methods.

Lastly, I separated the `disk.encrypt` from `pool_/format_disks.py` since it overly complicated `def format_disks` unnecessarily.