### PR TITLE
NAS-115417 / 13.0 / prevent lossful translation on enclosure mapping

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -350,7 +350,7 @@ class EnclosureService(Service):
                     orig_id = orig[0]["id"]
                     # pull out the original slots
                     orig_slots = orig[0]["elements"].pop("Array Device Slot")
-                    # go ahead and pull out the other elements from the head-unit to prevent lossfull translation
+                    # go ahead and pull out the other elements from the head-unit to prevent lossful translation
                     mapped[0]["elements"].update(orig[0]["elements"])
                     # set the model of the mapped enclosure
                     mapped[0]["model"] = orig[0]["model"]

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -349,14 +349,16 @@ class EnclosureService(Service):
                     this_num = mapping.num
                     orig_id = orig[0]["id"]
                     # pull out the original slots
-                    orig_slots = orig[0]["elements"]["Array Device Slot"]
+                    orig_slots = orig[0]["elements"].pop("Array Device Slot")
+                    # go ahead and pull out the other elements from the head-unit to prevent lossfull translation
+                    mapped[0]["elements"].update(orig[0]["elements"])
                     # set the model of the mapped enclosure
                     mapped[0]["model"] = orig[0]["model"]
 
             # now we need to map the original enclosures disk slots to the new mapping
             try:
                 orig_slot = orig_slots[mapping.slot]
-            except IndexError:
+            except KeyError:
                 self.logger.error(
                     "Failed to detect slot %d in enclosure /dev/ses%d. Mapping slot failed.", mapping.slot, mapping.num
                 )


### PR DESCRIPTION
It's been requested that the other element types in the head-unit be included in the enclosure mapping on the r-series. Before this change we were mapping the drive slots and then dropping the other element types (PSU/Voltage/Temp/etc) now we keep all the other element types that are reported by kernel.