### PR TITLE
NAS-114978 / 22.12 / Default to enabling SA-based xattrs

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3073,7 +3073,7 @@ class PoolDatasetService(CRUDService):
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
         Inheritable(Str('acltype', enum=['OFF', 'NOACL', 'NFSV4', 'NFS4ACL', 'POSIX', 'POSIXACL']), has_default=False),
         Str('share_type', default='GENERIC', enum=['GENERIC', 'SMB']),
-        Inheritable(Str('xattr', enum=['ON', 'SA'])),
+        Inheritable(Str('xattr', default='SA', enum=['ON', 'SA'])),
         Ref('encryption_options'),
         Bool('encryption', default=False),
         Bool('inherit_encryption', default=True),


### PR DESCRIPTION
This will significantly improve xattr performance and there has not been reports of issues since we added feature to ZoL on FreeBSD.