### PR TITLE
NAS-116584 / 22.02.2 / Add initial bunch of returns decorators to DS-related plugins (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -3,7 +3,7 @@ import asyncio
 import errno
 import os
 import datetime
-from middlewared.schema import accepts, Bool, Dict, Int, Patch, Str, LDAP_DN, OROperator
+from middlewared.schema import accepts, Bool, Dict, Int, Patch, Ref, Str, LDAP_DN, OROperator
 from middlewared.service import CallError, TDBWrapCRUDService, job, private, ValidationErrors, filterable
 from middlewared.plugins.directoryservices import SSL
 import middlewared.sqlalchemy as sa
@@ -608,7 +608,7 @@ class IdmapDomainService(TDBWrapCRUDService):
         OROperator(
             Dict(
                 'idmap_ad_options',
-                Str('schema_mode', required=True, enum=['RFC2307', 'SFU', 'SFU20']),
+                Ref('nss_info_ad', 'schema_mode'),
                 Bool('unix_primary_group', default=False),
                 Bool('unix_nss_info', default=False),
             ),
@@ -625,7 +625,7 @@ class IdmapDomainService(TDBWrapCRUDService):
                 Str('ldap_user_dn_password', private=True),
                 Str('ldap_url'),
                 Bool('readonly', default=False),
-                Str('ssl', enum=[x.value for x in SSL]),
+                Ref('ldap_ssl_choice', 'ssl'),
                 Bool('validate_certificates', default=True),
             ),
             Dict(
@@ -644,7 +644,7 @@ class IdmapDomainService(TDBWrapCRUDService):
                 Str('ldap_url'),
                 LDAP_DN('ldap_user_dn'),
                 Str('ldap_user_dn_password', private=True),
-                Str('ssl', enum=[x.value for x in SSL]),
+                Ref('ldap_ssl_choice', 'ssl'),
                 Bool('validate_certificates', default=True),
             ),
             Dict(

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -897,15 +897,17 @@ class Cron(Dict):
 
 class Ref(object):
 
-    def __init__(self, name):
-        self.name = name
+    def __init__(self, name, new_name=None):
+        self.schema_name = name
+        self.name = new_name or name
         self.resolved = False
 
     def resolve(self, schemas):
-        schema = schemas.get(self.name)
+        schema = schemas.get(self.schema_name)
         if not schema:
-            raise ResolverError('Schema {0} does not exist'.format(self.name))
+            raise ResolverError('Schema {0} does not exist'.format(self.schema_name))
         schema = schema.copy()
+        schema.name = self.name
         schema.register = False
         schema.resolved = True
         self.resolved = True


### PR DESCRIPTION
Add new optional argument to Ref schema to specify a new name
for it. Ref('ldap_ssl_choice', 'ssl') will make reference to
the registered `ldap_ssl_choice` schema validator, but will
present it with a different name. This allows easier
normalization of schemas between disparate plugins that for
historical reasons use different names for same-ish keys.
It also allows us to register more descriptive names.

The PR also adds returns decorators to a significant amount
of different methods in the directoryservices, activedirectory,
ldap, and idmap plugins.

Original PR: https://github.com/truenas/middleware/pull/9136
Jira URL: https://jira.ixsystems.com/browse/NAS-116584