### PR TITLE
Update _device-info._tcp. model payload (#8145)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -15,6 +15,7 @@ class DevType(enum.Enum):
     AIRPORT = 'AirPort'
     APPLETV = 'AppleTv1,1'
     MACPRO = 'MacPro'
+    MACPRORACK = 'MacPro7,1@ECOLOR=226,226,224'
     RACKMAC = 'RackMac'
     TIMECAPSULE = 'TimeCapsule6,106'
     XSERVE = 'Xserve'
@@ -122,7 +123,7 @@ class mDNSService(object):
 
         txtrecord = {}
         if self.service == 'DEV_INFO':
-            txtrecord['model'] = DevType.RACKMAC
+            txtrecord['model'] = DevType.MACPRORACK
             return (txtrecord, [AvahiConst.AVAHI_IF_UNSPEC])
 
         if self.service == 'ADISK':


### PR DESCRIPTION
macOS Big Sur and later stopped support for "RackMac" side bar icon in Finder. Update this to use the new Mac Pro rack style.