### PR TITLE
NAS-116433 / 22.02.2 / device.get_disks() optimizations

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
@@ -64,8 +64,8 @@ hardware_func()
 	lsblk -o NAME,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,ROTA,SCHED,RQ-SIZE,RA,WSAME,HCTL,PATH
 	section_footer
 
-	section_header "Disk information (device.retrieve_disks_data)"
-	midclt call device.retrieve_disks_data | jq
+	section_header "Disk information (device.get_disks)"
+	midclt call device.get_disks | jq
 	section_footer
 
 	section_header "sensors -j"

--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -33,14 +33,15 @@ class DeviceService(Service, DeviceInfoBase):
                 continue
 
             try:
-                disks[dev.sys_name] = self.get_disk_details(dev, is_nvme=dev.sys_name.startswith('nvme'))
+                disks[dev.sys_name] = self.get_disk_details(dev)
             except Exception:
                 self.logger.debug('Failed to retrieve disk details for %s', dev.sys_name, exc_info=True)
 
         return disks
 
     @private
-    def get_disk_details(self, dev, is_nvme=False):
+    def get_disk_details(self, dev):
+        is_nvme = dev.sys_name.startswith('nvme')
         size = mediasize = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
         ident = serial = self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT' if is_nvme else 'ID_SCSI_SERIAL', '')
         model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)

--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -12,9 +12,6 @@ from middlewared.utils.gpu import get_gpus
 from middlewared.utils import osc
 from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 
-RE_DISK_SERIAL = re.compile(r'Unit serial number:\s*(.*)')
-RE_SERIAL = re.compile(r'state.*=\s*(\w*).*io (.*)-(\w*)\n.*', re.S | re.A)
-RE_UART_TYPE = re.compile(r'is a\s*(\w+)')
 RE_NVME_PRIV = re.compile(r'nvme[0-9]+c')
 
 

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -1,5 +1,7 @@
 from asyncio import ensure_future
 
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
+
 
 async def added_disk(middleware, disk_name):
     await middleware.call('disk.sync', disk_name)
@@ -16,9 +18,11 @@ async def remove_disk(middleware, disk_name):
 
 
 async def udev_block_devices_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block' or data.get('DEVTYPE') != 'disk' or data['SYS_NAME'].startswith((
-        'dm-', 'loop', 'md', 'sr', 'zd',
-    )):
+    if data.get('SUBSYSTEM') != 'block':
+        return
+    elif data.get('DEVTYPE') != 'disk':
+        return
+    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
         return
 
     if data['ACTION'] == 'add':

--- a/src/middlewared/middlewared/plugins/disk_/enums.py
+++ b/src/middlewared/middlewared/plugins/disk_/enums.py
@@ -1,0 +1,1 @@
+DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import glob
 import logging
 import os
@@ -9,6 +8,7 @@ from collections import OrderedDict
 from middlewared.schema import Dict, Int, Str, accepts
 from middlewared.service import CallError, CRUDService, filterable, private
 from middlewared.service_exception import MatchNotFound
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list
 
@@ -1193,9 +1193,11 @@ async def zfs_events_hook(middleware, data):
 
 
 async def udev_block_devices_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block' or data.get('DEVTYPE') != 'disk' or data['SYS_NAME'].startswith((
-        'sr', 'md', 'dm-', 'loop'
-    )):
+    if data.get('SUBSYSTEM') != 'block':
+        return
+    elif data.get('DEVTYPE') != 'disk':
+        return
+    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
         return
 
     if data['ACTION'] in ['add', 'remove']:


### PR DESCRIPTION
This optimizes retrieving disk information on SCALE. On a system with 439 disks, `device.get_disks` was taking `0.867` seconds. After my changes it takes `0.439` seconds which is ~66% decrease in time it takes to get disk information.

My changes do roughly the following:
1. remove a call to `lsblk -OJdb` when querying disks. `lsblk` gets the _same_ disk information that `pyudev` gets
2. There was a `self.logger` crash in `get_disks()` method
3. Stop doing `self.disk_default.copy()` for each disk. Every little thing adds up when we're dealing with a system with many hundreds (or more) disks.
4. Remove the extra `subprocess` calls to `sg_vpd`. If udev doesn't have the information, `sg_vpd` isn't going to get it either since the kernel asks the disks for the same information using the same requests....
5. we had overly complicated logic to calculate the `number` key which isn't necessary when we can get a unique number from udev (device_number)