### PR TITLE
NAS-113808 / 23.10 / Add unit tests workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,41 @@
+name: unittests
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: 'Image URI'
+        required: true
+        type: string
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: |
+        sudo apt update && sudo apt install -y curl squashfs-tools
+    - name: Download update file
+      run: |
+        curl "$URI" -o truenas_image.update
+      env:
+        URI: ${{ github.event.inputs.url }}
+    - name: Run unit tests
+      run: |
+        mkdir unit_test_temp
+        mkdir outer_layer_temp
+        sudo unsquashfs -f -d ./outer_layer_temp truenas_image.update
+        sudo unsquashfs -f -d ./unit_test_temp ./outer_layer_temp/rootfs.squashfs
+        sudo chroot ./unit_test_temp bash -c 'echo "nameserver 8.8.8.8" >> /etc/resolv.conf'
+        sudo cp -a src/middlewared/middlewared/pytest ./unit_test_temp/usr/lib/python3/dist-packages/middlewared/
+        sudo chroot ./unit_test_temp curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        sudo chroot ./unit_test_temp python3 get-pip.py
+        sudo chroot ./unit_test_temp python3 -m pip install --upgrade pip
+        sudo mkdir -p ./unit_test_temp/dev
+        sudo mount -t devtmpfs udev ./unit_test_temp/dev
+        sudo chroot ./unit_test_temp pip install asynctest pytest asyncmock pytest-asyncio
+        sudo chroot ./unit_test_temp pytest -v --disable-pytest-warnings /usr/lib/python3/dist-packages/middlewared/pytest
+        echo "exit code : " $?


### PR DESCRIPTION
## Context

We would like to run unit tests on github PRs so that we can catch errors before. This is a workflow which is triggered by a webhook i.e `curl` which will be executed once jenkins completes the incremental build of a PR.

Right now, this expects the update image URI to be available so that it could run unit tests in it. We are waiting on QE team to finalize the workflow wrt having this triggered and making the update image be publicly available before we can move forward with having this working on PRs.