### PR TITLE
NFS server: change mapping of gids fully optional

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/nfs-kernel-server.mako
+++ b/src/middlewared/middlewared/etc_files/default/nfs-kernel-server.mako
@@ -5,9 +5,8 @@
 
     if not config["v4"]:
         nfsd_opts.append('-N 4')
-        if config["userd_manage_gids"]:
-            mountd_opts.append("--manage-gids")
-    else:
+
+    if config["userd_manage_gids"]:
         mountd_opts.append("--manage-gids")
 
     if not config["udp"]:


### PR DESCRIPTION
Hi there!

We found that with TrueNAS Scale 22.02 RELEASE, the `--manage-gids` option is now always added to `rpc.mountd` options even though it was not enabled in web UI. Based upon the code, I think that this currently tied to enabling NFSv4. From our testing, it is totally fine to run NFSv4 without managed groups hence this PR provides this functionality again :)

Best, phpfs

P.S.: Open to discuss different solutions here! (@anodos325)