### PR TITLE
NAS-115659 / Enable spl_panic_halt for ZFS

### DIFF
--- a/src/freenas/usr/lib/modprobe.d/truenas.conf
+++ b/src/freenas/usr/lib/modprobe.d/truenas.conf
@@ -1,4 +1,5 @@
 options ntb driver_override="ntb_split"
 options ntb_split config="ntb_pmem:1:4:0,ntb_transport"
 options ntb_transport use_dma=1
+options spl spl_panic_halt=1
 blacklist irdma


### PR DESCRIPTION
spl_panic_halt enables kernel panic upon assertion failures. By default,
the asserting thread is halted to facilitate debugging.

Signed-off-by: Umer Saleem <usaleem@ixsystems.com>