### PR TITLE
Fix logger call in exports etc file

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -35,7 +35,7 @@
         try:
             mapall = do_map(share, "mapall")
         except KeyError:
-            self.logger.warning(
+            middleware.logger.warning(
                 "NSS lookup for anonymous account failed. "
                 "disabling NFS exports.",
                 exc_info = True
@@ -49,7 +49,7 @@
         try:
             maproot = do_map(share, "maproot")
         except KeyError:
-            self.logger.warning(
+            middleware.logger.warning(
                 "NSS lookup for anonymous account failed. "
                 "disabling NFS exports.",
                 exc_info = True


### PR DESCRIPTION
This fixes a crash when exports are generated with
invalid / non-existing user for maproot or mapall