### PR TITLE
NAS-115327 / 22.02.1 / Fix openapi json manifest (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -261,6 +261,8 @@ http {
             proxy_set_header X-Real-Remote-Port $remote_port;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Server-Port $server_port;
+            proxy_set_header X-Scheme $Scheme;
         }
 
         location /_download {

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -364,9 +364,14 @@ class OpenAPIResource(object):
 
         servers = []
         host = req.headers.get('Host')
+        scheme = req.headers.get('X-Scheme') or req.scheme
+        port = int(req.headers.get('X-Server-Port') or 80)
         if host:
+            # This condition is only cosmetic to avoid specifying 80/443 in the uri
+            if port not in [80, 443]:
+                host = f'{host}:{port}'
             servers.append({
-                'url': f'{req.scheme}://{host}/api/v2.0',
+                'url': f'{scheme}://{host}/api/v2.0',
             })
 
         result = {

--- a/tests/api2/test_openapi.py
+++ b/tests/api2/test_openapi.py
@@ -1,0 +1,15 @@
+import pytest
+import sys
+import os
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import GET
+
+
+@pytest.mark.parametrize('protocol,force_ssl', [('http', False), ('https', True)])
+def test_protocol_reported_correctly(protocol, force_ssl):
+    response = GET('', force_ssl=force_ssl)
+    server_urls = response.json()['servers']
+    for url_dict in filter(lambda d: 'url' in d, server_urls):
+        assert url_dict['url'].startswith(protocol) is True, url_dict


### PR DESCRIPTION
## Problem

We use reverse proxy, and the point where we build the api manifest doesn't have the correct port or scheme, resulting in the manifest reporting the wrong server url and breaking Swagger.

## Conclusion

Use the request to get correct port / scheme and report accordingly in the api manifest.

Original PR: https://github.com/truenas/middleware/pull/8667
Jira URL: https://jira.ixsystems.com/browse/NAS-115327