### PR TITLE
NAS-115425 / 22.02.2 / Fix SMB service start on reboot for clustered truenas (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -392,6 +392,7 @@ class IdmapDomainService(TDBWrapCRUDService):
             self.logger.warning("clear_idmap_cache is unsafe on clustered smb servers.")
             return
 
+        smb_started = await self.middleware.call('service.started', 'cifs')
         await self.middleware.call('service.stop', 'idmap')
 
         try:
@@ -408,6 +409,8 @@ class IdmapDomainService(TDBWrapCRUDService):
             raise CallError(f'Attempt to flush gencache failed with error: {gencache_flush.stderr.decode().strip()}')
 
         await self.middleware.call('service.start', 'idmap')
+        if smb_started:
+            await self.middleware.call('service.start', 'cifs')
 
     @private
     async def autodiscover_trusted_domains(self):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -603,7 +603,7 @@ class SMBService(TDBWrapConfigService):
         )
 
         job.set_progress(70, 'Checking SMB server status.')
-        if await self.middleware.call("service.started", "cifs"):
+        if await self.middleware.call("service.started_or_enabled", "cifs"):
             job.set_progress(80, 'Restarting SMB service.')
             await self.middleware.call("service.restart", "cifs")
         job.set_progress(100, 'Finished configuring SMB.')


### PR DESCRIPTION
When clustered SMB is in place, smb-related daemons will
fail when started in normal systemd manner on boot (ctdb isn't
ready). Adjust check for whether to restart SMB service at
tail of smb.configure to include case where SMB is enabled
but not running.

During investigation I realized that clear_idmap_cache on
SCALE was stopping SMB service (systemd stops smbd when
winbindd service stops). Keep track of running state
at beginning of cache clear, and restart SMB if required.

Original PR: https://github.com/truenas/middleware/pull/9190
Jira URL: https://jira.ixsystems.com/browse/NAS-115425