### PR TITLE
NAS-116174 / 22.12 / Show most important alerts first

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -347,10 +347,18 @@ class AlertService(Service):
         """
 
         as_ = AlertSerializer(self.middleware)
+        classes = (await self.middleware.call("alertclasses.config"))["classes"]
 
         return [
             await as_.serialize(alert)
-            for alert in sorted(self.alerts, key=lambda alert: (alert.klass.title, alert.datetime))
+            for alert in sorted(
+                self.alerts,
+                key=lambda alert: (
+                    -get_alert_level(alert, classes).value,
+                    alert.klass.title,
+                    alert.datetime,
+                ),
+            )
             if await as_.should_show_alert(alert)
         ]
 


### PR DESCRIPTION
When vmware snapshot task fails, an alert is issued. User ignored this alert and was unaware that vmware snapshots were not taken due to network misconfiguration. I had a hard time noting this alert too because it was Nth after N "enclosure is HEALTHY" alerts and was not visible in a small browser window. We might want to sort alerts by their level first.