### PR TITLE
NAS-113663 / 22.12 / Make sure we open disk with exclusive flag set when wiping

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -11,7 +11,7 @@ class DiskService(Service):
 
     @private
     def _wipe(self, data):
-        with open(f'/dev/{data["dev"]}', 'wb') as f:
+        with open(os.open(f'/dev/{data["dev"]}', os.O_WRONLY | os.O_EXCL), 'wb') as f:
             size = os.lseek(f.fileno(), 0, os.SEEK_END)
             if size == 0:
                 # no size means nothing else will work


### PR DESCRIPTION
As recommended by OS team, we should open disk with O_EXCL flag when we intend to wipe it.