### PR TITLE
NAS-115849 / 13.0 / Hook improvements

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1073,7 +1073,12 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         return self.__hooks
 
     def update_hook(self, hook_name, block):
-        ignore = ('core.on_connect', 'ha_permission')  # if you block these, you're going to have a bad time
+        # if you block these, you're going to have a bad time
+        ignore = (
+            'core.on_connect',
+            'ha_permission',
+            'datastore.post_execute_write',  # for HA systems
+        )
 
         if hook_name == 'all':
             for rname, rhooks in filter(lambda x: x[0] not in ignore, self.__hooks.copy().items()):

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -776,6 +776,15 @@ class ServicePartBase(metaclass=ServicePartBaseMeta):
 
 class CoreService(Service):
 
+    @private
+    @accepts(Dict('hook_info', Str('hook_name', required=True), Bool('block', required=True)))
+    def update_hook(self, data):
+        hook_name = data['hook_name']
+        if hook_name != 'all' and (hook_name not in self.middleware.get_hooks()):
+            raise ValidationError(None, f'{hook_name!r} not found in registered hooks')
+
+        self.middleware.update_hook(hook_name, data['block'])
+
     @accepts(Str('id'), Int('cols'), Int('rows'))
     async def resize_shell(self, id, cols, rows):
         """


### PR DESCRIPTION
Optimizing middlewared service on a system with ~1.2k hard drives has exposed some fundamental design flaws. 1 of those is the fact of how we're using hooks. The overly simplified problem is that we have hooks being called which is creating async tasks and each task (potentially) could be calling the same method. In some scenarios we're actually calling methods 2, 3 and sometimes 4+ times. This is painful normally but excruciating on larger systems. To make matters worse, we've designed hooks to be called based off of OS devd events. This means we could get a bunch of devd events (triggered by an API endpoint) that call specific methods and then in the API endpoint that triggered the devd events we go ahead and explicitly call a hook that does the same thing as what our devd hooks do.....

This is the best idea that I could come up with and that is to add the ability to "block" (disable) hooks temporarily. The idea is that in some API endpoints you would disable conflicting hooks, run the necessary logic, then re-enable the hooks that you disabled. Testing this on a very large system has shown that adding a single vdev to a > 200 drive zpool cuts the time down from like ~12mins to ~10 seconds.

Fixes implemented:
1. add the ability to "block" (disable) hooks temporarily
2. fix a `RuntimeWarning` that showed up when I was QA'ing these changes on a live system