### PR TITLE
DOCS-3530 / 22.02.01 / Fixed api2.test_system_dataset.test_system_dataset_migrate error

### DIFF
--- a/tests/api2/test_system_dataset.py
+++ b/tests/api2/test_system_dataset.py
@@ -1,9 +1,8 @@
-from middlewared.test.integration.utils import call, mock, pool
+from middlewared.test.integration.utils import call, mock, pool, ssh
 
 
 def read_log():
-    with open("/var/log/middlewared.log") as f:
-        return f.read()
+    return ssh("cat /var/log/middlewared.log")
 
 
 def write_to_log(string):


### PR DESCRIPTION
/var/log/middlewared.log is not on the host of the test.