### PR TITLE
NAS-116534 / 22.02.2 / bump event-timeout to 300 seconds (by yocalebo)

### DIFF
--- a/src/freenas/etc/systemd/systemd-udevd.service.d/override.conf
+++ b/src/freenas/etc/systemd/systemd-udevd.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/lib/systemd/systemd-udevd --event-timeout=300


### PR DESCRIPTION
On an M60 with 1255 disks, the default event-timeout for systemd-udevd is too low. Because it's set too low, systemd-udevd starts to SIGKILL kernel processes during boot.

```
Jun 01 07:24:24 m60-100b systemd-udevd[1691]: 0000:3d:00.0: Worker [1822] processing SEQNUM=23088 is taking a long time
Jun 01 07:26:24 m60-100b systemd-udevd[1691]: 0000:3d:00.0: Worker [1822] processing SEQNUM=23088 killed
Jun 01 07:26:45 m60-100b systemd-udevd[1691]: 0000:3d:00.0: Worker [1822] failed
```

Logs above show this and it just so happens that `0000:3d:00.0` is the ntb device so `ntb0` doesn't exist after boot rendering HA unusable. After a few reboots, 300 seconds was found to allow everything to get setup properly.

Original PR: https://github.com/truenas/middleware/pull/9095
Jira URL: https://jira.ixsystems.com/browse/NAS-116534