### PR TITLE
NAS-115231 / 22.02.1 / fix regression in zfs.pool.get_disks (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1037,13 +1037,10 @@ class PoolService(CRUDService):
         Get all disks in use by pools.
         If `id` is provided only the disks from the given pool `id` will be returned.
         """
-        filters = []
         disks = []
-        if oid:
-            filters.append(('id', '=', oid))
-        for pool in await self.query(filters):
+        for pool in await self.middleware.call('pool.query', [] if not oid else [('id', '=', oid)]):
             if pool['is_decrypted'] and pool['status'] != 'OFFLINE':
-                disks.extend(list(await self.middleware.call('zfs.pool.get_disks', pool['name'])))
+                disks.extend(await self.middleware.call('zfs.pool.get_disks', pool['name']))
         return disks
 
     @item_method

--- a/src/middlewared/middlewared/plugins/zfs_/disks.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks.py
@@ -11,23 +11,23 @@ class ZFSPoolService(Service):
         process_pool = True
 
     def get_disks(self, name):
-        disks = self.middleware.call_sync('zfs.pool.get_devices', name)
-        mapping = {}
-        for dev in filter(
-            lambda d: not d.sys_name.startswith('sr') and d.get('DEVTYPE') in ('disk', 'partition'),
-            pyudev.Context().list_devices(subsystem='block')
-        ):
-            if dev['DEVTYPE'] == 'disk':
-                mapping[dev.sys_name] = dev.sys_name
+        sys_devices = {}
+        for dev in pyudev.Context().list_devices(subsystem='block'):
+            if dev.sys_name.startswith('sr') or dev.properties['DEVTYPE'] not in ('disk', 'partition'):
+                continue
 
-            for link in (dev.get('DEVLINKS') or '').split():
-                mapping[link[len('/dev/'):]] = dev.sys_name
+            # this is "sda/sda1/sda2/sda3" etc
+            sys_devices[dev.sys_name] = dev.sys_name
 
-        pool_disks = []
-        for dev in disks:
-            # dev can be partition name ( sdb1/sda2 etc ) or raw uuid ( disk/by-partuuid/uuid )
-            if dev in mapping:
-                pool_disks.append(mapping[dev])
-            else:
-                self.logger.debug(f'Could not find disk for {dev}')
-        return pool_disks
+            # this is the various "disk/by-partuuid" or "disk/by-label" or "disk/by-id" etc
+            for link in (dev.properties['DEVLINKS'] or '').split():
+                sys_devices[link.removeprefix('/dev/')] = dev.sys_name
+
+        mapping = {name: set()}
+        for disk in self.middleware.call_sync('zfs.pool.get_devices', name):
+            try:
+                mapping[name].add(sys_devices[disk])
+            except KeyError:
+                continue
+
+        return list(mapping[name])

--- a/tests/api2/test_009_pool.py
+++ b/tests/api2/test_009_pool.py
@@ -124,7 +124,7 @@ def test_08_get_pool_disks(request, pool_data):
     payload = {'msg': 'method', 'method': 'pool.get_disks', 'params': [pool_data['id']]}
     res = make_ws_request(ip, payload)
     assert isinstance(res['result'], list), res
-    assert res['result'] and res['result'] == tank_disk_pool, res
+    assert res['result'] and (set(res['result']) == set(tank_disk_pool)), res
 
 
 def test_09_get_pool_id_info(request, pool_data):

--- a/tests/api2/test_090_boot.py
+++ b/tests/api2/test_090_boot.py
@@ -7,6 +7,7 @@ import pytest
 import sys
 import os
 from time import time, sleep
+from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET
@@ -15,14 +16,18 @@ from auto_config import dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
 
+@pytest.mark.dependency(name='BOOT_DISKS')
 def test_01_get_boot_disks():
     results = GET('/boot/get_disks/')
     assert results.status_code == 200, results.text
     disks = results.json()
     assert isinstance(disks, list) is True, results.text
+    assert disks, results.text
 
 
-def test_02_get_boot_state():
+@pytest.mark.dependency(name='BOOT_STATE')
+def test_02_get_boot_state(request):
+    depends(request, ['BOOT_DISKS'])
     results = GET('/boot/get_state/')
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict) is True, results.text
@@ -30,7 +35,9 @@ def test_02_get_boot_state():
     boot_state = results.json()
 
 
+@pytest.mark.dependency(name='BOOT_SCRUB')
 def test_03_get_boot_scrub():
+    depends(request, ['BOOT_STATE'])
     global JOB_ID
     results = GET('/boot/scrub/')
     assert results.status_code == 200, results.text
@@ -39,6 +46,7 @@ def test_03_get_boot_scrub():
 
 
 def test_04_verify_boot_scrub_job():
+    depends(request, ['BOOT_SCRUB'])
     stop_time = time() + 600
     while True:
         get_job = GET(f'/core/get_jobs/?id={JOB_ID}')

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -134,6 +134,7 @@ ntpServer = "10.20.20.122"
 localHome = "{localHome}"
 keyPath = "{keyPath}"
 pool_name = "tank"
+ha_pool_name = "ha"
 ha = {ha}
 update = {update}
 dev_test = {dev_test}


### PR DESCRIPTION
Fix many things:

1. `pyudev` gives this warning when accessing `DEVTYPE` directly `<stdin>:4: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.`
2. our "integration" tests for testing `boot.get_disks` were bad
3. our "integration" tests for creating zpools didn't test the "pool.get_disks" method which is how this regression got in

Original PR: https://github.com/truenas/middleware/pull/8551
Jira URL: https://jira.ixsystems.com/browse/NAS-115231