### PR TITLE
Password storage

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
+++ b/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
@@ -3,7 +3,6 @@ import os
 import hashlib
 
 from contextlib import suppress
-from string import digits, ascii_uppercase, ascii_lowercase
 
 from middlewared.plugins.account import crypted_password
 from middlewared.plugins.webdav import WEBDAV_USER

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -14,10 +14,8 @@ import errno
 import glob
 import hashlib
 import os
-import random
 import shlex
 import shutil
-import string
 import stat
 import time
 from pathlib import Path

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -60,9 +60,7 @@ def crypted_password(cleartext):
     """
     Generates an unix hash from `cleartext`.
     """
-    return crypt.crypt(cleartext, '$6$' + ''.join([
-        random.choice(string.ascii_letters + string.digits) for _ in range(16)]
-    ))
+    return crypt.crypt(cleartext, crypt.METHOD_BLOWFISH)
 
 
 def nt_password(cleartext):


### PR DESCRIPTION
A single round of SHA-512 is not an acceptable way to store passwords in 2022. Python has supported bcrypt in `crypt` calls since version 3.7, so it can be used with minimal changes.

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
https://docs.python.org/3/library/crypt.html#crypt.METHOD_BLOWFISH