### PR TITLE
NAS-115823 / 13.0 / use block_hooks context manager in pool plugin

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure.py
@@ -292,5 +292,5 @@ async def pool_post_delete(middleware, id):
 
 
 def setup(middleware):
-    middleware.register_hook('devd.zfs', devd_zfs_hook)
+    middleware.register_hook('devd.zfs', devd_zfs_hook, blockable=True)
     middleware.register_hook('pool.post_delete', pool_post_delete)

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -180,10 +180,8 @@ class Job(object):
         # Otherwise we create a new stub for the job with the Event for when
         # the job event arrives to use existing event.
         with client._jobs_lock:
-            job = client._jobs.get(job_id)
-            self.event = None
-            if job:
-                self.event = job.get('__ready')
+            job = client._jobs[job_id]
+            self.event = job.get('__ready')
             if self.event is None:
                 self.event = job['__ready'] = Event()
             job['__callback'] = callback
@@ -364,6 +362,29 @@ class Client(object):
         })
 
     def on_close(self, code, reason=None):
+        error = f'WebSocket connection closed with code={code!r}, reason={reason!r}'
+
+        for call in self._calls.values():
+            if not call.returned.is_set():
+                call.errno = errno.ECONNABORTED
+                call.error = error
+                call.returned.set()
+
+        for job in self._jobs.values():
+            event = job.get('__ready')
+            if event is None:
+                event = job['__ready'] = Event()
+
+            if not event.is_set():
+                job['error'] = error
+                job['exception'] = error
+                job['exc_info'] = {
+                    'type': 'Exception',
+                    'repr': error,
+                    'extra': None,
+                }
+                event.set()
+
         self._closed.set()
 
     def _register_call(self, call):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -17,6 +17,7 @@ from .utils.service.call import ServiceCallMixin
 from .webui_auth import WebUIAuth
 from .worker import main_worker, worker_init
 from aiohttp import web
+from aiohttp.http_websocket import WSCloseCode
 from aiohttp.web_exceptions import HTTPPermanentRedirect
 from aiohttp.web_middlewares import normalize_path_middleware
 from aiohttp_wsgi import WSGIHandler
@@ -1488,19 +1489,45 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
 
         try:
             async for msg in ws:
-                if not connection.authenticated and len(msg.data) > 8192:
-                    await ws.close(message='Anonymous connection max message length is 8 kB'.encode('utf-8'))
+                if msg.type == web.WSMsgType.ERROR:
+                    self.logger.error('Websocket error: %r', msg.data)
                     break
 
-                x = json.loads(msg.data)
+                if msg.type != web.WSMsgType.TEXT:
+                    await ws.close(
+                        code=WSCloseCode.UNSUPPORTED_DATA,
+                        message=f'Invalid websocket message type: {msg.type!r}'.encode('utf-8'),
+                    )
+                    break
+
+                if not connection.authenticated and len(msg.data) > 8192:
+                    await ws.close(
+                        code=WSCloseCode.INVALID_TEXT,
+                        message='Anonymous connection max message length is 8 kB'.encode('utf-8'),
+                    )
+                    break
+
                 try:
-                    await connection.on_message(x)
+                    message = json.loads(msg.data)
+                except ValueError as f:
+                    await ws.close(
+                        code=WSCloseCode.INVALID_TEXT,
+                        message=f'{f}'.encode('utf-8'),
+                    )
+                    break
+
+                try:
+                    await connection.on_message(message)
                 except Exception as e:
                     self.logger.error('Connection closed unexpectedly', exc_info=True)
-                    await ws.close(message=str(e).encode('utf-8'))
+                    await ws.close(
+                        code=WSCloseCode.INTERNAL_ERROR,
+                        message=str(e).encode('utf-8'),
+                    )
                     break
         finally:
             await connection.on_close()
+
         return ws
 
     _loop_monitor_ignore_frames = (

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -99,4 +99,4 @@ async def devd_devfs_hook(middleware, data):
 
 def setup(middleware):
     # Listen to DEVFS events so we can sync on disk attach/detach
-    middleware.register_hook('devd.devfs', devd_devfs_hook)
+    middleware.register_hook('devd.devfs', devd_devfs_hook, blockable=True)

--- a/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
+++ b/src/middlewared/middlewared/plugins/disk_/zfs_guid.py
@@ -72,5 +72,5 @@ async def hook(middleware, pool):
 
 
 async def setup(middleware):
-    middleware.register_hook("devd.zfs", devd_zfs_hook)
+    middleware.register_hook("devd.zfs", devd_zfs_hook, blockable=True)
     middleware.register_hook("pool.post_create_or_update", hook)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -851,7 +851,8 @@ class PoolService(CRUDService):
                 extend_job = await self.middleware.call('zfs.pool.extend', pool['name'], vdevs)
                 await extend_job.wait(raise_error=True)
 
-                await self.middleware.call('pool.save_encrypteddisks', id, enc_disks, disks_cache)
+                if enc_disks:
+                    await self.middleware.call('pool.save_encrypteddisks', id, enc_disks, disks_cache)
 
                 if pool['encrypt'] >= 2:
                     # FIXME: ask current passphrase and validate

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -706,7 +706,7 @@ class PoolService(CRUDService):
             os.makedirs(cachefile_dir)
 
         pool_id = z_pool = encrypted_dataset_pk = None
-        with self.middleware.block_hooks('devd.zfs'):
+        with self.middleware.block_hooks('devd.zfs', 'zfs.pool.events'):
             try:
                 job.set_progress(90, 'Creating ZFS Pool')
                 z_pool = await self.middleware.call('zfs.pool.create', {
@@ -839,7 +839,7 @@ class PoolService(CRUDService):
         enc_options = {'enc_keypath': enc_keypath}
 
         if disks:
-            with self.middleware.block_hooks('devd.devfs', 'devd.zfs'):
+            with self.middleware.block_hooks('devd.devfs', 'devd.zfs', 'zfs.pool.events'):
                 await self.middleware.call('pool.format_disks', job, disks)
                 vdevs, enc_disks = await self.middleware.call(
                     'pool.convert_topology_to_vdevs', data['topology'], enc_options
@@ -1603,7 +1603,7 @@ class PoolService(CRUDService):
 
         # We don't want to configure swap immediately after removing those disks because we might get in a race
         # condition where swap starts using the pool disks as the pool might not have been exported/destroyed yet
-        with self.middleware.block_hooks('devd.devfs', 'devd.zfs'):
+        with self.middleware.block_hooks('devd.devfs', 'devd.zfs', 'zfs.pool.events'):
             await self.middleware.call('disk.swaps_remove_disks', disks, {'configure_swap': False})
 
             sysds = await self.middleware.call('systemdataset.config')

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -171,5 +171,5 @@ async def zfs_events(middleware, data):
 
 def setup(middleware):
     middleware.event_register('zfs.pool.scan', 'Progress of pool resilver/scrub.')
-    middleware.register_hook('zfs.pool.events', zfs_events, sync=False)
+    middleware.register_hook('zfs.pool.events', zfs_events, sync=False, blockable=True)
     middleware.register_hook('devd.zfs', devd_zfs_hook, blockable=True)

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -7,7 +7,7 @@ import time
 from middlewared.alert.base import (
     Alert, AlertCategory, AlertClass, AlertLevel, OneShotAlertClass, SimpleOneShotAlertClass
 )
-from middlewared.utils import osc, start_daemon_thread
+from middlewared.utils import start_daemon_thread
 
 CACHE_POOLS_STATUSES = 'system.system_health_pools'
 
@@ -172,5 +172,4 @@ async def zfs_events(middleware, data):
 def setup(middleware):
     middleware.event_register('zfs.pool.scan', 'Progress of pool resilver/scrub.')
     middleware.register_hook('zfs.pool.events', zfs_events, sync=False)
-    if osc.IS_FREEBSD:
-        middleware.register_hook('devd.zfs', devd_zfs_hook)
+    middleware.register_hook('devd.zfs', devd_zfs_hook, blockable=True)


### PR DESCRIPTION
This looks like a lot of change but it's not. Original code has stayed the same but has been moved inside the `self.middleware.block_hooks` context manager. This does 3 things:

1. backport https://github.com/truenas/middleware/pull/8298 because it fixes a potential issue and we should have it (even though we're not exposed to it on 13 AFAICT)
2. On the zpool CRUD operations, use `self.middleware.block_hooks` context manager.
3. we were grabbing an `asyncio.Lock()`, checking for legacy encryption information and then doing the work. I've changed it so that we check to see if we have any encryption work to be done and then grab the lock if necessary.

This fixes the major issue of overloading the main event loop with a bunch of duplicate tasks that get run at the same time causing cpu to spike to 100% for 20mins + on a system with 1.2k+ hard drives. This takes the time to create/update or remove a pool with 100 vdevs (striped mirror) down from 8-12mins to ~10-30 seconds.