### PR TITLE
NAS-114967 / 22.02.1 / add send_event key to datastore plugin (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/write.py
+++ b/src/middlewared/middlewared/plugins/datastore/write.py
@@ -8,6 +8,26 @@ from .filter import FilterMixin
 from .schema import SchemaMixin
 
 
+"""
+By default, when an update/insert/delete operation occurs we will
+emit an event via our event plugin to be processed for the webui.
+This is important, for example, when a new disk is inserted/removed.
+In either of the above scenarios, the webUI will process this event
+and update the front-end accordingly. It negates the front-end having
+to poll the backend (which is expensive). However, on very large
+systems (i.e. systems with 100+ disks) emitting an event can become absurdly
+expensive. This reason why this becomes expensive is because for every
+db operation, we run the plugins associated "query" method. So if we
+update 1000 table entries, then we run "disk.query" 1000 times. In
+real world testing, this has shown to take roughly 82 seconds to update
+100 entries on the `storage_disk` table when there are 641 entries total.
+The database was on a NVMe disk. The solution to this is adding the
+`send_events` key. If this is set to False, then an event will not be
+sent for the db operation. It is the callers responsibility to emit an event
+after all the db operations are complete.
+"""
+
+
 class DatastoreService(Service, FilterMixin, SchemaMixin):
 
     class Config:
@@ -20,6 +40,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
+            Bool('send_events', default=True),
         ),
     )
     async def insert(self, name, data, options):
@@ -53,7 +74,8 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
 
         await self._handle_relationships(pk, relationships)
 
-        await self.middleware.call('datastore.send_insert_events', name, insert)
+        if options['send_events']:
+            await self.middleware.call('datastore.send_insert_events', name, insert)
 
         return pk
 
@@ -65,6 +87,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
+            Bool('send_events', default=True),
         ),
     )
     async def update(self, name, id_or_filters, data, options):
@@ -101,7 +124,8 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             if result.rowcount != 1:
                 raise RuntimeError('No rows were updated')
 
-            await self.middleware.call('datastore.send_update_events', name, id)
+            if options['send_events']:
+                await self.middleware.call('datastore.send_update_events', name, id)
 
         await self._handle_relationships(id, relationships)
 
@@ -156,6 +180,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             'options',
             Bool('ha_sync', default=True),
             Str('prefix', default=''),
+            Bool('send_events', default=True),
         ),
     )
     async def delete(self, name, id_or_filters, options):
@@ -172,8 +197,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             },
         )
 
-        # FIXME: Sending events for batch deletes not implemented yet
-        if not isinstance(id_or_filters, list):
+        if not isinstance(id_or_filters, list) and options['send_events']:
             await self.middleware.call('datastore.send_delete_events', name, id_or_filters)
 
         return True

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -67,7 +67,7 @@ class DiskService(Service, ServiceChangeMixin):
         sys_disks = await self.middleware.call('device.get_disks')
 
         number_of_disks = len(sys_disks)
-        if 0 > number_of_disks <= 25:
+        if number_of_disks <= 25:
             # output logging information to middlewared.log in case we sync disks
             # when not all the disks have been resolved
             log_info = {

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -139,15 +139,16 @@ class DiskService(Service, ServiceChangeMixin):
 
             seen_disks[name] = disk
 
+        qs = None
         for name in sys_disks:
             if name not in seen_disks:
                 disk_identifier = await self.middleware.call('disk.device_to_identifier', name, sys_disks)
-                qs = await self.middleware.call(
-                    'datastore.query', 'storage.disk', [('disk_identifier', '=', disk_identifier)]
-                )
-                if qs:
+                if qs is None:
+                    qs = await self.middleware.call('datastore.query', 'storage.disk')
+
+                if disk := [i for i in qs if i['disk_identifier'] == disk_identifier]:
                     new = False
-                    disk = qs[0]
+                    disk = disk[0]
                 else:
                     new = True
                     disk = {'disk_identifier': disk_identifier}

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -1,12 +1,7 @@
-import logging
-
 import bidict
 
 from middlewared.service import private, Service
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils import osc
-
-logger = logging.getLogger(__name__)
 
 
 class DiskService(Service):
@@ -40,40 +35,26 @@ class DiskService(Service):
                 if vdev["disk"] is not None:
                     disk_to_guid[vdev["disk"]] = vdev["guid"]
                 else:
-                    logger.debug("Pool %r vdev %r disk is None", pool["name"], vdev["guid"])
+                    self.logger.debug("Pool %r vdev %r disk is None", pool["name"], vdev["guid"])
 
         for disk in await self.middleware.call("disk.query", [], {"extra": {"include_expired": True}}):
             guid = disk_to_guid.get(disk["devname"])
             if guid is not None and guid != disk["zfs_guid"]:
-                logger.debug("Setting disk %r zfs_guid %r", disk["identifier"], guid)
+                self.logger.debug("Setting disk %r zfs_guid %r", disk["identifier"], guid)
                 await self.middleware.call(
                     "datastore.update", "storage.disk", disk["identifier"], {"zfs_guid": guid}, {"prefix": "disk_"},
                 )
             elif disk["zfs_guid"]:
                 devname = disk_to_guid.inv.get(disk["zfs_guid"])
                 if devname is not None and devname != disk["devname"]:
-                    logger.debug("Removing disk %r zfs_guid as %r has it", disk["identifier"], devname)
+                    self.logger.debug("Removing disk %r zfs_guid as %r has it", disk["identifier"], devname)
                     await self.middleware.call(
                         "datastore.update", "storage.disk", disk["identifier"], {"zfs_guid": None}, {"prefix": "disk_"},
                     )
 
 
-async def devd_zfs_hook(middleware, data):
-    if data.get("type") in (
-        "sysevent.fs.zfs.config_sync",
-    ):
-        try:
-            await middleware.call("disk.sync_zfs_guid", data["pool"])
-        except MatchNotFound:
-            pass
-
-
 async def zfs_events_hook(middleware, data):
-    event_id = data["class"]
-
-    if event_id in [
-        "sysevent.fs.zfs.config_sync",
-    ]:
+    if data["class"] == "sysevent.fs.zfs.config_sync":
         try:
             await middleware.call("disk.sync_zfs_guid", data["pool"])
         except MatchNotFound:
@@ -85,9 +66,5 @@ async def hook(middleware, pool):
 
 
 async def setup(middleware):
-    if osc.IS_FREEBSD:
-        middleware.register_hook("devd.zfs", devd_zfs_hook)
-    else:
-        middleware.register_hook("zfs.pool.events", zfs_events_hook)
-
+    middleware.register_hook("zfs.pool.events", zfs_events_hook)
     middleware.register_hook("pool.post_create_or_update", hook)


### PR DESCRIPTION
By default, when an update/insert/delete operation occurs we will
emit an event via our event plugin to be processed for the webui.
This is important, for example, when a new disk is inserted/removed.
In either of the above scenarios, the webUI will process this event
and update the front-end accordingly. It negates the front-end having
to poll the backend (which is expensive). However, on very large
systems (i.e. systems with 100+ disks) emitting an event can become absurdly
expensive. This reason why this becomes expensive is because for every
db operation, we run the plugins associated "query" method. So if we
update 1000 table entries, then we run "disk.query" 1000 times. In
real world testing, this has shown to take roughly 82 seconds to update
100 entries on the `storage_disk` table when there are 641 entries total.
The database was on a NVMe disk. The solution to this is adding the
`send_event` key. If this is set to False, then an event will not be
sent for the db operation. It is the callers responsibility to emit an event
after all the db operations are complete.

Original PR: https://github.com/truenas/middleware/pull/8334
Jira URL: https://jira.ixsystems.com/browse/NAS-114967

Original PR: https://github.com/truenas/middleware/pull/8475
Jira URL: https://jira.ixsystems.com/browse/NAS-114967