### PR TITLE
NAS-115452 / 22.12 / optimize and improve failover.disabled.reasons

### DIFF
--- a/src/freenas/usr/local/sbin/hactl
+++ b/src/freenas/usr/local/sbin/hactl
@@ -47,8 +47,8 @@ def main(command, quiet):
                 print("Failover status: Unavailable (no network interfaces are marked critical for failover)")
             elif 'MISMATCH_DISKS' in ret:
                 print("Failover status: Unavailable (disks do not match between storage controllers)")
-            elif 'DISAGREE_CARP' in ret:
-                print("Failover status: Unavailable (nodes CARP states do not agree)")
+            elif 'DISAGREE_VIP' in ret:
+                print("Failover status: Unavailable (nodes Virtual IP states do not agree)")
             elif 'NO_LICENSE' in ret:
                 print("Failover status: Unavailable (standby storage controller has no license)")
             elif 'NO_FAILOVER' in ret:

--- a/src/freenas/usr/local/sbin/hactl
+++ b/src/freenas/usr/local/sbin/hactl
@@ -42,7 +42,7 @@ def main(command, quiet):
                     other_serial = f'ERROR: {e}'
                 print(f"Other node serial: {other_serial}{' (ACTIVE)' if ret == 'BACKUP' else ''}")
 
-            ret = client.call('failover.disabled_reasons')
+            ret = client.call('failover.disabled.reasons')
             if 'NO_CRITICAL_INTERFACES' in ret:
                 print("Failover status: Unavailable (no network interfaces are marked critical for failover)")
             elif 'MISMATCH_DISKS' in ret:

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -259,7 +259,7 @@ class FailoverService(ConfigService):
         await self.middleware.call('cache.pop', 'failover_status')
         # Kick a new status so it may be ready on next user call
         await self.middleware.call('failover.status')
-        await self.middleware.call('failover.disabled_reasons')
+        await self.middleware.call('failover.disabled.reasons')
 
     @accepts()
     @returns(Bool())
@@ -1324,7 +1324,7 @@ async def setup(middleware):
     middleware.event_register('failover.setup', 'Sent when failover is being setup.')
     middleware.event_register('failover.status', 'Sent when failover status changes.')
     middleware.event_register(
-        'failover.disabled_reasons',
+        'failover.disabled.reasons',
         'Sent when the reasons for failover being disabled have changed.'
     )
     middleware.event_register('failover.upgrade_pending', textwrap.dedent('''\

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -11,6 +11,7 @@ import time
 from functools import partial
 
 from middlewared.plugins.failover_.journal import SQL_QUEUE
+from middlewared.plugins.failover_.utils import throttle_condition
 from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str, returns, Patch
 from middlewared.service import (
     job, no_auth_required, pass_app, private, throttle, CallError, ConfigService, ValidationErrors,
@@ -29,13 +30,6 @@ logger = logging.getLogger('failover')
 
 class TruenasNodeSessionManagerCredentials(SessionManagerCredentials):
     pass
-
-
-def throttle_condition(middleware, app, *args, **kwargs):
-    # app is None means internal middleware call
-    if app is None or (app and app.authenticated):
-        return True, 'AUTHENTICATED'
-    return False, None
 
 
 class FailoverModel(sa.Model):
@@ -437,78 +431,6 @@ class FailoverService(ConfigService):
                     dest, base64.b64encode(read).decode(), {'mode': mode, 'append': not first}
                 ])
                 first = False
-
-    @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
-    @accepts()
-    @returns(List('reasons', items=[Str('reason')]))
-    @pass_app()
-    def disabled_reasons(self, app):
-        """
-        Returns a list of reasons why failover is not enabled/functional.
-
-        NO_VOLUME - There are no pools configured.
-        NO_VIP - There are no interfaces configured with Virtual IP.
-        NO_SYSTEM_READY - Other storage controller has not finished booting.
-        NO_PONG - Other storage controller is not communicable.
-        NO_FAILOVER - Failover is administratively disabled.
-        NO_LICENSE - Other storage controller has no license.
-        DISAGREE_CARP - Nodes CARP states do not agree.
-        MISMATCH_DISKS - The storage controllers do not have the same quantity of disks.
-        NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
-        """
-        reasons = set(self._disabled_reasons(app))
-        if reasons != self.LAST_DISABLEDREASONS:
-            self.LAST_DISABLEDREASONS = reasons
-            self.middleware.send_event(
-                'failover.disabled_reasons', 'CHANGED',
-                fields={'disabled_reasons': list(reasons)}
-            )
-        return list(reasons)
-
-    def _disabled_reasons(self, app):
-        reasons = []
-        if not self.middleware.call_sync('pool.query'):
-            reasons.append('NO_VOLUME')
-        if not any(filter(
-            lambda x: x.get('failover_virtual_aliases'), self.middleware.call_sync('interface.query'))
-        ):
-            reasons.append('NO_VIP')
-        try:
-            assert self.middleware.call_sync('failover.remote_connected') is True
-
-            # if the remote node panic's (this happens on failover event if we cant export the
-            # zpool in 4 seconds on freeBSD systems (linux reboots silently by design)
-            # then the p2p interface stays "UP" and the websocket remains open.
-            # At this point, we have to wait for the TCP timeout (60 seconds default).
-            # This means the assert line up above will return `True`.
-            # However, any `call_remote` method will hang because the websocket is still
-            # open but hasn't closed due to the default TCP timeout window. This can be painful
-            # on failover events because it delays the process of restarting services in a timely
-            # manner. To work around this, we place a `timeout` of 5 seconds on the system.ready
-            # call. This essentially bypasses the TCP timeout window.
-            if not self.middleware.call_sync('failover.call_remote', 'system.ready', [], {'timeout': 5}):
-                reasons.append('NO_SYSTEM_READY')
-
-            if not self.middleware.call_sync('failover.call_remote', 'failover.licensed'):
-                reasons.append('NO_LICENSE')
-
-            local = self.middleware.call_sync('failover.vip.get_states')
-            remote = self.middleware.call_sync('failover.call_remote', 'failover.vip.get_states')
-            if self.middleware.call_sync('failover.vip.check_states', local, remote):
-                reasons.append('DISAGREE_CARP')
-
-            mismatch_disks = self.middleware.call_sync('failover.mismatch_disks')
-            if mismatch_disks['missing_local'] or mismatch_disks['missing_remote']:
-                reasons.append('MISMATCH_DISKS')
-
-            if not self.middleware.call_sync('datastore.query', 'network.interfaces', [['int_critical', '=', True]]):
-                reasons.append('NO_CRITICAL_INTERFACES')
-        except Exception:
-            reasons.append('NO_PONG')
-        if self.middleware.call_sync('failover.config')['disabled']:
-            reasons.append('NO_FAILOVER')
-        return reasons
 
     @private
     async def mismatch_disks(self):

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -25,7 +25,7 @@ class FailoverDisabledReasonsService(ConfigService):
         NO_PONG - Other storage controller is not communicable.
         NO_FAILOVER - Failover is administratively disabled.
         NO_LICENSE - Other storage controller has no license.
-        DISAGREE_CARP - Nodes CARP states do not agree.
+        DISAGREE_VIP - Nodes Virtual IP states do not agree.
         MISMATCH_DISKS - The storage controllers do not have the same quantity of disks.
         NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
         """
@@ -83,7 +83,7 @@ class FailoverDisabledReasonsService(ConfigService):
             local = self.middleware.call_sync('failover.vip.get_states', ifaces)
             remote = self.middleware.call_sync('failover.call_remote', 'failover.vip.get_states')
             if self.middleware.call_sync('failover.vip.check_states', local, remote):
-                reasons.add('DISAGREE_CARP')
+                reasons.add('DISAGREE_VIP')
 
             mismatch_disks = self.middleware.call_sync('failover.mismatch_disks')
             if mismatch_disks['missing_local'] or mismatch_disks['missing_remote']:

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -8,7 +8,7 @@ class FailoverDisabledReasonsService(ConfigService):
     class Config:
         namespace = 'failover.disabled'
 
-    LAST_DISABLEDREASONS = None
+    LAST_DISABLED_REASONS = None
 
     @no_auth_required
     @throttle(seconds=2, condition=throttle_condition)
@@ -30,8 +30,8 @@ class FailoverDisabledReasonsService(ConfigService):
         NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
         """
         reasons = set(self.middleware.call_sync('failover.disabled.get_reasons', app))
-        if reasons != self.LAST_DISABLEDREASONS:
-            self.LAST_DISABLEDREASONS = reasons
+        if reasons != FailoverDisabledReasonsService.LAST_DISABLED_REASONS:
+            FailoverDisabledReasonsService.LAST_DISABLED_REASONS = reasons
             self.middleware.send_event(
                 'failover.disabled.reasons', 'CHANGED',
                 fields={'disabled_reasons': list(reasons)}

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -1,0 +1,80 @@
+from middlewared.schema import accepts, returns, List, Str
+from middlewared.service import ConfigService, throttle, pass_app, no_auth_required
+from middlewared.plugins.failover_.utils import throttle_condition
+
+
+class FailoverService(ConfigService):
+
+    LAST_DISABLEDREASONS = None
+
+    @no_auth_required
+    @throttle(seconds=2, condition=throttle_condition)
+    @accepts()
+    @returns(List('reasons', items=[Str('reason')]))
+    @pass_app()
+    def disabled_reasons(self, app):
+        """
+        Returns a list of reasons why failover is not enabled/functional.
+
+        NO_VOLUME - There are no pools configured.
+        NO_VIP - There are no interfaces configured with Virtual IP.
+        NO_SYSTEM_READY - Other storage controller has not finished booting.
+        NO_PONG - Other storage controller is not communicable.
+        NO_FAILOVER - Failover is administratively disabled.
+        NO_LICENSE - Other storage controller has no license.
+        DISAGREE_CARP - Nodes CARP states do not agree.
+        MISMATCH_DISKS - The storage controllers do not have the same quantity of disks.
+        NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
+        """
+        reasons = set(self._disabled_reasons(app))
+        if reasons != self.LAST_DISABLEDREASONS:
+            self.LAST_DISABLEDREASONS = reasons
+            self.middleware.send_event(
+                'failover.disabled_reasons', 'CHANGED',
+                fields={'disabled_reasons': list(reasons)}
+            )
+        return list(reasons)
+
+    def _disabled_reasons(self, app):
+        reasons = []
+        if not self.middleware.call_sync('pool.query'):
+            reasons.append('NO_VOLUME')
+        if not any(filter(
+            lambda x: x.get('failover_virtual_aliases'), self.middleware.call_sync('interface.query'))
+        ):
+            reasons.append('NO_VIP')
+        try:
+            assert self.middleware.call_sync('failover.remote_connected') is True
+
+            # if the remote node panic's (this happens on failover event if we cant export the
+            # zpool in 4 seconds on freeBSD systems (linux reboots silently by design)
+            # then the p2p interface stays "UP" and the websocket remains open.
+            # At this point, we have to wait for the TCP timeout (60 seconds default).
+            # This means the assert line up above will return `True`.
+            # However, any `call_remote` method will hang because the websocket is still
+            # open but hasn't closed due to the default TCP timeout window. This can be painful
+            # on failover events because it delays the process of restarting services in a timely
+            # manner. To work around this, we place a `timeout` of 5 seconds on the system.ready
+            # call. This essentially bypasses the TCP timeout window.
+            if not self.middleware.call_sync('failover.call_remote', 'system.ready', [], {'timeout': 5}):
+                reasons.append('NO_SYSTEM_READY')
+
+            if not self.middleware.call_sync('failover.call_remote', 'failover.licensed'):
+                reasons.append('NO_LICENSE')
+
+            local = self.middleware.call_sync('failover.vip.get_states')
+            remote = self.middleware.call_sync('failover.call_remote', 'failover.vip.get_states')
+            if self.middleware.call_sync('failover.vip.check_states', local, remote):
+                reasons.append('DISAGREE_CARP')
+
+            mismatch_disks = self.middleware.call_sync('failover.mismatch_disks')
+            if mismatch_disks['missing_local'] or mismatch_disks['missing_remote']:
+                reasons.append('MISMATCH_DISKS')
+
+            if not self.middleware.call_sync('datastore.query', 'network.interfaces', [['int_critical', '=', True]]):
+                reasons.append('NO_CRITICAL_INTERFACES')
+        except Exception:
+            reasons.append('NO_PONG')
+        if self.middleware.call_sync('failover.config')['disabled']:
+            reasons.append('NO_FAILOVER')
+        return reasons

--- a/src/middlewared/middlewared/plugins/failover_/utils.py
+++ b/src/middlewared/middlewared/plugins/failover_/utils.py
@@ -1,0 +1,5 @@
+def throttle_condition(middleware, app, *args, **kwargs):
+    # app is None means internal middleware call
+    if app is None or (app and app.authenticated):
+        return True, 'AUTHENTICATED'
+    return False, None

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -233,7 +233,7 @@ class UpdateService(Service):
         if self.middleware.call_sync('failover.licensed'):
 
             # First, let's make sure HA is functional
-            if self.middleware.call_sync('failover.disabled_reasons'):
+            if self.middleware.call_sync('failover.disabled.reasons'):
                 return {'status': 'HA_UNAVAILABLE'}
 
             # If its HA and standby is running old version we assume


### PR DESCRIPTION
1. move `disabled_reasons` to it's own module
2. `DISAGREE_CARP` doesn't apply to SCALE HA since we're using VRRP so use `DISAGREE_VIP` instead
3. The new `failover.disabled.reasons` has been restructured and optimized
4. move the common `throttle_condition` method to it's own file `failover_/utils.py`