### PR TITLE
NAS-115840 / 22.12 / Blacklist irdma driver.

### DIFF
--- a/src/freenas/usr/lib/modprobe.d/truenas.conf
+++ b/src/freenas/usr/lib/modprobe.d/truenas.conf
@@ -1,3 +1,4 @@
 options ntb driver_override="ntb_split"
 options ntb_split config="ntb_pmem:1:4:0,ntb_transport"
 options ntb_transport use_dma=1
+blacklist irdma


### PR DESCRIPTION
This driver tends to allocate 160-210MB of RAM per Intel NIC port,
that overflows CMA region we need for ntb_transport and can't just
increase to few GB considering small systems.  Wasting GBs of RAM
for smaller systems with good NICs is also not good.  Since we
currently do not use any RDMA services, blocking this driver seems
to be the obvious choice.

Ticket:	NAS-115840