### PR TITLE
NAS-116049 / 13.0 / add release-date to dmi cache

### DIFF
--- a/src/middlewared/middlewared/plugins/system_/dmi.py
+++ b/src/middlewared/middlewared/plugins/system_/dmi.py
@@ -8,7 +8,7 @@ class SystemService(Service):
     # DMI information is mostly static so cache it
     HAS_CACHE = False
     CACHE = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': None,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -82,6 +82,6 @@ class SystemService(Service):
         # 2 digit year instead of a 4 digit year...gross
         formatter = '%m/%d/%Y' if len(parts[-1]) == 4 else '%m/%d/%y'
         try:
-            SystemService.CACHE['bios-release-date-parsed'] = datetime(string, formatter).date()
+            SystemService.CACHE['bios-release-date'] = datetime(string, formatter).date()
         except Exception:
             self.logger.warning('Failed to format BIOS release date to datetime object', exc_info=True)

--- a/src/middlewared/middlewared/plugins/system_/dmi.py
+++ b/src/middlewared/middlewared/plugins/system_/dmi.py
@@ -1,5 +1,5 @@
 import subprocess
-from datetime import datetime
+from datetime import date
 
 from middlewared.service import private, Service
 
@@ -82,6 +82,6 @@ class SystemService(Service):
         # 2 digit year instead of a 4 digit year...gross
         formatter = '%m/%d/%Y' if len(parts[-1]) == 4 else '%m/%d/%y'
         try:
-            SystemService.CACHE['bios-release-date'] = datetime(string, formatter).date()
+            SystemService.CACHE['bios-release-date'] = date(string, formatter)
         except Exception:
             self.logger.warning('Failed to format BIOS release date to datetime object', exc_info=True)

--- a/src/middlewared/middlewared/plugins/system_/dmi.py
+++ b/src/middlewared/middlewared/plugins/system_/dmi.py
@@ -8,8 +8,7 @@ class SystemService(Service):
     # DMI information is mostly static so cache it
     HAS_CACHE = False
     CACHE = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': None,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -71,10 +70,7 @@ class SystemService(Service):
 
     @private
     def _parse_bios_release_date(self, string):
-        SystemService.CACHE['bios-release-date-raw'] = string
-        if not (string := string.strip()):
-            return
-        elif (parts := string.split('/')) < 3:
+        if (parts := string.strip().split('/')) < 3:
             # dont know what the BIOS is reporting so
             # assume it's invalid
             return
@@ -86,6 +82,6 @@ class SystemService(Service):
         # 2 digit year instead of a 4 digit year...gross
         formatter = '%m/%d/%Y' if len(parts[-1]) == 4 else '%m/%d/%y'
         try:
-            SystemService.CACHE['bios-release-date-formatted'] = datetime(string, formatter).date()
+            SystemService.CACHE['bios-release-date-parsed'] = datetime(string, formatter).date()
         except Exception:
             self.logger.warning('Failed to format BIOS release date to datetime object', exc_info=True)

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -222,8 +222,7 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
-        'bios-release-date-raw': '12/03/2020',
-        'bios-release-date-formatted': datetime(2020, 12, 3).date(),
+        'bios-release-date-parsed': datetime(2020, 12, 3).date(),
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -239,8 +238,7 @@ def test__full_dmi():
 
 def test__double_colon_dmi():
     expected_result = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
@@ -256,8 +254,7 @@ def test__double_colon_dmi():
 
 def test__missing_dmi():
     expected_result = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': '',
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -273,8 +270,7 @@ def test__missing_dmi():
 
 def test__missing_dmi_type1():
     expected_result = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -290,8 +286,7 @@ def test__missing_dmi_type1():
 
 def test__missing_dmi_type2():
     expected_result = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': True,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -307,8 +302,7 @@ def test__missing_dmi_type2():
 
 def test__missing_dmi_type16():
     expected_result = {
-        'bios-release-date-raw': '',
-        'bios-release-date-formatted': '',
+        'bios-release-date-parsed': '',
         'ecc-memory': '',
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -7,6 +7,35 @@ full_dmi = ("""
 Getting SMBIOS data from sysfs.
 SMBIOS 3.2.1 present.
 
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+        Vendor: American Megatrends Inc.
+        Version: 3.3aV3
+        Release Date: 12/03/2020
+        Address: 0xF0000
+        Runtime Size: 64 kB
+        ROM Size: 32 MB
+        Characteristics:
+                PCI is supported
+                BIOS is upgradeable
+                BIOS shadowing is allowed
+                Boot from CD is supported
+                Selectable boot is supported
+                BIOS ROM is socketed
+                EDD is supported
+                5.25"/1.2 MB floppy services are supported (int 13h)
+                3.5"/720 kB floppy services are supported (int 13h)
+                3.5"/2.88 MB floppy services are supported (int 13h)
+                Print screen service is supported (int 5h)
+                Serial services are supported (int 14h)
+                Printer services are supported (int 17h)
+                ACPI is supported
+                USB legacy is supported
+                BIOS boot specification is supported
+                Targeted content distribution is supported
+                UEFI is supported
+        BIOS Revision: 5.14
+
 Handle 0x0001, DMI type 1, 27 bytes
 System Information
         Manufacturer: iXsystems
@@ -191,6 +220,7 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
+        'release-date': '12/03/2020',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -206,6 +236,7 @@ def test__full_dmi():
 
 def test__double_colon_dmi():
     expected_result = {
+        'release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
@@ -221,6 +252,7 @@ def test__double_colon_dmi():
 
 def test__missing_dmi():
     expected_result = {
+        'release-date': '',
         'ecc-memory': '',
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -236,6 +268,7 @@ def test__missing_dmi():
 
 def test__missing_dmi_type1():
     expected_result = {
+        'release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -251,6 +284,7 @@ def test__missing_dmi_type1():
 
 def test__missing_dmi_type2():
     expected_result = {
+        'release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -266,6 +300,7 @@ def test__missing_dmi_type2():
 
 def test__missing_dmi_type16():
     expected_result = {
+        'release-date': '',
         'ecc-memory': '',
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -222,7 +222,7 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
-        'bios-release-date-parsed': datetime(2020, 12, 3).date(),
+        'bios-release-date': datetime(2020, 12, 3).date(),
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -238,7 +238,7 @@ def test__full_dmi():
 
 def test__double_colon_dmi():
     expected_result = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
@@ -254,7 +254,7 @@ def test__double_colon_dmi():
 
 def test__missing_dmi():
     expected_result = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': '',
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -270,7 +270,7 @@ def test__missing_dmi():
 
 def test__missing_dmi_type1():
     expected_result = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -286,7 +286,7 @@ def test__missing_dmi_type1():
 
 def test__missing_dmi_type2():
     expected_result = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -302,7 +302,7 @@ def test__missing_dmi_type2():
 
 def test__missing_dmi_type16():
     expected_result = {
-        'bios-release-date-parsed': '',
+        'bios-release-date': '',
         'ecc-memory': '',
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 
 from middlewared.plugins.system_.dmi import SystemService
 from middlewared.service import Service
@@ -222,7 +222,7 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
-        'bios-release-date': datetime(2020, 12, 3).date(),
+        'bios-release-date': date(2020, 12, 3),
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from middlewared.plugins.system_.dmi import SystemService
 from middlewared.service import Service
 
@@ -220,7 +222,8 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
-        'release-date': '12/03/2020',
+        'bios-release-date-raw': '12/03/2020',
+        'bios-release-date-formatted': datetime(2020, 12, 3).date(),
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -236,7 +239,8 @@ def test__full_dmi():
 
 def test__double_colon_dmi():
     expected_result = {
-        'release-date': '',
+        'bios-release-date-raw': '',
+        'bios-release-date-formatted': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
@@ -252,7 +256,8 @@ def test__double_colon_dmi():
 
 def test__missing_dmi():
     expected_result = {
-        'release-date': '',
+        'bios-release-date-raw': '',
+        'bios-release-date-formatted': '',
         'ecc-memory': '',
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -268,7 +273,8 @@ def test__missing_dmi():
 
 def test__missing_dmi_type1():
     expected_result = {
-        'release-date': '',
+        'bios-release-date-raw': '',
+        'bios-release-date-formatted': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -284,7 +290,8 @@ def test__missing_dmi_type1():
 
 def test__missing_dmi_type2():
     expected_result = {
-        'release-date': '',
+        'bios-release-date-raw': '',
+        'bios-release-date-formatted': '',
         'ecc-memory': True,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -300,7 +307,8 @@ def test__missing_dmi_type2():
 
 def test__missing_dmi_type16():
     expected_result = {
-        'release-date': '',
+        'bios-release-date-raw': '',
+        'bios-release-date-formatted': '',
         'ecc-memory': '',
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',


### PR DESCRIPTION
Adding this information to what we cache because we're `subprocess`'ing (unnecessarily) in an alert to get this information.