### PR TITLE
NAS-116029 / 22.02.2 / Improve error handling in smb.sharesec and SID parsing (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -914,10 +914,10 @@ class IdmapDomainService(TDBWrapCRUDService):
         """
         wb = await run([SMBCmd.WBINFO.value, '--sid-to-name', sid], check=False)
         if wb.returncode != 0:
-            self.logger.debug("wbinfo failed with error: %s",
-                              wb.stderr.decode().strip())
+            raise CallError(f'wbinfo failed with error: {wb.stderr.decode().strip()}')
 
-        return wb.stdout.decode().strip()[:-2]
+        out = wb.stdout.decode().strip()
+        return {"name": out[:-2], "type": int(out[-2:])}
 
     @private
     async def sid_to_unixid(self, sid_str):

--- a/src/middlewared/middlewared/plugins/smb_/util_sd.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_sd.py
@@ -242,7 +242,10 @@ class SMBService(Service):
         else:
             out['sid'] = await self.middleware.call('idmap.unixid_to_sid', {"id": unixid, "id_type": id_type})
             if out['sid'] is not None:
-                out['name'] = await self.middleware.call('idmap.sid_to_name', out['sid'])
+                try:
+                    out['name'] = (await self.middleware.call('idmap.sid_to_name', out['sid']))['name']
+                except CallError:
+                    out['name'] = None
 
         return out
 


### PR DESCRIPTION
wbinfo --sid-to-name will succeed on cases where RID is omitted.
In this case set 'name' to NULL. This API was written ages ago
and not touched much. Use new idmap plugin function to convert
sid to name. Also improve output of said new API to include SID
type.

Original PR: https://github.com/truenas/middleware/pull/9080
Jira URL: https://jira.ixsystems.com/browse/NAS-116029