### PR TITLE
NAS-114511 / 13.0 / fix creating zpools with hot-spares on 13

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -644,6 +644,13 @@ class PoolService(CRUDService):
         if not data['topology']['data']:
             verrors.add('pool_create.topology.data', 'At least one data vdev is required')
 
+        if spares := data['topology'].pop('spares', []):
+            # every other vdev type that's passed to us follows this structure
+            # so to keep `mark_disks_for_topology` and `convert_topology_to_vdevs`
+            # simple, we just make the `spares` topology object follow the structure
+            # of the other vdev types.
+            data['topology']['spares'] = [{'type': 'STRIPE', 'disks': spares}]
+
         encryption_dict = await self.middleware.call(
             'pool.dataset.validate_encryption_data', None, verrors, {
                 'enabled': data.pop('encryption'), **data.pop('encryption_options'), 'key_file': False,


### PR DESCRIPTION
When a zpool is created, the structure of the data passed to us follows the same layout _except_ for the `spares` vdev type. Instead of making the `mark_disks_for_topology` and `convert_topology_to_vdevs` methods overly complicated, just convert the `spares` arg passed to us to the same layout as the other vdev types.