### PR TITLE
NAS-115442 / 22.12 / Fix error in generating exports on firstboot

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -3,6 +3,7 @@
     import socket
     import os
     from pathlib import Path
+    from contextlib import suppress
 
     map_ids = {
         'maproot_user': -1,
@@ -127,6 +128,10 @@
 
     def disable_exportsd():
         immutable_disabled = False
+
+        with suppress(FileExistsError):
+            os.mkdir('/etc/exports.d', mode=0o755)
+
         for file in os.listdir('/etc/exports.d'):
             if not immutable_disabled:
                 middleware.call_sync('filesystem.set_immutable', False, '/etc/exports.d')

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1451,8 +1451,11 @@ class PoolService(CRUDService):
             except CallError as e:
                 if e.errno != errno.EPROTONOSUPPORT:
                     self.logger.warning('Failed to inherit mountpoints recursively for %r dataset: %r', child, e)
+                    continue
+
                 try:
                     await self.disable_shares(child)
+                    self.logger.warning('%s: disabling ZFS dataset property-based shares', child)
                 except Exception:
                     self.logger.warning('%s: failed to disable share: %s.', child, str(e), exc_info=True)
 


### PR DESCRIPTION
exports.d directory does not exist on firstboot. Create said dir
while generating exports file, to ensure it exists and is immutable
as expected.