### PR TITLE
NAS-116549 / 22.12 / fix regression in calculating disk size (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -76,14 +76,19 @@ class DeviceService(Service):
     @private
     def get_disk_details(self, dev, get_partitions=False):
         is_nvme = dev.sys_name.startswith('nvme')
-        size = mediasize = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
+        blocks = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
         ident = serial = self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT' if is_nvme else 'ID_SCSI_SERIAL', '')
         model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)
         driver = self.safe_retrieval(dev.parent.properties, 'DRIVER', '') if not is_nvme else 'nvme'
+        sectorsize = self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True),
+
+        size = mediasize = None
+        if blocks and sectorsize:
+            size = mediasize = blocks * sectorsize
 
         disk = {
             'name': dev.sys_name,
-            'sectorsize': self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True),
+            'sectorsize': sectorsize,
             'number': dev.device_number,
             'subsystem': self.safe_retrieval(dev.parent.properties, 'SUBSYSTEM', ''),
             'driver': driver,
@@ -97,7 +102,7 @@ class DeviceService(Service):
             'lunid': self.safe_retrieval(dev.properties, 'ID_WWN', '').removeprefix('0x').removeprefix('eui.') or None,
             'bus': self.safe_retrieval(dev.properties, 'ID_BUS', 'UNKNOWN').upper(),
             'type': 'UNKNOWN',
-            'blocks': None,
+            'blocks': blocks,
             'serial_lunid': None,
             'rotationrate': None,
             'stripesize': None,  # remove this? (not used)
@@ -107,18 +112,12 @@ class DeviceService(Service):
         if get_partitions:
             disk['parts'] = self.get_disk_partitions(dev, disk['sectorsize'])
 
-        if disk['size'] and disk['sectorsize']:
-            disk['blocks'] = int(disk['size'] / disk['sectorsize'])
-
         if self.safe_retrieval(dev.attributes, 'queue/rotational', None) == '1':
             disk['type'] = 'HDD'
             disk['rotationrate'] = self._get_rotation_rate(f'/dev/{dev.sys_name}')
         else:
             disk['type'] = 'SSD'
             disk['rotationrate'] = None
-
-        if not disk['size'] and (disk['blocks'] and disk['sectorsize']):
-            disk['size'] = disk['mediasize'] = disk['blocks'] * disk['sectorsize']
 
         if disk['serial'] and disk['lunid']:
             disk['serial_lunid'] = f'{disk["serial"]}_{disk["lunid"]}'

--- a/tests/api2/test_device_get_disks_size.py
+++ b/tests/api2/test_device_get_disks_size.py
@@ -12,7 +12,7 @@ from auto_config import dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
 
 
-def test_get_disk_details():
+def test_device_get_disks_size():
     boot_disk = call('boot.get_disks')[0]
     fdisk_size = int(ssh('fdisk -s /dev/{boot_disk}').strip()) * 1024
     assert call('device.get_disks')[boot_disk]['size'] == fdisk_size

--- a/tests/api2/test_get_disk_details.py
+++ b/tests/api2/test_get_disk_details.py
@@ -1,0 +1,18 @@
+import sys
+import os
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+import pytest
+
+from middlewared.test.integration.utils import call, ssh
+from auto_config import dev_test
+
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason='Skip for testing')
+
+
+def test_get_disk_details():
+    boot_disk = call('boot.get_disks')[0]
+    fdisk_size = int(ssh('fdisk -s /dev/{boot_disk}').strip()) * 1024
+    assert call('device.get_disks')[boot_disk]['size'] == fdisk_size


### PR DESCRIPTION
Thought this was weird when I was writing it. Shame I didn't notice the obvious "size" discrepancy. Anyways, "size" is actually what we're referring to as "blocks" so change it appropriately. Tested and confirmed this is resolved on VMs and real hardware. Added API integration test to ensure (hopefully) this doesn't get broken in future.

Original PR: https://github.com/truenas/middleware/pull/9118
Jira URL: https://jira.ixsystems.com/browse/NAS-116549