### PR TITLE
NAS-114409 / 22.12 / Allow deleting unused images on app deletion

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/images.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/images.py
@@ -1,0 +1,51 @@
+import errno
+
+from middlewared.plugins.docker_linux.utils import normalize_reference, get_chart_releases_consuming_image
+from middlewared.schema import Dict, Str, returns
+from middlewared.service import accepts, CallError, private, Service
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @accepts(Str('chart_release_name'))
+    @returns(Dict(example={'minio2': ['minio/minio:RELEASE.2022-03-05T06-32-39Z']}))
+    async def get_chart_releases_using_chart_release_images(self, chart_release_name):
+        """
+        Retrieve chart releases which are consuming any images in use by `chart_release_name`.
+        """
+        chart_releases = await self.middleware.call('chart.release.query', [], {'extra': {'retrieve_resources': True}})
+        idx = next((idx for (idx, d) in enumerate(chart_releases) if d['name'] == chart_release_name), None)
+        if idx is None:
+            raise CallError(f'{chart_release_name!r} not found', errno=errno.ENOENT)
+
+        chart_release = chart_releases.pop(idx)
+        return get_chart_releases_consuming_image(chart_release['resources']['container_images'], chart_releases, True)
+
+    @private
+    async def delete_unused_app_images(self, chart_release):
+        failed_to_delete = {}
+        to_delete_tags = await self.get_to_delete_unused_app_images(chart_release)
+        for image in await self.middleware.call('container.image.query', [['OR', [
+            ['complete_tags', 'rin', tag] for tag in to_delete_tags
+        ]]], {'extra': {'complete_tags': True}}) if to_delete_tags else []:
+            try:
+                await self.middleware.call('container.image.delete', image['id'])
+            except Exception as e:
+                failed_to_delete[', '.join(image['complete_tags'])] = str(e)
+        return failed_to_delete
+
+    @private
+    async def get_to_delete_unused_app_images(self, chart_release):
+        to_delete = {normalize_reference(i)['complete_tag'] for i in chart_release['resources']['container_images']}
+        in_use = get_chart_releases_consuming_image(
+            to_delete, await self.middleware.call(
+                'chart.release.query', [['id', '!=', chart_release['name']]], {'extra': {'retrieve_resources': True}}
+            ), True
+        )
+        for image_list in in_use.values():
+            for image in filter(lambda i: i['complete_tag'] in to_delete, map(normalize_reference, image_list)):
+                to_delete.remove(image['complete_tag'])
+        return list(to_delete)

--- a/src/middlewared/middlewared/plugins/docker_linux/chart_releases.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/chart_releases.py
@@ -1,0 +1,22 @@
+from middlewared.schema import List, returns, Str
+from middlewared.service import accepts, Service
+
+from .utils import get_chart_releases_consuming_image
+
+
+class DockerImagesService(Service):
+
+    class Config:
+        namespace = 'container.image'
+        namespace_alias = 'docker.images'
+        cli_namespace = 'app.docker.image'
+
+    @accepts(List('image_tags', empty=False, items=[Str('image_tag')]))
+    @returns(List())
+    async def get_chart_releases_consuming_image(self, image_tags):
+        """
+        Retrieve chart releases consuming `image_tag` image.
+        """
+        return get_chart_releases_consuming_image(
+            image_tags, await self.middleware.call('chart.release.query', [], {'extra': {'retrieve_resources': True}})
+        )

--- a/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_chart_releases_consuming_image.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_chart_releases_consuming_image.py
@@ -1,0 +1,90 @@
+import pytest
+
+from middlewared.plugins.docker_linux.utils import get_chart_releases_consuming_image
+
+
+payload = [
+    {
+        'name': 'plex',
+        'resources': {
+            'container_images': {
+                'plexinc/pms-docker:1.25.3.5409-f11334058': {
+                    'id': 'sha256:6749cc56cfe405a3a1a23be95289e374d00ff46ecf3d652e5d9bef42eb775484',
+                    'update_available': False
+                }
+            }
+        }
+    },
+    {
+        'name': 'nextcloud',
+        'resources': {
+            'container_images': {
+                'postgres:13.1': {
+                    'id': 'sha256:407cece1abfffb1e84b5feb8a763f3773c905c409e52c0ee5f57f33acf0c10c6',
+                    'update_available': False
+                },
+                'nextcloud:23': {
+                    'id': 'sha256:2f974665ca82ec404766ad4505a84dedacf418fed11cf4b37ab649827b3d1fc9',
+                    'update_available': False
+                }
+            }
+        }
+    },
+    {
+        'name': 'minio',
+        'resources': {
+            'container_images': {
+                'minio/minio:RELEASE.2022-01-25T19-56-04Z': {
+                    'id': 'sha256:5999fef911660af13f3d73876ed6cdefc78ddc53a455574ff3a6834f31d68b5c',
+                    'update_available': False
+                }
+            }
+        }
+    },
+    {
+        'name': 'miniotest',
+        'resources': {
+            'container_images': {
+                'minio/minio:RELEASE.2022-02-16T00-35-27Z': {
+                    'id': 'sha256:1031ccfe95e009180f49144b3634433a9220d5d7a5602583d3c274eff69b0e8d',
+                    'update_available': False
+                }
+            }
+        }
+    },
+    {
+        'name': 'odoo',
+        'resources': {
+            'container_images': {
+                'ghcr.io/truecharts/postgresql:v14.1.0@sha256:1eb6ede5a83b4'
+                'f6d15633c98b49f813b39519e3233b72e5d212a76f7e29bcd17': {
+                    'id': None,
+                    'update_available': False
+                },
+                'tccr.io/truecharts/odoo:v15.0@sha256:d20448fc89fdad7c1208d'
+                '2f4882742bb7bd864171ba341806bc574e7c2e92955': {
+                    'id': None,
+                    'update_available': False
+                }
+            }
+        }
+    }
+]
+
+
+@pytest.mark.parametrize('image_ref,chart_releases', [
+    (['minio/minio:RELEASE.2022-02-16T00-35-27Z'], ['miniotest']),
+    (
+        ['ghcr.io/truecharts/postgresql:v14.1.0@sha256:1eb6ede5a83b4f6d15633c98'
+         'b49f813b39519e3233b72e5d212a76f7e29bcd17'], ['odoo']
+    ),
+    (['minio/minio:RELEASE.2022-01-25T19-56-04Z'], ['minio']),
+    (['minio/minio:RELEASE.2022-01-25T19-56-04Z', 'minio/minio:RELEASE.2022-02-16T00-35-27Z'], ['minio', 'miniotest']),
+    (
+        ['ghcr.io/truecharts/postgresql:v14.1.0@sha256:1eb6ede5a83b4f6d15633c98b'
+         '49f813b39519e3233b72e5d212a76f7e29bcd17', 'minio/minio:RELEASE.2022-02-16T00-35-27Z'], ['odoo', 'miniotest']
+    ),
+])
+def test_chart_release_images(image_ref, chart_releases):
+    actual_results = get_chart_releases_consuming_image(image_ref, payload)
+    assert set(actual_results) == set(chart_releases)


### PR DESCRIPTION
# Background

An app's docker image is not removed when it's deleted through `helm uninstall` cmd. This PR:

1. Adds an option to delete its images while app's uninstallation
2. Adds APIs: Get chart releases that are consuming image (to be deleted), Find and delete images.
3. Handle tags vs digests during the picking of image to be removed
4. Add tests