### PR TITLE
NAS-115850 / 22.02.2 / remove loginshell mapping from nslcd config (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
@@ -57,7 +57,6 @@
     scope 	sub
     timelimit	${ldap['timeout']}
     bind_timelimit ${ldap['dns_timeout']}
-    map passwd loginShell "/bin/sh"
   % if ldap['schema'] == 'RFC2307BIS':
     nss_nested_groups yes
   % endif


### PR DESCRIPTION
This is no longer needed.

Original PR: https://github.com/truenas/middleware/pull/8820
Jira URL: https://jira.ixsystems.com/browse/NAS-115850