### PR TITLE
NAS-116683 / 22.02.3 / Add new helper function to convert mountinfo to dict (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -103,12 +103,13 @@
                if not line.strip() or line.startswith('#'):
                    continue
 
-               ds_name = middleware.call_sync(
-                   'zfs.dataset.path_to_dataset',
-                   line.rsplit(" ", 1)[0]
-               )
-               if ds_name is None:
-                   middleware.logger.warning("%s: dataset lookup failed", line)
+               try:
+                   ds_name = middleware.call_sync(
+                       'zfs.dataset.path_to_dataset',
+                       line.rsplit(" ", 1)[0]
+                   )
+               except Exception:
+                   middleware.logger.warning("%s: dataset lookup failed", line, exc_info=True)
                    continue
 
                datasets.append(ds_name)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3710,10 +3710,7 @@ class PoolDatasetService(CRUDService):
                     p = parent
                     break
 
-        ds_name = await self.middleware.call("zfs.dataset.path_to_dataset", p.as_posix())
-        if not ds_name:
-            raise CallError(f"Failed to convert path [{path}] to ZFS dataset.", errno.ENOENT)
-
+        ds_name = await self.middleware.call("zfs.dataset.path_to_dataset", p.as_posix(), True)
         return await self.middleware.call(
             "pool.dataset.query",
             [("id", "=", ds_name)],

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -17,8 +17,10 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
         if not s3_config['storage_path'] or not os.path.exists(s3_config['storage_path']):
             return []
 
-        s3_ds = await self.middleware.call('zfs.dataset.path_to_dataset', s3_config['storage_path'])
-        if s3_ds is None:
+        try:
+            s3_ds = await self.middleware.call('zfs.dataset.path_to_dataset', s3_config['storage_path'])
+        except Exception:
+            self.logger.warning('%s: failed to look up dataset', s3_config['storage_path'], exc_info=True)
             return []
 
         if is_child(os.path.join('/mnt', s3_ds), path):

--- a/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
@@ -1,0 +1,106 @@
+from middlewared.utils.osc.linux.mount import __parse_mntent
+
+
+fake_mntinfo = r"""21 26 0:19 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
+22 26 0:20 / /proc rw,nosuid,nodev,noexec,relatime shared:12 - proc proc rw
+23 26 0:5 / /dev rw,nosuid,relatime shared:2 - devtmpfs udev rw,size=1841320k,nr_inodes=460330,mode=755,inode64
+24 23 0:21 / /dev/pts rw,nosuid,noexec,relatime shared:3 - devpts devpts rw,gid=5,mode=620,ptmxmode=000
+25 26 0:22 / /run rw,nosuid,nodev,noexec,relatime shared:5 - tmpfs tmpfs rw,size=402344k,mode=755,inode64
+26 1 0:23 / / rw,relatime shared:1 - zfs boot-pool/ROOT/22.12-MASTER-20220616-071633 rw,xattr,noacl
+27 21 0:6 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:8 - securityfs securityfs rw
+28 23 0:24 / /dev/shm rw,nosuid,nodev shared:4 - tmpfs tmpfs rw,inode64
+29 25 0:25 / /run/lock rw,nosuid,nodev,noexec,relatime shared:6 - tmpfs tmpfs rw,size=5120k,inode64
+30 21 0:26 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:9 - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot
+31 21 0:27 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:10 - pstore pstore rw
+32 21 0:28 / /sys/fs/bpf rw,nosuid,nodev,noexec,relatime shared:11 - bpf bpf rw,mode=700
+33 22 0:29 / /proc/sys/fs/binfmt_misc rw,relatime shared:13 - autofs systemd-1 rw,fd=30,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=12795
+34 23 0:30 / /dev/hugepages rw,relatime shared:14 - hugetlbfs hugetlbfs rw,pagesize=2M
+35 23 0:18 / /dev/mqueue rw,nosuid,nodev,noexec,relatime shared:15 - mqueue mqueue rw
+36 21 0:7 / /sys/kernel/debug rw,nosuid,nodev,noexec,relatime shared:16 - debugfs debugfs rw
+37 21 0:12 / /sys/kernel/tracing rw,nosuid,nodev,noexec,relatime shared:17 - tracefs tracefs rw
+38 26 0:31 / /tmp rw,nosuid,nodev shared:18 - tmpfs tmpfs rw,inode64
+39 25 0:32 / /run/rpc_pipefs rw,relatime shared:19 - rpc_pipefs sunrpc rw
+40 22 0:33 / /proc/fs/nfsd rw,relatime shared:20 - nfsd nfsd rw
+41 21 0:34 / /sys/fs/fuse/connections rw,nosuid,nodev,noexec,relatime shared:21 - fusectl fusectl rw
+42 21 0:35 / /sys/kernel/config rw,nosuid,nodev,noexec,relatime shared:22 - configfs configfs rw
+279 33 0:49 / /proc/sys/fs/binfmt_misc rw,nosuid,nodev,noexec,relatime shared:154 - binfmt_misc binfmt_misc rw
+285 26 0:50 / /boot/grub rw,relatime shared:157 - zfs boot-pool/grub rw,xattr,noacl
+292 26 0:51 / /mnt/dozer rw,noatime shared:161 - zfs dozer rw,xattr,posixacl
+355 292 0:62 / /mnt/dozer/posixacltest rw,noatime shared:197 - zfs dozer/posixacltest rw,xattr,posixacl
+397 355 0:66 / /mnt/dozer/posixacltest/foo rw,noatime shared:221 - zfs dozer/posixacltest/foo rw,xattr,posixacl
+334 292 0:59 / /mnt/dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rw,noatime shared:185 - zfs dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa rw,xattr,posixacl
+383 334 0:65 / /mnt/dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb rw,noatime shared:213 - zfs dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb rw,xattr,posixacl
+418 383 0:69 / /mnt/dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/cccccccccccccccccccccccccccccccccccccccccccccc rw,noatime shared:233 - zfs dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/cccccccccccccccccccccccccccccccccccccccccccccc rw,xattr,posixacl
+439 334 0:72 / /mnt/dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/fdd rw,noatime shared:245 - zfs dozer/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/fdd rw,xattr,posixacl
+313 292 0:54 / /mnt/dozer/RO ro,nosuid,noexec,noatime shared:173 - zfs dozer/RO ro,xattr,posixacl
+320 292 0:57 / /mnt/dozer/TESTSMB rw,noatime shared:177 - zfs dozer/TESTSMB rw,xattr,nfs4acl
+299 292 0:52 / /mnt/dozer/NFS4 rw shared:165 - zfs dozer/NFS4 rw,xattr,nfs4acl
+411 299 0:67 / /mnt/dozer/NFS4/stuff rw shared:229 - zfs dozer/NFS4/stuff rw,xattr,nfs4acl
+390 292 0:64 / /mnt/dozer/test_homes rw,noatime shared:217 - zfs dozer/test_homes rw,xattr,nfs4acl
+341 292 0:55 / /mnt/dozer/SMB rw,noatime shared:189 - zfs dozer/SMB rw,xattr,nfs4acl
+425 341 0:70 / /mnt/dozer/SMB/SUBDATASET rw,noatime shared:237 - zfs dozer/SMB/SUBDATASET rw,xattr,nfs4acl
+348 292 0:58 / /mnt/dozer/TESTNFS rw,noatime shared:193 - zfs dozer/TESTNFS rw,xattr,posixacl
+376 292 0:63 / /mnt/dozer/smb-vss rw,noatime shared:209 - zfs dozer/smb-vss rw,xattr,nfs4acl
+432 376 0:71 / /mnt/dozer/smb-vss/sub1 rw,noatime shared:241 - zfs dozer/smb-vss/sub1 rw,xattr,nfs4acl
+327 292 0:56 / /mnt/dozer/TESTFUN rw,noatime shared:181 - zfs dozer/TESTFUN rw,xattr,noacl
+369 292 0:61 / /mnt/dozer/administrative_share rw,noatime shared:205 - zfs dozer/administrative_share rw,xattr,posixacl
+404 369 0:68 / /mnt/dozer/administrative_share/backups_dataset rw,noatime shared:225 - zfs dozer/administrative_share/backups_dataset rw,xattr,posixacl
+446 404 0:73 / /mnt/dozer/administrative_share/backups_dataset/userdata rw,noatime shared:249 - zfs dozer/administrative_share/backups_dataset/userdata rw,xattr,posixacl
+453 446 0:74 / /mnt/dozer/administrative_share/backups_dataset/userdata/DOMAIN_GOAT rw,noatime shared:253 - zfs dozer/administrative_share/backups_dataset/userdata/DOMAIN_GOAT rw,xattr,posixacl
+460 453 0:75 / /mnt/dozer/administrative_share/backups_dataset/userdata/DOMAIN_GOAT/bob rw,noatime shared:257 - zfs dozer/administrative_share/backups_dataset/userdata/DOMAIN_GOAT/bob rw,xattr,posixacl
+306 292 0:53 / /mnt/dozer/EXPORT rw,noatime shared:169 - zfs dozer/EXPORT rw,xattr,posixacl
+362 292 0:60 / /mnt/dozer/noacl rw,noatime shared:201 - zfs dozer/noacl rw,xattr,noacl
+93 26 0:38 / /var/db/system rw,relatime shared:48 - zfs dozer/.system rw,xattr,noacl
+100 93 0:39 / /var/db/system/cores rw,relatime shared:52 - zfs dozer/.system/cores rw,xattr,noacl
+107 93 0:40 / /var/db/system/samba4 rw,relatime shared:56 - zfs dozer/.system/samba4 rw,xattr,noacl
+114 93 0:41 / /var/db/system/syslog-f803551cf3cd4df8a1ddb0569466b72a rw,relatime shared:60 - zfs dozer/.system/syslog-f803551cf3cd4df8a1ddb0569466b72a rw,xattr,noacl
+121 93 0:42 / /var/db/system/rrd-f803551cf3cd4df8a1ddb0569466b72a rw,relatime shared:64 - zfs dozer/.system/rrd-f803551cf3cd4df8a1ddb0569466b72a rw,xattr,noacl
+151 93 0:43 / /var/db/system/configs-f803551cf3cd4df8a1ddb0569466b72a rw,relatime shared:68 - zfs dozer/.system/configs-f803551cf3cd4df8a1ddb0569466b72a rw,xattr,noacl
+158 93 0:44 / /var/db/system/webui rw,relatime shared:100 - zfs dozer/.system/webui rw,xattr,noacl
+187 93 0:45 / /var/db/system/services rw,relatime shared:104 - zfs dozer/.system/services rw,xattr,noacl
+234 93 0:46 / /var/db/system/glusterd rw,relatime shared:143 - zfs dozer/.system/glusterd rw,xattr,noacl
+241 93 0:47 / /var/db/system/ctdb_shared_vol rw,relatime shared:147 - zfs dozer/.system/ctdb_shared_vol rw,xattr,noacl
+271 26 0:39 / /var/lib/systemd/coredump rw,relatime shared:52 - zfs dozer/.system/cores rw,xattr,noacl
+467 26 0:76 / /mnt/tank\040space\040 rw,noatime shared:261 - zfs tank\040space\040 rw,xattr,posixacl
+474 467 0:77 / /mnt/tank\040space\040/Dataset\040With\040a\040space rw,noatime shared:265 - zfs tank\040space\040/Dataset\040With\040a\040space rw,xattr,posixacl
+"""
+
+
+def test__mntinfo_spaces():
+    line = r'474 467 0:77 / /mnt/tank\040space\040/Dataset\040With\040a\040space rw,noatime shared:265 - zfs tank\040space\040/Dataset\040With\040a\040space rw,xattr,posixacl'
+    data = {}
+    __parse_mntent(line, data)
+    assert 77 in data
+    mntent = data[77]
+    assert mntent['mount_id'] == 474
+    assert mntent['parent_id'] == 467
+    assert mntent['device_id'] == {'major': 0, 'minor': 77, 'dev_t': 77}
+    assert mntent['root'] == '/'
+    assert mntent['mountpoint'] == '/mnt/tank space /Dataset With a space'
+    assert mntent['mount_opts'] == ['RW', 'NOATIME']
+    assert mntent['fs_type'] == 'zfs'
+    assert mntent['mount_source'] == 'tank space /Dataset With a space'
+    assert mntent['super_opts'] == ['RW', 'XATTR', 'POSIXACL']
+
+
+def test__getmntinfo():
+    def __rebuild_device_info(e):
+        return f'{e["mount_id"]} {e["parent_id"]} {e["device_id"]["major"]}:{e["device_id"]["minor"]} {e["root"]}'
+
+    def __rebuild_opts(e):
+        mnt_opts = ','.join([x.lower() for x in e['mount_opts']])
+        sb_opts = ','.join([x.lower() for x in e['super_opts']])
+        return mnt_opts, sb_opts
+
+    for line in fake_mntinfo.splitlines():
+        data = {}
+        __parse_mntent(line, data)
+
+        mnt_data = list(data.values())[0]
+        assert __rebuild_device_info(mnt_data) in line
+        for opt in __rebuild_opts(mnt_data):
+            assert opt.casefold() in line.casefold()
+
+        assert mnt_data['mountpoint'] in line.replace('\\040', ' ')
+        assert mnt_data['mount_source'] in line.replace('\\040', ' ')
+        assert mnt_data['fs_type'] in line

--- a/src/middlewared/middlewared/utils/osc/linux/__init__.py
+++ b/src/middlewared/middlewared/utils/osc/linux/__init__.py
@@ -3,3 +3,4 @@ from .multiprocessing import *  # noqa
 from .os import *  # noqa
 from .system import *  # noqa
 from .user_context import *  # noqa
+from .mount import * # noqa

--- a/src/middlewared/middlewared/utils/osc/linux/mount.py
+++ b/src/middlewared/middlewared/utils/osc/linux/mount.py
@@ -1,0 +1,56 @@
+# -*- coding=utf-8 -*-
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["getmntinfo"]
+
+
+def __parse_mntent(line, out_dict):
+    mnt_id, parent_id, maj_min, root, mp, opts, extra = line.split(" ", 6)
+    fstype, mnt_src, super_opts = extra.split(' - ')[1].split()
+
+    major, minor = maj_min.split(':')
+    devid = os.makedev(int(major), int(minor))
+    out_dict.update({devid: {
+        'mount_id': int(mnt_id),
+        'parent_id': int(parent_id),
+        'device_id': {
+            'major': int(major),
+            'minor': int(minor),
+            'dev_t': devid,
+        },
+        'root': root.replace('\\040', ' '),
+        'mountpoint': mp.replace('\\040', ' '),
+        'mount_opts': opts.upper().split(','),
+        'fs_type': fstype,
+        'mount_source': mnt_src.replace('\\040', ' '),
+        'super_opts': super_opts.upper().split(','),
+    }})
+
+
+def getmntinfo(dev_id=None):
+    """
+    Get mount information. returns dictionary indexed by dev_t.
+    User can optionally specify dev_t for faster lookup of single
+    device.
+    """
+    if dev_id:
+        maj_min = f'{os.major(dev_id)}:{os.minor(dev_id)}'
+    else:
+        maj_min = None
+
+    out = {}
+    with open('/proc/self/mountinfo') as f:
+        for line in f:
+            if maj_min:
+                if line.find(maj_min) == -1:
+                    continue
+
+                __parse_mntent(line, out)
+                break
+
+            __parse_mntent(line, out)
+
+    return out

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job
+from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job, make_ws_request
 from auto_config import ip, pool_name, user, password
 from auto_config import dev_test
 # comment pytestmark for development testing with --dev-test
@@ -306,7 +306,7 @@ def test_29_verify_the_id_zvol_does_not_exist(request):
 
 
 @pytest.mark.parametrize("create_dst", [True, False])
-def test_28_delete_dataset_with_receive_resume_token(request, create_dst):
+def test_30_delete_dataset_with_receive_resume_token(request, create_dst):
     depends(request, ["pool_04", "ssh_password"], scope="session")
     result = POST('/pool/dataset/', {'name': f'{pool_name}/src'})
     assert result.status_code == 200, result.text
@@ -333,3 +333,24 @@ def test_28_delete_dataset_with_receive_resume_token(request, create_dst):
             'recursive': True,
         })
         assert result.status_code == 200, result.text
+
+
+def test_31_path_to_dataset(request):
+    """
+    This test is to check results of private method to convert
+    a path to a dataset name. Return is expected to be None if the
+    path points to the boot pool.
+    """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
+
+    get_payload = {'msg': 'method', 'method': 'zfs.dataset.path_to_dataset', 'params': []}
+    get_payload['params'] = [f'/mnt/{pool_name}']
+
+    res = make_ws_request(ip, get_payload)
+    assert res.get('error') is None, res['error']
+    assert res['result'] == pool_name, res
+
+    get_payload['params'] = ['/mnt']
+    res = make_ws_request(ip, get_payload)
+    assert 'error' in res
+    assert 'path is on boot pool' in res['error']['reason']


### PR DESCRIPTION
We were using libzfs to convert paths to dataset name. Internally
libzfs does this thorugh stat() on the path and looking up
mount entries. We can instead do this ourselves without having
to use a libzfs handle.

To facilitate this add a new general-purpose method to return
a dict containing mount information indexed by devid. The
reason to index this way is because it allows efficient lookup
of an entry based on stat / lstat output. Refactor
filesystem.statvfs to use this as well.

Original PR: https://github.com/truenas/middleware/pull/9200
Jira URL: https://jira.ixsystems.com/browse/NAS-116683