### PR TITLE
NAS-115469 / 22.12 / Optimize acl_is_trivial

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -17,6 +17,7 @@ from middlewared.plugins.filesystem_ import chflags, stat_x
 from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str
 from middlewared.service import private, CallError, filterable_returns, Service, job
 from middlewared.utils import filter_list
+from middlewared.plugins.filesystem_.acl_base import ACLType
 
 
 class FilesystemService(Service):
@@ -458,8 +459,10 @@ class FilesystemService(Service):
         if not os.path.exists(path):
             raise CallError(f'Path not found [{path}].', errno.ENOENT)
 
-        acl = self.middleware.call_sync('filesystem.getacl', path, True)
-        return acl['trivial']
+        acl_xattrs = ACLType.xattr_names()
+        xattrs_present = set(os.listxattr(path))
+
+        return False if (xattrs_present & acl_xattrs) else True
 
 
 class FileFollowTailEventSource(EventSource):

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -83,6 +83,13 @@ class ACLType(enum.Enum):
 
         return out
 
+    def xattr_names():
+        return set([
+            "system.posix_acl_access",
+            "system.posix_acl_default",
+            "system.nfs4_acl_xdr"
+        ])
+
 
 class ACLBase(ServicePartBase):
 


### PR DESCRIPTION
This method is called when we call filesystem.listdir and
filesystem.stat. Unfortunately because of how it was implemented
for cases with relatively largish numbers of files, it would
become quite slow. filesystem.listdir took ~30 seconds for a
directory with 1000 files. Now that the ZFS ACL_IS_TRIVIAL
flag is included in the ACL flags, we can directly check this
via a getxattr call. With this new optimization, filesystem.listdir
on the same directory now takes less than 1 second.