### PR TITLE
NAS-114724 / 13.0 / Do not remove minio conf dir (#7912)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/minio/configure.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/configure.py
@@ -42,18 +42,10 @@ def render_certificates(s3, middleware):
         os.chmod(minio_privatekey, 0o600)
 
 
-def configure_minio_sys_dir(s3):
-    storage_path = s3['storage_path']
-    # Create storage path if it does not exist
-    os.makedirs(storage_path, exist_ok=True)
-    minio_dir = os.path.join(storage_path, '.minio.sys')
-    shutil.rmtree(minio_dir, ignore_errors=True)
-
-
-def render(service, middleware):
+def render(__, middleware):
     s3 = middleware.call_sync('s3.config')
     if not s3['storage_path']:
         return
 
-    configure_minio_sys_dir(s3)
+    os.makedirs(s3['storage_path'], exist_ok=True)
     render_certificates(s3, middleware)


### PR DESCRIPTION
## Background

On a teamviewer session with a user I saw that user had a minio dataset which was using terabytes of space, this resulted in it's `.minio.sys` configuration directory growing as well possibly consuming terabytes of space. This part is fine but we remove the directory on each service start of the minio plugin as we had a bug earlier where user was unable to change keys while using the same path as minio required providing old keys to change the current key to newly configured one. However with latest minio this was no longer required and necessary changes were made to SCALE but not backported to CORE.

Because of this, while on call Devin and I saw failover issues which initially Devin thought were unrelated. After the provided solution, the fo process was smooth.

## Solution

The solution was to backport the changes from SCALE as removing this directory is no longer required.

ref: https://github.com/minio/minio/blob/master/docs/kms/IAM.md#kms-iamconfig-encryption
> After release `RELEASE.2021-04-22T15-44-28Z` onwards, MinIO will use the KMS provided keys to encrypt the IAM data instead of the cluster root credentials. If the KMS is not enabled, MinIO will store the IAM data as plain text in its backend.