### PR TITLE
NAS-115215 / 13.0 / Remove pwd and grp lookups from minio etc file (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/minio/configure.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/configure.py
@@ -1,7 +1,6 @@
-import grp
 import os
-import pwd
 import shutil
+from middlewared.plugins.etc import EtcUSR, EtcGRP
 
 
 def render_certificates(s3, middleware):
@@ -24,22 +23,22 @@ def render_certificates(s3, middleware):
         minio_certificate = os.path.join(minio_certpath, "public.crt")
         minio_privatekey = os.path.join(minio_certpath, "private.key")
 
-        minio_uid = pwd.getpwnam('minio').pw_uid
-        minio_gid = grp.getgrnam('minio').gr_gid
+        minio_uid = EtcUSR.MINIO
+        minio_gid = EtcGRP.MINIO
 
         os.makedirs(minio_CApath, mode=0o555, exist_ok=True)
         os.chown(minio_CApath, minio_uid, minio_gid)
         os.chown(minio_path, minio_uid, minio_gid)
 
         with open(minio_certificate, 'w') as f:
+            os.fchown(f.fileno(), minio_uid, minio_gid)
+            os.fchmod(f.fileno(), 0o644)
             f.write(cert['certificate'])
-        os.chown(minio_certificate, minio_uid, minio_gid)
-        os.chmod(minio_certificate, 0o644)
 
         with open(minio_privatekey, 'w') as f:
+            os.fchown(f.fileno(), minio_uid, minio_gid)
+            os.fchmod(f.fileno(), 0o600)
             f.write(cert['privatekey'])
-        os.chown(minio_privatekey, minio_uid, minio_gid)
-        os.chmod(minio_privatekey, 0o600)
 
 
 def render(__, middleware):

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -18,6 +18,7 @@ class EtcUSR(enum.IntEnum):
     ROOT = 0
     UUCP = 66
     NSLCD = 110
+    MINIO = 473
     WEBDAV = 666
 
 
@@ -27,6 +28,7 @@ class EtcGRP(enum.IntEnum):
     UUCP = 66
     NSLCD = 115
     NUT = 126
+    MINIO = 473
     WEBDAV = 666
 
 


### PR DESCRIPTION
Since these IDs should never change, add them to the list of
known values to avoid unnecessary pwd and grp lookups. Also use
fchmod / fchown because we already have an fds for files when
we open them.

Original PR: https://github.com/truenas/middleware/pull/8487
Jira URL: https://jira.ixsystems.com/browse/NAS-115215