### PR TITLE
NAS-116481 / 22.12 / Validate zfs resource names

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
@@ -1,0 +1,13 @@
+import libzfs
+
+
+def validate_pool_name(name: str) -> bool:
+    return libzfs.validate_pool_name(name)
+
+
+def validate_dataset_name(name: str) -> bool:
+    return libzfs.validate_dataset_name(name)
+
+
+def validate_snapshot_name(name: str) -> bool:
+    return libzfs.validate_snapshot_name(name)


### PR DESCRIPTION
## Context

Right now when we create a zfs resource i.e pool/dataset/snapshot, we do not validate it's name and it errors out when we create the specific resource.

## Solution

Use py-libzfs for getting the validation which zfs performs to determine if the name in question is valid or not.