### PR TITLE
NAS-115432 / 22.12 / net.inet.tcp.recvbuf_inc was removed in 13 (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/13.0/2022-03-23_11-40_remove_recvbuf_inc_tunable.py
+++ b/src/middlewared/middlewared/alembic/versions/13.0/2022-03-23_11-40_remove_recvbuf_inc_tunable.py
@@ -1,0 +1,19 @@
+"""remove net.inet.tcp.recvbuf_inc (was removed in 13)
+
+Revision ID: 88bfe11b5be5
+Revises: 99aef90c4cd6
+Create Date: 2022-03-23 11:40:32.149486+00:00
+
+"""
+from alembic import op
+
+
+revision = '88bfe11b5be5'
+down_revision = '99aef90c4cd6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute('DELETE FROM system_tunable WHERE tun_var = "net.inet.tcp.recvbuf_in"')

--- a/src/middlewared/middlewared/alembic/versions/22.02/2022-04-01_16_09_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2022-04-01_16_09_merge.py
@@ -1,0 +1,21 @@
+"""merge
+
+Revision ID: 19eb67dcdee2
+Revises: 6980b63de512, 88bfe11b5be5
+Create Date: 2022-04-01 16:09:55.446715+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '19eb67dcdee2'
+down_revision = ('6980b63de512', '88bfe11b5be5')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-04-01_16-26_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-04-01_16-26_merge.py
@@ -1,0 +1,21 @@
+""merge
+
+Revision ID: 6e73632d6e88
+Revises: d46d345ef8a8, 19eb67dcdee2
+Create Date: 2022-04-01 17:28:01.759559+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6e73632d6e88'
+down_revision = ('d46d345ef8a8', '19eb67dcdee2')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Fix 2 issues:
1. The sysctl tunable was removed in 13 and so, therefore, not needed.
2. We were querying the database for every variable set in the autotune.py script instead of querying the database once.

Jira URL: https://jira.ixsystems.com/browse/NAS-115432
Original PR: https://github.com/truenas/middleware/pull/8618 (13)
Original PR: https://github.com/truenas/middleware/pull/8686 (22.02)