### PR TITLE
NAS-116470 / 22.12 / Ensure disk_choices methods don't show in-use zvols

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -4,7 +4,7 @@ import re
 
 import middlewared.sqlalchemy as sa
 
-from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
+from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.schema import accepts, Bool, Dict, Error, Int, Patch, returns, Str
 from middlewared.service import CallError, CRUDService, private, ValidationErrors
 from middlewared.utils import run
@@ -55,14 +55,17 @@ class VMDeviceService(CRUDService):
         """
         Returns disk choices for device type "DISK".
         """
-        return {
-            zvol_name_to_path(vol['id']): vol['id']
-            for vol in await self.middleware.call(
-                'pool.dataset.query', [['type', '=', 'VOLUME'], ['locked', '=', False]], {
-                    'extra': {'properties': ['encryption', 'keystatus']}
-                }
-            )
-        }
+        out = {}
+        zvols = await self.middleware.call(
+            'zfs.dataset.unlocked_zvols_fast',
+            [["OR", [["attachment", "=", None], ["attachment.method", "=", "vm.devices.query"]]]],
+            {}, ['ATTACHMENT']
+        )
+
+        for zvol in zvols:
+            out[zvol['path']] = zvol['name']
+
+        return out
 
     @private
     async def create_resource(self, device, old=None):

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -8,6 +8,12 @@ logger = logging.getLogger(__name__)
 __all__ = ["zvol_name_to_path", "zvol_path_to_name"]
 
 
+class ZFSCTL(enum.IntEnum):
+    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
+    INO_ROOT = 0x0000FFFFFFFFFFFF
+    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
+
+
 def zvol_name_to_path(name):
     return os.path.join("/dev/zvol", name.replace(" ", "+"))
 
@@ -19,7 +25,88 @@ def zvol_path_to_name(path):
     return path[len("/dev/zvol/"):].replace("+", " ")
 
 
-class ZFSCTL(enum.IntEnum):
-    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
-    INO_ROOT = 0x0000FFFFFFFFFFFF
-    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
+def unlocked_zvols_fast(options=None, data=None):
+    """
+    Get zvol information from /sys/block and /dev/zvol.
+    This is quite a bit faster than using py-libzfs.
+
+    supported options:
+    `SIZE` - size of zvol
+    `DEVID` - the device id of the zvol
+    `RO` - whether zvol is flagged as ro (snapshot)
+    `ATTACHMENT` - where zvol is currently being used
+
+    If 'ATTACHMENT' is used, then dict of attachemnts
+    should be provided under `data` key `attachments`
+    """
+    def get_size(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/size', 'r') as f:
+            nblocks = f.readline()
+
+        return int(nblocks[:-1]) * 512
+
+    def get_devid(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/dev', 'r') as f:
+            devid = f.readline()
+        return devid[:-1]
+
+    def get_ro(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/ro', 'r') as f:
+            ro = f.readline()
+        return ro[:-1] == '1'
+
+    def get_attachment(zvol_vdev, data):
+        out = None
+        for method, attachment in data.items():
+            val = attachment.pop(zvol_vdev, None)
+            if val is not None:
+                out = {
+                    'method': method,
+                    'data': val
+                }
+                break
+
+        return out
+
+    def get_zvols(info_level, data):
+        out = {}
+        zvol_path = '/dev/zvol/'
+        do_get_size = 'SIZE' in info_level
+        do_get_dev = 'DEVID' in info_level
+        do_get_ro = 'RO' in info_level
+        do_get_attachment = 'ATTACHMENT' in info_level
+
+        for root, dirs, files in os.walk(zvol_path):
+            if not files:
+                continue
+
+            for file in files:
+                path = root + '/' + file
+                zvol_name = zvol_path_to_name(path)
+                dev_name = os.readlink(path).split('/')[-1]
+
+                out.update({
+                    zvol_name: {
+                        'path': path,
+                        'name': zvol_name,
+                        'dev': dev_name,
+                    }
+                })
+
+                if do_get_size is True:
+                    out[zvol_name]['size'] = get_size(dev_name)
+
+                if do_get_dev is True:
+                    out[zvol_name]['devid'] = get_devid(dev_name)
+
+                if do_get_ro is True:
+                    out[zvol_name]['ro'] = get_ro(dev_name)
+
+                if do_get_attachment:
+                    out[zvol_name]['attachment'] = get_attachment(zvol_name, data.get('attachments', {}))
+
+        return out
+
+    info_level = options or []
+    zvols = get_zvols(info_level, data or {})
+    return zvols


### PR DESCRIPTION
Add function to lookup available zvols via /sys/block and /dev/zvol.
This can be significantly faster than using py-libzfs. Plumb new
function into iscsi.extent.disk_choices and vm.devices.disk_choices
so that they are aware of each other, and in-use iscsi extents
don't get presented as options for VM disks and vice-versa.