### PR TITLE
NAS-115792 / 22.02.1 / generate new hostname properly (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/global.py
+++ b/src/middlewared/middlewared/plugins/network_/global.py
@@ -264,7 +264,7 @@ class NetworkConfigurationService(ConfigService):
                 'NAS is configured as a time machine target. mDNS is required.'
             )
 
-        lhost_changed = config['hostname_local'] != new_config['hostname_local']
+        lhost_changed = config['hostname'] != new_config['hostname']
         bhost_changed = config.get('hostname_b') and config['hostname_b'] != new_config['hostname_b']
         vhost_changed = config.get('hostname_virtual') and config['hostname_virtual'] != new_config['hostname_virtual']
 

--- a/tests/api2/test_network_configuration.py
+++ b/tests/api2/test_network_configuration.py
@@ -1,0 +1,23 @@
+import sys
+import os
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+import pytest
+
+from middlewared.test.integration.utils import call, ssh
+from auto_config import dev_test
+
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
+NEW_HOSTNAME = 'dummy123'
+
+
+def test_changing_hostname():
+    current_hostname = call('network.configuration.config')['hostname']
+
+    call('network.configuration.update', {'hostname': NEW_HOSTNAME})
+    assert ssh('hostname').strip() == NEW_HOSTNAME
+
+    call('network.configuration.update', {'hostname': current_hostname})
+    assert ssh('hostname').strip() == current_hostname


### PR DESCRIPTION
`hostname_local` key is added via the `_extend` method and doesn't reflect the current changes submitted via the API.

Original PR: https://github.com/truenas/middleware/pull/8805
Jira URL: https://jira.ixsystems.com/browse/NAS-115792