### PR TITLE
Fix path validation for non-existent paths

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -10,8 +10,26 @@ from middlewared.plugins.zfs_.utils import ZFSCTL
 async def check_path_resides_within_volume(verrors, middleware, name, path):
 
     # we need to make sure the sharing service is configured within the zpool
-    st = await middleware.call("filesystem.stat", path)
+    def get_file_info(path):
+        """
+        avoid filesytem.stat here because we do not want to fail if path does
+        not exist
+        """
+        rv = {'realpath': None, 'inode': None, 'dev': None, 'is_mountpoint': False}
+        try:
+            st = os.stat(path)
+            rv['inode'] = st.st_inode
+            rv['dev'] = st.st_dev
+        except FileNotFoundError:
+            pass
+
+        rv['realpath'] = os.path.realpath(path)
+        rv['is_mountpoint'] = os.path.ismount(path)
+        return rv
+
+    st = await middleware.run_in_thread(get_file_info, path)
     rp = st["realpath"]
+
     vol_names = [vol["vol_name"] for vol in await middleware.call("datastore.query", "storage.volume")]
     vol_paths = [os.path.join("/mnt", vol_name) for vol_name in vol_names]
     if not path.startswith("/mnt/") or not any(


### PR DESCRIPTION
When I reworked this area for preventing ops on .zfs and
.zfs/snapshot I forgot that os.path.realpath is not strict by
default. This PR reworks the validator to run the path-based
checks (stat, realpath, and friends) in a thread. This
validator is still susceptible to symlink races, but it's
probably safe for what we're trying to prevent (users
attempting to bypass path validation through creative use
of symlinks). If we develop file browser based on the
filesystem API then we will need to take a closer look at
path and symlink handling.