### PR TITLE
NAS-114163 / 22.02 / ensure unique mac addresses for bonds

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -89,6 +89,13 @@ class InterfaceService(Service):
             # be sure and bring the lagg back up after making changes
             iface.up()
 
+        # set mac address if needed
+        iface_link_addr = iface.link_address.address.address
+        db_link_addr = lagg['lagg_interface']['int_link_address']
+        if iface_link_addr and iface_link_addr != db_link_addr:
+            self.logger.info('Setting link address for %r to %s', name, db_link_addr)
+            iface.link_address = db_link_addr
+
         members_database = []
         members_configured = {p[0] for p in iface.ports}
         for member in members:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -90,6 +90,10 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         except IndexError:
             return None
 
+    @link_address.setter
+    def link_address(self, link_address):
+        run(["ip", "link", "set", "dev", self.name, "address", link_address])
+
     def __getstate__(self, address_stats=False, vrrp_config=None):
         state = {
             'name': self.name,


### PR DESCRIPTION
Different physical systems using the same hardware have shown that linux kernel's mechanism for generating a mac address for the `bond` interface is deterministic and causes collisions. This means systemA with bond0 will have the same mac address as systemB with bond0.

To fix this, I generate a LAA (locally administered address) which guarantees that we do not collide with the UAA (universally administered address). (i.e. we don't want to generate a mac address that has the same vendor bits as Intel/Microsoft/Juniper etc etc)