### PR TITLE
NAS-114945 / 13.0 / Expand warning for shell modifications (by anodos325)

### DIFF
--- a/src/freenas/root/.warning
+++ b/src/freenas/root/.warning
@@ -1,4 +1,6 @@
 
-Warning: settings changed through the CLI are not written to
-the configuration database and will be reset on reboot.
+Warning: the supported mechanisms for making configuration changes
+are the TrueNAS WebUI and API exclusively. ALL OTHERS ARE
+NOT SUPPORTED AND WILL RESULT IN UNDEFINED BEHAVIOR AND MAY
+RESULT IN SYSTEM FAILURE.
 


### PR DESCRIPTION
"CLI" is now ambiguous because it refers to the TrueNAS CLI (which
is a supported way of making changes).

Original PR: https://github.com/truenas/middleware/pull/8322
Jira URL: https://jira.ixsystems.com/browse/NAS-114945