### PR TITLE
NAS-115140 / 22.02.1 / Convert webdav etc group to use render_ctx (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
+++ b/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
@@ -1,14 +1,65 @@
 import re
+import os
+import secrets
+import hashlib
+import crypt
+
+from contextlib import suppress
+from middlewared.plugins.etc import EtcUSR, EtcGRP
+from string import digits, ascii_uppercase, ascii_lowercase
 
 
-def generate_webdav_config(service, middleware):
-    webdav_config = middleware.call_sync('webdav.config')
-    apache_dir = '/etc/apache2'
+def generate_webdav_auth(middlewared, render_ctx, dirfd):
+    def salt():
+        letters = f'{ascii_lowercase}{ascii_uppercase}{digits}/.'
+        return '$6${0}'.format(''.join([secrets.choice(letters) for i in range(16)]))
+
+    def remove_auth(dirfd):
+        with suppress(FileNotFoundError):
+            os.remove('webdavhtbasic', dir_fd=dirfd)
+
+        with suppress(FileNotFoundError):
+            os.remove('webdavhtdigest', dir_fd=dirfd)
+
+    auth_type = render_ctx['webdav.config']['htauth'].upper()
+    password = render_ctx['webdav.config']['password']
+
+    if auth_type not in ['NONE', 'BASIC', 'DIGEST']:
+        remove_auth(dirfd)
+        raise ValueError("Invalid auth_type (must be one of 'NONE', 'BASIC', 'DIGEST')")
+
+    if auth_type == 'BASIC':
+        with suppress(FileNotFoundError):
+            os.remove('webdavhtdigest', dir_fd=dirfd)
+
+        with open(os.open('webdavhtbasic', os.O_WRONLY | os.O_CREAT | os.O_TRUNC, dir_fd=dirfd), 'w') as f:
+            os.fchmod(f.fileno(), 0o600)
+            os.fchown(f.fileno(), EtcUSR.WEBDAV, EtcGRP.WEBDAV)
+            f.write(f'webdav:{crypt.crypt(password, salt())}')
+
+    elif auth_type == 'DIGEST':
+        with suppress(FileNotFoundError):
+            os.remove('webdavhtbasic', dir_fd=dirfd)
+
+        with open(os.open('webdavhtdigest', os.O_WRONLY | os.O_CREAT | os.O_TRUNC, dir_fd=dirfd), 'w') as f:
+            os.fchmod(f.fileno(), 0o600)
+            os.fchown(f.fileno(), EtcUSR.WEBDAV, EtcGRP.WEBDAV)
+            f.write(
+                "webdav:webdav:{0}".format(hashlib.md5(f"webdav:webdav:{password}".encode()).hexdigest())
+            )
+
+    else:
+        remove_auth(dirfd)
+
+
+def generate_webdav_config(middleware, render_ctx, dirfd):
+    webdav_config = render_ctx['webdav.config']
+    to_blank = None
 
     if webdav_config['protocol'] in ('HTTPS', 'HTTPHTTPS'):
         middleware.call_sync('certificate.cert_services_validation', webdav_config['certssl'], 'webdav.certssl')
 
-        with open(f'{apache_dir}/Includes/webdav.conf', 'r') as f:
+        with open(os.open('Includes/webdav.conf', os.O_RDONLY, dir_fd=dirfd), 'r') as f:
             data = f.read()
 
         webdav_config['certssl'] = middleware.call_sync(
@@ -28,19 +79,26 @@ def generate_webdav_config(service, middleware):
             data
         )
 
-        with open(f'{apache_dir}/Includes/webdav-ssl.conf', 'w') as f:
+        with open(os.open('Includes/webdav-ssl.conf', os.O_WRONLY | os.O_CREAT | os.O_TRUNC, dir_fd=dirfd), 'w') as f:
             f.write(data)
 
         if webdav_config['protocol'] == 'HTTPS':
-            # Empty webdav.conf
-            with open(f'{apache_dir}/Includes/webdav.conf', 'w+') as f:
-                pass
-    else:
-        if webdav_config['protocol'] == 'HTTP':
-            # Empty webdav-ssl.conf
-            with open(f'{apache_dir}/Includes/webdav-ssl.conf', 'w+') as f:
-                pass
+            to_blank = 'Includes/webdav.conf'
+
+    elif webdav_config['protocol'] == 'HTTP':
+        to_blank = 'Includes/webdav-ssl.conf'
+
+    if to_blank is not None:
+        try:
+            fd = os.open(to_blank, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, dir_fd=dirfd)
+        finally:
+            os.close(fd)
 
 
-def render(service, middleware):
-    generate_webdav_config(service, middleware)
+def render(service, middleware, render_ctx):
+    dirfd = os.open("/etc/apache2", os.O_PATH | os.O_DIRECTORY)
+    try:
+        generate_webdav_config(middleware, render_ctx, dirfd)
+        generate_webdav_auth(middleware, render_ctx, dirfd)
+    finally:
+        os.close(dirfd)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -180,25 +180,31 @@ class EtcService(Service):
         'scst': [
             {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'}
         ],
-        'webdav': [
-            {
-                'type': 'mako',
-                'local_path': 'local/apache24/httpd.conf',
-                'path': 'local/apache2/apache2.conf',
-            },
-            {
-                'type': 'mako',
-                'local_path': 'local/apache24/Includes/webdav.conf',
-                'path': 'local/apache2/Includes/webdav.conf',
-                'checkpoint': 'pool_import'
-            },
-            {
-                'type': 'py',
-                'local_path': 'local/apache24/webdav_config',
-                'path': 'local/apache2/webdav_config',
-                'checkpoint': 'pool_import',
-            },
-        ],
+        'webdav': {
+            'ctx': [
+                {'method': 'sharing.webdav.query', 'args': [[("enabled", "=", True)]]},
+                {'method': 'webdav.config'},
+            ],
+            'entries': [
+                {
+                    'type': 'mako',
+                    'local_path': 'local/apache24/httpd.conf',
+                    'path': 'local/apache2/apache2.conf',
+                },
+                {
+                    'type': 'mako',
+                    'local_path': 'local/apache24/Includes/webdav.conf',
+                    'path': 'local/apache2/Includes/webdav.conf',
+                    'checkpoint': 'pool_import'
+                },
+                {
+                    'type': 'py',
+                    'local_path': 'local/apache24/webdav_config',
+                    'path': 'local/apache2/webdav_config',
+                    'checkpoint': 'pool_import',
+                },
+            ]
+        },
         'nginx': [
             {'type': 'mako', 'path': 'local/nginx/nginx.conf', 'checkpoint': 'interface_sync'}
         ],


### PR DESCRIPTION
Apart from having shared context (which is probably of negligable
benefit here). This also makes several changes to how webdav
config files are generated.

We now always ensure that password hashes are owned by webdav user and
permissions are 0o600 and use secrets.choice() rather than
random.choice() for generating hashes. A subprocess call to change
owner has also been replaced with shutil.chown(). Futher investigation
may be required in order to determine whether this chown call is
actually needed.

Original PR: https://github.com/truenas/middleware/pull/8444
Jira URL: https://jira.ixsystems.com/browse/NAS-115140