### PR TITLE
NAS-114581 / 22.02 / fix exorbitant middlewared service memory usage

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -107,10 +107,10 @@ class Application(object):
     def _send(self, data):
         serialized = json.dumps(data)
         asyncio.run_coroutine_threadsafe(self.response.send_str(serialized), loop=self.loop)
-        _1MB = 1000000
-        if sys.getsizeof(serialized) > _1MB:
+        _1KB = 1000
+        if sys.getsizeof(serialized) > _1KB:
             # no reason to store data in the deque that
-            # is larger than 1MB after being serialized.
+            # is larger than 1KB after being serialized.
             # This gets _really_ painful on systems with
             # many (100's) of snapshots because running a
             # simple `zfs.snapshot.query` via midclt from
@@ -118,7 +118,7 @@ class Application(object):
             # Caching that in the main middleware process
             # is excessive and only hurts us. Instead we'll
             # truncate to 1MB.
-            message = serialized[:_1MB]
+            message = serialized[:_1KB]
         else:
             message = serialized
 
@@ -880,7 +880,7 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         self.__terminate_task = None
         self.jobs = JobsQueue(self)
         self.mocks = {}
-        self.socket_messages_queue = deque(maxlen=50)
+        self.socket_messages_queue = deque(maxlen=200)
 
     def __init_services(self):
         from middlewared.service import CoreService

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -108,16 +108,16 @@ class Application(object):
         serialized = json.dumps(data)
         asyncio.run_coroutine_threadsafe(self.response.send_str(serialized), loop=self.loop)
         _1KB = 1000
-        if sys.getsizeof(serialized) > _1KB:
+        if len(serialized) > _1KB:
             # no reason to store data in the deque that
-            # is larger than 1KB after being serialized.
+            # is larger than ~1KB after being serialized.
             # This gets _really_ painful on systems with
             # many (100's) of snapshots because running a
             # simple `zfs.snapshot.query` via midclt from
             # the cli produces ridiculously large output.
             # Caching that in the main middleware process
             # is excessive and only hurts us. Instead we'll
-            # truncate to 1MB.
+            # truncate to ~1KB.
             message = serialized[:_1KB]
         else:
             message = serialized


### PR DESCRIPTION
The fact that we even have this makes me squirm in my seat. The "debugability" that this provides doesn't outweigh the cons that it introduces in my opinion...but I digress. I've found 4 major problems.

1. because we put all websocket results in this queue, a reference is held which prevents the memory from being reclaimed from the parent middlewared process. The _ONLY_ way memory is "reclaimed" and therefore shrinks in size is when the deque is full and a new entry is added _AND_ the entry in the deque that is being replaced is smaller than the entry being inserted.....so this gets out of hand quite quickly
2. we were storing the non-serialized results so the memory usage was, in theory, considerably larger than what it should be
3. we set the deque size to 1000 entries which is kind of insane, this allows the potential of growing exponentially
4. we're performing a `copy.deepcopy` for every single websocket call just so we can format the `params` key before we store it in the `deque`. We can get rid of this by storing in the `deque` as the last step in the associated method.

This almost immediately starts eating memory on large systems (systems with 100's of hard drives) because every 5 minutes a websocket call is made to `disk.temperatures`. On a system with lots of hard drives, the result is quite large. While a single entry isn't that big a deal, 1000 of them is.

Furthermore, this is used by the webUI team and we capture this in the debug by running `core.get_websocket_messages` HOWEVER when you call that message via websocket it returns the entire contents of the `deque` and then turns around and stores those results in the `deque`.....

To fix, I've done somethings:

1. shrunk the deque to 50....no reason to have 1000
2. if the serialized string of the result is greater than 1MB in size, then instead of storing the result we overwrite the results with a string letting the end user know.
3. get rid of a `copy.deepcopy` by changing the order in which we append to the `deque` since we were only doing it so we don't mess up the structure of the original argument passed to us

With my fixes, this resolves massive memory usage on a system with 20k snapshots and calling `zfs.snapshot.query` multiple times. (Calling it 5 times grew the parent process to ~1.4GB of resident memory).