### PR TITLE
NAS-116252 / 13.0 / Blacklist wide links related parameters (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1057,6 +1057,8 @@ class SharingSMBService(SharingService):
             'private directory',
             'private dir',
             'cache directory',
+            'wide links',
+            'insecure wide links',
         ]
         for entry in data.splitlines():
             if entry == '' or entry.startswith(('#', ';')):


### PR DESCRIPTION
I will soon be merging in changes that basically chroot us into
the share's connectpath, which will break widelinks functionality.

This also removes one more way for our customers to significantly
degrades security of their server.