### PR TITLE
NAS-115771 / 22.12 / Add oneshot alert for deprecated services that are running

### DIFF
--- a/src/middlewared/middlewared/alert/source/deprecated_service.py
+++ b/src/middlewared/middlewared/alert/source/deprecated_service.py
@@ -1,0 +1,19 @@
+import json
+
+from middlewared.alert.base import Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel
+
+
+class DeprecatedServiceAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "Deprecated Service is Running"
+    text = "The following running service is deprecated and will be removed in a future release: %(service)s"
+
+    async def create(self, args):
+        return Alert(DeprecatedServiceAlertClass, args, key=args['service'])
+
+    async def delete(self, alerts, query):
+        return list(filter(
+            lambda alert: json.loads(alert.key) != str(query),
+            alerts
+        ))

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -4,6 +4,7 @@ class ServiceInterface:
     etc = []
     restartable = False  # Implements `restart` method instead of `stop` + `start`
     reloadable = False  # Implements `reload` method
+    deprecated = False  # Alert if service is running
 
     def __init__(self, middleware):
         self.middleware = middleware


### PR DESCRIPTION
Currently this only contains AFP in 13, but having general-purpose
alert may be useful so that users can plan migration off things
that we will remove in the future.

Make backend changes to flag service as "deprecated"

Deprecated services generate alert when they are running that
they will soon be removed. This allows us to nag users to
make plans to migrate away from the service.