### PR TITLE
NAS-114733 / 22.02.1 / Fix serial console test when checking enabled serial

### DIFF
--- a/tests/api2/test_serial_consoles.py
+++ b/tests/api2/test_serial_consoles.py
@@ -38,7 +38,7 @@ def test_disabling_serial_port():
 
 def assert_serial_port_configuration(ports):
     for port, enabled in ports.items():
-        is_enabled = ssh(f'systemctl is-enabled --quiet serial-getty@{port}.service', False, True)['return_code'] == 0
+        is_enabled = ssh(f'systemctl is-enabled serial-getty@{port}.service', False).strip() == 'enabled'
         assert is_enabled is enabled, f'{port!r} enabled assertion failed: {is_enabled!r} != {enabled!r}'
         is_enabled = ssh(f'systemctl is-active --quiet serial-getty@{port}.service', False, True)['return_code'] == 0
         assert is_enabled is enabled, f'{port!r} active assertion failed: {is_enabled!r} != {enabled!r}'


### PR DESCRIPTION
This commit fixes an issue where when system boots with a serial port configured in the grub configuration, if we disable the serial port once the system has booted - for enable check it says `enabled-runtime`  instead of saying `disabled`. Now this gives the impression that this systemd service will start when the system reboots but that does not hold as grub is updated when we make such changes and on subsequent reboot we do not pass serial console parameters which results in systemd unit for that serial port correctly saying `disabled`. So the gist is, that instead of relying on returncode, we explicitly check for enabled keyword when seeing if service is enabled or not after it has been disabled via middleware.