### PR TITLE
NAS-115177 / 22.12 / Fix broken SSH on fresh installs

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/ssh/config.py
+++ b/src/middlewared/middlewared/etc_files/local/ssh/config.py
@@ -25,7 +25,6 @@ def generate_ssh_config(middleware, ssh_config, dirfd):
         return os.open(path, flags, mode=mode, dir_fd=dirfd)
 
     for k in SSH_KEYS:
-        must_remove = True
         s_key = re.sub(r'([.-])', '_', k).replace('ssh_', '', 1)
         if ssh_config[s_key]:
             decoded_key = base64.b64decode(ssh_config[s_key])
@@ -60,11 +59,6 @@ def generate_ssh_config(middleware, ssh_config, dirfd):
                         os.fchown(f.fileno(), 0, 0)
 
                     f.write(decoded_key)
-                    must_remove = False
-
-        if must_remove:
-            with suppress(FileNotFoundError):
-                os.remove(os.path.join(SSH_CONFIG_PATH, k))
 
     expected_files = SSH_KEYS + DEFAULT_FILES
     with os.scandir(dirfd) as entries:


### PR DESCRIPTION
The changes I made to make sure we don't have things in the
SSH dir that shouldn't be there was overly aggressive and
on first boot of server on fresh install would remove the
keys before they were written to the DB.