### PR TITLE
NAS-116163 / 22.12 / ensure unique /etc/machine-id on upgrade from CORE

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/freebsd_to_scale_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/freebsd_to_scale_linux.py
@@ -1,6 +1,5 @@
-import contextlib
 import logging
-import os
+from pathlib import Path
 
 from middlewared.service import job, private, Service
 from middlewared.utils import run
@@ -12,9 +11,11 @@ class UpdateService(Service):
 
     @private
     def remove_files(self):
-        with contextlib.suppress(FileNotFoundError):
-            for i in ("/data/freebsd-to-scale-update", "/var/lib/dbus/machine-id", "/etc/machine-id"):
-                os.unlink(i)
+        for i in ("/data/freebsd-to-scale-update", "/var/lib/dbus/machine-id", "/etc/machine-id"):
+            try:
+                Path(i).unlink(missing_ok=True)
+            except Exception:
+                logger.error('Failed removing %r', i, exc_info=True)
 
     @private
     @job()


### PR DESCRIPTION
`/etc/machine-id` is used by kernel to generate globally unique mac addresses along with many other things. We're ensuring that this is unique on fresh installation or upgrade between SCALE releases but we're not ensuring this on upgrade from CORE to SCALE so all CORE machines being upgraded to SCALE have the same `/etc/machine-id` which means, for example, virtual interfaces will share the same mac addresses. This should fix that by removing the associated files and regenerating it at upgrade time.