### PR TITLE
Fix for unhandled devices

### DIFF
--- a/src/middlewared/middlewared/plugins/geom_/cache.py
+++ b/src/middlewared/middlewared/plugins/geom_/cache.py
@@ -191,8 +191,10 @@ class GeomCachedObjects:
 
         disks = {}
         for xmlelm in xml.findall('.//class[name="DISK"]/geom'):
-            name, info = self.fill_disks_details(xmlelm, topology)
-            disks[name] = info
+            detail = self.fill_disks_details(xmlelm, topology)
+            if detail:
+                name, info = detail
+                disks[name] = info
 
         multipath = {}
         for xmlelm in xml.findall('.//class[name="MULTIPATH"]/geom'):


### PR DESCRIPTION
On a NAS with a CD drive many functions are broken, even Truenas dashboard does not appear.

Fixes 369d0151fc4824db157f8469812a4d80542e12a3