### PR TITLE
NAS-115913 / 13.0 / Secure temporary dir with `generate_ssh_key_pair` (by oittaa)

### DIFF
--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -3,7 +3,6 @@ import enum
 import errno
 import os
 import re
-import string
 import subprocess
 import tempfile
 import urllib.parse

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -469,22 +469,13 @@ class KeychainCredentialService(CRUDService):
             }
         """
 
-        key = os.path.join("/tmp", "".join(random.choice(string.ascii_letters) for _ in range(32)))
-        if os.path.exists(key):
-            os.unlink(key)
-        if os.path.exists(f"{key}.pub"):
-            os.unlink(f"{key}.pub")
-        try:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            key = os.path.join(tmpdirname, "key")
             subprocess.check_call(["ssh-keygen", "-t", "rsa", "-f", key, "-N", "", "-q"])
             with open(key) as f:
                 private_key = f.read()
             with open(f"{key}.pub") as f:
                 public_key = f.read()
-        finally:
-            if os.path.exists(key):
-                os.unlink(key)
-            if os.path.exists(f"{key}.pub"):
-                os.unlink(f"{key}.pub")
 
         return {
             "private_key": private_key,

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -2,7 +2,6 @@ import base64
 import enum
 import errno
 import os
-import random
 import re
 import string
 import subprocess


### PR DESCRIPTION
https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory

Btw. Is there a reason for not using some more modern key type like `ed25519` instead of `rsa`?

Original PR: https://github.com/truenas/middleware/pull/8823
Jira URL: https://jira.ixsystems.com/browse/NAS-115913