### PR TITLE
NAS-115848 / 23.10 / FreeIPA groups do not work

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -876,7 +876,6 @@ class LDAPService(TDBWrapConfigService):
 
             default_naming_context = rootdse[0]['data']['defaultnamingcontext'][0]
             aux_params = [
-                'map group member uniqueMember',
                 f'base passwd cn=users,cn=accounts,{default_naming_context}',
                 f'base group cn=groups,cn=accounts,{default_naming_context}',
             ]


### PR DESCRIPTION
FreeIPA does not have a uniqueMember attribute by default.
(in fact, you have to generate them if you want to integrate vsphere and FreeIPA, for example)

As a result, the default configuration of "map group member uniqueMember" causes users to lose all their groups :)
There is no need to do this mapping, as the default group mapping is correct.

I have given an example before/after for a user on the Jira bugreport