### PR TITLE
NAS-114792 / 22.02.1 / check=false for track_processes api test

### DIFF
--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -34,4 +34,4 @@ def test__open_path_and_check_proc():
             assert res[0]['cmdline'] == cmdline, res
         finally:
             if opened:
-                ssh(f'kill -9 {open_pid}')
+                ssh(f'kill -9 {open_pid}', check=False)


### PR DESCRIPTION
By the time we go to kill the process, it could have already been killed so pass `check=False` so we don't raise an `AssertionError` causing the API test to fail.