### PR TITLE
NAS-114480 / 13.0 / Update truecommand for TN 13

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1941,7 +1941,7 @@ class InterfaceService(CRUDService):
 
         """
         list_of_ip = []
-        ignore_nics = ['tap', 'epair', 'pflog']
+        ignore_nics = ['tap', 'epair', 'pflog', 'wg']
         if not choices['loopback']:
             ignore_nics.append('lo')
         ignore_nics = tuple(ignore_nics)

--- a/src/middlewared/middlewared/plugins/service_/services/base_freebsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_freebsd.py
@@ -15,6 +15,7 @@ class SimpleServiceFreeBSD:
     freebsd_rc = NotImplemented
     freebsd_pidfile = None
     freebsd_procname = None
+    freebsd_proc_arguments_match = False
 
     async def _get_state_freebsd(self):
         procname = self.freebsd_procname or self.freebsd_rc
@@ -22,7 +23,7 @@ class SimpleServiceFreeBSD:
         if self.freebsd_pidfile:
             cmd = ["pgrep", "-F", self.freebsd_pidfile, procname]
         else:
-            cmd = ["pgrep", procname]
+            cmd = ["pgrep"] + (["-f"] if self.freebsd_proc_arguments_match else []) + [procname]
 
         proc = await run(*cmd, check=False, encoding="utf-8")
         if proc.returncode == 0:

--- a/src/middlewared/middlewared/plugins/service_/services/truecommand.py
+++ b/src/middlewared/middlewared/plugins/service_/services/truecommand.py
@@ -7,6 +7,7 @@ class TruecommandService(SimpleService):
     etc = ['rc', 'truecommand']
 
     freebsd_rc = 'wireguard'
-    freebsd_procname = 'wireguard-go'
+    freebsd_procname = 'wg-quick'
+    freebsd_proc_arguments_match = True
 
     systemd_unit = 'wg-quick@wg0'

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -145,6 +145,8 @@ class TruecommandService(ConfigService):
                     'endpoint': None,
                     'tc_public_key': None,
                     'wg_address': None,
+                    'wg_public_key': None,
+                    'wg_private_key': None,
                     'api_key_state': Status.DISABLED.value,
                 })
 

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import subprocess
 import time
@@ -129,6 +130,7 @@ class TruecommandService(Service):
             ):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
+                asyncio.ensure_future(self.middleware.call('truecommand.health_check'))
             else:
                 # start polling iX Portal to see what's up and why we don't have these values set
                 # This can happen in instances where system was polling and then was rebooted,


### PR DESCRIPTION
This PR introduces following changes:

1. Mark wireguard interface as internal when retrieving used ips in a system
2. Allow matching arguments of process when checking if service has started
3. Update freebsd proc name to reflect it's argument `wg-quick` as `wireguard-go` process is no longer there
4. When truecommand service is started, health check can potentially run up to 30 minutes later, we initiate the health check right after starting truecommand so middleware updates it's status wrt truecommand quickly
5. If API keys changes, we should be clearing out wireguard public/private keys