### PR TITLE
NFS: Fix map_id for multiple shares (#8629)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -3,13 +3,6 @@
     import socket
     from pathlib import Path
 
-    map_ids = {
-        'maproot_user': -1,
-        'maproot_group': -1,
-        'mapall_user': -1,
-        'mapall_group': -1,
-    }
-
     def do_map(share, map_type):
         output = []
         if share[f'{map_type}_user']:
@@ -32,8 +25,13 @@
 
     def generate_options(share, global_sec, config):
         params = []
+        map_ids = {
+            'maproot_user': -1,
+            'maproot_group': -1,
+            'mapall_user': -1,
+            'mapall_group': -1,
+        }
 
-        all_squash = False
         if share["security"]:
             sec = f'sec={":".join(share["security"])}'
             params.append(sec.lower())


### PR DESCRIPTION
Ensure that root_squash is properly evaluated on a per-share basis when generating exports file.