### PR TITLE
NAS-114967 / 13.0 / add send_event key to datastore plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/write.py
+++ b/src/middlewared/middlewared/plugins/datastore/write.py
@@ -22,7 +22,7 @@ update 1000 table entries, then we run "disk.query" 1000 times. In
 real world testing, this has shown to take roughly 82 seconds to update
 100 entries on the `storage_disk` table when there are 641 entries total.
 The database was on a NVMe disk. The solution to this is adding the
-`batch_operation` key. If this is set to True, then an event will not be
+`send_event` key. If this is set to False, then an event will not be
 sent for the db operation. It is the callers responsibility to emit an event
 after all the db operations are complete.
 """
@@ -40,7 +40,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
-            Bool('batch_operation', default=False),
+            Bool('send_event', default=True),
         ),
     )
     async def insert(self, name, data, options):
@@ -74,7 +74,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
 
         await self._handle_relationships(pk, relationships)
 
-        if not options['batch_operation']:
+        if options['send_event']:
             await self.middleware.call('datastore.send_insert_events', name, insert)
 
         return pk
@@ -87,7 +87,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
-            Bool('batch_operation', default=False),
+            Bool('send_event', default=True),
         ),
     )
     async def update(self, name, id_or_filters, data, options):
@@ -124,7 +124,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             if result.rowcount != 1:
                 raise RuntimeError('No rows were updated')
 
-            if not options['batch_operation']:
+            if options['send_event']:
                 await self.middleware.call('datastore.send_update_events', name, id)
 
         await self._handle_relationships(id, relationships)
@@ -180,7 +180,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
-            Bool('batch_operation', default=False),
+            Bool('send_event', default=True),
         ),
     )
     async def delete(self, name, id_or_filters, options):
@@ -197,7 +197,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             },
         )
 
-        if not isinstance(id_or_filters, list) and not options['batch_operation']:
+        if not isinstance(id_or_filters, list) and options['send_event']:
             await self.middleware.call('datastore.send_delete_events', name, id_or_filters)
 
         return True

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -145,7 +145,7 @@ class DiskService(Service, ServiceChangeMixin):
                 if not disk['disk_expiretime']:
                     disk['disk_expiretime'] = datetime.utcnow() + timedelta(days=self.DISK_EXPIRECACHE_DAYS)
                     await self.middleware.call(
-                        'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_event': False}
+                        'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_events': False}
                     )
                     changed.add(disk['disk_identifier'])
                 elif disk['disk_expiretime'] < datetime.utcnow():
@@ -159,7 +159,7 @@ class DiskService(Service, ServiceChangeMixin):
                             'kmip.reset_sed_disk_password', disk['disk_identifier'], disk['disk_kmip_uid']
                         ))
                     await self.middleware.call(
-                        'datastore.delete', 'storage.disk', disk['disk_identifier'], {'send_event': False}
+                        'datastore.delete', 'storage.disk', disk['disk_identifier'], {'send_events': False}
                     )
                     deleted.add(disk['disk_identifier'])
                 continue
@@ -182,7 +182,7 @@ class DiskService(Service, ServiceChangeMixin):
             # when lots of drives are present
             if self._disk_changed(disk, original_disk):
                 await self.middleware.call(
-                    'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_event': False}
+                    'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_events': False}
                 )
                 changed.add(disk['disk_identifier'])
 
@@ -217,11 +217,11 @@ class DiskService(Service, ServiceChangeMixin):
                     # when lots of drives are present
                     if self._disk_changed(disk, original_disk):
                         await self.middleware.call(
-                            'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_event': False}
+                            'datastore.update', 'storage.disk', disk['disk_identifier'], disk, {'send_events': False}
                         )
                         changed.add(disk['disk_identifier'])
                 else:
-                    await self.middleware.call('datastore.insert', 'storage.disk', disk, {'send_event': False})
+                    await self.middleware.call('datastore.insert', 'storage.disk', disk, {'send_events': False})
                     changed.add(disk['disk_identifier'])
 
         # make sure the database entries for enclosure slot information for each disk

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -3,7 +3,6 @@ import os
 from datetime import datetime, timedelta
 from itertools import zip_longest
 
-from bsd import geom
 from middlewared.schema import accepts, Str
 from middlewared.service import job, private, Service, ServiceChangeMixin
 
@@ -110,7 +109,7 @@ class DiskService(Service, ServiceChangeMixin):
                 self.logger.warning('Starting disk.sync_all when devd is not connected yet')
 
         sys_disks = await self.middleware.call('device.get_disks')
-        geom_xml = geom.class_by_name('DISK').xml
+        geom_xml = await self.middleware.call('geom.cache.get_class_xml', 'DISK')
 
         number_of_disks = len(sys_disks)
         if 0 > number_of_disks <= 25:

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -54,10 +54,9 @@ class DiskService(Service):
                     )
 
         if events:
-            disks = await self.middleware.call("disk.query", [], {"prefix": "disk_"})
+            disks = {i['identifier']: i for i in await self.middleware.call("disk.query", [], {"prefix": "disk_"})}
             for event in events:
-                if fields := [i for i in disks if i['identifier'] == event]:
-                    self.middleware.send_event("disk.query", "CHANGED", id=event, fields=fields[0])
+                self.middleware.send_event("disk.query", "CHANGED", id=event, fields=disks[event])
 
 
 async def devd_zfs_hook(middleware, data):

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -54,7 +54,7 @@ class DiskService(Service):
                     )
 
         if events:
-            disks = await self.middleware.call('disk.query', [], {'prefix': 'disk_', 'get': True})
+            disks = await self.middleware.call("disk.query", [], {"prefix": "disk_", "get": True})
             for event in events:
                 if fields := disks.get(event):
                     self.middleware.send_event("disk.query", "CHANGED", id=event, fields=fields)

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -41,7 +41,7 @@ class DiskService(Service):
                 events.add(disk["identifier"])
                 await self.middleware.call(
                     "datastore.update", "storage.disk", disk["identifier"],
-                    {"zfs_guid": guid}, {"prefix": "disk_", "send_event": False},
+                    {"zfs_guid": guid}, {"prefix": "disk_", "send_events": False},
                 )
             elif disk["zfs_guid"]:
                 devname = disk_to_guid.inv.get(disk["zfs_guid"])
@@ -50,7 +50,7 @@ class DiskService(Service):
                     events.add(disk["identifier"])
                     await self.middleware.call(
                         "datastore.update", "storage.disk", disk["identifier"],
-                        {"zfs_guid": None}, {"prefix": "disk_", "send_event": False},
+                        {"zfs_guid": None}, {"prefix": "disk_", "send_events": False},
                     )
 
         if events:

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -54,10 +54,10 @@ class DiskService(Service):
                     )
 
         if events:
-            disks = await self.middleware.call("disk.query", [], {"prefix": "disk_", "get": True})
+            disks = await self.middleware.call("disk.query", [], {"prefix": "disk_"})
             for event in events:
-                if fields := disks.get(event):
-                    self.middleware.send_event("disk.query", "CHANGED", id=event, fields=fields)
+                if fields := [i for i in disks if i['identifier'] == event]:
+                    self.middleware.send_event("disk.query", "CHANGED", id=event, fields=fields[0])
 
 
 async def devd_zfs_hook(middleware, data):

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -53,8 +53,8 @@ class DiskService(Service):
                         {"zfs_guid": None}, {"prefix": "disk_", "send_event": False},
                     )
 
-        if events:
-            self.middleware.send_event('disk.query', 'CHANGED', fields=events)
+        for event in events:
+            self.middleware.send_event("disk.query", "CHANGED", id=event["id"], fields={"zfs_guid": event["zfs_guid"]})
 
 
 async def devd_zfs_hook(middleware, data):

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -1,12 +1,7 @@
-import logging
-
 import bidict
 
 from middlewared.service import private, Service
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils import osc
-
-logger = logging.getLogger(__name__)
 
 
 class DiskService(Service):
@@ -41,35 +36,21 @@ class DiskService(Service):
         for disk in await self.middleware.call("disk.query", [], {"extra": {"include_expired": True}}):
             guid = disk_to_guid.get(disk["devname"])
             if guid is not None and guid != disk["zfs_guid"]:
-                logger.debug("Setting disk %r zfs_guid %r", disk["identifier"], guid)
+                self.logger.debug("Setting disk %r zfs_guid %r", disk["identifier"], guid)
                 await self.middleware.call(
                     "datastore.update", "storage.disk", disk["identifier"], {"zfs_guid": guid}, {"prefix": "disk_"},
                 )
             elif disk["zfs_guid"]:
                 devname = disk_to_guid.inv.get(disk["zfs_guid"])
                 if devname is not None and devname != disk["devname"]:
-                    logger.debug("Removing disk %r zfs_guid as %r has it", disk["identifier"], devname)
+                    self.logger.debug("Removing disk %r zfs_guid as %r has it", disk["identifier"], devname)
                     await self.middleware.call(
                         "datastore.update", "storage.disk", disk["identifier"], {"zfs_guid": None}, {"prefix": "disk_"},
                     )
 
 
 async def devd_zfs_hook(middleware, data):
-    if data.get("type") in (
-        "sysevent.fs.zfs.config_sync",
-    ):
-        try:
-            await middleware.call("disk.sync_zfs_guid", data["pool"])
-        except MatchNotFound:
-            pass
-
-
-async def zfs_events_hook(middleware, data):
-    event_id = data["class"]
-
-    if event_id in [
-        "sysevent.fs.zfs.config_sync",
-    ]:
+    if data.get("type") == "sysevent.fs.zfs.config_sync":
         try:
             await middleware.call("disk.sync_zfs_guid", data["pool"])
         except MatchNotFound:
@@ -81,9 +62,5 @@ async def hook(middleware, pool):
 
 
 async def setup(middleware):
-    if osc.IS_FREEBSD:
-        middleware.register_hook("devd.zfs", devd_zfs_hook)
-    else:
-        middleware.register_hook("zfs.pool.events", zfs_events_hook)
-
+    middleware.register_hook("devd.zfs", devd_zfs_hook)
     middleware.register_hook("pool.post_create_or_update", hook)

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -33,24 +33,24 @@ class DiskService(Service):
             if vdev["type"] == "DISK" and vdev["disk"] is not None:
                 disk_to_guid[vdev["disk"]] = vdev["guid"]
 
-        events = {}
+        events = []
         for disk in await self.middleware.call("disk.query", [], {"extra": {"include_expired": True}}):
             guid = disk_to_guid.get(disk["devname"])
             if guid is not None and guid != disk["zfs_guid"]:
                 self.logger.debug("Setting disk %r zfs_guid %r", disk["identifier"], guid)
-                events.update({"id": disk["identifier"], "zfs_guid": guid})
+                events.append({"id": disk["identifier"], "zfs_guid": guid})
                 await self.middleware.call(
                     "datastore.update", "storage.disk", disk["identifier"],
-                    {"zfs_guid": guid}, {"prefix": "disk_", "batch_operation": True},
+                    {"zfs_guid": guid}, {"prefix": "disk_", "send_event": False},
                 )
             elif disk["zfs_guid"]:
                 devname = disk_to_guid.inv.get(disk["zfs_guid"])
                 if devname is not None and devname != disk["devname"]:
                     self.logger.debug("Removing disk %r zfs_guid as %r has it", disk["identifier"], devname)
-                    events.update({"id": disk["identifier"], "zfs_guid": None})
+                    events.append({"id": disk["identifier"], "zfs_guid": None})
                     await self.middleware.call(
                         "datastore.update", "storage.disk", disk["identifier"],
-                        {"zfs_guid": None}, {"prefix": "disk_", "batch_operation": True},
+                        {"zfs_guid": None}, {"prefix": "disk_", "send_event": False},
                     )
 
         if events:

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -54,7 +54,7 @@ class DiskService(Service):
                     )
 
         if events:
-            self.middleware.send_event('storage.disk', 'CHANGED', fields=events)
+            self.middleware.send_event('disk.query', 'CHANGED', fields=events)
 
 
 async def devd_zfs_hook(middleware, data):


### PR DESCRIPTION
By default, when an update/insert/delete operation occurs we will
emit an event via our event plugin to be processed for the webui.
This is important, for example, when a new disk is inserted/removed.
In either of the above scenarios, the webUI will process this event
and update the front-end accordingly. It negates the front-end having
to poll the backend (which is expensive). However, on very large
systems (i.e. systems with 100+ disks) emitting an event can become absurdly
expensive. This reason why this becomes expensive is because for every
db operation, we run the plugins associated "query" method. So if we
update 1000 table entries, then we run "disk.query" 1000 times. In
real world testing, this has shown to take roughly 82 seconds to update
100 entries on the `storage_disk` table when there are 641 entries total.
The database was on a NVMe disk. The solution to this is adding the
`send_event` key. If this is set to False, then an event will not be
sent for the db operation. It is the callers responsibility to emit an event
after all the db operations are complete.