### PR TITLE
NAS-114762 / 13.0 / Make WebUI Shells persistent

### DIFF
--- a/src/freenas/root/.zlogin
+++ b/src/freenas/root/.zlogin
@@ -1,3 +1,7 @@
+if (( ${+WEB_CLIENT} )); then
+	screen -xRR WebShell
+fi
+
 if [ -f /usr/local/sbin/hactl ]; then
 	/usr/local/sbin/hactl status -q
 fi

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -591,6 +591,7 @@ class ShellWorkerThread(threading.Thread):
                 'HOME': '/root',
                 'LANG': 'en_US.UTF-8',
                 'PATH': '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/root/bin',
+                'WEB_CLIENT': 'xterm',
             })
 
         # Terminal baudrate affects input queue size


### PR DESCRIPTION
Currently, the WebUI shell ends when navigating the UI, getting logged out, or restarting the backend middlewared.

By declaring a WEB_CLIENT variable for web shells and detecting those variables in .zlogin, we can have the web shell survive a `service middlewared restart` as well as timeouts or navigation.

This is especially useful when troublehooting or running long tasks like rsync.