### PR TITLE
NAS-116252 / 22.12 / Blacklist wide links related parameters

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1325,6 +1325,8 @@ class SharingSMBService(SharingService):
             'socket options',
             'include',
             'interfaces',
+            'wide links',
+            'insecure wide links'
         ]
         freebsd_vfs_objects = [
             'zfsacl',


### PR DESCRIPTION
I will soon be merging in changes that basically chroot us into
the share's connectpath, which will break widelinks functionality.

This also removes one more way for our customers to significantly
degrades security of their server.