### PR TITLE
NAS-115356 / 22.02.1 / Disable root squashing in export config on demand (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -1,6 +1,13 @@
 <%
     from pathlib import Path
 
+    map_ids = {
+        'maproot_user': -1,
+        'maproot_group': -1,
+        'mapall_user': -1,
+        'mapall_group': -1,
+    }
+
     def do_map(share, map_type):
         output = []
         if share[f'{map_type}_user']:
@@ -8,6 +15,7 @@
                 'user.get_user_obj',
                 {'username': share[f'{map_type}_user']}
             )['pw_uid']
+            map_ids[f'{map_type}_user'] = uid
             output.append(f'anonuid={uid}')
 
         if share[f'{map_type}_group']:
@@ -15,12 +23,14 @@
                 'group.get_group_obj',
                 {'groupname': share[f'{map_type}_group']}
             )['gr_gid']
+            map_ids[f'{map_type}_group'] = gid
             output.append(f'anongid={gid}')
 
         return output
 
     def generate_options(share, global_sec, config):
         params = []
+
         all_squash = False
         if share["security"]:
             sec = f'sec={":".join(share["security"])}'
@@ -58,6 +68,9 @@
 
         if maproot:
             params.extend(maproot)
+
+        if map_ids['maproot_user'] == 0 and map_ids['maproot_group'] == 0:
+            params.append('no_root_squash')
 
         if config['allow_nonroot']:
             params.append("insecure")


### PR DESCRIPTION
If user has specified that they want to set anonuid and anongid to id 0, then disable root squashing explicitly.

Original PR: https://github.com/truenas/middleware/pull/8580
Jira URL: https://jira.ixsystems.com/browse/NAS-115356