### PR TITLE
NAS-116490 / 22.02.2 / Raise validation errors on ZFS ctldir and snapdir (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -19,7 +19,7 @@ from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, retur
 from middlewared.service import private, CallError, filterable_returns, Service, job
 from middlewared.utils import filter_list
 from middlewared.plugins.filesystem_.acl_base import ACLType
-from middlewared.plugins.zfs import ZFSCTL
+from middlewared.plugins.zfs_.utils import ZFSCTL
 
 
 class FilesystemService(Service):

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -1,6 +1,5 @@
 import copy
 import errno
-import enum
 import os
 import subprocess
 from collections import defaultdict
@@ -17,12 +16,6 @@ from middlewared.utils.path import is_child
 from middlewared.validators import Match, ReplicationSnapshotNamingSchema
 
 SEARCH_PATHS = ['/dev/disk/by-partuuid', '/dev']
-
-
-class ZFSCTL(enum.IntEnum):
-    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
-    INO_ROOT = 0x0000FFFFFFFFFFFF
-    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
 
 
 class ZFSSetPropertyError(CallError):

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -1,4 +1,5 @@
 # -*- coding=utf-8 -*-
+import enum
 import logging
 import os
 
@@ -16,3 +17,9 @@ def zvol_path_to_name(path):
         raise ValueError(f"Invalid zvol path: {path!r}")
 
     return path[len("/dev/zvol/"):].replace("+", " ")
+
+
+class ZFSCTL(enum.IntEnum):
+    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
+    INO_ROOT = 0x0000FFFFFFFFFFFF
+    INO_SNAPDIR = 0x0000FFFFFFFFFFFD


### PR DESCRIPTION
Directly sharing .zfs or .zfs/snapshot should probably be
prevented since there may be special behavior on these paths
depending on server configuration details.

While adding validation, I realized we were making some blocking
calls here and so addressed the issue via new data returned
in filesystem.stat.

Original PR: https://github.com/truenas/middleware/pull/9061
Jira URL: https://jira.ixsystems.com/browse/NAS-116490