### PR TITLE
NAS-115217 / 13.0 / Fix CallError when expanding zpool when there is a pmem device

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/expand.py
+++ b/src/middlewared/middlewared/plugins/pool_/expand.py
@@ -100,7 +100,7 @@ class PoolService(Service):
 
     async def _resize_disk(self, part_data, encrypted_pool, geli_resize):
         partition_number = part_data['partition_number']
-        if not part_data['disk'].startswith(('nvd', 'vtbd')):
+        if not part_data['disk'].startswith(('nvd', 'vtbd', 'pmem')):
             await run('camcontrol', 'reprobe', part_data['disk'])
         await run('gpart', 'recover', part_data['disk'])
         await run('gpart', 'resize', '-a', '4k', '-i', str(partition_number), part_data['disk'])


### PR DESCRIPTION
```
[EFAULT] Command camcontrol reprobe pmem0 failed (code 1):
camcontrol: cam_lookup_pass: CAMGETPASSTHRU ioctl failed cam_lookup_pass:
No such file or directory cam_lookup_pass: either the pass driver isn't in your kernel cam_lookup_pass:or pmem0 doesn't exist.
```

While here, remove `osc` plugin and do general clean-up along with flake8 fixes