### PR TITLE
NAS-116361 / 13.0 / minor improvement in disk.sync_all

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -351,7 +351,7 @@ class DiskService(Service, ServiceChangeMixin):
             for delete in deleted:
                 self.middleware.send_event('disk.query', 'CHANGED', id=delete, cleared=True)
 
-        if self.middleware.call_sync('failover.licensed'):
+        if licensed:
             job.set_progress(97, 'Synchronizing database to standby node')
             # there could be, literally, > 1k databse changes in this method on large systems
             # so we've forgoed from queuing up the number of db changes in the HA journal thread


### PR DESCRIPTION
We get `failover.licensed` at the top of this function so just reuse the variable to remove a call to `middleware.call`