### PR TITLE
bump syslog-ng.conf version

### DIFF
--- a/src/freenas/usr/local/etc/syslog-ng.conf.freenas
+++ b/src/freenas/usr/local/etc/syslog-ng.conf.freenas
@@ -1,4 +1,4 @@
-@version:3.29
+@version:3.35
 
 #
 # options


### PR DESCRIPTION
`syslog-ng` was updated in 13 so we need to update the `@version:` string or it will barf messages like this anytime the service is reloaded/restarted.

```
[2022-03-02T08:46:11.266571] WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.35 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file; config-version='3.29'
```