### PR TITLE
Properly wait for libvirt guests to terminate

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
+++ b/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
@@ -1,0 +1,9 @@
+<%
+    from middlewared.plugins.vm.utils import LIBVIRT_URI
+
+
+    vm_max_shutdown = max(map(lambda v: v['shutdown_timeout'], middleware.call_sync('vm.query')), default=10)
+%>\
+URIS="${LIBVIRT_URI}"
+ON_SHUTDOWN=shutdown
+SHUTDOWN_TIMEOUT=${vm_max_shutdown}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -336,6 +336,9 @@ class EtcService(Service):
         'libvirt': [
             {'type': 'py', 'path': 'libvirt', 'checkpoint': None},
         ],
+        'libvirt_guests': [
+            {'type': 'mako', 'path': 'default/libvirt-guests', 'checkpoint': None},
+        ]
     }
     LOCKS = defaultdict(asyncio.Lock)
 

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -31,7 +31,7 @@ from .idmap import IdmapService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
-from .pseudo.libvirtd import LibvirtdService
+from .pseudo.libvirtd import LibvirtdService, LibvirtGuestService
 from .pseudo.misc import (
     CronService,
     DiskService,
@@ -91,6 +91,7 @@ all_services = [
     CollectDService,
     RRDCacheDService,
     LibvirtdService,
+    LibvirtGuestService,
     CronService,
     DiskService,
     KmipService,

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/libvirtd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/libvirtd.py
@@ -3,7 +3,18 @@ from middlewared.plugins.service_.services.base import SimpleService
 
 class LibvirtdService(SimpleService):
     name = "libvirtd"
-
     systemd_unit = "libvirtd"
-
     etc = ["libvirt"]
+
+    async def after_start(self):
+        await self.middleware.call("service.start", "libvirt-guests")
+
+    async def before_stop(self):
+        await self.middleware.call("service.stop", "libvirt-guests")
+
+
+class LibvirtGuestService(SimpleService):
+    name = "libvirt-guests"
+    systemd_unit = "libvirt-guests"
+    systemd_async_start = True
+    etc = ["libvirt_guests"]

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -158,6 +158,7 @@ class VMService(CRUDService, VMSupervisorMixin):
 
         vm_id = await self.middleware.call('datastore.insert', 'vm.vm', data)
         await self.middleware.run_in_thread(self._add, vm_id)
+        await self.middleware.call('etc.generate', 'libvirt_guests')
 
         return await self.get_instance(vm_id)
 
@@ -282,6 +283,9 @@ class VMService(CRUDService, VMSupervisorMixin):
         if new['name'] != old['name']:
             await self.middleware.run_in_thread(self._rename_domain, old, vm_data)
 
+        if old['shutdown_timeout'] != new['shutdown_timeout']:
+            await self.middleware.call('etc.generate', 'libvirt_guests')
+
         return await self.get_instance(id)
 
     @accepts(
@@ -344,6 +348,8 @@ class VMService(CRUDService, VMSupervisorMixin):
             if not await self.middleware.call('vm.query'):
                 await self.middleware.call('vm.deinitialize_vms')
                 self._clear()
+            else:
+                await self.middleware.call('etc.generate', 'libvirt_guests')
             return result
 
     @item_method


### PR DESCRIPTION
## Problem

When TrueNAS is shutdown, VM guests were not gracefully shutting down and instead were forcefully terminated even though libvirt service is running at that point ( when middleware is waiting for vms to gracefully shutdown ).

## Solution

We have `libvirt-guests` service which can be used to gracefully shutdown the VMs.