### PR TITLE
NAS-116701 / 22.02.3 / NAS-116701 / Fix VM Raw file support (by dberlin)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -27,7 +27,7 @@ class StorageDevice(Device):
             'disk', type=self.TYPE, device='disk', attribute_dict={
                 'children': [
                     create_element('driver', name='qemu', type='raw', cache='none'),
-                    create_element('source', dev=self.data['attributes']['path']),
+                    self.create_source_element(),
                     create_element(
                         'target', bus='sata' if not virtio else 'virtio',
                         dev=f'{"vd" if virtio else "sd"}{disk_from_number(disk_number)}'
@@ -41,7 +41,8 @@ class StorageDevice(Device):
                 ]
             }
         )
-
+    def create_source_element(self):
+        raise NotImplementedError
 
 class RAW(StorageDevice):
 
@@ -59,6 +60,8 @@ class RAW(StorageDevice):
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
     )
+    def create_source_element(self):
+        return create_element('source', file=self.data['attributes']['path'])
 
 
 class DISK(StorageDevice):
@@ -75,3 +78,5 @@ class DISK(StorageDevice):
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
     )
+    def create_source_element(self):
+        return create_element('source', dev=self.data['attributes']['path'])

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -41,8 +41,10 @@ class StorageDevice(Device):
                 ]
             }
         )
+
     def create_source_element(self):
         raise NotImplementedError
+
 
 class RAW(StorageDevice):
 
@@ -60,6 +62,7 @@ class RAW(StorageDevice):
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
     )
+
     def create_source_element(self):
         return create_element('source', file=self.data['attributes']['path'])
 
@@ -78,5 +81,6 @@ class DISK(StorageDevice):
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
     )
+
     def create_source_element(self):
         return create_element('source', dev=self.data['attributes']['path'])


### PR DESCRIPTION
RAW file support is broken because it creates a domain XML element with the
wrong attribute (dev rather than file). This fixes it to create the correct
XML element.


Original PR: https://github.com/truenas/middleware/pull/9206
Jira URL: https://jira.ixsystems.com/browse/NAS-116701