### PR TITLE
NAS-116116 / 22.02.2 / Fix certificate paths of k3s (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -255,6 +255,8 @@ class KubernetesService(Service):
     async def setup_pool(self):
         config = await self.middleware.call('kubernetes.config')
         await self.create_update_k8s_datasets(config['dataset'])
+        # We will make sure that certificate paths point to the newly configured pool
+        await self.middleware.call('kubernetes.update_server_credentials', config['dataset'])
         # Now we would like to setup catalogs
         await self.middleware.call('catalog.sync_all')
 


### PR DESCRIPTION
## Problem

We have a user who exported his pool via UI and imported the pool via command line changing the name in the process and then exporting it back and importing it via UI.
What happened during this is that the cert locations referenced to old pool name path whereas that did not hold anymore as the name had changed.

## Solution

Make sure each time a pool is configured to be used for Apps, we fix it's certificate paths as required. This looks after the case as well where user might have replicated the ix-applications dataset on his own.

Original PR: https://github.com/truenas/middleware/pull/8995
Jira URL: https://jira.ixsystems.com/browse/NAS-116116