### PR TITLE
NFS server: do not squash root by default

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -58,6 +58,8 @@
 
         if maproot:
             params.extend(maproot)
+        else:
+            params.append("no_root_squash")
 
         if config['allow_nonroot']:
             params.append("insecure")


### PR DESCRIPTION
Hi there,

thank you very much for bringing TrueNAS Scale to live - it really is amazing!

Since the official release of TrueNAS Scale, we noticed that there is no way to allow root access to an NFS share anymore (compared to RC2).
With NFS Ganesha, the default was to not squash root if not explicitly requested:
https://github.com/truenas/middleware/blob/e830ba3de32d8f263a6b4e468e5be357eacaca82/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako#L164-L166
This PR attempts to recreate this exact behavior to again allow "no_root_squash" access to exports :)

(Please let me know if I need to open an issue somewhere else prior to this PR - on first sight, I did not see such a platform.)

Best,
phpfs

P.S.: Could this be potentially included in 22.02.01 please?