### PR TITLE
NAS-114867 / 22.02.1 / remove copyright/cleanup failover_disks.py alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -1,52 +1,39 @@
-# Copyright (c) 2018 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 
+TITLE = 'Disks Missing On '
+TEXT = 'Disks with serial %(serial)s present on '
 
-class DisksAreNotPresentOnBackupNodeAlertClass(AlertClass):
+
+class DisksAreNotPresentOnStandbyNodeAlertClass(AlertClass):
     category = AlertCategory.HA
     level = AlertLevel.CRITICAL
-    title = "Disks Missing on Standby Storage Controller"
-    text = (
-        "Disks with serial %(serials)s present on active storage controller but missing on standby storage controller."
-    )
-
-    products = ("SCALE_ENTERPRISE",)
+    title = TITLE + 'Standby Storage Controller'
+    text = TEXT + 'active storage controller but missing on standby storage controller.'
+    products = ('SCALE_ENTERPRISE',)
 
 
-class DisksAreNotPresentOnMasterNodeAlertClass(AlertClass):
+class DisksAreNotPresentOnActiveNodeAlertClass(AlertClass):
     category = AlertCategory.HA
     level = AlertLevel.CRITICAL
-    title = "Disks Missing on Active Storage Controller"
-    text = (
-        "Disks with serial %(serials)s present on standby storage controller but missing on active storage controller."
-    )
-
-    products = ("SCALE_ENTERPRISE",)
+    title = TITLE + 'Active Storage Controller'
+    text = TEXT + 'standby storage controller but missing on active storage controller.'
+    products = ('SCALE_ENTERPRISE',)
 
 
 class FailoverDisksAlertSource(AlertSource):
-    products = ("SCALE_ENTERPRISE",)
+    products = ('SCALE_ENTERPRISE',)
     failover_related = True
     run_on_backup_node = False
 
     async def check(self):
-        alerts = []
-
-        if not await self.middleware.call("failover.licensed"):
-            return alerts
-
-        mismatch_disks = await self.middleware.call("failover.mismatch_disks")
-
-        if mismatch_disks["missing_remote"]:
-            alerts.append(Alert(DisksAreNotPresentOnBackupNodeAlertClass,
-                                {"serials": ", ".join(mismatch_disks["missing_remote"])}))
-
-        if mismatch_disks["missing_local"]:
-            alerts.append(Alert(DisksAreNotPresentOnMasterNodeAlertClass,
-                                {"serials": ", ".join(mismatch_disks["missing_local"])}))
-
-        return alerts
+        licensed = await self.middleware.call('failover.licensed')
+        if licensed and (md := await self.middleware.call('failover.mismatch_disks')):
+            if md['missing_remote']:
+                return [Alert(
+                    DisksAreNotPresentOnStandbyNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
+                )]
+            if md['missing_remote']:
+                return [Alert(
+                    DisksAreNotPresentOnActiveNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
+                )]
+        return []


### PR DESCRIPTION
There should be no functional change. This does 2 primary things.

1. remove outdated copyright
2. refactor the code to be a little more simpler since I'm here