### PR TITLE
NAS-116520 / 22.02.2 / Allow setting gid 0 on new groups (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1350,7 +1350,7 @@ class GroupService(CRUDService):
         await self.__common_validation(verrors, data, 'group_create')
         verrors.check()
 
-        if not data.get('gid'):
+        if data.get('gid') is None:
             data['gid'] = await self.get_next_gid()
 
         group = data.copy()


### PR DESCRIPTION
Some users may want to create group "wheel" with gid 0.

Original PR: https://github.com/truenas/middleware/pull/9074
Jira URL: https://jira.ixsystems.com/browse/NAS-116520