### PR TITLE
NAS-116704 / 22.02.3 / Fix debug size (by themylogin)

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -61,6 +61,34 @@ truncate_files ()
 	local IFS='
 	'
 
+	for file in $(find $dir/log -type f -name '*.gz' -print) ; do
+		size=$(stat -c%s "$file")
+		if [ "$size" -lt "1000000" ]; then
+			continue
+		fi
+		tmpfile="$(env TMPDIR="${tmpdir}" mktemp /tmp/XXXXXX)"
+		cat "$file" | gunzip | tail -c $limit - > "$tmpfile" 2>/dev/null
+		if [ $? = 0 ] ; then
+			gzip "$tmpfile"
+			mv "$tmpfile".gz "$file"
+		else
+			rm "$tmpfile"
+		fi
+	done
+	for file in $(find $dir/log -type f -name '*.bz2' -print) ; do
+		size=$(stat -c%s "$file")
+		if [ "$size" -lt "1000000" ]; then
+			continue
+		fi
+		tmpfile="$(env TMPDIR="${tmpdir}" mktemp /tmp/XXXXXX)"
+		cat "$file" | bunzip2 | tail -c $limit - > "$tmpfile" 2>/dev/null
+		if [ $? = 0 ] ; then
+			bzip2 "$tmpfile"
+			mv "$tmpfile".gz "$file"
+		else
+			rm "$tmpfile"
+		fi
+	done
 	for file in $(find $dir -type f -a \
 		! -name '*.tar' -a \
 		! -name '*.tar.gz' -a \
@@ -75,7 +103,7 @@ truncate_files ()
 		! -name 'dump.txt' -a \
 		! -name '*.compressed' -print) ; do
 		tmpfile="$(env TMPDIR="${tmpdir}" mktemp /tmp/XXXXXX)"
-		tail -n $limit "$file" > "$tmpfile" 2>/dev/null
+		tail -c $limit "$file" > "$tmpfile" 2>/dev/null
 		if [ $? = 0 ] ; then
 			mv "$tmpfile" "$file"
 		else
@@ -94,7 +122,7 @@ fi
 has_ticket_info=false
 dont_delete=false
 print=false
-limit=10000
+limit=10000000
 
 while getopts "Fd:psl:" opt ; do
 	case "${opt}" in


### PR DESCRIPTION
1) Truncate uncompressed log files by bytes count, not by lines count.
2) Increase bytes count limit (middleware logs are often truncated to a too short size)
3) Also truncate compressed log files

Some guy had a 380M debug, most of it were OOM-killer stack traces happening every 5 seconds or so, gzipped into kern.log.

Original PR: https://github.com/truenas/middleware/pull/9208
Jira URL: https://jira.ixsystems.com/browse/NAS-116704