### PR TITLE
NAS-116332 / 22.12 / Don't allow putting files on locked paths

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -460,8 +460,11 @@ class FilesystemService(Service):
         else:
             openmode = 'wb+'
 
-        with open(path, openmode) as f:
-            await self.middleware.run_in_thread(shutil.copyfileobj, job.pipes.input.r, f)
+        try:
+            with open(path, openmode) as f:
+                await self.middleware.run_in_thread(shutil.copyfileobj, job.pipes.input.r, f)
+        except PermissionError:
+            raise CallError(f'Unable to put contents at {path!r} as the path exists on a locked dataset', errno.EINVAL)
 
         mode = options.get('mode')
         if mode:

--- a/tests/api2/test_filesystem__put.py
+++ b/tests/api2/test_filesystem__put.py
@@ -1,0 +1,59 @@
+import json
+import os
+import sys
+import tempfile
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import wait_on_job, POST
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+
+def upload_file(file_path, file_path_on_tn):
+    data = {'method': 'filesystem.put', 'params': [file_path_on_tn]}
+    with open(file_path, 'rb') as f:
+        response = POST(
+            '/_upload/',
+            files={'data': json.dumps(data), 'file': f},
+            use_ip_only=True,
+            force_new_headers=True,
+        )
+
+    job_id = json.loads(response.text)['job_id']
+    return wait_on_job(job_id, 300)
+
+
+def file_exists(file_path):
+    return any(
+        entry for entry in call('filesystem.listdir', os.path.dirname(file_path))
+        if entry['name'] == os.path.basename(file_path) and entry['type'] == 'FILE'
+    )
+
+
+def test_put_file():
+    upload_file_impl(False)
+
+
+def test_put_file_in_locked_dataset():
+    upload_file_impl(True)
+
+
+def upload_file_impl(lock):
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        f.write('filesystem.put test')
+        f.flush()
+
+        with dataset(
+            'test_filesystem_put', data={
+                'encryption': True,
+                'inherit_encryption': False,
+                'encryption_options': {'passphrase': '12345678'}
+            },
+        ) as test_dataset:
+            if lock:
+                call('pool.dataset.lock', test_dataset, job=True)
+            file_path_on_tn = f'/mnt/{test_dataset}/testfile'
+            job_detail = upload_file(f.name,file_path_on_tn)
+            assert job_detail['results']['state'] == ('FAILED' if lock else 'SUCCESS')
+            assert file_exists(file_path_on_tn) is not lock

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -11,6 +11,7 @@ import websocket
 import uuid
 from subprocess import run, Popen, PIPE
 from time import sleep
+from urllib.parse import urlparse
 
 from auto_config import api_url, user, password
 
@@ -50,16 +51,23 @@ def GET(testpath, payload=None, controller_a=False, **optional):
 def POST(testpath, payload=None, controller_a=False, **optional):
     data = {} if payload is None else payload
     url = controller1_api_url if controller_a else api_url
+    if optional.get("use_ip_only"):
+        parsed = urlparse(url)
+        url = f"{parsed.scheme}://{parsed.netloc}"
     if optional.pop("anonymous", False):
         auth = None
     else:
         auth = authentication
+    files = optional.get("files")
+    headers = dict(({} if optional.get("force_new_headers") else header), **optional.get("headers", {}))
     if payload is None:
-        postit = requests.post(f'{url}{testpath}', headers=dict(header, **optional.get("headers", {})),
-                               auth=auth)
+        postit = requests.post(
+            f'{url}{testpath}', headers=headers, auth=auth, files=files)
     else:
-        postit = requests.post(f'{url}{testpath}', headers=dict(header, **optional.get("headers", {})),
-                               auth=auth, data=json.dumps(data))
+        postit = requests.post(
+            f'{url}{testpath}', headers=headers, auth=auth,
+            data=json.dumps(data), files=files
+        )
     return postit
 
 


### PR DESCRIPTION
## Problem

`filesystem.put` allows uploading files to locked paths.

## Solution

Validate that middleware does not allow uploading files to locked paths.