### PR TITLE
NAS-115222 / 22.12 / Explicitly ask for web port for Display devices

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-03-19_20-20_display_devices.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-03-19_20-20_display_devices.py
@@ -1,0 +1,47 @@
+"""
+Normalize VM Display Device Port(s)
+
+Revision ID: d46d345ef8a8
+Revises: 0b02e21a1a10
+Create Date: 2022-03-19 20:20:11.823446+00:00
+
+"""
+import json
+
+from alembic import op
+
+
+revision = 'd46d345ef8a8'
+down_revision = '0b02e21a1a10'
+branch_labels = None
+depends_on = None
+
+
+def get_web_port(port):
+    split_port = int(str(port)[:2]) - 1
+    return int(str(split_port) + str(port)[2:])
+
+
+def upgrade():
+    conn = op.get_bind()
+    # ensure vnc port
+
+    display_devices = {
+        row['id']: json.loads(row['attributes'])
+        for row in map(dict, conn.execute("SELECT * FROM vm_device WHERE dtype = 'DISPLAY'").fetchall())
+    }
+    reserved_ports = [d['port'] for d in display_devices.values()] + [6000]
+
+    for display_id, display_device in display_devices.items():
+        web_port = get_web_port(display_device['port'])
+        while web_port in reserved_ports:
+            web_port += 1
+        display_device['web_port'] = web_port
+        reserved_ports.append(web_port)
+        conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (
+            json.dumps(display_device), display_id
+        ))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-03-28_20-20_display_devices.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-03-28_20-20_display_devices.py
@@ -2,8 +2,8 @@
 Normalize VM Display Device Port(s)
 
 Revision ID: d46d345ef8a8
-Revises: 0b02e21a1a10
-Create Date: 2022-03-19 20:20:11.823446+00:00
+Revises: 696b3d876084
+Create Date: 2022-03-28 20:20:11.823446+00:00
 
 """
 import json
@@ -12,7 +12,7 @@ from alembic import op
 
 
 revision = 'd46d345ef8a8'
-down_revision = '0b02e21a1a10'
+down_revision = '696b3d876084'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -22,6 +22,7 @@ class DISPLAY(Device):
         'attributes',
         Str('resolution', enum=RESOLUTION_ENUM, default='1024x768'),
         Int('port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
+        Int('web_port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
         Str('bind', default='0.0.0.0'),
         Bool('wait', default=False),
         Str('password', default=None, null=True, private=True),
@@ -86,15 +87,10 @@ class DISPLAY(Device):
             ]
         })
 
-    @staticmethod
-    def get_web_port(port):
-        split_port = int(str(port)[:2]) - 1
-        return int(str(split_port) + str(port)[2:])
-
     def get_start_attrs(self):
         port = self.data['attributes']['port']
         bind = self.data['attributes']['bind']
-        web_port = self.get_web_port(port)
+        web_port = self.data['attributes']['web_port']
         return {
             'web_bind': f':{web_port}' if bind == '0.0.0.0' else f'{bind}:{web_port}',
             'server_addr': f'{bind}:{port}'
@@ -119,5 +115,5 @@ class DISPLAY(Device):
             'id': self.data['id'],
             'path': f'{NGINX_PREFIX}/{self.data["id"]}/',
             'redirect_uri': f'{self.data["attributes"]["bind"]}:'
-                            f'{self.get_web_port(self.data["attributes"]["port"])}',
+                            f'{self.data["attributes"]["web_port"]}',
         }

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -452,7 +452,7 @@ class VMDeviceService(CRUDService):
                 await self.validate_display_devices(verrors, vm_instance)
 
             all_ports = await self.middleware.call(
-                'vm.device.all_used_display_device_ports', [['id', '!=', device.get('id')]]
+                'vm.all_used_display_device_ports', [['id', '!=', device.get('id')]]
             )
             new_ports = list((await self.middleware.call('vm.port_wizard')).values())
             for key in ('port', 'web_port'):


### PR DESCRIPTION
Right now we have some magic to determine display device client/web port via server port. This PR adds changes to be explicit about it and let the user configure a specific port if he/she desires.