### PR TITLE
NAS-114509 / 22.02 / minor fixes to cluster API tests

### DIFF
--- a/cluster-tests/init_cluster.py
+++ b/cluster-tests/init_cluster.py
@@ -37,7 +37,7 @@ def setup_zpool_and_datasets(ip):
             return result
         else:
             if status['state'] != 'SUCCESS':
-                result['ERROR'] = 'Exporting "{pool["name"]}" failed on {ip}'
+                result['ERROR'] = f'Exporting "{pool["name"]}" failed on {ip}'
                 return result
 
     # wipe the disks to clean any remnants of previous zpools

--- a/cluster-tests/init_cluster.py
+++ b/cluster-tests/init_cluster.py
@@ -6,6 +6,9 @@ from config import CLUSTER_INFO, DATASET_HIERARCHY
 from exceptions import JobTimeOut
 
 
+JOB_TIMEOUT = 120  # number of seconds to wait on a job to complete
+
+
 def setup_zpool_and_datasets(ip):
     result = {'ERROR': ''}
 
@@ -28,7 +31,7 @@ def setup_zpool_and_datasets(ip):
             return result
         try:
             print(f'Waiting on "{pool["name"]}" to be exported on {ip}')
-            status = wait_on_job(ans.json(), ip, 20)
+            status = wait_on_job(ans.json(), ip, JOB_TIMEOUT)
         except JobTimeOut:
             result['ERROR'] = f'Timed out waiting on "{pool["name"]}" to be exported on {ip}'
             return result
@@ -47,7 +50,7 @@ def setup_zpool_and_datasets(ip):
         return result
     try:
         print(f'Waiting for disk "{CLUSTER_INFO["ZPOOL_DISK"]}" on {ip} to be wiped')
-        status = wait_on_job(ans.json(), ip, 10)
+        status = wait_on_job(ans.json(), ip, JOB_TIMEOUT)
     except JobTimeOut:
         result['ERROR'] = f'Timed out waiting for disk to be wiped on {ip}'
         return result
@@ -70,7 +73,7 @@ def setup_zpool_and_datasets(ip):
         return result
     try:
         print(f'Waiting on zpool "{CLUSTER_INFO["ZPOOL"]}" to be created on {ip}')
-        status = wait_on_job(ans.json(), ip, 30)
+        status = wait_on_job(ans.json(), ip, JOB_TIMEOUT)
     except JobTimeOut:
         result['ERROR'] = f'Timed out waiting on zpool to be created on {ip}'
         return result

--- a/cluster-tests/init_cluster.py
+++ b/cluster-tests/init_cluster.py
@@ -65,7 +65,8 @@ def setup_zpool_and_datasets(ip):
     payload = {
         'name': CLUSTER_INFO['ZPOOL'],
         'encryption': False,
-        'topology': {'data': [{'type': 'STRIPE', 'disks': [CLUSTER_INFO['ZPOOL_DISK']]}]}
+        'topology': {'data': [{'type': 'STRIPE', 'disks': [CLUSTER_INFO['ZPOOL_DISK']]}]},
+        'allow_duplicate_serials': True,
     }
     ans = make_request('post', url, data=payload)
     if ans.status_code != 200:


### PR DESCRIPTION
While running these against the cluster, I came across a few problems.

1. tests were randomly timing out in various places when setting everything up so bump the timeout to a universal 2mins
2. missing a `f` in a f-string
3. `allow_duplicate_serials=True` to allow creating the zpool since the VMs disks are provided by KVM and do not have a serial so they are being flagged as having "duplicate serials"