### PR TITLE
Set log level of pyroute.netlink to critical

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -28,6 +28,7 @@ logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 logging.getLogger('passlib.registry').setLevel(logging.INFO)
 # pyroute2.ndb is chatty....only log errors
 logging.getLogger('pyroute2.ndb').setLevel(logging.CRITICAL)
+logging.getLogger('pyroute2.netlink').setLevel(logging.CRITICAL)
 logging.getLogger('pyroute2.netlink.nlsocket').setLevel(logging.CRITICAL)
 # It logs each call made to the k8s api server when in debug mode, so we set the level to warn
 logging.getLogger('kubernetes_asyncio.client.rest').setLevel(logging.WARN)


### PR DESCRIPTION
Suppress logs from pyroute as they are polluting middleware logs
```
[2022/02/10 06:29:23] (WARNING) pyroute2.netlink.try_to_decode():1523 - decoding NDA_LLADDR
[2022/02/10 06:29:23] (WARNING) pyroute2.netlink.try_to_decode():1524 - Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/__init__.py", line 1520, in try_to_decode
    cell.decode()
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/__init__.py", line 1901, in decode
    raise TypeError('Unsupported link layer address length {}'
TypeError: Unsupported link layer address length 0
```