### PR TITLE
NAS-115066 / 22.02 / Add truecommand connection information to debug (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
@@ -207,4 +207,8 @@ system_func()
 	section_header "Failed updates /data/update.failed"
 	sc /data/update.failed
 	section_footer
+
+	section_header "Truecommand connection"
+	midclt call truecommand.connected | jq 'del(.truecommand_ip,.truecommand_url)'
+	section_footer
 }	


### PR DESCRIPTION
Sample output in the debug
```
+--------------------------------------------------------------------------------+
+Truecommand connection - midclt call truecommand.connected | jq 'del(.truecommand_ip,.truecommand_url)' @1646156868 +
+--------------------------------------------------------------------------------+
{
  "connected": true,
  "status": "CONNECTED",
  "status_reason": "Truecommand service is connected."
}
```

Original PR: https://github.com/truenas/middleware/pull/8388
Jira URL: https://jira.ixsystems.com/browse/NAS-115066