### PR TITLE
NAS-115402 / 22.12 / Use nftables instead of legacy iptables

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -45,11 +45,6 @@ systemctl disable nvidia-persistenced
 
 # Update alternatives
 update-alternatives --install "/usr/sbin/sendmail" sendmail "/etc/find_alias_for_smtplib.sh" "10"
-# We will be using legacy iptables until k3s introduces fixes upstream to properly handle iptables
-update-alternatives --set iptables /usr/sbin/iptables-legacy
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-update-alternatives --set arptables /usr/sbin/arptables-legacy
-update-alternatives --set ebtables /usr/sbin/ebtables-legacy
 
 # Add nut to dialout group - NAS-110578
 usermod -a -G dialout nut


### PR DESCRIPTION
This commit adds changes to use nftables now as upstream k3s/kube-router seems stable enough now to make the move.