### PR TITLE
NAS-114815 / 22.02.1 / Add regression tests for NFS server config

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -226,7 +226,7 @@ def test_19_updating_the_nfs_service(request):
     """
     This test verifies that service can be updated in general,
     and also that the 'servers' key can be altered.
-    Latter goal is achieved by readig the nfs config file
+    Latter goal is achieved by reading the nfs config file
     and verifying that the value here was set correctly.
     """
     depends(request, ["pool_04"], scope="session")


### PR DESCRIPTION
* verify that NFSv4 support is being enabled / disabled properly
* verify that udp support is being enabled / disabled properly
* verify that NFS-related port configuration options are set
* verify that number of servers is set correctly