### PR TITLE
NAS-111109 / 13.0 / Mark vnetX interfaces as private when syncing interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1848,7 +1848,7 @@ class InterfaceService(CRUDService):
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
-        internal_interfaces = ['wg', 'lo', 'pflog', 'pfsync', 'tun', 'tap', 'epair']
+        internal_interfaces = ['wg', 'lo', 'pflog', 'pfsync', 'tun', 'tap', 'epair', 'vnet']
         if not await self.middleware.call('system.is_freenas'):
             internal_interfaces.extend(await self.middleware.call('failover.internal_interfaces') or [])
         internal_interfaces = tuple(internal_interfaces)


### PR DESCRIPTION
We should mark vnet interfaces as internal so that we don't unconfigure them whenever networking changes are synced as that results in network connectivity for jails/vms breaking each time network is synced.