### PR TITLE
NAS-114306 / 22.02 / Do not allow ix-applications path to be shared

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -142,6 +142,9 @@ class FilesystemService(Service):
         if not path.is_dir():
             raise CallError(f'Path {path} is not a directory', errno.ENOTDIR)
 
+        if 'ix-applications' in path.parts:
+            raise CallError('Ix-applications is a system managed dataset and it\'s contents cannot be listed')
+
         rv = []
         only_top_level = path.absolute() == pathlib.Path('/mnt')
         for entry in path.iterdir():
@@ -154,6 +157,8 @@ class FilesystemService(Service):
                 # prevent shares from being configured to point to
                 # a path that doesn't exist on a zpool, we'll
                 # filter these here.
+                continue
+            if 'ix-applications' in entry.parts:
                 continue
             if entry.is_symlink():
                 etype = 'SYMLINK'

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -143,7 +143,7 @@ class FilesystemService(Service):
             raise CallError(f'Path {path} is not a directory', errno.ENOTDIR)
 
         if 'ix-applications' in path.parts:
-            raise CallError('Ix-applications is a system managed dataset and it\'s contents cannot be listed')
+            raise CallError('Ix-applications is a system managed dataset and its contents cannot be listed')
 
         rv = []
         only_top_level = path.absolute() == pathlib.Path('/mnt')

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -1,5 +1,5 @@
 from middlewared.async_validators import check_path_resides_within_volume, resolve_hostname
-from middlewared.schema import accepts, Bool, Dict, Dir, Int, Patch, Str
+from middlewared.schema import Bool, Dict, Dir, Int, Str
 from middlewared.validators import Exact, Match, Or, Range
 from middlewared.service import private, SystemServiceService, ValidationErrors
 import middlewared.sqlalchemy as sa


### PR DESCRIPTION
Make sure that the path does not get validated if its path to k8s dataset or one of its children.