### PR TITLE
NAS-115863 / 13.0 / fix importing geli encrypted zpools 13

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -5,7 +5,7 @@
 
 # PROVIDE: ix-etc
 # REQUIRE: middlewared earlykld ix-syncdisks
-# BEFORE: fsck
+# BEFORE: disks
 
 . /etc/rc.subr
 


### PR DESCRIPTION
On non-HA 13 systems, `ix-etc` must run before `disks` rc script (/etc/rc.d/geli) since it's responsible for populating the geli provider information to /etc/rc.conf.freenas. Without this, geli volumes do not get mounted on upgrade/reboot for 13.