### PR TITLE
NAS-115001 / 22.02.1 / Correct vm disks path on SCALE

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-03-04_13-24_vm_disk_device.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-03-04_13-24_vm_disk_device.py
@@ -1,0 +1,33 @@
+"""
+Fix disk type devices path
+
+Revision ID: b3c5a5321aef
+Revises: 2ed09f3b17b7
+Create Date: 2022-03-04 13:24:38.186590+00:00
+
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b3c5a5321aef'
+down_revision = '2ed09f3b17b7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    for device in map(dict, conn.execute("SELECT * FROM vm_device WHERE dtype = 'DISK'").fetchall()):
+        if device["attributes"].get("path"):
+            device["attributes"]["path"] = device["attributes"]["path"].replace(" ", "+")
+            conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (
+                json.dumps(device["attributes"]), device["id"]
+            ))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-03-04_13-24_vm_disk_device.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-03-04_13-24_vm_disk_device.py
@@ -22,6 +22,7 @@ depends_on = None
 def upgrade():
     conn = op.get_bind()
     for device in map(dict, conn.execute("SELECT * FROM vm_device WHERE dtype = 'DISK'").fetchall()):
+        device["attributes"] = json.loads(device["attributes"])
         if device["attributes"].get("path"):
             device["attributes"]["path"] = device["attributes"]["path"].replace(" ", "+")
             conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (

--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-03-08_13-24_vm_disk_device.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-03-08_13-24_vm_disk_device.py
@@ -2,8 +2,8 @@
 Fix disk type devices path
 
 Revision ID: b3c5a5321aef
-Revises: 2ed09f3b17b7
-Create Date: 2022-03-04 13:24:38.186590+00:00
+Revises: 4e027c93e4d1
+Create Date: 2022-03-08 13:24:38.186590+00:00
 
 """
 import json
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'b3c5a5321aef'
-down_revision = '2ed09f3b17b7'
+down_revision = '4e027c93e4d1'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/plugins/vm/attachments.py
+++ b/src/middlewared/middlewared/plugins/vm/attachments.py
@@ -1,7 +1,8 @@
 import asyncio
-import re
+import os.path
 
 from middlewared.common.attachment import FSAttachmentDelegate
+from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.utils.path import is_child
 
 
@@ -24,7 +25,8 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
             if not disk:
                 continue
 
-            disk = re.sub(r'^/dev/zvol', '/mnt', disk)
+            if disk.startswith('/dev/zvol'):
+                disk = os.path.join('/mnt', zvol_path_to_name(disk))
 
             if is_child(disk, path):
                 vm = {

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -49,7 +49,7 @@ class VMDeviceService(CRUDService):
         cli_namespace = 'service.vm.device'
 
     @accepts()
-    @returns(Dict())
+    @returns(Dict(additional_attrs=True, example={'vms/test 1': '/dev/zvol/vms/test+1'}))
     async def disk_choices(self):
         """
         Returns disk choices for device type "DISK".
@@ -57,7 +57,9 @@ class VMDeviceService(CRUDService):
         return {
             vol['id']: os.path.join('/dev/zvol', vol['id'].replace(' ', '+'))
             for vol in await self.middleware.call(
-                'pool.dataset.query', [['type', '=', 'VOLUME']], {'extra': {'properties': []}}
+                'pool.dataset.query', [['type', '=', 'VOLUME'], ['locked', '=', False]], {
+                    'extra': {'properties': ['encryption', 'keystatus']}
+                }
             )
         }
 

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -48,6 +48,19 @@ class VMDeviceService(CRUDService):
         datastore_extend = 'vm.device.extend_device'
         cli_namespace = 'service.vm.device'
 
+    @accepts()
+    @returns(Dict())
+    async def disk_choices(self):
+        """
+        Returns disk choices for device type "DISK".
+        """
+        return {
+            vol['id']: os.path.join('/dev/zvol', vol['id'].replace(' ', '+'))
+            for vol in await self.middleware.call(
+                'pool.dataset.query', [['type', '=', 'VOLUME']], {'extra': {'properties': []}}
+            )
+        }
+
     @private
     async def create_resource(self, device, old=None):
         return (

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -4,6 +4,7 @@ import re
 
 import middlewared.sqlalchemy as sa
 
+from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.schema import accepts, Bool, Dict, Error, Int, Patch, returns, Str
 from middlewared.service import CallError, CRUDService, private, ValidationErrors
 from middlewared.utils import osc, run
@@ -55,7 +56,7 @@ class VMDeviceService(CRUDService):
         Returns disk choices for device type "DISK".
         """
         return {
-            vol['id']: os.path.join('/dev/zvol', vol['id'].replace(' ', '+'))
+            zvol_name_to_path(vol['id']): vol['id']
             for vol in await self.middleware.call(
                 'pool.dataset.query', [['type', '=', 'VOLUME'], ['locked', '=', False]], {
                     'extra': {'properties': ['encryption', 'keystatus']}
@@ -193,7 +194,9 @@ class VMDeviceService(CRUDService):
         if options['zvol']:
             if device['dtype'] != 'DISK':
                 raise CallError('The device is not a disk and has no zvol to destroy.')
-            zvol_id = device['attributes'].get('path', '').rsplit('/dev/zvol/')[-1]
+            if not device['attributes'].get('path', '').startswith('/dev/zvol'):
+                raise CallError('Unable to destroy zvol as disk device has misconfigured path')
+            zvol_id = zvol_path_to_name(device['attributes']['path'])
             if await self.middleware.call('pool.dataset.query', [['id', '=', zvol_id]]):
                 # FIXME: We should use pool.dataset.delete but right now FS attachments will consider
                 # the current device as a valid reference. Also should we stopping the vm only when deleting an

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -6,6 +6,7 @@ import warnings
 
 import middlewared.sqlalchemy as sa
 
+from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Ref, returns, Str, ValidationErrors
 from middlewared.service import CallError, CRUDService, item_method, private
 from middlewared.validators import Range, UUID
@@ -407,7 +408,7 @@ class VMService(CRUDService, VMSupervisorMixin):
                     if not zvol['attributes']['path'].startswith('/dev/zvol/'):
                         continue
 
-                    disk_name = zvol['attributes']['path'].rsplit('/dev/zvol/')[-1]
+                    disk_name = zvol_path_to_name(zvol['attributes']['path'])
                     try:
                         await self.middleware.call('zfs.dataset.delete', disk_name, {'recursive': True})
                     except Exception:


### PR DESCRIPTION
Volumes are mounted as `/dev/zvol/vms/test 1` in freebsd but as `/dev/zvol/vms/test+1` in linux.

This PR adds:
1. An API to provide list of disks with correct zvol paths so UI can consume it as is unlike today (i.e. UI pre-fixes the `/dev/zvol` into volume name).
2. Add a migration for correcting existing vm disk devices for users who would be upgrading from CORE

PS: I have confirmed this behavior with @freqlabs on freebsd vs linux

