### PR TITLE
NAS-114833 / 22.02.1 / Remove disable offload capabilities

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-15_20-08_remove_hardware_offload.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-15_20-08_remove_hardware_offload.py
@@ -1,0 +1,24 @@
+"""remove disable_offload_capabilities column
+
+Revision ID: cda35deeed4f
+Revises: 8f72494885e6
+Create Date: 2022-02-15 20:08:46.180173+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'cda35deeed4f'
+down_revision = '8f72494885e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
+        batch_op.drop_column('int_disable_offload_capabilities')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -9,7 +9,7 @@ class InterfaceService(Service):
         namespace_alias = 'interfaces'
 
     @private
-    def lag_setup(self, lagg, members, disable_capabilities, parent_interfaces, sync_interface_opts):
+    def lag_setup(self, lagg, members, parent_interfaces, sync_interface_opts):
         name = lagg['lagg_interface']['int_interface']
         self.logger.info('Setting up %s', name)
 
@@ -27,13 +27,6 @@ class InterfaceService(Service):
         if iface is None:
             netif.create_interface(name)
             iface = netif.get_interface(name)
-
-        # FIXME: this will fail on SCALE since we don't even have
-        # a "disable_capabilities" method
-        """
-        if disable_capabilities:
-            self.middleware.call_sync('interface.disable_capabilities', name)
-        """
 
         info = {'protocol': None, 'xmit_hash_policy': None, 'lacpdu_rate': None, 'primary_interface': None}
         protocol = getattr(netif.AggregationProtocol, lagg['lagg_protocol'].upper())

--- a/src/middlewared/middlewared/plugins/interface/vlan.py
+++ b/src/middlewared/middlewared/plugins/interface/vlan.py
@@ -1,6 +1,4 @@
 from middlewared.service import private, Service
-from middlewared.utils import osc
-
 from .netif import netif
 
 
@@ -10,52 +8,37 @@ class InterfaceService(Service):
         namespace_alias = 'interfaces'
 
     @private
-    def vlan_setup(self, vlan, disable_capabilities, parent_interfaces):
-        self.logger.info('Setting up {}'.format(vlan['vlan_vint']))
+    def vlan_setup(self, vlan, parent_interfaces):
+        self.logger.info('Setting up %r', vlan['vlan_vint'])
         try:
             iface = netif.get_interface(vlan['vlan_vint'])
         except KeyError:
-            if osc.IS_FREEBSD:
-                netif.create_interface(vlan['vlan_vint'])
-            if osc.IS_LINUX:
-                try:
-                    netif.create_vlan(vlan['vlan_vint'], vlan['vlan_pint'], vlan['vlan_tag'])
-                except FileNotFoundError:
-                    self.logger.warn(
-                        'VLAN %s parent interface %s not found, skipping.',
-                        vlan['vlan_vint'],
-                        vlan['vlan_pint'],
-                    )
-                    return
+            try:
+                netif.create_vlan(vlan['vlan_vint'], vlan['vlan_pint'], vlan['vlan_tag'])
+            except FileNotFoundError:
+                self.logger.warning(
+                    'VLAN %r parent interface %r not found, skipping.', vlan['vlan_vint'], vlan['vlan_pint']
+                )
+                return
             iface = netif.get_interface(vlan['vlan_vint'])
-
-        if disable_capabilities:
-            self.middleware.call('interface.disable_capabilities', vlan['vlan_vint'])
 
         if iface.parent != vlan['vlan_pint'] or iface.tag != vlan['vlan_tag'] or iface.pcp != vlan['vlan_pcp']:
             iface.unconfigure()
             try:
                 iface.configure(vlan['vlan_pint'], vlan['vlan_tag'], vlan['vlan_pcp'])
             except FileNotFoundError:
-                self.logger.warn(
-                    'VLAN %s parent interface %s not found, skipping.',
-                    vlan['vlan_vint'],
-                    vlan['vlan_pint'],
+                self.logger.warning(
+                    'VLAN %r parent interface %r not found, skipping.', vlan['vlan_vint'], vlan['vlan_pint']
                 )
                 return
 
         try:
             parent_iface = netif.get_interface(iface.parent)
         except KeyError:
-            self.logger.warn('Could not find {} from {}'.format(iface.parent, vlan['vlan_vint']))
+            self.logger.warning('Could not find %r from %r', iface.parent, vlan['vlan_vint'])
             return
+
         parent_interfaces.append(iface.parent)
         parent_iface.up()
 
-        # On HA systems, there seems to be an issue (race in kernel maybe?)
-        # that when adding a CARP alias to the interface BEFORE the physical
-        # IP address gets added that CARP will stay in INIT state. The only
-        # way to get it out of that state is to ifconfig down/up the interface
-        # and then it will transition into MASTER/BACKUP accordingly.
-        # To workaround this, we up ourselves here explicitly.
         iface.up()

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1579,12 +1579,11 @@ class InterfaceService(CRUDService):
             members = await self.middleware.call('datastore.query', 'network.lagginterfacemembers',
                                                  [('lagg_interfacegroup_id', '=', lagg['id'])],
                                                  {'order_by': ['lagg_physnic']})
-            disable_capabilities = name in disable_capabilities_ifaces
-
             cloned_interfaces.append(name)
             try:
-                await self.middleware.call('interface.lag_setup', lagg, members, disable_capabilities,
-                                           parent_interfaces, sync_interface_opts)
+                await self.middleware.call(
+                    'interface.lag_setup', lagg, members, parent_interfaces, sync_interface_opts
+                )
             except Exception:
                 self.middleware.logger.error('Error setting up LAG %s', name, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1566,20 +1566,10 @@ class InterfaceService(CRUDService):
         """
         await self.middleware.call_hook('interface.pre_sync')
 
-        disable_capabilities_ifaces = {
-            i['name'] for i in await self.middleware.call(
-                'interface.query', [['disable_offload_capabilities', '=', True]]
-            )
-        }
         interfaces = [i['int_interface'] for i in (await self.middleware.call('datastore.query', 'network.interfaces'))]
         cloned_interfaces = []
         parent_interfaces = []
         sync_interface_opts = defaultdict(dict)
-
-        for physical_iface in await self.middleware.call(
-            'interface.query', [['type', '=', 'PHYSICAL'], ['disable_offload_capabilities', '=', True]]
-        ):
-            await self.middleware.call('interface.disable_capabilities', physical_iface['name'])
 
         # First of all we need to create the virtual interfaces
         # LAGG comes first and then VLAN

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -55,7 +55,6 @@ class NetworkInterfaceModel(sa.Model):
     int_critical = sa.Column(sa.Boolean(), default=False)
     int_group = sa.Column(sa.Integer(), nullable=True)
     int_mtu = sa.Column(sa.Integer(), nullable=True)
-    int_disable_offload_capabilities = sa.Column(sa.Boolean(), default=False)
     int_link_address = sa.Column(sa.String(17), nullable=True)
 
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1585,17 +1585,15 @@ class InterfaceService(CRUDService):
                     'interface.lag_setup', lagg, members, parent_interfaces, sync_interface_opts
                 )
             except Exception:
-                self.middleware.logger.error('Error setting up LAG %s', name, exc_info=True)
+                self.logger.error('Error setting up LAG %s', name, exc_info=True)
 
         vlans = await self.middleware.call('datastore.query', 'network.vlan')
         for vlan in vlans:
-            disable_capabilities = vlan['vlan_vint'] in disable_capabilities_ifaces
-
             cloned_interfaces.append(vlan['vlan_vint'])
             try:
-                await self.middleware.call('interface.vlan_setup', vlan, disable_capabilities, parent_interfaces)
+                await self.middleware.call('interface.vlan_setup', vlan, parent_interfaces)
             except Exception:
-                self.middleware.logger.error('Error setting up VLAN %s', vlan['vlan_vint'], exc_info=True)
+                self.logger.error('Error setting up VLAN %s', vlan['vlan_vint'], exc_info=True)
 
         run_dhcp = []
         # Set VLAN interfaces MTU last as they are restricted by underlying interfaces MTU


### PR DESCRIPTION
This was added on CORE for an extremely rare situation where we have HA customers using jails/vms and an underlying limitation with the kernel. This doesn't apply to SCALE HA so remove it entirely.