### PR TITLE
NAS-116105 / 22.02.2 / Memory improvements for catalogs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -5,7 +5,6 @@ from middlewared.schema import accepts, Bool, Dict, List, returns, Str
 from middlewared.service import CallError, Service
 
 from .items_util import get_item_details
-from .questions_utils import normalise_questions
 
 
 class CatalogService(Service):
@@ -17,7 +16,6 @@ class CatalogService(Service):
         Str('item_name'),
         Dict(
             'item_version_details',
-            Bool('cache', default=True),
             Str('catalog', required=True),
             Str('train', required=True),
         )
@@ -49,21 +47,5 @@ class CatalogService(Service):
             raise CallError(f'{item_location!r} must be a directory')
 
         questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
-        if options['cache'] and self.middleware.call_sync(
-            'cache.has_key', f'catalog_{options["catalog"]}_train_details'
-        ):
-            cached_data = self.middleware.call_sync('cache.get', f'catalog_{options["catalog"]}_train_details')
-            if item := cached_data.get(options['train'], {}).get(item_name):
-                # We need to update enums for refs in schema, cannot rely on cache for the latest values. Those
-                # refer to fields in schema showing us the available interfaces GPUs, Certificates, CAs etc.
-                for version in item['versions']:
-                    versioned_item = item['versions'][version]
-                    needs_normalization = versioned_item['healthy'] and versioned_item['required_features'] and any(
-                        feature.startswith('definitions/')
-                        for feature in versioned_item['required_features']
-                    )
-                    if needs_normalization:
-                        normalise_questions(versioned_item, questions_context)
-                return item
-
         return get_item_details(item_location, questions_context, {'retrieve_versions': True})
+

--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -16,6 +16,7 @@ class CatalogService(Service):
         Str('item_name'),
         Dict(
             'item_version_details',
+            Bool('cache'),  # TODO: Remove this once UI adapts
             Str('catalog', required=True),
             Str('train', required=True),
         )
@@ -48,4 +49,3 @@ class CatalogService(Service):
 
         questions_context = self.middleware.call_sync('catalog.get_normalised_questions_context')
         return get_item_details(item_location, questions_context, {'retrieve_versions': True})
-

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -38,8 +38,7 @@ class CatalogService(Service):
             Bool('cache', default=True),
             Bool('cache_only', default=False),
             Bool('retrieve_all_trains', default=True),
-            List('trains', items=[Str('train_name')])
-            ,
+            List('trains', items=[Str('train_name')]),
         )
     )
     @returns(Dict(

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -55,7 +55,6 @@ class CatalogService(Service):
             'cache': False,
             'cache_only': False,
             'retrieve_all_trains': True,
-            'retrieve_versions': True,
             'trains': [],
         }
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -94,9 +94,7 @@ class CatalogService(CRUDService):
                         'retrieve_all_trains': extra.get('retrieve_all_trains', True),
                         'trains': extra.get('trains', []),
                     }),
-                    'cached': label == OFFICIAL_LABEL or await self.middleware.call(
-                        'catalog.cached', label, False
-                    ) or await self.middleware.call('catalog.cached', label, True),
+                    'cached': label == OFFICIAL_LABEL or await self.middleware.call('catalog.cached', label),
                     'normalized_progress': None,
                 }
                 if not catalog_info['cached']:
@@ -135,9 +133,7 @@ class CatalogService(CRUDService):
                 'healthy': all(
                     app['healthy'] for train in item_job.result for app in item_job.result[train].values()
                 ),
-                'cached': label == OFFICIAL_LABEL or await self.middleware.call(
-                    'catalog.cached', label, False
-                ) or await self.middleware.call('catalog.cached', label, True),
+                'cached': label == OFFICIAL_LABEL or await self.middleware.call('catalog.cached', label),
                 'error': False,
                 'caching_progress': None,
                 'caching_job': None,
@@ -289,8 +285,7 @@ class CatalogService(CRUDService):
 
         # Remove cached content of the catalog in question so that if a catalog is created again
         # with same label but different repo/branch, we don't reuse old cache
-        self.middleware.call_sync('cache.pop', get_cache_key(id, True))
-        self.middleware.call_sync('cache.pop', get_cache_key(id, False))
+        self.middleware.call_sync('cache.pop', get_cache_key(id))
 
         return ret
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/utils.py
@@ -58,6 +58,5 @@ def pull_clone_repository(repository_uri, parent_dir, branch, depth=None):
         return True
 
 
-def get_cache_key(label, retrieve_versions):
-    suffix = '' if retrieve_versions else '_without_versions'
-    return f'catalog_{label}_train_details{suffix}'
+def get_cache_key(label):
+    return f'catalog_{label}_train_details'


### PR DESCRIPTION
This PR adds following changes:

1. Do not cache entire contents of catalogs. Just caching names of the apps is sufficient with some other metadata.
2. Remove retrieving versions from `catalog.items` as it introduces lots of overhead wrt cpu/memory with no apparent benefit.
3. Do not keep the results of `catalog.items` job in memory and have a 30 second callback which will remove the results output as just keeping the results around for multiple jobs can consume memory.
4. Do not trigger redundant `catalog.items` job.
5. Make sure we don't queue multiple `catalog.items` jobs when the same parameters are specified

With these changes, i see my machine consuming around 250-300mb of RAM whereas without these changes we see it hover at 2GB which is pretty significant.


Original PR: https://github.com/truenas/middleware/pull/9137
Jira URL: https://jira.ixsystems.com/browse/NAS-116105