### PR TITLE
Revert "Do not show SCALE trains in 12.0-U2"

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/trains_freebsd.py
+++ b/src/middlewared/middlewared/plugins/update_/trains_freebsd.py
@@ -116,8 +116,8 @@ class UpdateService(Service):
                 'sequence': train.LastSequence(),
             }
 
-        # scale_trains = self.middleware.call_sync('update.get_scale_trains_data')
-        # trains.update(**scale_trains['trains'])
+        scale_trains = self.middleware.call_sync('update.get_scale_trains_data')
+        trains.update(**scale_trains['trains'])
 
         return {
             'trains': trains,


### PR DESCRIPTION
This reverts commit 8e741801255ad2938096d2c72d9d0352e61d999d.