### PR TITLE
NAS-116289 / 22.02.2 / Generate new uuid when cloning a VM (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -1,5 +1,6 @@
 import errno
 import re
+import uuid
 
 from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.schema import accepts, Bool, Int, returns, Str
@@ -83,6 +84,7 @@ class VMService(Service):
         del vm['status']
 
         vm['name'] = await self.__next_clone_name(vm['name'])
+        vm['uuid'] = str(uuid.uuid4())  # We want to use a newer uuid here as it is supposed to be unique per VM
 
         if name is not None:
             vm['name'] = name

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -419,7 +419,13 @@ class VMService(CRUDService, VMSupervisorMixin):
                                 'Failed to delete %r volume when removing %r VM', disk_name, vm['name'], exc_info=True
                             )
 
-            await self.middleware.run_in_thread(self._undefine_domain, vm['name'])
+            try:
+                await self.middleware.run_in_thread(self._undefine_domain, vm['name'])
+            except Exception:
+                if not force_delete:
+                    raise
+                else:
+                    self.logger.error('Failed to un-define %r VM\'s domain', vm['name'], exc_info=True)
 
             # We remove vm devices first
             for device in vm['devices']:


### PR DESCRIPTION
This PR adds following changes:

1. Generate different uuid when cloning a vm as vms cannot share the same uuid
2. Allow force deleting a VM even if libvirt complains undefining a domain

Original PR: https://github.com/truenas/middleware/pull/9018
Jira URL: https://jira.ixsystems.com/browse/NAS-116289