### PR TITLE
NAS-115098 / 22.02 / Add ability to specify render_context for etc files (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/nfs-common.mako
+++ b/src/middlewared/middlewared/etc_files/default/nfs-common.mako
@@ -1,5 +1,5 @@
 <%
-    config = middleware.call_sync("nfs.config")
+    config = render_ctx["nfs.config"]
     statd_opts = ["-N 2"]
     if config["rpcstatd_port"]:
         statd_opts.append(f'--port {config["rpcstatd_port"]}')

--- a/src/middlewared/middlewared/etc_files/default/nfs-kernel-server.mako
+++ b/src/middlewared/middlewared/etc_files/default/nfs-kernel-server.mako
@@ -1,5 +1,5 @@
 <%
-    config = middleware.call_sync("nfs.config")
+    config = render_ctx["nfs.config"]
     mountd_opts = [f'--num-threads {config["servers"]}', '-N 2']
     nfsd_opts = ['-s', '-N 2']
 

--- a/src/middlewared/middlewared/etc_files/default/rpcbind.mako
+++ b/src/middlewared/middlewared/etc_files/default/rpcbind.mako
@@ -1,5 +1,5 @@
 <%
-    config = middleware.call_sync("nfs.config")
+    config = render_ctx["nfs.config"]
     options = ["-w"]
     for ip in config["bindip"]:
         options.append(f'-h {ip}')

--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -65,11 +65,8 @@
         return ','.join(params)
 
     entries = []
-    config = middleware.call_sync("nfs.config")
-    shares = middleware.call_sync("sharing.nfs.query", [
-        ["enabled", "=", True],
-        ["locked", "=", False],
-    ])
+    config = render_ctx["nfs.config"]
+    shares = render_ctx["sharing.nfs.query"]
     if not shares:
         raise FileShouldNotExist()
 

--- a/src/middlewared/middlewared/etc_files/idmapd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/idmapd.conf.mako
@@ -1,5 +1,5 @@
 <%
-    config = middleware.call_sync("nfs.config")
+    config = render_ctx["nfs.config"]
     if not config["v4"]:
         raise FileShouldNotExist()
 %>

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -30,7 +30,7 @@ class MakoRenderer(object):
     def __init__(self, service):
         self.service = service
 
-    async def render(self, path):
+    async def render(self, path, ctx):
         try:
             # Mako is not asyncio friendly so run it within a thread
             def do():
@@ -44,6 +44,7 @@ class MakoRenderer(object):
                     FileShouldNotExist=FileShouldNotExist,
                     IS_FREEBSD=osc.IS_FREEBSD,
                     IS_LINUX=osc.IS_LINUX,
+                    render_ctx=ctx
                 )
 
             return await self.service.middleware.run_in_thread(do)
@@ -61,16 +62,18 @@ class PyRenderer(object):
     def __init__(self, service):
         self.service = service
 
-    async def render(self, path):
+    async def render(self, path, ctx):
         name = os.path.basename(path)
         find = imp.find_module(name, [os.path.dirname(path)])
         mod = imp.load_module(name, *find)
+        args = [self.service, self.service.middleware]
+        if ctx is not None:
+            args.append(ctx)
+
         if asyncio.iscoroutinefunction(mod.render):
-            return await mod.render(self.service, self.service.middleware)
+            return await mod.render(*args)
         else:
-            return await self.service.middleware.run_in_thread(
-                mod.render, self.service, self.service.middleware,
-            )
+            return await self.service.middleware.run_in_thread(mod.render, *args)
 
 
 class EtcService(Service):
@@ -111,13 +114,19 @@ class EtcService(Service):
         'dhclient': [
             {'type': 'mako', 'path': 'dhcp/dhclient.conf', 'local_path': 'dhclient.conf'},
         ],
-        'nfsd': [
-            {'type': 'mako', 'path': 'default/nfs-common'},
-            {'type': 'mako', 'path': 'default/nfs-kernel-server'},
-            {'type': 'mako', 'path': 'default/rpcbind'},
-            {'type': 'mako', 'path': 'idmapd.conf'},
-            {'type': 'mako', 'path': 'exports'},
-        ],
+        'nfsd': {
+            'ctx': [
+                {'method': 'sharing.nfs.query', 'args': [[("enabled", "=", True), ("locked", "=", False)]]},
+                {'method': 'nfs.config'},
+            ],
+            'entries': [
+                {'type': 'mako', 'path': 'default/nfs-common'},
+                {'type': 'mako', 'path': 'default/nfs-kernel-server'},
+                {'type': 'mako', 'path': 'default/rpcbind'},
+                {'type': 'mako', 'path': 'idmapd.conf'},
+                {'type': 'mako', 'path': 'exports'},
+            ]
+        },
         'pam': [
             {'type': 'mako', 'path': os.path.join('pam.d', f.name[:-5])}
             for f in PAM_FILES
@@ -335,13 +344,29 @@ class EtcService(Service):
             'py': PyRenderer(self),
         }
 
+    async def gather_ctx(self, methods):
+        rv = {}
+        for m in methods:
+            method = m['method']
+            args = m.get('args', [])
+            rv[method] = await self.middleware.call(method, *args)
+
+        return rv
+
     async def generate(self, name, checkpoint=None):
         group = self.GROUPS.get(name)
         if group is None:
             raise ValueError('{0} group not found'.format(name))
 
         async with self.LOCKS[name]:
-            for entry in group:
+            if isinstance(group, dict):
+                ctx = await self.gather_ctx(group['ctx'])
+                entries = group['entries']
+            else:
+                ctx = None
+                entries = group
+
+            for entry in entries:
                 renderer = self._renderers.get(entry['type'])
                 if renderer is None:
                     raise ValueError(f'Unknown type: {entry["type"]}')
@@ -365,7 +390,7 @@ class EtcService(Service):
                         entry_path = entry_path[len('local/'):]
                 outfile = f'/etc/{entry_path}'
                 try:
-                    rendered = await renderer.render(path)
+                    rendered = await renderer.render(path, ctx)
                 except FileShouldNotExist:
                     self.logger.debug(f'{entry["type"]}:{entry["path"]} file removed.')
 


### PR DESCRIPTION
It's often the case that several members of the same etc files
group will perform identical queries. Add ability to specify
a general configure context (methods whose results should be
avaliable to all members of the etc_files group) to avoid
duplicate queries. This is helpful for cases where method
being called is expensive.

Original PR: https://github.com/truenas/middleware/pull/8390
Jira URL: https://jira.ixsystems.com/browse/NAS-115098