### PR TITLE
NAS-115037 / 22.02.1 / Add changes to comply with openssl security level 2 (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/migration/0006_system_cert.py
+++ b/src/middlewared/middlewared/migration/0006_system_cert.py
@@ -1,0 +1,8 @@
+async def migrate(middleware):
+    # This is required because earlier middleware was running considering openssl security level to be 1
+    # but with moving to debian, the default now is 2 which enforces security standards. It means that potentially
+    # user might have configured cert for system which might not comply with security level 2 and UI becoming
+    # inaccessible in this regard because of that
+    system_cert = (await middleware.call('system.general.config'))['ui_certificate']
+    if await middleware.call('certificate.cert_services_validation', system_cert['id'], 'certificate', False):
+        await middleware.call('certificate.setup_self_signed_cert_for_ui')

--- a/src/middlewared/middlewared/migration/0006_system_cert.py
+++ b/src/middlewared/middlewared/migration/0006_system_cert.py
@@ -8,3 +8,4 @@ async def migrate(middleware):
         'certificate.cert_services_validation', system_cert['id'], 'certificate', False
     ):
         await middleware.call('certificate.setup_self_signed_cert_for_ui')
+        await middleware.call('service.restart', 'http')

--- a/src/middlewared/middlewared/migration/0006_system_cert.py
+++ b/src/middlewared/middlewared/migration/0006_system_cert.py
@@ -4,5 +4,7 @@ async def migrate(middleware):
     # user might have configured cert for system which might not comply with security level 2 and UI becoming
     # inaccessible in this regard because of that
     system_cert = (await middleware.call('system.general.config'))['ui_certificate']
-    if await middleware.call('certificate.cert_services_validation', system_cert['id'], 'certificate', False):
+    if not system_cert or await middleware.call(
+        'certificate.cert_services_validation', system_cert['id'], 'certificate', False
+    ):
         await middleware.call('certificate.setup_self_signed_cert_for_ui')

--- a/src/middlewared/middlewared/plugins/crypto_/__init__.py
+++ b/src/middlewared/middlewared/plugins/crypto_/__init__.py
@@ -14,22 +14,13 @@ async def setup(middleware):
     if not failure and (not system_cert or system_cert['id'] not in [c['id'] for c in certs]):
         # create a self signed cert if it doesn't exist and set ui_certificate to it's value
         try:
-            if not any(DEFAULT_CERT_NAME == c['name'] for c in certs):
-                await middleware.call('certificate.setup_self_signed_cert_for_ui', DEFAULT_CERT_NAME)
-                middleware.logger.debug('Default certificate for System created')
-            else:
-                id = [c['id'] for c in certs if c['name'] == DEFAULT_CERT_NAME][0]
-                await middleware.call('certificate.cert_services_validation', id, 'certificate')
-
-
-                await middleware.call(
-                    'datastore.update', 'system.settings', system_general_config['id'], {'stg_guicertificate': id}
-                )
+            await middleware.call('certificate.setup_self_signed_cert_for_ui', DEFAULT_CERT_NAME)
         except Exception as e:
             failure = True
             middleware.logger.debug(
                 'Failed to set certificate for system.general plugin: %s', e, exc_info=True
             )
+
 
     if not failure:
         middleware.logger.debug('Certificate setup for System complete')

--- a/src/middlewared/middlewared/plugins/crypto_/__init__.py
+++ b/src/middlewared/middlewared/plugins/crypto_/__init__.py
@@ -21,6 +21,5 @@ async def setup(middleware):
                 'Failed to set certificate for system.general plugin: %s', e, exc_info=True
             )
 
-
     if not failure:
         middleware.logger.debug('Certificate setup for System complete')

--- a/src/middlewared/middlewared/plugins/crypto_/__init__.py
+++ b/src/middlewared/middlewared/plugins/crypto_/__init__.py
@@ -1,4 +1,4 @@
-from .utils import CERT_TYPE_EXISTING
+from .utils import CERT_TYPE_EXISTING, DEFAULT_CERT_NAME
 
 
 async def setup(middleware):
@@ -14,13 +14,13 @@ async def setup(middleware):
     if not failure and (not system_cert or system_cert['id'] not in [c['id'] for c in certs]):
         # create a self signed cert if it doesn't exist and set ui_certificate to it's value
         try:
-            if not any('freenas_default' == c['name'] for c in certs):
+            if not any(DEFAULT_CERT_NAME == c['name'] for c in certs):
                 cert, key = await middleware.call('cryptokey.generate_self_signed_certificate')
 
                 cert_dict = {
                     'certificate': cert,
                     'privatekey': key,
-                    'name': 'freenas_default',
+                    'name': DEFAULT_CERT_NAME,
                     'type': CERT_TYPE_EXISTING,
                 }
 
@@ -36,7 +36,7 @@ async def setup(middleware):
 
                 middleware.logger.debug('Default certificate for System created')
             else:
-                id = [c['id'] for c in certs if c['name'] == 'freenas_default'][0]
+                id = [c['id'] for c in certs if c['name'] == DEFAULT_CERT_NAME][0]
                 await middleware.call('certificate.cert_services_validation', id, 'certificate')
 
             await middleware.call(

--- a/src/middlewared/middlewared/plugins/crypto_/__init__.py
+++ b/src/middlewared/middlewared/plugins/crypto_/__init__.py
@@ -1,4 +1,4 @@
-from .utils import CERT_TYPE_EXISTING, DEFAULT_CERT_NAME
+from .utils import CERT_TYPE_EXISTING
 
 
 async def setup(middleware):
@@ -14,7 +14,7 @@ async def setup(middleware):
     if not failure and (not system_cert or system_cert['id'] not in [c['id'] for c in certs]):
         # create a self signed cert if it doesn't exist and set ui_certificate to it's value
         try:
-            await middleware.call('certificate.setup_self_signed_cert_for_ui', DEFAULT_CERT_NAME)
+            await middleware.call('certificate.setup_self_signed_cert_for_ui')
         except Exception as e:
             failure = True
             middleware.logger.debug(

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -103,10 +103,10 @@ class CertificateService(CRUDService):
                     schema_name,
                     'Failed to parse certificate\'s private key'
                 )
-            elif cert['key_type'] != 'EC' and cert['key_length'] < 1024:
+            elif cert['key_type'] != 'EC' and cert['key_length'] < 2048:
                 verrors.add(
                     schema_name,
-                    f'{cert["name"]}\'s private key size is less then 1024 bits'
+                    f'{cert["name"]}\'s private key size is less then 2048 bits'
                 )
 
             if cert['revoked']:
@@ -151,7 +151,7 @@ class CertificateService(CRUDService):
             Dict('dns_mapping', additional_attrs=True),
             Int('csr_id'),
             Int('signedby'),
-            Int('key_length', enum=[1024, 2048, 4096]),
+            Int('key_length', enum=[2048, 4096]),
             Int('renew_days'),
             Int('type'),
             Int('lifetime'),
@@ -175,7 +175,7 @@ class CertificateService(CRUDService):
                 'CERTIFICATE_CREATE_INTERNAL', 'CERTIFICATE_CREATE_IMPORTED',
                 'CERTIFICATE_CREATE_CSR', 'CERTIFICATE_CREATE_IMPORTED_CSR',
                 'CERTIFICATE_CREATE_ACME'], required=True),
-            Str('digest_algorithm', enum=['SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512']),
+            Str('digest_algorithm', enum=['SHA224', 'SHA256', 'SHA384', 'SHA512']),
             List('san', items=[Str('san')]),
             Ref('cert_extensions'),
             register=True

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -118,6 +118,12 @@ class CertificateService(CRUDService):
                     f'{cert["name"]!r} has expired (it was valid until {cert["until"]!r})'
                 )
 
+            if cert['digest_algorithm'] in ['MD5', 'SHA1']:
+                verrors.add(
+                    schema_name,
+                    'Please use a certificate whose digest algorithm has at least 112 security bits'
+                )
+
             if cert['revoked']:
                 verrors.add(
                     schema_name,

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -110,6 +110,14 @@ class CertificateService(CRUDService):
                     f'{cert["name"]}\'s private key size is less then {valid_key_size[cert["key_type"]]} bits'
                 )
 
+            if cert['until'] and datetime.datetime.strptime(
+                cert['until'], '%a %b  %d %H:%M:%S %Y'
+            ) < datetime.datetime.now():
+                verrors.add(
+                    schema_name,
+                    f'{cert["name"]!r} has expired ( it was valid until {cert["until"]} )'
+                )
+
             if cert['revoked']:
                 verrors.add(
                     schema_name,

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -80,6 +80,7 @@ class CertificateService(CRUDService):
         # General method to check certificate health wrt usage in services
         cert = await self.middleware.call('certificate.query', [['id', '=', id]])
         verrors = ValidationErrors()
+        valid_key_size = {'EC': 28, 'RSA': 2048}
         if cert:
             cert = cert[0]
             if cert['cert_type'] != 'CERTIFICATE' or cert['cert_type_CSR']:
@@ -103,10 +104,10 @@ class CertificateService(CRUDService):
                     schema_name,
                     'Failed to parse certificate\'s private key'
                 )
-            elif cert['key_type'] != 'EC' and cert['key_length'] < 2048:
+            elif cert['key_length'] < valid_key_size[cert['key_type']]:
                 verrors.add(
                     schema_name,
-                    f'{cert["name"]}\'s private key size is less then 2048 bits'
+                    f'{cert["name"]}\'s private key size is less then {valid_key_size[cert["key_type"]]} bits'
                 )
 
             if cert['revoked']:

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -115,7 +115,7 @@ class CertificateService(CRUDService):
             ) < datetime.datetime.now():
                 verrors.add(
                     schema_name,
-                    f'{cert["name"]!r} has expired ( it was valid until {cert["until"]} )'
+                    f'{cert["name"]!r} has expired (it was valid until {cert["until"]!r})'
                 )
 
             if cert['revoked']:

--- a/src/middlewared/middlewared/plugins/crypto_/default_cert.py
+++ b/src/middlewared/middlewared/plugins/crypto_/default_cert.py
@@ -43,7 +43,8 @@ class CertificateService(Service):
             'type': CERT_TYPE_EXISTING,
         }
 
-        # We use datastore.insert to directly insert in db as jobs cannot be waited for at this point
+        # We use datastore.insert to directly insert in db as this is a self-signed cert
+        # and we don't allow that via regular api
         return await self.middleware.call(
             'datastore.insert',
             'system.certificate',

--- a/src/middlewared/middlewared/plugins/crypto_/default_cert.py
+++ b/src/middlewared/middlewared/plugins/crypto_/default_cert.py
@@ -1,0 +1,31 @@
+from middlewared.service import private, Service
+
+from .utils import CERT_TYPE_EXISTING
+
+
+class CertificateService(Service):
+
+    @private
+    async def setup_self_signed_cert_for_ui(self, cert_name):
+        config = await self.middleware.call('system.general.config')
+        cert, key = await self.middleware.call('cryptokey.generate_self_signed_certificate')
+
+        cert_dict = {
+            'certificate': cert,
+            'privatekey': key,
+            'name': cert_name,
+            'type': CERT_TYPE_EXISTING,
+        }
+
+        # We use datastore.insert to directly insert in db as jobs cannot be waited for at this point
+        id = await self.middleware.call(
+            'datastore.insert',
+            'system.certificate',
+            cert_dict,
+            {'prefix': 'cert_'}
+        )
+
+        await self.middleware.call('datastore.update', 'system.settings', config['id'], {'stg_guicertificate': id})
+
+        await self.middleware.call('service.start', 'ssl')
+        await self.middleware.call('service.reload', 'http')

--- a/src/middlewared/middlewared/plugins/crypto_/default_cert.py
+++ b/src/middlewared/middlewared/plugins/crypto_/default_cert.py
@@ -12,6 +12,7 @@ class CertificateService(Service):
         while not cert_id:
             cert = await self.middleware.call('certificate.query', [['name', '=', cert_name]])
             if cert:
+                cert = cert[0]
                 if await self.middleware.call('certificate.cert_services_validation', cert['id'], 'certificate', False):
                     cert_name = f'{cert_name}_{index}'
                     index += 1
@@ -30,7 +31,6 @@ class CertificateService(Service):
         )
 
         await self.middleware.call('service.start', 'ssl')
-        await self.middleware.call('service.reload', 'http')
 
     @private
     async def setup_self_signed_cert_for_ui_impl(self, cert_name):

--- a/src/middlewared/middlewared/plugins/crypto_/default_cert.py
+++ b/src/middlewared/middlewared/plugins/crypto_/default_cert.py
@@ -1,12 +1,12 @@
 from middlewared.service import private, Service
 
-from .utils import CERT_TYPE_EXISTING
+from .utils import CERT_TYPE_EXISTING, DEFAULT_CERT_NAME
 
 
 class CertificateService(Service):
 
     @private
-    async def setup_self_signed_cert_for_ui(self, cert_name):
+    async def setup_self_signed_cert_for_ui(self, cert_name=DEFAULT_CERT_NAME):
         cert_id = None
         index = 1
         while not cert_id:

--- a/src/middlewared/middlewared/plugins/crypto_/utils.py
+++ b/src/middlewared/middlewared/plugins/crypto_/utils.py
@@ -15,6 +15,7 @@ CERT_BACKEND_MAPPINGS = {
 # Cert locations
 CERT_ROOT_PATH = '/etc/certificates'
 CERT_CA_ROOT_PATH = '/etc/certificates/CA'
+DEFAULT_CERT_NAME = 'truenas_default'
 # This constant defines the default lifetime of certificate ( https://support.apple.com/en-us/HT211025 )
 DEFAULT_LIFETIME_DAYS = 397
 EC_CURVES = [


### PR DESCRIPTION
This PR adds changes to ensure we comply with openssl security level 2 which enforces certain restrictions on what kind of certs can be used.

It also adds a migration which will ensure that if a user has a malformed cert configured before these changes went in or is coming from CORE for example, we validate his cert and generate a self signed cert if his selected cert is invalid. Motivation behind this is that without this change nginx would fail to start complaining about openssl errors.

Original PR: https://github.com/truenas/middleware/pull/8715
Jira URL: https://jira.ixsystems.com/browse/NAS-115037