### PR TITLE
NAS-115095 / 22.02.1 / Retrieve complete list of valid timezones (by Qubad786)

### DIFF
--- a/tests/api2/test_490_system_general.py
+++ b/tests/api2/test_490_system_general.py
@@ -2,6 +2,9 @@
 # License: BSD
 
 import pytest
+
+from middlewared.test.integration.utils import call, ssh
+
 import sys
 import os
 from pytest_dependency import depends
@@ -79,3 +82,13 @@ def test_10_Checking_sysloglevel_using_api():
     assert results.status_code == 200, results.text
     data = results.json()
     assert data['sysloglevel'] == SYSLOGLEVEL
+
+
+def test_11_timezone_choices():
+    timezones_dic = call('system.general.get_timezone_choices')
+    result = ssh('timedatectl list-timezones')
+    missing = []
+    for timezone in filter(bool, result.split('\n')):
+        if not timezones_dic.get(timezone):
+            missing.append(timezone)
+    assert missing == []


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b8b816611c7b7d04d5c183a29d668272d6303267

### Background
In TrueNAS SCALE, some timezone-related files are symlinked, so these are missed by `find` command when used without follow argument.

### Solution
Updating `find` command arguments with follow.


Original PR: https://github.com/truenas/middleware/pull/8514
Jira URL: https://jira.ixsystems.com/browse/NAS-115095