### PR TITLE
NAS-115027 / 22.02.1 / Optimize reloads of user service (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/group.mako
+++ b/src/middlewared/middlewared/etc_files/group.mako
@@ -1,7 +1,9 @@
 <%
+    from middlewared.utils import filter_list
+
     users_map = {
         i['id']: i
-        for i in middleware.call_sync('user.query')
+        for i in render_ctx['user.query']
     }
 
     def get_usernames(group):
@@ -11,14 +13,7 @@
             if i in users_map and users_map[i]['group']['id'] != group['id']
         ])
 
-    if IS_FREEBSD:
-        no_password = '*'
-    else:
-        no_password = 'x'
 %>\
-% for group in middleware.call_sync('group.query', [], {'order_by': ['-builtin', 'gid']}):
-${group['group']}:${no_password}:${group['gid']}:${get_usernames(group)}
+% for group in filter_list(render_ctx['group.query'], [], {'order_by': ['-builtin', 'gid']}):
+${group['group']}:x:${group['gid']}:${get_usernames(group)}
 % endfor
-% if IS_FREEBSD and middleware.call_sync('nis.config')['enable']:
-+:${no_password}::\
-% endif

--- a/src/middlewared/middlewared/etc_files/local/smbusername.map.mako
+++ b/src/middlewared/middlewared/etc_files/local/smbusername.map.mako
@@ -2,11 +2,13 @@
 # SMB.CONF(5)		The configuration file for the Samba suite 
 #
 <%
+    from middlewared.utils import filter_list
+
     """
     The username map is required for proper support of microsoft accounts
     that are also email addresses. See SMB.CONF(5) for more details.
     """
-    users = middleware.call_sync('user.query', [
+    users = filter_list(render_ctx['user.query'], [
         ('microsoft_account', '=', True),
         ('email', '!=', None),
         ('email', '!=', ''),

--- a/src/middlewared/middlewared/etc_files/local/sudoers.mako
+++ b/src/middlewared/middlewared/etc_files/local/sudoers.mako
@@ -1,7 +1,8 @@
 <%
-    users = middleware.call_sync('user.query', [["sudo", "=", True]])
-    groups = middleware.call_sync('group.query', [["sudo", "=", True]])
-    ups_user = "nut" if IS_LINUX else "uucp"
+    from middlewared.utils import filter_list
+
+    users = filter_list(render_ctx['user.query'], [["sudo", "=", True]])
+    groups = filter_list(render_ctx['group.query'], [["sudo", "=", True]])
 
     def sudo_commands(commands):
         commands = list(filter(None, [command.strip() for command in commands]))
@@ -15,9 +16,7 @@
         return command
 
 %>\
-% if IS_LINUX:
 root ALL=(ALL:ALL) ALL
-% endif
 % for user in users:
 % if user['sudo_nopasswd']:
 ${user['username']} ALL=(ALL) NOPASSWD: ${sudo_commands(user['sudo_commands'])}
@@ -38,4 +37,4 @@ Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/
 # Let find_alias_for_smtplib.py runs as root (it needs database access)
 ALL ALL=(ALL) NOPASSWD: /etc/find_alias_for_smtplib.py
 ALL ALL=(ALL) NOPASSWD: /etc/find_alias_for_smtplib.sh
-${ups_user} ALL=(root) NOPASSWD: /usr/local/bin/custom-upssched-cmd
+nut ALL=(root) NOPASSWD: /usr/local/bin/custom-upssched-cmd

--- a/src/middlewared/middlewared/etc_files/mail/aliases.mako
+++ b/src/middlewared/middlewared/etc_files/mail/aliases.mako
@@ -1,10 +1,10 @@
 <%
-    import os
+    from middlewared.utils import filter_list
     import re
 
-    users = middleware.call_sync('user.query', [['email', '!=', '']])
+    users = filter_list(render_ctx['user.query'], [['email', 'nin', ['', None]]])
 
-    with open(os.path.join('/conf/base/etc', '' if IS_LINUX else 'mail', 'aliases'), 'r') as f:
+    with open('/conf/base/etc/aliases', 'r') as f:
         base_data = f.read()
 
     write_users = []

--- a/src/middlewared/middlewared/etc_files/master.passwd.mako
+++ b/src/middlewared/middlewared/etc_files/master.passwd.mako
@@ -1,24 +1,9 @@
-% for user in middleware.call_sync('user.query', [], {'order_by': ['-builtin', 'uid']}):
 <%
-if IS_FREEBSD:
-    if user['password_disabled']:
-        passwd = "*"
-    elif user['locked']:
-        passwd = "*LOCKED*"
-    else:
-        passwd = user['unixhash']
-else:
-    passwd = "x"
+    from middlewared.utils import filter_list
 
-if IS_FREEBSD:
-    freebsd_fields = ":0:0:"
-else:
-    freebsd_fields = ""
+    users = filter_list(render_ctx['user.query'], [], {'order_by': ['-builtin', 'uid']})
 %>\
-${user['username']}:${passwd}:${user['uid']}:${user['group']['bsdgrp_gid']}:${freebsd_fields}${user['full_name']}:${user['home']}:${user['shell']}
+% for user in users:
+${user['username']}:x:${user['uid']}:${user['group']['bsdgrp_gid']}:${user['full_name']}:${user['home']}:${user['shell']}
 % endfor
-% if IS_FREEBSD and middleware.call_sync('nis.config')['enable']:
-
-+:::::::::\
-% endif
 

--- a/src/middlewared/middlewared/etc_files/pwd_db.py
+++ b/src/middlewared/middlewared/etc_files/pwd_db.py
@@ -1,5 +1,0 @@
-from middlewared.utils import run
-
-
-async def render(service, middleware):
-    await run('pwd_mkdb', '-p', '/etc/master.passwd', check=False)

--- a/src/middlewared/middlewared/etc_files/shadow.mako
+++ b/src/middlewared/middlewared/etc_files/shadow.mako
@@ -1,11 +1,14 @@
-% for user in middleware.call_sync('user.query', [], {'order_by': ['-builtin', 'uid']}):
 <%
-if user['password_disabled']:
-    passwd = "*"
-elif user['locked']:
-    passwd = "!"
-else:
-    passwd = user['unixhash']
+    from middlewared.utils import filter_list
+
+    def get_passwd(entry):
+        if entry['password_disabled']:
+            return "*"
+        elif user['locked']:
+            return "!"
+
+        return entry['unixhash']
 %>\
-${user['username']}:${passwd}:18397:0:99999:7:::
+% for user in filter_list(render_ctx['user.query'], [], {'order_by': ['-builtin', 'uid']}):
+${user['username']}:${get_passwd(user)}:18397:0:99999:7:::
 % endfor

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1034,6 +1034,12 @@ class UserService(CRUDService):
                 'The ":" character is not allowed in a "Full Name".'
             )
 
+        if 'full_name' in data and '\n' in data['full_name']:
+            verrors.add(
+                f'{schema}.full_name',
+                'The "\\n" character is not allowed in a "Full Name".'
+            )
+
         if 'shell' in data and data['shell'] not in await self.middleware.call('user.shell_choices', pk):
             verrors.add(
                 f'{schema}.shell', 'Please select a valid shell.'

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -81,13 +81,20 @@ class EtcService(Service):
     APACHE_DIR = 'local/apache24' if osc.IS_FREEBSD else 'local/apache2'
 
     GROUPS = {
-        'user': [
-            {'type': 'mako', 'path': 'local/smbusername.map'},
-            {'type': 'mako', 'path': 'group'},
-            {'type': 'mako', 'path': 'master.passwd' if osc.IS_FREEBSD else 'passwd', 'local_path': 'master.passwd'},
-            {'type': 'py', 'path': 'pwd_db', 'platform': 'FreeBSD'},
-            {'type': 'mako', 'path': 'shadow', 'platform': 'Linux', 'group': 'shadow', 'mode': 0o0640},
-        ],
+        'user': {
+            'ctx': [
+                {'method': 'user.query'},
+                {'method': 'group.query'},
+            ],
+            'entries': [
+                {'type': 'mako', 'path': 'local/smbusername.map'},
+                {'type': 'mako', 'path': 'group'},
+                {'type': 'mako', 'path': 'passwd', 'local_path': 'master.passwd'},
+                {'type': 'mako', 'path': 'shadow', 'platform': 'Linux', 'group': 'shadow', 'mode': 0o0640},
+                {'type': 'mako', 'path': 'local/sudoers'},
+                {'type': 'mako', 'path': 'aliases', 'local_path': 'mail/aliases'}
+            ]
+        },
         'fstab': [
             {'type': 'mako', 'path': 'fstab'},
             {'type': 'py', 'path': 'fstab_configure', 'checkpoint_linux': 'post_init'}
@@ -262,9 +269,6 @@ class EtcService(Service):
         'snmpd': [
             {'type': 'mako', 'path': 'snmp/snmpd.conf', 'local_path': 'local/snmpd.conf'},
         ],
-        'sudoers': [
-            {'type': 'mako', 'path': 'local/sudoers'}
-        ],
         'syslogd': [
             {'type': 'mako', 'path': 'default/syslog-ng', 'checkpoint': 'pool_import'},
             {'type': 'py', 'path': 'syslogd', 'checkpoint': 'pool_import'},
@@ -288,9 +292,6 @@ class EtcService(Service):
         ],
         'inadyn': [
             {'type': 'mako', 'path': 'local/inadyn.conf'}
-        ],
-        'aliases': [
-            {'type': 'mako', 'path': 'mail/aliases' if osc.IS_FREEBSD else 'aliases', 'local_path': 'mail/aliases'}
         ],
         'openvpn_server': [
             {

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -279,7 +279,7 @@ class DSCacheService(PseudoServiceBase):
 class UserService(PseudoServiceBase):
     name = "user"
 
-    etc = ["user", "aliases", "sudoers"]
+    etc = ["user"]
     reloadable = True
 
     async def reload(self):


### PR DESCRIPTION
Consolidate all the mako files associated with a user service
reload into a single python file. This minimizes the amount
of times that user.query and group.query must be called. On
test server with high user count, this changeset halves the
amount of time it takes to add or delete a new user.

Original PR: https://github.com/truenas/middleware/pull/8386
Jira URL: https://jira.ixsystems.com/browse/NAS-115027