### PR TITLE
NAS-116303 / 22.02.2 / add r50b rear nvme drive bay mapping (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -293,10 +293,8 @@ MAPPINGS = [
             MappingSlot(1, 21, False),
             MappingSlot(1, 22, False),
             MappingSlot(1, 23, False),
-            # FIXME: rear nvme drive mapping on SCALE
-            # MappingSlot(2, 0, False),
-            # MappingSlot(2, 1, False),
-            # MappingSlot(2, 2, False),
+            MappingSlot(2, 0, False),  # rear nvme
+            MappingSlot(2, 1, False),  # rear nvme
         ]),
     ]),
 ]

--- a/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
@@ -25,12 +25,12 @@ class EnclosureService(Service):
             2,  # r50b has 2 rear nvme
             {},
         ]
-        apci_handles = (b'\\_SB_.PC03.BR3A', b'\\_SB_.PC00.RP01.PXSX')
+        acpi_handles = (b'\\_SB_.PC03.BR3A', b'\\_SB_.PC00.RP01.PXSX')
         mapped = info[-1]
         num_of_nvme_slots = info[-2]
 
         for i in ctx.list_devices(subsystem='acpi'):
-            if (path := i.attributes.get('path')) and path in apci_handles:
+            if (path := i.attributes.get('path')) and path in acpi_handles:
                 try:
                     phys_node = Devices.from_path(ctx, i.sys_path + '/physical_node')
                 except DeviceNotFoundByNameError:

--- a/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r50_nvme.py
@@ -63,5 +63,5 @@ class EnclosureService(Service):
             return []
 
         ctx = Context()
-        method = self.map_r50 if prod.endswith('R50') else self.map_r50b
+        method = self.map_r50 if prod == 'TRUENAS-R50' else self.map_r50b
         return self.middleware.call_sync('enclosure.fake_nvme_enclosure', *method(ctx))


### PR DESCRIPTION
This adds r50b rear drive bay mapping. Whenever I can get ahold of a r50 device, it should be as simple as adding to the `self.R50` dict appropriately.

Original PR: https://github.com/truenas/middleware/pull/8998
Jira URL: https://jira.ixsystems.com/browse/NAS-116303