### PR TITLE
NAS-115582 / 22.12 / add network_/common.py plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -426,18 +426,6 @@ class InterfaceService(CRUDService):
 
         self._original_datastores.clear()
 
-    async def __check_dhcp_or_aliases(self):
-        for iface in await self.middleware.call('interface.query'):
-            if iface['ipv4_dhcp'] or iface['ipv6_auto']:
-                break
-            if iface['aliases']:
-                break
-        else:
-            raise CallError(
-                'At least one interface configured with either IPv4 DHCP, IPv6 auto or a static IP'
-                ' is required.'
-            )
-
     @private
     async def get_original_datastores(self):
         return self._original_datastores
@@ -516,7 +504,7 @@ class InterfaceService(CRUDService):
         verrors = ValidationErrors()
         schema = 'interface.commit'
         await self.middleware.call('network.common.check_failover_disabled', schema, verrors)
-        await self.__check_dhcp_or_aliases()
+        await self.middleware.call('network.common.check_dhcp_or_aliases', schema, verrors)
         verrors.check()
 
         try:

--- a/src/middlewared/middlewared/plugins/network_/common.py
+++ b/src/middlewared/middlewared/plugins/network_/common.py
@@ -1,0 +1,23 @@
+from middlewared.service import Service
+
+
+class NetworkCommonService(Service):
+
+    class Config:
+        namespace = 'network.common'
+        private = True
+
+    async def check_failover_disabled(self, schema, verrors):
+        if not await self.middleware.call('failover.licensed'):
+            return
+        elif await self.middleware.call('failover.status') == 'SINGLE':
+            return
+        elif not (await self.middleware.call('failover.config'))['disabled']:
+            verrors.add(schema, 'Failover must be disabled.')
+
+    async def check_dhcp_or_aliases(self, schema, verrors):
+        keys = ('ipv4_dhcp', 'ipv6_auto', 'aliases')
+        if not any([i[key] for key in keys] for i in await self.middleware.call('interface.query')):
+            verrors.add(
+                schema, 'At least one interface must be configured with IPv4 DHCP, IPv6 Autoconfig or a static IP.'
+            )


### PR DESCRIPTION
This fixes 3 issues:

1. we were raising `CallError` for all interface CRUD validations instead of `ValidationErrors`
2. in `do_delete` we cached the database entries in memory before doing the appropriate validation, so it was possible to commit and checkin the changes even though an error was raised
3. move the `__check*` methods to their own module to clean up `network.py`