### PR TITLE
NAS-116559 / 22.02.3 / Add help text for application names regex (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -4,6 +4,7 @@ import errno
 import itertools
 import os
 import shutil
+import textwrap
 
 from pkg_resources import parse_version
 
@@ -354,7 +355,20 @@ class ChartReleaseService(CRUDService):
             Dict('values', additional_attrs=True),
             Str('catalog', required=True),
             Str('item', required=True),
-            Str('release_name', required=True, validators=[Match(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')]),
+            Str(
+                'release_name', required=True, validators=[Match(
+                    r'^[a-z]([-a-z0-9]*[a-z0-9])?$',
+                    explanation=textwrap.dedent(
+                        '''
+                        Application name must have the following:
+                        1) Lowercase alphanumeric characters can be specified
+                        2) Name must start with an alphabetic character and can end with alphanumeric character
+                        3) Hyphen '-' is allowed but not as the first or last character
+                        e.g abc123, abc, abcd-1232
+                        '''
+                    )
+                )]
+            ),
             Str('train', default='charts'),
             Str('version', default='latest'),
         )


### PR DESCRIPTION
## Problem

Right now invalid application name fails with reporting valid regex to the user however that is not helpful.

## Solution

Add an explanation as to what is allowed and not allowed so user has a better idea of what he can use for app name.

Original PR: https://github.com/truenas/middleware/pull/9204
Jira URL: https://jira.ixsystems.com/browse/NAS-116559