### PR TITLE
NAS-115639 / 22.02.1 / properly display zfs dataset recordsize choices (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3093,9 +3093,7 @@ class PoolDatasetService(CRUDService):
         Inheritable(Str('deduplication', enum=['ON', 'VERIFY', 'OFF'])),
         Inheritable(Str('checksum', enum=ZFS_CHECKSUM_CHOICES)),
         Inheritable(Str('readonly', enum=['ON', 'OFF'])),
-        Inheritable(Str('recordsize', enum=[
-            '512', '1K', '2K', '4K', '8K', '16K', '32K', '64K', '128K', '256K', '512K', '1024K',
-        ]), has_default=False),
+        Inheritable(Str('recordsize'), has_default=False),
         Inheritable(Str('casesensitivity', enum=['SENSITIVE', 'INSENSITIVE', 'MIXED']), has_default=False),
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
         Inheritable(Str('acltype', enum=['OFF', 'NOACL', 'NFSV4', 'NFS4ACL', 'POSIX', 'POSIXACL']), has_default=False),
@@ -3518,6 +3516,9 @@ class PoolDatasetService(CRUDService):
                     f'{schema}.special_small_block_size',
                     'This field can be "INHERIT", 0 or multiple of 512, up to 1048576'
                 )
+            if rs := data.get('recordsize'):
+                if rs not in await self.middleware.call('pool.dataset.recordsize_choices'):
+                    verrors.add(f'{schema}.recordsize', '{rs!r} is an invalid recordsize.')
         elif data['type'] == 'VOLUME':
             if mode == 'CREATE' and 'volsize' not in data:
                 verrors.add(f'{schema}.volsize', 'This field is required for VOLUME')

--- a/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
@@ -1,0 +1,36 @@
+from middlewared.schema import accepts, returns, List, Str
+from middlewared.service import Service
+
+
+class PoolDatasetService(Service):
+
+    class Config:
+        namespace = 'pool.dataset'
+
+    # https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-max-recordsize
+    # Maximum supported (at time of writing) is 16MB.
+    MAPPING = {
+        1 << 9: '512B',
+        1 << 10: '1K',
+        1 << 11: '2K',
+        1 << 12: '4K',
+        1 << 13: '8K',
+        1 << 14: '16K',
+        1 << 15: '32K',
+        1 << 16: '64K',
+        1 << 17: '128K',
+        1 << 18: '256K',
+        1 << 19: '512K',
+        1 << 20: '1M',
+        1 << 21: '2M',
+        1 << 22: '4M',
+        1 << 23: '8M',
+        1 << 24: '16M',
+    }
+
+    @accepts()
+    @returns(List(items=[Str('recordsize_value')]))
+    def recordsize_choices(self):
+        with open('/sys/module/zfs/parameters/zfs_max_recordsize') as f:
+            val = int(f.read().strip())
+            return [v for k, v in self.MAPPING.items() if k <= val]

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_recordsize_choices.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_recordsize_choices.py
@@ -1,0 +1,10 @@
+import io
+from unittest.mock import patch
+
+from middlewared.plugins.pool_.dataset_recordsize import PoolDatasetService
+
+
+def test_recordsize_choices():
+    with patch("middlewared.plugins.pool_.dataset_recordsize.open") as mock:
+        mock.return_value = io.StringIO("32768\n")
+        assert PoolDatasetService(None).recordsize_choices() == ["512B", "1K", "2K", "4K", "8K", "16K", "32K"]


### PR DESCRIPTION
We need to base the maximum dataset recordsize off of `zfs_max_recordsize` module option. Furthermore, ZFS supports up to 16MB recordsize. All you have to do is `echo '16777216' > /sys/module/zfs/parameters/zfs_max_recordsize`.

This changes it so that we always determine the maximum size based off of that module option.

Original PR: https://github.com/truenas/middleware/pull/8739
Jira URL: https://jira.ixsystems.com/browse/NAS-115639