### PR TITLE
Add Certificate profiles for HTTPS RSA and EC

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
@@ -7,6 +7,81 @@ from .utils import DEFAULT_LIFETIME_DAYS
 
 
 CERTIFICATE_PROFILES = {
+        # Options / EKUs reference rfc5246
+        'HTTPS RSA Cert': {
+        'cert_extensions': {
+            'BasicConstraints': {
+                'enabled': True,
+                'ca': False,
+                'extension_critical': True
+            },
+            'AuthorityKeyIdentifier': {
+                'enabled': True,
+                'authority_cert_issuer': True,
+                'extension_critical': False
+            },
+            #Most TLS certs these days want "ClientAuth" these days.
+            #LetsEncrypt appears to want this extension to issue.
+            #https://community.letsencrypt.org/t/extendedkeyusage-tls-client-authentication-in-tls-server-certificates/59140/7
+            'ExtendedKeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'usages': [
+                    'SERVER_AUTH',
+                    'CLIENT_AUTH',
+                ]
+            },
+            # RSA certs should have "digitalSignature" for DHE, and "keyEncipberment" for nonDHE
+            # Include "keyAgreement" for compatibility, "Required" for DH_DSS / DH_RSA
+            # See rfc5246
+            'KeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'digital_signature': True,
+                'key_encipherment': True,
+                'key_agreement': True,
+            }
+        },
+        'key_length': 2048,
+        'key_type': 'RSA',
+        'lifetime': NOT_VALID_AFTER_DEFAULT,
+        'digest_algorithm': 'SHA256'
+    },
+    'HTTPS ECC Cert': {
+        'cert_extensions': {
+            'BasicConstraints': {
+                'enabled': True,
+                'ca': False,
+                'extension_critical': True
+            },
+            'AuthorityKeyIdentifier': {
+                'enabled': True,
+                'authority_cert_issuer': True,
+                'extension_critical': False
+            },
+            #Most TLS certs these days want "ClientAuth" these days.
+            #LetsEncrypt appears to want this extension to issue.
+            #https://community.letsencrypt.org/t/extendedkeyusage-tls-client-authentication-in-tls-server-certificates/59140/7
+            'ExtendedKeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'usages': [
+                    'SERVER_AUTH',
+                    'CLIENT_AUTH',
+                ]
+            },
+            # keyAgreement is not generally required for EC certs. See Google, cloudflare certs
+            'KeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'digital_signature': True,
+            }
+        },
+        'ec_curve': 'SECP384R1',
+        'key_type': 'EC',
+        'lifetime': NOT_VALID_AFTER_DEFAULT,
+        'digest_algorithm': 'SHA256'
+    },
     'Openvpn Server Certificate': {
         'cert_extensions': {
             'BasicConstraints': {


### PR DESCRIPTION
Profiles for RSA HTTPS and EC HTTPS certificates
Options based on LetsEncrypt guidelines, rfc5246, and common usages by e.g. google, cloudflare, and AWS

Justification for CLIENT_AUTH flag-- seems wanted by LetsEncrypt
https://community.letsencrypt.org/t/extendedkeyusage-tls-client-authentication-in-tls-server-certificates/59140

Example certs used as basis:
https://crt.sh/?id=1821366302
https://crt.sh/?id=2332064942