### PR TITLE
NAS-115383 / 22.12 / Prevent contents of /etc/exports.d from altering NFS config

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -1,6 +1,7 @@
 <%
     import ipaddress
     import socket
+    import os
     from pathlib import Path
 
     map_ids = {
@@ -95,11 +96,70 @@
 
         return hostname
 
+    def disable_sharenfs():
+        datasets = []
+        with open('/etc/exports.d/zfs.exports', 'r') as f:
+           for line in f:
+               if not line.strip() or line.startswith('#'):
+                   continue
+
+               ds_name = middleware.call_sync(
+                   'zfs.dataset.path_to_dataset',
+                   line.rsplit(" ", 1)[0]
+               )
+               if ds_name is None:
+                   middleware.logger.warning("%s: dataset lookup failed", line)
+                   continue
+
+               datasets.append(ds_name)
+
+        for ds in datasets:
+            try:
+                middleware.call_sync(
+                    'zfs.dataset.update',
+                    ds,
+                    {'properties': {'sharenfs': {'value': 'off'}}}
+                )
+            except Exception:
+                middleware.logger.warning("%s: failed to disable sharenfs", ds, exc_info=True)
+
+        return
+
+    def disable_exportsd():
+        immutable_disabled = False
+        for file in os.listdir('/etc/exports.d'):
+            if not immutable_disabled:
+                middleware.call_sync('filesystem.set_immutable', False, '/etc/exports.d')
+                immutable_disabled = True
+
+            if file == 'zfs.exports':
+                middleware.logger.warning("Disabling sharenfs ZFS property on datasets")
+                disable_sharenfs()
+            else:
+                middleware.logger.warning("%s: unexpected file found in exports.d", file)
+
+            try:
+                os.remove(os.path.join('/etc/exports.d', file))
+            except Exception:
+                middleware.logger.warning(
+                    "%s: failed to remove unexpected file in exports.d",
+                    file, exc_info=True
+                )
+                return False
+
+        if not immutable_disabled and middleware.call_sync('filesystem.is_immutable', '/etc/exports.d'):
+            return True
+
+        middleware.call_sync('filesystem.set_immutable', True, '/etc/exports.d')
+        return True
+
     entries = []
     gaierrors = []
     config = render_ctx["nfs.config"]
     shares = render_ctx["sharing.nfs.query"]
-    if not shares:
+    poison_exports = not disable_exportsd()
+
+    if not poison_exports and not shares:
         raise FileShouldNotExist()
 
     has_nfs_principal = middleware.call_sync('kerberos.keytab.has_nfs_principal')
@@ -151,6 +211,15 @@
     if not entries:
         raise FileShouldNotExist()
 %>
+% if poison_exports:
+WARNING:
+# /etc/exports.d contains unexpected files that could not be removed.
+# This message has been added to prevent the NFS service from starting until the
+# issue has been resolved.
+
+% else:
+
+% endif
 % for export in entries:
 "${export["path"]}"${"\\\n\t"}${"\\\n\t".join(export["options"])}
 % endfor


### PR DESCRIPTION
knfsd / exportfs will attempt to load any exports file added
to /etc/exports.d. This can lead to filesystems being
unexpectedly exported and a broken NFS configuration.

In this PR, we add an additional check when generating
exports where we remove any unexpected file from
/etc/exports.d and then make the directory immutable.

If for some reason, a file cannot be removed, then we
intentionally generate an invalid exports config with
a comment stating that the user needs to clean up whatever
he or she did there.