### PR TITLE
NAS-114332 / 13.0 / properly map rear U.2 nvme drives on M/R series

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/nvme.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/nvme.py
@@ -27,6 +27,7 @@ class EnclosureService(Service):
 
         return [{
             'id': id,
+            'number': 1,
             'name': name,
             'label': name,
             'model': model,


### PR DESCRIPTION
Even though the rear U.2 nvme drive bays on the M and R series aren't in an enclosure, we still "mapped" them to `/dev/ses1` (`number: 1`). This change does the same thing by mapping the rear U.2 nvme drive bays to `number: 1` like we did in 12.