### PR TITLE
NAS-116433 / 22.12 / device.get_disks() optimizations (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
@@ -64,8 +64,8 @@ hardware_func()
 	lsblk -o NAME,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,ROTA,SCHED,RQ-SIZE,RA,WSAME,HCTL,PATH
 	section_footer
 
-	section_header "Disk information (device.retrieve_disks_data)"
-	midclt call device.retrieve_disks_data | jq
+	section_header "Disk information (device.get_disks)"
+	midclt call device.get_disks | jq
 	section_footer
 
 	section_header "sensors -j"

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -71,7 +71,7 @@ class DeviceService(Service):
 
         if self.safe_retrieval(dev.attributes, 'queue/rotational', None) == '1':
             disk['type'] = 'HDD'
-            disk['rotationrate'] = self.get_rotational_rate(f'/dev/{dev.sys_name}')
+            disk['rotationrate'] = self._get_rotation_rate(f'/dev/{dev.sys_name}')
         else:
             disk['type'] = 'SSD'
             disk['rotationrate'] = None

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -1,8 +1,6 @@
 import os
 import pyudev
 import re
-import subprocess
-import json
 
 import libsgio
 
@@ -10,36 +8,14 @@ from middlewared.schema import Dict, returns
 from middlewared.service import accepts, private, Service
 from middlewared.utils.gpu import get_gpus
 from middlewared.utils.serial import serial_port_choices
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 
-RE_DISK_SERIAL = re.compile(r'Unit serial number:\s*(.*)')
-RE_NVME_PRIVATE_NAMESPACE = re.compile(r'nvme[0-9]+c')
-RE_SERIAL = re.compile(r'state.*=\s*(\w*).*io (.*)-(\w*)\n.*', re.S | re.A)
-RE_UART_TYPE = re.compile(r'is a\s*(\w+)')
+RE_NVME_PRIV = re.compile(r'nvme[0-9]+c')
 
 
 class DeviceService(Service):
 
     DISK_ROTATION_ERROR_LOG_CACHE = set()
-    HOST_TYPE = None
-    DISK_DEFAULT = {
-        'name': None,
-        'mediasize': None,
-        'sectorsize': None,
-        'stripesize': None,
-        'rotationrate': None,
-        'ident': '',
-        'lunid': None,
-        'descr': None,
-        'subsystem': '',
-        'number': 1,  # Database defaults
-        'model': None,
-        'type': 'UNKNOWN',
-        'bus': 'UNKNOWN',
-        'serial': '',
-        'size': None,
-        'serial_lunid': None,
-        'blocks': None,
-    }
 
     @private
     def get_serials(self):
@@ -47,73 +23,88 @@ class DeviceService(Service):
 
     @private
     def get_disks(self):
+        ctx = pyudev.Context()
         disks = {}
-        disks_data = self.retrieve_disks_data()
-
-        for dev in pyudev.Context().list_devices(subsystem='block', DEVTYPE='disk'):
-            if dev.sys_name.startswith(('sr', 'md', 'dm-', 'loop', 'zd')):
+        for dev in ctx.list_devices(subsystem='block', DEVTYPE='disk'):
+            if dev.sys_name.startswith(DISKS_TO_IGNORE) or RE_NVME_PRIV.match(dev.sys_name):
                 continue
-            if RE_NVME_PRIVATE_NAMESPACE.match(dev.sys_name):
-                continue
-            device_type = os.path.join('/sys/block', dev.sys_name, 'device/type')
-            if os.path.exists(device_type):
-                with open(device_type, 'r') as f:
-                    if f.read().strip() != '0':
-                        continue
-            # nvme drives won't have this
 
             try:
-                disks[dev.sys_name] = self.get_disk_details(dev, self.DISK_DEFAULT.copy(), disks_data)
+                disks[dev.sys_name] = self.get_disk_details(dev)
             except Exception:
-                self.logger.debug('Failed to retrieve disk details for %s : %s', dev.sys_name, exc_info=True)
+                self.logger.debug('Failed to retrieve disk details for %s', dev.sys_name, exc_info=True)
 
         return disks
 
     @private
-    def retrieve_disks_data(self):
+    def get_disk_details(self, dev):
+        is_nvme = dev.sys_name.startswith('nvme')
+        size = mediasize = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
+        ident = serial = self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT' if is_nvme else 'ID_SCSI_SERIAL', '')
+        model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)
+        driver = self.safe_retrieval(dev.parent.properties, 'DRIVER', '') if not is_nvme else 'nvme'
 
-        # some disk information will fail to be retrived
-        # based on what type of guest this is. For example,
-        # if this a qemu/kvm guest, then rotation_rate is
-        # expected to fail since th ioctl to query that
-        # information is invalid. So cache the result here
-        # so that we don't have to continually call this
-        # method for every disk on the system
-        if self.HOST_TYPE is None:
-            self.HOST_TYPE = self.middleware.call_sync('system.dmidecode_info')['system-manufacturer']
+        disk = {
+            'name': dev.sys_name,
+            'sectorsize': self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True),
+            'number': dev.device_number,
+            'subsystem': self.safe_retrieval(dev.parent.properties, 'SUBSYSTEM', ''),
+            'driver': driver,
+            'hctl': self.safe_retrieval(dev.parent.properties, 'DEVPATH', '').split('/')[-1],
+            'size': size,
+            'mediasize': mediasize,
+            'ident': ident,
+            'serial': serial,
+            'model': model,
+            'descr': descr,
+            'lunid': self.safe_retrieval(dev.properties, 'ID_WWN', '').removeprefix('0x').removeprefix('eui.') or None,
+            'bus': self.safe_retrieval(dev.properties, 'ID_BUS', 'UNKNOWN').upper(),
+            'type': 'UNKNOWN',
+            'blocks': None,
+            'serial_lunid': None,
+            'rotationrate': None,
+            'stripesize': None,  # remove this? (not used)
+        }
 
-        lsblk_disks = {}
-        disks_cp = subprocess.run(
-            ['lsblk', '-OJdb'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            errors='ignore'
-        )
-        if not disks_cp.returncode:
-            try:
-                lsblk_disks = json.loads(disks_cp.stdout)['blockdevices']
-                lsblk_disks = {i['path']: i for i in lsblk_disks}
-            except Exception as e:
-                self.logger.error(
-                    'Failed parsing lsblk information with error: %s', e
-                )
+        if disk['size'] and disk['sectorsize']:
+            disk['blocks'] = int(disk['size'] / disk['sectorsize'])
+
+        if self.safe_retrieval(dev.attributes, 'queue/rotational', None) == '1':
+            disk['type'] = 'HDD'
+            disk['rotationrate'] = self.get_rotational_rate(f'/dev/{dev.sys_name}')
         else:
-            self.logger.error(
-                'Failed running lsblk command with error: %s', disks_cp.stderr.decode()
-            )
+            disk['type'] = 'SSD'
+            disk['rotationrate'] = None
 
-        return lsblk_disks
+        if not disk['size'] and (disk['blocks'] and disk['sectorsize']):
+            disk['size'] = disk['mediasize'] = disk['blocks'] * disk['sectorsize']
+
+        if disk['serial'] and disk['lunid']:
+            disk['serial_lunid'] = f'{disk["serial"]}_{disk["lunid"]}'
+
+        return disk
+
+    @private
+    def safe_retrieval(self, prop, key, default, asint=False):
+        value = prop.get(key)
+        if value is not None:
+            if type(value) == bytes:
+                value = value.strip().decode()
+            else:
+                value = value.strip()
+            return value if not asint else int(value)
+
+        return default
 
     @private
     def get_disk(self, name):
-        disk = self.DISK_DEFAULT.copy()
         context = pyudev.Context()
         try:
             block_device = pyudev.Devices.from_name(context, 'block', name)
         except pyudev.DeviceNotFoundByNameError:
             return None
 
-        return self.get_disk_details(block_device, disk, self.retrieve_disks_data())
+        return self.get_disk_details(block_device)
 
     def _get_type_and_rotation_rate(self, disk_data, device_path):
         if disk_data['rota']:
@@ -157,93 +148,6 @@ class DeviceService(Service):
         return str(rotation_rate)
 
     @private
-    def get_disk_details(self, block_device, disk, disks_data):
-
-        device_path = os.path.join('/dev', block_device.sys_name)
-        disk_sys_path = os.path.join('/sys/block', block_device.sys_name)
-        driver_name = os.path.realpath(os.path.join(disk_sys_path, 'device/driver')).split('/')[-1]
-
-        number = 0
-        if driver_name != 'driver':
-            number = sum(
-                (ord(letter) - ord('a') + 1) * 26 ** i
-                for i, letter in enumerate(reversed(block_device.sys_name[len(driver_name):]))
-            )
-        elif block_device.sys_name.startswith('nvme'):
-            number = int(block_device.sys_name.rsplit('n', 1)[-1])
-
-        disk.update({
-            'name': block_device.sys_name,
-            'number': number,
-            'subsystem': os.path.realpath(os.path.join(disk_sys_path, 'device/subsystem')).split('/')[-1],
-        })
-
-        if device_path in disks_data:
-            disk_data = disks_data[device_path]
-
-            # get type of disk and rotational rate (if HDD)
-            disk['type'], disk['rotationrate'] = self._get_type_and_rotation_rate(disk_data, device_path)
-
-            # get model and serial
-            disk['ident'] = disk['serial'] = (disk_data.get('serial') or '').strip()
-            disk['descr'] = disk['model'] = (disk_data.get('model') or '').strip()
-
-            # get all relevant size attributes of disk
-            disk['sectorsize'] = disk_data['log-sec']
-            disk['size'] = disk['mediasize'] = disk_data['size']
-            if disk['size'] and disk['sectorsize']:
-                disk['blocks'] = int(disk['size'] / disk['sectorsize'])
-
-            # get lunid
-            if disk_data['wwn']:
-                if disk_data['tran'] == 'nvme':
-                    disk['lunid'] = disk_data['wwn'].lstrip('eui.')
-                else:
-                    disk['lunid'] = disk_data['wwn'].lstrip('0x')
-
-            if disk_data['tran']:
-                disk['bus'] = disk_data['tran'].upper()
-
-        if not disk['size'] and os.path.exists(os.path.join(disk_sys_path, 'size')):
-            with open(os.path.join(disk_sys_path, 'size'), 'r') as f:
-                disk['blocks'] = int(f.read().strip())
-            disk['size'] = disk['mediasize'] = disk['blocks'] * disk['sectorsize']
-
-        if not disk['serial'] and (block_device.get('ID_SERIAL_SHORT') or block_device.get('ID_SERIAL')):
-            disk['serial'] = block_device.get('ID_SERIAL_SHORT') or block_device.get('ID_SERIAL')
-
-        if not disk['serial']:
-            serial_cp = subprocess.Popen(
-                ['sg_vpd', '--quiet', '--page=0x80', device_path],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            cp_stdout, cp_stderr = serial_cp.communicate()
-            if not serial_cp.returncode:
-                reg = RE_DISK_SERIAL.search(cp_stdout.decode().strip())
-                if reg:
-                    disk['serial'] = disk['ident'] = reg.group(1)
-
-        if not disk['lunid']:
-            # We make a device ID query to get DEVICE ID VPD page of the drive if available and then use that identifier
-            # as the lunid - FreeBSD does the same, however it defaults to other schemes if this is unavailable
-            lun_id_cp = subprocess.Popen(
-                ['sg_vpd', '--quiet', '-i', device_path],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            )
-            cp_stdout, cp_stderr = lun_id_cp.communicate()
-            if not lun_id_cp.returncode and lun_id_cp.stdout:
-                lunid = cp_stdout.decode().strip()
-                if lunid:
-                    disk['lunid'] = lunid.split()[0]
-                if lunid and disk['lunid'].startswith('0x'):
-                    disk['lunid'] = disk['lunid'][2:]
-
-        if disk['serial'] and disk['lunid']:
-            disk['serial_lunid'] = f'{disk["serial"]}_{disk["lunid"]}'
-
-        return disk
-
-    @private
     def logical_sector_size(self, name):
         path = os.path.join('/sys/block', name, 'queue/logical_block_size')
         if os.path.exists(path):
@@ -260,20 +164,16 @@ class DeviceService(Service):
 
     @private
     def get_storage_devices_topology(self):
-        disks = self.get_disks()
         topology = {}
-        for disk in filter(lambda d: d['subsystem'] == 'scsi', disks.values()):
-            disk_path = os.path.join('/sys/block', disk['name'])
-            hctl = os.path.realpath(os.path.join(disk_path, 'device')).split('/')[-1]
-            if hctl.count(':') == 3:
-                driver = os.path.realpath(os.path.join(disk_path, 'device/driver')).split('/')[-1]
+        for disk in filter(lambda d: d['subsystem'] == 'scsi', self.get_disks().values()):
+            if disk['hctl'].count(':') == 3:
+                hctl = disk['hctl'].split(':')
                 topology[disk['name']] = {
-                    'driver': driver if driver != 'driver' else disk['subsystem'], **{
-                        k: int(v) for k, v in zip(
-                            ('controller_id', 'channel_no', 'target', 'lun_id'), hctl.split(':')
-                        )
+                    'driver': disk['driver'], **{
+                        k: int(v) for k, v in zip(('controller_id', 'channel_no', 'target', 'lun_id'), hctl)
                     }
                 }
+
         return topology
 
     @private

--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -1,5 +1,7 @@
 from asyncio import ensure_future
 
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
+
 
 async def added_disk(middleware, disk_name):
     await middleware.call('disk.sync', disk_name)
@@ -16,9 +18,11 @@ async def remove_disk(middleware, disk_name):
 
 
 async def udev_block_devices_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block' or data.get('DEVTYPE') != 'disk' or data['SYS_NAME'].startswith((
-        'dm-', 'loop', 'md', 'sr', 'zd',
-    )):
+    if data.get('SUBSYSTEM') != 'block':
+        return
+    elif data.get('DEVTYPE') != 'disk':
+        return
+    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
         return
 
     if data['ACTION'] == 'add':

--- a/src/middlewared/middlewared/plugins/disk_/enums.py
+++ b/src/middlewared/middlewared/plugins/disk_/enums.py
@@ -1,0 +1,1 @@
+DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from middlewared.schema import Dict, Int, Str, accepts
 from middlewared.service import CallError, CRUDService, filterable, private
 from middlewared.service_exception import MatchNotFound
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list
 
@@ -1193,9 +1194,11 @@ async def zfs_events_hook(middleware, data):
 
 
 async def udev_block_devices_hook(middleware, data):
-    if data.get('SUBSYSTEM') != 'block' or data.get('DEVTYPE') != 'disk' or data['SYS_NAME'].startswith((
-        'sr', 'md', 'dm-', 'loop'
-    )):
+    if data.get('SUBSYSTEM') != 'block':
+        return
+    elif data.get('DEVTYPE') != 'disk':
+        return
+    elif data['SYS_NAME'].startswith(DISKS_TO_IGNORE):
         return
 
     if data['ACTION'] in ['add', 'remove']:


### PR DESCRIPTION
This optimizes retrieving disk information on SCALE. On a system with 439 disks, `device.get_disks` was taking `0.867` seconds. After my changes it takes `0.439` seconds which is ~66% decrease in time it takes to get disk information.

My changes do roughly the following:
1. remove a call to `lsblk -OJdb` when querying disks. `lsblk` gets the _same_ disk information that `pyudev` gets
2. There was a `self.logger` crash in `get_disks()` method
3. Stop doing `self.disk_default.copy()` for each disk. Every little thing adds up when we're dealing with a system with many hundreds (or more) disks.
4. Remove the extra `subprocess` calls to `sg_vpd`. If udev doesn't have the information, `sg_vpd` isn't going to get it either since the kernel asks the disks for the same information using the same requests....
5. we had overly complicated logic to calculate the `number` key which isn't necessary when we can get a unique number from udev (device_number)

Original PR: https://github.com/truenas/middleware/pull/9033
Jira URL: https://jira.ixsystems.com/browse/NAS-116433