### PR TITLE
NAS-116366 / 13.0 / Load vendor's Realtek NIC driver.

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -33,6 +33,10 @@ if_atlantic_load="YES"
 if_bnxt_load="YES"
 if_qlxgbe_load="YES"
 
+# Load vendor's Realtek NIC driver, supporting 2.5G Realtek RTL8125.
+if_re_load="YES"
+if_re_name="/boot/modules/if_re.ko"
+
 # Disable IPv6 link local addresses.  We'll enable this per interface
 # if IPv6 is configured for the interface later on in boot.
 net.inet6.ip6.auto_linklocal="0"


### PR DESCRIPTION
It supports 2.5G Realtek RTL8125 and workarounds hardware bugs.
Will see where it introduce new ones, but people are using it.

Ticket:	NAS-116366