### PR TITLE
NAS-114480 / 22.02.1 / Improvements to Truecommand lifecycle (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -157,6 +157,8 @@ class TruecommandService(ConfigService):
                     'endpoint': None,
                     'tc_public_key': None,
                     'wg_address': None,
+                    'wg_public_key': None,
+                    'wg_private_key': None,
                     'api_key_state': Status.DISABLED.value,
                 })
 

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import subprocess
 import time
@@ -138,6 +139,7 @@ class TruecommandService(Service):
             ):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
+                asyncio.ensure_future(self.middleware.call('truecommand.health_check'))
             else:
                 # start polling iX Portal to see what's up and why we don't have these values set
                 # This can happen in instances where system was polling and then was rebooted,


### PR DESCRIPTION
This PR introduces following changes:

1. When truecommand service is started, health check can potentially run up to 30 minutes later, we initiate the health check right after starting truecommand so middleware updates it's status wrt truecommand quickly
2. If API keys changes, we should be clearing out wireguard public/private keys

Original PR: https://github.com/truenas/middleware/pull/8255
Jira URL: https://jira.ixsystems.com/browse/NAS-114480