### PR TITLE
NAS-114999 / 22.12 / fix sysDescr OID on SCALE

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/snmpd.conf.mako
@@ -1,32 +1,18 @@
 <%
-    if IS_FREEBSD:
-        import sysctl
-
-        hw_machine = sysctl.filter("hw.machine")[0].value
-        hw_model = f'{sysctl.filter("hw.model")[0].value} running at {sysctl.filter("hw.clockrate")[0].value} MHz'
-        kern_ostype = sysctl.filter("kern.ostype")[0].value
-        kern_osrelease = sysctl.filter("kern.osrelease")[0].value
-        kern_osrevision = sysctl.filter("kern.osrevision")[0].value
-    else:
-        import os
-
-        uname = os.uname()
-
-        hw_machine = uname.machine
-        hw_model = middleware.call_sync("system.cpu_info")["cpu_model"]
-        kern_ostype = uname.sysname
-        kern_osrelease = uname.release
-        kern_osrevision = uname.version
-
-    with open("/etc/version") as f:
-        freenas_version = f.read().strip()
-
+    import os
+    uname = os.uname()
+    hw_machine = uname.machine
+    hw_model = middleware.call_sync("system.cpu_info")["cpu_model"]
+    kern_ostype = uname.sysname
+    kern_osrelease = uname.release
+    kern_osrevision = uname.version
+    version = middleware.call_sync('system.version')
     config = middleware.call_sync("snmp.config")
 %>
 agentAddress udp:161,udp6:161,unix:/var/run/snmpd.sock
 sysLocation ${config["location"] or "unknown"}
 sysContact ${config["contact"] or "unknown@localhost"}
-sysDescr ${freenas_version}. Hardware: ${hw_machine} ${hw_model}. Software: ${kern_ostype} ${kern_osrelease} (revision ${kern_osrevision})
+sysDescr ${version}. Hardware: ${hw_machine} ${hw_model}. Software: ${kern_ostype} ${kern_osrelease} (revision ${kern_osrevision})
 sysObjectID 1.3.6.1.4.1.50536.3.${"1" if not middleware.call_sync("system.is_enterprise") else "2"}
 
 master agentx

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -251,8 +251,7 @@ class EtcService(Service):
             },
         ],
         'snmpd': [
-            {'type': 'mako', 'path': 'local/snmpd.conf' if osc.IS_FREEBSD else 'snmp/snmpd.conf',
-             'local_path': 'local/snmpd.conf'},
+            {'type': 'mako', 'path': 'snmp/snmpd.conf', 'local_path': 'local/snmpd.conf'},
         ],
         'sudoers': [
             {'type': 'mako', 'path': 'local/sudoers'}


### PR DESCRIPTION
`/etc/version` is just `22.02.0` on the 22.02-RELEASE. Whether or not that is intended is besides the point so instead of reading `/etc/version`, call `system.version` and remove the `osc` plugin while I'm here.