### PR TITLE
NAS-114715 / 22.02.1 / Update nvidia device plugin tag

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -24,7 +24,7 @@ GPU_CONFIG = {
                     ],
                     'priorityClassName': 'system-node-critical',
                     'containers': [{
-                        'image': 'nvidia/k8s-device-plugin:v0.9.0',
+                        'image': 'nvidia/k8s-device-plugin:v0.10.0',
                         'name': 'nvidia-device-plugin-ctr',
                         'securityContext': {'allowPrivilegeEscalation': False, 'capabilities': {'drop': ['ALL']}},
                         'volumeMounts': [{'name': 'device-plugin', 'mountPath': '/var/lib/kubelet/device-plugins'}]


### PR DESCRIPTION
This just updates the k8s-device-plugin image tag, 
Just noticed that it was a outdated while I was looking for something else.