### PR TITLE
NAS-116496 / 22.02.2 / Raise validation error on permissions changes to .zfs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -293,9 +293,12 @@ class FilesystemService(Service):
         path should be specified as `CLUSTER:smb01/data`.
         """
         path = pathlib.Path(self.resolve_cluster_path(_path))
+        if not path.is_absolute():
+            raise CallError(f'{_path}: path must be absolute', errno.EINVAL)
+
         st = self.stat_entry_impl(path, None)
         if st is None:
-            raise CallError(f'Path {path} not found', errno.ENOENT)
+            raise CallError(f'Path {_path} not found', errno.ENOENT)
 
         realpath = path.resolve().as_posix() if st['etype'] == 'SYMLINK' else path.absolute().as_posix()
 


### PR DESCRIPTION
This would fail with EROFS, but I think explicit validation error
is better here. Use filesystem.stat to get realpath and inode
number for validation here. Add requirement for absolute paths
in filesystem.stat.

Original PR: https://github.com/truenas/middleware/pull/9065
Jira URL: https://jira.ixsystems.com/browse/NAS-116496