### PR TITLE
NAS-116310 / 22.02.2 / Remove automatic quota on TM preset (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -115,8 +115,7 @@ class SMBSharePreset(enum.Enum):
         'path_suffix': '%U',
         'timemachine': True,
         'auxsmbconf': '\n'.join([
-            'ixnas:zfs_auto_homedir=true' if osc.IS_FREEBSD else 'zfs_core:zfs_auto_create=true',
-            'ixnas:default_user_quota=1T' if osc.IS_FREEBSD else 'zfs_core:base_user_quota=1T',
+            'zfs_core:zfs_auto_create=true'
         ])
     }}
     MULTI_PROTOCOL_NFS = {"verbose_name": "Multi-protocol (NFSv3/SMB) shares", "params": {


### PR DESCRIPTION
Remove the default automatic user quota on time machine datasets.
This feature was added for convenience of users in large
environments. (It automatically generates separate time machine
shares for different users and sets quota to limit how much
space time machine will take). Unfortunately, users regularly
apply preset to home environments and get confused when
multi-terabyte time machine backups fail with EDQUOT, which
MacOS now translates back to being a permissions error.

Original PR: https://github.com/truenas/middleware/pull/8999
Jira URL: https://jira.ixsystems.com/browse/NAS-116310