### PR TITLE
Fix iSCSI disk tests

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -598,7 +598,7 @@ class ZFSDatasetService(CRUDService):
         def get_attachments():
             extents = self.middleware.call_sync('iscsi.extent.query', [('type', '=', 'DISK')])
             iscsi_zvols = {
-                i['path'][len('zvol/'):]: i for i in extents
+                zvol_path_to_name('/dev/' + i['path']): i for i in extents
             }
 
             vm_devices = self.middleware.call_sync('vm.device.query', [['dtype', '=', 'DISK']])


### PR DESCRIPTION
Output format strings are slightly different from what they
originally were. Additionaly zvol snapdev needs to be visible
in order for snapshots of zvols to be available as choices