### PR TITLE
NAS-115471 / 22.02.1 / Remove LEGACY HA mode for SMB on SCALE (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -388,8 +388,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
 
         if new['enable']:
             if await self.middleware.call('failover.licensed'):
-                sysdataset = await self.middleware.call('systemdataset.config')
-                if sysdataset['pool'] == 'freenas-boot':
+                if await self.middleware.call('systemdataset.is_boot_pool'):
                     raise ValidationError(
                         'activedirectory.enable',
                         'Active Directory may not be enabled while '

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -65,10 +65,7 @@ class DirectorySecrets(object):
         self.is_open = False
 
     def open_tdb(self):
-        if self.ha_mode == "LEGACY":
-            secret_path = f'{SMBPath.LEGACYPRIVATE.platform()}/secrets.tdb'
-        else:
-            secret_path = f'{SMBPath.PRIVATEDIR.platform()}/secrets.tdb'
+        secret_path = f'{SMBPath.PRIVATEDIR.platform()}/secrets.tdb'
 
         if os.path.isfile(secret_path):
             self.tdb = tdb.open(secret_path, self.flags)

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1112,7 +1112,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         if ad_state == 'DISABLED' or not os.path.exists(keytab['SYSTEM'].value):
             return
 
-        if (await self.middleware.call("smb.get_smb_ha_mode")) in ("LEGACY", "CLUSTERED"):
+        if (await self.middleware.call("smb.get_smb_ha_mode")) == "CLUSTERED":
             return
 
         if await self.middleware.call('cache.has_key', 'KEYTAB_MTIME'):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -4,6 +4,7 @@ from middlewared.service_exception import InstanceNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils import Popen, run
 from middlewared.utils.size import format_size
+from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
 
 try:
     from middlewared.plugins.cluster_linux.utils import CTDBConfig
@@ -93,6 +94,11 @@ class SystemDatasetService(ConfigService):
             config['path'] = SYSDATASET_PATH
 
         return config
+
+    @private
+    async def is_boot_pool(self):
+        pool = (await self.confg())['pool']
+        return pool in BOOT_POOL_NAME_VALID
 
     @accepts()
     @returns(Dict('systemdataset_pool_choices', additional_attrs=True))


### PR DESCRIPTION
This alternate / legacy behavior was to prevent users with
legacy geli-encrypted pools in AD from breaking further. It adds
complexity and in general breaks kerberos auth in AD environments.

Original PR: https://github.com/truenas/middleware/pull/8643
Jira URL: https://jira.ixsystems.com/browse/NAS-115471