### PR TITLE
NAS-116013 / 13.0 / catch up network.globalconfiguration on 13 to match SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -272,6 +272,7 @@ class EtcService(Service):
         'syslogd': [
             {'type': 'py', 'path': 'syslogd', 'checkpoint': 'pool_import'},
         ],
+        'hosts': [{'type': 'mako', 'path': 'hosts'}],
         'hostname': [
             {'type': 'mako', 'path': 'hosts'},
             {'type': 'py', 'path': 'hostname', 'platform': 'Linux'},

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -279,7 +279,7 @@ class NetworkConfigurationService(ConfigService):
         if domainname_changed:
             local_actions[2].add('rc')
             local_actions[2].add('hosts')
-            local_actions[3].add(('collectd', 'restart'))
+            local_actions[3].add(('restart', 'collectd'))
             if licensed:
                 remote_actions[2].add('rc')
                 remote_actions[2].add('hosts')
@@ -287,17 +287,15 @@ class NetworkConfigurationService(ConfigService):
         # hostname of this controller changed
         if lhost_changed:
             local_actions[2].add('rc')
-            local_actions[2].add('hostname')
             local_actions[2].add('hosts')
-            local_actions[3].add(('hostname', 'restart'))
-            local_actions[3].add(('collectd', 'restart'))
+            local_actions[3].add(('restart', 'hostname'))
+            local_actions[3].add(('restart', 'collectd'))
 
         # hostname of standby controller changed
         if bhost_changed:
             remote_actions[2].add('rc')
-            remote_actions[2].add('hostname')
             remote_actions[2].add('hosts')
-            remote_actions[3].add(('service.restart', 'hostname'))
+            remote_actions[3].add(('restart', 'hostname'))
 
         # default gateways changed
         ipv4gw_changed = config['ipv4gateway'] != new_config['ipv4gateway']
@@ -305,15 +303,14 @@ class NetworkConfigurationService(ConfigService):
         if ipv4gw_changed or ipv6gw_changed:
             local_actions[1].add('route.sync')
             local_actions[2].add('rc')
-            local_actions[3].add(('service.restart', 'routing'))
+            local_actions[3].add(('restart', 'routing'))
             if licensed:
                 remote_actions[1].add('route.sync')
                 remote_actions[2].add('rc')
-                remote_actions[3].add(('service.restart', 'routing'))
+                remote_actions[3].add(('restart', 'routing'))
 
         # netwait ip changed
-        netwait_changed = set(config['netwait_ip'].split()) != set(new_config['netwait_ip'].split())
-        if netwait_changed:
+        if set(config['netwait_ip'].split()) != set(new_config['netwait_ip'].split()):
             local_actions[2].add('rc')
             if licensed:
                 remote_actions[2].add('rc')
@@ -322,7 +319,7 @@ class NetworkConfigurationService(ConfigService):
         if await self.middleware.call('kerberos.keytab.has_nfs_principal'):
             if any((lhost_changed, vhost_changed, domainname_changed)):
                 local_actions[2].add('rc')
-                local_actions[3].add(('service.restart', 'nfs'))
+                local_actions[3].add(('restart', 'nfs'))
 
         # proxy server has changed
         if new_config['httpproxy'] != config['httpproxy']:
@@ -349,7 +346,7 @@ class NetworkConfigurationService(ConfigService):
                 if not verb:
                     continue
 
-                local_actions[3].add((service_name, verb))
+                local_actions[3].add((verb, service_name))
 
         # finally, we need to iterate over the `local_actions` and `remote_actions`
         # and perform the necessary operations. Since they're a dict, we sort them

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1,6 +1,6 @@
 from middlewared.service import (CallError, ConfigService, CRUDService, Service,
                                  filterable, pass_app, private)
-from middlewared.utils import Popen, filter_list, run
+from middlewared.utils import filter_list, run
 from middlewared.schema import (Bool, Dict, Int, IPAddr, List, Patch, Ref, Str,
                                 ValidationErrors, accepts)
 import middlewared.sqlalchemy as sa
@@ -2363,26 +2363,35 @@ class StaticRouteService(CRUDService):
 class DNSService(Service):
 
     @filterable
-    async def query(self, filters, options):
+    def query(self, filters, options):
         """
         Query Name Servers with `query-filters` and `query-options`.
         """
-        data = []
-        resolvconf = (await run('resolvconf', '-l')).stdout.decode()
-        for nameserver in RE_NAMESERVER.findall(resolvconf):
-            data.append({'nameserver': nameserver})
-        return filter_list(data, filters, options)
+        ips = set()
+        with contextlib.suppress(Exception):
+            with open('/etc/resolv.conf') as f:
+                for line in f:
+                    if line.startswith('nameserver'):
+                        ip = line[len('nameserver'):].strip()
+                        try:
+                            IPAddr().validate(ip)  # make sure it's a valid IP (better safe than sorry)
+                            ips.add(ip)
+                        except ValidationErrors:
+                            self.logger.warning('IP %r in resolv.conf does not seem to be valid', ip)
+                            continue
+
+        return filter_list([{'nameserver': i} for i in ips], filters, options)
 
     @private
-    async def sync(self):
+    def sync(self):
+        domain = ''
         domains = []
         nameservers = []
-
-        gc = await self.middleware.call('datastore.query', 'network.globalconfiguration', [], {'get': True})
+        gc = self.middleware.call_sync('datastore.query', 'network.globalconfiguration')[0]
         if gc['gc_domain']:
-            domains.append(gc['gc_domain'])
+            domain = gc['gc_domain']
         if gc['gc_domains']:
-            domains += gc['gc_domains'].split()
+            domains = gc['gc_domains'].split()
         if gc['gc_nameserver1']:
             nameservers.append(gc['gc_nameserver1'])
         if gc['gc_nameserver2']:
@@ -2391,19 +2400,53 @@ class DNSService(Service):
             nameservers.append(gc['gc_nameserver3'])
 
         resolvconf = ''
+        if domain:
+            resolvconf += 'domain {}\n'.format(domain)
         if domains:
             resolvconf += 'search {}\n'.format(' '.join(domains))
-        for ns in nameservers:
-            resolvconf += 'nameserver {}\n'.format(ns)
 
-        proc = await Popen([
-            '/sbin/resolvconf', '-a', 'lo0'
-        ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        data = await proc.communicate(input=resolvconf.encode())
-        if proc.returncode != 0:
-            self.logger.warn(f'Failed to run resolvconf: {data[1].decode()}')
+        resolvconf += self.configure_nameservers(nameservers)
 
-        await self.middleware.call_hook('dns.post_sync')
+        try:
+            with open('/etc/resolv.conf', 'w') as f:
+                f.write(resolvconf)
+        except Exception:
+            self.logger.error('Failed to write /etc/resolv.conf', exc_info=True)
+
+    @private
+    def configure_nameservers(self, nameservers):
+        result = ''
+        if nameservers:
+            # means nameservers are configured explicitly so add them
+            for i in nameservers:
+                result += f'nameserver {i}\n'
+        else:
+            # means there aren't any nameservers configured so let's
+            # check to see if dhcp is running on any of the interfaces
+            # and if there are, then check dhclient leases file for
+            # nameservers that were handed to us via dhcp
+            interfaces = self.middleware.call_sync('datastore.query', 'network.interfaces')
+            if interfaces:
+                interfaces = [i['int_interface'] for i in interfaces if i['int_dhcp']]
+            else:
+                ignore = self.middleware.call_sync('interface.internal_interfaces')
+                ignore.extend(self.middleware.call_sync('failover.internal_interfaces'))
+                ignore = tuple(ignore)
+                interfaces = list(filter(lambda x: not x.startswith(ignore), netif.list_interfaces().keys()))
+
+            dns_from_dhcp = set()
+            for iface in interfaces:
+                dhclient_running, dhclient_pid = self.middleware.call_sync('interface.dhclient_status', iface)
+                if dhclient_running:
+                    leases = self.middleware.call_sync('interface.dhclient_leases', iface)
+                    for dns_srvs in re.findall(r'option domain-name-servers (.+)', leases or ''):
+                        for dns in dns_srvs.split(';')[0].split(','):
+                            dns_from_dhcp.add(f'nameserver {dns.strip()}\n')
+
+            for dns in dns_from_dhcp:
+                result += dns
+
+        return result
 
 
 class NetworkGeneralService(Service):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -280,9 +280,11 @@ class NetworkConfigurationService(ConfigService):
             local_actions[2].add('rc')
             local_actions[2].add('hosts')
             local_actions[3].add(('restart', 'collectd'))
+            local_actions[3].add(('restart', 'hostname'))
             if licensed:
                 remote_actions[2].add('rc')
                 remote_actions[2].add('hosts')
+                remote_actions[3].add(('restart', 'hostname'))
 
         # hostname of this controller changed
         if lhost_changed:
@@ -367,7 +369,7 @@ class NetworkConfigurationService(ConfigService):
 
         # this is the exact same methodology as above but for the remote node (only on HA)
         try:
-            for key, value in remote_actions.items():
+            for key, values in remote_actions.items():
                 if key == 1:
                     for method in values:
                         # middleware specific methods for generating configs

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2287,6 +2287,7 @@ class StaticRouteService(CRUDService):
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
 
+        await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('service.restart', 'routing')
 
         return await self._get_instance(id)
@@ -2314,6 +2315,7 @@ class StaticRouteService(CRUDService):
             'datastore.update', self._config.datastore, id, new,
             {'prefix': self._config.datastore_prefix})
 
+        await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('service.restart', 'routing')
 
         return await self._get_instance(id)

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2376,17 +2376,16 @@ class DNSService(Service):
         Query Name Servers with `query-filters` and `query-options`.
         """
         ips = set()
-        with contextlib.suppress(Exception):
-            with open('/etc/resolv.conf') as f:
-                for line in f:
-                    if line.startswith('nameserver'):
-                        ip = line[len('nameserver'):].strip()
-                        try:
-                            IPAddr().validate(ip)  # make sure it's a valid IP (better safe than sorry)
-                            ips.add(ip)
-                        except ValidationErrors:
-                            self.logger.warning('IP %r in resolv.conf does not seem to be valid', ip)
-                            continue
+        with open('/etc/resolv.conf') as f:
+            for line in f:
+                if line.startswith('nameserver'):
+                    ip = line[len('nameserver'):].strip()
+                    try:
+                        IPAddr('ip').validate(ip)  # make sure it's a valid IP (better safe than sorry)
+                        ips.add(ip)
+                    except ValidationErrors:
+                        self.logger.warning('IP %r in resolv.conf does not seem to be valid', ip)
+                        continue
 
         return filter_list([{'nameserver': i} for i in ips], filters, options)
 

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -19,6 +19,7 @@ from .truecommand import TruecommandService
 from .ups import UPSService
 from .webdav import WebDAVService
 from .wsd import WSDService
+from .routing import RoutingService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
@@ -38,7 +39,6 @@ from .pseudo.misc import (
     PowerdService,
     RcService,
     ResolvConfService,
-    RoutingService,
     SslService,
     SysconsService,
     SysctlService,

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -20,6 +20,7 @@ from .ups import UPSService
 from .webdav import WebDAVService
 from .wsd import WSDService
 from .routing import RoutingService
+from .hostname import HostnameService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
@@ -31,7 +32,6 @@ from .pseudo.misc import (
     KmipService,
     LoaderService,
     MOTDService,
-    HostnameService,
     HttpService,
     NetworkService,
     NetworkGeneralService,

--- a/src/middlewared/middlewared/plugins/service_/services/hostname.py
+++ b/src/middlewared/middlewared/plugins/service_/services/hostname.py
@@ -1,0 +1,6 @@
+from middlewared.plugins.service_.services.base import SimpleService
+
+
+class HostnameService(SimpleService):
+    name = 'hostname'
+    freebsd_rc = 'hostname'

--- a/src/middlewared/middlewared/plugins/service_/services/hostname.py
+++ b/src/middlewared/middlewared/plugins/service_/services/hostname.py
@@ -1,6 +1,10 @@
-from middlewared.plugins.service_.services.base import SimpleService
+from middlewared.plugins.service_.services.base import SimpleService, ServiceState
 
 
 class HostnameService(SimpleService):
     name = 'hostname'
     freebsd_rc = 'hostname'
+    restartable = True
+
+    async def _get_state_freebsd(self):
+        return ServiceState(True, [])

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from middlewared.utils import osc, run
+from middlewared.utils import osc
 
 from middlewared.plugins.service_.services.base import ServiceState, ServiceInterface, SimpleService
 from middlewared.plugins.service_.services.base_freebsd import freebsd_service

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -179,19 +179,6 @@ class ResolvConfService(PseudoServiceBase):
         await self.middleware.call("dns.sync")
 
 
-class RoutingService(SimpleService):
-    name = "routing"
-
-    etc = ["rc"]
-
-    restartable = True
-
-    freebsd_rc = "routing"
-
-    async def get_state(self):
-        return ServiceState(True, [])
-
-
 class SslService(PseudoServiceBase):
     name = "ssl"
 

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -82,22 +82,6 @@ class MOTDService(PseudoServiceBase):
             await freebsd_service("motd", "start")
 
 
-class HostnameService(PseudoServiceBase):
-    name = "hostname"
-
-    reloadable = True
-
-    async def reload(self):
-        if osc.IS_FREEBSD:
-            await run(["hostname", ""])
-        await self.middleware.call("etc.generate", "hostname")
-        if osc.IS_FREEBSD:
-            await self.middleware.call("etc.generate", "rc")
-            await freebsd_service("hostname", "start")
-        await self.middleware.call("service.restart", "mdns")
-        await self.middleware.call("service.restart", "collectd")
-
-
 class HttpService(PseudoServiceBase):
     name = "http"
 

--- a/src/middlewared/middlewared/plugins/service_/services/routing.py
+++ b/src/middlewared/middlewared/plugins/service_/services/routing.py
@@ -1,0 +1,6 @@
+from middlewared.plugins.service_.services.base import SimpleService
+
+
+class RoutingService(SimpleService):
+    name = 'routing'
+    freebsd_rc = 'routing'

--- a/src/middlewared/middlewared/plugins/service_/services/routing.py
+++ b/src/middlewared/middlewared/plugins/service_/services/routing.py
@@ -1,6 +1,10 @@
-from middlewared.plugins.service_.services.base import SimpleService
+from middlewared.plugins.service_.services.base import SimpleService, ServiceState
 
 
 class RoutingService(SimpleService):
     name = 'routing'
     freebsd_rc = 'routing'
+    restartable = True
+
+    async def _get_state_freebsd(self):
+        return ServiceState(True, [])

--- a/src/middlewared/middlewared/plugins/service_/services/wsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/wsd.py
@@ -1,13 +1,8 @@
-from .base import SimpleService, ServiceState
+from .base import SimpleService
 
 
 class WSDService(SimpleService):
     name = "wsdd"
     etc = ["wsd"]
     freebsd_rc = "wsdd"
-
-    async def _get_state_freebsd(self):
-        stdout = (await self._freebsd_service("wsdd", "status")).stdout
-        running = 'wsdd running as pid' in stdout
-        pid = [] if not running else stdout.split('wsdd running as pid')[1].strip()
-        return ServiceState(running, pid)
+    freebsd_proc_arguments_match = True

--- a/src/middlewared/middlewared/plugins/service_/services/wsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/wsd.py
@@ -1,11 +1,13 @@
-from .base import SimpleService
+from .base import SimpleService, ServiceState
 
 
 class WSDService(SimpleService):
     name = "wsdd"
-
     etc = ["wsd"]
-
     freebsd_rc = "wsdd"
 
-    systemd_unit = "wsdd"
+    async def _get_state_freebsd(self):
+        stdout = (await self._freebsd_service("wsdd", "status")).stdout
+        running = 'wsdd running as pid' in stdout
+        pid = [] if not running else stdout.split('wsdd running as pid')[1].strip()
+        return ServiceState(running, pid)


### PR DESCRIPTION
I've fixed _many_ issues on SCALE but they were never backported so this makes it so that the `network.globalconfiguration` on 13 matches what we have on SCALE. I've just "massaged" the code to be CORE specific.

Major issues fixed:
1. hostname of the local or standby node would not change based on what node is active
2. collectd, rc.conf.freenas, _many_ subprocesses were being called/generated many times over unnecessarily
3. `wsdd` was not propertly reporting it's `service.started` status so it would fail to be stopped/started depending on situation