### PR TITLE
NAS-116546 / 22.02.2 / SCST rotational config option is 0 or 1 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -65,7 +65,9 @@ HANDLER ${handler} {
         naa_id ${extent['naa']}
         prod_id "iSCSI Disk"
 %       if extent['rpm'] != 'SSD':
-        rotational ${extent['rpm']}
+        rotational 1
+%       else:
+        rotational 0
 %       endif
         t10_vend_id ${extent['vendor']}
         t10_dev_id ${extent['t10_dev_id']}


### PR DESCRIPTION
A democratic CSI user was experiencing crashes/restarts/failures when using SCST to mount a lun inside a PVC (I think I'm using the correct terminology). Either way, the user noticed that doing `rotational 7200` was incorrect.

Further investigation shows that the `rotational` config parameter is either 1 (HDD) or 0 (SSD) respectively.

Original PR: https://github.com/truenas/middleware/pull/9106
Jira URL: https://jira.ixsystems.com/browse/NAS-116546