### PR TITLE
NAS-115071 / 22.02 / Improve user.query and group.query performance (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -21,6 +21,7 @@ import string
 import stat
 import time
 from pathlib import Path
+from contextlib import suppress
 
 SKEL_PATH = '/etc/skel/'
 
@@ -129,6 +130,7 @@ class UserService(CRUDService):
     class Config:
         datastore = 'account.bsdusers'
         datastore_extend = 'user.user_extend'
+        datastore_extend_context = 'user.user_extend_context'
         datastore_prefix = 'bsdusr_'
         cli_namespace = 'account.user'
 
@@ -151,27 +153,43 @@ class UserService(CRUDService):
     )
 
     @private
-    async def user_extend(self, user):
+    async def user_extend_context(self, rows, extra):
+        memberships = {}
+        res = await self.middleware.call(
+            'datastore.query', 'account.bsdgroupmembership',
+            [], {'prefix': 'bsdgrpmember_'}
+        )
+
+        for i in res:
+            uid = i['user']['id']
+            if uid in memberships:
+                memberships[uid].append(i['group']['id'])
+            else:
+                memberships[uid] = [i['group']['id']]
+
+        return {"memberships": memberships}
+
+    @private
+    def _read_authorized_keys(self, homedir):
+        keysfile = f'{homedir}/.ssh/authorized_keys'
+        rv = None
+        with suppress(FileNotFoundError):
+            with open(keysfile, 'r') as f:
+                rv = f.read()
+
+        return rv
+
+    @private
+    async def user_extend(self, user, ctx):
 
         # Normalize email, empty is really null
         if user['email'] == '':
             user['email'] = None
 
-        # Get group membership
-        user['groups'] = [gm['group']['id'] for gm in await self.middleware.call(
-            'datastore.query', 'account.bsdgroupmembership',
-            [('user', '=', user['id'])], {'prefix': 'bsdgrpmember_'}
-        )]
-
+        user['groups'] = ctx['memberships'].get(user['id'], [])
         # Get authorized keys
-        keysfile = f'{user["home"]}/.ssh/authorized_keys'
-        user['sshpubkey'] = None
-        if os.path.exists(keysfile):
-            try:
-                with open(keysfile, 'r') as f:
-                    user['sshpubkey'] = f.read()
-            except Exception:
-                pass
+        user['sshpubkey'] = await self.middleware.run_in_thread(self._read_authorized_keys, user['home'])
+
         return user
 
     @private
@@ -1153,6 +1171,7 @@ class GroupService(CRUDService):
         datastore = 'account.bsdgroups'
         datastore_prefix = 'bsdgrp_'
         datastore_extend = 'group.group_extend'
+        datastore_extend_context = 'group.group_extend_context'
         cli_namespace = 'account.group'
 
     ENTRY = Patch(
@@ -1168,27 +1187,34 @@ class GroupService(CRUDService):
     )
 
     @private
-    async def group_extend(self, group):
+    async def group_extend_context(self, rows, extra):
+        mem = {}
+        membership = await self.middleware.call('datastore.query', 'account.bsdgroupmembership', [], {'prefix': 'bsdgrpmember_'})
+        users = await self.middleware.call('datastore.query', 'account.bsdusers')
+
+        # uid and gid variables here reference database ids rather than OS uid / gid
+        for g in membership:
+            gid = g['group']['id']
+            uid = g['user']['id']
+            if gid in mem:
+                mem[gid].append(uid)
+            else:
+                mem[gid] = [uid]
+
+        for u in users:
+            gid = u['bsdusr_group']['id']
+            uid = u['id']
+            if gid in mem:
+                mem[gid].append(uid)
+            else:
+                mem[gid] = [uid]
+
+        return {"memberships": mem}
+
+    @private
+    async def group_extend(self, group, ctx):
         group['name'] = group['group']
-        # Get group membership
-        group['users'] = [
-            gm['user']['id']
-            for gm in await self.middleware.call(
-                'datastore.query',
-                'account.bsdgroupmembership',
-                [('group', '=', group['id'])],
-                {'prefix': 'bsdgrpmember_'}
-            )
-        ]
-        group['users'] += [
-            gmu['id']
-            for gmu in await self.middleware.call(
-                'datastore.query',
-                'account.bsdusers',
-                [('bsdusr_group_id', '=', group['id'])]
-            )
-            if gmu['id'] not in group['users']
-        ]
+        group['users'] = ctx['memberships'].get(group['id'], [])
         return group
 
     @private


### PR DESCRIPTION
Original code was performing one datastore query per user, and
two datastore queries per group for each user or group in
user.query and group.query respectively.

This contains an optimization whereby we query the related
datastores only once per query request and convert relevant
data to a dictionary that allows O(1) retrieval for information
as we iterate through query results. The practical impact
on server with 500 users is that user.query speed dropped
from 7 seconds to 0.6 seconds. This has broad-ranging impacts
due to datastore and etc file design where user.query may
be called a significant number of times when adding, modifying,
or deleting users. In this case, I observed a 10x improvement
in speed.

Original PR: https://github.com/truenas/middleware/pull/8376
Jira URL: https://jira.ixsystems.com/browse/NAS-115071