### PR TITLE
NAS-115329 / 13.0 / rate limit and add settle time to disk events

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -2,16 +2,20 @@ import asyncio
 
 DISK = ('da', 'ada', 'vtbd', 'mfid', 'nvd', 'pmem')
 SHELF = ('ses',)
+TYPES = ('CREATE', 'DESTROY')
 PREVIOUS = {'method': '', 'task': None}
 MAX_WAIT_TIME = 60
-SETTLE_TIME = 2
+SETTLE_TIME = 5
 LAST_EVENT_TIME = None
 
 
 async def reset_cache(middleware, *args):
     await middleware.call('geom.cache.invalidate')
     await (await middleware.call('disk.sync_all')).wait()
-    await middleware.call('sed_unlock_all')
+    await middleware.call('disk.sed_unlock_all')
+    global PREVIOUS
+    PREVIOUS['method'] = ''
+    PREVIOUS['task'] = None
 
 
 async def added_disk(middleware, disk_name):
@@ -20,6 +24,9 @@ async def added_disk(middleware, disk_name):
     await middleware.call('disk.sed_unlock', disk_name)
     await middleware.call('disk.multipath_sync')
     await middleware.call('alert.oneshot_delete', 'SMART', disk_name)
+    global PREVIOUS
+    PREVIOUS['method'] = ''
+    PREVIOUS['task'] = None
 
 
 async def remove_disk(middleware, disk_name):
@@ -30,10 +37,13 @@ async def remove_disk(middleware, disk_name):
     # If a disk dies we need to reconfigure swaps so we are not left
     # with a single disk mirror swap, which may be a point of failure.
     asyncio.ensure_future(middleware.call('disk.swaps_configure'))
+    global PREVIOUS
+    PREVIOUS['method'] = ''
+    PREVIOUS['task'] = None
 
 
 async def devd_devfs_hook(middleware, data):
-    if data.get('subsystem') != 'CDEV' or data['type'] not in ('CREATE', 'DESTROY'):
+    if data.get('subsystem') != 'CDEV' or data['type'] not in TYPES:
         return
     elif not data['cdev'].startswith(DISK + SHELF):
         return

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -1,12 +1,13 @@
 import asyncio
+import collections
 import re
 
 
 DISKS = ('da', 'ada', 'vtbd', 'mfid', 'nvd', 'pmem')
 SHELF = ('ses',)
 TYPES = ('CREATE', 'DESTROY')
-PREVIOUS = {'method': '', 'task': None}
-MAX_WAIT_TIME = 60
+PREV_TASK = collections.deque(maxlen=1)
+MAX_WAIT_TIME = 15
 SETTLE_TIME = 5
 HAS_PARTITION = re.compile(rf'^({"|".join(DISKS)})[0-9]+p[0-9]+.*$')
 
@@ -15,11 +16,7 @@ async def reset_cache(middleware, *args):
     await middleware.call('geom.cache.invalidate')
     await (await middleware.call('disk.sync_all')).wait()
     await middleware.call('disk.sed_unlock_all')
-
-    global PREVIOUS
-    PREVIOUS['method'] = 'reset_cache'
-    PREVIOUS['task'] = None
-    PREVIOUS['task_time'] = asyncio.get_event_loop().time()
+    PREV_TASK.clear()
 
 
 async def added_disk(middleware, disk_name):
@@ -28,11 +25,7 @@ async def added_disk(middleware, disk_name):
     await middleware.call('disk.sed_unlock', disk_name)
     await middleware.call('disk.multipath_sync')
     await middleware.call('alert.oneshot_delete', 'SMART', disk_name)
-
-    global PREVIOUS
-    PREVIOUS['method'] = 'added_disk'
-    PREVIOUS['task'] = None
-    PREVIOUS['task_time'] = asyncio.get_event_loop().time()
+    PREV_TASK.clear()
 
 
 async def remove_disk(middleware, disk_name):
@@ -43,11 +36,7 @@ async def remove_disk(middleware, disk_name):
     # If a disk dies we need to reconfigure swaps so we are not left
     # with a single disk mirror swap, which may be a point of failure.
     asyncio.ensure_future(middleware.call('disk.swaps_configure'))
-
-    global PREVIOUS
-    PREVIOUS['method'] = 'remove_disk'
-    PREVIOUS['task'] = None
-    PREVIOUS['task_time'] = asyncio.get_event_loop().time()
+    PREV_TASK.clear()
 
 
 async def devd_devfs_hook(middleware, data):
@@ -56,22 +45,25 @@ async def devd_devfs_hook(middleware, data):
     elif not data['cdev'].startswith(DISKS + SHELF):
         return
     elif data['type'] == 'CREATE' and data['cdev'].startswith(DISKS) and HAS_PARTITION.match(data['cdev']):
-        # Means we received an event for something like "da1p1" which means
-        # we have (or will) receive an event for the raw disk (i.e. "da1")
-        # so we ignore this event
+        # Means we received an event for a disk with a partition already on it (i.e. da1p1).
+        # This means we have (or will) receive an event for the raw disk (i.e. "da1")
+        # so we ignore this event.
         return
 
-    global PREVIOUS
-    if not PREVIOUS['task']:
+    now = asyncio.get_event_loop().time()
+    task = asyncio.get_event_loop().call_later
+
+    if not PREV_TASK:
         if data['cdev'].startswith(DISKS):
             method = added_disk if data['type'] == 'CREATE' else remove_disk
         else:
             method = reset_cache
 
-        PREVIOUS['task'] = asyncio.get_event_loop().call_later(
-            SETTLE_TIME, lambda: asyncio.ensure_future(method(middleware, data['cdev']))
-        )
-    elif PREVIOUS['method'] != 'reset_cache':
+        PREV_TASK.append({
+            'task': task(SETTLE_TIME, lambda: asyncio.ensure_future(method(middleware, data['cdev']))),
+            'method': method.__qualname__,
+        })
+    elif PREV_TASK[-1]['method'] != 'reset_cache':
         # we have a previously scheduled task and the event we received came
         # in within SETTLE_TIME AND the previous task method to be run was
         # not "reset_cache" so we assume that we're receiving a "burst" of
@@ -79,20 +71,30 @@ async def devd_devfs_hook(middleware, data):
         # a failure event that causes an undefined pattern of behavior. In
         # either of these scenarios, we need to reset the entirety of the
         # disk cache to play it safe.
-        PREVIOUS['task'].cancel()
-        PREVIOUS['task'] = asyncio.get_event_loop().call_later(
-            SETTLE_TIME, lambda: asyncio.ensure_future(reset_cache(middleware))
+        PREV_TASK[-1]['task'].cancel()
+        PREV_TASK.append({
+            'task': task(SETTLE_TIME, lambda: asyncio.ensure_future(reset_cache(middleware, data['cdev']))),
+            'method': 'reset_cache',
+        })
+    elif 'backoff' not in PREV_TASK[-1]:
+        # This means we're continuing to receive a stream of events but we've
+        # already created a task to wipe the entirety of the cache so we need
+        # to cancel the currently pending task and create a new one to run after
+        # MAX_WAIT_TIME to give the system "time to settle down". This shouldn't
+        # occur but the logic needs to be here to cover edge-case scenarios.
+        PREV_TASK[-1]['task'].cancel()
+        PREV_TASK.append({
+            'task': task(MAX_WAIT_TIME, lambda: asyncio.ensure_future(reset_cache(middleware, data['cdev']))),
+            'method': 'reset_cache',
+            'backoff': True,
+        })
+    elif (PREV_TASK[-1]['task'].when() - now) <= 0:
+        # We have continually received a stream of events for at least
+        # MAX_WAIT_TIME which means something is misbehaving badly.
+        # This is an edge-case so at least log a warning.
+        middleware.logger.warning(
+            f'Continually received disk events for {MAX_WAIT_TIME} seconds. Disk cache was reset during this time.'
         )
-    elif (asyncio.get_event_loop().time() - PREVIOUS['task_time']) >= MAX_WAIT_TIME:
-        # we have continually received a stream of events for at least
-        # MAX_WAIT_TIME which means something is misbehaving badly. Log
-        # a warning and run the method directly
-        PREVIOUS['task'].cancel()
-
-        err = f'Waited at least {MAX_WAIT_TIME}seconds but have continually received devd events.'
-        err += ' Resetting disk cache.'
-        middleware.logger.warning(err)
-        await reset_cache(middleware)
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -1,8 +1,17 @@
 import asyncio
-import re
 
-import sysctl
-RE_ISDISK = re.compile(r'^(da|ada|vtbd|mfid|nvd|pmem)[0-9]+$')
+DISK = ('da', 'ada', 'vtbd', 'mfid', 'nvd', 'pmem')
+SHELF = ('ses',)
+PREVIOUS = {'method': '', 'task': None}
+MAX_WAIT_TIME = 60
+SETTLE_TIME = 2
+LAST_EVENT_TIME = None
+
+
+async def reset_cache(middleware, *args):
+    await middleware.call('geom.cache.invalidate')
+    await (await middleware.call('disk.sync_all')).wait()
+    await middleware.call('sed_unlock_all')
 
 
 async def added_disk(middleware, disk_name):
@@ -24,21 +33,50 @@ async def remove_disk(middleware, disk_name):
 
 
 async def devd_devfs_hook(middleware, data):
-    if data.get('subsystem') != 'CDEV':
+    if data.get('subsystem') != 'CDEV' or data['type'] not in ('CREATE', 'DESTROY'):
+        return
+    elif not data['cdev'].startswith(DISK + SHELF):
         return
 
-    if data['type'] == 'CREATE':
-        disks = await middleware.run_in_thread(lambda: sysctl.filter('kern.disks')[0].value.split())
-        # Device notified about is not a disk
-        if data['cdev'] not in disks:
-            return
-        await added_disk(middleware, data['cdev'])
+    now = asyncio.get_event_loop().time()
 
-    elif data['type'] == 'DESTROY':
-        # Device notified about is not a disk
-        if not RE_ISDISK.match(data['cdev']):
-            return
-        await remove_disk(middleware, data['cdev'])
+    global PREVIOUS, LAST_EVENT_TIME
+    if not PREVIOUS['task']:
+        if data['cdev'].startswith(DISK):
+            method = added_disk if data['type'] == 'CREATE' else remove_disk
+        else:
+            method = reset_cache
+
+            PREVIOUS['task'] = asyncio.get_event_loop().call_later(
+                SETTLE_TIME, lambda: asyncio.ensure_future(method(middleware, data['cdev']))
+            )
+            PREVIOUS['method'] = method.__name__
+            LAST_EVENT_TIME = now
+    elif PREVIOUS['method'] != 'reset_cache':
+        # we have a previously scheduled task and the event we received came
+        # in within SETTLE_TIME AND the previous task method to be run was
+        # not "reset_cache" so we assume that we're receiving a "burst" of
+        # events. This happens when a shelf is attached/detached or we have
+        # a failure event that causes an undefined pattern of behavior. In
+        # either of these scenarios, we need to reset the entirety of the
+        # disk cache to play it safe.
+        PREVIOUS['task'].cancel()
+        PREVIOUS['task'] = asyncio.get_event_loop().call_later(
+            SETTLE_TIME, lambda: asyncio.ensure_future(reset_cache(middleware))
+        )
+        PREVIOUS['method'] = 'reset_cache'
+    elif (now - LAST_EVENT_TIME >= MAX_WAIT_TIME):
+        # we have continually received a stream of events for at least
+        # MAX_WAIT_TIME which means something is misbehaving badly. Log
+        # a warning and run the method directly
+        PREVIOUS['task'].cancel()
+        PREVIOUS = {'method': '', 'task': None}
+        LAST_EVENT_TIME = None
+
+        err = f'Waited at least {MAX_WAIT_TIME}seconds but have continually received devd events.'
+        err += ' Resetting disk cache.'
+        middleware.logger.warning(err)
+        await reset_cache(middleware)
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -8,7 +8,7 @@ TYPES = ('CREATE', 'DESTROY')
 PREVIOUS = {'method': '', 'task': None}
 MAX_WAIT_TIME = 60
 SETTLE_TIME = 5
-HAS_PARTITION = re.compile(rf'^({"|".join(DISKS)})p[0-9].*$')
+HAS_PARTITION = re.compile(rf'^({"|".join(DISKS)})[0-9]+p[0-9]+.*$')
 
 
 async def reset_cache(middleware, *args):

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -83,7 +83,7 @@ async def devd_devfs_hook(middleware, data):
         PREVIOUS['task'] = asyncio.get_event_loop().call_later(
             SETTLE_TIME, lambda: asyncio.ensure_future(reset_cache(middleware))
         )
-    elif (asyncio.get_event_loop().time() - PREVIOUS['event_time']) >= MAX_WAIT_TIME:
+    elif (asyncio.get_event_loop().time() - PREVIOUS['task_time']) >= MAX_WAIT_TIME:
         # we have continually received a stream of events for at least
         # MAX_WAIT_TIME which means something is misbehaving badly. Log
         # a warning and run the method directly

--- a/src/middlewared/middlewared/plugins/geom.py
+++ b/src/middlewared/middlewared/plugins/geom.py
@@ -63,9 +63,9 @@ class GeomCache(Service):
 
     def remove_disk(self, disk):
         with self.LOCK:
-            self.DISKS.pop(disk)
-            self.MULTIPATH.pop(disk)
-            self.TOPOLOGY.pop(disk)
+            self.DISKS.pop(disk, None)
+            self.MULTIPATH.pop(disk, None)
+            self.TOPOLOGY.pop(disk, None)
             if ele := self.XML.find(f'.//class[name="DISK"]/geom[name="{disk}"]'):
                 self.XML.find('.//class[name="DISK"]').remove(ele)
             if ele := self.XML.find(f'.//class[name="MULTIPATH"]/geom[name="{disk}"]'):


### PR DESCRIPTION
Now that we are caching disk information on 13 (to make middleware usable on very large systems (100's of HDDs)), it has been found that when an expansion shelf is attached/detached we receive a "burst" of events all within <= 1 second but we're missing some of these events so the in-memory cache isn't properly invalidated/updated.

This PR adds the following logic.
1. schedule a task to be run within (`SETTLE_TIME`) seconds
2. if another event is received within `SETTLE_TIME`, then we cancel the current task and schedule another task to run within `SETTLE_TIME`.
3. if we keep receiving events while we already have a scheduled task, then we cancel the scheduled task and schedule a new one to run at `MAX_WAIT_TIME` seconds, then we will log a warning and then reset the deque object.
4. we now monitor for `ses` events (attaching/detaching) of expansion shelves and act accordingly

The simple ideas that this tries to enforce:
1. give middleware service `SETTLE_TIME` (or `MAX_WAIT_TIME`) seconds to ensure we don't have a burst of events
2. ensure middleware doesn't miss any disk events so the cache remains valid
3. rate limit the amount of devd events we act upon