### PR TITLE
NAS-115674 / 22.12 / Provide cluster cidr information in chart release context

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -449,13 +449,13 @@ class ChartReleaseService(CRUDService):
 
             job.set_progress(75, 'Installing Catalog Item')
 
-            new_values = add_context_to_configuration(new_values, {
+            new_values = await add_context_to_configuration(new_values, {
                 CONTEXT_KEY_NAME: {
                     **get_action_context(data['release_name']),
                     'operation': 'INSTALL',
                     'isInstall': True,
                 }
-            })
+            }, self.middleware)
 
             await self.middleware.call(
                 'chart.release.create_update_storage_class_for_chart_release',
@@ -522,13 +522,13 @@ class ChartReleaseService(CRUDService):
 
         await self.perform_actions(context)
 
-        config = add_context_to_configuration(config, {
+        config = await add_context_to_configuration(config, {
             CONTEXT_KEY_NAME: {
                 **get_action_context(chart_release),
                 'operation': 'UPDATE',
                 'isUpdate': True,
             }
-        })
+        }, self.middleware)
 
         await self.middleware.call('chart.release.helm_action', chart_release, chart_path, config, 'update')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
@@ -28,13 +28,13 @@ class ChartReleaseService(Service):
                 errno=errno.ENOENT
             )
 
-        config = add_context_to_configuration(release['config'], {
+        config = await add_context_to_configuration(release['config'], {
             CONTEXT_KEY_NAME: {
                 **get_action_context(release_name),
                 'operation': 'UPDATE',
                 'isUpdate': True,
             }
-        })
+        }, self.middleware)
         await self.middleware.call('chart.release.helm_action', release_name, chart_path, config, 'update')
 
         job.set_progress(90, 'Syncing secrets for chart release')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -281,7 +281,7 @@ class ChartReleaseService(Service):
         # version it's happening.
         # Helm considers simple config change as an upgrade as well, and we have no way of determining the old/new
         # chart versions during helm upgrade in the helm template, hence the requirement for a context object.
-        config = add_context_to_configuration(config, {
+        config = await add_context_to_configuration(config, {
             CONTEXT_KEY_NAME: {
                 **get_action_context(release_name),
                 'operation': 'UPGRADE',
@@ -292,7 +292,7 @@ class ChartReleaseService(Service):
                     'preUpgradeRevision': release['version'],
                 }
             }
-        })
+        }, self.middleware)
 
         job.set_progress(60, 'Upgrading chart release version')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -37,7 +37,11 @@ def get_action_context(release_name):
     })
 
 
-def add_context_to_configuration(config, context_dict):
+async def add_context_to_configuration(config, context_dict, middleware):
+    context_dict[CONTEXT_KEY_NAME]['kubernetes_config'] = {
+        k: v for k, v in (await middleware.call('kubernetes.config')).items()
+        if k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
+    }
     if 'global' in config:
         config['global'].update(context_dict)
         config.update(context_dict)


### PR DESCRIPTION
This commit adds chagnes to provide cluster cidr related information in chart release context as it can be useful for apps like a proxy which want to whitelist cidrs.