### PR TITLE
NAS-115678 / 22.02.1 / fix NameError crash in exports.mako (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -174,7 +174,7 @@
         for path in share["paths"]:
             p = Path(path)
             if not p.exists():
-                middleware.logger.debug("%s: path does not exist, omitting from NFS exports", path)
+                middleware.logger.debug("%s: path does not exist, omitting from NFS exports", p)
                 continue
 
             anonymous = True


### PR DESCRIPTION
```
Message: '%s: path does not exist, omitting from NFS exports'
Arguments: (<mako.runtime.Undefined object at 0x7f8dbc81a6d0>,)
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.9/logging/handlers.py", line 73, in emit
    if self.shouldRollover(record):
  File "/usr/lib/python3.9/logging/handlers.py", line 191, in shouldRollover
    msg = "%s\n" % self.format(record)
  File "/usr/lib/python3.9/logging/__init__.py", line 923, in format
    return fmt.format(record)
  File "/usr/lib/python3.9/logging/__init__.py", line 659, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.9/logging/__init__.py", line 363, in getMessage
    msg = msg % self.args
  File "/usr/lib/python3/dist-packages/mako/runtime.py", line 230, in __str__
    raise NameError("Undefined")
NameError: Undefined
```

Original PR: https://github.com/truenas/middleware/pull/8727
Jira URL: https://jira.ixsystems.com/browse/NAS-115678