### PR TITLE
NAS-116118 / 22.02.2 / include pool name and GUID in lsblk output (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -141,8 +141,8 @@ zfs_func()
 	done
 	section_footer
 
-	section_header "lsblk -o name,partuuid -l"
-	lsblk -o name,partuuid -l
+	section_header "lsblk -o NAME,FSTYPE,LABEL,UUID,PARTUUID -l -e 230"
+	lsblk -o NAME,FSTYPE,LABEL,UUID,PARTUUID -l -e 230
 	section_footer
 	section_header  "zpool status -v"
 	zpool status -v


### PR DESCRIPTION
Include UUID which is the zpool GUID and label which is zpool
name.

Original PR: https://github.com/truenas/middleware/pull/8899
Jira URL: https://jira.ixsystems.com/browse/NAS-116118