### PR TITLE
NAS-114877 / 22.02.1 / make sata dom alert run on SCALE HA

### DIFF
--- a/src/middlewared/middlewared/alert/source/sata_dom_wear.py
+++ b/src/middlewared/middlewared/alert/source/sata_dom_wear.py
@@ -21,13 +21,11 @@ class SATADOMWearCriticalAlertClass(AlertClass):
 
 class SATADOMWearAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(hours=1))
-
-    products = ("ENTERPRISE",)
+    products = ("SCALE_ENTERPRISE",)
 
     async def check(self):
-        data = await self.middleware.call("system.info")
-        product = data["system_product"]
-        if not product.startswith(("TRUENAS-M", "TRUENAS-Z")):
+        dmi = await self.middleware.call("system.dmidecode_info")
+        if not dmi["system-product-name"].startswith(("TRUENAS-M", "TRUENAS-Z")):
             return []
 
         alerts = []


### PR DESCRIPTION
Make `SATADOMWearAlertSource` run on SCALE HA. While I'm here, don't call `system.info` and instead call `system.dmidecode_info` since it's less expensive.