### PR TITLE
NAS-114676 / 13.0 / Do not crash one-time cloud sync if snapshot option is selected (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -178,7 +178,9 @@ async def rclone(middleware, job, cloud_sync, dry_run=False):
                     await middleware.call("zfs.dataset.query", [["type", "=", "FILESYSTEM"]]),
                     cloud_sync["path"],
                 )
-                snapshot_name = f"cloud_sync-{cloud_sync['id']}-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+                snapshot_name = (
+                    f"cloud_sync-{cloud_sync.get('id', 'onetime')}-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+                )
 
                 snapshot = {"dataset": dataset["name"], "name": snapshot_name}
                 await middleware.call("zfs.snapshot.create", dict(snapshot, recursive=recursive))


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fd8174b0d929cf420885644ab1c499f5886add62



Original PR: https://github.com/truenas/middleware/pull/8230
Jira URL: https://jira.ixsystems.com/browse/NAS-114676