### PR TITLE
NAS-116659 / 22.02.2 / Fix iSCSI disk tests

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -594,7 +594,7 @@ class ZFSDatasetService(CRUDService):
         def get_attachments():
             extents = self.middleware.call_sync('iscsi.extent.query', [('type', '=', 'DISK')])
             iscsi_zvols = {
-                i['path'][len('zvol/'):]: i for i in extents
+                zvol_path_to_name('/dev/' + i['path']): i for i in extents
             }
 
             vm_devices = self.middleware.call_sync('vm.device.query', [['dtype', '=', 'DISK']])

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -30,20 +30,27 @@ def test__iscsi_extent__disk_choices(request):
         "type": "VOLUME",
         "volsize": 1024000,
     }) as ds:
+        # Make snapshots available for devices
+        call("zfs.dataset.update", ds, {"properties": {"snapdev": {"parsed": "visible"}}})
         call("zfs.snapshot.create", {"dataset": ds, "name": "snap-1"})
-
         assert call("iscsi.extent.disk_choices") == {
-            f'zvol/{ds.replace(" ", "+")}': f'{ds} (1000K)',
+            f'zvol/{ds.replace(" ", "+")}': f'{ds} (1000 KiB)',
             f'zvol/{ds.replace(" ", "+")}@snap-1': f'{ds}@snap-1 [ro]',
         }
 
+        # Create new extent
         with iscsi_extent({
             "name": "test_extent",
             "type": "DISK",
             "disk": f"zvol/{ds.replace(' ', '+')}",
         }):
+            # Verify that zvol is not available in iscsi disk choices
             assert call("iscsi.extent.disk_choices") == {
                 f'zvol/{ds.replace(" ", "+")}@snap-1': f'{ds}@snap-1 [ro]',
+            }
+            # Verify that zvol is not availabe in VM disk choices
+            assert call("vm.device.disk_choices") == {
+                f'/dev/zvol/{ds.replace(" ", "+")}@snap-1': f'{ds}@snap-1'
             }
 
 


### PR DESCRIPTION
Output format strings are slightly different from what they
originally were. Additionaly zvol snapdev needs to be visible
in order for snapshots of zvols to be available as choices