### PR TITLE
NAS-114500 / 22.02 / optimize get_Kstat in snmp-agent.py

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -17,12 +17,10 @@ def get_Kstat():
     Kstat = {}
 
     with open("/proc/spl/kstat/zfs/arcstats") as f:
-        arcstats = f.readlines()
-
-    for line in arcstats[2:]:
-        if line.strip():
-            name, type, data = line.strip().split()
-            Kstat[f"kstat.zfs.misc.arcstats.{name}"] = Decimal(int(data))
+        for lineno, line in enumerate(f, start=1):
+            if lineno > 2 and (info := line.strip()):
+                name, _, data = info.split()
+                Kstat[f"kstat.zfs.misc.arcstats.{name}"] = Decimal(int(data))
 
     Kstat["vfs.zfs.version.spa"] = Decimal(5000)
 


### PR DESCRIPTION
I'd consider this a micro-optimization, but one nonetheless. `readlines()` reads the entire contents of the file into memory so instead we iterate over the file object since the file is newline separated.