### PR TITLE
NAS-115854 / 22.12 / Can't change SMB admin group due to typo

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -827,7 +827,7 @@ class SMBService(TDBWrapConfigService):
             await self.middleware.call("smb.synchronize_group_mappings")
 
         if new['admin_group'] and new['admin_group'] != old['admin_group']:
-            job = await self.middleware.call('smb.synchronize_group_mapping')
+            job = await self.middleware.call('smb.synchronize_group_mappings')
             await job.wait()
 
         await self._service_change(self._config.service, 'restart')


### PR DESCRIPTION
Fix typo in name of API to call to synchronize group mappings.
Without this, attempts to edit the admin group name fail