### PR TITLE
NAS-116278 / 22.12 / Allow users to specify authorized networks for iscsi targets

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-06-12_17-50_iscsi_target_networks.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-06-12_17-50_iscsi_target_networks.py
@@ -1,0 +1,47 @@
+"""
+iSCSI Target authorized networks
+
+Revision ID: 34df1ca8a04e
+Revises: afa3965ed8fc
+Create Date: 2022-06-12 17:50:03.593598+00:00
+
+"""
+import json
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = '34df1ca8a04e'
+down_revision = 'afa3965ed8fc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_iscsitarget', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('iscsi_target_auth_networks', sa.TEXT(), nullable=False, server_default='[]'))
+
+    conn = op.get_bind()
+
+    target_groups = [dict(row) for row in conn.execute("SELECT * FROM services_iscsitargetgroups").fetchall()]
+    for target_group in target_groups:
+        initiator = dict(conn.execute(
+            "SELECT * FROM services_iscsitargetauthorizedinitiator WHERE id = ?",
+            [target_group['iscsi_target_initiatorgroup_id']]
+        ).first())
+
+
+        auth_network = initiator['iscsi_target_initiator_auth_network']
+
+        conn.execute("UPDATE services_iscsitarget SET iscsi_target_auth_networks = ? WHERE id = ?", (
+            json.dumps([] if auth_network == 'ALL' else auth_network.split()),
+            target_group['iscsi_target_id']
+        ))
+
+    with op.batch_alter_table('services_iscsitargetauthorizedinitiator', schema=None) as batch_op:
+        batch_op.drop_column('iscsi_target_initiator_auth_network')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/initiators.allow.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.allow.mako
@@ -1,0 +1,7 @@
+<%
+    base_name = middleware.call_sync('iscsi.global.config')['basename']
+    targets = middleware.call_sync('iscsi.target.query', [['auth_networks', '!=', []]])
+%>\
+% for target in targets:
+${base_name}:${target['name']} ${', '.join(targets['auth_networks'])}
+% endfor

--- a/src/middlewared/middlewared/etc_files/initiators.allow.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.allow.mako
@@ -3,5 +3,5 @@
     targets = middleware.call_sync('iscsi.target.query', [['auth_networks', '!=', []]])
 %>\
 % for target in targets:
-${base_name}:${target['name']} ${', '.join(targets['auth_networks'])}
+${base_name}:${target['name']} ${', '.join(target['auth_networks'])}
 % endfor

--- a/src/middlewared/middlewared/etc_files/initiators.deny.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.deny.mako
@@ -1,0 +1,7 @@
+<%
+    base_name = middleware.call_sync('iscsi.global.config')['basename']
+    targets = middleware.call_sync('iscsi.target.query', [['auth_networks', '!=', []]])
+%>\
+% for target in targets:
+${base_name}:${target['name']} ALL
+% endfor

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -168,6 +168,10 @@ class EtcService(Service):
         'scst': [
             {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'}
         ],
+        'scst_targets': [
+            {'type': 'mako', 'path': 'initiators.allow', 'checkpoint': 'pool_import'},
+            {'type': 'mako', 'path': 'initiators.deny', 'checkpoint': 'pool_import'},
+        ],
         'webdav': {
             'ctx': [
                 {'method': 'sharing.webdav.query', 'args': [[('enabled', '=', True)]]},

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -19,7 +19,7 @@ class iSCSITargetModel(sa.Model):
     iscsi_target_name = sa.Column(sa.String(120), unique=True)
     iscsi_target_alias = sa.Column(sa.String(120), nullable=True, unique=True)
     iscsi_target_mode = sa.Column(sa.String(20), default='iscsi')
-    iscsi_target_auth_networks = sa.Column(sa.JSON(), default=[])
+    iscsi_target_auth_networks = sa.Column(sa.JSON(type=list))
 
 
 class iSCSITargetGroupModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -3,7 +3,7 @@ import re
 
 import middlewared.sqlalchemy as sa
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Str
+from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Patch, Str
 from middlewared.service import CallError, CRUDService, private, ValidationErrors
 from middlewared.utils import run
 
@@ -19,6 +19,7 @@ class iSCSITargetModel(sa.Model):
     iscsi_target_name = sa.Column(sa.String(120), unique=True)
     iscsi_target_alias = sa.Column(sa.String(120), nullable=True, unique=True)
     iscsi_target_mode = sa.Column(sa.String(20), default='iscsi')
+    iscsi_target_auth_networks = sa.Column(sa.JSON(), default=[])
 
 
 class iSCSITargetGroupModel(sa.Model):
@@ -88,6 +89,7 @@ class iSCSITargetService(CRUDService):
                 Int('auth', default=None, null=True),
             ),
         ]),
+        List('auth_networks', items=[IPAddr('ip', network=True)]),
         register=True
     ))
     async def do_create(self, data):
@@ -97,6 +99,9 @@ class iSCSITargetService(CRUDService):
         `groups` is a list of group dictionaries which provide information related to using a `portal`, `initiator`,
         `authmethod` and `auth` with this target. `auth` represents a valid iSCSI Authorized Access and defaults to
         null.
+
+        `auth_networks` is a list of IP/CIDR addresses which are allowed to use this initiator. If all networks are
+        to be allowed, this field should be left empty.
         """
         verrors = ValidationErrors()
         await self.__validate(verrors, data, 'iscsi_target_create')

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -7,7 +7,7 @@ class ISCSITargetService(SimpleService):
     name = "iscsitarget"
     reloadable = True
 
-    etc = ["scst"]
+    etc = ["scst", "scst_targets"]
 
     systemd_unit = "scst"
 


### PR DESCRIPTION
This PR adds changes allowing users to specify authorized networks which will be authorized to access a certain target.
Earlier we used to have this in initiator level where with initiator + auth networks, we could manage this with targets but scst does not offer us that and we can only allow/deny connections at target level.