### PR TITLE
NAS-116053 / 13.0 / cache truenas.get_chassis_hardware

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/truenas.py
@@ -5,6 +5,7 @@ import os
 
 from middlewared.schema import accepts, Bool, Dict, Str
 from middlewared.service import job, private, Service
+from middlewared.utils.functools import cache
 import middlewared.sqlalchemy as sa
 
 EULA_FILE = '/usr/local/share/truenas/eula.html'
@@ -39,6 +40,7 @@ class TruenasCustomerInformationModel(sa.Model):
 class TrueNASService(Service):
 
     @accepts()
+    @cache
     async def get_chassis_hardware(self):
         """
         Returns what type of hardware this is, detected from dmidecode.


### PR DESCRIPTION
This method is called by `system.is_enterprise` which, surprisingly, is called by many other methods. This is information based off dmidecode information (which is burned into BIOS) so cache it for a micro-optimization.