### PR TITLE
NAS-115113 / 13.0 / Fix validation for raw uids / gids in pool.dataset.set_quota (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3751,16 +3751,8 @@ class PoolDatasetService(CRUDService):
                         )
                 else:
                     id_type = ('user', 'uid') if 'user' in quota_type else ('group', 'gid')
-                    try:
-                        xid_obj = await self.middleware.call(f'{id_type[0]}.get_{id_type[0]}_obj',
-                                                             {id_type[1]: q["id"]})
-                        xid = xid_obj['pw_uid'] if id_type[1] == 'uid' else xid_obj['gr_gid']
-                    except Exception:
-                        self.logger.debug("Failed to convert %s [%s] to id.", id_type[1], q["id"], exc_info=True)
-                        verrors.add(
-                            f'quotas.{i}.id',
-                            f'{quota_type} {q["id"]} is not valid.'
-                        )
+                    xid = int(q["id"])
+
                 if xid == 0:
                     verrors.add(
                         f'quotas.{i}.id',


### PR DESCRIPTION
There's no strict requirement to verify that these ids map to
existing users/groups. Just pass along to ZFS.

Original PR: https://github.com/truenas/middleware/pull/8404
Jira URL: https://jira.ixsystems.com/browse/NAS-115113