### PR TITLE
NAS-116601 / 22.12 / Do not automount .system on pool import

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1416,9 +1416,11 @@ class PoolService(CRUDService):
         # Recursively reset dataset mountpoints for the zpool.
         recursive = True
         for child in await self.middleware.call('zfs.dataset.child_dataset_names', pool_name):
-            if child == os.path.join(pool_name, 'ix-applications'):
+            if child in (os.path.join(pool_name, 'ix-applications'), os.path.join(pool_name, '.system')):
                 # We exclude `ix-applications` dataset since resetting it will
                 # cause PVC's to not mount because "mountpoint=legacy" is expected.
+                # Ditto for .system dataset. This may contain sensitive informatoin and should not
+                # be exposed through user permissions misconfiguration
                 continue
             try:
                 # Reset all mountpoints


### PR DESCRIPTION
Our system dataset plugin should handle auto-mounting .system.
Mounting .system under our normal filesystem tree may expose
sensitive information.