### PR TITLE
NAS-116288 / 22.02.2 / Use /proc/spl/kstat/zfs for quick zpool checks (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1387,7 +1387,7 @@ class PoolService(CRUDService):
 
         # get the zpool name
         if not new_name:
-            pool_name = (await self.middleware.call('zfs.pool.query_imported_fast'))[guid]
+            pool_name = (await self.middleware.call('zfs.pool.query_imported_fast'))[guid]['name']
         else:
             pool_name = new_name
 


### PR DESCRIPTION
We can get pool status and whether it's imported in this way
without having to use libzfs or ZFS cmd.

Original PR: https://github.com/truenas/middleware/pull/8901
Jira URL: https://jira.ixsystems.com/browse/NAS-116288