### PR TITLE
NAS-115642 / 22.02.1 / generate dual-nvdimm config on gen3 mseries hardware (by yocalebo)

### DIFF
--- a/debian/debian/ix-etc.service
+++ b/debian/debian/ix-etc.service
@@ -5,7 +5,7 @@ DefaultDependencies=no
 Before=network-pre.target
 
 After=middlewared.service
-Before=local-fs.target
+Before=local-fs.target systemd-modules-load.service
 
 [Service]
 Type=oneshot

--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -4,7 +4,7 @@ DefaultDependencies=no
 
 Before=network-pre.target
 
-After=middlewared.service
+After=middlewared.service systemd-modules-load.service
 Before=local-fs.target
 Conflicts=systemd-networkd.service
 

--- a/src/middlewared/middlewared/etc_files/dual-nvdimm.mako
+++ b/src/middlewared/middlewared/etc_files/dual-nvdimm.mako
@@ -1,4 +1,6 @@
 <%
+    from packaging import version
+
     info = middleware.call_sync('system.dmidecode_info')
     vers = info['system-version']
     prod = info['system-product-name']

--- a/src/middlewared/middlewared/etc_files/dual-nvdimm.mako
+++ b/src/middlewared/middlewared/etc_files/dual-nvdimm.mako
@@ -1,0 +1,36 @@
+<%
+    info = middleware.call_sync('system.dmidecode_info')
+    vers = info['system-version']
+    prod = info['system-product-name']
+
+    if (prod and not prod.startswith('TRUENAS-M')) or (vers and vers in ('0123456789', '123456789')):
+        # dual-nvdimm config module is only relevant on gen3 m-series.
+        # 0123456789/12345679 are some of the default values that we've
+        # seen from supermicro. Before gen3 m-series hardware, we were not
+        # changing this value so this is a way to identify gen1/2.
+	raise FileShouldNotExist()
+
+    try:
+        curr_vers = version.parse(vers)
+        min_vers = version.Version('3.0')
+    except Exception as e:
+        middleware.logger.error('Failed determining hardware version: %r', e)
+        raise FileShouldNotExist()
+
+    if curr_vers.major == min_vers:
+        # for now we only check to make sure that the current version is 3 because
+        # we quickly found out that the SMBIOS defaults for the system-version value
+        # from supermicro aren't very predictable. Since setting these values on a
+        # system that doesn't support the dual-nvdimm configs leads to "no carrier"
+	# on the ntb0 interface, we play it safe. The `min_vers` will need to be
+        # changed as time goes on if we start tagging hardware with 4.0,5.0 etc etc
+        options = [
+            'options ntb_hw_plx usplit=1',
+            'options ntb_split config="ntb_pmem:1:4:0,ntb_pmem:1:4:0,ntb_transport"',
+        ]
+    else:
+        raise FileShouldNotExist()
+%>\
+% for option in options:
+${option}
+% endfor

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -92,6 +92,9 @@ class PyRenderer(object):
 class EtcService(Service):
 
     GROUPS = {
+        'dual-nvdimm': [
+            {'type': 'mako', 'path': 'modprobe.d/truenas-dual-nvdimm.conf', 'local_path': 'dual-nvdimm'}
+        ],
         'user': {
             'ctx': [
                 {'method': 'user.query'},
@@ -261,7 +264,10 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'local/nut/upsd.conf', 'owner': EtcUSR.ROOT, 'group': EtcGRP.NUT, 'mode': 0o440},
             {'type': 'mako', 'path': 'local/nut/upsd.users', 'owner': EtcUSR.ROOT, 'group': EtcGRP.NUT, 'mode': 0o440},
             {'type': 'mako', 'path': 'local/nut/upsmon.conf', 'owner': EtcUSR.ROOT, 'group': EtcGRP.NUT, 'mode': 0o440},
-            {'type': 'mako', 'path': 'local/nut/upssched.conf', 'owner': EtcUSR.ROOT, 'group': EtcGRP.NUT, 'mode': 0o440},
+            {
+                'type': 'mako', 'path': 'local/nut/upssched.conf',
+                'owner': EtcUSR.ROOT, 'group': EtcGRP.NUT, 'mode': 0o440
+            },
             {
                 'type': 'mako', 'path': 'local/nut/nut.conf', 'owner': EtcUSR.ROOT,
                 'group': EtcGRP.NUT, 'mode': 0o440


### PR DESCRIPTION
By default, we statically load the ntb kernel modules (`modules.d/truenas.conf`) and (statically) load the associated kernel options in `modprobe.d/truenas.conf`. These options are for single nvdimm devices (x and gen1/2 m series), however our gen3+ m-series utilize dual-nvdimms which requires different kernel module options.

This makes it so that we add a new file `modprobe.d/truenas-dual-nvdimm.conf` and because the length of the file name is longer than `modprobe.d/truenas.conf`, the `systemd-modules-load.service` will overwrite any duplicate kernel module options from the file with the longer name.

This also makes it so that `ix-etc.service` loads before the `systemd-modules-load.service`.

Original PR: https://github.com/truenas/middleware/pull/8721
Jira URL: https://jira.ixsystems.com/browse/NAS-115642