### PR TITLE
NAS-113826 / 22.02.1 / Allow enabling/disabling STP on bridge interfaces at creation

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-02-17_14-24_add_stp_column.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-02-17_14-24_add_stp_column.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('network_bridge', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('stp', sa.Boolean(), nullable=False))
+        batch_op.add_column(sa.Column('stp', sa.Boolean(), server_default='1', nullable=False))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-02-17_14-24_add_stp_column.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-02-17_14-24_add_stp_column.py
@@ -1,0 +1,26 @@
+"""add stp column to bridge table
+
+Revision ID: 7a143979d99b
+Revises: cda35deeed4f
+Create Date: 2022-02-17 14:24:38.186590+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7a143979d99b'
+down_revision = 'cda35deeed4f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('network_bridge', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('stp', sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    with op.batch_alter_table('network_bridge', schema=None) as batch_op:
+        batch_op.drop_column('stp')

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,6 +52,9 @@ class InterfaceService(Service):
 
             parent_interfaces.append(member)
 
+        self.logger.info('Toggling STP to {bridge["stp"]} for {name!r}')
+        iface.toggle_stp(name, int(bridge['stp']))
+
         # finally we need to up the main bridge if it's not already up
         if netif.InterfaceFlags.UP not in iface.flags:
             self.logger.info('Bringing up %r', name)

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,7 +52,7 @@ class InterfaceService(Service):
 
             parent_interfaces.append(member)
 
-        self.logger.info('Toggling STP to {bridge["stp"]} for {name!r}')
+        self.logger.info(f'Toggling STP to {bridge["stp"]} for {name!r}')
         iface.toggle_stp(name, int(bridge['stp']))
 
         # finally we need to up the main bridge if it's not already up

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,8 +52,10 @@ class InterfaceService(Service):
 
             parent_interfaces.append(member)
 
-        self.logger.info(f'Toggling STP to {bridge["stp"]} for {name!r}')
-        iface.toggle_stp(name, int(bridge['stp']))
+        if iface.stp != bridge['stp']:
+            verb = 'off' if not bridge['stp'] else 'on'
+            self.logger.info(f'Turning STP {verb} for {name!r}')
+            iface.toggle_stp(name, int(bridge['stp']))
 
         # finally we need to up the main bridge if it's not already up
         if netif.InterfaceFlags.UP not in iface.flags:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -29,6 +29,12 @@ class BridgeMixin:
             if link.get("master") == self.name
         ]
 
+    @property
+    def stp(self):
+        with NDB(log="off") as ndb:
+            with ndb.interfaces[self.name] as br:
+                return bool(br['br_stp_state'])
+
     def toggle_stp(self, name, value):
         # 0 is off > 0 is on
         with NDB(log="off") as ndb:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -11,7 +11,7 @@ __all__ = ["create_bridge", "BridgeMixin"]
 
 def create_bridge(name):
     with NDB(log="off") as ndb:
-        ndb.interfaces.create(ifname=name, kind="bridge").set("br_stp_state", 1).set("state", "up").commit()
+        ndb.interfaces.create(ifname=name, kind="bridge").set("state", "up").commit()
 
 
 class BridgeMixin:
@@ -28,3 +28,9 @@ class BridgeMixin:
             for link in json.loads(run(["bridge", "-json", "link"]).stdout)
             if link.get("master") == self.name
         ]
+
+    def toggle_stp(self, name, value):
+        # 0 is off > 0 is on
+        with NDB(log="off") as ndb:
+            with ndb.interfaces[name] as br:
+                br['br_stp_state'] = value

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1206,13 +1206,14 @@ class InterfaceService(CRUDService):
             )
 
             if iface['type'] == 'BRIDGE':
+                options = {}
                 if 'bridge_members' in data:
-                    await self.middleware.call(
-                        'datastore.update',
-                        'network.bridge',
-                        [('interface', '=', config['id'])],
-                        {'members': data['bridge_members']},
-                    )
+                    options['members'] = data['bridge_members']
+                if 'stp' in data:
+                    options['stp'] = data['stp']
+                if options:
+                    filters = [('interface', '=', config['id'])]
+                    await self.middleware.call('datastore.update', 'network.bridge', filters, options)
             elif iface['type'] == 'LINK_AGGREGATION':
                 xmit = lacpdu = None
                 if new['lag_protocol'] in ('LACP', 'LOADBALANCE'):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -33,7 +33,7 @@ class NetworkBridgeModel(sa.Model):
     id = sa.Column(sa.Integer(), primary_key=True)
     members = sa.Column(sa.JSON(type=list), default=[])
     interface_id = sa.Column(sa.ForeignKey('network_interfaces.id', ondelete='CASCADE'))
-    stp = sa.Column(sa.Boolean(), default=True)
+    stp = sa.Column(sa.Boolean())
 
 
 class NetworkInterfaceModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -33,6 +33,7 @@ class NetworkBridgeModel(sa.Model):
     id = sa.Column(sa.Integer(), primary_key=True)
     members = sa.Column(sa.JSON(type=list), default=[])
     interface_id = sa.Column(sa.ForeignKey('network_interfaces.id', ondelete='CASCADE'))
+    stp = sa.Column(sa.Boolean(), default=True)
 
 
 class NetworkInterfaceModel(sa.Model):
@@ -600,6 +601,7 @@ class InterfaceService(CRUDService):
             )
         ]),
         List('bridge_members'),
+        Bool('stp', default=True),
         Str('lag_protocol', enum=['LACP', 'FAILOVER', 'LOADBALANCE', 'ROUNDROBIN', 'NONE']),
         Str('xmit_hash_policy', enum=[i.value for i in XmitHashChoices], default=None, null=True),
         Str('lacpdu_rate', enum=[i.value for i in LacpduRateChoices], default=None, null=True),
@@ -666,22 +668,14 @@ class InterfaceService(CRUDService):
         if data['type'] == 'BRIDGE':
             name = data.get('name') or await self.middleware.call('interface.get_next', 'br')
             try:
-                async for i in self.__create_interface_datastore(data, {
-                    'interface': name,
-                }):
+                async for i in self.__create_interface_datastore(data, {'interface': name}):
+                    await self.middleware.call('datastore.insert', 'network.bridge', {
+                        'interface': i, 'members': data['bridge_members'], 'stp': data['stp']
+                    })
                     interface_id = i
-
-                await self.middleware.call(
-                    'datastore.insert',
-                    'network.bridge',
-                    {'interface': interface_id, 'members': data['bridge_members']},
-                )
             except Exception:
                 if interface_id:
-                    with contextlib.suppress(Exception):
-                        await self.middleware.call(
-                            'datastore.delete', 'network.interfaces', interface_id
-                        )
+                    await self.middleware.call('datastore.delete', 'network.interfaces', interface_id)
                 raise
         elif data['type'] == 'LINK_AGGREGATION':
             name = data.get('name') or await self.middleware.call('interface.get_next', 'bond')


### PR DESCRIPTION
This is very important for when we're connected to an actual enterprise(y) network that has BPDU guard on. When that feature is turned on and the port the TrueNAS is connected to exchanges BPDUs with the switch, then the (depending on how the switch feature is configured) switch can disable the switchport that the TrueNAS is connected to. Add the ability to toggle this setting at creation of the bridge defaulting to on.