### PR TITLE
NAS-116810 / 22.02.3 / Place mako module directory under /run (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/mako.py
+++ b/src/middlewared/middlewared/utils/mako.py
@@ -10,7 +10,7 @@ __all__ = ["get_template"]
 
 lookup = TemplateLookup(
     directories=[os.path.dirname(os.path.dirname(__file__))],
-    module_directory="/tmp/mako",
+    module_directory="/run/mako",
 )
 
 


### PR DESCRIPTION
We don't need to use /tmp for this purpose. Shifting to dedicated
/run directory will help avoid having other processes / manual user
intervention affect our mako directory.

Original PR: https://github.com/truenas/middleware/pull/9252
Jira URL: https://jira.ixsystems.com/browse/NAS-116810