### PR TITLE
NAS-117011 / 23.10 / Check that writes to ADS work on DOS RO file

### DIFF
--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -216,8 +216,9 @@ def test_011_check_dos_ro_cred_handling(request):
     c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file("RO_TEST", "w", "r")
     c.write(fd, b"TESTING123\n")
+    fd2 = c.create_file("RO_TEST:test_stream", "w")
+    c.write(fd2, b"TESTING456\n")
     c.disconnect()
-
 
 @pytest.mark.dependency(name="SMB1_ENABLED")
 def test_050_enable_smb1(request):


### PR DESCRIPTION
It is expected to still be able to write to an alternate
data stream on a file that has the DOS readonly bit set.