### PR TITLE
NAS-116121 / 22.02.2 / Fix updating default storage class (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/storage_classes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/storage_classes.py
@@ -77,9 +77,9 @@ class KubernetesStorageClassService(CRUDService):
             ['metadata.annotations.storageclass\\.kubernetes\\.io/is-default-class', '=', 'true'],
             ['metadata.name', '=', DEFAULT_STORAGE_CLASS],
         ]):
-            await self.middleware.call('k8s.storage_class.update', DEFAULT_STORAGE_CLASS, config)
-        else:
-            await self.middleware.call('k8s.storage_class.create', config)
+            await self.middleware.call('k8s.storage_class.delete', DEFAULT_STORAGE_CLASS)
+
+        await self.middleware.call('k8s.storage_class.create', config)
 
     async def retrieve_storage_class_manifest(self):
         return {


### PR DESCRIPTION
This commit fixes an issue where we are not actually able to update a storage class parameters ( which should change when ix-applications is migrated from one pool to another ), so we delete the default storage class and create a new one to address this issue.

Original PR: https://github.com/truenas/middleware/pull/8935
Jira URL: https://jira.ixsystems.com/browse/NAS-116121