### PR TITLE
NAS-115135 / 22.12 / Improve webdav validation and disable deprecated TLS versions

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/httpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/apache24/httpd.conf.mako
@@ -123,7 +123,7 @@ LogLevel warn
 <IfModule ssl_module>
 SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
-SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2
+SSLProtocol +TLSv1.2 +TLSv1.3
 </IfModule>
 
 Include Includes/*.conf

--- a/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
+++ b/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
@@ -23,7 +23,7 @@ def generate_webdav_config(service, middleware):
             f'<VirtualHost *:{webdav_config["tcpportssl"]}>\n\t\tSSLEngine on\n\t\t'
             f'SSLCertificateFile "{webdav_config["certssl"]["certificate_path"]}"\n\t\t'
             f'SSLCertificateKeyFile "{webdav_config["certssl"]["privatekey_path"]}"\n\t\t'
-            f'SSLProtocol +TLSv1 +TLSv1.1 +TLSv1.2\n\t\t'
+            f'SSLProtocol +TLSv1.2 +TLSv1.3\n\t\t'
             f'SSLCipherSuite HIGH:MEDIUM\n\n',
             data
         )

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -18,6 +18,7 @@ import enum
 class EtcUSR(enum.IntEnum):
     ROOT = 0
     NSLCD = 110
+    WEBDAV = 666
 
 
 class EtcGRP(enum.IntEnum):
@@ -25,6 +26,7 @@ class EtcGRP(enum.IntEnum):
     SHADOW = 42
     NSLCD = 115
     NUT = 126
+    WEBDAV = 666
 
 
 class FileShouldNotExist(Exception):


### PR DESCRIPTION
Remove support for TLSv1, TLSv1.1 and add support for TLSv1.3
Add webdav.cert_choices method