### PR TITLE
NAS-116269 / 22.12 / validate user/group entries can execute on path in setacl

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 
 from middlewared.schema import accepts, Bool, Dict, returns, Str
-from middlewared.service import CallError, Service
+from middlewared.service import CallError, Service, private
 
 from middlewared.utils.osc import run_with_user_context
 
@@ -24,6 +24,62 @@ def check_access(path: str, check_perms: dict) -> bool:
 
 
 class FilesystemService(Service):
+
+    @private
+    def generate_user_details(self, id_type, xid):
+        if id_type not in ['USER', 'GROUP']:
+            raise CallError(f'{id_type}: invalid ID type. Must be "USER" or "GROUP"')
+
+        if id_type == 'USER':
+            try:
+                out = self.middleware.call_sync(
+                    'user.get_user_obj',
+                    {'uid': xid, 'get_groups': True}
+                )
+                out['id_name'] = out['pw_name']
+                return out
+            except KeyError:
+                return None
+
+        try:
+            grp = self.middleware.call_sync('group.get_group_obj', {'gid': xid})
+        except KeyError:
+            return None
+
+        # get a UID not currently in use
+        tmp_uid = self.middleware.call_sync('user.get_next_uid')
+
+        try:
+            res = self.middleware.call_sync(
+                'user.get_user_obj',
+                {'uid': tmp_uid}
+            )
+            self.logger.warning(
+                '%s: user exists on system but not in TrueNAS configuration. '
+                'This may indicate that it was created manually from shell '
+                'or there is an unexpected overlap between local and directory '
+                'services user accounts', res['pw_name']
+            )
+            # daemon user probably should not have access to user data
+            # so we'll use this for testing
+            uid = 1
+        except KeyError:
+            uid = tmp_uid
+
+        return {
+            'pw_name': 'synthetic_user',
+            'pw_uid': uid,
+            'pw_gid': grp['gr_gid'],
+            'pw_gecos': 'synthetic user',
+            'pw_dir': '/var/empty',
+            'pw_shell': '/usr/bin/zsh',
+            'grouplist': [grp['gr_gid']],
+            'id_name': grp['gr_name']
+        }
+
+    @private
+    def check_as_user_impl(self, user_details, path, perms):
+        return run_with_user_context(check_access, user_details, [path, perms])
 
     @accepts(
         Str('username', empty=False),
@@ -56,4 +112,58 @@ class FilesystemService(Service):
         except KeyError:
             raise CallError(f'{username!r} user does not exist', errno=errno.ENOENT)
 
-        return run_with_user_context(check_access, user_details, [path, perms])
+        return self.check_as_user_impl(user_details, path, perms)
+
+    @private
+    def check_path_execute(self, path, id_type, xid):
+        user_details = self.generate_user_details(id_type, xid)
+        if user_details is None:
+            # User or group does not exist on server.
+            # This can happen for a variety of reasons that are potentially
+            # acceptable (or better than alternative of changing permissions).
+            # Hence, skip validation.
+            self.logger.trace('%s %d does not exist. Skipping validation',
+                              id_type.lower(), xid)
+            return
+
+        parts = pathlib.Path(path).parts
+        for idx, part in enumerate(parts):
+            if idx < 2:
+                continue
+
+            path_to_check = f'/{"/".join(parts[1:idx])}'
+            ok = self.check_as_user_impl(user_details, path_to_check, {'read': None, 'write': None, 'execute': True})
+            if not ok:
+                raise CallError(
+                    f'Filesystem permissions on path {path_to_check} prevent access for '
+                    f'{id_type.lower()} {user_details["id_name"]} to the path {path}. '
+                    f'This may be fixed by granting the aforementioned {id_type.lower()} '
+                    f'execute permissions on the path: {path_to_check}.', errno.EPERM
+                )
+
+    @private
+    def check_acl_execute(self, path, acl, uid, gid):
+        for entry in acl:
+            if entry['tag'] in ('everyone@', 'OTHER', 'MASK'):
+                continue
+
+            if entry.get('type', 'ALLOW') != 'ALLOW':
+                continue
+
+            id_info = {'id_type': None, 'xid': entry['id']}
+
+            if entry['tag'] == 'GROUP':
+                id_info['id_type'] = 'GROUP'
+
+            elif entry['tag'] == 'USER':
+                id_info['id_type'] = 'USER'
+
+            elif entry['tag'] in ('owner@', 'USER_OBJ'):
+                id_info['id_type'] = 'USER'
+                id_info['xid'] = uid
+
+            elif entry['tag'] in ('group@', 'GROUP_OBJ'):
+                id_info['id_type'] = 'USER'
+                id_info['xid'] = gid
+
+            self.check_path_execute(path, id_info['id_type'], id_info['xid'])


### PR DESCRIPTION
One of the most common permissions misconfigurations by
end-users is to remove execute on a parent directory path.

This PR validates during setacl that all users and groups in
the proposed ACL have execute access(path, F_OK) on path
leading up to share. Walk up each path component so that
we can identify the exact problem path and give it to the
user as a sort of "hey you need to fix this here path"
message.