### PR TITLE
NAS-115111 / 22.12 / Only validate the subquestion if value is provided

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -106,7 +106,7 @@ class ChartReleaseService(Service):
         if subquestions_enabled:
             for sub_question in schema.get('subquestions', []):
                 # TODO: Add support for nested subquestions validation for List schema types.
-                if isinstance(parent_attr, Dict):
+                if isinstance(parent_attr, Dict) and sub_question['variable'] in parent_value:
                     item_key, attr = sub_question['variable'], parent_attr.attrs[sub_question['variable']]
                     await self.validate_question(
                         verrors, parent_value, parent_value[sub_question['variable']], sub_question,


### PR DESCRIPTION
```python
File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/validation.py", line 81, in validate_question
    await self.validate_question(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/validation.py", line 81, in validate_question
    await self.validate_question(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/validation.py", line 81, in validate_question
    await self.validate_question(
  [Previous line repeated 1 more time]
  File "/usr/lib/python3/dist-packages/middlewared/plugins/chart_releases_linux/validation.py", line 112, in validate_question
    verrors, parent_value, parent_value[sub_question['variable']], sub_question,
KeyError: 'nodePort'
```