### PR TITLE
NAS-114753 / 22.02.1 / Add tests for NFS share parameters

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -13,7 +13,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from auto_config import pool_name, ha, hostname
-from auto_config import dev_test
+from auto_config import dev_test, password, user
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
@@ -33,6 +33,34 @@ try:
 except ImportError:
     bsd_host_cfg = pytest.mark.skipif(True, reason=Reason)
 
+
+def parse_exports():
+    results = SSH_TEST("cat /etc/exports", user, password, ip)
+    assert results['result'] is True, results['error']
+    exp = results['output'].splitlines()
+    rv = []
+    for idx, line in enumerate(exp):
+        if not line or line.startswith('\t'):
+            continue
+
+        entry = {"path": line.strip()[1:-2], "opts": []}
+
+        i = idx + 1
+        while i < len(exp):
+            if not exp[i].startswith('\t'):
+                break
+
+            e = exp[i].strip()
+            host, params = e.split('(', 1)
+            entry['opts'].append({
+                "host": host,
+                "parameters": params[:-1].split(",")
+            })
+            i += 1
+
+        rv.append(entry)
+
+    return rv
 
 # Enable NFS server
 def test_01_creating_the_nfs_server():
@@ -77,11 +105,13 @@ def test_04_verify_the_job_id_is_successfull(request):
 
 def test_05_creating_a_nfs_share_on_nfs_PATH(request):
     depends(request, ["pool_04"], scope="session")
+    global nfsid
     paylaod = {"comment": "My Test Share",
                "paths": [NFS_PATH],
                "security": ["SYS"]}
     results = POST("/sharing/nfs/", paylaod)
     assert results.status_code == 200, results.text
+    nfsid = results.json()['id']
 
 
 def test_06_starting_nfs_service_at_boot(request):
@@ -261,14 +291,204 @@ def test_29_removing_nfs_mountpoint(request):
     assert results['result'] is True, results['output']
 
 
-def test_30_delete_nfs_share(request):
-    depends(request, ["pool_04"], scope="session")
-    nfsid = GET('/sharing/nfs?comment=My Test Share').json()[0]['id']
-    results = DELETE(f"/sharing/nfs/id/{nfsid}")
+def test_30_add_second_nfs_path(request):
+    """
+    Verify that adding a second path generates second exports entry
+    Sample:
+
+    "/mnt/dozer/NFSV4/foo"\
+    	*(sec=sys,rw,subtree_check)
+    "/mnt/dozer/NFSV4/foobar"\
+    	*(sec=sys,rw,subtree_check)
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+
+    paths = [NFS_PATH, NFS_PATH]
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'paths': paths})
     assert results.status_code == 200, results.text
 
+    exports_paths = [x['path'] for x in parse_exports()]
+    diff = set(exports_paths) ^ set(paths)
+    assert len(diff) == 0, str(diff)
 
-def test_31_stoping_nfs_service(request):
+    # Restore to single entry
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'paths': [NFS_PATH]})
+    assert results.status_code == 200, results.text
+
+    exports_paths = [x['path'] for x in parse_exports()]
+    assert len(exports_paths) == 1, exports_paths
+
+
+def test_31_check_nfs_share_network(request):
+    """
+    Verify that adding a network generates an appropriate line in exports
+    file for same path. Sample:
+
+    "/mnt/dozer/nfs"\
+    	192.168.0.0/24(sec=sys,rw,subtree_check)\
+    	192.168.1.0/24(sec=sys,rw,subtree_check)
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+    networks_to_test = ["192.168.0.0/24", "192.168.1.0/24"]
+
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'networks': networks_to_test})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+
+    exports_networks = [x['host'] for x in parsed[0]['opts']]
+    diff = set(networks_to_test) ^ set(exports_networks)
+    assert len(diff) == 0, f'diff: {diff}, exports: {parsed}'
+
+    # Reset to default
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'networks': []})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    exports_networks = [x['host'] for x in parsed[0]['opts']]
+    assert len(exports_networks) == 1, str(parsed)
+    assert exports_networks[0] == '*', str(parsed)
+
+
+def test_32_check_nfs_share_hosts(request):
+    """
+    Verify that adding a network generates an appropriate line in exports
+    file for same path. Sample:
+
+    "/mnt/dozer/nfs"\
+    	192.168.0.69(sec=sys,rw,subtree_check)\
+    	192.168.0.70(sec=sys,rw,subtree_check)
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+    hosts_to_test = ["192.168.0.69", "192.168.0.70"]
+
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hosts_to_test})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+
+    exports_hosts = [x['host'] for x in parsed[0]['opts']]
+    diff = set(hosts_to_test) ^ set(exports_hosts)
+    assert len(diff) == 0, f'diff: {diff}, exports: {parsed}'
+
+    # Reset to default
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': []})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    exports_hosts= [x['host'] for x in parsed[0]['opts']]
+    assert len(exports_hosts) == 1, str(parsed)
+
+
+def test_33_check_nfs_share_ro(request):
+    """
+    Verify that toggling `ro` will cause appropriate change in
+    exports file.
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    assert "rw" in parsed[0]['opts'][0]['parameters'], str(parsed)
+
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'ro': True})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    assert "rw" not in parsed[0]['opts'][0]['parameters'], str(parsed)
+
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", {'ro': False})
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    assert "rw" in parsed[0]['opts'][0]['parameters'], str(parsed)
+
+
+def test_34_check_nfs_share_maproot(request):
+    """
+    root squash is always enabled, and so maproot accomplished through
+    anonuid and anongid
+
+    Sample:
+    "/mnt/dozer/NFSV4"\
+    	*(sec=sys,rw,anonuid=65534,anongid=65534,subtree_check)
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+    payload = {
+        'maproot_user': 'nobody',
+        'maproot_group': 'nogroup'
+    }
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+
+    params = parsed[0]['opts'][0]['parameters']
+    assert 'anonuid=65534' in params, str(parsed)
+    assert 'anongid=65534' in params, str(parsed)
+
+    payload = {
+        'maproot_user': '',
+        'maproot_group': ''
+    }
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    params = parsed[0]['opts'][0]['parameters']
+
+    assert not any(filter(lambda x: x.startswith('anon'), params)), str(parsed)
+
+
+def test_35_check_nfs_share_mapall(request):
+    """
+    mapall is accomplished through anonuid and anongid and
+    setting 'all_squash'.
+
+    Sample:
+    "/mnt/dozer/NFSV4"\
+    	*(sec=sys,rw,all_squash,anonuid=65534,anongid=65534,subtree_check)
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+    payload = {
+        'mapall_user': 'nobody',
+        'mapall_group': 'nogroup'
+    }
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+
+    params = parsed[0]['opts'][0]['parameters']
+    assert 'anonuid=65534' in params, str(parsed)
+    assert 'anongid=65534' in params, str(parsed)
+    assert 'all_squash' in params, str(parsed)
+
+    payload = {
+        'mapall_user': '',
+        'mapall_group': ''
+    }
+    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
+    assert results.status_code == 200, results.text
+
+    parsed = parse_exports()
+    assert len(parsed) == 1, str(parsed)
+    params = parsed[0]['opts'][0]['parameters']
+
+    assert not any(filter(lambda x: x.startswith('anon'), params)), str(parsed)
+    assert 'all_squash' not in params, str(parsed)
+
+
+def test_51_stoping_nfs_service(request):
     depends(request, ["pool_04"], scope="session")
     payload = {"service": "nfs"}
     results = POST("/service/stop/", payload)
@@ -276,25 +496,25 @@ def test_31_stoping_nfs_service(request):
     sleep(1)
 
 
-def test_32_checking_to_see_if_nfs_service_is_stop(request):
+def test_52_checking_to_see_if_nfs_service_is_stop(request):
     depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "STOPPED", results.text
 
 
-def test_33_disable_nfs_service_at_boot(request):
+def test_53_disable_nfs_service_at_boot(request):
     depends(request, ["pool_04"], scope="session")
     results = PUT("/service/id/nfs/", {"enable": False})
     assert results.status_code == 200, results.text
 
 
-def test_34_checking_nfs_disable_at_boot(request):
+def test_54_checking_nfs_disable_at_boot(request):
     depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]['enable'] is False, results.text
 
 
-def test_35_destroying_smb_dataset(request):
+def test_55_destroying_smb_dataset(request):
     depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -303,7 +303,10 @@ def test_30_add_second_nfs_path(request):
     """
     depends(request, ["pool_04", "ssh_password"], scope="session")
 
-    paths = [NFS_PATH, NFS_PATH]
+    paths = [f'{NFS_PATH}/sub1', f'{NFS_PATH}/sub2']
+    results = SSH_TEST(f"mkdir {' '.join(paths)}", user, password, ip)
+    assert results['result'] is True, results['error']
+
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'paths': paths})
     assert results.status_code == 200, results.text
 


### PR DESCRIPTION
This commit adds tests that verify that NFS
share parameters may be successfully set through the
REST API.