### PR TITLE
NAS-114332 / 13.0 / fix enclosure mapping on 13 for Mini XL+

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -327,6 +327,7 @@ class EnclosureService(Service):
     async def _map_enclosures(self, enclosures, slots):
         mapped = [{
             "id": "mapped_enclosure_0",
+            "number": 0,
             "name": "Drive Bays",
             "model": "",
             "controller": True,


### PR DESCRIPTION
The `TRUENAS-MINI` line of products doesn't support additional enclosures. However, we still map the on-board enclosure device to make it more user friendly in the webUI. When this mapping occurs, the ses number was being dropped which is needed when sync'ing enclosure disks to zpools. This adds back the `number: 0` key which represents the ses number.