### PR TITLE
NAS-115860 / 22.12 / fix importing zpools on SCALE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 flake8-import-order
+        pip install flake8
     - name: Get current errors
       run: |
         tmpafter=$(mktemp)
-        find src -name \*.py -exec flake8 --application-import-names middlewared --ignore=I101,E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
+        find src -name \*.py -exec flake8 --ignore=E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
         num_errors_after=`cat $tmpafter | wc -l`
         echo "CURRENT_ERROR_FILE=${tmpafter}" >> $GITHUB_ENV
         echo "CURRENT_ERRORS=${num_errors_after}" >> $GITHUB_ENV
@@ -35,7 +35,7 @@ jobs:
     - name: Get errors from base branch
       run: |
         tmpbefore=$(mktemp)
-        find src -name \*.py -exec flake8 --application-import-names middlewared --ignore=I101,E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpbefore
+        find src -name \*.py -exec flake8 --ignore=E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpbefore
         num_errors_before=`cat $tmpbefore | wc -l`
         echo "OLD_ERROR_FILE=${tmpbefore}" >> $GITHUB_ENV
         echo "OLD_ERRORS=${num_errors_before}" >> $GITHUB_ENV

--- a/debian/debian/ix-zfs.service
+++ b/debian/debian/ix-zfs.service
@@ -8,6 +8,7 @@ After=middlewared.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=/usr/bin/python3 /usr/lib/python3/dist-packages/middlewared/scripts/ix_zfs_service_helper.py
 ExecStart=-midclt call disk.sed_unlock_all
 ExecStart=midclt call -job --job-print description pool.import_on_boot
 StandardOutput=null

--- a/debian/debian/ix-zfs.service
+++ b/debian/debian/ix-zfs.service
@@ -8,7 +8,7 @@ After=middlewared.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/usr/bin/python3 /usr/lib/python3/dist-packages/middlewared/scripts/ix_zfs_service_helper.py
+ExecStartPre=/usr/bin/zpoolhelper
 ExecStart=-midclt call disk.sed_unlock_all
 ExecStart=midclt call -job --job-print description pool.import_on_boot
 StandardOutput=null

--- a/src/middlewared/middlewared/scripts/ix_zfs_service_helper.py
+++ b/src/middlewared/middlewared/scripts/ix_zfs_service_helper.py
@@ -1,0 +1,53 @@
+from collections import deque
+from time import time, sleep
+from sys import exit
+
+from pyudev import Context, Monitor, MonitorObserver
+
+dq = deque()
+
+
+def callback(dev):
+    t = time()
+    if uuid := dev.get('ID_PART_ENTRY_UUID'):
+        dq.append({'time': t, 'name': dev.sys_name, 'uuid': uuid, 'action': dev.action})
+
+
+def get_observer():
+    ctx = Context()
+    mon = Monitor.from_netlink(ctx)
+    mon.filter_by('block')
+    return MonitorObserver(mon, callback=callback)
+
+
+def main():
+    obs = get_observer(dq)
+    obs.start()  # start background thread
+
+    max_time_to_wait = 600  # total time to wait in seconds
+    interval = 5  # seconds to sleep before checking for new event
+    last_event = {}
+    while max_time_to_wait > 0:
+        max_time_to_wait -= interval
+        sleep(interval)
+
+        try:
+            event = dq[-1]
+        except IndexError:
+            # no events received
+            break
+        else:
+            if event == last_event:
+                # we've waited 5 seconds and no more events have come in
+                break
+            else:
+                last_event = event
+
+    obs.send_stop()  # clean up background thread (non-blocking)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    finally:
+        exit(0)  # always exit success (for now)

--- a/src/middlewared/middlewared/scripts/zpoolhelper.py
+++ b/src/middlewared/middlewared/scripts/zpoolhelper.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 from collections import deque
 from time import time, sleep
 from sys import exit

--- a/src/middlewared/middlewared/scripts/zpoolhelper.py
+++ b/src/middlewared/middlewared/scripts/zpoolhelper.py
@@ -5,7 +5,7 @@ from sys import exit
 
 from pyudev import Context, Monitor, MonitorObserver
 
-dq = deque()
+dq = deque(maxlen=2)
 
 
 def callback(dev):
@@ -22,7 +22,7 @@ def get_observer():
 
 
 def main():
-    obs = get_observer(dq)
+    obs = get_observer()
     obs.start()  # start background thread
 
     max_time_to_wait = 600  # total time to wait in seconds

--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -68,6 +68,7 @@ setup(
             'midclt = middlewared.client.client:main',
             'midgdb = middlewared.scripts.gdb:main',
             'sedhelper = middlewared.scripts.sedhelper:main',
+            'zpoolhelper = middlewared.scripts.zpoolhelper:main',
         ],
     },
     cmdclass={


### PR DESCRIPTION
Discovered and witnessed on an internal M50 (no expansion shelf) as well as an R50b with an ES60 expansion shelf (in the field). The simplified version is that `/dev/disk/by-partuuid` symlinks aren't being created by the time the raw devices are being populated inside `/dev/`.

Since we're trying to import the zpools specifying `/dev/disk/by-partuuid` AND `/dev/` it means zpool is importing the disks via gptid but if it can't find one, it's choosing a random raw device. The device letters for raw devices aren't guaranteed between reboots and often change so when the zpool is imported, certain devices are "missing" and other drives are being put in their place.

This is painful because the zpool is now imported and in an unhealthy state. This adds a simple helper script that gets called as a prerequisite to the `ExecStart` entries in the `ix-zfs.service` file. Testing this on the M50, fixed the problem and the zpool imported with gptid's and produced a healthy pool.

NOTE: This is still "flawed" and not something that I want to do but our hand is forced. The "proper" solution is for openzfs to actually integrate with systemd and use the proper mechanism(s) to automagically handle this.

The `ix-zfs.service` has a time limit of 15mins while we allow udev "events" to be received for a maximum of 10mins. This worked on the R50b and the M50 so I'm leaving those time limits for now.

BONUS: adding `After=systemd-udevd-settle.service` is what I initially thought would be the "solution" but that emits a DeprecationWarning from systemd. Furthermore, reading the documentation uses big scary verbiage about how this is absolutely the wrong approach, so I've refrained from doing that.