### PR TITLE
NAS-115041 / 22.12 / Proper way of mapping ZFS pool vdevs to disks (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/disks.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks.py
@@ -1,4 +1,3 @@
-import os
 import pyudev
 
 from middlewared.service import Service
@@ -20,10 +19,9 @@ class ZFSPoolService(Service):
         ):
             if dev['DEVTYPE'] == 'disk':
                 mapping[dev.sys_name] = dev.sys_name
-            elif dev.get('ID_PART_ENTRY_UUID'):
-                parent = dev.find_parent('block')
-                mapping[dev.sys_name] = parent.sys_name
-                mapping[os.path.join('disk/by-partuuid', dev['ID_PART_ENTRY_UUID'])] = parent.sys_name
+
+            for link in (dev.get('DEVLINKS') or '').split():
+                mapping[link[len('/dev/'):]] = dev.sys_name
 
         pool_disks = []
         for dev in disks:


### PR DESCRIPTION
If TrueNAS is installed on a USB stick, Debian changes boot pool vdev to something like
`/dev/disk/by-id/usb-JetFlash_Transcend_16GB_XXXXXXXXXXXXX-0:0-part3`. This was not
being mapped properly.

Original PR: https://github.com/truenas/middleware/pull/8412
Jira URL: https://jira.ixsystems.com/browse/NAS-115041