### PR TITLE
NAS-114980 / 22.02.1 / switch to using mpm_event from mpm_prefork (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf.mako
@@ -53,7 +53,6 @@
 Listen ${webdav_config['tcpport']}
 	<VirtualHost *:${webdav_config['tcpport']}>
 		DavLockDB "/etc/apache2/var/DavLock"
-		AssignUserId webdav webdav
 
 		<Directory />
 % if auth_type != 'none':


### PR DESCRIPTION
Convert to using the default mpm for webdav. mpm_prefork was
crashing on a NULL dereference and is most likely not a great
choice for our purposes..

Since this change means that apache server is no longer setuid,
ensure that apache is running as webdav rather than www-data
so that users don't lose access to files written by webdav.

Original PR: https://github.com/truenas/middleware/pull/8432
Jira URL: https://jira.ixsystems.com/browse/NAS-114980