### PR TITLE
NAS-115498 / 22.02.1 / Fix typo in filesystem.listdir and add optimization (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import pwd
 import shutil
+import stat as statlib
 import time
 
 import pyinotify
@@ -106,7 +107,7 @@ class FilesystemService(Service):
         Str('name', required=True),
         Path('path', required=True),
         Path('realpath', required=True),
-        Str('type', required=True, enum=['DIRECTORY', 'FILESYSTEM', 'SYMLINK', 'OTHER']),
+        Str('type', required=True, enum=['DIRECTORY', 'FILE', 'SYMLINK', 'OTHER']),
         Int('size', required=True, null=True),
         Int('mode', required=True, null=True),
         Bool('acl', required=True, null=True),
@@ -127,13 +128,45 @@ class FilesystemService(Service):
           name(str): name of the file
           path(str): absolute path of the entry
           realpath(str): absolute real path of the entry (if SYMLINK)
-          type(str): DIRECTORY | FILESYSTEM | SYMLINK | OTHER
+          type(str): DIRECTORY | FILE | SYMLINK | OTHER
           size(int): size of the entry
           mode(int): file mode/permission
           uid(int): user id of entry owner
           gid(int): group id of entry onwer
           acl(bool): extended ACL is present on file
         """
+
+        def stat_entry(entry):
+            out = {'st': None, 'etype': None}
+            try:
+                out['st'] = entry.lstat()
+            except Exception:
+                return None
+
+            if statlib.S_ISDIR(out['st'].st_mode):
+                out['etype'] = 'DIRECTORY'
+
+            elif statlib.S_ISLNK(out['st'].st_mode):
+                out['etype'] = 'SYMLINK'
+                try:
+                    out['st'] = entry.stat()
+                except Exception:
+                    return None
+
+            elif statlib.S_ISREG(out['st'].st_mode):
+                out['etype'] = 'FILE'
+
+            else:
+                out['etype'] = 'OTHER'
+
+            if dir_only and out['etype'] != 'DIRECTORY':
+                return None
+
+            elif file_only and out['etype'] != 'FILE':
+                return None
+
+            return out
+
         path = self.resolve_cluster_path(path)
         path = pathlib.Path(path)
         if not path.exists():
@@ -145,9 +178,30 @@ class FilesystemService(Service):
         if 'ix-applications' in path.parts:
             raise CallError('Ix-applications is a system managed dataset and its contents cannot be listed')
 
+        file_only = False
+        dir_only = False
+        for filter in filters:
+            if filter[0] not in ['type']:
+                continue
+
+            if filter[1] != '=' and filter[2] not in ['DIRECTORY', 'FILE']:
+                continue
+
+            if filter[2] == 'DIRECTORY':
+                dir_only = True
+            else:
+                file_only = True
+
         rv = []
+        if dir_only and file_only:
+            return rv
+
         only_top_level = path.absolute() == pathlib.Path('/mnt')
         for entry in path.iterdir():
+            st = stat_entry(entry)
+            if st is None:
+                continue
+
             if only_top_level and not entry.is_mount():
                 # sometimes (on failures) the top-level directory
                 # where the zpool is mounted does not get removed
@@ -160,35 +214,27 @@ class FilesystemService(Service):
                 continue
             if 'ix-applications' in entry.parts:
                 continue
-            if entry.is_symlink():
-                etype = 'SYMLINK'
-            elif entry.is_dir():
-                etype = 'DIRECTORY'
-            elif entry.is_file():
-                etype = 'FILE'
-            else:
-                etype = 'OTHER'
+
+            etype = st['etype']
+            stat = st['st']
+            realpath = entry.resolve().as_posix() if etype == 'SYMLINK' else entry.absolute().as_posix()
 
             data = {
                 'name': entry.name,
                 'path': entry.as_posix().replace(
                     f'{FuseConfig.FUSE_PATH_BASE.value}/', FuseConfig.FUSE_PATH_SUBST.value
                 ),
-                'realpath': entry.resolve().as_posix() if etype == 'SYMLINK' else entry.absolute().as_posix(),
+                'realpath': realpath,
                 'type': etype,
+                'size': stat.st_size,
+                'mode': stat.st_mode,
+                'acl': False if self.acl_is_trivial(realpath) else True,
+                'uid': stat.st_uid,
+                'gid': stat.st_gid,
             }
-            try:
-                stat = entry.stat()
-                data.update({
-                    'size': stat.st_size,
-                    'mode': stat.st_mode,
-                    'acl': False if self.acl_is_trivial(data["path"]) else True,
-                    'uid': stat.st_uid,
-                    'gid': stat.st_gid,
-                })
-            except FileNotFoundError:
-                data.update({'size': None, 'mode': None, 'acl': None, 'uid': None, 'gid': None})
+
             rv.append(data)
+
         return filter_list(rv, filters=filters or [], options=options or {})
 
     @accepts(Str('path'))


### PR DESCRIPTION
FILESYSTEM -> FILE for type. Shift stat / lstat calls earlier in
function so that we can short-circuit in case of filter to only
show directories or files. This is optimization for improving
webui performance for various dropdowns in case user has written
huge numbers of files to a directory.

Original PR: https://github.com/truenas/middleware/pull/8654
Jira URL: https://jira.ixsystems.com/browse/NAS-115498