### PR TITLE
Do not generate coredumps for containers

### DIFF
--- a/src/freenas/etc/systemd/system/containerd.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/containerd.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitCORE=1

--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitCORE=1


### PR DESCRIPTION
## Problem

Apps when break potentially generate a coredump which is useless for us as we are not responsible for fixing the apps themselves.

## Solution

According to various docs, setting `core` soft/hard limit to `0` should disable the coredumps but that was not working even after trying various ways via `ulimit` etc. After juggling through various solutions, I found out setting the limit to `1` kb worked. Coredumps have at least generally more then 10kb even for small programs like sleep etc so this should function pretty well for suppressing coredumps of apps. By setting this core limit for docker/containerd daemons, any child processes they spawn inherit these limits and we don't see coredumps being generated anymore.