### PR TITLE
NAS-116232 / 13.0 / fix geom cache crash on cd devs

### DIFF
--- a/src/middlewared/middlewared/plugins/geom_/cache.py
+++ b/src/middlewared/middlewared/plugins/geom_/cache.py
@@ -54,7 +54,7 @@ class GeomCachedObjects:
         name = xmlelem.find('provider/name').text
         if name.startswith('cd'):
             # ignore cd devices
-            return
+            return None, None
 
         # make a copy of disk template
         disk = DISK_TEMPLATE.copy()
@@ -192,7 +192,8 @@ class GeomCachedObjects:
         disks = {}
         for xmlelm in xml.findall('.//class[name="DISK"]/geom'):
             name, info = self.fill_disks_details(xmlelm, topology)
-            disks[name] = info
+            if name and info:
+                disks[name] = info
 
         multipath = {}
         for xmlelm in xml.findall('.//class[name="MULTIPATH"]/geom'):


### PR DESCRIPTION
Original PR submitted by user is https://github.com/truenas/middleware/pull/8955. This fixes the return value of `fill_disks_details` to always be a tuple and make sure the caller handles it as expected.