### PR TITLE
NAS-116231 / 22.12 / Add support for AMD gpus in kubernetes

### DIFF
--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -38,6 +38,8 @@ def get_gpus():
             vendor = 'NVIDIA'
         elif 'intel' in vendor_id_from_db:
             vendor = 'INTEL'
+        elif 'amd' in vendor_id_from_db:
+            vendor = 'AMD'
 
         devices = []
         critical = False


### PR DESCRIPTION
## Background

AMD GPUs were not recognized as supported which resulted in users not able to use them for apps. Before, users could however manually deploy device plugins and users were able to consume the GPUs nicely. However a change was added in `3ff6482b15426565e13c945bd76285f9aac575ed` as it had become problematic for some users and we added explicit checks to only show those GPUs in the UI which were actually supported by us.
