### PR TITLE
NAS-115203 / 22.02.1 / Improve permissions handling in temporary keytab files (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.keytab.py
+++ b/src/middlewared/middlewared/etc_files/krb5.keytab.py
@@ -2,53 +2,64 @@ import logging
 import os
 import base64
 import subprocess
-import contextlib
+import stat
 
-from middlewared.utils import Popen
+from contextlib import suppress
 
 logger = logging.getLogger(__name__)
 kdir = "/etc/kerberos"
 keytabfile = "/etc/krb5.keytab"
-ktutil_cmd = "ktutil"
 
 
-async def mit_copy(temp_keytab):
-    kt_copy = await Popen(['ktutil'],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
-                          stdin=subprocess.PIPE)
-    output = await kt_copy.communicate(
-        f'rkt {temp_keytab}\nwkt /etc/mit_tmp.keytab'.encode()
+def mit_copy(temp_keytab):
+    kt_copy = subprocess.run(
+        ['ktutil'],
+        input=f'rkt {temp_keytab}\nwkt /etc/mit_tmp.keytab'.encode(),
+        capture_output=True
     )
-    if output[1]:
-        logger.debug(f"failed to generate [{keytabfile}]: {output[1].decode()}")
+    if kt_copy.stderr:
+        logger.debug("%s: failed to generate keytab: %s",
+                     keytabfile, kt_copy.stderr.decode())
 
 
-async def write_keytab(db_keytabname, db_keytabfile):
-    temp_keytab = f'{kdir}/{db_keytabname}'
-    if not os.path.exists(kdir):
-        os.mkdir(kdir)
-    if os.path.exists(temp_keytab):
-        os.remove(temp_keytab)
-    with open(temp_keytab, "wb") as f:
-        f.write(db_keytabfile)
+def write_keytab(db_keytabname, db_keytabfile):
+    dirfd = None
 
-    await mit_copy(temp_keytab)
-    os.remove(temp_keytab)
+    def opener(path, flags):
+        return os.open(path, flags, mode=0o600, dir_fd=dirfd)
+
+    with suppress(FileExistsError):
+        os.mkdir(kdir, mode=0o700)
+
+    try:
+        dirfd = os.open(kdir, os.O_DIRECTORY)
+        st = os.fstat(dirfd)
+        if stat.S_IMODE(st.st_mode) != 0o700:
+            os.fchmod(dirfd, 0o700)
+
+        with open(db_keytabname, "wb", opener=opener) as f:
+            f.write(db_keytabfile)
+            kt_name = os.readlink(f'/proc/self/fd/{f.fileno()}')
+
+        mit_copy(kt_name)
+        os.remove(db_keytabname, dir_fd=dirfd)
+
+    finally:
+        os.close(dirfd)
 
 
-async def render(service, middleware):
-    keytabs = await middleware.call('kerberos.keytab.query')
+def render(service, middleware):
+    keytabs = middleware.call_sync('kerberos.keytab.query')
     if not keytabs:
         logger.trace('No keytabs in configuration database, skipping keytab generation')
         return
 
     for keytab in keytabs:
         db_keytabfile = base64.b64decode(keytab['file'].encode())
-        db_keytabname = keytab['id']
-        await write_keytab(db_keytabname, db_keytabfile)
+        db_keytabname = f'keytab_{keytab["id"]}'
+        write_keytab(db_keytabname, db_keytabfile)
 
-    with contextlib.suppress(OSError):
+    with suppress(FileNotFoundError):
         os.unlink(keytabfile)
 
     os.rename("/etc/mit_tmp.keytab", keytabfile)


### PR DESCRIPTION
Ensure that temporary keytab files are generated with
0o600 permissions and that directory where they are
created has 0o700 permissions. Generally clean up
this script as well.

Original PR: https://github.com/truenas/middleware/pull/8476
Jira URL: https://jira.ixsystems.com/browse/NAS-115203