### PR TITLE
NAS-114573 / 22.02 / fix process pool deadlock (work-around)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -1030,12 +1030,6 @@ class ZFSSnapshot(CRUDService):
         select = options.pop('select', None)
         result = filter_list(snapshots, filters, options)
 
-        if not select or 'retention' in select:
-            if isinstance(result, list):
-                result = self.middleware.call_sync('zettarepl.annotate_snapshots', result)
-            elif isinstance(result, dict):
-                result = self.middleware.call_sync('zettarepl.annotate_snapshots', [result])[0]
-
         if select:
             if isinstance(result, list):
                 result = [{k: v for k, v in item.items() if k in select} for item in result]


### PR DESCRIPTION
This causes a process pool deadlock on a system with 20k snapshots because of an inherit design issue with our process pool. After discussion with @themylogin, we've determined to remove the call that is causing the failure condition and will design a proper process pool fix for a later scale release.