### PR TITLE
NAS-116566 / 22.12 / fix encrypted_provider and remove glob to optimize (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -1,7 +1,6 @@
 import os
 import pyudev
 import re
-import glob
 
 import libsgio
 
@@ -66,8 +65,12 @@ class DeviceService(Service):
                 part['end'] = lss * part['end_sector']
                 part['size'] = lss * int(i['ID_PART_ENTRY_SIZE'])
 
-            if ep := glob.glob(f'/sys/block/dm-*/slaves/{part_name}'):
-                part['encrypted_provider'] = f'/dev/{ep[0].split("/")[3]}'
+            attrs = list(i.attributes.available_attributes)
+            for idx, attr in enumerate(attrs):
+                if attr.find('holders/md') != -1:
+                    # looks like `holders/md123`
+                    part['encrypted_provider'] = f'/dev/{attrs[idx].split("/", 1)[-1].strip()}'
+                    break
 
             parts.append(part)
 

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -67,7 +67,7 @@ class DeviceService(Service):
 
             attrs = list(i.attributes.available_attributes)
             for idx, attr in enumerate(attrs):
-                if attr.find('holders/md') != -1:
+                if attr.startswith('holders/md'):
                     # looks like `holders/md123`
                     part['encrypted_provider'] = f'/dev/{attrs[idx].split("/", 1)[-1].strip()}'
                     break

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -65,12 +65,10 @@ class DeviceService(Service):
                 part['end'] = lss * part['end_sector']
                 part['size'] = lss * int(i['ID_PART_ENTRY_SIZE'])
 
-            attrs = list(i.attributes.available_attributes)
-            for attr in attrs:
-                if attr.startswith('holders/md'):
-                    # looks like `holders/md123`
-                    part['encrypted_provider'] = f'/dev/{attr.split("/", 1)[1].strip()}'
-                    break
+            for attr in filter(lambda x: x.startswith('holders/md'), i.attributes.available_attributes):
+                # looks like `holders/md123`
+                part['encrypted_provider'] = f'/dev/{attr.split("/", 1)[1].strip()}'
+                break
 
             parts.append(part)
 

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -66,7 +66,7 @@ class DeviceService(Service):
                 part['size'] = lss * int(i['ID_PART_ENTRY_SIZE'])
 
             attrs = list(i.attributes.available_attributes)
-            for idx, attr in enumerate(attrs):
+            for attr in attrs:
                 if attr.startswith('holders/md'):
                     # looks like `holders/md123`
                     part['encrypted_provider'] = f'/dev/{attr.split("/", 1)[1].strip()}'

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -69,7 +69,7 @@ class DeviceService(Service):
             for idx, attr in enumerate(attrs):
                 if attr.startswith('holders/md'):
                     # looks like `holders/md123`
-                    part['encrypted_provider'] = f'/dev/{attrs[idx].split("/", 1)[-1].strip()}'
+                    part['encrypted_provider'] = f'/dev/{attr.split("/", 1)[1].strip()}'
                     break
 
             parts.append(part)


### PR DESCRIPTION
As best as I can tell, `encrypted_provider` hasn't worked. But the bigger problem is that calling `glob.glob` for every disk adds up to quite a bit of time on a ~1.2k hdd system.

This maps the encrypted_provider to the `/dev/md*` device using the `udev` information that we've already enumerated.

Before: my changes `device.get_disks true` would take 25 seconds
After: my changes `device.get_disks true` takes 6 seconds **(~76% decrease in time)**

Original PR: https://github.com/truenas/middleware/pull/9129
Jira URL: https://jira.ixsystems.com/browse/NAS-116566