### PR TITLE
NAS-116049 / 22.12 / add release-date to dmi cache (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/dmi.py
+++ b/src/middlewared/middlewared/plugins/system/dmi.py
@@ -62,7 +62,7 @@ class SystemService(Service):
                 break
 
     @private
-    def _prase_bios_release_date(self, string):
+    def _parse_bios_release_date(self, string):
         if (parts := string.strip().split('/')) < 3:
             # dont know what the BIOS is reporting so
             # assume it's invalid

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -1,4 +1,6 @@
-from middlewared.plugins.system.dmi import SystemService
+from datetime import date
+
+from middlewared.plugins.system_.dmi import SystemService
 from middlewared.service import Service
 
 
@@ -6,6 +8,35 @@ full_dmi = ("""
 # dmidecode 3.3
 Getting SMBIOS data from sysfs.
 SMBIOS 3.2.1 present.
+
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+        Vendor: American Megatrends Inc.
+        Version: 3.3aV3
+        Release Date: 12/03/2020
+        Address: 0xF0000
+        Runtime Size: 64 kB
+        ROM Size: 32 MB
+        Characteristics:
+                PCI is supported
+                BIOS is upgradeable
+                BIOS shadowing is allowed
+                Boot from CD is supported
+                Selectable boot is supported
+                BIOS ROM is socketed
+                EDD is supported
+                5.25"/1.2 MB floppy services are supported (int 13h)
+                3.5"/720 kB floppy services are supported (int 13h)
+                3.5"/2.88 MB floppy services are supported (int 13h)
+                Print screen service is supported (int 5h)
+                Serial services are supported (int 14h)
+                Printer services are supported (int 17h)
+                ACPI is supported
+                USB legacy is supported
+                BIOS boot specification is supported
+                Targeted content distribution is supported
+                UEFI is supported
+        BIOS Revision: 5.14
 
 Handle 0x0001, DMI type 1, 27 bytes
 System Information
@@ -191,6 +222,7 @@ Base Board Information
 
 def test__full_dmi():
     expected_result = {
+        'bios-release-date': date(2020, 12, 3),
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -206,6 +238,7 @@ def test__full_dmi():
 
 def test__double_colon_dmi():
     expected_result = {
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
@@ -221,6 +254,7 @@ def test__double_colon_dmi():
 
 def test__missing_dmi():
     expected_result = {
+        'bios-release-date': '',
         'ecc-memory': False,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -236,6 +270,7 @@ def test__missing_dmi():
 
 def test__missing_dmi_type1():
     expected_result = {
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',
@@ -251,6 +286,7 @@ def test__missing_dmi_type1():
 
 def test__missing_dmi_type2():
     expected_result = {
+        'bios-release-date': '',
         'ecc-memory': True,
         'baseboard-manufacturer': '',
         'baseboard-product-name': '',
@@ -266,6 +302,7 @@ def test__missing_dmi_type2():
 
 def test__missing_dmi_type16():
     expected_result = {
+        'bios-release-date': '',
         'ecc-memory': False,
         'baseboard-manufacturer': 'Supermicro',
         'baseboard-product-name': 'X11SPH-nCTPF',


### PR DESCRIPTION
Adding this information to what we cache because we're `subprocess`'ing (unnecessarily) in an alert to get this information.

Original PR: https://github.com/truenas/middleware/pull/8878
Jira URL: https://jira.ixsystems.com/browse/NAS-116049