### PR TITLE
NAS-114755 / 22.02.1 / Nas-114755

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -33,6 +33,7 @@ class InterfaceService(Service):
             # remove members from the bridge that aren't in the db
             self.logger.info('Removing member interface %r from %r', member, name)
             iface.delete_member(member)
+            ## TODO: Add IP address back to former bridge member based on db
 
         for member in db_members - os_members:
             # now add members that are written in db but do not exist in
@@ -40,6 +41,7 @@ class InterfaceService(Service):
             try:
                 self.logger.info('Adding member interface %r to %r', member, name)
                 iface.add_member(member)
+                ## TODO: Remove IP address from bridge member (but not from db!)
             except FileNotFoundError:
                 self.logger.error('Bridge member %r not found', member)
                 continue

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -77,14 +77,13 @@ class InterfaceService(Service):
                     'address': data[ipv4_field],
                     'netmask': data['int_v4netmaskbit'],
                 }))
-                # TODO: Handle IPv4 / IPv6 commit (messages to user?)
             if data[ipv6_field] and not has_ipv6:
                 addrs_database.add(self.alias_to_addr({
                     'address': data[ipv6_field],
                     'netmask': data['int_v6netmaskbit'],
                 }))
                 has_ipv6 = True
-                # TODO: Handle IPv4 / IPv6 commit (messages to user?)
+
         # configure VRRP
         vip = data.get('int_vip', '')
         if vip:

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -77,13 +77,14 @@ class InterfaceService(Service):
                     'address': data[ipv4_field],
                     'netmask': data['int_v4netmaskbit'],
                 }))
+                # TODO: Handle IPv4 / IPv6 commit (messages to user?)
             if data[ipv6_field] and not has_ipv6:
                 addrs_database.add(self.alias_to_addr({
                     'address': data[ipv6_field],
                     'netmask': data['int_v6netmaskbit'],
                 }))
                 has_ipv6 = True
-
+                # TODO: Handle IPv4 / IPv6 commit (messages to user?)
         # configure VRRP
         vip = data.get('int_vip', '')
         if vip:

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -133,6 +133,7 @@ class InterfaceService(Service):
 
         # Remove addresses configured and not in database
         for addr in addrs_configured:
+            # TODO: Handle IPv4 / IPv6 commit (messages to user?)
             address = str(addr.address)
             # keepalived service is responsible for deleting the VIP(s)
             if address in (vip, vipv6) or address in alias_vips:
@@ -155,6 +156,7 @@ class InterfaceService(Service):
 
         # Add addresses in database and not configured
         for addr in (addrs_database - addrs_configured):
+            # TODO: Handle IPv4 / IPv6 commit (messages to user?)
             address = str(addr.address)
             # keepalived service is responsible for adding the VIP(s)
             if address in (vip, vipv6) or address in alias_vips:

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -37,11 +37,19 @@ class InterfaceService(Service):
             ipv4_field = 'int_ipv4address_b'
             ipv6_field = 'int_ipv6address_b'
             alias_field = 'alias_address_b'
+        elif (
+            # Bridge interface members should not have IP addresses
+            self.middleware.call_sync('interface.type', iface.__getstate__()) in [
+                InterfaceType.BRIDGE,
+                ]):
+            self.logger.info('%r is bridge member, handle specially')
+            ipv4_field = 'int_ipv4address'
+            ipv6_field = 'int_ipv6address'
+            alias_field = 'alias_address'
         else:
             ipv4_field = 'int_ipv4address'
             ipv6_field = 'int_ipv6address'
             alias_field = 'alias_address'
-
         dhclient_running, dhclient_pid = self.middleware.call_sync('interface.dhclient_status', name)
         if dhclient_running and data['int_dhcp']:
             leases = self.middleware.call_sync('interface.dhclient_leases', name)

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -43,6 +43,8 @@ class InterfaceService(Service):
                 InterfaceType.BRIDGE,
                 ]):
             self.logger.info('%r is bridge member, handle specially')
+            # TODO: Specially handle bridge member interfaces: ip change should go to DB, but NOT live.
+            # TODO: signal to web UI that this change is not live, so config can be preemptively changed
             ipv4_field = 'int_ipv4address'
             ipv6_field = 'int_ipv6address'
             alias_field = 'alias_address'


### PR DESCRIPTION
First stab at this.
This first pull request is mostly Todos, with some minor logic introduced in control.py. I am seeking feedback on my approach here.

The idea is to perform the following:

- When an interface is added to a bridge, remove its IP from the actual interface (but not from the database)
- When it is removed from the bridge, re-add its IP from the DB
- When an IP change is made to a bridge member, store that change in DB but do not commit it to the interface, and communicate (somehow) this fact (to UI? to logs)

That last case is to allow someone to stage an IP address to go live when the interface is removed from bridge. This can allow avoiding chicken-and-egg problems where bridge removal destroys connectivity. 

Please provide feedback, and if this looks like a good approach I will proceed.