### PR TITLE
NAS-114906 / 22.02.1 / Unregister failed calls in the middleware client to prevent memory leak

### DIFF
--- a/src/middlewared/middlewared/worker.py
+++ b/src/middlewared/middlewared/worker.py
@@ -114,6 +114,7 @@ def main_worker(*call_args):
         res = MIDDLEWARE._run(*call_args)
     except SystemExit:
         raise RuntimeError('Worker call raised SystemExit exception')
+
     # TODO: python cant pickle generator for obvious reasons, we should implement
     # it using Pipe.
     if inspect.isgenerator(res):


### PR DESCRIPTION
Additionally investigated memory leak in the main middleware process. tracemalloc led me to the bytearray objects of Websocket request payload being read. Even explicitly clearing those did not free up memory. However, the memory is freed within 5-60 seconds of the "payload too large" websocket error. It seems that those bytearray memory is not given back to the OS immediately and that's how python memory management works. Upon running stress tests I was not able to make middleware process eat up all the memory — it was always freed shortly.