### PR TITLE
NAS-114909 / 22.02.1 / less verbosity of logs in disk.sync

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -70,7 +70,7 @@ class DiskService(Service, ServiceChangeMixin):
         # when not all the disks have been resolved
         log_info = {
             ok: {
-                ik: iv for ik, iv in ov.items() if ik in ('name', 'lunid', 'serial')
+                ik: iv for ik, iv in ov.items() if ik in ('lunid', 'serial')
             } for ok, ov in sys_disks.items()
         }
         self.logger.info('Found disks: %r', log_info)


### PR DESCRIPTION
When this prints out to middlewared.log, the `ident` and `serial` key are the exact same so there is no reason to print both of them. Also the `ok` is the exact same as the `name` key so don't print that either.

This changes the output from
```
{'sda': {'name': 'sda', 'ident': '11111', 'lunid': '2222', 'serial': '11111'}
```
to
```
{'sda': {'lunid': '2222', 'serial': '11111'}