### PR TITLE
NAS-116677 / 22.12 / Fix KeyError while collecting coredump info

### DIFF
--- a/src/middlewared/middlewared/plugins/system/coredump.py
+++ b/src/middlewared/middlewared/plugins/system/coredump.py
@@ -19,7 +19,7 @@ class SystemService(Service):
                         'pid': core['COREDUMP_PID'],
                         'uid': core['COREDUMP_UID'],
                         'gid': core['COREDUMP_GID'],
-                        'unit': core['COREDUMP_UNIT'],
+                        'unit': core.get('COREDUMP_UNIT'),
                         'sig': core['COREDUMP_SIGNAL'],
                         'exe': core['COREDUMP_EXE'],
                     }


### PR DESCRIPTION
Observed in user debug file. In this case the unit info was missing,
and so handle that error, otherwise generate a log entry with
the unparseable entry so that we have some hope of improving
parsing in the future.