### PR TITLE
NAS-114807 / 22.02.1 / Restart NFS service on configuration update

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -225,7 +225,7 @@ class NFSService(SystemServiceService):
 
         await self.nfs_compress(new)
 
-        await self._update_service(old, new)
+        await self._update_service(old, new, "restart")
 
         return await self.config()
 


### PR DESCRIPTION
Reload directive in systemd unit only reloads the exports
file.

Per rpc.nfsd manpage, if NFS server is already running, then the
options for specifying host, port, and protocol will be ignored.

This means that for all practical purposes service update requires
a restart of nfsd and will impact all existing NFS connections
(cannot be avoided).