### PR TITLE
NAS-115783 / 22.12 / Generated dhclient.conf files are broken

### DIFF
--- a/src/middlewared/middlewared/etc_files/dhclient.conf.mako
+++ b/src/middlewared/middlewared/etc_files/dhclient.conf.mako
@@ -7,9 +7,9 @@
         hostname = f"{gc['hostname']}.{gc['domain']}"
 %>
 % if use_fqdn:
-send fqdn.fqdn "${hostname}"
+send fqdn.fqdn "${hostname}";
 % else:
-send host-name "${hostname}"
+send host-name "${hostname}";
 % endif
 % if gc['ipv4gateway']:
 supersede routers ${gc['ipv4gateway']}
@@ -20,4 +20,4 @@ request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
         dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
         netbios-name-servers, netbios-scope, interface-mtu,
-        rfc3442-classless-static-routes, ntp-servers;
+        ntp-servers;


### PR DESCRIPTION
The bug contains more info, but the generated dhclient.conf files contain errors, and it's only by luck that dhclient ignores the errors rather than failing.
This patch fixes the missing semicolon for the send line, and the classless option that doesn't exist in dhclient.

At a glance, the supersede statement may be wrong as well, but i'm not familiar enough with dhclient.conf errors.