### PR TITLE
NAS-116540 / 22.02.2 / fix KeyError crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/disks.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks.py
@@ -27,7 +27,7 @@ class ZFSPoolService(Service):
 
             # these are the the various by-{partuuid/label/id/path} etc labels
             if dev.properties['DEVTYPE'] == 'partition':
-                for link in (dev.properties['DEVLINKS'] or '').split():
+                for link in (dev.properties.get('DEVLINKS') or '').split():
                     sys_devices[link.removeprefix('/dev/')] = dev.find_parent('block').sys_name
 
         mapping = {name: set()}


### PR DESCRIPTION
`DEVLINKS` attribute might not exist so we'll crash here. Use the `.get()` method to prevent this

Original PR: https://github.com/truenas/middleware/pull/9097
Jira URL: https://jira.ixsystems.com/browse/NAS-116540