### PR TITLE
NAS-115930 / 22.12 / Autoconnect VNC display device when it's opened

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -46,9 +46,7 @@ class DISPLAY(Device):
 
     def web_uri(self, host, password=None, protocol='http'):
         path = self.get_webui_info()['path'][1:]
-        params = {'path': path}
-        if self.is_spice_type():
-            params['autoconnect'] = 1
+        params = {'path': path, 'autoconnect': 1}
         if self.password_configured():
             if password != self.data['attributes'].get('password'):
                 return


### PR DESCRIPTION
This commit introduces changes to restore previous behaviour when opening display device from UI, VNC is already connected instead of having to click again.