### PR TITLE
NAS-115834 / 13.0 / remove unnecessary disk.swaps_configure call

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -774,7 +774,6 @@ class PoolService(CRUDService):
 
         # There is really no point in waiting all these services to reload so do them
         # in background.
-        asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
         asyncio.ensure_future(self.restart_services())
 
         pool = await self.get_instance(pool_id)


### PR DESCRIPTION
`pool.post_create_or_update` calls `disk.swaps_configure` so there is no reason to call this here.