### PR TITLE
NAS-116470 / 22.02.2 / Ensure disk_choices methods don't show in-use zvols (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -8,6 +8,7 @@ from middlewared.service import CallError, CRUDService, private, ServiceChangeMi
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run
 from middlewared.utils.path import is_child
+from middlewared.utils.size import format_size
 from middlewared.validators import Range
 
 import bidict
@@ -835,34 +836,20 @@ class iSCSITargetExtentService(SharingService):
         """
         diskchoices = {}
 
-        zvol_query_filters = [('type', '=', 'DISK')]
-
-        used_zvols = [
-            i['path'] for i in (await self.query(zvol_query_filters))
-        ]
-
         zvols = await self.middleware.call(
-            'pool.dataset.query', [
-                ('type', '=', 'VOLUME'),
-                ('locked', '=', False)
-            ]
+            'zfs.dataset.unlocked_zvols_fast',
+            [['attachment', '=', None]], {},
+            ['SIZE', 'RO', 'ATTACHMENT']
         )
-        zvol_list = []
-        for zvol in zvols:
-            zvol_name = zvol['name']
-            zvol_size = zvol['volsize']['value']
-            zvol_list.append(zvol_name)
-            key = os.path.relpath(zvol_name_to_path(zvol_name), '/dev')
-            if key not in used_zvols:
-                diskchoices[key] = f'{zvol_name} ({zvol_size})'
 
-        zfs_snaps = await self.middleware.call(
-            'zfs.snapshot.query',
-            [['dataset', 'in', [zvol['name'] for zvol in zvols]]],
-            {'select': ['name']},
-        )
-        for snap in zfs_snaps:
-            diskchoices[os.path.relpath(zvol_name_to_path(snap['name']), '/dev')] = f'{snap["name"]} [ro]'
+        for zvol in zvols:
+            key = os.path.relpath(zvol['path'], '/dev')
+            if zvol['ro']:
+                description = f'{zvol["name"]} [ro]'
+            else:
+                description = f'{zvol["name"]} ({format_size(zvol["size"])})'
+
+            diskchoices[key] = description
 
         return diskchoices
 

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -7,13 +7,15 @@ from copy import deepcopy
 
 import libzfs
 
-from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Str
+from middlewared.plugins.zfs_.utils import zvol_path_to_name, unlocked_zvols_fast
+from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Ref, Str
 from middlewared.service import (
     CallError, CRUDService, ValidationErrors, filterable, job, private,
 )
 from middlewared.utils import filter_list, filter_getattrs
 from middlewared.utils.path import is_child
 from middlewared.validators import Match, ReplicationSnapshotNamingSchema
+
 
 SEARCH_PATHS = ['/dev/disk/by-partuuid', '/dev']
 
@@ -574,6 +576,42 @@ class ZFSDatasetService(CRUDService):
             }
             for dataset in self.query()
         ]
+
+    @accepts(
+        Ref('query-filters'),
+        Ref('query-options'),
+        List(
+            'additional_information',
+            items=[Str('desideratum', enum=['SIZE', 'RO', 'DEVID', 'ATTACHMENT'])]
+        )
+    )
+    def unlocked_zvols_fast(self, filters, options, additional_information):
+        """
+        Fast check for zvol information. Supports `additional_information` to
+        expand output on an as-needed basis. Adding additional_information to
+        the output may impact performance of 'fast' method.
+        """
+        def get_attachments():
+            extents = self.middleware.call_sync('iscsi.extent.query', [('type', '=', 'DISK')])
+            iscsi_zvols = {
+                i['path'][len('zvol/'):]: i for i in extents
+            }
+
+            vm_devices = self.middleware.call_sync('vm.device.query', [['dtype', '=', 'DISK']])
+            vm_zvols = {
+                zvol_path_to_name(i['attributes']['path']): i for i in vm_devices
+            }
+            return {
+                'iscsi.extent.query': iscsi_zvols,
+                'vm.devices.query': vm_zvols
+            }
+
+        data = {}
+        if 'ATTACHMENT' in additional_information:
+            data['attachments'] = get_attachments()
+
+        zvol_list = list(unlocked_zvols_fast(additional_information, data).values())
+        return filter_list(zvol_list, filters, options)
 
     def common_load_dataset_checks(self, ds):
         self.common_encryption_checks(ds)

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -8,6 +8,12 @@ logger = logging.getLogger(__name__)
 __all__ = ["zvol_name_to_path", "zvol_path_to_name"]
 
 
+class ZFSCTL(enum.IntEnum):
+    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
+    INO_ROOT = 0x0000FFFFFFFFFFFF
+    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
+
+
 def zvol_name_to_path(name):
     return os.path.join("/dev/zvol", name.replace(" ", "+"))
 
@@ -19,7 +25,88 @@ def zvol_path_to_name(path):
     return path[len("/dev/zvol/"):].replace("+", " ")
 
 
-class ZFSCTL(enum.IntEnum):
-    # from include/os/linux/zfs/sys/zfs_ctldir.h in ZFS repo
-    INO_ROOT = 0x0000FFFFFFFFFFFF
-    INO_SNAPDIR = 0x0000FFFFFFFFFFFD
+def unlocked_zvols_fast(options=None, data=None):
+    """
+    Get zvol information from /sys/block and /dev/zvol.
+    This is quite a bit faster than using py-libzfs.
+
+    supported options:
+    `SIZE` - size of zvol
+    `DEVID` - the device id of the zvol
+    `RO` - whether zvol is flagged as ro (snapshot)
+    `ATTACHMENT` - where zvol is currently being used
+
+    If 'ATTACHMENT' is used, then dict of attachemnts
+    should be provided under `data` key `attachments`
+    """
+    def get_size(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/size', 'r') as f:
+            nblocks = f.readline()
+
+        return int(nblocks[:-1]) * 512
+
+    def get_devid(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/dev', 'r') as f:
+            devid = f.readline()
+        return devid[:-1]
+
+    def get_ro(zvol_dev):
+        with open(f'/sys/block/{zvol_dev}/ro', 'r') as f:
+            ro = f.readline()
+        return ro[:-1] == '1'
+
+    def get_attachment(zvol_vdev, data):
+        out = None
+        for method, attachment in data.items():
+            val = attachment.pop(zvol_vdev, None)
+            if val is not None:
+                out = {
+                    'method': method,
+                    'data': val
+                }
+                break
+
+        return out
+
+    def get_zvols(info_level, data):
+        out = {}
+        zvol_path = '/dev/zvol/'
+        do_get_size = 'SIZE' in info_level
+        do_get_dev = 'DEVID' in info_level
+        do_get_ro = 'RO' in info_level
+        do_get_attachment = 'ATTACHMENT' in info_level
+
+        for root, dirs, files in os.walk(zvol_path):
+            if not files:
+                continue
+
+            for file in files:
+                path = root + '/' + file
+                zvol_name = zvol_path_to_name(path)
+                dev_name = os.readlink(path).split('/')[-1]
+
+                out.update({
+                    zvol_name: {
+                        'path': path,
+                        'name': zvol_name,
+                        'dev': dev_name,
+                    }
+                })
+
+                if do_get_size is True:
+                    out[zvol_name]['size'] = get_size(dev_name)
+
+                if do_get_dev is True:
+                    out[zvol_name]['devid'] = get_devid(dev_name)
+
+                if do_get_ro is True:
+                    out[zvol_name]['ro'] = get_ro(dev_name)
+
+                if do_get_attachment:
+                    out[zvol_name]['attachment'] = get_attachment(zvol_name, data.get('attachments', {}))
+
+        return out
+
+    info_level = options or []
+    zvols = get_zvols(info_level, data or {})
+    return zvols


### PR DESCRIPTION
Add function to lookup available zvols via /sys/block and /dev/zvol.
This can be significantly faster than using py-libzfs. Plumb new
function into iscsi.extent.disk_choices and vm.devices.disk_choices
so that they are aware of each other, and in-use iscsi extents
don't get presented as options for VM disks and vice-versa.

Original PR: https://github.com/truenas/middleware/pull/9051
Jira URL: https://jira.ixsystems.com/browse/NAS-116470