### PR TITLE
NAS-114834 / 22.02.1 / Wait for k8s taints to be added

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -43,8 +43,10 @@ class KubernetesNodeService(ConfigService):
                 await nodes.add_taint(context['core_api'], taint, context['node'])
 
         remaining_taints = {t['key'] for t in taints}
-        while remaining_taints:
+        timeout = 600
+        while remaining_taints and timeout > 0:
             await asyncio.sleep(3)
+            timeout -= 3
 
             config = await self.config()
             if not config['node_configured']:


### PR DESCRIPTION
This commit adds changes to wait for k8s taints to be added as we saw for a user that even after doing a k8s patch with api client, the operation was not idempotent and did not return control when the taints had been added but just the request had been registered with k8s api server. So with this change, we wait for the taints to be added before giving the consumer control back.