### PR TITLE
update paths to path

### DIFF
--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -467,7 +467,7 @@ def test_30_check_nfs_exports_sec(request):
     depends(request, ["KRB5_IS_HEALTHY", "ssh_password", "KRB_DATASET"], scope="session")
     payload = {
         "comment": "KRB Test Share",
-        "paths": [f'/mnt/{dataset}'],
+        "path": [f'/mnt/{dataset}'],
     }
     results = POST("/sharing/nfs/", payload)
     assert results.status_code == 200, results.text


### PR DESCRIPTION
Due to change here: https://github.com/truenas/middleware/commit/558ea76887b99134f16b11914671b31e3847def4

The test needs to be updated as well, since we've got nightly API test failures: https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/API%20Tests%20-%20TrueNAS%20SCALE%20(Full%20-%20Nightly%20ISO)/857/testReport/junit/api2/test_032_ad_kerberos/test_30_check_nfs_exports_sec/
