### PR TITLE
NAS-114315 / 22.02.1 / Do not reset mountpoints while importing pools

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1750,17 +1750,6 @@ class PoolService(CRUDService):
                     'Failed to set cache file for %s', pool['name'], exc_info=True,
                 )
 
-            try:
-                if os.path.isdir('/mnt/mnt'):
-                    # Reset all mountpoints
-                    self.middleware.call_sync(
-                        'zfs.dataset.inherit', pool['name'], 'mountpoint', True
-                    )
-            except Exception:
-                self.logger.warning(
-                    'Failed to inherit mountpoints for %s', pool['name'], exc_info=True,
-                )
-
             unlock_job = self.middleware.call_sync(
                 'pool.dataset.unlock', pool['name'], {'recursive': True, 'toggle_attachments': False}
             )


### PR DESCRIPTION
## Background
It was pretty unclear why we would do this. After discussing with Waqar I came to know that we had a faulty behavior merged once that mounted those kinds of paths and that code patch was written to undo those mounts – pretty untrivial that we didn't write some sort of migration for existing users and left this hacky patch around.

For this specific user, he had manually created /mnt/mnt dorectory that caused the actual pool's mountpoints to reset 🤦  

With this, the behavior where PVC's mountpoints were reset, is also fixed.