### PR TITLE
NAS-112344 / 13.0 / Do not overreact to `.fail` TLD

### DIFF
--- a/src/middlewared/middlewared/alert/source/ssh_login_failures.py
+++ b/src/middlewared/middlewared/alert/source/ssh_login_failures.py
@@ -50,7 +50,11 @@ def get_login_failures(now, messages):
         message = message.decode("utf-8", "ignore")
         if message.strip():
             if message.startswith(yesterday):
-                if re.search(r"\b(fail(ures?|ed)?|invalid|bad|illegal|auth.*error)\b", message, re.I):
+                if re.search(
+                    r"\b(fail(ures?|ed)?|invalid|bad|illegal|auth.*error)\b",
+                    message.replace(".fail", ""),
+                    re.I,
+                ):
                     if "sshd" not in message:
                         continue
 


### PR DESCRIPTION
SCALE does not have this regex so no backport is needed