### PR TITLE
NAS-115374 / 22.12 / Do not report coredumps generated in containers

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -24,11 +24,12 @@ class CoreFilesArePresentAlertSource(AlertSource):
         "/usr/sbin/smartctl",
     )
     ignore_units = (
-        # Unit: "containerd.service" is related to k3s.
+        # Unit: "containerd.service"/"docker.service" is related to k3s.
         # users are free to run whatever they would like to in containers
         # and we don't officially support all the apps themselves so we
         # ignore those core dumps
         "containerd.service",
+        "docker.service",
         # Unit: "syslog-ng.service" has been core dumping for, literally, years
         # on freeBSD and now also on linux. The fix is non-trivial and it seems
         # to be very specific to how we implemented our system dataset. Anyways,


### PR DESCRIPTION
Example coredump payload:
```
{
    "time": "Fri Mar 18 19:43:03 2022",
    "pid": 2668312,
    "uid": 568,
    "gid": 0,
    "unit": "docker.service",
    "sig": 3,
    "exe": "/opt/bitnami/redis/bin/redis-cli",
    "corefile": "missing"
  }
```