### PR TITLE
NAS-115070 / 13.0 / fix rcorder on 13

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-etc
-# REQUIRE: earlykld ix-syncdisks
+# REQUIRE: middlewared earlykld ix-syncdisks
 # BEFORE: fsck
 
 . /etc/rc.subr

--- a/src/freenas/etc/ix.rc.d/ix-kinit
+++ b/src/freenas/etc/ix.rc.d/ix-kinit
@@ -6,9 +6,7 @@
 #
 
 # PROVIDE: ix-kinit
-# REQUIRE: kdc
-# REQUIRE: ix-pre-samba
-# REQUIRE: ntpd
+# REQUIRE: middlewared kdc ix-pre-samba ntpd
 
 . /etc/rc.freenas
 

--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-netif
-# REQUIRE: sysctl
+# REQUIRE: middlewared sysctl
 # BEFORE: netif
 
 . /etc/rc.freenas

--- a/src/freenas/etc/ix.rc.d/ix-nfsbind
+++ b/src/freenas/etc/ix.rc.d/ix-nfsbind
@@ -4,6 +4,7 @@
 #
 
 # PROVIDE: ix-nfsbind
+# REQUIRE: middlewared
 # BEFORE: mountd gssd nfsuserd nfsd
 
 

--- a/src/freenas/etc/ix.rc.d/ix-nsswitch
+++ b/src/freenas/etc/ix.rc.d/ix-nsswitch
@@ -5,7 +5,7 @@
 
 # PROVIDE: ix-nsswitch
 # BEFORE: nsswitch
-# REQUIRE: rtsold
+# REQUIRE: middlewared rtsold
 
 . /etc/rc.freenas
 

--- a/src/freenas/etc/ix.rc.d/ix-preinit
+++ b/src/freenas/etc/ix.rc.d/ix-preinit
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-preinit
-# REQUIRE: FILESYSTEMS
+# REQUIRE: middlewared FILESYSTEMS
 # BEFORE: SERVERS
 
 . /etc/rc.subr

--- a/src/freenas/etc/ix.rc.d/ix-sed
+++ b/src/freenas/etc/ix.rc.d/ix-sed
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-sed
-# REQUIRE: ix-syncdisks
+# REQUIRE: middlewared ix-syncdisks
 # BEFORE: ix-zfs
 
 . /etc/rc.freenas

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-shutdown
-# REQUIRE: LOGIN
+# REQUIRE: middlewared LOGIN
 # KEYWORD: shutdown
 
 . /etc/rc.subr

--- a/src/freenas/etc/ix.rc.d/ix-syncdisks
+++ b/src/freenas/etc/ix.rc.d/ix-syncdisks
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-syncdisks
-# REQUIRE: devd earlykld
+# REQUIRE: middlewared devd earlykld
 # BEFORE: fsck
 
 . /etc/rc.subr

--- a/src/freenas/etc/ix.rc.d/ix-syncmultipaths
+++ b/src/freenas/etc/ix.rc.d/ix-syncmultipaths
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-syncmultipaths
-# REQUIRE: FILESYSTEMS ix-syncdisks
+# REQUIRE: middlewared FILESYSTEMS ix-syncdisks
 
 . /etc/rc.subr
 

--- a/src/freenas/etc/ix.rc.d/ix-zfs
+++ b/src/freenas/etc/ix.rc.d/ix-zfs
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-zfs
-# REQUIRE: hostid mountcritlocal
+# REQUIRE: middlewared hostid mountcritlocal
 # BEFORE: FILESYSTEMS var
 
 . /etc/rc.subr

--- a/src/freenas/etc/rc.d/ix-haready
+++ b/src/freenas/etc/rc.d/ix-haready
@@ -9,7 +9,7 @@
 #
 
 # PROVIDE: ix-haready
-# REQUIRES: ix-postinit securelevel
+# REQUIRES: middlewared ix-postinit securelevel
 # KEYWORD: shutdown
 
 . /etc/rc.subr

--- a/src/freenas/etc/rc.d/ix-postinit
+++ b/src/freenas/etc/rc.d/ix-postinit
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-postinit
-# REQUIRES: cron swaplate
+# REQUIRES: middlewared cron swaplate
 
 . /etc/rc.subr
 


### PR DESCRIPTION
I'm not sure how 13 has ever worked without these changes. Without `REQUIRE: middlewared` for any script that makes a call to `midclt` there exists a possibility of that rc script to start before the `middlewared` rc script which means they would fail immediately.

We're seeing this now on 13 because interface configuration (`ix-netif`) is being called before `middlewared` so it's booting up with no IP addresses....

Adding `REQUIRE: middlewared` ensures that the `middlewared` service is started before any of our scripts run.