### PR TITLE
NAS-115866 / 22.02.2 / Changed rollback_snapshot to False in chart release test 40 (by ericbsd)

### DIFF
--- a/tests/api2/test_025_chart_release.py
+++ b/tests/api2/test_025_chart_release.py
@@ -425,7 +425,7 @@ if not ha:
         payload = {
             'release_name': 'plex',
             'rollback_options': {
-                'rollback_snapshot': True,
+                'rollback_snapshot': False,
                 'item_version': old_plex_version
             }
         }
@@ -434,7 +434,7 @@ if not ha:
         assert isinstance(results.json(), int), results.text
         job_status = wait_on_job(results.json(), 600)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
-        time.sleep(5)
+        time.sleep(10)
 
     def test_41_verify_plex_is_at_the_old_version(request):
         depends(request, ['rollback_plex'])


### PR DESCRIPTION
This seems to fix the issue we see with zfs hanging in the API test.

Original PR: https://github.com/truenas/middleware/pull/8857
Jira URL: https://jira.ixsystems.com/browse/NAS-115866