### PR TITLE
NAS-114970 / 13.0 / optimize logic for overprovisioning log devices when creating zpool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -367,7 +367,7 @@ class PoolService(CRUDService):
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
                 )
                 data = (await proc.communicate())[0].decode('utf8').strip('\n')
-                for line in [l for l in data.split('\n') if l.startswith('feature') and '\t' in l]:
+                for line in [i for i in data.split('\n') if i.startswith('feature') and '\t' in i]:
                     prop, value = line.split('\t', 1)
                     if value not in ('active', 'enabled'):
                         return False

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -666,9 +666,10 @@ class PoolService(CRUDService):
 
         if overprovsize := (await self.middleware.call('system.advanced.config'))['overprovision']:
             log_disks = sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])
+            len_log_disks = len(log_disks)
             for i, disk in enumerate(log_disks):
                 try:
-                    job.set_progress(10, f'Overprovisioning disks ({i}/{len(log_disks)})')
+                    job.set_progress(10, f'Overprovisioning disks ({i}/{len_log_disks})')
                     await self.middleware.call('disk.overprovision', disk, overprovsize, i == 0)
                 except CanNotBeOverprovisionedException:
                     pass


### PR DESCRIPTION
There is no reason to iterate the `log` vdev key if overprovisioning hasn't even been set.