### PR TITLE
NAS-115771 / 22.02.2 / Add oneshot alert for deprecated services that are running

### DIFF
--- a/src/middlewared/middlewared/alert/source/deprecated_service.py
+++ b/src/middlewared/middlewared/alert/source/deprecated_service.py
@@ -1,0 +1,19 @@
+import json
+
+from middlewared.alert.base import Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel
+
+
+class DeprecatedServiceAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "Deprecated Service is Running"
+    text = "The following running service is deprecated and will be removed in a future release: %(service)s"
+
+    async def create(self, args):
+        return Alert(DeprecatedServiceAlertClass, args, key=args['service'])
+
+    async def delete(self, alerts, query):
+        return list(filter(
+            lambda alert: json.loads(alert.key) != str(query),
+            alerts
+        ))

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -7,7 +7,7 @@ from middlewared.plugins.service_.services.all import all_services
 from middlewared.plugins.service_.services.base import IdentifiableServiceInterface
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, returns, Str
-from middlewared.service import filterable, CallError, CRUDService, private
+from middlewared.service import filterable, CallError, CRUDService, periodic, private
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list
@@ -138,6 +138,12 @@ class ServiceService(CRUDService):
         if state.running:
             await service_object.after_start()
             await self.middleware.call('service.notify_running', service)
+            if service_object.deprecated:
+                await self.middleware.call(
+                    'alert.oneshot_create',
+                    'DeprecatedService',
+                    {"service": service_object.name}
+                )
             return True
         else:
             self.logger.error("Service %r not running after start", service)
@@ -153,6 +159,17 @@ class ServiceService(CRUDService):
         service_object = await self.middleware.call('service.object', service)
 
         state = await service_object.get_state()
+
+        if service_object.deprecated:
+            if state.running:
+                await self.middleware.call(
+                    'alert.oneshot_create',
+                    'DeprecatedService',
+                    {"service": service_object.name}
+                )
+            else:
+                await self.middleware.call('alert.oneshot_delete', 'DeprecatedService', service_object.name)
+
         return state.running
 
     @accepts(Str('service'))
@@ -187,6 +204,9 @@ class ServiceService(CRUDService):
         if not state.running:
             await service_object.after_stop()
             await self.middleware.call('service.notify_running', service)
+            if service_object.deprecated:
+                await self.middleware.call('alert.oneshot_delete', 'DeprecatedService', service_object.name)
+
             return False
         else:
             self.logger.error("Service %r running after stop", service)
@@ -217,13 +237,11 @@ class ServiceService(CRUDService):
             await service_object.after_restart()
 
             state = await service_object.get_state()
-            if state.running:
-                await self.middleware.call('service.notify_running', service)
-                return True
-            else:
+            if not state.running:
                 await self.middleware.call('service.notify_running', service)
                 self.logger.error("Service %r not running after restart", service)
                 return False
+
         else:
             try:
                 await service_object.before_stop()
@@ -239,14 +257,18 @@ class ServiceService(CRUDService):
             await service_object.before_start()
             await service_object.start()
             state = await service_object.get_state()
-            if state.running:
-                await service_object.after_start()
-                await self.middleware.call('service.notify_running', service)
-                return True
-            else:
+            if not state.running:
                 await self.middleware.call('service.notify_running', service)
                 self.logger.error("Service %r not running after restart-caused start", service)
                 return False
+
+            await service_object.after_start()
+
+        await self.middleware.call('service.notify_running', service)
+        if service_object.deprecated:
+            await self.middleware.call('alert.oneshot_create', 'DeprecatedService', {"service": service_object.name})
+
+        return True
 
     @accepts(
         Str('service'),
@@ -342,7 +364,26 @@ class ServiceService(CRUDService):
 
         return False
 
+    @periodic(3600, run_on_start=False)
+    @private
+    async def check_deprecated_services(self):
+        """
+        Simple call to service.started is sufficient to toggle alert
+        """
+        for service_name, service in self.SERVICES.items():
+            if not service.deprecated:
+                continue
+
+            await self.started(service.name)
+
+
+async def __event_service_ready(middleware, event_type, args):
+    if args['id'] == 'ready':
+        asyncio.ensure_future(middleware.call('service.check_deprecated_services'))
+
 
 async def setup(middleware):
     for klass in all_services:
         await middleware.call('service.register_object', klass(middleware))
+
+    middleware.event_subscribe('system', __event_service_ready)

--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -15,6 +15,7 @@ class ServiceInterface:
     etc = []
     restartable = False  # Implements `restart` method instead of `stop` + `start`
     reloadable = False  # Implements `reload` method
+    deprecated = False  # Alert if service is running
 
     def __init__(self, middleware):
         self.middleware = middleware


### PR DESCRIPTION
Currently this only contains AFP in 13, but having general-purpose
alert may be useful so that users can plan migration off things
that we will remove in the future.

Make backend changes to flag service as "deprecated"

Deprecated services generate alert when they are running that
they will soon be removed. This allows us to nag users to
make plans to migrate away from the service.

Original PR: https://github.com/truenas/middleware/pull/8934
Jira URL: https://jira.ixsystems.com/browse/NAS-115771