### PR TITLE
NAS-115240 / 13.0 / Prevent jobs entering the same lock queue twice when `lock_queue_size` is used (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -35,17 +35,17 @@ class JobSharedLock(object):
     def __init__(self, queue, name):
         self.queue = queue
         self.name = name
-        self.jobs = []
+        self.jobs = set()
         self.semaphore = asyncio.Semaphore()
 
     def add_job(self, job):
-        self.jobs.append(job)
+        self.jobs.add(job)
 
     def get_jobs(self):
         return self.jobs
 
     def remove_job(self, job):
-        self.jobs.remove(job)
+        self.jobs.discard(job)
 
     def locked(self):
         return self.semaphore.locked()


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x e9b75c776d0492e295c3ee5cd65f6fb1514b3ca4



Original PR: https://github.com/truenas/middleware/pull/8521
Jira URL: https://jira.ixsystems.com/browse/NAS-115240