### PR TITLE
NAS-114954 / 22.12 / refactor network_interfaces table

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-03-01_14-40_simplify_network_interfaces.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-03-01_14-40_simplify_network_interfaces.py
@@ -1,0 +1,101 @@
+"""simplify network_interfaces table
+
+Revision ID: a2ae33484fed
+Revises: 4c852b54dfa1
+Create Date: 2022-03-01 14:40:25.351989+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a2ae33484fed'
+down_revision = '4c852b54dfa1'
+branch_labels = None
+depends_on = None
+
+
+def create_new_entries(old_entry):
+    new_entry = {}
+    alias_entry = {}
+    if old_entry['int_ipv4address'] and old_entry['int_ipv6address']:
+        # this shouldn't happen but we'll play it safe
+        # we'll write the ipv4 address to the network_interface table
+        new_entry['id'] = old_entry['id']
+        new_entry['int_address'] = old_entry['int_ipv4address']
+        new_entry['int_address_b'] = old_entry['int_ipv4address_b']
+        new_entry['int_version'] = 4
+        new_entry['int_netmask'] = int(old_entry['int_v4netmaskbit']) if old_entry['int_v4netmaskbit'] else 32
+
+        # we'll write the ipv6 address to the network_alias table
+        alias_entry['alias_interface_id'] = old_entry['id']
+        alias_entry['alias_address'] = old_entry['int_ipv6address'],
+        alias_entry['alias_address_b'] = old_entry['int_ipv6address_b']
+        alias_entry['alias_vip'] = old_entry['int_vipv6address']
+        alias_entry['alias_version'] = 6
+        alias_entry['alias_netmask'] = int(old_entry['int_v6netmaskbit']) if old_entry['int_v6netmaskbit'] else 128
+    elif old_entry['int_ipv4address']:
+        new_entry['id'] = old_entry['id']
+        new_entry['int_address'] = old_entry['int_ipv4address']
+        new_entry['int_address_b'] = old_entry['int_ipv4address_b']
+        new_entry['int_version'] = 4
+        new_entry['int_netmask'] = int(old_entry['int_v4netmaskbit']) if old_entry['int_v4netmaskbit'] else 32
+    elif old_entry['int_ipv6address']:
+        new_entry['id'] = old_entry['id']
+        new_entry['int_address'] = old_entry['int_ipv6address']
+        new_entry['int_address_b'] = old_entry['int_ipv6address_b']
+        new_entry['int_vip'] = old_entry['int_vipv6address']
+        new_entry['int_version'] = 6
+        new_entry['int_netmask'] = int(old_entry['int_v6netmaskbit']) if old_entry['int_v6netmaskbit'] else 128
+    return new_entry, alias_entry
+
+
+def upgrade():
+    con = op.get_bind()
+    new_entries = []
+    for old_entry in map(dict, con.execute('SELECT * FROM network_interfaces').fetchall()):
+        new_entries.append(create_new_entries(old_entry))
+
+    # add new columns
+    with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('int_address', sa.String(length=45), server_default='', nullable=False))
+        batch_op.add_column(sa.Column('int_address_b', sa.String(length=45), server_default='', nullable=True))
+        batch_op.add_column(sa.Column('int_netmask', sa.Integer(), server_default='', nullable=False))
+        batch_op.add_column(sa.Column('int_version', sa.Integer(), server_default='', nullable=False))
+
+    # update new columns
+    for new_entry, alias_entry in new_entries:
+        if new_entry:
+            _id = new_entry.pop('id')
+            for column, value in new_entry.items():
+                con.execute(f'UPDATE network_interfaces SET {column} = "{value}" WHERE id = "{_id}"')
+        if alias_entry:
+            columns = tuple(alias_entry.keys())
+            values = tuple(alias_entry.values())
+            con.execute(f'INSERT INTO network_alias {columns} VALUES {values}')
+
+    # remove old columns
+    with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
+        batch_op.drop_column('int_ipv6address_b')
+        batch_op.drop_column('int_ipv6address')
+        batch_op.drop_column('int_vipv6address')
+        batch_op.drop_column('int_ipv4address')
+        batch_op.drop_column('int_v4netmaskbit')
+        batch_op.drop_column('int_v6netmaskbit')
+        batch_op.drop_column('int_ipv4address_b')
+
+
+def downgrade():
+    with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('int_ipv4address_b', sa.VARCHAR(length=42), nullable=False))
+        batch_op.add_column(sa.Column('int_v6netmaskbit', sa.VARCHAR(length=3), nullable=False))
+        batch_op.add_column(sa.Column('int_v4netmaskbit', sa.VARCHAR(length=3), nullable=False))
+        batch_op.add_column(sa.Column('int_ipv4address', sa.VARCHAR(length=42), nullable=False))
+        batch_op.add_column(sa.Column('int_vipv6address', sa.VARCHAR(length=45), nullable=True))
+        batch_op.add_column(sa.Column('int_ipv6address', sa.VARCHAR(length=45), nullable=False))
+        batch_op.add_column(sa.Column('int_ipv6address_b', sa.VARCHAR(length=45), nullable=False))
+        batch_op.drop_column('int_version')
+        batch_op.drop_column('int_netmask')
+        batch_op.drop_column('int_address_b')
+        batch_op.drop_column('int_address')

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -21,76 +21,42 @@ class InterfaceService(Service):
         self.logger.info('Configuring interface %r', name)
         iface = netif.get_interface(name)
         addrs_configured = set([a for a in iface.addresses if a.af != netif.AddressFamily.LINK])
-
-        has_ipv6 = data['int_ipv6auto'] or False
-
+        has_ipv6 = data['int_version'] == 6 or data['int_ipv6auto']
         if self.middleware.call_sync('failover.node') == 'B':
-            ipv4_field = 'int_ipv4address_b'
-            ipv6_field = 'int_ipv6address_b'
-            alias_field = 'alias_address_b'
+            addr_key = 'int_address_b'
+            alias_key = 'alias_address_b'
         else:
-            ipv4_field = 'int_ipv4address'
-            ipv6_field = 'int_ipv6address'
-            alias_field = 'alias_address'
+            addr_key = 'int_address'
+            alias_key = 'alias_address'
 
         addrs_database = set()
-        dhclient_running, dhclient_pid = self.middleware.call_sync('interface.dhclient_status', name)
-        if dhclient_running and data['int_dhcp']:
-            if leases := self.middleware.call_sync('interface.dhclient_leases', name):
-                _addr = re.search(r'fixed-address\s+(.+);', leases)
-                _net = re.search(r'option subnet-mask\s+(.+);', leases)
-                if (_addr and (_addr := _addr.group(1))) and (_net and (_net := _net.group(1))):
-                    addrs_database.add(self.alias_to_addr({'address': _addr, 'netmask': _net}))
-                else:
-                    self.logger.info('Unable to get address from dhclient')
-            if data[ipv6_field] and not has_ipv6:
-                addrs_database.add(self.alias_to_addr(
-                    {'address': data[ipv6_field], 'netmask': data['int_v6netmaskbit']}
-                ))
-                has_ipv6 = True
-        else:
-            if data[ipv4_field] and not data['int_dhcp']:
-                addrs_database.add(self.alias_to_addr({
-                    'address': data[ipv4_field],
-                    'netmask': data['int_v4netmaskbit'],
-                }))
-            if data[ipv6_field] and not has_ipv6:
-                addrs_database.add(self.alias_to_addr({
-                    'address': data[ipv6_field],
-                    'netmask': data['int_v6netmaskbit'],
-                }))
-                has_ipv6 = True
+        dhclient_run, dhclient_pid = self.middleware.call_sync('interface.dhclient_status', name)
+        if dhclient_run and data['int_dhcp'] and (i := self.middleware.call_sync('interface.dhclient_leases', name)):
+            # dhclient is running and is marked for dhcp AND we have a lease file for the interface
+            _addr = re.search(r'fixed-address\s+(.+);', i)
+            _net = re.search(r'option subnet-mask\s+(.+);', i)
+            if (_addr and (_addr := _addr.group(1))) and (_net and (_net := _net.group(1))):
+                addrs_database.add(self.alias_to_addr({'address': _addr, 'netmask': _net}))
+            else:
+                self.logger.info('Unable to get address from dhclient lease file for %r', name)
+        elif has_ipv6 and data[addr_key]:
+            # TODO: this will _ONLY_ ever work when an IPv6 address has been given to us.
+            # We're ignoring int_ipv6auto column...
+            addrs_database.add(self.alias_to_addr({'address': data[addr_key], 'netmask': data['int_netmask']}))
 
-        # configure VRRP
-        vip = data.get('int_vip', '')
-        if vip:
-            addrs_database.add(self.alias_to_addr({
-                'address': vip,
-                'netmask': '32',
-            }))
-
-        vipv6 = data.get('int_vipv6address', '')
-        if vipv6:
-            addrs_database.add(self.alias_to_addr({
-                'address': vipv6,
-                'netmask': '128',
-            }))
+        if vip := data.get('int_vip', ''):
+            netmask = '32' if data['int_version'] == 4 else '128'
+            addrs_database.add(self.alias_to_addr({'address': vip, 'netmask': netmask}))
 
         alias_vips = []
         for alias in aliases:
-            if alias[alias_field]:
-                addrs_database.add(self.alias_to_addr({
-                    'address': alias[alias_field],
-                    'netmask': alias['alias_netmask'],
-                }))
-
+            addrs_database.add(self.alias_to_addr({'address': alias[alias_key], 'netmask': alias['alias_netmask']}))
             if alias['alias_vip']:
                 alias_vip = alias['alias_vip']
                 alias_vips.append(alias_vip)
-                addrs_database.add(self.alias_to_addr({
-                    'address': alias_vip,
-                    'netmask': '32' if alias['alias_version'] == 4 else '128',
-                }))
+                addrs_database.add(self.alias_to_addr(
+                    {'address': alias_vip, 'netmask': '32' if alias['alias_version'] == 4 else '128'}
+                ))
 
         if has_ipv6 and not [i for i in map(str, iface.addresses) if i.startswith('fe80::')]:
             # https://tools.ietf.org/html/rfc4291#section-2.5.1
@@ -98,32 +64,28 @@ class InterfaceService(Service):
             mac = iface.link_address.address.address.replace(':', '')
             mac = mac[0:6] + 'fffe' + mac[6:]
             mac = hex(int(mac[0:2], 16) ^ 2)[2:].zfill(2) + mac[2:]
-            link_local = {
-                'address': 'fe80::' + ':'.join(textwrap.wrap(mac, 4)),
-                'netmask': '64',
-            }
+            link_local = {'address': 'fe80::' + ':'.join(textwrap.wrap(mac, 4)), 'netmask': '64'}
             addrs_database.add(self.alias_to_addr(link_local))
 
-        if dhclient_running and not data['int_dhcp']:
+        if dhclient_run and not data['int_dhcp']:
             self.logger.debug('Killing dhclient for %r', name)
             os.kill(dhclient_pid, signal.SIGTERM)
 
-        # Remove addresses configured and not in database
         for addr in addrs_configured:
             address = str(addr.address)
-            # keepalived service is responsible for deleting the VIP(s)
-            if address in (vip, vipv6) or address in alias_vips:
+            if address == vip or address in alias_vips or has_ipv6 and address.startswith('fe80::'):
+                # keepalived service is responsible for deleting the VIP(s)
                 continue
-            if vipv6 and address.startswith('fe80::'):
-                continue
-            if addr not in addrs_database:
+            elif addr not in addrs_database:
+                # Remove addresses configured and not in database
                 self.logger.debug('%s: removing %s', name, addr)
                 iface.remove_address(addr)
             elif not data['int_dhcp']:
                 self.logger.debug('%s: removing possible valid_lft and preferred_lft on %s', name, addr)
                 iface.replace_address(addr)
+            # TODO: what are we doing with ipv6auto??
 
-        if vip or vipv6 or alias_vips:
+        if vip or alias_vips:
             if not self.middleware.call_sync('service.started', 'keepalived'):
                 self.middleware.call_sync('service.start', 'keepalived')
             else:
@@ -134,7 +96,7 @@ class InterfaceService(Service):
         for addr in (addrs_database - addrs_configured):
             address = str(addr.address)
             # keepalived service is responsible for adding the VIP(s)
-            if address in (vip, vipv6) or address in alias_vips:
+            if address == vip or address in alias_vips:
                 continue
             self.logger.debug('%s: adding %s', name, addr)
             iface.add_address(addr)
@@ -157,8 +119,10 @@ class InterfaceService(Service):
         if netif.InterfaceFlags.UP not in iface.flags:
             iface.up()
 
-        # If dhclient is not running and dhcp is configured, lets start it
-        return not dhclient_running and data['int_dhcp']
+        # If dhclient is not running and dhcp is configured, the caller should
+        # start it based on what we return here
+        # TODO: what are we doing with ipv6auto??
+        return not dhclient_run and data['int_dhcp']
 
     @private
     def autoconfigure(self, iface, wait_dhcp):

--- a/src/middlewared/middlewared/plugins/interface/listen.py
+++ b/src/middlewared/middlewared/plugins/interface/listen.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import namedtuple
+from itertools import zip_longest
 
 from middlewared.schema import Dict, List, returns, Str
 from middlewared.service import accepts, Service, private
@@ -67,14 +68,13 @@ class InterfaceService(Service):
 
     def _collect_addresses(self, datastores):
         addresses = set()
-        for interface in datastores["interfaces"]:
-            for k in ["int_ipv4address", "int_ipv6address"]:
-                addresses.add(interface[k])
-                addresses.add(interface[f"{k}_b"])
-        for alias in datastores["alias"]:
-            addresses.add(alias["alias_address"])
-            addresses.add(alias["alias_address_b"])
-            addresses.add(alias["alias_vip"])
+        for iface, alias in zip_longest(datastores["interfaces"], datastores["alias"], fillvalue={}):
+            addresses.add(iface.get("int_address", ""))
+            addresses.add(iface.get("int_address_b", ""))
+            addresses.add(iface.get("int_vip", ""))
+            addresses.add(alias.get("alias_address", ""))
+            addresses.add(alias.get("alias_address_b", ""))
+            addresses.add(alias.get("alias_vip", ""))
         addresses.discard("")
         return addresses
 

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -88,15 +88,13 @@ class ISCSIPortalService(CRUDService):
         Returns possible choices for `listen.ip` attribute of portal create and update.
         """
         choices = {'0.0.0.0': '0.0.0.0', '::': '::'}
-        alua = (await self.middleware.call('iscsi.global.config'))['alua']
-        if alua:
+        if (await self.middleware.call('iscsi.global.config'))['alua']:
             # If ALUA is enabled we actually want to show the user the IPs of each node
             # instead of the VIP so its clear its not going to bind to the VIP even though
             # thats the value used under the hoods.
-            for i in await self.middleware.call('datastore.query', 'network.Interfaces', [
-                ('int_vip', 'nin', [None, '']),
-            ]):
-                choices[i['int_vip']] = f'{i["int_ipv4address"]}/{i["int_ipv4address_b"]}'
+            filters = [('int_vip', 'nin', [None, ''])]
+            for i in await self.middleware.call('datastore.query', 'network.Interfaces', filters):
+                choices[i['int_vip']] = f'{i["int_address"]}/{i["int_address_b"]}'
 
             filters = [('alias_vip', 'nin', [None, ''])]
             for i in await self.middleware.call('datastore.query', 'network.Alias', filters):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -44,7 +44,7 @@ class NetworkInterfaceModel(sa.Model):
     int_name = sa.Column(sa.String(120))
     int_dhcp = sa.Column(sa.Boolean(), default=False)
     int_address = sa.Column(sa.String(45), default='')
-    int_ipv4address_b = sa.Column(sa.String(42), default='')
+    int_address_b = sa.Column(sa.String(45), default='')
     int_v4netmaskbit = sa.Column(sa.String(3), default='')
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
     int_ipv6address = sa.Column(sa.String(45), default='')
@@ -257,10 +257,10 @@ class InterfaceService(CRUDService):
                 'failover_vhid': config['int_vhid'],
                 'failover_group': config['int_group'],
             })
-            if config['int_ipv4address_b']:
+            if config['int_address_b']:
                 iface['failover_aliases'].append({
                     'type': 'INET',
-                    'address': config['int_ipv4address_b'],
+                    'address': config['int_address_b'],
                     'netmask': int(config['int_v4netmaskbit']),
                 })
             if config['int_ipv6address_b']:
@@ -1003,7 +1003,7 @@ class InterfaceService(CRUDService):
         aliases = []
         iface = {
             'address': '',
-            'ipv4address_b': '',
+            'address_b': '',
             'v4netmaskbit': '',
             'ipv6address': '',
             'ipv6address_b': '',
@@ -1022,7 +1022,7 @@ class InterfaceService(CRUDService):
                 # first IP address is always written to `network_interface` table
                 if version == 4:
                     a_key = 'address'
-                    b_key = 'ipv4address_b'
+                    b_key = 'address_b'
                     v_key = 'vip'
                     net_key = 'v4netmaskbit'
                 else:
@@ -1077,7 +1077,7 @@ class InterfaceService(CRUDService):
                 portinterface.update({
                     'dhcp': False,
                     'address': '',
-                    'ipv4address_b': '',
+                    'address_b': '',
                     'v4netmaskbit': '',
                     'ipv6auto': False,
                     'ipv6address': '',

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -43,7 +43,7 @@ class NetworkInterfaceModel(sa.Model):
     int_interface = sa.Column(sa.String(300))
     int_name = sa.Column(sa.String(120))
     int_dhcp = sa.Column(sa.Boolean(), default=False)
-    int_ipv4address = sa.Column(sa.String(42), default='')
+    int_address = sa.Column(sa.String(45), default='')
     int_ipv4address_b = sa.Column(sa.String(42), default='')
     int_v4netmaskbit = sa.Column(sa.String(3), default='')
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
@@ -338,10 +338,10 @@ class InterfaceService(CRUDService):
                     'vlan_pcp': None,
                 })
 
-        if not config['int_dhcp'] and if config['int_ipv4address']:
+        if not config['int_dhcp'] and if config['int_address']:
             iface['aliases'].append({
                 'type': 'INET',
-                'address': config['int_ipv4address'],
+                'address': config['int_address'],
                 'netmask': int(config['int_v4netmaskbit']),
             })
 
@@ -1002,7 +1002,7 @@ class InterfaceService(CRUDService):
 
         aliases = []
         iface = {
-            'ipv4address': '',
+            'address': '',
             'ipv4address_b': '',
             'v4netmaskbit': '',
             'ipv6address': '',
@@ -1021,7 +1021,7 @@ class InterfaceService(CRUDService):
             if idx == 0:
                 # first IP address is always written to `network_interface` table
                 if version == 4:
-                    a_key = 'ipv4address'
+                    a_key = 'address'
                     b_key = 'ipv4address_b'
                     v_key = 'vip'
                     net_key = 'v4netmaskbit'
@@ -1076,7 +1076,7 @@ class InterfaceService(CRUDService):
                 portinterface = portinterface[0]
                 portinterface.update({
                     'dhcp': False,
-                    'ipv4address': '',
+                    'address': '',
                     'ipv4address_b': '',
                     'v4netmaskbit': '',
                     'ipv6auto': False,

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -45,6 +45,7 @@ class NetworkInterfaceModel(sa.Model):
     int_dhcp = sa.Column(sa.Boolean(), default=False)
     int_address = sa.Column(sa.String(45), default='')
     int_address_b = sa.Column(sa.String(45), default='')
+    int_version = sa.Column(sa.Integer())
     int_netmask = sa.Column(sa.Integer())
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
     int_vip = sa.Column(sa.String(45), nullable=True)

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -47,7 +47,7 @@ class NetworkInterfaceModel(sa.Model):
     int_address_b = sa.Column(sa.String(45), default='')
     int_netmask = sa.Column(sa.Integer())
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
-    int_vip = sa.Column(sa.String(42), nullable=True)
+    int_vip = sa.Column(sa.String(45), nullable=True)
     int_vhid = sa.Column(sa.Integer(), nullable=True)
     int_critical = sa.Column(sa.Boolean(), default=False)
     int_group = sa.Column(sa.Integer(), nullable=True)

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -978,37 +978,20 @@ class InterfaceService(CRUDService):
         dfva = data.get('failover_virtual_aliases', [])
 
         aliases = []
-        iface = {
-            'address': '',
-            'address_b': '',
-            'netmask': 0,
-            'vip': '',
-        }
+        iface = {}
         for idx, (a, fa, fva) in enumerate(zip_longest(da, dfa, dfva, fillvalue={})):
             netmask = a['netmask']
             ipa = a['address']
             ipb = fa.get('address', '')
             ipv = fva.get('address', '')
-
             version = ipaddress.ip_interface(ipa).version
             if idx == 0:
                 # first IP address is always written to `network_interface` table
-                if version == 4:
-                    a_key = 'address'
-                    b_key = 'address_b'
-                    v_key = 'vip'
-                    net_key = 'netmask'
-                else:
-                    a_key = 'address'
-                    b_key = 'address_b'
-                    v_key = 'vip'
-                    net_key = 'netmask'
-
-                # fill out info
-                iface[a_key] = ipa
-                iface[b_key] = ipb
-                iface[v_key] = ipv
-                iface[net_key] = netmask
+                iface['address'] = ipa
+                iface['address_b'] = ipb
+                iface['netmask'] = netmask
+                iface['version'] = version
+                iface['vip'] = ipv
             else:
                 # this means it's the 2nd (or more) ip address
                 # on a singular interface so we need to write

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -47,7 +47,6 @@ class NetworkInterfaceModel(sa.Model):
     int_address_b = sa.Column(sa.String(45), default='')
     int_netmask = sa.Column(sa.Integer())
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
-    int_ipv6address_b = sa.Column(sa.String(45), default='')
     int_v6netmaskbit = sa.Column(sa.String(3), default='')
     int_vip = sa.Column(sa.String(42), nullable=True)
     int_vipv6address = sa.Column(sa.String(45), nullable=True)
@@ -251,6 +250,7 @@ class InterfaceService(CRUDService):
         })
 
         if ha_hardware:
+            _type = 'INET' if config['int_version'] == 4 else 'INET6'
             iface.update({
                 'failover_critical': config['int_critical'],
                 'failover_vhid': config['int_vhid'],
@@ -258,25 +258,19 @@ class InterfaceService(CRUDService):
             })
             if config['int_address_b']:
                 iface['failover_aliases'].append({
-                    'type': 'INET',
+                    'type': _type,
                     'address': config['int_address_b'],
                     'netmask': config['int_netmask'],
                 })
-            if config['int_ipv6address_b']:
-                iface['failover_aliases'].append({
-                    'type': 'INET6',
-                    'address': config['int_ipv6address_b'],
-                    'netmask': int(config['int_v6netmaskbit']),
-                })
             if config['int_vip']:
                 iface['failover_virtual_aliases'].append({
-                    'type': 'INET',
+                    'type': _type,
                     'address': config['int_vip'],
                     'netmask': 32,
                 })
             if config['int_vipv6address']:
                 iface['failover_virtual_aliases'].append({
-                    'type': 'INET6',
+                    'type': _type,
                     'address': config['int_vipv6address'],
                     'netmask': 128,
                 })
@@ -996,7 +990,6 @@ class InterfaceService(CRUDService):
             'address': '',
             'address_b': '',
             'netmask': 0,
-            'ipv6address_b': '',
             'v6netmaskbit': '',
             'vip': '',
             'vipv6address': ''
@@ -1017,7 +1010,7 @@ class InterfaceService(CRUDService):
                     net_key = 'netmask'
                 else:
                     a_key = 'address'
-                    b_key = 'ipv6address_b'
+                    b_key = 'address_b'
                     v_key = 'vipv6address'
                     net_key = 'v6netmaskbit'
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -45,7 +45,7 @@ class NetworkInterfaceModel(sa.Model):
     int_dhcp = sa.Column(sa.Boolean(), default=False)
     int_address = sa.Column(sa.String(45), default='')
     int_address_b = sa.Column(sa.String(45), default='')
-    int_v4netmaskbit = sa.Column(sa.String(3), default='')
+    int_netmask = sa.Column(sa.Integer())
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
     int_ipv6address = sa.Column(sa.String(45), default='')
     int_ipv6address_b = sa.Column(sa.String(45), default='')
@@ -261,7 +261,7 @@ class InterfaceService(CRUDService):
                 iface['failover_aliases'].append({
                     'type': 'INET',
                     'address': config['int_address_b'],
-                    'netmask': int(config['int_v4netmaskbit']),
+                    'netmask': config['int_netmask'],
                 })
             if config['int_ipv6address_b']:
                 iface['failover_aliases'].append({
@@ -338,11 +338,11 @@ class InterfaceService(CRUDService):
                     'vlan_pcp': None,
                 })
 
-        if not config['int_dhcp'] and if config['int_address']:
+        if not config['int_dhcp'] and config['int_address']:
             iface['aliases'].append({
                 'type': 'INET',
                 'address': config['int_address'],
-                'netmask': int(config['int_v4netmaskbit']),
+                'netmask': config['int_netmask'],
             })
 
         if not config['int_ipv6auto']:
@@ -1004,7 +1004,7 @@ class InterfaceService(CRUDService):
         iface = {
             'address': '',
             'address_b': '',
-            'v4netmaskbit': '',
+            'netmask': 0,
             'ipv6address': '',
             'ipv6address_b': '',
             'v6netmaskbit': '',
@@ -1024,7 +1024,7 @@ class InterfaceService(CRUDService):
                     a_key = 'address'
                     b_key = 'address_b'
                     v_key = 'vip'
-                    net_key = 'v4netmaskbit'
+                    net_key = 'netmask'
                 else:
                     a_key = 'ipv6address'
                     b_key = 'ipv6address_b'
@@ -1078,7 +1078,7 @@ class InterfaceService(CRUDService):
                     'dhcp': False,
                     'address': '',
                     'address_b': '',
-                    'v4netmaskbit': '',
+                    'netmask': 0,
                     'ipv6auto': False,
                     'ipv6address': '',
                     'v6netmaskbit': '',

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -47,7 +47,6 @@ class NetworkInterfaceModel(sa.Model):
     int_address_b = sa.Column(sa.String(45), default='')
     int_netmask = sa.Column(sa.Integer())
     int_ipv6auto = sa.Column(sa.Boolean(), default=False)
-    int_v6netmaskbit = sa.Column(sa.String(3), default='')
     int_vip = sa.Column(sa.String(42), nullable=True)
     int_vipv6address = sa.Column(sa.String(45), nullable=True)
     int_vhid = sa.Column(sa.Integer(), nullable=True)
@@ -990,7 +989,6 @@ class InterfaceService(CRUDService):
             'address': '',
             'address_b': '',
             'netmask': 0,
-            'v6netmaskbit': '',
             'vip': '',
             'vipv6address': ''
         }
@@ -1012,7 +1010,7 @@ class InterfaceService(CRUDService):
                     a_key = 'address'
                     b_key = 'address_b'
                     v_key = 'vipv6address'
-                    net_key = 'v6netmaskbit'
+                    net_key = 'netmask'
 
                 # fill out info
                 iface[a_key] = ipa
@@ -1063,7 +1061,6 @@ class InterfaceService(CRUDService):
                     'address_b': '',
                     'netmask': 0,
                     'ipv6auto': False,
-                    'v6netmaskbit': '',
                     'vip': '',
                     'vhid': None,
                     'critical': False,

--- a/src/middlewared/middlewared/pytest/unit/plugins/network/test_convert_aliases_to_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/network/test_convert_aliases_to_datastore.py
@@ -18,14 +18,11 @@ non_ha_with_1_v4ip = (
     },
     (
         {
-            'ipv4address': '1.1.1.1',
-            'ipv4address_b': '',
-            'v4netmaskbit': 24,
-            'ipv6address': '',
-            'ipv6address_b': '',
-            'v6netmaskbit': '',
+            'address': '1.1.1.1',
+            'address_b': '',
+            'netmaskt': 24,
             'vip': '',
-            'vipv6address': '',
+            'version': 4,
         },
         []
     )
@@ -43,14 +40,11 @@ non_ha_with_1_v6ip = (
     },
     (
         {
-            'ipv4address': '',
-            'ipv4address_b': '',
-            'v4netmaskbit': '',
-            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
-            'ipv6address_b': '',
-            'v6netmaskbit': 64,
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            'address_b': '',
+            'netmaskt': 64,
+            'version': 6,
             'vip': '',
-            'vipv6address': '',
         },
         []
     )
@@ -73,14 +67,11 @@ non_ha_with_2_v4ips = (
     },
     (
         {
-            'ipv4address': '1.1.1.1',
-            'ipv4address_b': '',
-            'v4netmaskbit': 24,
-            'ipv6address': '',
-            'ipv6address_b': '',
-            'v6netmaskbit': '',
+            'address': '1.1.1.1',
+            'address_b': '',
+            'netmask': 24,
+            'version': 4,
             'vip': '',
-            'vipv6address': '',
         },
         [{
             'address': '2.2.2.2',
@@ -109,14 +100,11 @@ non_ha_with_2_v6ips = (
     },
     (
         {
-            'ipv4address': '',
-            'ipv4address_b': '',
-            'v4netmaskbit': '',
-            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
-            'ipv6address_b': '',
-            'v6netmaskbit': 64,
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            'address_b': '',
+            'netmask': 64,
+            'version': 6,
             'vip': '',
-            'vipv6address': '',
         },
         [{
             'address': 'aaaa:bbbb:cccc:eeee::1',
@@ -145,14 +133,11 @@ non_ha_with_2_mixed_ips = (
     },
     (
         {
-            'ipv4address': '1.1.1.1',
-            'ipv4address_b': '',
-            'v4netmaskbit': 24,
-            'ipv6address': '',
-            'ipv6address_b': '',
-            'v6netmaskbit': '',
+            'address': '1.1.1.1',
+            'address_b': '',
+            'netmask': 24,
+            'version': 4,
             'vip': '',
-            'vipv6address': '',
         },
         [{
             'address': 'aaaa:bbbb:cccc:dddd::1',
@@ -182,14 +167,11 @@ ha_with_1_v4ip = (
     },
     (
         {
-            'ipv4address': '1.1.1.1',
-            'ipv4address_b': '1.1.1.2',
-            'v4netmaskbit': 24,
-            'ipv6address': '',
-            'ipv6address_b': '',
-            'v6netmaskbit': '',
+            'address': '1.1.1.1',
+            'address_b': '1.1.1.2',
+            'netmask': 24,
+            'version': 4,
             'vip': '1.1.1.3',
-            'vipv6address': '',
         },
         []
     )
@@ -213,14 +195,11 @@ ha_with_1_v6ip = (
     },
     (
         {
-            'ipv4address': '',
-            'ipv4address_b': '',
-            'v4netmaskbit': '',
-            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
-            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
-            'v6netmaskbit': 64,
-            'vip': '',
-            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+            '6address': 'aaaa:bbbb:cccc:dddd::1',
+            'address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'netmask': 64,
+            'version': 6,
+            'vip': 'aaaa:bbbb:cccc:dddd::3',
         },
         []
     )
@@ -263,14 +242,11 @@ ha_with_2_v4ips = (
     },
     (
         {
-            'ipv4address': '1.1.1.1',
-            'ipv4address_b': '1.1.1.2',
-            'v4netmaskbit': 24,
-            'ipv6address': '',
-            'ipv6address_b': '',
-            'v6netmaskbit': '',
+            'address': '1.1.1.1',
+            'address_b': '1.1.1.2',
+            'netmask': 24,
+            'version': 4,
             'vip': '1.1.1.3',
-            'vipv6address': '',
         },
         [{
             'address': '2.2.2.1',
@@ -320,14 +296,11 @@ ha_with_2_v6ips = (
     },
     (
         {
-            'ipv4address': '',
-            'ipv4address_b': '',
-            'v4netmaskbit': '',
-            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
-            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
-            'v6netmaskbit': 64,
-            'vip': '',
-            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            '6address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'netmask': 64,
+            'version': 6,
+            'vip': 'aaaa:bbbb:cccc:dddd::3',
         },
         [{
             'address': 'aaaa:bbbb:3333:eeee::1',
@@ -376,14 +349,11 @@ ha_with_2_mixed_ips = (
     },
     (
         {
-            'ipv4address': '',
-            'ipv4address_b': '',
-            'v4netmaskbit': '',
-            'ipv6address': 'aaaa:bbbb:cccc:dddd::1',
-            'ipv6address_b': 'aaaa:bbbb:cccc:dddd::2',
-            'v6netmaskbit': 64,
-            'vip': '',
-            'vipv6address': 'aaaa:bbbb:cccc:dddd::3',
+            'address': 'aaaa:bbbb:cccc:dddd::1',
+            'address_b': 'aaaa:bbbb:cccc:dddd::2',
+            'netmask': 64,
+            'version': 6,
+            'vip': 'aaaa:bbbb:cccc:dddd::3',
         },
         [{
             'address': '1.1.1.1',


### PR DESCRIPTION
This does, essentially, the same thing that was done in https://github.com/truenas/middleware/pull/8030. This PR is for  the `network_interface` table instead. It had a bunch of redundant, unnecessary columns that made the backend code considerably more complex than what it needed to be. I've broken the commits up into small chunks so they're easy to follow and I've updated the unit tests as well.