### PR TITLE
NAS-116654 / 13.0 / fix get_nsid return type and fix fenced to use nvme nsid devices

### DIFF
--- a/src/fenced/fenced/disks.py
+++ b/src/fenced/fenced/disks.py
@@ -1,9 +1,3 @@
-# Copyright (c) 2020 iXsystems, Inc.
-# All rights reserved.
-# This file is a part of TrueNAS
-# and may not be copied and/or distributed
-# without the express permission of iXsystems.
-
 from concurrent.futures import ThreadPoolExecutor, wait as fut_wait
 
 import cam
@@ -117,7 +111,8 @@ class Disk(object):
         self.cam = None
 
         if self.name.startswith('nvd'):
-            self.nvme = nvme.NvmeDevice(f'/dev/{name}')
+            ctrl, nsid = nvme.get_nsid(f'/dev/{name}')
+            self.nvme = nvme.NvmeDevice(f'/dev/{ctrl}ns{nsid}')
         else:
             self.cam = cam.CamDevice(f'/dev/{name}')
 

--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -23,7 +23,7 @@ async def get_smartctl_args(context, disk):
 
     if disk.startswith(('nvd', 'nvme')):
         try:
-            nvme = await middleware.run_in_thread(get_nsid, f'/dev/{disk}')
+            nvme, nsid = await middleware.run_in_thread(get_nsid, f'/dev/{disk}')
         except Exception as e:
             logger.warning('Unable to run nvme.get_nsid for %r: %r', disk, e)
             return

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -436,7 +436,7 @@ class DiskService(CRUDService):
 
     def sed_dev_name(self, disk_name):
         if disk_name.startswith("nvd"):
-            nvme = get_nsid(f"/dev/{disk_name}")
+            nvme, nsid = get_nsid(f"/dev/{disk_name}")
             return f"/dev/{nvme}"
 
         return f"/dev/{disk_name}"

--- a/src/middlewared/middlewared/plugins/disk_/nvme_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/nvme_freebsd.py
@@ -23,7 +23,7 @@ class DiskService(Service):
             if not exists(nvd):
                 continue
 
-            nvme = get_nsid(nvd)
+            nvme, nsid = get_nsid(nvd)
             if nvme:
                 nvme_to_nvd[int(nvme[4:])] = n
 

--- a/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
+++ b/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
@@ -16,7 +16,7 @@ async def test__get_smartctl_args__disk_nonexistent():
 
 @pytest.mark.asyncio
 async def test__get_smartctl_args__nvd():
-    with patch("middlewared.common.smart.smartctl.get_nsid", Mock(return_value="nvme1")):
+    with patch("middlewared.common.smart.smartctl.get_nsid", Mock(return_value=("nvme1", 1))):
         with patch("middlewared.common.smart.smartctl.osc.IS_LINUX", False):
             assert await get_smartctl_args(Middleware(), {}, "nvd0") == ["/dev/nvme1"]
 


### PR DESCRIPTION
1. `nvme.get_nsid` now returns a tuple of (controller, nsid)
2. fenced was using the `/dev/nvd` devices which go through GEOM layer. This isn't a problem until the `disk_resize` script runs and wants to make sure that the device isn't in use. Since fenced opens the device once in readonly mode, the script fails because GEOM shows the device "in use". This changes it so that fenced uses the `/dev/nvme0ns1` device which doesn't go through GEOM layer.