### PR TITLE
NAS-113959 / 13.0 / fix enclosure mapping on MINI XL+

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -327,6 +327,7 @@ class EnclosureService(Service):
     async def _map_enclosures(self, enclosures, slots):
         mapped = [{
             "id": "mapped_enclosure_0",
+            "number": 0,
             "name": "Drive Bays",
             "model": "",
             "controller": True,


### PR DESCRIPTION
The truenas `MINI` line doesn't support additional enclosures but we still map the on-board enclosure information. We map this to provide a friendly user experience in the webUI. During mapping, the `/dev/ses#` is being dropped so this adds a `number: 0` key so that when we map enclosure slot to disks and disks to pools, it will show correctly in the webUI.