### PR TITLE
NAS-115185 / 22.02.1 / Get correct stats path for ups service when configured in slave mode (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -375,7 +375,13 @@ class UPSBase:
             files = os.listdir(remote_host)
             if not any(f.endswith('.rrd') for f in files):
                 remote_host = next(
-                    (f for f in map(lambda f: os.path.join(remote_host, f), files) if os.path.isdir(f)), remote_host
+                    (
+                        f for f in sorted(
+                            filter(os.path.isdir, map(lambda f: os.path.join(remote_host, f), files)),
+                            key=lambda f: os.path.getmtime(f), reverse=True
+                        )
+                    ),
+                    remote_host
                 )
             return remote_host
         else:

--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -371,7 +371,13 @@ class UPSBase:
     def _base_path(self):
         ups_config = self.middleware.call_sync('ups.config')
         if ups_config['mode'] == 'SLAVE':
-            return os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
+            remote_host = os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
+            files = os.listdir(remote_host)
+            if not any(f.endswith('.rrd') for f in files):
+                remote_host = next(
+                    (f for f in map(lambda f: os.path.join(remote_host, f), files) if os.path.isdir(f)), remote_host
+                )
+            return remote_host
         else:
             return super()._base_path
 


### PR DESCRIPTION
For a user we are seeing where when ups is configured in slave mode, we don't have his stats living at '/var/db/collectd/rrd/remotehost_ip_here` and instead we have a directory named after master's driver.

Original PR: https://github.com/truenas/middleware/pull/8535
Jira URL: https://jira.ixsystems.com/browse/NAS-115185