### PR TITLE
NAS-114450 / 13.0 / stop spamminmg kern.geom.confxml

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/info.py
+++ b/src/middlewared/middlewared/plugins/disk_/info.py
@@ -12,9 +12,10 @@ class DiskService(Service):
         Returns list of all partitions present in the system
         """
         disks = await self.middleware.call('device.get_disks')
+        part_xml = await self.middleware.call('geom.cache.get_class_xml', 'PART')
         parts = []
         for disk in disks:
-            parts.extend(await self.middleware.call('disk.list_partitions', disk))
+            parts.extend(await self.middleware.call('disk.list_partitions', disk, part_xml))
         return filter_list(parts, filters, options)
 
     @private


### PR DESCRIPTION
This is spamming `kern.geom.confxml` for _every_ disk which is painfully expensive to convert to xml. Especially on a system with 100's of drives.... To fix the problem, generate the xml once in the caller and pass it to the called method.