### PR TITLE
NAS-116063 / 13.0 / optimize system_is_enterprise_ix_hardware calls in smartctl

### DIFF
--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -1,4 +1,5 @@
 from asyncio import Lock
+from collections import namedtuple
 import logging
 import re
 import subprocess
@@ -11,10 +12,15 @@ from .areca import annotate_devices_with_areca_dev_id
 logger = logging.getLogger(__name__)
 
 SMARTCTL_POWERMODES = ['NEVER', 'SLEEP', 'STANDBY', 'IDLE']
+SMARTCTX = namedtuple('smartctl_args', ['middleware', 'devices', 'enterprise_hardware'])
 areca_lock = Lock()
 
 
-async def get_smartctl_args(middleware, devices, enterprise_hardware, disk):
+async def get_smartctl_args(context, disk):
+    middleware = context.middleware
+    devices = context.devices
+    enterprise_hardware = context.enterprise_hardware
+
     if disk.startswith(('nvd', 'nvme')):
         try:
             nvme = await middleware.run_in_thread(get_nsid, f'/dev/{disk}')

--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -14,7 +14,7 @@ SMARTCTL_POWERMODES = ['NEVER', 'SLEEP', 'STANDBY', 'IDLE']
 areca_lock = Lock()
 
 
-async def get_smartctl_args(middleware, devices, disk, enterprise_hardware):
+async def get_smartctl_args(middleware, devices, enterprise_hardware, disk):
     if disk.startswith(('nvd', 'nvme')):
         try:
             nvme = await middleware.run_in_thread(get_nsid, f'/dev/{disk}')

--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -19,7 +19,7 @@ else:
     get_nsid = None
 
 
-async def get_smartctl_args(middleware, devices, disk):
+async def get_smartctl_args(middleware, devices, disk, enterprise_hardware):
     if disk.startswith(('nvd', 'nvme')):
         if osc.IS_LINUX:
             return [f'/dev/{disk}', '-d', 'nvme']
@@ -85,7 +85,7 @@ async def get_smartctl_args(middleware, devices, disk):
         return [f"/dev/{driver}{controller_id}", "-d", f"3ware,{port}"]
 
     args = [f"/dev/{disk}"]
-    if disk.startswith("da") and not await middleware.call("system.is_enterprise_ix_hardware"):
+    if disk.startswith("da") and not enterprise_hardware:
         p = await smartctl(args + ["-i"], stderr=subprocess.STDOUT, check=False, encoding="utf8", errors="ignore")
         if "Unknown USB bridge" in p.stdout:
             args = args + ["-d", "sat"]

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -9,8 +9,8 @@ from middlewared.utils.asyncio_ import asyncio_map
 logger = logging.getLogger(__name__)
 
 
-async def annotate_disk_for_smart(middleware, devices, disk, enterprise_hardware):
-    if args := await get_smartctl_args(middleware, devices, disk, enterprise_hardware):
+async def annotate_disk_for_smart(middleware, devices, enterprise_hardware, disk):
+    if args := await get_smartctl_args(middleware, devices, enterprise_hardware, disk):
         if enterprise_hardware or await ensure_smart_enabled(args):
             # On Enterprise hardware we only use S.M.A.R.T.-enabled disks,
             # there is no need to check for this every time.

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -65,7 +65,7 @@ class DiskService(Service):
             else:
                 devices = await self.middleware.call('device.get_storage_devices_topology')
                 enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
-                smartctl_args = await get_smartctl_args(self.middleware, devices, disk, enterprise_hardware)
+                smartctl_args = await get_smartctl_args(self.middleware, devices, enterprise_hardware, disk)
 
             if smartctl_args is None:
                 raise CallError(f'S.M.A.R.T. is unavailable for disk {disk}')

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -28,10 +28,13 @@ class DiskService(Service):
                 ]
 
                 devices = await self.middleware.call('device.get_storage_devices_topology')
+                enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
 
                 self.smartctl_args_for_disk = dict(zip(
                     disks,
-                    await asyncio_map(functools.partial(get_smartctl_args, self.middleware, devices), disks, 8)
+                    await asyncio_map(
+                        functools.partial(get_smartctl_args, self.middleware, devices, enterprise_hardware), disks, 8
+                    )
                 ))
             except Exception:
                 self.logger.error("update_smartctl_args_for_disks failed", exc_info=True)
@@ -61,7 +64,8 @@ class DiskService(Service):
                 smartctl_args = await self.middleware.call('disk.smartctl_args', disk)
             else:
                 devices = await self.middleware.call('device.get_storage_devices_topology')
-                smartctl_args = await get_smartctl_args(self.middleware, devices, disk)
+                enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+                smartctl_args = await get_smartctl_args(self.middleware, devices, disk, enterprise_hardware)
 
             if smartctl_args is None:
                 raise CallError(f'S.M.A.R.T. is unavailable for disk {disk}')

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 import subprocess
 
-from middlewared.common.smart.smartctl import get_smartctl_args, smartctl
+from middlewared.common.smart.smartctl import get_smartctl_args, smartctl, SMARTCTX
 from middlewared.service import accepts, Bool, Dict, CallError, List, private, Service, Str
 from middlewared.utils.asyncio_ import asyncio_map
 
@@ -28,13 +28,10 @@ class DiskService(Service):
                 ]
 
                 devices = await self.middleware.call('device.get_storage_devices_topology')
-                enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
-
+                hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+                context = SMARTCTX(middleware=self.middleware, devices=devices, enterprise_hardware=hardware)
                 self.smartctl_args_for_disk = dict(zip(
-                    disks,
-                    await asyncio_map(
-                        functools.partial(get_smartctl_args, self.middleware, devices, enterprise_hardware), disks, 8
-                    )
+                    disks, await asyncio_map(functools.partial(get_smartctl_args, context), disks, 8)
                 ))
             except Exception:
                 self.logger.error("update_smartctl_args_for_disks failed", exc_info=True)
@@ -64,8 +61,9 @@ class DiskService(Service):
                 smartctl_args = await self.middleware.call('disk.smartctl_args', disk)
             else:
                 devices = await self.middleware.call('device.get_storage_devices_topology')
-                enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
-                smartctl_args = await get_smartctl_args(self.middleware, devices, enterprise_hardware, disk)
+                hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+                context = SMARTCTX(middleware=self.middleware, devices=devices, enterprise_hardware=hardware)
+                smartctl_args = await get_smartctl_args(context, disk)
 
             if smartctl_args is None:
                 raise CallError(f'S.M.A.R.T. is unavailable for disk {disk}')

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -6,7 +6,7 @@ from itertools import chain
 
 import asyncio
 
-from middlewared.common.smart.smartctl import SMARTCTL_POWERMODES, get_smartctl_args, smartctl
+from middlewared.common.smart.smartctl import SMARTCTL_POWERMODES, get_smartctl_args, smartctl, SMARTCTX
 from middlewared.schema import accepts, Bool, Cron, Dict, Int, List, Patch, Str
 from middlewared.validators import Range
 from middlewared.service import (
@@ -21,11 +21,11 @@ RE_TIME = re.compile(r'test will complete after ([a-z]{3} [a-z]{3} [0-9 ]+ \d\d:
 RE_TIME_SCSIPRINT_EXTENDED = re.compile(r'Please wait (\d+) minutes for test to complete')
 
 
-async def annotate_disk_smart_tests(middleware, devices, enterprise_hardware, disk):
+async def annotate_disk_smart_tests(context, disk):
     if disk["disk"] is None:
         return
 
-    if args := await get_smartctl_args(middleware, devices, enterprise_hardware, disk["disk"]):
+    if args := await get_smartctl_args(context, disk["disk"]):
         p = await smartctl(args + ["-l", "selftest"], check=False, encoding="utf8")
         tests = parse_smart_selftest_results(p.stdout)
         if tests is not None:
@@ -551,18 +551,12 @@ class SMARTTestService(CRUDService):
         )
 
         devices = await self.middleware.call('device.get_storage_devices_topology')
-        enterprise_hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+        hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+        context = SMARTCTX(middleware=self.middleware, devices=devices, enterprise_hardware=hardware)
         return filter_list(
-            list(
-                filter(
-                    None,
-                    await asyncio_map(
-                        functools.partial(
-                            annotate_disk_smart_tests, self.middleware, devices, enterprise_hardware
-                        ), disks, 16
-                    )
-                )
-            ),
+            list(filter(None, await asyncio_map(
+                functools.partial(annotate_disk_smart_tests, context), disks, 16
+            ))),
             [],
             {"get": get},
         )

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -21,11 +21,11 @@ RE_TIME = re.compile(r'test will complete after ([a-z]{3} [a-z]{3} [0-9 ]+ \d\d:
 RE_TIME_SCSIPRINT_EXTENDED = re.compile(r'Please wait (\d+) minutes for test to complete')
 
 
-async def annotate_disk_smart_tests(middleware, devices, disk, enterprise_hardware):
+async def annotate_disk_smart_tests(middleware, devices, enterprise_hardware, disk):
     if disk["disk"] is None:
         return
 
-    if args := await get_smartctl_args(middleware, devices, disk["disk"], enterprise_hardware):
+    if args := await get_smartctl_args(middleware, devices, enterprise_hardware, disk["disk"]):
         p = await smartctl(args + ["-l", "selftest"], check=False, encoding="utf8")
         tests = parse_smart_selftest_results(p.stdout)
         if tests is not None:


### PR DESCRIPTION
We're calling `system.is_enterprise_ix_hardware` for every disk. This isn't really that big of a deal until you're on a system with 1.2k+ disks. Call this method once in the caller and pass to the callees appropriately.