### PR TITLE
NAS-115439 / 22.02.1 / Making sure helm apps are redeployed when some cert is renewed (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
@@ -1,4 +1,5 @@
 from middlewared.common.attachment.certificate import CertificateCRUDServiceAttachmentDelegate
+from middlewared.service import private, Service
 
 
 class ChartReleaseCertificateAttachmentDelegate(CertificateCRUDServiceAttachmentDelegate):
@@ -15,11 +16,34 @@ class ChartReleaseCertificateAttachmentDelegate(CertificateCRUDServiceAttachment
 
     async def redeploy(self, cert_id):
         chart_releases = [r['name'] for r in await self.attachments(cert_id)]
+        # We use chart.release.update as here we want the configuration to be refreshed as well
+        # in this specific case that being getting the renewed certificate
         bulk_job = await self.middleware.call(
-            'core.bulk', 'chart.release.redeploy', [[r] for r in await self.attachments(cert_id)]
+            'core.bulk', 'chart.release.update', [[r, {'values': {}}] for r in await self.attachments(cert_id)]
         )
         for index, status in enumerate(await bulk_job.wait()):
             if status['error']:
                 self.middleware.logger.error(
                     'Failed to redeploy %r chart release: %s', chart_releases[index], status['error']
                 )
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    async def get_chart_releases_consuming_outdated_certs(self, filters=None):
+        chart_releases = []
+        filters = filters or []
+        certs = {c['id']: c for c in await self.middleware.call('certificate.query')}
+        for chart_release in await self.middleware.call('chart.release.query', filters):
+            for cert_id, cert in filter(
+                lambda v: int(v[0]) in certs, chart_release['config'].get('ixCertificates', {}).items()
+            ):
+                cert_id = int(cert_id)
+                if cert['certificate'] != certs[cert_id]['certificate']:
+                    chart_releases.append(chart_release['id'])
+                    break
+        return chart_releases

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
@@ -179,6 +179,11 @@ class ChartReleaseService(Service):
                 f'during rollback were: {cp.stderr.decode()}'
             )
 
+        if await self.middleware.call(
+            'chart.release.get_chart_releases_consuming_outdated_certs', [['id', '=', release_name]]
+        ):
+            await self.middleware.call('chart.release.update', release_name, {'values': {}})
+
         return await self.middleware.call('chart.release.get_instance', release_name)
 
     @private

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -260,6 +260,13 @@ class KubernetesService(Service):
             else:
                 restored_chart_releases[release_name]['resources'] = chart_releases[release_name]['resources']
 
+        bulk_job = self.middleware.call_sync('kubernetes.redeploy_chart_releases_consuming_outdated_certs')
+        for index, status in enumerate(bulk_job.wait_sync()):
+            if status['error']:
+                self.middleware.logger.error(
+                    'Failed to redeploy %r chart release: %s', chart_releases[index], status['error']
+                )
+
         job.set_progress(97, 'Scaling scalable workloads')
 
         for chart_release in restored_chart_releases.values():


### PR DESCRIPTION
## Problem
White upgrading certs from middleware few scenarios might result in inconsistency like:
1. K8s not running
2. App rollback resulting in consuming an old cert
3. K8s complete cluster restore resulting in apps potentially using old cert(s)

### Desired behavior
Once certs are upgraded, apps consuming those certs should be updated regardless of any scenario(s).

### Solution
Redeploy apps which are consuming an outdated cert on the problematic scenarios.

Original PR: https://github.com/truenas/middleware/pull/8722
Jira URL: https://jira.ixsystems.com/browse/NAS-115439