### PR TITLE
NAS-114427 / 13.0 / Load ctl.ko at boot

### DIFF
--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -42,7 +42,7 @@ dumpdev="NO"
 dumpdir="/data/crash"
 
 # A set of storage supporting kernel modules, they must be loaded before ix-fstab.
-early_kld_list="dtraceall geom_multipath"
+early_kld_list="ctl dtraceall geom_multipath"
 
 # A set of kernel modules that can be loaded after mounting local filesystems.
 kld_list="hwpmc t4_tom"


### PR DESCRIPTION
We need the ctl module loaded early for HA configuration and collectd
plugin initialization.  It used to be built into a kernel, but now it is
a module for space reasons.