### PR TITLE
NAS-114519 / 22.02 / Configure timeout on kubernetes_asyncio client instance

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/kubernetes_linux/kubernetes.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/kubernetes_linux/kubernetes.sh
@@ -10,7 +10,7 @@ kubernetes_func()
 	midclt call kubernetes.config | jq .
 	section_footer
 
-	k8s_running="$(midclt call service.started kubernetes)"
+	k8s_running="$(midclt call kubernetes.validate_k8s_setup false)"
 	if [ "$k8s_running" = "True" ]; then
 		section_header "k3s kubectl describe nodes"
 		k3s kubectl describe nodes

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -365,7 +365,7 @@ class CatalogService(Service):
 
     @private
     async def get_normalised_questions_context(self):
-        k8s_started = await self.middleware.call('service.started', 'kubernetes')
+        k8s_started = await self.middleware.call('kubernetes.validate_k8s_setup', False)
         return {
             'nic_choices': await self.middleware.call('chart.release.nic_choices'),
             'gpus': await self.middleware.call('k8s.gpu.available_gpus') if k8s_started else {},

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -23,7 +23,7 @@ class CatalogService(Service):
             sync_job = await self.middleware.call('catalog.sync', catalog['id'])
             await sync_job.wait()
 
-        if await self.middleware.call('service.started', 'kubernetes'):
+        if await self.middleware.call('kubernetes.validate_k8s_setup', False):
             asyncio.ensure_future(self.middleware.call('chart.release.chart_releases_update_checks_internal'))
 
     @accepts(Str('label', required=True))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -102,11 +102,11 @@ class ChartReleaseService(CRUDService):
         `query-options.extra.resource_events` is a boolean when set will retrieve individual events of each resource.
         This only has effect if `query-options.extra.retrieve_resources` is set.
         """
-        k8s_config = await self.middleware.call('kubernetes.config')
-        if not await self.middleware.call('service.started', 'kubernetes') or not k8s_config['dataset']:
+        if not await self.middleware.call('kubernetes.validate_k8s_setup', False):
             # We use filter_list here to ensure that `options` are respected, options like get: true
             return filter_list([], filters, options)
 
+        k8s_config = await self.middleware.call('kubernetes.config')
         update_catalog_config = {}
         catalogs = await self.middleware.call('catalog.query', [], {'extra': {'item_details': True}})
         container_images = {}

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -125,5 +125,5 @@ async def chart_release_event(middleware, event_type, args):
 
 async def setup(middleware):
     middleware.event_subscribe('kubernetes.events', chart_release_event)
-    if await middleware.call('service.started', 'kubernetes'):
+    if await middleware.call('kubernetes.validate_k8s_setup', False):
         asyncio.ensure_future(middleware.call('chart.release.refresh_events_state'))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -342,7 +342,7 @@ class ChartReleaseService(Service):
 
         sync_job = await self.middleware.call('catalog.sync_all')
         await sync_job.wait()
-        if not await self.middleware.call('service.started', 'kubernetes'):
+        if not await self.middleware.call('kubernetes.validate_k8s_setup', False):
             return
 
         await self.chart_releases_update_checks_internal()

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -95,7 +95,7 @@ class KubernetesService(Service):
         """
         List existing chart releases backups.
         """
-        if not self.middleware.call_sync('service.started', 'kubernetes'):
+        if not self.middleware.call_sync('kubernetes.validate_k8s_setup', False):
             return {}
 
         k8s_config = self.middleware.call_sync('kubernetes.config')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/events.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/events.py
@@ -43,7 +43,7 @@ class KubernetesEventService(CRUDService):
 
     @private
     async def setup_k8s_events(self):
-        if not await self.middleware.call('service.started', 'kubernetes'):
+        if not await self.middleware.call('kubernetes.validate_k8s_setup', False):
             return
 
         try:
@@ -79,5 +79,5 @@ class KubernetesEventService(CRUDService):
 
 async def setup(middleware):
     middleware.event_register('kubernetes.events', 'Kubernetes cluster events')
-    if await middleware.call('service.started', 'kubernetes'):
-        asyncio.ensure_future(middleware.call('k8s.event.setup_k8s_events'))
+    # We are going to check in setup k8s events if setting up events is relevant or not
+    asyncio.ensure_future(middleware.call('k8s.event.setup_k8s_events'))

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
@@ -23,11 +23,12 @@ async def api_client(context=None, api_client_kwargs=None):
         'custom_object_api': client.CustomObjectsApi(api_cl),
         'extensions_api': client.ApiextensionsV1Api(api_cl),
     }
-    for k in filter(lambda k: context[k], context):
-        if k == 'node':
-            user_context[k] = await get_node(user_context['core_api'])
 
     try:
+        for k in filter(lambda k: context[k], context):
+            if k == 'node':
+                user_context[k] = await get_node(user_context['core_api'])
+
         yield api_cl, user_context
     finally:
         await api_cl.close()

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/api_client.py
@@ -11,7 +11,9 @@ async def api_client(context=None, api_client_kwargs=None):
     await config.load_kube_config(config_file=KUBECONFIG_FILE)
     context = context or {}
     context['core_api'] = True
-    api_cl = ApiClient(**(api_client_kwargs or {}))
+    api_client_kwargs = api_client_kwargs or {}
+    api_client_kwargs.setdefault('request_timeout', 5)
+    api_cl = ApiClient(**api_client_kwargs)
     user_context = {
         'core_api': client.CoreV1Api(api_cl),
         'apps_api': client.AppsV1Api(api_cl),


### PR DESCRIPTION
Kubernetes service went unresponsive and `middleware` was stalled forever to hear back from `kubernetes` service since mw is making API calls to `kubernetes` service (its unknown so far why service went unresponsive for this instance for the reporter). However, `middleware` should timeout at some point if `kubernetes` goes unresponsive.

It looks like there wasn't any parameter that could be used to set a timeout in `kubernetes_asyncio` client and client also does not have any default timeout.

I have made those updates so that we can have a standard timeout for these API requests: https://github.com/truenas/kubernetes_asyncio/pull/20

Reporter has also reported that his `debug` generation was stalled on trying to dump kubernetes service details. I also updated kubernetes service checks in debug generation to fix this.