### PR TITLE
NAS-116812 / 22.12 / minor improvement to interface.sync

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -2,6 +2,7 @@ import glob
 
 from middlewared.plugins.interface.netif import netif
 from middlewared.service import Service
+from middlewared.utils.functools import cache
 
 
 ZSERIES_PCI_ID = 'PCI_ID=8086:10D3'
@@ -15,6 +16,7 @@ class InternalInterfaceService(Service):
         private = True
         namespace = 'failover.internal_interface'
 
+    @cache
     def detect(self):
         hardware = self.middleware.call_sync('failover.hardware')
         # Return BHYVE heartbeat interface

--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -10,4 +10,4 @@ class InterfaceService(Service):
 
     @private
     async def internal_interfaces(self):
-        return netif.INTERNAL_INTERFACES
+        return netif.INTERNAL_INTERFACES + await self.middleware.call('failover.internal_interface.detect')

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1523,11 +1523,7 @@ class InterfaceService(CRUDService):
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
-        internal_interfaces = await self.middleware.call('interface.internal_interfaces')
-        if await self.middleware.call('system.is_enterprise'):
-            internal_interfaces.extend(await self.middleware.call('failover.internal_interfaces') or [])
-        internal_interfaces = tuple(internal_interfaces)
-
+        internal_interfaces = tuple(await self.middleware.call('interface.internal_interfaces'))
         dhclient_aws = []
         for name, iface in await self.middleware.run_in_thread(lambda: list(netif.list_interfaces().items())):
             # Skip internal interfaces


### PR DESCRIPTION
3 minor improvements.

1. remove an unnecessary `system.is_enterprise` call
2. add `failover.internal_interface.detect` result to `interface.internal_interfaces`
3. cache the results of `failover.internal_interface.detect` since name of that interface doesn't change