### PR TITLE
Revert "NAS-115752 / 22.02.1 / set netbios name in cluster api tests (by yocalebo)"

### DIFF
--- a/cluster-tests/config.py
+++ b/cluster-tests/config.py
@@ -28,8 +28,7 @@ CLUSTER_INFO = {
 CLUSTER_ADS = {
     'DOMAIN': environ.get('AD_DOMAIN'),
     'USERNAME': environ.get('AD_USERNAME'),
-    'PASSWORD': environ.get('AD_PASSWORD'),
-    'NETBIOS': environ.get('NETBIOS'),
+    'PASSWORD': environ.get('AD_PASSWORD')
 }
 
 CLUSTER_LDAP = {

--- a/cluster-tests/tests/directoryservices/test_001_activedirectory.py
+++ b/cluster-tests/tests/directoryservices/test_001_activedirectory.py
@@ -48,11 +48,10 @@ def test_003_join_activedirectory(request):
     depends(request, ['DS_NETWORK_CONFIGURED'])
 
     payload = {
-        'netbiosname': CLUSTER_ADS['NETBIOS'],
-        'domainname': CLUSTER_ADS['DOMAIN'],
-        'bindname': CLUSTER_ADS['USERNAME'],
-        'bindpw': CLUSTER_ADS['PASSWORD'],
-        'enable': True
+        "domainname": CLUSTER_ADS['DOMAIN'],
+        "bindname": CLUSTER_ADS['USERNAME'],
+        "bindpw": CLUSTER_ADS['PASSWORD'],
+        "enable": True
     }
     url = f'http://{CLUSTER_IPS[0]}/api/v2.0/activedirectory/'
     res = make_request('put', url, data=payload)


### PR DESCRIPTION
Reverts truenas/middleware#8762

This requires middleware backport to fix null not allowed, and isn't working yet in master since computer name is still getting set to TRUENAS even though NETBIOS variable is being exported.  Reverting for now to get CI back in order and once this works in master we can revert the revert.