### PR TITLE
NAS-116608 / 22.02.2 / fix enclosure mapping on MINI XL+ on SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -468,6 +468,11 @@ class Enclosure(object):
         except (FileNotFoundError, IndexError):
             pass
 
+        try:
+            return os.listdir(f"/sys/class/enclosure/{self.devname[len('bsg/'):]}/Slot {element_number:02X}/device/block")[0]
+        except (FileNotFoundError, IndexError):
+            pass
+
         if slot := glob.glob(f"/sys/class/enclosure/{self.devname[len('bsg/'):]}/slot{element_number:02} *"):
             try:
                 return os.listdir(f"{slot[0]}/device/block")[0]


### PR DESCRIPTION
Virtual AHCI driver presents the drives as `/sys/class/enclosure/8:0:0:0/Slot 00/...`