### PR TITLE
NFS: Fix map_id for multiple shares

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -32,7 +32,6 @@
             'mapall_group': -1,
         }
 
-        all_squash = False
         if share["security"]:
             sec = f'sec={":".join(share["security"])}'
             params.append(sec.lower())

--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -3,13 +3,6 @@
     import socket
     from pathlib import Path
 
-    map_ids = {
-        'maproot_user': -1,
-        'maproot_group': -1,
-        'mapall_user': -1,
-        'mapall_group': -1,
-    }
-
     def do_map(share, map_type):
         output = []
         if share[f'{map_type}_user']:
@@ -32,6 +25,12 @@
 
     def generate_options(share, global_sec, config):
         params = []
+        map_ids = {
+            'maproot_user': -1,
+            'maproot_group': -1,
+            'mapall_user': -1,
+            'mapall_group': -1,
+        }
 
         all_squash = False
         if share["security"]:


### PR DESCRIPTION
Hi @anodos325 ,

I noticed that our latest changes to NFS export generation did not consider multiple shares with different configurations. Is this correct? If so, this PR supplies a possible solution.

Best, phpfs