### PR TITLE
NAS-116102 / 13.0 / remove bsd.geom from remove_disk_from_graid

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/remove_disk_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/remove_disk_freebsd.py
@@ -1,5 +1,3 @@
-from bsd import geom
-
 from middlewared.service import private, Service
 from middlewared.utils import run
 
@@ -10,16 +8,13 @@ class DiskService(Service):
     async def remove_disk_from_graid(self, dev):
         # Its possible a disk was previously used by graid so we need to make sure to
         # remove the disk from it (#40560)
-        gdisk = geom.class_by_name('DISK')
-        graid = geom.class_by_name('RAID')
-        if gdisk and graid:
-            prov = gdisk.xml.find(f'.//provider[name = "{dev}"]')
-            if prov is not None:
-                provid = prov.attrib.get('id')
-                graid = graid.xml.find(f'.//consumer/provider[@ref = "{provid}"]/../../name')
-                if graid is not None:
-                    cp = await run('graid', 'remove', graid.text, dev, check=False)
-                    if cp.returncode != 0:
-                        self.logger.debug(
-                            'Failed to remove %s from %s: %s', dev, graid.text, cp.stderr.decode()
-                        )
+        gdisk = await self.middleware.call('geom.cache.get_class_xml', 'DISK')
+        graid = await self.middleware.call('geom.cache.get_class_xml', 'RAID')
+        if (gdisk and graid) and (prov := gdisk.xml.find(f'.//provider[name = "{dev}"]')):
+            provid = prov.attrib.get('id')
+            if graid := graid.xml.find(f'.//consumer/provider[@ref = "{provid}"]/../../name'):
+                cp = await run('graid', 'remove', graid.text, dev, check=False)
+                if cp.returncode != 0:
+                    self.logger.debug(
+                        'Failed to remove %s from %s: %s', dev, graid.text, cp.stderr.decode()
+                    )


### PR DESCRIPTION
`bsd.geom` doesn't run `geom.scan()` at module import time so this will crash with `AttributeError`. Fix this by removing the module and using `geom.cache.get_class_xml` like we are (most) every where else.