### PR TITLE
NAS-115412 / 22.12 / improve disk.get_dev_size

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info.py
@@ -8,29 +8,27 @@ from middlewared.service import CallError, private, Service
 class DiskService(Service):
 
     @private
-    def get_dev_size(self, dev):
+    def get_dev_size(self, device):
         try:
-            block_device = pyudev.Devices.from_name(pyudev.Context(), 'block', dev)
+            dev = pyudev.Devices.from_name(pyudev.Context(), 'block', device)
         except pyudev.DeviceNotFoundByNameError:
             return
+        else:
+            if dev.get('DEVTYPE') not in ('disk', 'partition'):
+                return
 
-        if block_device.get('DEVTYPE') not in ('disk', 'partition'):
+        size = dev.attributes.asint('size')
+
+        try:
+            attr = 'queue/logical_block_size'
+            if parent := dev.find_parent('block'):
+                lbs = pyudev.Devices.from_name(pyudev.Context(), 'block', parent.sys_name).attributes.asint(attr)
+            else:
+                lbs = dev.attributes.asint(attr)
+        except KeyError:
             return
 
-        logical_sector_size = self.middleware.call_sync(
-            'device.logical_sector_size',
-            dev if block_device['DEVTYPE'] == 'disk' else block_device.find_parent('block').sys_name
-        )
-        if not logical_sector_size:
-            return
-
-        if block_device['DEVTYPE'] == 'disk':
-            path = os.path.join('/sys/block', dev, 'device/block', dev, 'size')
-            if os.path.exists(path):
-                with open(path, 'r') as f:
-                    return int(f.read().strip()) * logical_sector_size
-        elif block_device.get('ID_PART_ENTRY_SIZE'):
-            return logical_sector_size * int(block_device['ID_PART_ENTRY_SIZE'])
+        return size * lbs
 
     @private
     def list_partitions(self, disk):

--- a/tests/api2/test_disk_get_dev_size.py
+++ b/tests/api2/test_disk_get_dev_size.py
@@ -1,0 +1,11 @@
+import pytest
+
+from middlewared.test.integration.utils import call
+
+DISKS = list(call('device.get_disks').keys())
+TYPES = (type(None), int)
+
+
+@pytest.mark.parametrize('disk', DISKS)
+def test_get_dev_size_for(disk):
+    assert isinstance(call('disk.get_dev_size', disk), TYPES)


### PR DESCRIPTION
Been meaning to push this PR for a while but this simplifies and speeds up (in the case a disk partition is passed to us) the `disk.get_dev_size` method. The `pyudev.Devices` object that we create gives us all the information we need without having to call another method in another module that goes out to disk and reads a file.