### PR TITLE
NAS-116388 / 22.02.2 / Allow custom reporting realtime interval (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -83,8 +83,11 @@ class EventSource(metaclass=EventSourceMetabase):
 
     async def validate_arg(self):
         verrors = ValidationErrors()
-        with contextlib.suppress(json.JSONDecodeError, TypeError):
-            self.arg = json.loads(self.arg)
+        try:
+            with contextlib.suppress(json.JSONDecodeError):
+                self.arg = json.loads(self.arg)
+        except TypeError:
+            self.arg = self.ACCEPTS[0].default
 
         self.arg = clean_and_validate_arg(verrors, self.ACCEPTS[0], self.arg)
         verrors.check()


### PR DESCRIPTION
## Problem

It was requested that the interval in which we send reporting data should be configurable. While adding the change, i came across an issue where default value specified for our event source was not being respected.

## Solution

Allow user to pass paramaters to `reporting.realtime` event source so that they can specify custom interval. Also use the default value specified by schema instead of passing on `None` to validation as it will error out and conflict with the schema specified.

Original PR: https://github.com/truenas/middleware/pull/9038
Jira URL: https://jira.ixsystems.com/browse/NAS-116388