### PR TITLE
NAS-116518 / 22.12 / fix SCST crash when migrating from CORE ctld

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -42,6 +42,7 @@
             )
             continue
 
+        extent['name'] = extent['name'].replace('.', '_')  # CORE ctl device names are incompatible with SCALE SCST
         extents_io[extents_io_key].append(extent)
 
         extent['t10_dev_id'] = extent['serial']


### PR DESCRIPTION
ctld on CORE allows `.` (periods) in the extent name but SCST doesn't.
```
kern  :info  : [Wed Jun  1 17:02:53 2022] [15773]: dev_vdisk: Registering virtual vdisk_blockio device testing.blah.blah (BLOCKIO, ROTATIONAL)
kern  :err   : [Wed Jun  1 17:02:53 2022] [15773]: scst: ***ERROR***: Dev name testing.blah.blah contains illegal character '.'
```

For users upgrading from CORE to SCALE this will prevent SCST from working. Replace these with `_` (underscores). (Note: target names do not change)