### PR TITLE
NAS-115211 / 22.02.1 / Remove legacy LDAP truenas_cacerts.pem file (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
@@ -35,7 +35,7 @@
     base 	${ldap['basedn']}
   % if ldap['ssl'] in ('START_TLS', 'ON'):
     ssl 	${ldap['ssl'].lower()}
-    tls_cacert	/etc/ssl/truenas_cacerts.pem
+    tls_cacert	/etc/ssl/certs/ca-certificates.crt
     % if certpath:
     tls_cert	${certpath}
     tls_key	${keypath}

--- a/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
@@ -74,7 +74,7 @@ BASE ${base}
     %endif
 NETWORK_TIMEOUT ${network_timeout}
 TIMEOUT ${timeout}
-TLS_CACERT /etc/ssl/truenas_cacerts.pem
+TLS_CACERT /etc/ssl/certs/ca-certificates.crt
     % if ssl:
         % if tls_certfile:
 TLS_CERT ${tls_certfile}

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -223,7 +223,7 @@ class LDAPClient(Service):
 
         pyldap.set_option(
             pyldap.OPT_X_TLS_CACERTFILE,
-            '/etc/ssl/truenas_cacerts.pem'
+            '/etc/ssl/certs/ca-certificates.crt'
         )
 
         if data['security']['validate_certificates']:


### PR DESCRIPTION
For historical reasons we had single cacert file with manually
concatenated cacerts. Convert LDAP service to use newer
general-purpose one. Also use existing fd for fchmod call.

Original PR: https://github.com/truenas/middleware/pull/8480
Jira URL: https://jira.ixsystems.com/browse/NAS-115211