### PR TITLE
NAS-114506 / 22.02 / PCI device should only be attachable if there is no error with it

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -56,7 +56,9 @@ class PCI(Device):
         return self.middleware.call_sync('vm.query', [['id', 'in', [dev['vm'] for dev in devs]]])
 
     def safe_to_reattach(self):
-        return all(vm['status']['state'] != 'RUNNING' for vm in self.get_vms_using_device())
+        return not self.get_details()['error'] and all(
+            vm['status']['state'] != 'RUNNING' for vm in self.get_vms_using_device()
+        )
 
     def post_stop_vm_linux(self, *args, **kwargs):
         if self.safe_to_reattach():


### PR DESCRIPTION
```bash
❯ midclt call vm.device.passthrough_device pci_0000_2a_50_1 | jq
{
  "capability": {
    "class": null,
    "domain": null,
    "bus": null,
    "slot": null,
    "function": null,
    "product": "Not Available",
    "vendor": "Not Available"
  },
  "iommu_group": {},
  "available": false,
  "drivers": [],
  "error": "error: Could not find matching device 'pci_0000_2b_50_1'\nerror: Node device not found: no node device with matching name 'pci_0000_2b_50_1'\n",
  "device_path": "/sys/bus/pci/devices/0000:2b:50.1",
  "reset_mechanism_defined": false
}
```