### PR TITLE
NAS-116326 / 22.12 / Significantly increase maxPods per node

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -30,6 +30,9 @@ def render(service, middleware):
         'service-account-lookup=true',
         'feature-gates=MixedProtocolLBService=true',
     ]
+    kubelet_args = [
+        'max-pods=250',
+    ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
@@ -37,9 +40,10 @@ def render(service, middleware):
             'service-cidr': config['service_cidr'],
             'cluster-dns': config['cluster_dns_ip'],
             'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
-            'kube-controller-manager-arg': kube_controller_args,
             'node-ip': config['node_ip'],
+            'kube-controller-manager-arg': kube_controller_args,
             'kube-apiserver-arg': kube_api_server_args,
+            'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
             'disable': [] if config['servicelb'] else ['servicelb'],
         }))


### PR DESCRIPTION
Current singleNode setup combined with the current build-in loadbalancer that adds 1 extra(!) pod per loadbalancer, users run into issues where the max amount of pods is limited to 110 pods.

This increases said limit to 250 pods, which is slightly more than double, but not so-large that it would cause significant issues.
In the future, if need be, this could easily be adapted to grab a database value instead, but that does not seem to be really needed currently.

Also minor formatting change:
It puts the major k3s settings (kubelet, api-server and kubecontroller), right beneat eachother in the yaml file. For clean reading.

Note:
Also needs to be backported to 22.02.2.