### PR TITLE
NAS-115412 / 22.02.1 / improve disk.get_dev_size (by yocalebo)

### DIFF
--- a/tests/api2/test_disk_get_dev_size.py
+++ b/tests/api2/test_disk_get_dev_size.py
@@ -1,0 +1,11 @@
+import pytest
+
+from middlewared.test.integration.utils import call
+
+DISKS = list(call('device.get_disks').keys())
+TYPES = (type(None), int)
+
+
+@pytest.mark.parametrize('disk', DISKS)
+def test_get_dev_size_for(disk):
+    assert isinstance(call('disk.get_dev_size', disk), TYPES)


### PR DESCRIPTION
Been meaning to push this PR for a while but this simplifies and speeds up (in the case a disk partition is passed to us) the `disk.get_dev_size` method. The `pyudev.Devices` object that we create gives us all the information we need without having to call another method in another module that goes out to disk and reads a file.

Original PR: https://github.com/truenas/middleware/pull/8613
Jira URL: https://jira.ixsystems.com/browse/NAS-115412