### PR TITLE
NAS-115083 / 22.12 / Add link state of interfaces for reporting realtime event source

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -32,8 +32,9 @@ def destroy_interface(name):
         run(["ip", "link", "set", name, "down"])
 
 
-def get_interface(name):
-    return list_interfaces()[name]
+def get_interface(name, safe_retrieval=False):
+    ifaces = list_interfaces()
+    return ifaces.get(name) if safe_retrieval else ifaces[name]
 
 
 def list_interfaces():

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -213,11 +213,7 @@ class RealtimeEventSource(EventSource):
                 if iface_name.startswith(internal_interfaces):
                     continue
 
-                try:
-                    iface_obj = netif.get_interface(iface_name)
-                except KeyError:
-                    iface_obj = None
-
+                iface_obj = netif.get_interface(iface_name, True)
                 data['interfaces'][iface_name] = {
                     'speed': last_interface_speeds['speeds'].get(iface_name),
                     'link_state': iface_obj.link_state.name if iface_obj else 'LINK_STATE_UNKNOWN',

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -7,6 +7,7 @@ import time
 import humanfriendly
 
 from middlewared.event import EventSource
+from middlewared.plugins.interface.netif import netif
 
 from .iostat import DiskStats
 
@@ -208,6 +209,9 @@ class RealtimeEventSource(EventSource):
             stats_time = time.time()
             for i in glob.glob('/sys/class/net/*/statistics'):
                 iface_name = i.replace('/sys/class/net/', '').split('/')[0]
+                if iface_name.startswith(netif.INTERNAL_INTERFACES):
+                    continue
+
                 data['interfaces'][iface_name]['speed'] = last_interface_speeds['speeds'].get(iface_name)
                 for stat, name in retrieve_stat.items():
                     with open(f'{i}/{stat}', 'r') as f:


### PR DESCRIPTION
This PR adds changes to add link state for reporting realtime event source as this will be useful for the UI to update the link state for interfaces based on recent changes which might have been applied by the user. Also this removes internal interfaces from the `reporting.realtime` output.