### PR TITLE
NAS-115355 / 22.12 / fix test_400_service.py

### DIFF
--- a/tests/api2/test_400_enable_disable_services.py
+++ b/tests/api2/test_400_enable_disable_services.py
@@ -17,31 +17,21 @@ service_names = list(all_services.keys())
 
 @pytest.mark.dependency(name='ENABLE')
 @pytest.mark.parametrize('svc', service_names)
-def test_01_enable_service(svc):
+def test_01_enable_and_verify_service(svc):
     results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': True})
     assert results.status_code == 200, results.text
 
-
-@pytest.mark.dependency(name='VERIFY_ENABLE')
-@pytest.mark.parametrize('svc', service_names)
-def test_02_verify_service_was_enabled(svc, request):
-    depends(request, ['ENABLE'])
     results = GET(f'/service/id/{all_services[svc]["id"]}/')
     assert results.status_code == 200, results.text
     assert results.json()['enable'], results.text
 
 
-@pytest.mark.dependency(name='DISABLE')
 @pytest.mark.parametrize('svc', service_names)
-def test_03_disable_service(svc, request):
-    depends(request, ['VERIFY_ENABLE'])
+def test_02_disable_and_verify_service(svc, request):
+    depends(request, ['ENABLE'])
     results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': False})
     assert results.status_code == 200, results.text
 
-
-@pytest.mark.parametrize('svc', service_names)
-def test_04_verify_service_was_disabled(svc, request):
-    depends(request, ['DISABLE'])
     results = GET(f'/service/id/{all_services[svc]["id"]}/')
     assert results.status_code == 200, results.text
     assert not results.json()['enable'], results.text

--- a/tests/api2/test_400_service.py
+++ b/tests/api2/test_400_service.py
@@ -1,83 +1,45 @@
 #!/usr/bin/env python3
 
-# Author: Eric Turgeon
-# License: BSD
-
 import pytest
 import sys
 import os
-from time import sleep
+from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import GET, POST, PUT
-from auto_config import ha, dev_test
+from functions import GET, PUT
+from auto_config import dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
-services = ['cifs', 'iscsitarget', 'snmp', 'rsync']
+all_services = {i['service']: i for i in GET('/service').json()}
 
-all_services = []
-for service in GET('/service/', controller_a=ha).json():
-    all_services.append(service['id'])
-
-
-@pytest.fixture(scope='module')
-def services_list():
-    return {}
-
-
-def test_01_service_query():
-    results = GET('/service/')
-    assert results.status_code == 200, results.text
-    assert isinstance(results.json(), list) is True
-
-
-@pytest.mark.parametrize('svc', all_services)
-def test_02_get_service_info_for(svc, services_list):
-    results = GET(f'/service/id/{svc}/')
-    assert results.status_code == 200, results.text
-    services_list[svc] = results.json()
-
-
-@pytest.mark.parametrize('svc', all_services)
-def test_03_service_update(svc, services_list):
-    payload = {'enable': services_list[svc]['enable']}
-    results = PUT(f'/service/id/{svc}/', payload)
+@pytest.mark.dependency(name='ENABLE')
+@pytest.mark.parametrize('svc', list(all_services.keys()))
+def test_01_enable_service(svc):
+    results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': True})
     assert results.status_code == 200, results.text
 
 
-@pytest.mark.parametrize('svc', all_services)
-def test_04_looking_service_enable(svc, services_list):
-    results = GET(f'/service/id/{svc}/')
+@pytest.mark.dependency(name='VERIFY_ENABLE')
+@pytest.mark.parametrize('svc', list(all_services.keys()))
+def test_02_verify_service_was_enabled(svc, request):
+    depends(request, ['ENABLE'])
+    results = GET(f'/service/id/{all_services[svc]["id"]}/')
     assert results.status_code == 200, results.text
-    assert results.json()['enable'] == services_list[svc]['enable'], results.text
+    assert results.json()['enable'], results.text
 
 
-@pytest.mark.parametrize('svc', services)
-def test_05_start_service(svc):
-    results = POST('/service/start/', {'service': svc})
+@pytest.mark.dependency(name='DISABLE')
+@pytest.mark.parametrize('svc', list(all_services.keys()))
+def test_03_disable_service(svc, request):
+    depends(request, ['VERIFY_ENABLE'])
+    results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': False})
     assert results.status_code == 200, results.text
-    assert results.json() is True, results.text
-    sleep(1)
 
 
-@pytest.mark.parametrize('svc', services)
-def test_06_looking_if_service_is_running(svc):
-    results = GET(f'/service/?service={svc}')
+@pytest.mark.parametrize('svc', list(all_services.keys()))
+def test_04_verify_service_was_disabled(svc, request):
+    depends(request, ['DISABLE'])
+    results = GET(f'/service/id/{all_services[svc]["id"]}/')
     assert results.status_code == 200, results.text
-    assert results.json()[0]['state'] == 'RUNNING', results.text
-
-
-@pytest.mark.parametrize('svc', services)
-def test_07_service_stop(svc):
-    results = POST('/service/stop/', {'service': svc})
-    assert results.status_code == 200, results.text
-    assert results.json() is False, results.text
-    sleep(1)
-
-
-@pytest.mark.parametrize('svc', services)
-def test_08_looking_if_service_is_stopped(svc):
-    results = GET(f'/service/?service={svc}')
-    assert results.status_code == 200, results.text
-    assert results.json()[0]['state'] == 'STOPPED', results.text
+    assert not results.json()['enable'], results.text

--- a/tests/api2/test_400_service.py
+++ b/tests/api2/test_400_service.py
@@ -12,16 +12,18 @@ from auto_config import dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
 all_services = {i['service']: i for i in GET('/service').json()}
+service_names = list(all_services.keys())
+
 
 @pytest.mark.dependency(name='ENABLE')
-@pytest.mark.parametrize('svc', list(all_services.keys()))
+@pytest.mark.parametrize('svc', service_names)
 def test_01_enable_service(svc):
     results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': True})
     assert results.status_code == 200, results.text
 
 
 @pytest.mark.dependency(name='VERIFY_ENABLE')
-@pytest.mark.parametrize('svc', list(all_services.keys()))
+@pytest.mark.parametrize('svc', service_names)
 def test_02_verify_service_was_enabled(svc, request):
     depends(request, ['ENABLE'])
     results = GET(f'/service/id/{all_services[svc]["id"]}/')
@@ -30,14 +32,14 @@ def test_02_verify_service_was_enabled(svc, request):
 
 
 @pytest.mark.dependency(name='DISABLE')
-@pytest.mark.parametrize('svc', list(all_services.keys()))
+@pytest.mark.parametrize('svc', service_names)
 def test_03_disable_service(svc, request):
     depends(request, ['VERIFY_ENABLE'])
     results = PUT(f'/service/id/{all_services[svc]["id"]}/', {'enable': False})
     assert results.status_code == 200, results.text
 
 
-@pytest.mark.parametrize('svc', list(all_services.keys()))
+@pytest.mark.parametrize('svc', service_names)
 def test_04_verify_service_was_disabled(svc, request):
     depends(request, ['DISABLE'])
     results = GET(f'/service/id/{all_services[svc]["id"]}/')


### PR DESCRIPTION
1. The test results printed the service id (an integer) instead of the service name.  Now it prints service name
(i.e. `api2/test_400_service.py::test_02_get_service_info_for[4] PASSED` to `api2/test_400_service.py::test_01_enable_service[cifs] PASSED`)
2. It chose (randomly) 4 services to actually start which doesn't make much sense so I removed that because
`cifs` is handled in the `test_420_smb.py` script
`iscsitarget` is handled in the `test_260_iscsi.py` script
`snmp` is handled in the `test_440_snmp.py` script
`rsync` is handled in the `test_380_rsync.py` script
3. dramatically simplify the file and remove unnecessary code
4. rename this to `test_400_enable_disable_services.py` since that's what it's actually doing