### PR TITLE
NAS-116029 / 13.0 / Improve error handling in smb.sharesec and SID parsing (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -754,10 +754,10 @@ class IdmapDomainService(CRUDService):
         """
         wb = await run([SMBCmd.WBINFO.value, '--sid-to-name', sid], check=False)
         if wb.returncode != 0:
-            self.logger.debug("wbinfo failed with error: %s",
-                              wb.stderr.decode().strip())
+            raise CallError(f'wbinfo failed with error: {wb.stderr.decode().strip()}')
 
-        return wb.stdout.decode().strip()[:-2]
+        out = wb.stdout.decode().strip()
+        return {"name": out[:-2], "type": int(out[-2:])}
 
     @private
     async def sid_to_unixid(self, sid_str):

--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -62,18 +62,20 @@ class ShareSec(CRUDService):
 
             acl_entry.update(m.groupdict())
             if (options.get('resolve_sids', True)) is True:
-                wb = await run([SMBCmd.WBINFO.value, '--sid-to-name', acl_entry['ae_who_sid']], check=False)
-                if wb.returncode == 0:
-                    wb_ret = wb.stdout.decode()[:-3].split('\\')
-                    sidtypeint = int(wb.stdout.decode().strip()[-1:])
+                try:
+                    who = await self.middleware.call('idmap.sid_to_name', acl_entry['ae_who_sid'])
+                    if '\\' in who['name']:
+                        domain, name = who['name'].split('\\')
+                    else:
+                        domain = who['name']
+                        name = None
+
                     acl_entry['ae_who_name'] = {'domain': None, 'name': None, 'sidtype': SIDType.NONE}
-                    acl_entry['ae_who_name']['domain'] = wb_ret[0]
-                    acl_entry['ae_who_name']['name'] = wb_ret[1]
-                    acl_entry['ae_who_name']['sidtype'] = SIDType(sidtypeint).name
-                else:
-                    self.logger.debug(
-                        'Failed to resolve SID (%s) to name: (%s)' % (acl_entry['ae_who_sid'], wb.stderr.decode())
-                    )
+                    acl_entry['ae_who_name']['domain'] = domain
+                    acl_entry['ae_who_name']['name'] = name
+                    acl_entry['ae_who_name']['sidtype'] = SIDType(who['type']).name
+                except CallError as e:
+                    self.logger.debug('%s: failed to resolve SID to name: %s', acl_entry['ae_who_sid'], e)
 
             parsed_share_sd['share_acl'].append(acl_entry)
 
@@ -296,8 +298,7 @@ class ShareSec(CRUDService):
         Use query-filters to search the SMB share ACLs present on server.
         """
         share_acls = await self._view_all({'resolve_sids': True})
-        ret = filter_list(share_acls, filters, options)
-        return ret
+        return filter_list(share_acls, filters, options)
 
     @accepts(Dict(
         'smbsharesec_create',

--- a/src/middlewared/middlewared/plugins/smb_/util_sd.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_sd.py
@@ -242,7 +242,10 @@ class SMBService(Service):
         else:
             out['sid'] = await self.middleware.call('idmap.unixid_to_sid', {"id": unixid, "id_type": id_type})
             if out['sid'] is not None:
-                out['name'] = await self.middleware.call('idmap.sid_to_name', out['sid'])
+                try:
+                    out['name'] = (await self.middleware.call('idmap.sid_to_name', out['sid']))['name']
+                except CallError:
+                    out['name'] = None
 
         return out
 


### PR DESCRIPTION
wbinfo --sid-to-name will succeed on cases where RID is omitted.
In this case set 'name' to NULL. This API was written ages ago
and not touched much. Use new idmap plugin function to convert
sid to name. Also improve output of said new API to include SID
type.

Original PR: https://github.com/truenas/middleware/pull/9080
Jira URL: https://jira.ixsystems.com/browse/NAS-116029