### PR TITLE
NAS-116373 / 22.12 / include file type in filesystem.stat output

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -1,5 +1,6 @@
 import copy
 import errno
+import enum
 import os
 import subprocess
 from collections import defaultdict
@@ -16,6 +17,12 @@ from middlewared.utils.path import is_child
 from middlewared.validators import Match, ReplicationSnapshotNamingSchema
 
 SEARCH_PATHS = ['/dev/disk/by-partuuid', '/dev']
+
+
+class ZFSCTL(enum.IntEnum):
+    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
+    INO_ROOT = 0x0000FFFFFFFFFFFF
+    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
 
 
 class ZFSSetPropertyError(CallError):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,31 @@
+import contextlib
+import urllib.parse
+from functions import POST, SSH_TEST, DELETE, wait_on_job
+from time import sleep
+
+@contextlib.contextmanager
+def create_dataset(dataset, options=None, acl=None, mode=None):
+    assert "/" not in name
+    perm_job = None
+
+    result = POST("/pool/dataset/", {"name": dataset, **(options or {})})
+    assert result.status_code == 200, result.text
+
+    if mode is not None:
+        perm_job = POST("/filesystem/setperm/", {'path': f"/mnt/{dataset}", "mode": mode})
+    elif acl is not None:
+        perm_job = POST("/filesystem/setacl/", {'path': f"/mnt/{dataset}", "dacl": acl})
+
+    if perm_job:
+        assert perm_job.status_code == 200, result.text
+        job_status = wait_on_job(perm_job.json(), 180)
+        assert job_status["state"] == "SUCCESS", str(job_status["results"])
+
+    try:
+        yield dataset
+    finally:
+        # dataset may be busy
+        sleep(5)
+        result = DELETE(f"/pool/dataset/id/{urllib.parse.quote(dataset, '')}/",
+                        {'recursive': True})
+        assert result.status_code == 200, result.text


### PR DESCRIPTION
This is a convenience feature to show whether the target is
directory, symlink, etc with appropriate call to lstat() /
stat() depending on circumstances. Also include in stat() output
whether the path is a mountpoint.