### PR TITLE
NAS-116234 / 22.12 / Properly raise exception if specified user does not exist

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
@@ -51,4 +51,9 @@ class FilesystemService(Service):
         if all(v is None for v in perms.values()):
             raise CallError('At least one of read/write/execute flags must be set', errno.EINVAL)
 
-        return run_with_user_context(check_access, username, [path, perms])
+        try:
+            user_details = self.middleware.call_sync('user.get_user_obj', {'username': username, 'get_groups': True})
+        except KeyError:
+            raise CallError(f'{username!r} user does not exist', errno=errno.ENOENT)
+
+        return run_with_user_context(check_access, user_details, [path, perms])

--- a/src/middlewared/middlewared/utils/osc/linux/user_context.py
+++ b/src/middlewared/middlewared/utils/osc/linux/user_context.py
@@ -3,7 +3,6 @@ import concurrent.futures
 import functools
 import logging
 import os
-import pwd
 import subprocess
 
 from typing import Any, Callable, Optional
@@ -13,36 +12,37 @@ logger = logging.getLogger(__name__)
 __all__ = ["run_command_with_user_context", "run_with_user_context", "set_user_context"]
 
 
-def set_user_context(user: str) -> None:
-    user_details = pwd.getpwnam(user)
-    os.setgroups(os.getgrouplist(user, user_details.pw_gid))
-    os.setresgid(user_details.pw_gid, user_details.pw_gid, user_details.pw_gid)
-    os.setresuid(user_details.pw_uid, user_details.pw_uid, user_details.pw_uid)
+def set_user_context(user_details: dict) -> None:
+    os.setgroups(user_details['grouplist'])
+    os.setresgid(user_details['pw_gid'], user_details['pw_gid'], user_details['pw_gid'])
+    os.setresuid(user_details['pw_uid'], user_details['pw_uid'], user_details['pw_uid'])
 
     if any(
         c() != v for c, v in (
-            (os.getuid, user_details.pw_uid),
-            (os.geteuid, user_details.pw_uid),
-            (os.getgid, user_details.pw_gid),
-            (os.getegid, user_details.pw_gid),
+            (os.getuid, user_details['pw_uid']),
+            (os.geteuid, user_details['pw_uid']),
+            (os.getgid, user_details['pw_gid']),
+            (os.getegid, user_details['pw_gid']),
         )
     ):
-        raise Exception(f"Unable to set user context to {user!r} user")
+        raise Exception(f'Unable to set user context to {user_details["pw_name"]!r} user')
 
     try:
-        os.chdir(user_details.pw_dir)
+        os.chdir(user_details['pw_dir'])
     except Exception:
-        os.chdir("/var/empty")
+        os.chdir('/var/empty')
 
     os.environ.update({
-        "HOME": user_details.pw_dir,
-        "PATH": "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin",
+        'HOME': user_details['pw_dir'],
+        'PATH': '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin',
     })
 
 
-def run_with_user_context(func: Callable, user: str, func_args: Optional[list] = None) -> Any:
+def run_with_user_context(func: Callable, user_details: dict, func_args: Optional[list] = None) -> Any:
+    assert {'pw_uid', 'pw_gid', 'pw_dir', 'pw_name', 'grouplist'} - set(user_details) == set()
+
     with concurrent.futures.ProcessPoolExecutor(
-        max_workers=1, initializer=functools.partial(set_user_context, user)
+        max_workers=1, initializer=functools.partial(set_user_context, user_details)
     ) as exc:
         return exc.submit(func, *(func_args or [])).result()
 


### PR DESCRIPTION
This commit adds changes to make sure that we raise an exception if specified user does not exist instead of abruptly terminating the process pool.