### PR TITLE
NAS-114632 / 22.02 / Fix websocket regression

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -348,12 +348,16 @@ class Application(object):
             await self.unsubscribe(message['id'])
 
         if message.get('msg') == 'method' and message.get('method') and isinstance(message.get('params'), list):
-            message['params'] = self.middleware.dump_args(message.get('params', []), method_name=message['method'])
+            log_message = dict(
+                message, params=self.middleware.dump_args(message.get('params', []), method_name=message['method'])
+            )
+        else:
+            log_message = message
 
         self.middleware.socket_messages_queue.append({
             'type': 'incoming',
             'session_id': self.session_id,
-            'message': message,
+            'message': log_message,
         })
 
     def __getstate__(self):


### PR DESCRIPTION
This commit fixes an issue where we change message parameters which results in auth.login and other methods being called with the dumped version of args resulting in middleware client failing to authenticate/process other calls successfully.