### PR TITLE
NAS-115101 / 22.12 / Enable nscd for hosts

### DIFF
--- a/src/middlewared/middlewared/etc_files/nscd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nscd.conf.mako
@@ -1,0 +1,101 @@
+#
+# /etc/nscd.conf
+#
+# An example Name Service Cache config file.  This file is needed by nscd.
+#
+# WARNING: Running nscd with a secondary caching service like sssd may lead to
+#          unexpected behaviour, especially with how long entries are cached.
+#
+# Legal entries are:
+#
+#	logfile			<file>
+#	debug-level		<level>
+#	threads			<initial #threads to use>
+#	max-threads		<maximum #threads to use>
+#	server-user             <user to run server as instead of root>
+#		server-user is ignored if nscd is started with -S parameters
+#       stat-user               <user who is allowed to request statistics>
+#	reload-count		unlimited|<number>
+#	paranoia		<yes|no>
+#	restart-interval	<time in seconds>
+#
+#       enable-cache		<service> <yes|no>
+#	positive-time-to-live	<service> <time in seconds>
+#	negative-time-to-live   <service> <time in seconds>
+#       suggested-size		<service> <prime number>
+#	check-files		<service> <yes|no>
+#	persistent		<service> <yes|no>
+#	shared			<service> <yes|no>
+#	NOTE: Setting 'shared' to a value of 'yes' will accelerate the lookup,
+#	      but those lookups will not be counted as cache hits
+#	      i.e. 'nscd -g' may show '0%'.
+#	max-db-size		<service> <number bytes>
+#	auto-propagate		<service> <yes|no>
+#
+# Currently supported cache names (services): passwd, group, hosts, services
+#
+<%
+    import os
+    from contextlib import suppress
+
+    with suppress(FileExistsError):
+        os.mkdir("/var/run/nscd", mode=0o755)
+%>\
+
+
+#	logfile			/var/log/nscd.log
+#	threads			4
+#	max-threads		32
+#	server-user		nobody
+#	stat-user		somebody
+	debug-level		0
+#	reload-count		5
+	paranoia		yes
+	restart-interval	3600
+
+	enable-cache		passwd		no
+	positive-time-to-live	passwd		600
+	negative-time-to-live	passwd		20
+	suggested-size		passwd		211
+	check-files		passwd		yes
+	persistent		passwd		yes
+	shared			passwd		yes
+	max-db-size		passwd		33554432
+	auto-propagate		passwd		yes
+
+	enable-cache		group		no
+	positive-time-to-live	group		3600
+	negative-time-to-live	group		60
+	suggested-size		group		211
+	check-files		group		yes
+	persistent		group		yes
+	shared			group		yes
+	max-db-size		group		33554432
+	auto-propagate		group		yes
+
+	enable-cache		hosts		yes
+	positive-time-to-live	hosts		3600
+	negative-time-to-live	hosts		20
+	suggested-size		hosts		211
+	check-files		hosts		yes
+	persistent		hosts		yes
+	shared			hosts		yes
+	max-db-size		hosts		33554432
+
+	enable-cache		services	no
+	positive-time-to-live	services	28800
+	negative-time-to-live	services	20
+	suggested-size		services	211
+	check-files		services	yes
+	persistent		services	yes
+	shared			services	yes
+	max-db-size		services	33554432
+
+	enable-cache		netgroup	no
+	positive-time-to-live	netgroup	28800
+	negative-time-to-live	netgroup	20
+	suggested-size		netgroup	211
+	check-files		netgroup	yes
+	persistent		netgroup	yes
+	shared			netgroup	yes
+	max-db-size		netgroup	33554432

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -249,6 +249,9 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'local/avahi/avahi-daemon.conf', 'checkpoint': None},
             {'type': 'py', 'path': 'local/avahi/avahi_services', 'checkpoint': None}
         ],
+        'nscd': [
+            {'type': 'mako', 'path': 'nscd.conf'},
+        ],
         'wsd': [
             {'type': 'mako', 'path': 'local/wsdd.conf', 'checkpoint': 'post_init'},
         ],

--- a/src/middlewared/middlewared/plugins/network_/global.py
+++ b/src/middlewared/middlewared/plugins/network_/global.py
@@ -316,6 +316,7 @@ class NetworkConfigurationService(ConfigService):
 
         if hostname_changed or domainname_changed or dnssearch_changed or dnsservers_changed:
             await self.middleware.call('service.reload', 'resolvconf')
+            await self.middleware.call('service.reload', 'nscd')
 
             # need to tell the CLI program to reload so it shows the new info
             def reload_cli():

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -10,6 +10,7 @@ from .kubernetes import KubernetesService
 from .mdns import MDNSService
 from .netbios import NetBIOSService
 from .nfs import NFSService
+from .nscd import NSCDService
 from .openvpn_client import OpenVPNClientService
 from .openvpn_server import OpenVPNServerService
 from .rsync import RsyncService
@@ -65,6 +66,7 @@ all_services = [
     MDNSService,
     NetBIOSService,
     NFSService,
+    NSCDService,
     OpenVPNClientService,
     OpenVPNServerService,
     RsyncService,

--- a/src/middlewared/middlewared/plugins/service_/services/nscd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nscd.py
@@ -1,0 +1,10 @@
+from .base import SimpleService
+
+
+class NSCDService(SimpleService):
+    name = "nscd"
+    reloadable = True
+
+    etc = ["nscd"]
+
+    systemd_unit = "nscd"

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -247,16 +247,9 @@ class DSCacheService(PseudoServiceBase):
     name = "dscache"
 
     async def start(self):
-        ldap_enabled = (await self.middleware.call('ldap.config'))['enable']
-        if ldap_enabled:
-            await systemd_unit("nscd", "restart")
-        else:
-            await systemd_unit("nscd", "stop")
-
         await self.middleware.call('dscache.refresh')
 
     async def stop(self):
-        await systemd_unit("nscd", "stop")
         await self.middleware.call('idmap.clear_idmap_cache')
         await self.middleware.call('dscache.refresh')
 


### PR DESCRIPTION
There are some applications with borderline pathlogocial behavior
regarding lookups of hostnames. Enable nscd by default for
hosts, but leave disabled for passwd and group so that its caching
doesn't interfere with winbindd (the duplicate layers of caching
result in undefined behavior).

Actual nscd config is heavily based on default debian nscd config
with the following changes:
- disabling undesired components
- enabling paranoia mode (restarting the nscd service every 60 min