### PR TITLE
Add new `finalize_zpool_create_or_import` method and call it in pool plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -790,11 +790,14 @@ class PoolService(CRUDService):
             exclude_pool = None
             on_active = True
             # this restarts rrdcached and therefore collectd
+            job.set_progress(95, 'Setting up system dataset')
             await self.middleware.call('sysdataset.setup', mount, exclude_pool, boot_pool, on_active)
         else:
-            await self.middleware.call('service.restart', 'rrdcached')
+            job.set_progress(95, 'Restarting reporting services')
+            asyncio.ensure_future(self.middleware.call('service.restart', 'rrdcached'))
 
-        await self.middleware.call('disk.sync_zfs_guid', pool['topology'])
+        job.set_progress(96, 'Syncing ZFS GUID to disk')
+        await self.middleware.call('disk.sync_zfs_guid', pool)
 
     @private
     async def restart_services(self):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1529,8 +1529,7 @@ class PoolService(CRUDService):
                             await delegate.toggle(attachments, True)
             await self.middleware.call('keyvalue.delete', key)
 
-        await self.middleware.call('service.reload', 'disk')
-        asyncio.ensure_future(self.restart_services())
+        await self.finalize_zpool_create_or_import(job, pool)
         await self.middleware.call_hook(
             'pool.post_import', {
                 'passphrase': data.get('passphrase'),

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -188,31 +188,34 @@ class SystemDatasetService(ConfigService):
 
         return await self.config()
 
-    @accepts(Bool('mount', default=True), Str('exclude_pool', default=None, null=True))
+    @accepts(
+        Bool('mount', default=True),
+        Str('exclude_pool', default=None, null=True),
+        Bool('boot_pool', default=None, null=True),
+        Bool('on_active', default=False),
+    )
     @private
-    async def setup(self, mount, exclude_pool=None):
+    async def setup(self, mount, exclude_pool=None, boot_pool=None, on_active=False):
 
-        # FIXME: corefile for LINUX
-        if osc.IS_FREEBSD:
-            # We default kern.corefile value
-            await run('sysctl', "kern.corefile='/var/tmp/%N.core'")
+        # We default kern.corefile value
+        await run('sysctl', "kern.corefile='/var/tmp/%N.core'")
 
         config = await self.config()
         dbconfig = await self.middleware.call(
             'datastore.config', self._config.datastore, {'prefix': self._config.datastore_prefix}
         )
 
-        boot_pool = await self.middleware.call('boot.pool_name')
-        if (
-            not await self.middleware.call('system.is_freenas') and
-            await self.middleware.call('failover.status') == 'BACKUP' and
-            config.get('basename') and config['basename'] != f'{boot_pool}/.system'
-        ):
-            try:
-                os.unlink(SYSDATASET_PATH)
-            except OSError:
-                pass
-            return
+        if not boot_pool:
+            boot_pool = await self.middleware.call('boot.pool_name')
+
+        if await self.middleware.call('failover.licensed') and not on_active:
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                if config.get('basename') and config['basename'] != f'{boot_pool}/.system':
+                    try:
+                        os.unlink(SYSDATASET_PATH)
+                    except OSError:
+                        pass
+                    return
 
         # If the system dataset is configured in a data pool we need to make sure it exists.
         # In case it does not we need to use another one.


### PR DESCRIPTION
We were restarting `collectd` and `rrdcached` at least 2 times. This is particularly painful on large disk count systems. We were restarting `service.reload disk` at least 2 times. We're unnecessarily abstracting away what `service.reload disk` does unnecessarily. There was very little `job.set_progress` logging so the end-user would just get a spinning box in the webUI without any idea what was going on.

Added a new method `finalize_zpool_create_or_import` that gets called when a zpool is created or imported. This prevents CPU cores from spiking a core at 100% for many minutes. It also prevents `collectd` from being restarted more than once.