### PR TITLE
fix recordsize schema

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3151,7 +3151,6 @@ class PoolDatasetService(CRUDService):
         ('edit', _add_inherit('compression')),
         ('edit', _add_inherit('deduplication')),
         ('edit', _add_inherit('readonly')),
-        ('edit', _add_inherit('recordsize')),
         ('edit', _add_inherit('snapdir')),
         ('add', Inheritable('quota_warning', value=Int('quota_warning', validators=[Range(0, 100)]))),
         ('add', Inheritable('quota_critical', value=Int('quota_critical', validators=[Range(0, 100)]))),


### PR DESCRIPTION
Commit https://github.com/truenas/middleware/commit/aeb8566f4c53f817909da6a3319a84eaea18a55d fixed displaying the correct recordsize choices which removes the necessity for having `_add_inherit('recordsize')` line. Without this change, middlewared service won't start on 13