### PR TITLE
NAS-116103 / 13.0 / call geom.scan in overprovisioning code

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/overprovision_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/overprovision_freebsd.py
@@ -22,6 +22,7 @@ def can_overprovision(devname):
 async def temporarily_disassemble_multipath(middleware, devname, pre_check=None):
     if devname.startswith("multipath/"):
         multipath_name = devname[len("multipath/"):]
+        await middleware.run_in_thread(geom.scan)
         for g in geom.class_by_name("MULTIPATH").geoms:
             if g.name == multipath_name:
                 mode = g.config["Mode"]


### PR DESCRIPTION
`geom.scan()` doesn't get called on module import any more. Be sure and call it in this method.