### PR TITLE
NAS-116101 / 13.0 / fix AttributeError crash in ctld.py

### DIFF
--- a/src/middlewared/middlewared/etc_files/ctld.py
+++ b/src/middlewared/middlewared/etc_files/ctld.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sysctl
 
-from bsd import geom
 from middlewared.client.utils import Struct
 logger = logging.getLogger(__name__)
 
@@ -213,7 +212,7 @@ def main(middleware):
     poolthreshold = {}
     zpoollist = {i['name']: i for i in middleware.call_sync('zfs.pool.query')}
 
-    geom_xml = geom.class_by_name('DISK').xml
+    geom_xml = middleware.call_sync('geom.cache.get_class_xml', 'DISK')
     locked_extents = {d['id']: d for d in middleware.call_sync('iscsi.extent.query', [['locked', '=', True]])}
     # Generate the LUN section
     for extent in middleware.call_sync('datastore.query', 'services.iSCSITargetExtent',


### PR DESCRIPTION
`bsd.geom` no longer runs `geom.scan()` at module import time so this will fail here since we're not specifically `geom.scan()`'ing before calling it.

13 has a new plugin for caching geom information so use that instead.