### PR TITLE
Remove crossrename from vfs objects when recycle enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -258,9 +258,7 @@ class ShareSchema(RegistrySchema):
             "recycle:directory_mode": {"parsed": "0777"},
             "recycle:subdir_mode": {"parsed": "0700"},
         })
-        data_out['vfs objects']['parsed'].extend([
-            "recycle", "crossrename"
-        ])
+        data_out['vfs objects']['parsed'].append("recycle")
 
         return
 

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -364,7 +364,7 @@ def test_040_verify_that_recyclebin_is_true(request):
     assert results.json()['recyclebin'] is True, results.text
 
 
-@pytest.mark.parametrize('vfs_object', ["crossrename", "recycle"])
+@pytest.mark.parametrize('vfs_object', ["recycle"])
 def test_041_verify_smb_getparm_vfs_objects_share(request, vfs_object):
     depends(request, ["service_cifs_running", "ssh_password"], scope="session")
     cmd = f'midclt call smb.getparm "vfs objects" {SMB_NAME}'


### PR DESCRIPTION
Recycled files are now moved into per-dataset recycle bins.