### PR TITLE
NAS-114378 / 22.02 / Make sure locked datasets have immutable flag set on their mountpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3608,6 +3608,11 @@ class PoolDatasetService(CRUDService):
                 if attachments:
                     await delegate.delete(attachments)
 
+        if dataset['locked'] and os.path.exists(dataset['mountpoint']):
+            # We would like to remove the immutable flag in this case so that it's mountpoint can be
+            # cleaned automatically when we delete the dataset
+            await self.middleware.call('filesystem.set_immutable', False, dataset['mountpoint'])
+
         result = await self.middleware.call('zfs.dataset.delete', id, {
             'force': options['force'],
             'recursive': options['recursive'],

--- a/tests/api2/test_pool_unlock_lock_immutable_flags.py
+++ b/tests/api2/test_pool_unlock_lock_immutable_flags.py
@@ -1,0 +1,58 @@
+import pytest
+
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+
+import sys
+import os
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from auto_config import dev_test
+reason = 'Skip for testing'
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason=reason)
+
+
+PASSPHRASE = '12345678'
+
+
+def encryption_props():
+    return {
+        'encryption_options': {'generate_key': False, 'passphrase': PASSPHRASE},
+        'encryption': True,
+        'inherit_encryption': False
+    }
+
+
+def test_lock_sets_immutable_flag():
+    with dataset('parent', encryption_props()) as parent_ds:
+        with dataset('parent/child', encryption_props()) as child_ds:
+            child_ds_mountpoint = os.path.join('/mnt', child_ds)
+            assert call('filesystem.is_immutable', child_ds_mountpoint) is False, child_ds_mountpoint
+            call('pool.dataset.lock', child_ds, job=True)
+            assert call('filesystem.is_immutable', child_ds_mountpoint) is True, child_ds_mountpoint
+
+        parent_mountpoint = os.path.join('/mnt', parent_ds)
+        assert call('filesystem.is_immutable', parent_mountpoint) is False, parent_mountpoint
+        call('pool.dataset.lock', parent_ds, job=True)
+        assert call('filesystem.is_immutable', parent_mountpoint) is True, parent_mountpoint
+
+
+def test_unlock_unsets_immutable_flag():
+    with dataset('parent', encryption_props()) as parent_ds:
+        parent_mountpoint = os.path.join('/mnt', parent_ds)
+        with dataset('parent/child', encryption_props()) as child_ds:
+            child_ds_mountpoint = os.path.join('/mnt', child_ds)
+            call('pool.dataset.lock', parent_ds, job=True)
+            assert call('filesystem.is_immutable', parent_mountpoint) is True, parent_mountpoint
+
+            call('pool.dataset.unlock', parent_ds, {
+                'datasets': [{'name': parent_ds, 'passphrase': PASSPHRASE}, {'name': child_ds, 'passphrase': 'random'}],
+                'recursive': True,
+            }, job=True)
+            assert call('filesystem.is_immutable', parent_mountpoint) is False, parent_mountpoint
+            assert call('filesystem.is_immutable', child_ds_mountpoint) is True, child_ds_mountpoint
+            call('pool.dataset.unlock', child_ds, {
+                'datasets': [{'name': child_ds, 'passphrase': PASSPHRASE}],
+            }, job=True)
+            assert call('filesystem.is_immutable', child_ds_mountpoint) is False, child_ds_mountpoint


### PR DESCRIPTION
There were 2 cases where locked dataset(s) mountpoint did not have immutable flag set which posed a risk that a user/app or any other consumer might manipulate their mountpoint.

1. If a pool had unlocked datasets but the system was rebooted, the system would not in that case have set immutable flag on locked datasets and these mountpoints could be exploited.
2. If a pool is imported, locked dataset(s) mountpoint did not have immutable flag set and hence they were also exposed to the same problem.