### PR TITLE
NAS-114595 / 13.0 / Fix vnc args in 13

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -919,8 +919,7 @@ class VNC(Device):
             bool, [
                 '29',
                 'fbuf',
-                'vncserver',
-                f'tcp={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
+                f'vncserver={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
                 f'w={width}',
                 f'h={height}',
                 f'password={attrs["vnc_password"]}' if attrs.get('vnc_password') else None,


### PR DESCRIPTION
This commit brings change to middleware to provide new/updated args to bhyve for vnc as this changed when switching from 12->13.