### PR TITLE
Add stimer enlightenment to bring windows idle time to something reasonable

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
@@ -328,6 +328,7 @@ class VMSupervisorBase(LibvirtConnectionMixin):
                     create_element('synic', state='on'),
                     create_element('ipi', state='on'),
                     create_element('tlbflush', state='on'),
+                    create_element('stimer', state='on')
                 ],
             }
         )


### PR DESCRIPTION
This patch is necessary to achieve low CPU usage during windows idle time.
It enables the stimer enlightenment
Otherwise it will idle *very* high (50+% CPU, *per CPU assigned*).
So on a 32 core windows VM, it will often idle in the 1000-1200% CPU range.
This is documented to be the case and this enlightenment is documented to fix
it.
The short version why it does:
Windows polls some of the emulated timers *very* aggressively.
They are *very* slow.
stimer enlightenment gives it a very fast timer to use instead.
