### PR TITLE
NAS-115542 / 22.12 / fix uuidd service

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -71,8 +71,10 @@ done
 systemctl daemon-reload
 systemctl enable zfs-zed
 
-# We need to mask libvirtd related sockets and other services so that they don't start automatically
-systemctl mask exim4-base.service exim4.service libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
+# We need to mask certain services so that they don't start automatically
+systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
+systemctl mask exim4-base.service exim4.service
+systemctl mask uuidd.service uuidd.socket
 
 systemctl set-default truenas.target
 

--- a/src/freenas/etc/systemd/system/uuidd.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/uuidd.service.d/override.conf
@@ -1,4 +1,0 @@
-# we dont create a uuidd user/group so override with nobody/nogroup
-[Service]
-User=nobody
-Group=nogroup

--- a/src/freenas/etc/systemd/system/uuidd.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/uuidd.service.d/override.conf
@@ -1,0 +1,4 @@
+# we dont create a uuidd user/group so override with nobody/nogroup
+[Service]
+User=nobody
+Group=nogroup


### PR DESCRIPTION
2 issues.

1. `uuidd` user/group don't exist so override the systemd unit file with `nobody/nogroup` since we don't need or use this service. If a user manually starts this service, it will at least start with the overridden user/group information.
2. mask `uuidd.service` and `uuidd.socket` because, again, we don't need or use it