### PR TITLE
NAS-114978 / 13.0 / Default to enabling SA-based xattrs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2921,7 +2921,7 @@ class PoolDatasetService(CRUDService):
         Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED']),
         Str('acltype', enum=['NOACL', 'NFS4ACL', 'POSIXACL']),
         Str('share_type', default='GENERIC', enum=['GENERIC', 'SMB']),
-        Str('xattr', enum=['ON', 'SA']),
+        Str('xattr', default='SA', enum=['ON', 'SA']),
         Ref('encryption_options'),
         Bool('encryption', default=False),
         Bool('inherit_encryption', default=True),


### PR DESCRIPTION
This will significantly improve xattr performance and there has not been reports of issues since we added feature to ZoL on FreeBSD.

Original PR: https://github.com/truenas/middleware/pull/8331
Jira URL: https://jira.ixsystems.com/browse/NAS-114978