### PR TITLE
NAS-113655 / 22.02.1 / Properly use zpool cachefile on HA (by yocalebo)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Get current errors
       run: |
         tmpafter=$(mktemp)
-        find src -name \*.py -exec flake8 --application-import-names middlewared --ignore=E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
+        find src -name \*.py -exec flake8 --application-import-names middlewared --ignore=I101,E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
         num_errors_after=`cat $tmpafter | wc -l`
         echo "CURRENT_ERROR_FILE=${tmpafter}" >> $GITHUB_ENV
         echo "CURRENT_ERRORS=${num_errors_after}" >> $GITHUB_ENV

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -20,6 +20,7 @@ from middlewared.plugins.auth import AuthService, SessionManagerCredentials
 from middlewared.plugins.config import FREENAS_DATABASE
 from middlewared.plugins.datastore.connection import DatastoreService
 from middlewared.utils.contextlib import asyncnullcontext
+from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE, ZPOOL_CACHE_FILE_OVERWRITE
 
 ENCRYPTION_CACHE_LOCK = asyncio.Lock()
 
@@ -1237,6 +1238,12 @@ async def hook_setup_ha(middleware, *args, **kwargs):
             # standby node before we call `interface.sync`
             middleware.logger.debug('[HA] Sending database to standby node')
             await middleware.call('failover.send_database')
+
+            # Need to send the zpool cachefile to the other node so it matches
+            # when a failover event occurs
+            middleware.logger.debug('[HA] Sending zpool cachefile to standby node')
+            await middleware.call('failover.send_small_file', ZPOOL_CACHE_FILE, ZPOOL_CACHE_FILE_OVERWRITE)
+            await middleware.call('failover.call_remote', 'failover.zpool.cachefile.setup' ['SYNC'])
 
             middleware.logger.debug('[HA] Configuring network on standby node')
             await middleware.call('failover.call_remote', 'interface.sync')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -77,10 +77,6 @@ class FailoverService(Service):
     # that's being handled by us explicitly
     HA_PROPAGATE = {'ha_propagate': False}
 
-    # file created by the pool plugin during certain
-    # scenarios when importing zpools on boot
-    ZPOOL_KILLCACHE = '/data/zfs/killcache'
-
     # zpool cache file managed by ZFS
     ZPOOL_CACHE_FILE = '/data/zfs/zpool.cache'
 
@@ -386,19 +382,6 @@ class FailoverService(Service):
             logger.warning('No zpools to import, exiting failover event')
             self.FAILOVER_RESULT = 'INFO'
             return self.FAILOVER_RESULT
-
-        # remove the zpool cache files if necessary
-        if os.path.exists(self.ZPOOL_KILLCACHE):
-            for i in (self.ZPOOL_CACHE_FILE, self.ZPOOL_CACHE_FILE_SAVED):
-                with contextlib.suppress(Exception):
-                    os.unlink(i)
-
-        # create the self.ZPOOL_KILLCACHE file
-        else:
-            with contextlib.suppress(Exception):
-                with open(self.ZPOOL_KILLCACHE, 'w') as f:
-                    f.flush()  # be sure it goes straight to disk
-                    os.fsync(f.fileno())  # be EXTRA sure it goes straight to disk
 
         # if we're here and the zpool "saved" cache file exists we need to check
         # if it's modify time is < the standard zpool cache file and if it is

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from middlewared.utils import filter_list
 from middlewared.service import Service, job, accepts
 from middlewared.schema import Dict, Bool, Int
+from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 
 logger = logging.getLogger('failover')
 
@@ -34,28 +35,6 @@ logger = logging.getLogger('failover')
 # If any of the above scenarios occur, we want to ensure
 # that only one thread is trying to run fenced or import the
 # zpools.
-
-
-class AllZpoolsFailedToImport(Exception):
-    """
-    This is raised if all zpools failed to
-    import when becoming master.
-    """
-    pass
-
-
-class IgnoreFailoverEvent(Exception):
-    """
-    This is raised when a failover event is ignored.
-    """
-    pass
-
-
-class FencedError(Exception):
-    """
-    This is raised if fenced fails to run.
-    """
-    pass
 
 
 class FailoverService(Service):

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -400,16 +400,15 @@ class FailoverEventsService(Service):
                     vol['error'] = str(e)
                     failed.append(vol)
                     continue
+                try:
+                    # make sure the zpool cachefile property is set appropriately
+                    self.run_call(
+                        'zfs.pool.update', vol['name'], {'properties': {'cachefile': {'value': ZPOOL_CACHE_FILE}}}
+                    )
+                except Exception:
+                    logger.warning('Failed to set cachefile property for %r', vol['name'], exc_info=True)
 
-            self.logger.info('Successfully imported %r', vol['name'])
-
-            try:
-                # make sure the zpool cachefile property is set appropriately
-                self.run_call(
-                    'zfs.pool.update', vol['name'], {'properties': {'cachefile': {'value': ZPOOL_CACHE_FILE}}}
-                )
-            except Exception:
-                self.logger.warning('Failed to set cachefile property for %r', vol['name'], exc_info=True)
+            logger.info('Successfully imported %r', vol['name'])
 
             # try to unlock the zfs datasets (if any)
             unlock_job = self.run_call('failover.unlock_zfs_datasets', vol['name'])

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -364,6 +364,9 @@ class FailoverEventsService(Service):
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
 
+        # setup the zpool cachefile
+        self.run_call('failover.zpool.cachefile.setup', 'MASTER')
+
         # set the progress to IMPORTING
         job.set_progress(None, description='IMPORTING')
 
@@ -397,6 +400,16 @@ class FailoverEventsService(Service):
                     vol['error'] = str(e)
                     failed.append(vol)
                     continue
+
+            self.logger.info('Successfully imported %r', vol['name'])
+
+            try:
+                # make sure the zpool cachefile property is set appropriately
+                self.run_call(
+                    'zfs.pool.update', vol['name'], {'properties': {'cachefile': {'value': ZPOOL_CACHE_FILE}}}
+                )
+            except Exception:
+                self.logger.warning('Failed to set cachefile property for %r', vol['name'], exc_info=True)
 
             # try to unlock the zfs datasets (if any)
             unlock_job = self.run_call('failover.unlock_zfs_datasets', vol['name'])
@@ -571,6 +584,9 @@ class FailoverEventsService(Service):
                 f.write(int(time.time()).to_bytes(4, sys.byteorder))
                 f.flush()  # be sure it goes straight to disk
                 os.fsync(f.fileno())  # be EXTRA sure it goes straight to disk
+
+        # setup the zpool cachefile
+        self.run_call('failover.zpool.cachefile.setup', 'BACKUP')
 
         # export zpools in a thread and set a timeout to
         # to `self.ZPOOL_EXPORT_TIMEOUT`.

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -638,12 +638,11 @@ class FailoverService(Service):
         self.run_call('truecommand.stop_truecommand_service')
 
         # we keep SSH running on both controllers (if it's enabled by user)
-        for i in self.run_call('datastore.query', 'services_services'):
-            if i['srv_service'] == 'ssh':
-                if i['srv_enable']:
-                    logger.info('Restarting SSH')
-                    self.run_call('service.restart', 'ssh', self.HA_PROPAGATE)
-                break
+        filters = [['srv_service', '=', 'ssh']]
+        options = {'get': True}
+        if self.run_call('datastore.query', 'services.services', filters, options)['srv_enable']:
+            logger.info('Restarting SSH')
+            self.run_call('service.restart', 'ssh', self.HA_PROPAGATE)
 
         # TODO: ALUA on SCALE??
         # do something with iscsi service here

--- a/src/middlewared/middlewared/plugins/failover_/event_exceptions.py
+++ b/src/middlewared/middlewared/plugins/failover_/event_exceptions.py
@@ -1,0 +1,20 @@
+class AllZpoolsFailedToImport(Exception):
+    """
+    This is raised if all zpools failed to
+    import when becoming master.
+    """
+    pass
+
+
+class IgnoreFailoverEvent(Exception):
+    """
+    This is raised when a failover event is ignored.
+    """
+    pass
+
+
+class FencedError(Exception):
+    """
+    This is raised if fenced fails to run.
+    """
+    pass

--- a/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
+++ b/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from middlewared.service import Service
+from middlewared.schema import Str, accepts
+from middlewared.plugins.pool import ZPOOL_CACHE_FILE
+
+ZPOOL_CACHE_FILE_SAVED = f'{ZPOOL_CACHE_FILE}.saved'
+ZPOOL_CACHE_FILE_OVERWRITE = f'{ZPOOL_CACHE_FILE}.overwrite'
+
+
+class FailoverZpoolCacheFileService(Service):
+    class Config:
+        private = True
+        namespace = 'failover.zpool.cachefile'
+
+    @accepts(Str('event', enum=['MASTER', 'BACKUP', 'SYNC'], default='MASTER'))
+    def setup(self, event):
+        saved = Path(ZPOOL_CACHE_FILE_SAVED)
+        default = Path(ZPOOL_CACHE_FILE)
+        overwrite = Path(ZPOOL_CACHE_FILE_OVERWRITE)
+        saved_stat = default_stat = overwrite_stat = None
+        for i in [[saved, saved_stat], [default, default_stat], [overwrite, overwrite_stat]]:
+            try:
+                i[1] = i[0].stat()
+            except FileNotFoundError:
+                continue
+
+        if event == 'MASTER':
+            if (saved_stat and default_stat) and (saved_stat.mtime < default_stat.mtime):
+                # we're becoming master which means on backup
+                # event we modify the save cache file first and
+                # if the pool is successfully exported then the
+                # default cachefile is updated and the zpool entry
+                # is removed from that file. This is done by zfs
+                # itself and not us. That behavior is counter
+                # intuitive to what we're trying to do so that's
+                # why we save the cachefile before we export
+                saved.rename(default.as_posix())
+            elif saved_stat and not default_stat:
+                saved.rename(default.as_posix())
+        elif event == 'BACKUP' and default_stat:
+            # means we're becoming backup so we need to save
+            # the zpool cachefile before we export the zpools
+            saved.write_bytes(default.read_bytes())
+        elif event == 'SYNC' and overwrite_stat:
+            # a zpool was created/updated on the active controller
+            # and the newly created zpool cachefile was sent to this
+            # controller so we need to overwrite
+            overwrite.rename(default.as_posix())
+
+        default.touch(exist_ok=True)
+        if not event == 'BACKUP':
+            saved.unlink(missing_ok=True)
+        overwrite.unlink(missing_ok=True)

--- a/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
+++ b/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
@@ -18,15 +18,12 @@ class FailoverZpoolCacheFileService(Service):
         saved = Path(ZPOOL_CACHE_FILE_SAVED)
         default = Path(ZPOOL_CACHE_FILE)
         overwrite = Path(ZPOOL_CACHE_FILE_OVERWRITE)
-        saved_stat = default_stat = overwrite_stat = None
-        for i in [[saved, saved_stat], [default, default_stat], [overwrite, overwrite_stat]]:
-            try:
-                i[1] = i[0].stat()
-            except FileNotFoundError:
-                continue
+        se = saved.exists()
+        de = default.exists()
+        oe = overwrite.exists()
 
         if event == 'MASTER':
-            if (saved_stat and default_stat) and (saved_stat.mtime < default_stat.mtime):
+            if (se and de) or (se and not de):
                 # we're becoming master which means on backup
                 # event we modify the save cache file first and
                 # if the pool is successfully exported then the
@@ -35,18 +32,16 @@ class FailoverZpoolCacheFileService(Service):
                 # itself and not us. That behavior is counter
                 # intuitive to what we're trying to do so that's
                 # why we save the cachefile before we export
-                saved.rename(default.as_posix())
-            elif saved_stat and not default_stat:
-                saved.rename(default.as_posix())
-        elif event == 'BACKUP' and default_stat:
+                saved.rename(default)
+        elif event == 'BACKUP' and de:
             # means we're becoming backup so we need to save
             # the zpool cachefile before we export the zpools
             saved.write_bytes(default.read_bytes())
-        elif event == 'SYNC' and overwrite_stat:
+        elif event == 'SYNC' and oe:
             # a zpool was created/updated on the active controller
             # and the newly created zpool cachefile was sent to this
             # controller so we need to overwrite
-            overwrite.rename(default.as_posix())
+            overwrite.rename(default)
 
         default.touch(exist_ok=True)
         if not event == 'BACKUP':


### PR DESCRIPTION
After many hours testing, I've finally got this working. ZFS has a very subtle, non-intuitive behavior with respect to how it overwrites or appends to an existing zpool cachefile.

Before my changes:
```
[2022/03/22 08:11:31] (INFO) failover.vrrp_master():380 - Importing 'ha'
[2022/03/22 08:11:32] (INFO) failover.vrrp_master():380 - Importing 'zz'
[2022/03/22 08:11:32] (WARNING) failover.vrrp_master():390 - Failed importing 'zz' using cachefile so trying without it.
[2022/03/22 08:11:34] (INFO) failover.vrrp_master():451 - Volume imports complete.
```

After my changes:
```
[2022/03/22 12:40:05] (INFO) failover.vrrp_master():380 - Importing 'ha'
[2022/03/22 12:40:05] (INFO) failover.vrrp_master():417 - Successfully imported 'ha'
[2022/03/22 12:40:06] (INFO) failover.vrrp_master():380 - Importing 'zz'
[2022/03/22 12:40:06] (INFO) failover.vrrp_master():417 - Successfully imported 'zz'
```

Original PR: https://github.com/truenas/middleware/pull/8612
Jira URL: https://jira.ixsystems.com/browse/NAS-113655