### PR TITLE
NAS-116454 / 22.02.2 / Add mount flags to filesystem.statfs() output (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -503,6 +503,15 @@ class FilesystemService(Service):
             for line in f:
                 if line.find(maj_min) != -1:
                     fstype = line.rsplit(' - ')[1].split()[0]
+
+                    """
+                    Following gets mount flags. For filesystems, there are two
+                    varieties. First are flags returned by statfs(2) on Linux which
+                    are defined in manpage. These are located in middle of mountinfo line.
+                    The second info group is at end of mountinfo string and contains
+                    superblock info returned from FS. We attempt to consilidate this
+                    disparate info here.
+                    """
                     unsorted_info, mount_flags = line.rsplit(' ', 1)
                     flags = mount_flags.strip().upper().split(',')
 

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -10,7 +10,7 @@ import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 
-from functions import POST, SSH_TEST
+from functions import POST, PUT, SSH_TEST
 from auto_config import dev_test, pool_name, ip, user, password
 from middlewared.test.integration.assets.filesystem import directory
 from utils import create_dataset

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ from time import sleep
 
 @contextlib.contextmanager
 def create_dataset(dataset, options=None, acl=None, mode=None):
-    assert "/" not in name
     perm_job = None
 
     result = POST("/pool/dataset/", {"name": dataset, **(options or {})})


### PR DESCRIPTION
ZFS exposes many dataset properties via string at end of mountinfo.
The info is available already in data we gather for fstype return. Include it
as well. Some of info zfs provides here isn't available via simple statfs(2) call
on Linux.

Original PR: https://github.com/truenas/middleware/pull/9037
Jira URL: https://jira.ixsystems.com/browse/NAS-116454