### PR TITLE
NAS-115198 / 13.0 / Reuse fd in etc file generation and run unlink in thread (#8466)

### DIFF
--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -1,14 +1,27 @@
 import os
 
+O_EMPTY_PATH = 0x02000000
+
 
 def write_if_changed(path, data):
+    def opener(in_path_ignored, in_flags_ignored):
+        to_open = path
+        kwargs = {}
+        flags = os.O_CREAT | os.O_RDWR
+
+        if isinstance(path, int):
+            flags = os.O_RDWR | O_EMPTY_PATH
+            to_open = ''
+            kwargs['dir_fd'] = path
+
+        return os.open(to_open, flags, **kwargs)
 
     if isinstance(data, str):
         data = data.encode()
 
     changed = False
 
-    with open(os.open(path, os.O_CREAT | os.O_RDWR), 'wb+') as f:
+    with open(str(path), 'wb+', opener=opener) as f:
         f.seek(0)
         current = f.read()
         if current != data:


### PR DESCRIPTION
This contains a few improvements to permissions management in
etc plugin:

- write_if_changed is updated to allow passing an fd rather than
  only a path name
- permissions check and file contents check are now run from same
  thread.
- permissions are set on file before writing.
- set default permissions on config files to 0644 unless dev
  specifies something different.