### PR TITLE
NAS-114208 / 22.02 / Adding custom yaml representor for apps

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -4,9 +4,6 @@ import errno
 import itertools
 import os
 import shutil
-import subprocess
-import tempfile
-import yaml
 
 from pkg_resources import parse_version
 
@@ -571,37 +568,6 @@ class ChartReleaseService(CRUDService):
 
         job.set_progress(100, f'{release_name!r} chart release deleted')
         return True
-
-    @private
-    def helm_action(self, chart_release, chart_path, config, tn_action):
-        args = ['-f']
-        if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
-            args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
-
-        action = tn_action if tn_action == 'install' else 'upgrade'
-        if action == 'upgrade':
-            # We only keep history of max 5 upgrades
-            # We input 6 here because helm considers app setting modifications as upgrades as well
-            # which means that if an app setting is even just modified and is not an upgrade in scale terms
-            # we will essentially only be keeping 4 major upgrades revision history. With 6, we temporarily have 6
-            # secrets for the app but that gets sorted out asap after the upgrade action when we sync secrets and
-            # we end up with 5 revision secrets max per app
-            args.insert(0, '--history-max=6')
-
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(yaml.dump(config))
-            f.flush()
-
-            cp = subprocess.Popen(
-                ['helm', action, chart_release, chart_path, '-n', get_namespace(chart_release)] + args + [f.name],
-                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
-                env=dict(os.environ, KUBECONFIG='/etc/rancher/k3s/k3s.yaml'),
-            )
-            stderr = cp.communicate()[1]
-            if cp.returncode:
-                raise CallError(f'Failed to {tn_action} chart release: {stderr.decode()}')
-
-        self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)
 
     @accepts(Str('release_name'))
     @returns(ENTRY)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import tempfile
+import yaml
+
+from middlewared.plugins.kubernetes_linux.yaml import SafeDumper
+from middlewared.service import CallError, private, Service
+
+from .utils import get_namespace
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    def helm_action(self, chart_release, chart_path, config, tn_action):
+        args = ['-f']
+        if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
+            args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
+
+        action = tn_action if tn_action == 'install' else 'upgrade'
+        if action == 'upgrade':
+            # We only keep history of max 5 upgrades
+            # We input 6 here because helm considers app setting modifications as upgrades as well
+            # which means that if an app setting is even just modified and is not an upgrade in scale terms
+            # we will essentially only be keeping 4 major upgrades revision history. With 6, we temporarily have 6
+            # secrets for the app but that gets sorted out asap after the upgrade action when we sync secrets and
+            # we end up with 5 revision secrets max per app
+            args.insert(0, '--history-max=6')
+
+        with tempfile.NamedTemporaryFile(mode='w+') as f:
+            f.write(yaml.dump(config, Dumper=SafeDumper))
+            f.flush()
+
+            cp = subprocess.Popen(
+                ['helm', action, chart_release, chart_path, '-n', get_namespace(chart_release)] + args + [f.name],
+                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                env=dict(os.environ, KUBECONFIG='/etc/rancher/k3s/k3s.yaml'),
+            )
+            stderr = cp.communicate()[1]
+            if cp.returncode:
+                raise CallError(f'Failed to {tn_action} chart release: {stderr.decode()}')
+
+        self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -1,6 +1,7 @@
 import copy
 import enum
 import os
+import yaml
 
 from middlewared.utils import run as _run
 
@@ -24,6 +25,16 @@ class Resources(enum.Enum):
     PERSISTENT_VOLUME_CLAIM = 'persistent_volume_claims'
     POD = 'pods'
     STATEFULSET = 'statefulsets'
+
+
+# We would like to customize safe dumper here so that when it dumps values, we quote strings
+# why we want to do this is for instances when strings like 'y' are treated as boolean true
+# by yaml and if we don't dump this enclosed with quotes, helm treats 'y' as true and we get inconsistent
+# usage
+def initialize_yaml_str_representer():
+    yaml.add_representer(
+        str, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"'), yaml.SafeDumper
+    )
 
 
 def get_action_context(release_name):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -1,7 +1,6 @@
 import copy
 import enum
 import os
-import yaml
 
 from middlewared.utils import run as _run
 
@@ -25,16 +24,6 @@ class Resources(enum.Enum):
     PERSISTENT_VOLUME_CLAIM = 'persistent_volume_claims'
     POD = 'pods'
     STATEFULSET = 'statefulsets'
-
-
-# We would like to customize safe dumper here so that when it dumps values, we quote strings
-# why we want to do this is for instances when strings like 'y' are treated as boolean true
-# by yaml and if we don't dump this enclosed with quotes, helm treats 'y' as true and we get inconsistent
-# usage
-def initialize_yaml_str_representer():
-    yaml.add_representer(
-        str, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"'), yaml.SafeDumper
-    )
 
 
 def get_action_context(release_name):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/yaml.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/yaml.py
@@ -1,0 +1,14 @@
+import yaml
+
+
+class SafeDumper(yaml.SafeDumper):
+    pass
+
+
+# We would like to customize safe dumper here so that when it dumps values, we quote strings
+# why we want to do this is for instances when strings like 'y' are treated as boolean true
+# by yaml and if we don't dump this enclosed with quotes, helm treats 'y' as true and we get inconsistent
+# usage
+yaml.add_representer(
+    str, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data, style='"'), SafeDumper
+)

--- a/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_releases_values.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_releases_values.py
@@ -1,0 +1,21 @@
+import pytest
+import yaml
+
+from middlewared.plugins.kubernetes_linux.yaml import SafeDumper
+
+
+@pytest.mark.parametrize("reference", [
+    {'name': 'booltest_true', 'value': True},
+    {'name': 'booltest_false', 'value': False},
+    {'name': 'str_y', 'value': 'y'},
+    {'name': 'str_n', 'value': 'n'},
+    {'name': 'str_random', 'value': 'random'},
+    {'name': 'str_int', 'value': '1'},
+    {'name': 'int_val', 'value': 1},
+    {'name': 'float_val', 'value': 1.3},
+    {'name': 'list_val', 'value': []},
+    {'name': 'list_dict_val', 'value': [{'a': 'y', 'b': 'n', 'c': 'some', 'd': 1}]},
+])
+def test_yaml_load_dump(reference):
+    assert reference == yaml.safe_load(yaml.dump(reference, Dumper=SafeDumper))
+    assert reference == yaml.safe_load(yaml.dump(reference, Dumper=yaml.SafeDumper))


### PR DESCRIPTION
# Background
YAML's default behaviour is to consider `y` value as boolean true. For example:
```
key: y
```
would be read by hem as `key: true` instead of respecting `y` as string. This is problematic in our design as chart developers explicitly mention what the schema of the variable in question is.

# What does this do?

This quotes string type keys/values to make sure that they are read appropriately by helm. So object of `{'k': 'y'}` is dumped as
```
"k": "y"
```
instead of
```
k: y
```
. This ensures that chart developer specified schema is respected by yaml and we do not see yaml magic influencing user specified values.

Tested across:
- creating/updating apps
- Different python object formats work as intended
- We do not see a behavioural change at python level from the yaml dumper we were using before