### PR TITLE
NAS-116680 / 22.12 / Fix validation error for naming schema

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -62,7 +62,7 @@ class ChartReleaseService(Service):
                 question=questions[key],
                 parent_attr=dict_obj,
                 var_attr=dict_obj.attrs[key],
-                schema_name=schema_name,
+                schema_name=f'{schema_name}.{questions[key]["variable"]}',
                 release_data=release_data,
             )
 
@@ -71,9 +71,10 @@ class ChartReleaseService(Service):
         return dict_obj
 
     @private
-    async def validate_question(self, verrors, parent_value, value, question, parent_attr, var_attr, schema_name, release_data=None):
+    async def validate_question(
+        self, verrors, parent_value, value, question, parent_attr, var_attr, schema_name, release_data=None
+    ):
         schema = question['schema']
-        schema_name = f'{schema_name}.{question["variable"]}'
 
         if schema['type'] == 'dict' and value:
             dict_attrs = {v['variable']: v for v in schema['attrs']}

--- a/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
@@ -1,0 +1,52 @@
+import pytest
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.pytest.unit.helpers import load_compound_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+ChartReleaseService = load_compound_service('chart.release')
+
+schema_variables = ['appVolumeMounts', 'transcode', 'hostPath']
+QUESTION_DATA = {
+    'schema': {
+        'questions': [{
+            'variable': 'appVolumeMounts',
+            'schema': {
+                'type': 'dict',
+                'attrs': [{
+                    'variable': 'transcode',
+                    'schema': {
+                        'type': 'dict',
+                        'attrs': [{
+                            'variable': 'hostPath',
+                            'schema': {
+                                'type': 'hostpath',
+                                'required': True,
+                                '$ref': [
+                                    'validations/lockedHostPath'
+                                ],
+                            }
+                        }]
+                    }
+                }]
+            }
+        }]
+    }
+}
+
+values = {'appVolumeMounts': {'transcode': {'hostPath': '/mnt/evo'}}}
+
+
+@pytest.mark.asyncio
+async def test_create_schema_formation():
+    m = Middleware()
+    chart_release_svc = ChartReleaseService(m)
+
+    m['chart.release.validate_locked_host_path'] = chart_release_svc.validate_locked_host_path
+    m['pool.dataset.path_in_locked_datasets'] = lambda *args: True
+
+    with pytest.raises(ValidationErrors) as verrors:
+        await chart_release_svc.validate_values(QUESTION_DATA, values, False)
+
+    assert 'chart_release_create.appVolumeMounts.transcode.hostPath' in verrors.value


### PR DESCRIPTION
## Problem

We were not making up the error schema correctly when validating chart release values.

## Solution

Fix the issue to correctly make up naming schema for validation errors and add a unit test.