### PR TITLE
NAS-115345 / 22.02.1 / fix failover.call_remote (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/client/__init__.py
+++ b/src/middlewared/middlewared/client/__init__.py
@@ -1,1 +1,1 @@
-from .client import Client, ClientException, CallTimeout, ValidationErrors, ErrnoMixin  # NOQA
+from .client import Client, ClientException, CallTimeout, ValidationErrors, ErrnoMixin, CALL_TIMEOUT  # NOQA

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -233,7 +233,7 @@ class FailoverService(Service):
         Call a method in the other node.
         """
         options = options or {}
-        if options.get('job') and options.pop('job_return'):
+        if options.pop('job_return'):
             options['job'] = 'RETURN'
         try:
             return self.CLIENT.call(method, *args, **options)

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict
 from functools import partial
 
-from middlewared.client import Client, ClientException, CallTimeout
+from middlewared.client import Client, ClientException, CallTimeout, CALL_TIMEOUT
 from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Str, returns
 from middlewared.service import CallError, Service, job, private
 from middlewared.utils import start_daemon_thread
@@ -221,10 +221,10 @@ class FailoverService(Service):
         List('args'),
         Dict(
             'options',
-            Int('timeout'),
+            Int('timeout', default=CALL_TIMEOUT),
             Bool('job', default=False),
             Bool('job_return', default=None, null=True),
-            Any('callback'),
+            Any('callback', default=None, null=True),
         ),
     )
     @returns(Any(null=True))
@@ -233,8 +233,7 @@ class FailoverService(Service):
         Call a method in the other node.
         """
         options = options or {}
-        job_return = options.get('job_return')
-        if job_return is not None:
+        if options.get('job') and options.pop('job_return'):
             options['job'] = 'RETURN'
         try:
             return self.CLIENT.call(method, *args, **options)


### PR DESCRIPTION
d10a13e1f8b8e54b919cd4edb46de520fb2dae22 introduced changes to fail if an unknown kwarg was passed to it which broke `failover.call_remote`. This should fix it.

Original PR: https://github.com/truenas/middleware/pull/8569
Jira URL: https://jira.ixsystems.com/browse/NAS-115345