### PR TITLE
NAS-116547 / 22.02.3 / Sort timezones when displaying them in app questions (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/questions_utils.py
@@ -42,7 +42,7 @@ def normalise_question(question: dict, version_data: dict, context: dict) -> Non
             ]
         elif ref == 'definitions/timezone':
             data.update({
-                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in context['timezones']],
+                'enum': [{'value': t, 'description': f'{t!r} timezone'} for t in sorted(context['timezones'])],
                 'default': context['system.general.config']['timezone']
             })
         elif ref == 'definitions/nodeIP':


### PR DESCRIPTION
## Context

It was requested by user that the timezones being shown when installing apps should be ordered.

Original PR: https://github.com/truenas/middleware/pull/9220
Jira URL: https://jira.ixsystems.com/browse/NAS-116547