### PR TITLE
NAS-114441 / 22.02 / Add ix-truenas into hosts on k8s service start

### DIFF
--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -6,12 +6,18 @@
 	if ad_config['ad_enable']:
 		hostname = middleware.call_sync('smb.config')['netbiosname_local'].lower()
 		domain_name = ad_config['ad_domainname'].lower()
+
+	k8s_ds = middleware.call_sync('kubernetes.config')['dataset']
+	k8s_node = middleware.call_sync('k8s.node.node_name')
 %>
 % if network_config['hosts']:
 ${network_config['hosts']}
 % endif
 127.0.0.1	localhost
 127.0.0.1	${hostname}.${domain_name} ${hostname}
+% if k8s_ds:
+127.0.0.1	${k8s_node}
+% endif
 
 # The following lines are desirable for IPv6 capable hosts
 ::1	localhost ip6-localhost ip6-loopback

--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -7,7 +7,7 @@
 		hostname = middleware.call_sync('smb.config')['netbiosname_local'].lower()
 		domain_name = ad_config['ad_domainname'].lower()
 
-	k8s_ds = middleware.call_sync('kubernetes.config')['dataset']
+	k8s_entry_add = middleware.call_sync('kubernetes.config')['dataset'] and not middleware.call_sync('kerberos.keytab.has_nfs_principal')
 	k8s_node = middleware.call_sync('k8s.node.node_name')
 %>
 % if network_config['hosts']:
@@ -15,7 +15,7 @@ ${network_config['hosts']}
 % endif
 127.0.0.1	localhost
 127.0.0.1	${hostname}.${domain_name} ${hostname}
-% if k8s_ds:
+% if k8s_entry_add:
 127.0.0.1	${k8s_node}
 % endif
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -56,3 +56,6 @@ class KubernetesNodeService(ConfigService):
     @accepts()
     async def worker_node_password(self):
         return KUBERNETES_WORKER_NODE_PASSWORD
+
+    async def node_name(self):
+        return NODE_NAME

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -47,6 +47,7 @@ class KubernetesService(SimpleService):
 
             raise
 
+        await self.middleware.call('service.reload', 'hostname')
         await self.mount_kubelet_dataset()
         await self.clear_chart_releases_cache()
 
@@ -87,3 +88,4 @@ class KubernetesService(SimpleService):
         await asyncio.sleep(5)
         await self.middleware.call('k8s.cni.cleanup_cni')
         await self.unmount_kubelet_dataset()
+        await self.middleware.call('service.reload', 'hostname')


### PR DESCRIPTION
The requests to k8s can propagate to user specified dns server while they are not able to resolve it since they do not have any record for `ix-truenas` as it's local to one specific machine.

This PR adds `ix-truenas` into hosts on k8s service start and also clean up the hosts file when kubernetes service is stopped.