### PR TITLE
NAS-116233 / 22.12 / Fix alternate code path for SMB connection rename in tests

### DIFF
--- a/tests/protocols.py
+++ b/tests/protocols.py
@@ -61,6 +61,8 @@ class SMB(object):
         self._host = host
         self._share = share
         self._smb1 = smb1
+        self._username = username
+        self._password = password
         self._connection = libsmb.Conn(
             host,
             share,


### PR DESCRIPTION
On servers running API test that lack the rename() python smbclient binding we need to wrap around
the `smbclient` cli utility. I forgot to keep a copy of the credentials around when establishing the
SMB connection to use for the CLI utility.