### PR TITLE
NAS-116053 / 22.12 / cache truenas.get_chassis_hardware (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -5,6 +5,7 @@ import os
 
 from middlewared.schema import accepts, Bool, Dict, Patch, returns, Str
 from middlewared.service import cli_private, job, private, Service
+from middlewared.utils.functools import cache
 import middlewared.sqlalchemy as sa
 
 EULA_FILE = '/usr/local/share/truenas/eula.html'
@@ -44,6 +45,7 @@ class TrueNASService(Service):
     @accepts()
     @returns(Str('system_chassis_hardware'))
     @cli_private
+    @cache
     async def get_chassis_hardware(self):
         """
         Returns what type of hardware this is, detected from dmidecode.


### PR DESCRIPTION
This method is called by `system.is_enterprise` which, surprisingly, is called by many other methods. This is information based off dmidecode information (which is burned into BIOS) so cache it for a micro-optimization.

Original PR: https://github.com/truenas/middleware/pull/8879
Jira URL: https://jira.ixsystems.com/browse/NAS-116053

Original PR: https://github.com/truenas/middleware/pull/8919
Jira URL: https://jira.ixsystems.com/browse/NAS-116053