### PR TITLE
NAS-114904 / 13.0 / Improve `zfs.snapshot.query` `{"count": True}` performance. (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -912,7 +912,10 @@ class ZFSSnapshot(CRUDService):
         """
         # Special case for faster listing of snapshot names (#53149)
         if (
-            options and options.get('select') == ['name'] and (
+            (
+                options.get('select') == ['name'] or
+                options.get('count')
+            ) and (
                 not filters or
                 filter_getattrs(filters).issubset({'name', 'pool'})
             )


### PR DESCRIPTION
`usage.py` does `call('zfs.snapshot.query', [], {'count': True})` every 24 hours

Original PR: https://github.com/truenas/middleware/pull/8302
Jira URL: https://jira.ixsystems.com/browse/NAS-114904