### PR TITLE
NAS-114488 / 22.12 / Do not escape space when specifying docker data root

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker.py
+++ b/src/middlewared/middlewared/etc_files/docker.py
@@ -42,7 +42,7 @@ def render(service, middleware):
     data_root = os.path.join('/mnt', config['dataset'], 'docker')
     with open('/etc/docker/daemon.json', 'w') as f:
         f.write(json.dumps({
-            'data-root': data_root.replace(' ', r'\ '),
+            'data-root': data_root,
             'exec-opts': ['native.cgroupdriver=cgroupfs'],
             'iptables': False,
             'bridge': 'none',


### PR DESCRIPTION
## Problem

Docker was not able to handle spaces in `data-root` and we were escaping it with `\` but that resulted in docker creating another directory i.e if pool name is `Test Pool` and is mounted at `/mnt/Test Pool`, docker would create a path at `/mnt/Test\ Pool/ix-applications/docker` and take `\` literally


## Solution

The problem was fixed in https://github.com/truenas/moby/pull/5 so that docker does not need to be specified a space by escaping it.