### PR TITLE
NAS-116090 / 13.0 / fix off-by-one for enclosure mgmt for MINIs

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -25,8 +25,8 @@ MAPPINGS = [
             MappingSlot(0, 2, False),
             MappingSlot(0, 3, False),
             MappingSlot(0, 4, False),
-            MappingSlot(0, 1, False),
-            MappingSlot(0, 2, False),
+            MappingSlot(1, 1, False),
+            MappingSlot(1, 2, False),
         ]),
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -11,55 +11,55 @@ MappingSlot = namedtuple("MappingSlot", ["num", "slot", "identify"])
 MAPPINGS = [
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-E$"), [
         VersionMapping(re.compile(".*"), [
-            MappingSlot(0, 0, False),
-            MappingSlot(0, 1, False),
-            MappingSlot(0, 2, False),
-            MappingSlot(0, 3, False),
-            MappingSlot(0, 5, False),
-            MappingSlot(0, 4, False),
-        ]),
-    ]),
-    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-E\+$"), [
-        VersionMapping(re.compile(".*"), [
-            MappingSlot(0, 0, False),
-            MappingSlot(0, 1, False),
-            MappingSlot(0, 2, False),
-            MappingSlot(0, 3, False),
-            MappingSlot(0, 0, False),
-            MappingSlot(0, 1, False),
-        ]),
-    ]),
-    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [
-        VersionMapping(re.compile(r"1\.0"), [
-            MappingSlot(1, 0, False),
-            MappingSlot(1, 1, False),
-            MappingSlot(1, 3, False),
-            MappingSlot(1, 4, False),
-            MappingSlot(0, 0, False),
-            MappingSlot(0, 1, False),
-            MappingSlot(0, 2, False),
-        ]),
-    ]),
-    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [
-        VersionMapping(re.compile(".*"), [
-            MappingSlot(0, 0, False),
-            MappingSlot(0, 1, False),
-            MappingSlot(0, 2, False),
-            MappingSlot(0, 3, False),
-            MappingSlot(1, 0, False),
-            MappingSlot(1, 1, False),
-            MappingSlot(1, 3, False),
-        ]),
-    ]),
-    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X\+$"), [
-        VersionMapping(re.compile(".*"), [
-            MappingSlot(0, 0, False),
             MappingSlot(0, 1, False),
             MappingSlot(0, 2, False),
             MappingSlot(0, 3, False),
             MappingSlot(0, 4, False),
             MappingSlot(0, 5, False),
             MappingSlot(0, 6, False),
+        ]),
+    ]),
+    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-E\+$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 3, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 2, False),
+        ]),
+    ]),
+    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [
+        VersionMapping(re.compile(r"1\.0"), [
+            MappingSlot(1, 1, False),
+            MappingSlot(1, 2, False),
+            MappingSlot(1, 3, False),
+            MappingSlot(1, 4, False),
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 3, False),
+        ]),
+    ]),
+    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 3, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(1, 1, False),
+            MappingSlot(1, 2, False),
+            MappingSlot(1, 3, False),
+        ]),
+    ]),
+    ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X\+$"), [
+        VersionMapping(re.compile(".*"), [
+            MappingSlot(0, 1, False),
+            MappingSlot(0, 2, False),
+            MappingSlot(0, 3, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(0, 5, False),
+            MappingSlot(0, 6, False),
+            MappingSlot(0, 7, False),
         ]),
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-XL\+$"), [


### PR DESCRIPTION
We did this for the other hardware platforms but seems the minis were left out.