### PR TITLE
Invalidate geom cache when formatting boot devices

### DIFF
--- a/src/middlewared/middlewared/plugins/boot_/format.py
+++ b/src/middlewared/middlewared/plugins/boot_/format.py
@@ -121,3 +121,5 @@ class BootService(Service):
 
         if osc.IS_LINUX:
             await self.middleware.call('device.settle_udev_events')
+
+        await self.middleware.call('geom.cache.invalidate')


### PR DESCRIPTION
Attaching a boot device failed with the following exception:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 355, in run
    await self.future
  File "/usr/local/lib/python3.9/site-packages/middlewared/job.py", line 391, in __run_body
    rv = await self.method(*([self] + args))
  File "/usr/local/lib/python3.9/site-packages/middlewared/schema.py", line 975, in nf
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/boot.py", line 109, in attach
    'path': f'/dev/{zfs_dev_part["name"]}'
TypeError: 'NoneType' object is not subscriptable
```

This fixes that.