### PR TITLE
NAS-115235 / 22.12 / Restrict job log dir to root

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -577,6 +577,7 @@ class Job:
         if self.logs_path is not None:
             fd = self.logs_fd
             os.makedirs(LOGS_DIR, exist_ok=True)
+            os.chmod(LOGS_DIR, 0o700)
             self.logs_fd = open(self.logs_path, 'ab', buffering=0)
             if fd is not None:
                 fd.close()


### PR DESCRIPTION
Since cron jobs can contain arbitrary output (user scripts), protect job log dir from being world-readable.