### PR TITLE
NAS-115485 / 22.02.1 / Bug fix for normalizing SAN (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/generate_utils.py
+++ b/src/middlewared/middlewared/plugins/crypto_/generate_utils.py
@@ -61,11 +61,17 @@ def normalize_san(san_list: list) -> list:
     normalized = []
     ip_validator = IpAddress()
     for count, san in enumerate(san_list or []):
-        try:
-            ip_validator(san)
-        except ValueError:
-            normalized.append(['DNS', san])
+        # If we already have SAN normalized, let's use the normalized version and don't
+        # try to add a type ourselves
+        if ':' in san:
+            san_type, san = san.split(':', 1)
         else:
-            normalized.append(['IP', san])
+            try:
+                ip_validator(san)
+            except ValueError:
+                san_type = 'DNS'
+            else:
+                san_type = 'IP'
+        normalized.append([san_type, san])
 
     return normalized

--- a/src/middlewared/middlewared/pytest/unit/plugins/crypto/san.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/crypto/san.py
@@ -1,0 +1,12 @@
+import pytest
+
+from middlewared.plugins.crypto_.generate_utils import normalize_san
+
+
+@pytest.mark.parametrize("reference,expected_results", [
+    (['truenas.domain', '192.168.0.10'], [['DNS', 'truenas.domain'], ['IP', '192.168.0.10']]),
+    (['DNS:truenas.domain', '192.168.0.10'], [['DNS', 'truenas.domain'], ['IP', '192.168.0.10']]),
+    (['DNS:truenas.domain', 'IP:192.168.0.10'], [['DNS', 'truenas.domain'], ['IP', '192.168.0.10']]),
+])
+def test_normalize_san(reference, expected_results):
+    assert normalize_san(reference) == expected_results


### PR DESCRIPTION
This commit fixes an issue where if we have a CSR, it can already potentially have normalized SAN. In that case, let's not normalize it again as that will result in an inconsistent SAN value.

Original PR: https://github.com/truenas/middleware/pull/8649
Jira URL: https://jira.ixsystems.com/browse/NAS-115485