### PR TITLE
NAS-116723 / 22.02.3 / Disk/partition sizes are always expressed in blocks of 512 bytes (by themylogin) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -1,8 +1,7 @@
-import os
-import pyudev
 import re
 
 import libsgio
+import pyudev
 
 from middlewared.schema import Dict, returns
 from middlewared.service import accepts, private, Service
@@ -94,8 +93,8 @@ class DeviceService(Service):
         sectorsize = self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True)
 
         size = mediasize = None
-        if blocks and sectorsize:
-            size = mediasize = blocks * sectorsize
+        if blocks:
+            size = mediasize = blocks * 512
 
         disk = {
             'name': dev.sys_name,
@@ -176,21 +175,6 @@ class DeviceService(Service):
             return
 
         return str(rotation_rate)
-
-    @private
-    def logical_sector_size(self, name):
-        path = os.path.join('/sys/block', name, 'queue/logical_block_size')
-        if os.path.exists(path):
-            with open(path, 'r') as f:
-                size = f.read().strip()
-            if not size.isdigit():
-                self.logger.error(
-                    'Unable to retrieve %r disk logical block size: malformed value %r found', name, size
-                )
-            else:
-                return int(size)
-        else:
-            self.logger.error('Unable to retrieve %r disk logical block size at %r', name, path)
 
     @private
     def get_storage_devices_topology(self):


### PR DESCRIPTION
4k disks on r50b-2.dc1 were reporting 8x larger size.

Original PR: https://github.com/truenas/middleware/pull/9219
Jira URL: https://jira.ixsystems.com/browse/NAS-116723

Original PR: https://github.com/truenas/middleware/pull/9221
Jira URL: https://jira.ixsystems.com/browse/NAS-116723