### PR TITLE
NAS-115917 / 22.12 / replace "random" module with "secrets" module

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -4,6 +4,7 @@ from .utils import ProgressBar
 from collections import defaultdict, namedtuple, Callable
 from threading import Event as TEvent, Lock, Thread
 from ws4py.client.threadedclient import WebSocketClient
+from middlewared.utils.generate import random_sample
 
 import argparse
 from base64 import b64decode
@@ -15,7 +16,6 @@ import socket
 import sys
 import time
 import uuid
-import random
 import platform
 
 
@@ -99,10 +99,9 @@ class WSClient(WebSocketClient):
             # iteration in the for loop
             port_low = 600
             port_high = 1024
+            size = 5
 
-            ports_to_try = random.sample(range(port_low, port_high), 5)
-
-            for port in ports_to_try:
+            for port in random_sample(port_low, port_high, size):
                 try:
                     self.sock.bind(('', port))
                     return

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -1,11 +1,10 @@
 from datetime import datetime
 import fnmatch
-import random
 import re
-import string
 
 from passlib.hash import pbkdf2_sha256
 
+from middlewared.utils.generare import random_string
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Patch
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -203,7 +202,7 @@ class ApiKeyService(CRUDService):
             raise verrors
 
     def _generate(self):
-        return "".join([random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(64)])
+        return random_string(string_size=64)
 
     def _serve(self, data, key):
         if key is None:

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -1,10 +1,8 @@
 import crypt
 from datetime import datetime, timedelta
 import hmac
-import random
 import re
 import socket
-import string
 import time
 import warnings
 
@@ -19,6 +17,7 @@ from middlewared.service import (
 )
 import middlewared.sqlalchemy as sa
 from middlewared.validators import Range
+from middlewared.utils.generate import random_string
 
 
 def get_peer_process(remote_addr, remote_port):
@@ -66,7 +65,7 @@ class TokenManager:
     def create(self, ttl, attributes=None):
         attributes = attributes or {}
 
-        token = "".join(random.choice(string.ascii_letters + string.digits) for _ in range(64))
+        token = random_string(string_size=64)
         self.tokens[token] = Token(self, token, ttl, attributes)
         return self.tokens[token]
 

--- a/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
@@ -1,5 +1,4 @@
-import random
-
+from middlewared.utils.generate import random_bits
 from middlewared.schema import accepts, Bool, Dict, Int, Patch, Str
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -367,7 +366,7 @@ class CertificateAuthorityService(CRUDService):
     @private
     async def create_internal(self, data):
         cert_info = get_cert_info_from_data(data)
-        cert_info['serial'] = random.getrandbits(24)
+        cert_info['serial'] = random_bits(24)
 
         cert_info['cert_extensions'] = data['cert_extensions']
         (cert, key) = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
@@ -366,7 +366,7 @@ class CertificateAuthorityService(CRUDService):
     @private
     async def create_internal(self, data):
         cert_info = get_cert_info_from_data(data)
-        cert_info['serial'] = random_bits(24)
+        cert_info['serial'] = await self.middleware.run_in_thread(random_bits, 24)
 
         cert_info['cert_extensions'] = data['cert_extensions']
         (cert, key) = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/crypto_/generate_utils.py
+++ b/src/middlewared/middlewared/plugins/crypto_/generate_utils.py
@@ -1,11 +1,11 @@
 import datetime
 import ipaddress
-import random
 import typing
 
 from cryptography import x509
 from cryptography.x509.oid import NameOID
 
+from middlewared.utils.generate import random_int
 from middlewared.validators import IpAddress
 
 from .utils import DEFAULT_LIFETIME_DAYS
@@ -48,7 +48,7 @@ def generate_builder(options: dict) -> typing.Union[x509.CertificateBuilder, x50
             not_valid_before
         ).not_valid_after(
             not_valid_after
-        ).serial_number(options.get('serial') or random.randint(1000, pow(2, 30)))
+        ).serial_number(options.get('serial') or random_int(1000, pow(2, 30)))
 
     if san:
         cert = cert.add_extension(san, False)

--- a/src/middlewared/middlewared/plugins/failover_/sensor.py
+++ b/src/middlewared/middlewared/plugins/failover_/sensor.py
@@ -1,9 +1,9 @@
 import asyncio
-import random
 import re
 
 from middlewared.service import Service, filterable
 from middlewared.utils import filter_list, run
+from middlewared.utils.generate import random_uniform
 
 
 class SensorService(Service):
@@ -43,7 +43,7 @@ class SensorService(Service):
                         # randomly probing the status of the PSU's at the same time.
                         for i in range(3):
                             self.logger.info("%r Status = 0x0, rereading", ps)
-                            await asyncio.sleep(random.uniform(1, 3))
+                            await asyncio.sleep(random_uniform(1, 3))
 
                             found = False
                             for sensor_2 in await self._sensor_list():

--- a/src/middlewared/middlewared/plugins/failover_/sensor.py
+++ b/src/middlewared/middlewared/plugins/failover_/sensor.py
@@ -43,7 +43,7 @@ class SensorService(Service):
                         # randomly probing the status of the PSU's at the same time.
                         for i in range(3):
                             self.logger.info("%r Status = 0x0, rereading", ps)
-                            await asyncio.sleep(random_uniform(1, 3))
+                            await asyncio.sleep(await self.middleware.run_in_thread(random_uniform, 1, 3))
 
                             found = False
                             for sensor_2 in await self._sensor_list():

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -52,7 +52,7 @@ class UsageService(Service):
         now = datetime.utcnow()
         scheduled = (
             now.replace(hour=23, minute=59, second=59) - now
-        ).total_seconds() + random_uniform(1, 86400)
+        ).total_seconds() + await self.middleware.run_in_thread(random_uniform, 1, 86400)
 
         event_loop.call_later(
             scheduled,

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -582,11 +582,7 @@ async def setup(middleware):
     event_loop = asyncio.get_event_loop()
 
     await middleware.call('network.general.register_activity', 'usage', 'Anonymous usage statistics')
-    event_loop.call_at(
-        random_uniform(1, (
-            now.replace(hour=23, minute=59, second=59) - now
-        ).total_seconds()),
-        lambda: asyncio.ensure_future(
-            middleware.call('usage.start')
-        )
+    scheduled = await middleware.run_in_thread(
+        random_uniform(1, (now.replace(hour=23, minute=59, second=59) - now).total_seconds())
     )
+    event_loop.call_at(scheduled, lambda: asyncio.ensure_future(middleware.call('usage.start')))

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -1,6 +1,5 @@
 import json
 import asyncio
-import random
 import aiohttp
 import os
 
@@ -10,6 +9,7 @@ from datetime import datetime
 
 from middlewared.service import Service
 from middlewared.utils import osc
+from middlewared.utils.generate import random_uniform
 
 
 class UsageService(Service):
@@ -52,7 +52,7 @@ class UsageService(Service):
         now = datetime.utcnow()
         scheduled = (
             now.replace(hour=23, minute=59, second=59) - now
-        ).total_seconds() + random.uniform(1, 86400)
+        ).total_seconds() + random_uniform(1, 86400)
 
         event_loop.call_later(
             scheduled,
@@ -583,7 +583,7 @@ async def setup(middleware):
 
     await middleware.call('network.general.register_activity', 'usage', 'Anonymous usage statistics')
     event_loop.call_at(
-        random.uniform(1, (
+        random_uniform(1, (
             now.replace(hour=23, minute=59, second=59) - now
         ).total_seconds()),
         lambda: asyncio.ensure_future(

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -1,5 +1,4 @@
-import random
-
+from middlewared.utils.generate import random_hex
 from middlewared.plugins.interface.netif import netif
 from middlewared.schema import Dict, Str
 from middlewared.service import CallError
@@ -33,10 +32,7 @@ class NIC(Device):
 
     @staticmethod
     def random_mac():
-        mac_address = [
-            0x00, 0xa0, 0x98, random.randint(0x00, 0x7f), random.randint(0x00, 0xff), random.randint(0x00, 0xff)
-        ]
-        return ':'.join(['%02x' % x for x in mac_address])
+        return ':'.join([0x00, 0xa0, 0x98, random_hex(0x00, 0x7f), random_hex(0x00, 0xff), random_hex(0x00, 0xff)])
 
     def setup_nic_attach(self):
         nic_attach = self.data['attributes'].get('nic_attach')

--- a/src/middlewared/middlewared/utils/generate.py
+++ b/src/middlewared/middlewared/utils/generate.py
@@ -1,10 +1,10 @@
-import random
+import secrets
 from string import ascii_letters, digits, punctuation
 
 
 def random_string(string_size=8, punctuation_chars=False):
     """
-    Generate a random string of size `string_size`.
+    Generate a cryptographically secure random string of size `string_size`.
 
     If `punctuation_chars` is True, then punctuation
     characters will be added to the string.
@@ -12,13 +12,22 @@ def random_string(string_size=8, punctuation_chars=False):
     Otherwise, only ASCII (upper and lower) and
     digits (0-9) are used to generate the string.
     """
-
     initial_string = ascii_letters + digits
-
     if punctuation_chars:
         initial_string += punctuation
 
-    return ''.join(
-        random.SystemRandom().choice(initial_string)
-        for i in range(string_size)
-    )
+    return ''.join(secrets.choice(initial_string) for i in range(string_size))
+
+
+def random_bits(size):
+    """
+    Generate an integer with `size` random bits.
+    """
+    return secrets.randbits(size)
+
+
+def random_int(start, end):
+    """
+    Generate a random integer in range [`start`, `end`] inclusive.
+    """
+    return secrets.SystemRandom().randint(start, end)

--- a/src/middlewared/middlewared/utils/generate.py
+++ b/src/middlewared/middlewared/utils/generate.py
@@ -1,5 +1,7 @@
-import secrets
+from secrets import choice, randbits, SystemRandom
 from string import ascii_letters, digits, punctuation
+
+SR = SystemRandom()
 
 
 def random_string(string_size=8, punctuation_chars=False):
@@ -16,18 +18,25 @@ def random_string(string_size=8, punctuation_chars=False):
     if punctuation_chars:
         initial_string += punctuation
 
-    return ''.join(secrets.choice(initial_string) for i in range(string_size))
+    return ''.join(choice(initial_string) for i in range(string_size))
 
 
 def random_bits(size):
     """
     Generate an integer with `size` random bits.
     """
-    return secrets.randbits(size)
+    return randbits(size)
 
 
 def random_int(start, end):
     """
     Generate a random integer in range [`start`, `end`] inclusive.
     """
-    return secrets.SystemRandom().randint(start, end)
+    return SR.randint(start, end)
+
+
+def random_uniform(a, b):
+    """
+    Get a random number (float) in range [`a`, `b`), or [`a`, `b`] depending on rounding.
+    """
+    return SR.uniform(a, b)

--- a/src/middlewared/middlewared/utils/generate.py
+++ b/src/middlewared/middlewared/utils/generate.py
@@ -47,3 +47,10 @@ def random_uniform(a, b):
     Get a random number (float) in range [`a`, `b`), or [`a`, `b`] depending on rounding.
     """
     return SR.uniform(a, b)
+
+
+def random_sample(start, end, size):
+    """
+    Returns a list of `size` random elements in range [`start`, `end`] exclusive of `end`.
+    """
+    return SR.sample(range(start, end), size)

--- a/src/middlewared/middlewared/utils/generate.py
+++ b/src/middlewared/middlewared/utils/generate.py
@@ -35,6 +35,13 @@ def random_int(start, end):
     return SR.randint(start, end)
 
 
+def random_hex(start, end):
+    """
+    Generate a random hexadecimal in range [`start`, `end`] inclusive.
+    """
+    return hex(random_int(start, end))
+
+
 def random_uniform(a, b):
     """
     Get a random number (float) in range [`a`, `b`), or [`a`, `b`] depending on rounding.

--- a/src/middlewared/middlewared/utils/generate.py
+++ b/src/middlewared/middlewared/utils/generate.py
@@ -1,7 +1,22 @@
 from secrets import choice, randbits, SystemRandom
 from string import ascii_letters, digits, punctuation
+from passlib.hash import pbkdf2_sha256, pbkdf2_sha512
 
 SR = SystemRandom()
+
+
+def hash_string_512(string):
+    """
+    Hash `string` using `pbkdf2_sha512` message digest.
+    """
+    return pbkdf2_sha512.hash(string)
+
+
+def hash_string_256(string):
+    """
+    Hash `string` using `pbkdf2_sha256` message digest.
+    """
+    return pbkdf2_sha256.hash(string)
 
 
 def random_string(string_size=8, punctuation_chars=False):


### PR DESCRIPTION
Based on the original PR: https://github.com/truenas/middleware/pull/8821, we're using `random` module for certain tasks which is not recommended. Thanks to @oittaa , a patch was offered which I have "modified" here. Instead of `import secrets` in multiple middlewared modules, I've extended the `middlewared.utils.generate` module to use `secrets` and added the necessary functions. There should be no functional change.