### PR TITLE
NAS-116450 / 22.12 / fix off-by-one in enclosure mapping on M50 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -447,6 +447,7 @@ class Enclosure(object):
                     dev = ""
                     if element_type == "Array Device Slot":
                         dev = self._array_device_slot_dev(element_number)
+                        element_number += 1  # (webUI expects drives to start at slot 1 and not slot 0)
 
                     element = self._enclosure_element(
                         element_number,


### PR DESCRIPTION
WebUI is off by one on the m-series systems because it's expecting the drives to start at slot 1. Without these changes, it's starting at slot 0.

Original PR: https://github.com/truenas/middleware/pull/9168
Jira URL: https://jira.ixsystems.com/browse/NAS-116450