### PR TITLE
Sort timezones when displaying them in app questions

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
@@ -42,7 +42,7 @@ def normalise_question(question: dict, version_data: dict, context: dict) -> Non
             ]
         elif ref == 'definitions/timezone':
             data.update({
-                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in context['timezones']],
+                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in sorted(context['timezones'])],
                 'default': context['system.general.config']['timezone']
             })
         elif ref == 'definitions/nodeIP':


### PR DESCRIPTION
## Context

It was requested by user that the timezones being shown when installing apps should be ordered.