### PR TITLE
NAS-116283 / 13.0 / fix pool.is_upgraded_by_name (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -346,33 +346,9 @@ class PoolService(CRUDService):
                 "params": [1]
             }
         """
-        name = (await self.get_instance(oid))['name']
-        proc = await Popen(
-            f'zpool get -H -o value version {name}',
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-        )
-        res, err = await proc.communicate()
-        if proc.returncode != 0:
-            return True
-        res = res.decode('utf8').rstrip('\n')
         try:
-            int(res)
-        except ValueError:
-
-            if res == '-':
-                proc = await Popen(
-                    f"zpool get -H -o property,value all {name}",
-                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-                )
-                data = (await proc.communicate())[0].decode('utf8').strip('\n')
-                for line in [i for i in data.split('\n') if i.startswith('feature') and '\t' in i]:
-                    prop, value = line.split('\t', 1)
-                    if value not in ('active', 'enabled'):
-                        return False
-                return True
-            else:
-                return False
-        else:
+            return await self.middleware.call('zfs.pool.is_upgraded', (await self.get_instance(oid))['name'])
+        except CallError:
             return False
 
     @accepts(Int('id'))

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -31,7 +31,7 @@ from middlewared.service import (
 )
 from middlewared.service_exception import ValidationError
 import middlewared.sqlalchemy as sa
-from middlewared.utils import osc, Popen, filter_list, run, start_daemon_thread
+from middlewared.utils import osc, filter_list, run, start_daemon_thread
 from middlewared.utils.asyncio_ import asyncio_map
 from middlewared.utils.path import is_child
 from middlewared.utils.shell import join_commandline

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -87,6 +87,14 @@ class ZFSPoolService(CRUDService):
                 pools = [i.__getstate__(**state_kwargs) for i in zfs.pools]
         return filter_list(pools, filters, options)
 
+    def is_upgraded(self, pool_name):
+        enabled = (libzfs.FeatureState.ENABLED, libzfs.FeatureState.ACTIVE)
+        with libzfs.ZFS() as zfs:
+            for pool in filter(lambda x: x.name == pool_name, zfs.pools):
+                return all((i.state in enabled for i in pool.features))
+            else:
+                raise CallError(f'{pool_name!r} not found', errno.ENOENT)
+
     @accepts(
         Dict(
             'zfspool_create',


### PR DESCRIPTION
`py-libzfs` gives us the pool feature flags so there is no need to `subprocess` out (potentially twice) when checking to see if a pool's feature flags have been upgraded.

Original PR: https://github.com/truenas/middleware/pull/8984
Jira URL: https://jira.ixsystems.com/browse/NAS-116283