### PR TITLE
NAS-116273 / 22.02.2 / remove nonexistent entry point for middlewared (by yocalebo)

### DIFF
--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -63,7 +63,6 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'hadetect = middlewared.scripts.hadetect:main',
             'middlewared = middlewared.main:main',
             'midclt = middlewared.client.client:main',
             'midgdb = middlewared.scripts.gdb:main',


### PR DESCRIPTION
`hadetect` script was removed a long time ago so remove this so we don't create a broken script in `/usr/bin/hadetect`.

Original PR: https://github.com/truenas/middleware/pull/8978
Jira URL: https://jira.ixsystems.com/browse/NAS-116273