### PR TITLE
NAS-115700 / 22.12 / Be verbose about zpool list in TrueNAS debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -97,8 +97,8 @@ zfs_func()
 	ORDER BY +id"
 	section_footer
 	
-	section_header "zpool list"
-	zpool list
+	section_header "zpool list -v"
+	zpool list -v
 	section_footer
 
 	section_header "zfs list -ro space,refer,mountpoint"


### PR DESCRIPTION
## Description
Adding `-v` flag in listing zpools, that shows storage info of individual devices as well.

### PS
Request initially came from support.