### PR TITLE
NAS-114851 / 22.12 / Do not start exim4 service automatically

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -71,8 +71,8 @@ done
 systemctl daemon-reload
 systemctl enable zfs-zed
 
-# We need to mask libvirtd related sockets so that they don't start automatically
-systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
+# We need to mask libvirtd related sockets and other services so that they don't start automatically
+systemctl mask exim4.service libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 
 systemctl set-default truenas.target
 


### PR DESCRIPTION
### Problem
Exim4 package getting installed as a sub-dependency of certain python packages, and starts by default as generally expected, and fails while startup.

### Inspection
Exim4 is not used by scale.

### Solution
Do not start exim4 service automatically
- Disabling exim4 service still not fixing the issue as it gets started after rebooting.
- Masking exim4 blocks it even after rebooting.