### PR TITLE
NAS-116630 / 22.02.2 / fix BHYVE disk serial detection on SCALE (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -8,6 +8,7 @@ from middlewared.schema import Dict, returns
 from middlewared.service import accepts, private, Service
 from middlewared.utils.gpu import get_gpus
 from middlewared.utils import osc
+from middlewared.utils.functools import cache
 from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 
 RE_NVME_PRIV = re.compile(r'nvme[0-9]+c')
@@ -18,11 +19,17 @@ class DeviceService(Service):
     DISK_ROTATION_ERROR_LOG_CACHE = set()
 
     @private
+    @cache
+    def host_type(self):
+        return self.middleware.call_sync('system.dmidecode_info')['system-product-name']
+
+    @private
     def get_serials(self):
         return osc.system.serial_port_choices()
 
     @private
     def get_disks(self, get_partitions=False):
+        host_type = self.host_type()
         ctx = pyudev.Context()
         disks = {}
         for dev in ctx.list_devices(subsystem='block', DEVTYPE='disk'):
@@ -30,7 +37,7 @@ class DeviceService(Service):
                 continue
 
             try:
-                disks[dev.sys_name] = self.get_disk_details(dev, get_partitions)
+                disks[dev.sys_name] = self.get_disk_details(dev, get_partitions, host_type)
             except Exception:
                 self.logger.debug('Failed to retrieve disk details for %s', dev.sys_name, exc_info=True)
 
@@ -75,10 +82,13 @@ class DeviceService(Service):
         return parts
 
     @private
-    def get_disk_details(self, dev, get_partitions=False):
+    def get_disk_details(self, dev, get_partitions=False, host_type=''):
         is_nvme = dev.sys_name.startswith('nvme')
+        is_bhyve = host_type == 'BHYVE'
         blocks = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
-        ident = serial = self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT' if is_nvme else 'ID_SCSI_SERIAL', '')
+        ident = serial = self.safe_retrieval(
+            dev.properties, 'ID_SERIAL_SHORT' if any((is_nvme, is_bhyve)) else 'ID_SCSI_SERIAL', ''
+        )
         model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)
         driver = self.safe_retrieval(dev.parent.properties, 'DRIVER', '') if not is_nvme else 'nvme'
         sectorsize = self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True)


### PR DESCRIPTION
When SCALE is installed inside a bhyve VM, the serial for the disk is stored in `ID_SERIAL_SHORT` like it is for nvme drives. Make the necessary adjustments to get the serial appropriately.

Also I've noticed a 2nd issue, the `get_partitions` kwarg was not set in the `device.get_disks` method properly so that was a NO-OP (this is not a problem on stable) and prevents disk.sync_all from working properly.

Original PR: https://github.com/truenas/middleware/pull/9159
Jira URL: https://jira.ixsystems.com/browse/NAS-116630