### PR TITLE
NAS-115927 / 22.12 / fix regression in interface.update

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -960,7 +960,7 @@ class InterfaceService(CRUDService):
         dfva = data.get('failover_virtual_aliases', [])
 
         aliases = []
-        iface = {}
+        iface = {'address': '', 'address_b': '', 'netmask': '', 'version': '', 'vip': ''}
         for idx, (a, fa, fva) in enumerate(zip_longest(da, dfa, dfva, fillvalue={})):
             netmask = a['netmask']
             ipa = a['address']


### PR DESCRIPTION
When the `network_alias` and `network_interface` tables were fixed because of other unrelated bugs, I introduced a regression where on `interface.update` the 1st IP address of an interface cannot be removed.

The fix is trivial but all it does is make sure `convert_aliases_to_datastore` always returns a dict with default keys/values.