### PR TITLE
NAS-116385 / 22.12 / Hyper-V enlightenments

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-06-08_11-50_hyperv_enlightenments.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-06-08_11-50_hyperv_enlightenments.py
@@ -1,0 +1,24 @@
+"""
+Hyper-V enlightenments
+
+Revision ID: afa3965ed8fc
+Revises: 67d87d9cfc30
+Create Date: 2022-06-08 11:50:50.818433+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'afa3965ed8fc'
+down_revision = '67d87d9cfc30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vm_vm', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('hyperv_enlightenments', sa.Boolean(), server_default='0', nullable=False))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Add support for Hyper-V enlightenments which are important part of running Windows VMs on. I tried to follow TrueNAS philosophy of keeping it simple and hence the single flag to enable most commonly supported flags. Other option could be adding a option per each Hyper-V feature but that would quickly clutter the UI.

This is my first PR for TrueNAS so please instruct me if something is missing/incorrect.