### PR TITLE
NAS-114795 / 22.02.1 / Fix behavior for allow_nonroot

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -19,7 +19,7 @@
 
         return output
 
-    def generate_options(share, global_sec):
+    def generate_options(share, global_sec, config):
         params = []
         all_squash = False
         if share["security"]:
@@ -59,6 +59,9 @@
         if maproot:
             params.extend(maproot)
 
+        if config['allow_nonroot']:
+            params.append("insecure")
+
         return ','.join(params)
 
     entries = []
@@ -74,7 +77,7 @@
     global_sec = middleware.call_sync("nfs.sec", config, has_nfs_principal) or ["sys"]
 
     for share in shares:
-        opts = generate_options(share, global_sec)
+        opts = generate_options(share, global_sec, config)
         for path in share["paths"]:
             p = Path(path)
             if not p.exists():


### PR DESCRIPTION
In FreeBSD this was a global mountd setting. In Linux, it can be
configured on a per-export basis. For the sake of consistency,
we will keep same configuration option / behavior in Linux.