### PR TITLE
NAS-116586 / 22.02.2 / Properly wait for libvirt guests to terminate (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
+++ b/src/middlewared/middlewared/etc_files/default/libvirt-guests.mako
@@ -1,0 +1,9 @@
+<%
+    from middlewared.plugins.vm.utils import LIBVIRT_URI
+
+
+    vm_max_shutdown = max(map(lambda v: v['shutdown_timeout'], middleware.call_sync('vm.query')), default=10)
+%>\
+URIS="${LIBVIRT_URI}"
+ON_SHUTDOWN=shutdown
+SHUTDOWN_TIMEOUT=${vm_max_shutdown}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -333,6 +333,9 @@ class EtcService(Service):
         'libvirt': [
             {'type': 'py', 'path': 'libvirt', 'checkpoint': None},
         ],
+        'libvirt_guests': [
+            {'type': 'mako', 'path': 'default/libvirt-guests', 'checkpoint': None},
+        ]
     }
     LOCKS = defaultdict(asyncio.Lock)
 

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -32,7 +32,7 @@ from .idmap import IdmapService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
-from .pseudo.libvirtd import LibvirtdService
+from .pseudo.libvirtd import LibvirtdService, LibvirtGuestService
 from .pseudo.misc import (
     CronService,
     DiskService,
@@ -87,6 +87,7 @@ all_services = [
     CollectDService,
     RRDCacheDService,
     LibvirtdService,
+    LibvirtGuestService,
     CronService,
     DiskService,
     KmipService,

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/libvirtd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/libvirtd.py
@@ -1,17 +1,20 @@
-from middlewared.plugins.service_.services.base import SimpleService, ServiceState
+from middlewared.plugins.service_.services.base import SimpleService
 
 
 class LibvirtdService(SimpleService):
     name = "libvirtd"
-
-    freebsd_rc = "libvirtd"
-
     systemd_unit = "libvirtd"
-
     etc = ["libvirt"]
 
-    async def _get_state_freebsd(self):
-        return ServiceState(
-            (await self._freebsd_service("libvirtd", "status")).returncode == 0,
-            [],
-        )
+    async def after_start(self):
+        await self.middleware.call("service.start", "libvirt-guests")
+
+    async def before_stop(self):
+        await self.middleware.call("service.stop", "libvirt-guests")
+
+
+class LibvirtGuestService(SimpleService):
+    name = "libvirt-guests"
+    systemd_unit = "libvirt-guests"
+    systemd_async_start = True
+    etc = ["libvirt_guests"]

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -174,6 +174,7 @@ class VMService(CRUDService, VMSupervisorMixin):
                 await self.middleware.call('vm.device.create', {'vm': vm_id, **device})
 
         await self.middleware.run_in_thread(self._add, vm_id)
+        await self.middleware.call('etc.generate', 'libvirt_guests')
 
         return await self.get_instance(vm_id)
 
@@ -372,6 +373,9 @@ class VMService(CRUDService, VMSupervisorMixin):
         if new['name'] != old['name']:
             await self.middleware.run_in_thread(self._rename_domain, old, vm_data)
 
+        if old['shutdown_timeout'] != new['shutdown_timeout']:
+            await self.middleware.call('etc.generate', 'libvirt_guests')
+
         return await self.get_instance(id)
 
     @accepts(
@@ -434,6 +438,8 @@ class VMService(CRUDService, VMSupervisorMixin):
             if not await self.middleware.call('vm.query'):
                 await self.middleware.call('vm.deinitialize_vms')
                 self._clear()
+            else:
+                await self.middleware.call('etc.generate', 'libvirt_guests')
             return result
 
     @item_method


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x faf94db52e6c26953bd5a31c366ad6f719b984ed

## Problem

When TrueNAS is shutdown, VM guests were not gracefully shutting down and instead were forcefully terminated even though libvirt service is running at that point ( when middleware is waiting for vms to gracefully shutdown ).

## Solution

We have `libvirt-guests` service which can be used to gracefully shutdown the VMs.

Original PR: https://github.com/truenas/middleware/pull/9140
Jira URL: https://jira.ixsystems.com/browse/NAS-116586