### PR TITLE
Add cloudflare DDNS provider

### DIFF
--- a/src/middlewared/middlewared/plugins/dyndns.py
+++ b/src/middlewared/middlewared/plugins/dyndns.py
@@ -57,6 +57,7 @@ class DynDNSService(SystemServiceService):
         """
         return {
             'default@changeip.com': 'changeip.com',
+            'example.org': 'cloudflare.com',
             'default@cloudxns.net': 'cloudxns.net',
             'default@ddnss.de': 'ddnss.de',
             'default@dhis.org': 'dhis.org',


### PR DESCRIPTION
Based on https://github.com/troglobit/inadyn/blob/master/examples/cloudflare-ipv4-only.conf

Note: Supported on inadyn 2.9.x (9 dev 2021), couldn't see the version used anywhere in the repo, please correct if I missed it!