### PR TITLE
NAS-115783 / 22.02.2 / fix dhclient.conf generation (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/dhclient.conf.mako
+++ b/src/middlewared/middlewared/etc_files/dhclient.conf.mako
@@ -6,13 +6,14 @@
         use_fqdn = True
         hostname = f"{gc['hostname']}.{gc['domain']}"
 %>
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 % if use_fqdn:
-send fqdn.fqdn "${hostname}"
+send fqdn.fqdn "${hostname}";
 % else:
-send host-name "${hostname}"
+send host-name "${hostname}";
 % endif
 % if gc['ipv4gateway']:
-supersede routers ${gc['ipv4gateway']}
+supersede routers ${gc['ipv4gateway']};
 request subnet-mask, broadcast-address, time-offset,
 % else:
 request subnet-mask, broadcast-address, time-offset, routers,


### PR DESCRIPTION
I got on a vanilla debian box and noticed that we were missing the line (which is done by default)
```
option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
```

Furthermore, configuration statements must be suffixed with a `;` which we're not doing.

Original PR: https://github.com/truenas/middleware/pull/8785
Jira URL: https://jira.ixsystems.com/browse/NAS-115783