### PR TITLE
NAS-115554 / 22.12 / Move to using cgroups v2

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -17,11 +17,9 @@ if __name__ == "__main__":
     # We need to allow tpm in grub as sedutil-cli requires it
     # `zfsforce=1` is needed because FreeBSD bootloader imports boot pool with hostid=0 while SCALE releases up to
     # 22.02-RC.2 use real hostid. We need to be able to boot both of these configurations.
-    # TODO: Please remove kernel flag to use cgroups v1 when nvidia device plugin starts working
-    #  with it ( https://github.com/NVIDIA/k8s-device-plugin/issues/235 )
     config = [
         'GRUB_DISTRIBUTOR="TrueNAS Scale"',
-        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1 systemd.unified_cgroup_hierarchy=0 amd_iommu=on iommu=pt '
+        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1 amd_iommu=on iommu=pt '
         'kvm_amd.npt=1 kvm_amd.avic=1 intel_iommu=on zfsforce=1'
         f'{f" {kernel_extra_args}" if kernel_extra_args else ""}"',
     ]

--- a/src/middlewared/middlewared/utils/cgroups.py
+++ b/src/middlewared/middlewared/utils/cgroups.py
@@ -2,13 +2,9 @@
 def move_to_root_cgroups(pid):
     with open(f"/proc/{pid}/cgroup") as f:
         for line in f.readlines():
-            _, names, value = line.strip().split(":")
+            _, _, value = line.strip().split(":")
 
             if value == "/system.slice/middlewared.service":
-                for name in names.split(","):
-                    new_name = {
-                        "name=systemd": "systemd",
-                        "": "unified",
-                    }.get(name, name)
-                    with open(f"/sys/fs/cgroup/{new_name}/cgroup.procs", "w") as f2:
-                        f2.write(f"{pid}\n")
+                with open(f"/sys/fs/cgroup/cgroup.procs", "w") as f2:
+                    f2.write(f"{pid}\n")
+                    break


### PR DESCRIPTION
## Problem

We were using cgroups v1 as `libnvidia-container` did not have support for it but in Feb release version of it was available which provided cgroups v2 support.

## Conclusion

Moving to cgroups v2 and covering usage where we had a utility function which helps move a process id to root cgroup. This is useful for cases like when `dhclient` is started by middleware and the `dhclient` process is not moved to root cgroup, on middleware stop/crash/restart, dhclient would be killed.