### PR TITLE
NAS-115471 / 22.12 / Remove LEGACY HA mode for SMB on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -65,10 +65,7 @@ class DirectorySecrets(object):
         self.is_open = False
 
     def open_tdb(self):
-        if self.ha_mode == "LEGACY":
-            secret_path = f'{SMBPath.LEGACYPRIVATE.platform()}/secrets.tdb'
-        else:
-            secret_path = f'{SMBPath.PRIVATEDIR.platform()}/secrets.tdb'
+        secret_path = f'{SMBPath.PRIVATEDIR.platform()}/secrets.tdb'
 
         if os.path.isfile(secret_path):
             self.tdb = tdb.open(secret_path, self.flags)

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1112,7 +1112,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         if ad_state == 'DISABLED' or not os.path.exists(keytab['SYSTEM'].value):
             return
 
-        if (await self.middleware.call("smb.get_smb_ha_mode")) in ("LEGACY", "CLUSTERED"):
+        if (await self.middleware.call("smb.get_smb_ha_mode")) == "CLUSTERED":
             return
 
         if await self.middleware.call('cache.has_key', 'KEYTAB_MTIME'):


### PR DESCRIPTION
This alternate / legacy behavior was to prevent users with
legacy geli-encrypted pools in AD from breaking further. It adds
complexity and in general breaks kerberos auth in AD environments.