### PR TITLE
NAS-115767 / 22.12 / Fix middleware not starting

### DIFF
--- a/src/middlewared/middlewared/plugins/tunables.py
+++ b/src/middlewared/middlewared/plugins/tunables.py
@@ -94,8 +94,8 @@ class TunableService(CRUDService):
         Patch(
             'tunable_create',
             'tunable_update',
-            ('rm', 'var'),
-            ('rm', 'type'),
+            ('rm', {'name': 'var'}),
+            ('rm', {'name': 'type'}),
             ('attr', {'update': True}),
         )
     )


### PR DESCRIPTION
## Problem

`Patch` schema has not been used correctly which results in middleware not able to start as the schema cannot be resolved.