### PR TITLE
NAS-115367 / 22.02.1 / fix test_400_enable_disable_services on HA (by yocalebo)

### DIFF
--- a/tests/api2/test_400_enable_disable_services.py
+++ b/tests/api2/test_400_enable_disable_services.py
@@ -7,11 +7,11 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, PUT
-from auto_config import dev_test
+from auto_config import dev_test, ha
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
-all_services = {i['service']: i for i in GET('/service').json()}
+all_services = {i['service']: i for i in GET('/service', controller_a=ha).json()}
 service_names = list(all_services.keys())
 
 


### PR DESCRIPTION
Sigh....the way this was designed with our HA api tests is basically like running through a minefield. It's not easily decipherable on whether or not fixing non-HA API tests are going to break HA API tests and vice-versa.

This is failing because we're calling `GET` at module import time which is failing because it's trying to use the VIP of the HA machine but because the previous API tests haven't been run, the VIP hasn't been configured on the VM, yet so this non-intuitively tells the `GET` request to use the physical IP address of controller_a instead of the VIP.....

Original PR: https://github.com/truenas/middleware/pull/8586
Jira URL: https://jira.ixsystems.com/browse/NAS-115367