### PR TITLE
NAS-115249 / 22.12 / Fix regression in clusterjobs

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -134,14 +134,11 @@ class ClusterJob(Service):
             'is_job': is_job,
             'status': CLStatus.ACTIVE.name
         }
-
         await self.wait_for_method(job, method, 10)
-        nodes = await self.middleware.call('ctdb.general.status')
-
-        job.set_progress(50, f'Setting job status indicator for nodes {", ".join([node["pnn"] for node in nodes])!r}')
-        for node in nodes:
+        for node in await self.middleware.call('ctdb.general.status'):
             if node['this_node'] or node['pnn'] == -1:
                 continue
+            job.set_progress(50, f'Setting job status indicator for node {node["address"]!r}')
             key = f'CLJOB_{method}_{node["pnn"]}'
             await self.middleware.call('clustercache.put', key, payload, timeout)
 

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -57,8 +57,7 @@ class ClusterJob(Service):
     @periodic(3600)
     @job(lock="queue_lock", transient=True)
     async def process_queue(self, job):
-        gl_enabled = (await self.middleware.call('service.query', [('service', '=', 'glusterd')], {'get': True}))['enable']
-        if not gl_enabled:
+        if not (await self.middleware.call('service.query', [('service', '=', 'glusterd')], {'get': True}))['enable']:
             return
 
         node = (await self.middleware.call('ctdb.general.status', {'all_nodes': False}))[0]


### PR DESCRIPTION
71e799bfbde91aaec1faba2b495c069b2adbdbe0 introduced a regression which prevents clustering from working

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 423, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 459, in __run_body
    rv = await self.method(*([self] + args))
  File "/usr/lib/python3/dist-packages/middlewared/plugins/cluster_linux/ctdb_job.py", line 142, in submit
    job.set_progress(50, f'Setting job status indicator for nodes {", ".join([node["pnn"] for node in nodes])!r}')
TypeError: sequence item 0: expected str instance, int found