### PR TITLE
NAS-115976 / 22.02.2 / Add tests for renames over SMB protocol (by anodos325)

### DIFF
--- a/tests/protocols.py
+++ b/tests/protocols.py
@@ -7,6 +7,7 @@ import contextlib
 import os
 from samba import NTSTATUSError
 from functions import SSH_TEST
+libsmb_has_rename = 'rename' in dir(libsmb.Conn)
 
 
 class SMB(object):
@@ -154,6 +155,23 @@ class SMB(object):
         return self._connection.write(
             self._open_files[idx]["fh"], data, offset
         )
+
+    def rename(self, src, dst):
+        if libsmb_has_rename:
+            return self._connection.rename(src, dst)
+
+        cmd = [
+            "smbclient", f"//{self._host}/{self._share}",
+            "-U", f"{self._username}%{self._password}",
+        ]
+
+        if self._smb1:
+            cmd.extend(["-m", "NT1"])
+
+        cmd.extend(["-c", f'rename {src} {dst}'])
+        cl = subprocess.run(cmd, capture_output=True)
+        if cl.returncode != 0:
+            raise RuntimeError(cl.stdout.decode())
 
     def _parse_quota(self, quotaout):
         ret = []


### PR DESCRIPTION
We have had regressions here on a few occassions. Let's
add some CI tests so that it doesn't get missed again.

Original PR: https://github.com/truenas/middleware/pull/8863
Jira URL: https://jira.ixsystems.com/browse/NAS-115976