### PR TITLE
DOCS-3526 / 22.02.1 / Add a sleep of 5 second after garbing the device in iscsi test 35

### DIFF
--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -163,7 +163,8 @@ def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name(request):
             file_device_name = iscsictl_list[3]
             assert True
             break
-        sleep(3)
+        sleep(1)
+    sleep(5)
 
 
 @bsd_host_cfg
@@ -369,6 +370,7 @@ def test_35_waiting_for_iscsi_connection_before_grabbing_device_name(request):
             assert True
             break
         sleep(1)
+    sleep(5)
 
 
 @bsd_host_cfg
@@ -469,6 +471,7 @@ def test_48_waiting_for_iscsi_connection_before_grabbing_device_name(request):
             assert True
             break
         sleep(1)
+    sleep(5)
 
 
 @bsd_host_cfg


### PR DESCRIPTION
That make sure that the device is ready to be formatted and mounted

It is a back-port of 13.0-stable test