### PR TITLE
NAS-115232 / 22.12 / Improve net global

### DIFF
--- a/src/middlewared/middlewared/etc_files/hostname.py
+++ b/src/middlewared/middlewared/etc_files/hostname.py
@@ -4,12 +4,8 @@ from middlewared.service import CallError
 
 
 def render(service, middleware):
-    config = middleware.call_sync("network.configuration.config")
-    hostname = config['hostname_local']
-    if config['domain']:
-        hostname += f'.{config["domain"]}'
+    hostname = middleware.call_sync("network.configuration.config")['hostname_local']
 
-    # write the hostname to the file
     with open("/etc/hostname", "w") as f:
         f.write(hostname)
 

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -293,10 +293,8 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'default/syslog-ng', 'checkpoint': 'pool_import'},
             {'type': 'py', 'path': 'syslogd', 'checkpoint': 'pool_import'},
         ],
-        'hostname': [
-            {'type': 'mako', 'path': 'hosts', 'mode': 0o644},
-            {'type': 'py', 'path': 'hostname', 'checkpoint': 'pre_interface_sync'},
-        ],
+        'hosts': [{'type': 'mako', 'path': 'hosts', 'mode': 0o644, 'checkpoint': 'pre_interface_sync'}],
+        'hostname': [{'type': 'py', 'path': 'hostname', 'checkpoint': 'pre_interface_sync'}],
         'ssh': {
             "ctx": [
                 {'method': 'ssh.config'},

--- a/src/middlewared/middlewared/plugins/network_/global.py
+++ b/src/middlewared/middlewared/plugins/network_/global.py
@@ -295,6 +295,7 @@ class NetworkConfigurationService(ConfigService):
         if lhost_changed:
             await self.middleware.call('etc.generate', 'hostname')
             service_actions.add(('collectd', 'restart'))
+            service_actions.add(('nscd', 'reload'))
 
         if bhost_changed:
             try:
@@ -308,6 +309,7 @@ class NetworkConfigurationService(ConfigService):
         if domainname_changed:
             await self.middleware.call('etc.generate', 'hosts')
             service_actions.add(('collectd', 'restart'))
+            service_actions.add(('nscd', 'reload'))
             if licensed:
                 try:
                     await self.middleware.call('failover.call_remote', 'etc.generate', ['hosts'])
@@ -322,6 +324,7 @@ class NetworkConfigurationService(ConfigService):
         dnsservers_changed = any((dns1_changed, dns2_changed, dns3_changed))
         if dnssearch_changed or dnsservers_changed:
             await self.middleware.call('dns.sync')
+            service_actions.add(('nscd', 'reload'))
             if licensed:
                 try:
                     await self.middleware.call('failover.call_remote', 'dns.sync')

--- a/src/middlewared/middlewared/plugins/network_/global.py
+++ b/src/middlewared/middlewared/plugins/network_/global.py
@@ -251,6 +251,9 @@ class NetworkConfigurationService(ConfigService):
         new_config = config.copy()
         new_config.update(data)
         new_config['service_announcement'] = config['service_announcement'] | data.get('service_announcement', {})
+        if new_config == config:
+            # nothing changed so return early
+            return await self.config()
 
         verrors = await self.validate_general_settings(data, 'global_configuration_update')
 


### PR DESCRIPTION
Many problems fixed:

1. `/etc/hostname` generation should only contain the hostname (not the dns domain name according to man pages)
2. it was taking 7 seconds to change any single item in the `network.globalconfiguration` plugin
3. we were restarting the various service announcement daemons twice (or more) without actually checking what changed
4. we were restarting `collectd` twice or more
5. if you simply click "save" in the webUI (without changing anything) it will still run through this logic which is pointless

With these changes.
1. `/etc/hostname` is properly generated (without the dns domain name)
2. in my testing, changes now take 0.5 to 3 seconds total (instead of 7+)
3. only toggle the service announcement daemons once (if appropriate)
4. only restart collectd once (if appropriate)
5. if nothing changed, then return early