### PR TITLE
NAS-114594 / 22.02.1 / Validate CN / SANs and tls_server_uri

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
@@ -22,7 +22,7 @@ hostname_re = re.compile(r'^[a-z\.\-0-9]*[a-z0-9]$', flags=re.IGNORECASE)
 def is_valid_hostname(hostname: str):
     """
     Validates hostname and makes sure it
-    does not contain a valid card.
+    does not contain a wild card.
     """
     return hostname_re.match(hostname)
 

--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
@@ -27,7 +27,7 @@ def is_valid_hostname(hostname: str):
     except ValueError:
         return False
     else:
-        return "*" not in hostname
+        return True
 
 
 def upgrade():

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -131,17 +131,11 @@ class S3Service(SystemServiceService):
                 'certificate.cert_services_validation', new['certificate'], 's3_update.certificate', False
             )))
 
-        if new['certificate']:
-            if not new['tls_server_uri']:
-                verrors.add(
-                    's3_update.tls_server_uri',
-                    'Please provide a SAN or CN(i.e. Common Name) from the attached certificate.'
-                )
-            elif "*" in new['tls_server_uri']:
-                verrors.add(
-                    's3_update.tls_server_uri',
-                    'This cannot contain a wildcard "*".'
-                )
+        if new['certificate'] and not new['tls_server_uri']:
+            verrors.add(
+                's3_update.tls_server_uri',
+                'Please provide a SAN or CN(i.e. Common Name) from the attached certificate.'
+            )
 
         if new['bindip'] not in await self.bindip_choices():
             verrors.add('s3_update.bindip', 'Please provide a valid ip address')

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -41,7 +41,7 @@ class S3Service(SystemServiceService):
         Str('access_key', max_length=20, required=True),
         Str('secret_key', max_length=40, required=True),
         Bool('browser', required=True),
-        Str('tls_server_uri', validators=[Hostname()], null=True, required=True),
+        Str('tls_server_uri', null=True, required=True),
         Str('storage_path', required=True),
         Int('certificate', null=True, required=True),
         Int('id', required=True),
@@ -74,6 +74,9 @@ class S3Service(SystemServiceService):
         )}),
         ('edit', {'name': 'secret_key', 'method': lambda x: setattr(
             x, 'validators', [Match(r'^\w+$', explanation='Should only contain alphanumeric characters')]
+        )}),
+        ('edit', {'name': 'tls_server_uri', 'method': lambda x: setattr(
+            x, 'validators', [Hostname(explanation='Should be a valid hostname')]
         )}),
         ('rm', {'name': 'id'}),
         ('attr', {'update': True}),

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -87,7 +87,7 @@ class Match:
         self.regex = re.compile(pattern, flags)
 
     def __call__(self, value):
-        if not self.regex.match(value):
+        if value is not None and not self.regex.match(value):
             raise ValueError(self.explanation or f"Value does not match {self.pattern!r} pattern")
 
     def __deepcopy__(self, memo):

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -96,7 +96,11 @@ class Match:
 
 class Hostname(Match):
     def __init__(self, explanation=None):
-        super().__init__(r'^[a-zA-Z\.\-\0-9]+$', explanation=explanation)
+        super().__init__(
+            r'^[a-z\.\-0-9]*[a-z0-9]$',
+            flags=re.IGNORECASE,
+            explanation=explanation
+        )
 
 
 class Or:


### PR DESCRIPTION
1. Update the migration and fallback to `localhost` if its `SANs` / `CN` does not contain anything except for a wildcard domain.
2. Add validation into the `s3.config` API so that wild card domain cannot be updated into `tls_server_uri`