### PR TITLE
NAS-115198 / 22.12 / Reuse fd in etc file generation and run unlink in thread

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -7,12 +7,15 @@ from middlewared.utils.mako import get_template
 
 import asyncio
 from collections import defaultdict
+from contextlib import suppress
 import grp
 import imp
 import os
 import pwd
 import stat
 import enum
+
+DEFAULT_ETC_PERMS = 0o644
 
 
 class EtcUSR(enum.IntEnum):
@@ -374,11 +377,11 @@ class EtcService(Service):
 
         return rv
 
-    def set_etc_file_perms(self, file, entry):
+    def set_etc_file_perms(self, fd, entry):
         perm_changed = False
         uid = entry.get("owner", -1)
         gid = entry.get("group", -1)
-        mode = entry.get("mode", None)
+        mode = entry.get("mode", DEFAULT_ETC_PERMS)
 
         if uid == -1 and gid == -1 and mode is None:
             return perm_changed
@@ -389,29 +392,41 @@ class EtcService(Service):
         if isinstance(gid, str):
             gid = grp.getgrnam(entry["group"]).gr_gid
 
-        try:
-            fd = os.open(file, os.O_RDWR)
-            st = os.fstat(fd)
-            uid_to_set = -1
-            gid_to_set = -1
+        st = os.fstat(fd)
+        uid_to_set = -1
+        gid_to_set = -1
 
-            if uid != -1 and st.st_uid != uid:
-                uid_to_set = uid
+        if uid != -1 and st.st_uid != uid:
+            uid_to_set = uid
 
-            if gid != -1 and st.st_gid != gid:
-                gid_to_set = gid
+        if gid != -1 and st.st_gid != gid:
+            gid_to_set = gid
 
-            if gid_to_set != -1 or uid_to_set != -1:
-                os.fchown(fd, uid_to_set, gid_to_set)
-                perm_changed = True
+        if gid_to_set != -1 or uid_to_set != -1:
+            os.fchown(fd, uid_to_set, gid_to_set)
+            perm_changed = True
 
-            if mode and stat.S_IMODE(st.st_mode) != mode:
-                os.fchmod(fd, mode)
-                perm_changed = True
-        finally:
-            os.close(fd)
+        if mode and stat.S_IMODE(st.st_mode) != mode:
+            os.fchmod(fd, mode)
+            perm_changed = True
 
         return perm_changed
+
+    def make_changes(self, full_path, entry, rendered):
+        mode = entry.get('mode', DEFAULT_ETC_PERMS)
+
+        def opener(path, flags):
+            return os.open(path, os.O_CREAT | os.O_RDWR, mode=mode)
+
+        outfile_dirname = os.path.dirname(full_path)
+        if outfile_dirname != '/etc':
+            os.makedirs(outfile_dirname, exist_ok=True)
+
+        with open(full_path, "w", opener=opener) as f:
+            perms_changed = self.set_etc_file_perms(f.fileno(), entry)
+            contents_changed = write_if_changed(f.fileno(), rendered)
+
+        return perms_changed or contents_changed
 
     async def generate(self, name, checkpoint=None):
         group = self.GROUPS.get(name)
@@ -448,15 +463,14 @@ class EtcService(Service):
                 if entry_path.startswith('local/'):
                     entry_path = entry_path[len('local/'):]
                 outfile = f'/etc/{entry_path}'
+
                 try:
                     rendered = await renderer.render(path, ctx)
                 except FileShouldNotExist:
                     self.logger.debug(f'{entry["type"]}:{entry["path"]} file removed.')
 
-                    try:
-                        os.unlink(outfile)
-                    except FileNotFoundError:
-                        pass
+                    with suppress(FileNotFoundError):
+                        await self.middleware.run_in_thread(os.unlink, outfile)
 
                     continue
                 except Exception:
@@ -466,19 +480,7 @@ class EtcService(Service):
                 if rendered is None:
                     continue
 
-                outfile_dirname = os.path.dirname(outfile)
-                if not os.path.exists(outfile_dirname):
-                    os.makedirs(outfile_dirname)
-
-                changes = await self.middleware.run_in_thread(
-                    write_if_changed, outfile, rendered,
-                )
-
-                # If ownership or permissions are specified, see if
-                # they need to be changed.
-                changes = await self.middleware.run_in_thread(
-                    self.set_etc_file_perms, outfile, entry
-                )
+                changes = await self.middleware.run_in_thread(self.make_changes, outfile, entry, rendered)
 
                 if not changes:
                     self.logger.debug(f'No new changes for {outfile}')

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -6,6 +6,9 @@ def write_if_changed(path, data):
     if isinstance(data, str):
         data = data.encode()
 
+    if isinstance(path, int):
+        path = f'/proc/self/fd/{path}'
+
     changed = False
 
     with open(os.open(path, os.O_CREAT | os.O_RDWR), 'wb+') as f:


### PR DESCRIPTION
This contains a few improvements to permissions management in
etc plugin:

- write_if_changed is updated to allow passing an fd rather than
  only a path name
- permissions check and file contents check are now run from same
  thread.
- permissions are set on file before writing.
- set default permissions on config files to 0644 unless dev
  specifies something different.