### PR TITLE
NAS-115422 / 13.0 / fix typo in disk_/sync.py causing KeyError

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -194,7 +194,7 @@ class DiskService(Service, ServiceChangeMixin):
                 if qs is None:
                     qs = await self.middleware.call('datastore.query', 'storage.disk')
 
-                if disk := [i for i in qs if i['disk_identifer'] == disk_identifier]:
+                if disk := [i for i in qs if i['disk_identifier'] == disk_identifier]:
                     new = False
                     disk = disk[0]
                 else:


### PR DESCRIPTION
```
[2022/03/23 07:53:01] (ERROR) middlewared.job.run():379 - Job <bound method accepts.<locals>.wrap.<locals>.nf of
<middlewared.plugins.disk_.sync.DiskService object at 0x81d602100>> failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 367, in run
    await self.future
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 403, in __run_body
    rv = await self.method(*([self] + args))
  File "/usr/local/lib/python3.9/site-packages/middlewared/schema.py", line 975, in nf
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/disk_/sync.py", line 197, in sync_all
    if disk := [i for i in qs if i['disk_identifer'] == disk_identifier]:
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/disk_/sync.py", line 197, in <listcomp>
    if disk := [i for i in qs if i['disk_identifer'] == disk_identifier]:
KeyError: 'disk_identifer'