### PR TITLE
NAS-115683 / 13.0 / log to /var/log/messages on HA

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -220,11 +220,17 @@ class Logger(object):
                 },
                 'failover': {
                     'level': 'NOTSET',
-                    'handlers': ['failover_file'],
+                    'handlers': ['failover_file', 'sys-logger'],
                     'propagate': False,
                 },
             },
             'handlers': {
+                'sys-logger': {
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.SysLogHandler',
+                    'address': '/var/run/log',
+                    'formatter': 'file',
+                },
                 'file': {
                     'level': 'DEBUG',
                     'class': 'middlewared.logger.ErrorProneRotatingFileHandler',


### PR DESCRIPTION
Support has requested that the messages that get logged to `/root/syslog/failover.log` also get logged to `/var/log/messages`. This does that.