### PR TITLE
NAS-115496 / 22.02.1 / Add check that systemdataset pool is valid (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -97,7 +97,11 @@ class SystemDatasetService(ConfigService):
 
     @private
     async def is_boot_pool(self):
-        pool = (await self.confg())['pool']
+        pool = (await self.config())['pool']
+        if not pool:
+            raise CallError('System dataset pool is not set. This may prevent '
+                            'system services from functioning properly.')
+
         return pool in BOOT_POOL_NAME_VALID
 
     @accepts()


### PR DESCRIPTION
If for some reason the pool is unset, this is a significant
configuration error and should be noted.

Original PR: https://github.com/truenas/middleware/pull/8652
Jira URL: https://jira.ixsystems.com/browse/NAS-115496