### PR TITLE
NAS-115527 / 22.12 / Test public method (`timezone_choices`) instead of `get_timezone_choi… (by themylogin)

### DIFF
--- a/tests/api2/test_490_system_general.py
+++ b/tests/api2/test_490_system_general.py
@@ -85,7 +85,7 @@ def test_10_Checking_sysloglevel_using_api():
 
 
 def test_11_timezone_choices():
-    timezones_dic = call('system.general.get_timezone_choices')
+    timezones_dic = call('system.general.timezone_choices')
     result = ssh('timedatectl list-timezones')
     missing = []
     for timezone in filter(bool, result.split('\n')):


### PR DESCRIPTION
…ces` which does not even exist on 22.02

Original PR: https://github.com/truenas/middleware/pull/8701
Jira URL: https://jira.ixsystems.com/browse/NAS-115527