### PR TITLE
NAS-115578 / 22.12 / Force systemd to not terminate vms forcefully

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -3,7 +3,7 @@ Description=TrueNAS Middleware
 DefaultDependencies=no
 
 Wants=ix-conf.service dbus.socket
-After=ix-conf.service dbus.socket
+After=ix-conf.service dbus.socket libvirtd.service
 Before=reboot.target shutdown.target halt.target
 Conflicts=reboot.target shutdown.target halt.target
 


### PR DESCRIPTION
This commit adds a change to make sure that libvirtd is not terminated automatically when we reboot the system as it's middleware responsibility to terminate it cleanly. Idea is to change order and have middleware require libvirtd before starting ( libvirt won't start ofcourse because it's disabled by default and it's lifecycle is managed by middleware ), this way libvirt is not stopped on shutdown when services are being stopped and middleware cleanly exits it after the specified timeout occurs.