### PR TITLE
NAS-114777 / 22.02 / no seriously, fix pool_dataset_track_processes api

### DIFF
--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -17,24 +17,26 @@ def test__open_path_and_check_proc():
         try:
             path = f'/mnt/{ds}'
             test_file = f'{path}/test_file'
-            cmdline = f'python -c "import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)"'
-            open_pid = ssh(cmdline + ' & echo $!')
-            assert open_pid.strip().isdigit(), open_pid
+            open_pid = ssh(f"""python -c 'import time; f = open("{test_file}", "w+"); time.sleep(10)' > /dev/null 2>&1 & echo $!""")
+            open_pid = open_pid.strip()
+            assert open_pid.isdigit(), f'{open_pid!r} is not a digit'
             opened = True
 
             # spinning up python interpreter could take some time on busy system so sleep
             # for a couple seconds to give it time
             time.sleep(2)
 
+            # what the cmdline output is formatted to
+            cmdline = f"""python -c import time; f = open(\"{test_file}\", \"w+\"); time.sleep(10)"""
+
             # have to use websocket since the method being called is private
-            payload = {'msg': 'method', 'method': 'pool.dataset.processes_using_paths', 'params': [path]}
+            payload = {'msg': 'method', 'method': 'pool.dataset.processes_using_paths', 'params': [[path]]}
             res = make_ws_request(ip, payload)
-            for i in res:
-                if i['pid'] == int(open_pid):
-                    assert i['cmdline'] == cmdline, i
-                    break
-            else:
-                assert False, f'{open_pid!r} not found in {res!r}'
+            assert len(res['result']) == 1, f'Length of the result should only be 1 but is {len(res["result"])!r}'
+
+            result = res['result'][0]
+            assert result['pid'] == open_pid, f'{result["pid"]!r} does not match {open_pid!r}'
+            assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
         finally:
             if opened:
                 ssh(f'kill -9 {open_pid}', check=False)


### PR DESCRIPTION
Quoting issue led to the fact that the child process silently exited because of syntax issue which lead to the fact that the child process was holding on to stdout/stderr which lead to the fact that the the wrong params was being passed to the websocket call which lead to the fact that the returned cmdline was incorrect which lead to the fact that all of my assertion failure messages were completely worthless. After a shameful amount of time spent tracking all these issues down, I can confirm with 100% certainty that this now successfully runs.....at least on the machine I was using. I dont computer good.