### PR TITLE
NAS-115802 / 22.12 / Make sure system reflects newer cert before redeploying cert attachments

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/renew_certs.py
+++ b/src/middlewared/middlewared/plugins/crypto_/renew_certs.py
@@ -27,6 +27,7 @@ class CertificateService(Service):
         certs = self.middleware.call_sync('certificate.query', filters)
 
         progress = 0
+        changed_certs = []
         for cert in certs:
             progress += (100 / len(certs))
 
@@ -66,6 +67,11 @@ class CertificateService(Service):
                 cert_payload,
                 {'prefix': 'cert_'}
             )
+            changed_certs.append(cert)
+
+        self.middleware.call_sync('etc.generate', 'ssl')
+
+        for cert in changed_certs:
             try:
                 self.middleware.call_sync('certificate.redeploy_cert_attachments', cert['id'])
             except Exception:


### PR DESCRIPTION
This commit fixes an issue where we re-deployed cert attachments but did not update the certs on the filesystem which resulted in issues like nginx still using the old cert.