### PR TITLE
NAS-115707 / 22.12 / add ctdb.public.ips.interface_choices method

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
@@ -41,7 +41,7 @@ class CtdbPublicIpService(CRUDService):
             for j in filter(lambda x: x['type'] != 'LINK' and x['address'] not in priv_ips, i['aliases']):
                 choices.add(i['id'])
 
-        return list(choices - set(exclude))
+        return sorted(choices - set(exclude))
 
     @filterable
     def query(self, filters, options):


### PR DESCRIPTION
Returns a list of available interfaces that can be used to assign a ctdbd public address. Needed for and to be used by the TC team.