### PR TITLE
NAS-115094 / 22.02 / Allow Cluster Locations for CloudSync

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -826,7 +826,7 @@ class CloudSyncService(TaskPathService):
             if limit1["time"] >= limit2["time"]:
                 verrors.add(f"{name}.bwlimit.{i + 1}.time", f"Invalid time order: {limit1['time']}, {limit2['time']}")
 
-        await self.validate_path_field(data, name, verrors)
+        await self.validate_path_field(data, name, verrors, True)
 
         if data["snapshot"]:
             if data["direction"] != "PUSH":


### PR DESCRIPTION
Setting up my first cluster here and found that the validation for CloudSync was preventing me from saving backup jobs pointed at the /cluster/ mount points. Added the override flag to the validation to let those pass. Testing here, appears to be working properly.