### PR TITLE
NAS-115125 / 22.12 / fix interface.query aliases key

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -324,7 +324,7 @@ class InterfaceService(CRUDService):
                     'vlan_pcp': None,
                 })
 
-        if not (config['int_dhcp'] or not config['int_ipv6auto']) and config['int_address']:
+        if (not config['int_dhcp'] or not config['int_ipv6auto']) and config['int_address']:
             iface['aliases'].append({
                 'type': 'INET' if config['int_version'] == 4 else 'INET6',
                 'address': config['int_address'],


### PR DESCRIPTION
Subtle typo that prevents the `aliases` key from populating in `interface.query` (The `state['aliases']` key is unaffected)