### PR TITLE
NAS-116326 / 22.02.2 / Significantly increase maxPods per node (by Ornias1993)

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -29,6 +29,9 @@ def render(service, middleware):
         'audit-log-maxsize=100',
         'service-account-lookup=true',
     ]
+    kubelet_args = [
+        'max-pods=250',
+    ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
@@ -36,9 +39,10 @@ def render(service, middleware):
             'service-cidr': config['service_cidr'],
             'cluster-dns': config['cluster_dns_ip'],
             'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
-            'kube-controller-manager-arg': kube_controller_args,
             'node-ip': config['node_ip'],
+            'kube-controller-manager-arg': kube_controller_args,
             'kube-apiserver-arg': kube_api_server_args,
+            'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
             'disable': [] if config['servicelb'] else ['servicelb'],
         }))


### PR DESCRIPTION
Current singleNode setup combined with the current build-in loadbalancer that adds 1 extra(!) pod per loadbalancer, users run into issues where the max amount of pods is limited to 110 pods.

This increases said limit to 250 pods, which is slightly more than double, but not so-large that it would cause significant issues.
In the future, if need be, this could easily be adapted to grab a database value instead, but that does not seem to be really needed currently.

Also minor formatting change:
It puts the major k3s settings (kubelet, api-server and kubecontroller), right beneat eachother in the yaml file. For clean reading.

Note:
Also needs to be backported to 22.02.2.

Original PR: https://github.com/truenas/middleware/pull/9005
Jira URL: https://jira.ixsystems.com/browse/NAS-116326