### PR TITLE
NAS-115854 / 22.02.1 / Can't change SMB admin group due to typo (by dberlin)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -828,7 +828,7 @@ class SMBService(TDBWrapConfigService):
             await self.middleware.call("smb.synchronize_group_mappings")
 
         if new['admin_group'] and new['admin_group'] != old['admin_group']:
-            job = await self.middleware.call('smb.synchronize_group_mapping')
+            job = await self.middleware.call('smb.synchronize_group_mappings')
             await job.wait()
 
         await self._service_change(self._config.service, 'restart')


### PR DESCRIPTION
Fix typo in name of API to call to synchronize group mappings.
Without this, attempts to edit the admin group name fail

Original PR: https://github.com/truenas/middleware/pull/8802
Jira URL: https://jira.ixsystems.com/browse/NAS-115854