### PR TITLE
NAS-116283 / 22.02.2 / fix pool.is_upgraded_by_name (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -431,7 +431,10 @@ class PoolService(CRUDService):
 
     @private
     async def is_upgraded_by_name(self, name):
-        return await self.middleware.call('zfs.pool.is_upgraded', name)
+        try:
+            return await self.middleware.call('zfs.pool.is_upgraded', name)
+        except CallError:
+            return False
 
     @accepts(Int('id'))
     @returns(Bool('upgraded'))

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -100,12 +100,12 @@ class ZFSPoolService(CRUDService):
             raise CallError(f'Failed listing imported pools with error: {e}')
 
     def is_upgraded(self, pool_name):
-        is_upgraded = False
+        enabled = (libzfs.FeatureState.ENABLED, libzfs.FeatureState.ACTIVE)
         with libzfs.ZFS() as zfs:
             for pool in filter(lambda x: x.name == pool_name, zfs.pools):
-                is_upgraded = not any((i.state.name not in ('ACTIVE', 'ENABLED') for i in pool.features))
-
-        return is_upgraded
+                return all((i.state in enabled for i in pool.features))
+            else:
+                raise CallError(f'{pool_name!r} not found', errno.ENOENT)
 
     @accepts(
         Dict(

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -99,6 +99,14 @@ class ZFSPoolService(CRUDService):
         except libzfs.ZFSException as e:
             raise CallError(f'Failed listing imported pools with error: {e}')
 
+    def is_upgraded(self, pool_name):
+        is_upgraded = False
+        with libzfs.ZFS() as zfs:
+            for pool in filter(lambda x: x.name == pool_name, zfs.pools):
+                is_upgraded = not any((i.state.name not in ('ACTIVE', 'ENABLED') for i in pool.features))
+
+        return is_upgraded
+
     @accepts(
         Dict(
             'zfspool_create',


### PR DESCRIPTION
`py-libzfs` gives us the pool feature flags so there is no need to `subprocess` out (potentially twice) when checking to see if a pool's feature flags have been upgraded.

Original PR: https://github.com/truenas/middleware/pull/8984
Jira URL: https://jira.ixsystems.com/browse/NAS-116283