### PR TITLE
NAS-115237 / 22.12 / Add better handling for NFS hosts that don't resolve

### DIFF
--- a/src/middlewared/middlewared/alert/source/nfs_host.py
+++ b/src/middlewared/middlewared/alert/source/nfs_host.py
@@ -1,0 +1,11 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class NFSHostnameLookupFailAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "NFS shares reference hosts that could not be resolved"
+    text = "NFS shares refer to the following unresolvable hosts: %(hosts)s"
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -1,4 +1,6 @@
 <%
+    import ipaddress
+    import socket
     from pathlib import Path
 
     def do_map(share, map_type):
@@ -64,7 +66,24 @@
 
         return ','.join(params)
 
+    def parse_host(hostname, gaierrors):
+        try:
+            addr = ipaddress.ip_address(hostname)
+            return addr.compressed
+
+        except ValueError:
+            pass
+
+        try:
+            socket.getaddrinfo(hostname, None)
+        except socket.gaierror:
+            gaierrors.append(hostname)
+            return None
+
+        return hostname
+
     entries = []
+    gaierrors = []
     config = render_ctx["nfs.config"]
     shares = render_ctx["sharing.nfs.query"]
     if not shares:
@@ -87,8 +106,12 @@
             params += ",no_subtree_check" if p.is_mount() else ",subtree_check"
 
             for host in share["hosts"]:
-                options.append(f'{host}({params})')
                 anonymous = False
+                export_host = parse_host(host, gaierrors)
+                if export_host is None:
+                    continue
+
+                options.append(f'{host}({params})')
 
             for network in share["networks"]:
                 options.append(f'{network}({params})')
@@ -97,7 +120,20 @@
             if anonymous:
                 options.append(f'*({params})')
 
+            if not options:
+                # this may happen if no hosts resolve
+                continue
+
             entries.append({"path": path, "options": options})
+
+    if gaierrors:
+        middleware.call_sync(
+            'alert.oneshot_create',
+            'NFSHostnameLookupFail',
+            {'hosts': ', '.join(gaierrors)}
+        )
+    else:
+        middleware.call_sync('alert.oneshot_delete', 'NFSHostnameLookupFail', None)
 
     if not entries:
         raise FileShouldNotExist()

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -142,7 +142,7 @@ class EtcService(Service):
                 {'type': 'mako', 'path': 'default/nfs-kernel-server'},
                 {'type': 'mako', 'path': 'default/rpcbind'},
                 {'type': 'mako', 'path': 'idmapd.conf'},
-                {'type': 'mako', 'path': 'exports'},
+                {'type': 'mako', 'path': 'exports', 'checkpoint': 'interface_sync'},
             ]
         },
         'pam': {

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -540,15 +540,19 @@ class SharingNFSService(SharingService):
                     used_networks.add(ipaddress.ip_network("::/0"))
 
         for host in set(data["hosts"]):
-            host = dns_cache[host]
-            if host is None:
+            cached_host = dns_cache[host]
+            if cached_host is None:
+                verrors.add(
+                    f"{schema_name}.hosts",
+                    f"Unable to resolve host {host}"
+                )
                 continue
 
-            network = ipaddress.ip_network(host)
+            network = ipaddress.ip_network(cached_host)
             if network in used_networks:
                 verrors.add(
                     f"{schema_name}.hosts",
-                    f"Another NFS share already exports this dataset for {host}"
+                    f"Another NFS share already exports this dataset for {cached_host}"
                 )
 
             used_networks.add(network)


### PR DESCRIPTION
Raise a ValidationError if a hostname doesn't resolve during
share creation or update.

Omit export line when generating exports and generate an alert
if hostname cannot be resolved.