### PR TITLE
NAS-114808 / 13.0 / fix acltype logic in sysdataset plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -272,11 +272,9 @@ class SystemDatasetService(ConfigService):
             os.makedirs(SYSDATASET_PATH)
 
         acltype = await self.middleware.call('zfs.dataset.query', [('id', '=', config['basename'])])
-        if acltype and acltype[0]['properties']['acltype']['value'] == 'off':
+        if acltype and acltype[0]['properties']['acltype']['value'] != 'off':
             await self.middleware.call(
-                'zfs.dataset.update',
-                config['basename'],
-                {'properties': {'acltype': {'value': 'off'}}},
+                'zfs.dataset.update', config['basename'], {'properties': {'acltype': {'value': 'off'}}}
             )
 
         if mount:


### PR DESCRIPTION
Discovered while fixing https://github.com/truenas/middleware/pull/7889. The truth logic for checking the acltype on the system dataset is incorrect.

Original PR: https://github.com/truenas/middleware/pull/8261
Jira URL: https://jira.ixsystems.com/browse/NAS-114808