### PR TITLE
NAS-115472 / 22.12 / fix test_disk_get_dev_size

### DIFF
--- a/tests/api2/test_disk_get_dev_size.py
+++ b/tests/api2/test_disk_get_dev_size.py
@@ -5,9 +5,6 @@ from pytest_dependency import depends
 
 from middlewared.test.integration.utils import call, ssh
 
-DISKS = list(call('device.get_disks').keys())
-CONTROL = None
-
 
 @pytest.mark.dependency(name='GET_DISK_INFO')
 def test_get_disk_info():
@@ -15,7 +12,7 @@ def test_get_disk_info():
     CONTROL = {i['name']: i for i in json.loads(ssh('lsblk -bJ -o NAME,SIZE'))['blockdevices']}
 
 
-@pytest.mark.parametrize('disk', DISKS)
-def test_get_dev_size_for(disk, request):
+def test_get_dev_size_for_all_disks(request):
     depends(request, ['GET_DISK_INFO'])
-    assert CONTROL[disk]['size'] == call('disk.get_dev_size', disk)
+    for disk, disk_info in CONTROL.items():
+        assert disk_info['size'] == call('disk.get_dev_size', disk)


### PR DESCRIPTION
I tried every possible way to keep the `parametrize` decorator but pytest executes those at "collection time" (aka run/compile time) and this is failing on HA systems because it's trying to make websocket calls on the VIP before it's even had a chance to be setup properly.

Parametrize gives the benefit of appending the actual disk that we're testing in the pytest output. ANYWAYS, I've moved all the enumeration of data to test time instead of "collection time".