### PR TITLE
NAS-116484 / 22.12 / optimize disk.sync_all on SCALE (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -42,10 +42,10 @@ class DeviceService(Service):
         parts = []
         keys = tuple('ID_PART_ENTRY_' + i for i in ('TYPE', 'UUID', 'NUMBER', 'SIZE'))
         parent = dev.sys_name
-        is_nvme = parent.startswith('nvme')
+        is_nvme_or_pmem = parent.startswith(('nvme', 'pmem'))
         for i in filter(lambda x: all(x.get(k) for k in keys), dev.children):
             part_num = int(i['ID_PART_ENTRY_NUMBER'])
-            part_name = f'{parent}p{part_num}' if is_nvme else f'{parent}{part_num}'
+            part_name = f'{parent}p{part_num}' if is_nvme_or_pmem else f'{parent}{part_num}'
             part = {
                 'name': part_name,
                 'id': part_name,

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -226,11 +226,11 @@ class DiskService(Service, ServiceChangeMixin):
                 )
 
         if changed or deleted:
-            job.set_progress(85, 'Restarting necessary services')
+            job.set_progress(92, 'Restarting necessary services')
             self.middleware.call_sync('disk.restart_services_after_sync')
 
             # we query the db again since we've made changes to it
-            job.set_progress(95, 'Emitting disk events')
+            job.set_progress(94, 'Emitting disk events')
             disks = {i['disk_identifier']: i for i in self.middleware.call_sync('datastore.query', 'storage.disk')}
             for change in changed:
                 self.middleware.send_event('disk.query', 'CHANGED', id=change, fields=disks[change])
@@ -238,7 +238,7 @@ class DiskService(Service, ServiceChangeMixin):
                 self.middleware.send_event('disk.query', 'CHANGED', id=delete, cleared=True)
 
         if licensed:
-            job.set_progress(97, 'Synchronizing database to standby controller')
+            job.set_progress(96, 'Synchronizing database to standby controller')
             # there could be, literally, > 1k database changes in this method on large systems
             # so we've forgoed queuing up the number of db changes in the HA journal thread
             # in favor of just sync'ing the database to the remote node after we're done. The

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -104,9 +104,8 @@ class DiskService(Service, ServiceChangeMixin):
             return f'{{serial_lunid}}{dev["serial_lunid"]}'
         elif dev['serial']:
             return f'{{serial}}{dev["serial"]}'
-
-        for disk, info in sys_disks.items():
-            for part in filter(lambda x: x['partition_type'] in uuids, info['parts']):
+        elif dev['parts']:
+            for part in filter(lambda x: x['partition_type'] in uuids, dev['parts']):
                 return f'{{uuid}}{part["partition_uuid"]}'
 
         return f'{{devicename}}{name}'
@@ -227,7 +226,7 @@ class DiskService(Service, ServiceChangeMixin):
                 )
 
         if changed or deleted:
-            job.set_pgoress(85, 'Restarting necessary services')
+            job.set_progress(85, 'Restarting necessary services')
             self.middleware.call_sync('disk.restart_services_after_sync')
 
             # we query the db again since we've made changes to it

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -182,8 +182,9 @@ class DiskService(Service, ServiceChangeMixin):
             try:
                 self.middleware.call_sync('enclosure.sync_disk', disk['disk_identifier'], encs)
             except Exception:
-                self.middleware.logger.error('Unhandled exception in enclosure.sync_disk for %r',
-                                             disk['disk_identifier'], exc_info=True)
+                self.logger.error(
+                    'Unhandled exception in enclosure.sync_disk for %r', disk['disk_identifier'], exc_info=True
+                )
 
             seen_disks[name] = disk
 
@@ -221,8 +222,9 @@ class DiskService(Service, ServiceChangeMixin):
             try:
                 self.middleware.call_sync('enclosure.sync_disk', disk['disk_identifier'], encs)
             except Exception:
-                self.middleware.logger.error('Unhandled exception in enclosure.sync_disk for %r',
-                                             disk['disk_identifier'], exc_info=True)
+                self.logger.error(
+                    'Unhandled exception in enclosure.sync_disk for %r', disk['disk_identifier'], exc_info=True
+                )
 
         if changed or deleted:
             self.middleware.call_sync('disk.restart_services_after_sync')

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -97,8 +97,13 @@ class DiskService(Service, ServiceChangeMixin):
         serials = []
         changed = set()
         deleted = set()
+        increment = round((40 - 20) / number_of_disks, 3)  # 20% of the total percentage
+        progress_percent = 40
         encs = self.middleware.call_sync('enclosure.query')
-        for disk in db_disks:
+        for idx, disk in enumerate(db_disks, start=1):
+            progress_percent += increment
+            job.set_progress(progress_percent, f'Syncing disk {idx}/{number_of_disks}')
+
             original_disk = disk.copy()
 
             name = self.middleware.call_sync('disk.identifier_to_device', disk['disk_identifier'], sys_disks)

--- a/src/middlewared/middlewared/pytest/unit/plugins/disk/test_dev_to_ident.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/disk/test_dev_to_ident.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import Mock
+
+from middlewared.plugins.disk_.sync import DiskService
+
+OBJ = DiskService(Mock())
+UUIDS = [
+    "6a898cc3-1dd2-11b2-99a6-080020736631",
+    "516e7cba-6ecf-11d6-8ff8-00022d09712b"
+]
+BY_UUID = (
+    "pmem0",
+    {
+        "pmem0": {
+            "name": "pmem0",
+            "serial": None,
+            "serial_lunid": None,
+            "parts": [{
+                "partition_type": "516e7cba-6ecf-11d6-8ff8-00022d09712b",
+                "partition_uuid": "b9253137-a0a4-11ec-b194-3cecef615fde",
+            }],
+        }
+    },
+    "{uuid}b9253137-a0a4-11ec-b194-3cecef615fde",
+)
+BY_SERIAL_LUNID = (
+    "nvme0n1",
+    {
+        "nvme0n1": {
+            "name": "nvme0n1",
+            "serial": None,
+            "serial_lunid": "1234_XXXX",
+            "parts": []
+        }
+    },
+    "{serial_lunid}1234_XXXX",
+)
+BY_DEVICENAME = (
+    "sda",
+    {
+        "sda": {
+            "serial": None,
+            "serial_lunid": None,
+            "parts": []
+        }
+    },
+    "{devicename}sda",
+)
+BY_SERIAL = (
+    "sdaiy",
+    {
+        "sdaiy": {
+            "serial": "AAAAAAAA",
+            "serial_lunid": None,
+            "parts": []
+        }
+    },
+    "{serial}AAAAAAAA",
+)
+
+
+@pytest.mark.parametrize('disk_name, sys_disks, result', [BY_UUID, BY_SERIAL_LUNID, BY_DEVICENAME, BY_SERIAL])
+def test_dev_to_ident(disk_name, sys_disks, result):
+    assert result == OBJ.dev_to_ident(disk_name, sys_disks, UUIDS)

--- a/src/middlewared/middlewared/pytest/unit/plugins/disk/test_ident_to_dev.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/disk/test_ident_to_dev.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import Mock
+
+from middlewared.plugins.disk_.sync import DiskService
+
+OBJ = DiskService(Mock())
+BY_UUID = (
+    "{uuid}b9253137-a0a4-11ec-b194-3cecef615fde",
+    {
+        "pmem0": {
+            "name": "pmem0",
+            "serial": None,
+            "serial_lunid": None,
+            "parts": [{
+                "disk": "pmem0",
+                "partition_type": "516e7cba-6ecf-11d6-8ff8-00022d09712b",
+                "partition_uuid": "b9253137-a0a4-11ec-b194-3cecef615fde",
+            }],
+        }
+    },
+    "pmem0",
+)
+BY_SERIAL_LUNID = (
+    "{serial_lunid}1234_XXXX",
+    {
+        "nvme0n1": {
+            "name": "nvme0n1",
+            "serial": None,
+            "serial_lunid": "1234_XXXX",
+            "parts": []
+        }
+    },
+    "nvme0n1",
+)
+BY_DEVICENAME = (
+    "{devicename}sda",
+    {
+        "sda": {
+            "name": "sda",
+            "serial": None,
+            "serial_lunid": None,
+            "parts": []
+        }
+    },
+    "sda",
+)
+BY_SERIAL = (
+    "{serial}AAAAAAAA",
+    {
+        "sdaiy": {
+            "serial": "AAAAAAAA",
+            "serial_lunid": None,
+            "parts": []
+        }
+    },
+    "sdaiy",
+)
+
+
+@pytest.mark.parametrize('ident, sys_disks, result', [BY_UUID, BY_SERIAL_LUNID, BY_DEVICENAME, BY_SERIAL])
+def test_ident_to_dev(ident, sys_disks, result):
+    assert result == OBJ.ident_to_dev(ident, sys_disks)


### PR DESCRIPTION
Same principles that were done in 13 here https://github.com/truenas/middleware/pull/8937 are applied here to SCALE.

Differences in time that I've measured:

Inserting 1255 _new_ disk entries into db OLD took 1:54.17
Inserting 1255 _new_ disk entries into db NEW takes 1:00.24 **(~62% faster)**

Updating 1255 _existing_ disk entries into db OLD took 20:04.96
Updating 1255 _existing_ disk entries into db NEW takes 1:20.05 **(~175% faster)**

We're still missing some optimizations on SCALE (like `enclosure.sync_disk`) but this is a good first step.

Original PR: https://github.com/truenas/middleware/pull/9071
Jira URL: https://jira.ixsystems.com/browse/NAS-116484