### PR TITLE
NAS-114947 / 22.12 / remove osc from dhclient.py and clean-up

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/dhclient.py
+++ b/src/middlewared/middlewared/plugins/interface/dhclient.py
@@ -1,17 +1,14 @@
 import os
-import subprocess
+from contextlib import suppress
+from subprocess import PIPE, STDOUT
 
 from middlewared.service import private, Service
-from middlewared.utils import osc, Popen
+from middlewared.utils import Popen
 from middlewared.utils.cgroups import move_to_root_cgroups
 
 
-if osc.IS_FREEBSD:
-    LEASEFILE_TEMPLATE = '/var/db/dhclient.leases.{}'
-    PIDFILE_TEMPLATE = '/var/run/dhclient/dhclient.{}.pid'
-else:
-    LEASEFILE_TEMPLATE = '/var/lib/dhcp/dhclient.leases.{}'
-    PIDFILE_TEMPLATE = '/var/run/dhclient.{}.pid'
+LEASEFILE_TEMPLATE = '/var/lib/dhcp/dhclient.leases.{}'
+PIDFILE_TEMPLATE = '/var/run/dhclient.{}.pid'
 
 
 class InterfaceService(Service):
@@ -21,36 +18,23 @@ class InterfaceService(Service):
     @private
     async def dhclient_start(self, interface, wait=False):
         cmd = ['dhclient']
+        if not wait:
+            cmd.append('-nw')
+        cmd.extend(['-lf', LEASEFILE_TEMPLATE.format(interface)])
+        cmd.extend(['-pf', PIDFILE_TEMPLATE.format(interface)])
+        cmd.extend([interface])
 
-        if osc.IS_FREEBSD:
-            if not wait:
-                cmd.append('-b')
-
-        if osc.IS_LINUX:
-            if not wait:
-                cmd.append('-nw')
-
-            cmd.extend(['-lf', LEASEFILE_TEMPLATE.format(interface)])
-            cmd.extend(['-pf', PIDFILE_TEMPLATE.format(interface)])
-
-        proc = await Popen(
-            cmd + [interface],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True,
-        )
+        proc = await Popen(cmd, stdout=PIPE, stderr=STDOUT, close_fds=True)
         output = (await proc.communicate())[0].decode()
         if proc.returncode != 0:
-            self.logger.error('Failed to run dhclient on {}: {}'.format(
-                interface, output,
-            ))
+            self.logger.error('Failed to run dhclient on %r: %r', interface, output)
         else:
-            if osc.IS_LINUX:
-                try:
-                    with open(PIDFILE_TEMPLATE.format(interface)) as f:
-                        pid = int(f.read().strip())
-
-                    move_to_root_cgroups(pid)
-                except Exception:
-                    self.logger.warning('Failed to move dhclient to root cgroups', exc_info=True)
+            try:
+                with open(PIDFILE_TEMPLATE.format(interface)) as f:
+                    pid = int(f.read().strip())
+                move_to_root_cgroups(pid)
+            except Exception:
+                self.logger.warning('Failed to move dhclient to root cgroups', exc_info=True)
 
     @private
     def dhclient_status(self, interface):
@@ -63,22 +47,12 @@ class InterfaceService(Service):
         Returns:
             tuple(bool, pid): if dhclient is running follow its pid.
         """
-        pidfile = PIDFILE_TEMPLATE.format(interface)
         pid = None
-        if os.path.exists(pidfile):
-            with open(pidfile, 'r') as f:
-                try:
-                    pid = int(f.read().strip())
-                except ValueError:
-                    pass
-
         running = False
-        if pid:
-            try:
+        with suppress((FileNotFoundError, ValueError, OSError)):
+            with open(PIDFILE_TEMPLATE.format(interface)) as f:
+                pid = int(f.read().strip())
                 os.kill(pid, 0)
-            except OSError:
-                pass
-            else:
                 running = True
         return running, pid
 
@@ -93,7 +67,6 @@ class InterfaceService(Service):
         Returns:
             str: content of dhclient leases file for `interface`.
         """
-        leasesfile = LEASEFILE_TEMPLATE.format(interface)
-        if os.path.exists(leasesfile):
-            with open(leasesfile, 'r') as f:
+        with suppress(FileNotFoundError):
+            with open(LEASEFILE_TEMPLATE.format(interface)) as f:
                 return f.read()


### PR DESCRIPTION
No functional change, just removes the `osc` module. It also fixes the theoretical race condition where we check for a file before opening it. Instead just suppress `FileNotFoundError` per best practices.