### PR TITLE
NAS-114375 / 22.02 / make sure static routes are synced on reboot

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1749,6 +1749,12 @@ class InterfaceService(CRUDService):
             await asyncio.wait(dhclient_aws, timeout=30)
 
         try:
+            # static routes explicitly defined by the user need to be setup
+            await self.middleware.call('staticroute.sync')
+        except Exception:
+            self.logger.info('Failed to sync static routes', exc_info=True)
+
+        try:
             # We may need to set up routes again as they may have been removed while changing IPs
             await self.middleware.call('route.sync')
         except Exception:


### PR DESCRIPTION
Without this, on reboot, the static routes are sync'ed to the OS.