### PR TITLE
NAS-112058 / 22.12 / Allow intel GPU's to be used by multiple Apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -56,7 +56,7 @@ GPU_CONFIG = {
                         'env': [{'name': 'NODE_NAME', 'valueFrom': {'fieldRef': {'fieldPath': 'spec.nodeName'}}}],
                         'image': 'intel/intel-gpu-plugin:0.19.0',
                         'imagePullPolicy': 'IfNotPresent',
-                        'args':["-shared-dev-num","5"],
+                        'args': ["-shared-dev-num", "5"],
                         'securityContext': {'readOnlyRootFilesystem': True},
                         'volumeMounts': [
                             {'name': 'devfs', 'mountPath': '/dev/dri', 'readOnly': True},

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -56,6 +56,7 @@ GPU_CONFIG = {
                         'env': [{'name': 'NODE_NAME', 'valueFrom': {'fieldRef': {'fieldPath': 'spec.nodeName'}}}],
                         'image': 'intel/intel-gpu-plugin:0.19.0',
                         'imagePullPolicy': 'IfNotPresent',
+                        'args':["-shared-dev-num","5"],
                         'securityContext': {'readOnlyRootFilesystem': True},
                         'volumeMounts': [
                             {'name': 'devfs', 'mountPath': '/dev/dri', 'readOnly': True},


### PR DESCRIPTION
Reopen of #7431 as @sonicaj didn't create the promissed PR there and users are complaining about lack of progress on the iX Discord.
---
As discussed and not reported on Jira (afaik) here:
https://www.truenas.com/community/threads/intel-gpu-plugin.94955/

This allows the Intel GPU's using the Intel GPU plugin, to be used by multiple Apps at once.
As it currently throws errors when used by more than one App at the same time.

It's currently set to 5, which is more than the total amount of available GPU-supporting Apps in both Official and TrueCharts combined.