### PR TITLE
NAS-116600 / 22.02.2 / Fix mseries nvme mapping

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
@@ -25,16 +25,13 @@ class EnclosureService(Service):
         }
 
         slot_to_nvme = {}
-        context = pyudev.Context()
-        for i in filter(lambda x: x.attributes.get("path") == b"\\_SB_.PC03.BR3A",
-                        context.list_devices(subsystem="acpi")):
-            physical_node_path = f"{i.sys_path}/physical_node"
+        ctx = pyudev.Context()
+        for i in filter(lambda x: x.attributes.get("path") == b"\\_SB_.PC03.BR3A", ctx.list_devices(subsystem="acpi")):
             try:
-                physical_node = pyudev.Devices.from_path(context, physical_node_path)
+                physical_node = pyudev.Devices.from_path(context, f"{i.sys_path}/physical_node")
             except pyudev.DeviceNotFoundAtPathError:
-                self.logger.error("Failed to find PCI slot information for rear NVME drives at path %r",
-                                  physical_node_path)
-                return []
+                # happens when there are no rear-nvme drives plugged in
+                pass
             else:
                 for child in physical_node.children:
                     if not self.RE_NVME.fullmatch(child.sys_name):

--- a/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
@@ -28,7 +28,7 @@ class EnclosureService(Service):
         ctx = pyudev.Context()
         for i in filter(lambda x: x.attributes.get("path") == b"\\_SB_.PC03.BR3A", ctx.list_devices(subsystem="acpi")):
             try:
-                physical_node = pyudev.Devices.from_path(context, f"{i.sys_path}/physical_node")
+                physical_node = pyudev.Devices.from_path(ctx, f"{i.sys_path}/physical_node")
             except pyudev.DeviceNotFoundAtPathError:
                 # happens when there are no rear-nvme drives plugged in
                 pass

--- a/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/m_series_nvme.py
@@ -31,7 +31,7 @@ class EnclosureService(Service):
             physical_node_path = f"{i.sys_path}/physical_node"
             try:
                 physical_node = pyudev.Devices.from_path(context, physical_node_path)
-            except pyudev.DeviceNotFoundByNameError:
+            except pyudev.DeviceNotFoundAtPathError:
                 self.logger.error("Failed to find PCI slot information for rear NVME drives at path %r",
                                   physical_node_path)
                 return []


### PR DESCRIPTION
On an M50 with no NVMe drives plugged into the rear, it was crashing because we weren't capturing the proper `pyudev` exception. (i.e. `DeviceNotFoundByNameError` -> `DeviceNotFoundByPathError`).

However, the webUI was not displaying the rear section of the head unit because we are returning early (an empty list). This breaks the webUI because they're expecting to have an entry in `enclosure.query` that maps the rear nvme drive bays (even if there are none installed).

This fixes both of those scenarios.