### PR TITLE
NAS-116535 / 22.02.2 / bump kernel.watchdog_thresh to 60 (2mins) (by yocalebo)

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -3,3 +3,4 @@ kernel.panic_on_oops = 1
 kernel.panic_on_io_nmi = 1
 kernel.panic_on_unrecovered_nmi = 1
 kernel.unknown_nmi_panic = 1
+kernel.watchdog_thresh = 60


### PR DESCRIPTION
On an M60 with 12x ES102 JBODs fully populated, we're seeing the software watchdog interfere with boot up process. This bumps kernel.watchdog_thresh to 60 which is (2 * 60) (2mins to take into account systems with 100's (or more) disks).

Default is 10 (2 * 10) which is 20 seconds.

Original PR: https://github.com/truenas/middleware/pull/9096
Jira URL: https://jira.ixsystems.com/browse/NAS-116535