### PR TITLE
NAS-115009 / 22.12 / Enable Mixed port types in kubernetes services

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -28,6 +28,7 @@ def render(service, middleware):
         'audit-log-maxbackup=10',
         'audit-log-maxsize=100',
         'service-account-lookup=true',
+        'feature-gates=MixedProtocolLBService=true',
     ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
     with open(FLAGS_PATH, 'w') as f:


### PR DESCRIPTION
This flag enables mixed port types for kubernetes services for bluefin.
As the kubernetes feature will move to Beta state come 1.24 and this feature flag is one of the most used and most usefull featureflags, as some Apps and loadbalancers will not work correctly without this.

It will also allow catalog maintainers significant cleanup of their GUI, as it will not require per-port-type service anymore.

**note:**
*Can also be backported to 22.02 if someone wants that in there...*