### PR TITLE
Add (cli-only) support for switching io type for VM storage devices

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -86,4 +86,5 @@ class DISK(StorageDevice):
     )
 
     def create_source_element(self):
+        iotype = self.data['attributes']['iotype']
         return create_element('source', dev=self.data['attributes']['path'], io=iotype.lower())

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -22,11 +22,12 @@ class StorageDevice(Device):
         virtio = self.data['attributes']['type'] == 'VIRTIO'
         logical_sectorsize = self.data['attributes']['logical_sectorsize']
         physical_sectorsize = self.data['attributes']['physical_sectorsize']
+        iotype = self.data['attributes']['iotype']
 
         return create_element(
             'disk', type=self.TYPE, device='disk', attribute_dict={
                 'children': [
-                    create_element('driver', name='qemu', type='raw', cache='none'),
+                    create_element('driver', name='qemu', type='raw', cache='none', io=iotype),
                     self.create_source_element(),
                     create_element(
                         'target', bus='sata' if not virtio else 'virtio',
@@ -61,6 +62,7 @@ class RAW(StorageDevice):
         Int('size', default=None, null=True),
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
+        Str('iotype', enum=['native', 'threads', 'io_uring'], default='native'),
     )
 
     def create_source_element(self):
@@ -80,6 +82,7 @@ class DISK(StorageDevice):
         Int('zvol_volsize'),
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
+        Str('iotype', enum=['native', 'threads', 'io_uring'], default='native'),
     )
 
     def create_source_element(self):

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -27,7 +27,7 @@ class StorageDevice(Device):
         return create_element(
             'disk', type=self.TYPE, device='disk', attribute_dict={
                 'children': [
-                    create_element('driver', name='qemu', type='raw', cache='none', io=iotype),
+                    create_element('driver', name='qemu', type='raw', cache='none', io=iotype.lower()),
                     self.create_source_element(),
                     create_element(
                         'target', bus='sata' if not virtio else 'virtio',
@@ -62,7 +62,7 @@ class RAW(StorageDevice):
         Int('size', default=None, null=True),
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
-        Str('iotype', enum=['native', 'threads', 'io_uring'], default='native'),
+        Str('iotype', enum=['NATIVE', 'THREADS', 'IO_URING'], default='NATIVE'),
     )
 
     def create_source_element(self):
@@ -82,8 +82,8 @@ class DISK(StorageDevice):
         Int('zvol_volsize'),
         Int('logical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
-        Str('iotype', enum=['native', 'threads', 'io_uring'], default='native'),
+        Str('iotype', enum=['NATIVE', 'THREADS', 'IO_URING'], default='NATIVE'),
     )
 
     def create_source_element(self):
-        return create_element('source', dev=self.data['attributes']['path'])
+        return create_element('source', dev=self.data['attributes']['path'], io=iotype.lower())


### PR DESCRIPTION
QEMU supports a number of io types for storage devices some of which can have very significant affect on performance. 
For example, io_uring is *much* faster in practice and overhead for my windows guests, both on files and zvols (particularly on zvols).  My guests get io_uring gets 2x the throughput on 4k random reads regardless of queue depth or thread settings.

This commit simply enables one to set the io type, it does not attempt to change the default.



