### PR TITLE
NAS-113046 / 22.02 / fix get_smartd_schedule_piece parsing bug

### DIFF
--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -81,8 +81,7 @@ def get_smartd_schedule_piece(value, min, max, enum=None):
 
     if value == "*":
         return "." * width
-    m = re.match(r"((?P<min>[0-9]+)-(?P<max>[0-9]+)|\*)/(?P<divisor>[0-9]+)", value)
-    if m:
+    elif m := re.match(r"((?P<min>[0-9]+)-(?P<max>[0-9]+)|\*)/(?P<divisor>[0-9]+)", value):
         d = int(m.group("divisor"))
         if m.group("min") is None:
             if d == 1:
@@ -91,6 +90,13 @@ def get_smartd_schedule_piece(value, min, max, enum=None):
             min = int(m.group("min"))
             max = int(m.group("max"))
         values = [v for v in range(min, max + 1) if v % d == 0]
+    elif m := re.match(r"((?P<min>[0-9]+)-(?P<max>[0-9]+)|\*)", value):
+        start = int(m.group("min"))
+        end = int(m.group("max"))
+        if end < start:
+            values = [start]
+        else:
+            values = [i for i in range(start, end + 1)]
     else:
         values = list(filter(lambda v: v is not None,
                              map(lambda s: enum.get(s.lower(), int(s) if re.match("([0-9]+)$", s) else None),

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -93,7 +93,7 @@ def get_smartd_schedule_piece(value, min, max, enum=None):
     elif m := re.match(r"((?P<min>[0-9]+)-(?P<max>[0-9]+)|\*)", value):
         start = int(m.group("min"))
         end = int(m.group("max"))
-        if end < start:
+        if end <= start:
             values = [start]
         else:
             values = [i for i in range(start, end + 1)]

--- a/src/middlewared/middlewared/pytest/unit/etc_files/test_smartd.py
+++ b/src/middlewared/middlewared/pytest/unit/etc_files/test_smartd.py
@@ -162,6 +162,14 @@ def test__get_smartd_schedule_piece__range_with_divisor():
     assert get_smartd_schedule_piece("3-30/10", 1, 31) == "(10|20|30)"
 
 
+def test__get_smartd_schedule_piece__range_without_divisor():
+    assert get_smartd_schedule_piece("10-15", 1, 31) == "(10|11|12|13|14|15)"
+
+
+def test__get_smartd_schedule_piece__malformed_range_without_divisor():
+    assert get_smartd_schedule_piece("10-1", 1, 31) == "(10)"
+
+
 def test__get_smartd_config():
     assert get_smartd_config({
         "smartctl_args": ["/dev/ada0", "-d", "sat"],


### PR DESCRIPTION
Providing a valid smartd range in the webUI caused the `smartd.conf` to be written with empty range information `()`. The issue is that the `value` is expected to have a divisor if given a hyphenated range (i.e. `10-15/1`). However, it's perfectly fine to not have a divisor and just take the values between the hypen. This fixes the scenario when a hyphenated range is given without a divisor. I've also added 2 more unit tests for this scenario.