### PR TITLE
NAS-115218 / 22.02.1 / Avoid writing pool secrets to temp file and use fchmod where possible (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -125,7 +125,7 @@ class SSHKeyPair(KeychainCredentialType):
 
             attributes["private_key"] = (attributes["private_key"].strip()) + "\n"
             with tempfile.NamedTemporaryFile("w+") as f:
-                os.chmod(f.name, 0o600)
+                os.fchmod(f.file.fileno(), 0o600)
 
                 f.write(attributes["private_key"])
                 f.flush()
@@ -153,7 +153,7 @@ class SSHKeyPair(KeychainCredentialType):
             return
 
         with tempfile.NamedTemporaryFile("w+") as f:
-            os.chmod(f.name, 0o600)
+            os.fchmod(f.file.fileno(), 0o600)
 
             f.write(attributes["public_key"])
             f.flush()

--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -26,7 +26,7 @@ class PWEncService(Service):
     def generate_secret(self, reset_passwords=True):
         secret = os.urandom(PWENC_BLOCK_SIZE)
         with open(PWENC_FILE_SECRET, 'wb') as f:
-            os.chmod(PWENC_FILE_SECRET, 0o600)
+            os.fchmod(f.fileno(), 0o600)
             f.write(secret)
         self.reset_secret_cache()
 


### PR DESCRIPTION
This PR converts os.chmod calls to os.fchmod where possible, and
writes the pool encryption secrets to a BytesIO object rather than
a tempfile (since it's only being consumed by shutil.copyfileobj()).

Original PR: https://github.com/truenas/middleware/pull/8491
Jira URL: https://jira.ixsystems.com/browse/NAS-115218