### PR TITLE
NAS-115456 / 22.12 / Fix logic for ms-account validation

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -505,7 +505,7 @@ class UserService(CRUDService):
             verrors.add('user_update.microsoft_account',
                         'The Microsoft Account feature requires an email address.')
 
-        if updated['microsoft_account'] and not updated['builtin']:
+        if updated['microsoft_account'] and updated['builtin']:
             verrors.add('user_update.microsoft_account',
                         'This property is not permitted for builtin accounts.')
 


### PR DESCRIPTION
We shouldn't  allow this to be set on builtin accounts.