### PR TITLE
NAS-115450 / 22.02.1 / Remove anonuid / anongid if user sets uid 0 / gid 0 as maproot (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -58,6 +58,10 @@
 
         try:
             maproot = do_map(share, "maproot", map_ids)
+            if map_ids['maproot_user'] == 0 and map_ids['maproot_group'] == 0:
+                params.append('no_root_squash')
+                maproot = []
+
         except KeyError:
             middleware.logger.warning(
                 "NSS lookup for anonymous account failed. "
@@ -68,9 +72,6 @@
 
         if maproot:
             params.extend(maproot)
-
-        if map_ids['maproot_user'] == 0 and map_ids['maproot_group'] == 0:
-            params.append('no_root_squash')
 
         if config['allow_nonroot']:
             params.append("insecure")

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -525,8 +525,7 @@ def test_34_check_nfs_share_maproot(request):
     assert len(parsed) == 1, str(parsed)
     params = parsed[0]['opts'][0]['parameters']
     assert 'no_root_squash' in params, str(parsed)
-    assert 'anonuid=0' in params, str(parsed)
-    assert 'anongid=0' in params, str(parsed)
+    assert not any(filter(lambda x: x.startswith('anon'), params)), str(parsed)
 
     """
     Second share should have normal (no maproot) params.


### PR DESCRIPTION
Linux anonuid / anongid don't 100% match up with maproot behavior
on FreeBSD. The anonuid and anongid also are what is used in case
of INVALID_UID or INVALID_GID for fsuid/fsgid in fs/nfsd/auth.c

This means that we don't want this parameter populated when user
wants to simply not squash root.

Original PR: https://github.com/truenas/middleware/pull/8635
Jira URL: https://jira.ixsystems.com/browse/NAS-115450