### PR TITLE
NAS-114393 / 22.02 / Performance improvements when retrieving catalogs

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/features.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/features.py
@@ -19,11 +19,11 @@ SUPPORTED_FEATURES = {
 }
 
 
-class CatalogService(Service):
+def version_supported(version_details: dict) -> bool:
+    return not bool(set(version_details['required_features']) - SUPPORTED_FEATURES)
 
-    @private
-    async def version_supported(self, version_details):
-        return not bool(set(version_details['required_features']) - SUPPORTED_FEATURES)
+
+class CatalogService(Service):
 
     @private
     def get_feature_map(self, cache=True):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -4,6 +4,8 @@ import os
 from middlewared.schema import accepts, Bool, Dict, List, returns, Str
 from middlewared.service import CallError, Service
 
+from .questions_utils import normalise_questions
+
 
 class CatalogService(Service):
 
@@ -60,7 +62,7 @@ class CatalogService(Service):
                     )
                     if needs_normalization:
                         questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
-                        self.middleware.call_sync('catalog.normalise_questions', versioned_item, questions_context)
+                        normalise_questions(versioned_item, questions_context)
                 return item
 
         return self.middleware.call_sync('catalog.retrieve_item_details', item_location)

--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -4,6 +4,7 @@ import os
 from middlewared.schema import accepts, Bool, Dict, List, returns, Str
 from middlewared.service import CallError, Service
 
+from .items_util import get_item_details
 from .questions_utils import normalise_questions
 
 
@@ -47,6 +48,7 @@ class CatalogService(Service):
         elif not os.path.isdir(item_location):
             raise CallError(f'{item_location!r} must be a directory')
 
+        questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
         if options['cache'] and self.middleware.call_sync(
             'cache.has_key', f'catalog_{options["catalog"]}_train_details'
         ):
@@ -61,8 +63,7 @@ class CatalogService(Service):
                         for feature in versioned_item['required_features']
                     )
                     if needs_normalization:
-                        questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
                         normalise_questions(versioned_item, questions_context)
                 return item
 
-        return self.middleware.call_sync('catalog.retrieve_item_details', item_location)
+        return get_item_details(item_location, questions_context, {'retrieve_versions': True})

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -11,6 +11,8 @@ from pkg_resources import parse_version
 from middlewared.schema import Bool, Dict, List, returns, Str
 from middlewared.service import accepts, job, private, Service, ValidationErrors
 
+from .features import version_supported
+from .items_util import get_item_default_values
 from .utils import get_cache_key
 
 
@@ -352,11 +354,11 @@ class CatalogService(Service):
         # like a field referring to available interfaces on the system
         self.normalise_questions(version_data, questions_context)
 
-        version_data['supported'] = self.middleware.call_sync('catalog.version_supported', version_data)
-        version_data['required_features'] = list(version_data['required_features'])
-        version_data['values'] = self.middleware.call_sync(
-            'chart.release.construct_schema_for_item_version', version_data, {}, False
-        )['new_values']
+        version_data.update({
+            'supported': version_supported(version_data),
+            'required_features': list(version_data['required_features']),
+            'values': get_item_default_values(version_data)
+        })
         chart_metadata = version_data['chart_metadata']
         if chart_metadata['name'] != 'ix-chart' and chart_metadata.get('appVersion'):
             version_data['human_version'] = f'{chart_metadata["appVersion"]}_{chart_metadata["version"]}'

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -202,7 +202,7 @@ class CatalogService(Service):
 
         total_items = len(items)
 
-        with concurrent.futures.ProcessPoolExecutor(max_workers=2) as exc:
+        with concurrent.futures.ProcessPoolExecutor(max_workers=(5 if total_items > 10 else 2)) as exc:
             for index, result in enumerate(zip(items, exc.map(
                 functools.partial(item_details, items, location, questions_context, options),
                 items, chunksize=10

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -201,11 +201,10 @@ class CatalogService(Service):
         job.set_progress(8, f'Retrieving {", ".join(trains_to_traverse)!r} train(s) information')
 
         total_items = len(items)
-
         with concurrent.futures.ProcessPoolExecutor(max_workers=(5 if total_items > 10 else 2)) as exc:
             for index, result in enumerate(zip(items, exc.map(
                 functools.partial(item_details, items, location, questions_context, options),
-                items, chunksize=10
+                items, chunksize=(10 if total_items > 10 else 5)
             ))):
                 item_key = result[0]
                 item_info = result[1]

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -12,7 +12,7 @@ from middlewared.schema import Bool, Dict, List, returns, Str
 from middlewared.service import accepts, job, private, Service, ValidationErrors
 
 from .features import version_supported
-from .items_util import get_item_default_values
+from .items_util import get_item_default_values, get_item_version_details
 from .questions_utils import normalise_questions
 from .utils import get_cache_key
 
@@ -337,34 +337,7 @@ class CatalogService(Service):
     def item_version_details(self, version_path, questions_context=None):
         if not questions_context:
             questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
-        version_data = {'location': version_path, 'required_features': set()}
-        for key, filename, parser in (
-            ('chart_metadata', 'Chart.yaml', yaml.safe_load),
-            ('schema', 'questions.yaml', yaml.safe_load),
-            ('app_readme', 'app-readme.md', markdown.markdown),
-            ('detailed_readme', 'README.md', markdown.markdown),
-            ('changelog', 'CHANGELOG.md', markdown.markdown),
-        ):
-            if os.path.exists(os.path.join(version_path, filename)):
-                with open(os.path.join(version_path, filename), 'r') as f:
-                    version_data[key] = parser(f.read())
-            else:
-                version_data[key] = None
-
-        # We will normalise questions now so that if they have any references, we render them accordingly
-        # like a field referring to available interfaces on the system
-        normalise_questions(version_data, questions_context)
-
-        version_data.update({
-            'supported': version_supported(version_data),
-            'required_features': list(version_data['required_features']),
-            'values': get_item_default_values(version_data)
-        })
-        chart_metadata = version_data['chart_metadata']
-        if chart_metadata['name'] != 'ix-chart' and chart_metadata.get('appVersion'):
-            version_data['human_version'] = f'{chart_metadata["appVersion"]}_{chart_metadata["version"]}'
-
-        return version_data
+        return get_item_version_details(version_path, questions_context)
 
     @private
     async def get_normalised_questions_context(self):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -1,5 +1,43 @@
+import markdown
+import os
+import yaml
+
 from middlewared.plugins.chart_releases_linux.schema import construct_schema
+
+from .features import version_supported
+from .questions_utils import normalise_questions
 
 
 def get_item_default_values(version_details: dict) -> dict:
     return construct_schema(version_details, {}, False)['new_values']
+
+
+def get_item_version_details(version_path: str, questions_context: dict) -> dict:
+    version_data = {'location': version_path, 'required_features': set()}
+    for key, filename, parser in (
+        ('chart_metadata', 'Chart.yaml', yaml.safe_load),
+        ('schema', 'questions.yaml', yaml.safe_load),
+        ('app_readme', 'app-readme.md', markdown.markdown),
+        ('detailed_readme', 'README.md', markdown.markdown),
+        ('changelog', 'CHANGELOG.md', markdown.markdown),
+    ):
+        if os.path.exists(os.path.join(version_path, filename)):
+            with open(os.path.join(version_path, filename), 'r') as f:
+                version_data[key] = parser(f.read())
+        else:
+            version_data[key] = None
+
+    # We will normalise questions now so that if they have any references, we render them accordingly
+    # like a field referring to available interfaces on the system
+    normalise_questions(version_data, questions_context)
+
+    version_data.update({
+        'supported': version_supported(version_data),
+        'required_features': list(version_data['required_features']),
+        'values': get_item_default_values(version_data)
+    })
+    chart_metadata = version_data['chart_metadata']
+    if chart_metadata['name'] != 'ix-chart' and chart_metadata.get('appVersion'):
+        version_data['human_version'] = f'{chart_metadata["appVersion"]}_{chart_metadata["version"]}'
+
+    return version_data

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -1,0 +1,5 @@
+from middlewared.plugins.chart_releases_linux.schema import construct_schema
+
+
+def get_item_default_values(version_details: dict) -> dict:
+    return construct_schema(version_details, {}, False)['new_values']

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -2,14 +2,64 @@ import markdown
 import os
 import yaml
 
+from pkg_resources import parse_version
+
 from middlewared.plugins.chart_releases_linux.schema import construct_schema
+from middlewared.service import ValidationErrors
 
 from .features import version_supported
 from .questions_utils import normalise_questions
+from .validate_utils import validate_item_version
+
+
+ITEM_KEYS = ['icon_url']
 
 
 def get_item_default_values(version_details: dict) -> dict:
     return construct_schema(version_details, {}, False)['new_values']
+
+
+def get_item_details(item_path: str, schema: str, questions_context: dict, options: dict) -> dict:
+    # Each directory under item path represents a version of the item and we need to retrieve details
+    # for each version available under the item
+    retrieve_latest_version = options.get('retrieve_latest_version')
+    item_data = {'versions': {}}
+    with open(os.path.join(item_path, 'item.yaml'), 'r') as f:
+        item_data.update(yaml.safe_load(f.read()))
+
+    item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
+
+    for version in sorted(
+        filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
+        reverse=True, key=parse_version,
+    ):
+        item_data['versions'][version] = version_details = {
+            'healthy': False,
+            'supported': False,
+            'healthy_error': None,
+            'location': os.path.join(item_path, version),
+            'required_features': [],
+            'human_version': version,
+            'version': version,
+        }
+        try:
+            validate_item_version(version_details['location'], f'{schema}.{version}')
+        except ValidationErrors as verrors:
+            version_details['healthy_error'] = f'Following error(s) were found with {schema}.{version!r}:\n'
+            for verror in verrors:
+                version_details['healthy_error'] += f'{verror[0]}: {verror[1]}'
+
+            # There is no point in trying to see what questions etc the version has as it's invalid
+            continue
+
+        version_details.update({
+            'healthy': True,
+            **get_item_version_details(version_details['location'], questions_context)
+        })
+        if retrieve_latest_version:
+            break
+
+    return item_data
 
 
 def get_item_version_details(version_path: str, questions_context: dict) -> dict:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
@@ -1,0 +1,77 @@
+import itertools
+
+
+def normalise_questions(version_data: dict, context: dict) -> None:
+    version_data['required_features'] = set()
+    for question in version_data['schema']['questions']:
+        normalise_question(question, version_data, context)
+    version_data['required_features'] = list(version_data['required_features'])
+
+
+def normalise_question(question: dict, version_data: dict, context: dict) -> None:
+    schema = question['schema']
+    for attr in itertools.chain(*[schema.get(k, []) for k in ('attrs', 'items', 'subquestions')]):
+        normalise_question(attr, version_data, context)
+
+    if '$ref' not in schema:
+        return
+
+    data = {}
+    for ref in schema['$ref']:
+        version_data['required_features'].add(ref)
+        if ref == 'definitions/interface':
+            data['enum'] = [
+                {'value': i, 'description': f'{i!r} Interface'} for i in context['nic_choices']
+            ]
+        elif ref == 'definitions/gpuConfiguration':
+            data['attrs'] = [
+                {
+                    'variable': gpu,
+                    'label': f'GPU Resource ({gpu})',
+                    'description': 'Please enter the number of GPUs to allocate',
+                    'schema': {
+                        'type': 'int',
+                        'max': int(quantity),
+                        'enum': [
+                            {'value': i, 'description': f'Allocate {i!r} {gpu} GPU'}
+                            for i in range(int(quantity) + 1)
+                        ],
+                        'default': 0,
+                    }
+                } for gpu, quantity in context['gpus'].items()
+            ]
+        elif ref == 'definitions/timezone':
+            data.update({
+                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in context['timezones']],
+                'default': context['system.general.config']['timezone']
+            })
+        elif ref == 'definitions/nodeIP':
+            data['default'] = context['node_ip']
+        elif ref == 'definitions/certificate':
+            get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate'})
+            data['enum'] += [
+                {'value': i['id'], 'description': f'{i["name"]!r} Certificate'}
+                for i in context['certificates']
+            ]
+        elif ref == 'definitions/certificateAuthority':
+            get_cert_ca_options(schema, data, {'value': None, 'description': 'No Certificate Authority'})
+            data['enum'] += [{'value': None, 'description': 'No Certificate Authority'}] + [
+                {'value': i['id'], 'description': f'{i["name"]!r} Certificate Authority'}
+                for i in context['certificate_authorities']
+            ]
+
+    schema.update(data)
+
+
+def get_cert_ca_options(schema: dict, data: dict, default_entry: dict):
+    if schema.get('null', True):
+        data.update({
+            'enum': [default_entry],
+            'default': None,
+            'null': True,
+        })
+    else:
+        data.update({
+            'enum': [],
+            'required': True,
+        })

--- a/src/middlewared/middlewared/plugins/catalogs_linux/validate.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/validate.py
@@ -1,7 +1,7 @@
 import errno
 import os
 
-from catalog_validation.validation import validate_catalog, validate_catalog_item_version
+from catalog_validation.validation import validate_catalog
 
 from middlewared.schema import returns, Str
 from middlewared.service import accepts, CallError, job, private, Service
@@ -37,4 +37,3 @@ class CatalogService(Service):
             raise CallError(f'{path!r} does not exist', errno=errno.ENOENT)
 
         check_errors(validate_catalog, path)
-

--- a/src/middlewared/middlewared/plugins/catalogs_linux/validate.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/validate.py
@@ -1,11 +1,12 @@
 import errno
 import os
 
-from catalog_validation.exceptions import ValidationErrors as CatalogValidationErrors
-from catalog_validation.validation import validate_catalog, validate_catalog_item, validate_catalog_item_version
+from catalog_validation.validation import validate_catalog, validate_catalog_item_version
 
 from middlewared.schema import returns, Str
-from middlewared.service import accepts, CallError, job, private, Service, ValidationErrors
+from middlewared.service import accepts, CallError, job, private, Service
+
+from .validate_utils import check_errors
 
 
 class CatalogService(Service):
@@ -35,21 +36,5 @@ class CatalogService(Service):
         if not os.path.exists(path):
             raise CallError(f'{path!r} does not exist', errno=errno.ENOENT)
 
-        self.check_errors(validate_catalog, path)
+        check_errors(validate_catalog, path)
 
-    @private
-    def check_errors(self, func, *args, **kwargs):
-        verrors = ValidationErrors()
-        try:
-            func(*args, **kwargs)
-        except CatalogValidationErrors as e:
-            verrors.extend(e)
-        verrors.check()
-
-    @private
-    def validate_catalog_item(self, path, schema, validate_versions=True):
-        self.check_errors(validate_catalog_item, path, schema, validate_versions)
-
-    @private
-    def validate_catalog_item_version(self, path, schema):
-        self.check_errors(validate_catalog_item_version, path, schema)

--- a/src/middlewared/middlewared/plugins/catalogs_linux/validate_utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/validate_utils.py
@@ -1,0 +1,21 @@
+from catalog_validation.exceptions import ValidationErrors as CatalogValidationErrors
+from catalog_validation.validation import validate_catalog_item, validate_catalog_item_version
+
+from middlewared.service import ValidationErrors
+
+
+def check_errors(func: callable, *args, **kwargs):
+    verrors = ValidationErrors()
+    try:
+        func(*args, **kwargs)
+    except CatalogValidationErrors as e:
+        verrors.extend(e)
+    verrors.check()
+
+
+def validate_item(path: str, schema: dict, validate_versions: bool = True):
+    check_errors(validate_catalog_item, path, schema, validate_versions)
+
+
+def validate_item_version(path: str, schema: dict):
+    check_errors(validate_catalog_item_version, path, schema)

--- a/src/middlewared/middlewared/plugins/catalogs_linux/validate_utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/validate_utils.py
@@ -13,9 +13,9 @@ def check_errors(func: callable, *args, **kwargs):
     verrors.check()
 
 
-def validate_item(path: str, schema: dict, validate_versions: bool = True):
+def validate_item(path: str, schema: str, validate_versions: bool = True):
     check_errors(validate_catalog_item, path, schema, validate_versions)
 
 
-def validate_item_version(path: str, schema: dict):
+def validate_item_version(path: str, schema: str):
     check_errors(validate_catalog_item_version, path, schema)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -1,9 +1,12 @@
+import itertools
+
 from copy import deepcopy
 from itertools import chain
+from typing import Union
 
 from middlewared.service_exception import ValidationErrors
 from middlewared.schema import Bool, Cron, Dict, HostPath, Int, IPAddr, List, NOT_PROVIDED, Path, Str
-from middlewared.validators import Match, Range
+from middlewared.validators import Match, Range, validate_schema
 
 
 mapping = {
@@ -17,6 +20,33 @@ mapping = {
     'ipaddr': IPAddr,
     'cron': Cron,
 }
+
+
+def construct_schema(
+    item_version_details: dict, new_values: dict, update: bool, old_values: Union[dict, object] = NOT_PROVIDED
+) -> dict:
+    schema_name = f'chart_release_{"update" if update else "create"}'
+    attrs = list(itertools.chain.from_iterable(
+        get_schema(q, update, old_values) for q in item_version_details['schema']['questions']
+    ))
+    dict_obj = update_conditional_defaults(
+        Dict(schema_name, *attrs, update=update, additional_attrs=True), {
+            'schema': {'attrs': item_version_details['schema']['questions']}
+        }
+    )
+
+    verrors = ValidationErrors()
+    verrors.add_child('values', validate_schema(
+        attrs, new_values, True, dict_kwargs={
+            'conditional_defaults': dict_obj.conditional_defaults, 'update': update,
+        }
+    ))
+    return {
+        'verrors': verrors,
+        'new_values': new_values,
+        'dict_obj': dict_obj,
+        'schema_name': schema_name,
+    }
 
 
 def update_conditional_defaults(dict_obj, variable_details):


### PR DESCRIPTION
After profiling/investigating middleware process, it was found that when reading large catalog like truecharts - we ran into GIL issues where the thread responsible for reading the large catalog was taking too much time of the main process which is also responsible for managing/delegating middleware calls which resulted in system lag as middleware became very slow in processing requests.
After discussing with @themylogin, we decided to read the catalog in a separate process and the results show incredible improvements to the middleware process responsiveness and reading the catalog information as well. Earlier it used to take 4-5 minutes to read the catalog and it takes approx 50 secs now and all the while middleware is fully responsive and no lag is experienced on that end.