### PR TITLE
NAS-116544 / 22.02.2 / limit ix-syncdisks.service to 5mins (by yocalebo)

### DIFF
--- a/debian/debian/ix-syncdisks.service
+++ b/debian/debian/ix-syncdisks.service
@@ -10,6 +10,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=midclt call --job true --job-print description disk.sync_all
 StandardOutput=null
+TimeoutStartSec=5min
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When https://github.com/truenas/middleware/pull/9071 is merged, ix-syncdisks.service shouldn't take longer than ~90 seconds in the worst case scenario on the largest system we sell. Without this timeout, the service can block boot-up indefinitely.

NOTE: dependent on https://github.com/truenas/middleware/pull/9071 being merged.

Original PR: https://github.com/truenas/middleware/pull/9103
Jira URL: https://jira.ixsystems.com/browse/NAS-116544