### PR TITLE
NAS-114594 / 13.0 / Validate CN / SANs and tls_server_uri (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2021-12-22_12-59_add_server_tls_uri_to_s3_config.py
@@ -5,6 +5,8 @@ Revises: fee786dfe121
 Create Date: 2021-12-22 12:59:17.737066+00:00
 
 """
+import re
+
 from alembic import op
 import sqlalchemy as sa
 from OpenSSL import crypto
@@ -14,6 +16,17 @@ revision = '9c11f6c6f152'
 down_revision = 'fee786dfe121'
 branch_labels = None
 depends_on = None
+
+# Pattern is taken from middlewared.validators.Hostname
+hostname_re = re.compile(r'^[a-z\.\-0-9]*[a-z0-9]$', flags=re.IGNORECASE)
+
+
+def is_valid_hostname(hostname: str):
+    """
+    Validates hostname and makes sure it
+    does not contain a wild card.
+    """
+    return hostname_re.match(hostname)
 
 
 def upgrade():
@@ -31,18 +44,23 @@ def upgrade():
             try:
                 cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert_data[0])
                 cert_cn = cert.get_subject().CN
-                cert_san = []
+                if cert_cn and is_valid_hostname(cert_cn):
+                    s3_tls_server_uri = cert_cn
+
+                cert_sans = []
                 for ext in filter(lambda e: e.get_short_name().decode() != 'UNDEF', (
                     map(lambda i: cert.get_extension(i), range(cert.get_extension_count()))
                     if isinstance(cert, crypto.X509)
                     else cert.get_extensions()
                 )):
                     if 'subjectAltName' == ext.get_short_name().decode():
-                        cert_san = [s.strip() for s in ext.__str__().split(',') if s]
-                if cert_san:
-                    s3_tls_server_uri = cert_san[0].split(':')[-1].strip()
-                elif cert_cn:
-                    s3_tls_server_uri = cert_cn
+                        cert_sans = [s.strip() for s in ext.__str__().split(',') if s]
+
+                for cert_san in cert_sans:
+                    san = cert_san.split(':')[-1].strip()
+                    if san and is_valid_hostname(san):
+                        s3_tls_server_uri = san
+                        break
             except Exception:
                 pass
 

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -1,6 +1,6 @@
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.schema import accepts, Bool, Dict, Int, Str
-from middlewared.validators import Match, Range
+from middlewared.validators import Match, Range, Hostname
 from middlewared.service import SystemServiceService, ValidationErrors, private
 import middlewared.sqlalchemy as sa
 
@@ -61,7 +61,7 @@ class S3Service(SystemServiceService):
         Bool('browser'),
         Str('storage_path'),
         Int('certificate', null=True),
-        Str('tls_server_uri', null=True),
+        Str('tls_server_uri', validators=[Hostname(explanation='Should be a valid hostname')], null=True),
         update=True,
     ))
     async def do_update(self, data):

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -82,11 +82,20 @@ class Match:
         self.regex = re.compile(pattern, flags)
 
     def __call__(self, value):
-        if not self.regex.match(value):
+        if value is not None and not self.regex.match(value):
             raise ValueError(self.explanation or f"Does not match {self.pattern}")
 
     def __deepcopy__(self, memo):
         return Match(self.pattern, self.flags, self.explanation)
+
+
+class Hostname(Match):
+    def __init__(self, explanation=None):
+        super().__init__(
+            r'^[a-z\.\-0-9]*[a-z0-9]$',
+            flags=re.IGNORECASE,
+            explanation=explanation
+        )
 
 
 class Or:


### PR DESCRIPTION
1. Update the migration and fallback to `localhost` if its `SANs` / `CN` does not contain anything except for a wildcard domain.
2. Add validation into the `s3.config` API so that wild card domain cannot be updated into `tls_server_uri`

Original PR: https://github.com/truenas/middleware/pull/8204
Jira URL: https://jira.ixsystems.com/browse/NAS-114594