### PR TITLE
NAS-116063 / 22.12 / optimize system.is_enterprise_ix_hardware calls in smartctl (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -1,7 +1,7 @@
 import asyncio
 import subprocess
 
-from middlewared.common.smart.smartctl import get_smartctl_args, smartctl
+from middlewared.common.smart.smartctl import get_smartctl_args, smartctl, SMARTCTX
 from middlewared.service import accepts, Bool, Dict, CallError, List, private, Service, Str
 from middlewared.utils.asyncio_ import asyncio_map
 
@@ -19,13 +19,12 @@ class DiskService(Service):
                 disks = await self.middleware.call("disk.query", [["name", "!=", None]])
 
                 devices = await self.middleware.call("device.get_storage_devices_topology")
-
+                hardware = await self.middleware.call("system.is_enterprise_ix_hardware")
+                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
                 self.smartctl_args_for_disk = dict(zip(
                     [disk["name"] for disk in disks],
                     await asyncio_map(
-                        lambda disk: get_smartctl_args(self.middleware, devices, disk["name"], disk["smartoptions"]),
-                        disks,
-                        8
+                        lambda disk: get_smartctl_args(context, disk["name"], disk["smartoptions"]), disks, 8
                     )
                 ))
             except Exception:
@@ -56,14 +55,15 @@ class DiskService(Service):
                 smartctl_args = await self.middleware.call('disk.smartctl_args', disk)
             else:
                 devices = await self.middleware.call('device.get_storage_devices_topology')
-
+                hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
+                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
                 if disks := await self.middleware.call('disk.query', [['name', '=', disk]]):
                     smartoptions = disks[0]['smartoptions']
                 else:
                     self.middleware.logger.warning("No database row found for disk %r", disk)
                     smartoptions = ''
 
-                smartctl_args = await get_smartctl_args(self.middleware, devices, disk, smartoptions)
+                smartctl_args = await get_smartctl_args(context, disk, smartoptions)
 
             if smartctl_args is None:
                 raise CallError(f'S.M.A.R.T. is unavailable for disk {disk}')

--- a/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
+++ b/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
@@ -3,18 +3,19 @@ import subprocess
 from mock import Mock, patch
 import pytest
 
-from middlewared.common.smart.smartctl import get_smartctl_args
-from middlewared.pytest.unit.middleware import Middleware
+from middlewared.common.smart.smartctl import get_smartctl_args, SMARTCTX
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__disk_nonexistent():
-    assert await get_smartctl_args(None, {}, "ada0", "") is None
+    context = SMARTCTX(devices={}, enterprise_hardware=False)
+    assert await get_smartctl_args(context, "ada0", "") is None
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__nvme():
-    assert await get_smartctl_args(Middleware(), {}, "nvme0n1", "") == ["/dev/nvme0n1", "-d", "nvme"]
+    context = SMARTCTX(devices={}, enterprise_hardware=False)
+    assert await get_smartctl_args(context, "nvme0n1", "") == ["/dev/nvme0n1", "-d", "nvme"]
 
 
 @pytest.mark.parametrize("enclosure,dev", [
@@ -23,117 +24,157 @@ async def test__get_smartctl_args__nvme():
 ])
 @pytest.mark.asyncio
 async def test__get_smartctl_args__arcmsr(enclosure, dev):
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "arcmsrX",
+                "controller_id": 1000,
+                "bus": 0,
+                "channel_no": 100,
+                "lun_id": 10,
+            }
+        },
+        enterprise_hardware=False,
+    )
+
     async def annotate_devices_with_areca_dev_id(devices):
         for v in devices.values():
             v["areca_dev_id"] = enclosure
 
-    with patch("middlewared.common.smart.smartctl.annotate_devices_with_areca_dev_id",
-               annotate_devices_with_areca_dev_id):
-        assert await get_smartctl_args(None, {"ada0": {
-            "driver": "arcmsrX",
-            "controller_id": 1000,
-            "bus": 0,
-            "channel_no": 100,
-            "lun_id": 10,
-        }}, "ada0", "") == ["/dev/arcmsr1000", "-d", dev]
+    func_str = "middlewared.common.smart.smartctl.annotate_devices_with_areca_dev_id"
+    with patch(func_str, annotate_devices_with_areca_dev_id):
+        assert await get_smartctl_args(context, "ada0", "") == ["/dev/arcmsr1000", "-d", dev]
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__rr274x_3x():
-    assert await get_smartctl_args(None, {"ada0": {
-        "driver": "rr274x_3x",
-        "controller_id": 1,
-        "bus": 0,
-        "channel_no": 2,
-        "lun_id": 10,
-    }}, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "rr274x_3x",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 2,
+                "lun_id": 10,
+            }
+        },
+        enterprise_hardware=False,
+    )
+    assert await get_smartctl_args(context, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__rr274x_3x__1():
-    assert await get_smartctl_args(None, {"ada0": {
-        "driver": "rr274x_3x",
-        "controller_id": 1,
-        "bus": 0,
-        "channel_no": 18,
-        "lun_id": 10,
-    }}, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "rr274x_3x",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 18,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
+    assert await get_smartctl_args(context, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__rr274x_3x__2():
-    assert await get_smartctl_args(None, {"ada0": {
-        "driver": "rr274x_3x",
-        "controller_id": 1,
-        "bus": 0,
-        "channel_no": 10,
-        "lun_id": 10,
-    }}, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "rr274x_3x",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 10,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
+    assert await get_smartctl_args(context, "ada0", "") == ["/dev/rr274x_3x", "-d", "hpt,2/3"]
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__hpt():
-    assert await get_smartctl_args(None, {"ada0": {
-        "driver": "hptX",
-        "controller_id": 1,
-        "bus": 0,
-        "channel_no": 2,
-        "lun_id": 10,
-    }}, "ada0", "") == ["/dev/hptX", "-d", "hpt,2/3"]
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "hptx",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 2,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
+    assert await get_smartctl_args(context, "ada0", "") == ["/dev/hptX", "-d", "hpt,2/3"]
 
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__twa():
-    m = Middleware()
-    m["system.is_enterprise_ix_hardware"] = Mock(return_value=False)
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "twaX",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 2,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
     with patch("middlewared.common.smart.smartctl.run") as run:
         run.return_value = Mock(stdout="p28 u1\np29 u2")
 
-        assert await get_smartctl_args(m, {"ada0": {
-            "driver": "twaX",
-            "controller_id": 1,
-            "bus": 0,
-            "channel_no": 2,
-            "lun_id": 10,
-        }}, "ada0", "") == ["/dev/twaX1", "-d", "3ware,29"]
+        assert await get_smartctl_args(context, "ada0", "") == ["/dev/twaX1", "-d", "3ware,29"]
 
-        run.assert_called_once_with(
-            ["/usr/local/sbin/tw_cli", "/c1", "show"],
-            encoding="utf8",
-        )
+        run.assert_called_once_with(["/usr/local/sbin/tw_cli", "/c1", "show"], encoding="utf8")
 
 
 @pytest.mark.asyncio
 async def test_get_disk__unknown_usb_bridge():
-    m = Middleware()
-    m["system.is_enterprise_ix_hardware"] = Mock(return_value=False)
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "ata",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 2,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
+    stdout = "/dev/da0: Unknown USB bridge [0x0930:0x6544 (0x100)]\nPlease specify device type with the -d option."
     with patch("middlewared.common.smart.smartctl.run") as run:
-        run.return_value = Mock(stdout="/dev/da0: Unknown USB bridge [0x0930:0x6544 (0x100)]\n"
-                                       "Please specify device type with the -d option.")
+        run.return_value = Mock(stdout=stdout)
+        assert await get_smartctl_args(context, "ada0", "") == ["/dev/ada0", "-d", "sat"]
 
-        assert await get_smartctl_args(m, {"ada0": {
-            "driver": "ata",
-            "controller_id": 1,
-            "bus": 0,
-            "channel_no": 2,
-            "lun_id": 10,
-        }}, "ada0", "") == ["/dev/ada0", "-d", "sat"]
-
-    run.assert_called_once_with(["smartctl", "/dev/ada0", "-i"], stderr=subprocess.STDOUT, check=False,
-                                encoding="utf8", errors="ignore")
+    run.assert_called_once_with(
+        ["smartctl", "/dev/ada0", "-i"], stderr=subprocess.STDOUT, check=False, encoding="utf8", errors="ignore"
+    )
 
 
 @pytest.mark.asyncio
 async def test_get_disk__generic():
-    m = Middleware()
-    m["system.is_enterprise_ix_hardware"] = Mock(return_value=False)
+    context = SMARTCTX(
+        devices={
+            "ada0": {
+                "driver": "ata",
+                "controller_id": 1,
+                "bus": 0,
+                "channel_no": 2,
+                "lun_id": 10,
+            },
+        },
+        enterprise_hardware=False,
+    )
     with patch("middlewared.common.smart.smartctl.run") as run:
         run.return_value = Mock(stdout="Everything is OK")
 
-        assert await get_smartctl_args(m, {"ada0": {
-            "driver": "ata",
-            "controller_id": 1,
-            "bus": 0,
-            "channel_no": 2,
-            "lun_id": 10,
-        }}, "ada0", "") == ["/dev/ada0"]
+        assert await get_smartctl_args(context, "ada0", "") == ["/dev/ada0"]


### PR DESCRIPTION
We're calling `system.is_enterprise_ix_hardware` for every disk. This isn't really that big of a deal until you're on a system with 1.2k+ disks. Call this method once in the caller and pass to the callees appropriately.

Original PR: https://github.com/truenas/middleware/pull/8881
Jira URL: https://jira.ixsystems.com/browse/NAS-116063