### PR TITLE
NAS-115435 / 22.12 / Fix GSSAPI config in LDAP config

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+#+
+# Copyright 2011 iXsystems, Inc.
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#####################################################################
+
+
+NSLCD_CONF=${NSLCD_CONF:-"/etc/nslcd.conf"}
+LDAP_CONF=${LDAP_CONF:-"/etc/openldap/ldap.conf"}
+ldap_opt() { echo l; }
+ldap_help() { echo "Dump LDAP Configuration"; }
+ldap_directory() { echo "LDAP"; }
+ldap_func()
+{
+	local CONF=$(midclt call ldap.config | jq 'del(.bindpw)')
+	local onoff=$(echo ${CONF} | jq ".enable")
+	local has_samba_schema=$(echo ${CONF} | jq ".has_samba_schema")
+
+	enabled="DISABLED"
+	if [ "${onoff}" = "true" ]
+	then
+		enabled="ENABLED"
+	fi
+
+	section_header "LDAP Status"
+	echo "LDAP is ${enabled}"
+	section_footer
+
+	#
+	#	dump LDAP configuration
+	#
+	section_header "LDAP Settings"
+	echo ${CONF} | jq
+	section_footer
+
+	#
+	#	Dump nsswitch.conf
+	#
+	section_header "${PATH_NS_CONF}"
+	sc "${PATH_NS_CONF}"
+	section_footer
+
+	#
+	#	Dump kerberos configuration
+	#
+	section_header "${PATH_KRB5_CONFIG}"
+	sc "${PATH_KRB5_CONFIG}" 2>/dev/null
+	section_footer
+
+	#
+	#	List kerberos tickets
+	#
+	section_header "Kerberos Tickets - 'klist'"
+	klist
+	section_footer
+
+	#
+	#	List kerberos tickets
+	#
+	section_header "Kerberos keytab system"
+	klist -ket
+	section_footer
+
+	#
+	#	Dump OpenLDAP configuration
+	#
+	section_header "${LDAP_CONF}"
+	sc "${LDAP_CONF}"
+	section_footer
+
+	#
+	#	Dump NSLCD configuration
+	#
+	section_header "${NSLCD_CONF}"
+	sc "${NSLCD_CONF}" | grep -iv bindpw
+	section_footer
+
+	#
+	#	Dump nslcd state
+	#
+	if [ "${enabled}" = "ENABLED" ]
+	then
+	section_header "NSLCD health check - midclt call ldap.get_nslcd_status"
+	midclt call ldap.get_nslcd_status | jq
+	section_footer
+
+	section_header "ROOT DSE"
+	midclt call ldap.get_root_DSE | jq
+	section_footer
+	fi
+
+	if [ "${enabled}" = "ENABLED" ] && [ "${has_samba_schema}" = "true" ]
+	then
+	section_header "sambaDomains"
+	midclt call ldap.get_samba_domains | jq
+	section_footer
+	fi
+
+}

--- a/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nslcd.conf.mako
@@ -1,11 +1,12 @@
 #
 # NSLCD.CONF(5)		The configuration file for LDAP nameservice daemon
-# $FreeBSD$
 #
 <%
         ldap = middleware.call_sync('ldap.config')
+        kerberos_realm = None
         aux = []
         min_uid = 1000
+        kerberos_realm = None
         if ldap:
             certpath = None
             if ldap['certificate']:
@@ -16,6 +17,12 @@
                 else:
                     certpath = cert['certificate_path']
                     keypath = cert['privatekey_path']
+            if ldap['kerberos_realm']:
+                kerberos_realm = middleware.call_sync(
+                    'kerberos.realm.query',
+                    [('id', '=', ldap['kerberos_realm'])],
+                    {'get': True}
+                )['realm']
         else:
             ldap = None
 
@@ -50,9 +57,9 @@
   % if ldap['disable_freenas_cache']:
     nss_disable_enumeration yes
   % endif
-  % if ldap['kerberos_realm']:
+  % if kerberos_realm:
     sasl_mech 	GSSAPI
-    sasl_realm	${ldap['kerberos_realm']}
+    sasl_realm	${kerberos_realm}
   % endif
     scope 	sub
     timelimit	${ldap['timeout']}

--- a/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf.mako
@@ -28,7 +28,12 @@
 
         if ad['enable'] and idmap['idmap_backend'] in ["rfc2307", "ldap"]:
             is_kerberized = True
-            krb_realm = ad['kerberos_realm']
+            krb_realm = middleware.call_sync(
+                'kerberos.realm.query',
+                [('id', '=', ad['kerberos_realm'])],
+                {'get': True}
+            )['realm']
+
             base = idmap['ldap_base_dn']
             idmap_url = idmap['ldap_url']
             idmap_url = re.sub('^(ldaps?://)', '', idmap_url)
@@ -45,7 +50,12 @@
         elif ldap_enabled and ldap:
             uri = " ".join(ldap['uri_list'])
             if ldap['kerberos_realm']:
-                krb_realm = ldap['kerberos_realm']
+                krb_realm = middleware.call_sync(
+                    'kerberos.realm.query',
+                    [('id', '=', ldap['kerberos_realm'])],
+                    {'get': True}
+                )['realm']
+
                 is_kerberized = True
             else:
                 binddn = ldap['binddn']

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -46,7 +46,7 @@ _int32 = struct.Struct('!i')
 class NlscdConst(enum.Enum):
     NSLCD_CONF_PATH = '/usr/local/etc/nslcd.conf'
     NSLCD_PIDFILE = '/var/run/nslcd.pid'
-    NSLCD_SOCKET = '/var/run/nslcd/nslcd.ctl'
+    NSLCD_SOCKET = '/var/run/nslcd/socket'
     NSLCD_VERSION = 0x00000002
     NSLCD_ACTION_STATE_GET = 0x00010002
     NSLCD_RESULT_BEGIN = 1


### PR DESCRIPTION
Ensure that we have proper realm name populated in LDAP config
files. In typical case we have a kerberos keytab and ticket
available, but if ticket has expired this may cause failure
to bind to the server.