### PR TITLE
NAS-116253 / 13.0 / Remove crossrename from vfs objects when recycle enabled (#8967) (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -307,10 +307,7 @@ class SharingSMBService(Service):
             data['vfsobjects'].append('noacl')
 
         if data['recyclebin']:
-            # crossrename is required for 'recycle' to work across sub-datasets
-            # FIXME: crossrename imposes 20MB limit on filesize moves across mountpoints
-            # This really needs to be addressed with a zfs-aware recycle bin.
-            data['vfsobjects'].extend(['recycle', 'crossrename'])
+            data['vfsobjects'].append('recycle')
 
         if data['shadowcopy'] or data['fsrvp']:
             data['vfsobjects'].append('shadow_copy_zfs')

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -418,7 +418,7 @@ def test_040_verify_that_recyclebin_is_true(request):
     assert results.json()['recyclebin'] is True, results.text
 
 
-@pytest.mark.parametrize('vfs_object', ["crossrename", "recycle"])
+@pytest.mark.parametrize('vfs_object', ["recycle"])
 def test_041_verify_smb_getparm_vfs_objects_share(request, vfs_object):
     depends(request, ["service_cifs_running", "ssh_password"], scope="session")
     cmd = f'midclt call smb.getparm "vfs objects" {SMB_NAME}'


### PR DESCRIPTION
Recycled files are now moved into per-dataset recycle bins. This also protects us against some prominent bad advice online that suggests invalid auxiliary parameter for vfs_crossrename that can result in unexpected file deletion.