### PR TITLE
NAS-116667 / 13.0 / Load hpt27xx, hptnr and hptrr modules on boot.

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -32,6 +32,9 @@ openzfs_load="YES"
 if_atlantic_load="YES"
 if_bnxt_load="YES"
 if_qlxgbe_load="YES"
+if_hpt27xx_load="YES"
+if_hptnr_load="YES"
+if_hptrr_load="YES"
 
 # Load vendor's Realtek NIC driver, supporting 2.5G Realtek RTL8125.
 if_re_load="YES"


### PR DESCRIPTION
There is a chance those are still used.

Ticket:	NAS-116667