### PR TITLE
NAS-116835 / 22.02.3 / add ipv6 flags to interfaces (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bits.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bits.py
@@ -1,49 +1,54 @@
-# -*- coding=utf-8 -*-
-import enum
-import logging
+from enum import IntEnum
 
-logger = logging.getLogger(__name__)
-
-__all__ = ["InterfaceCapability", "InterfaceFlags", "InterfaceLinkState", "NeighborDiscoveryFlags"]
+__all__ = ["InterfaceFlags", "InterfaceV6Flags", "InterfaceLinkState", "NeighborDiscoveryFlags"]
 
 
-class InterfaceCapability(enum.IntEnum):
-    pass
-
-
-class InterfaceFlags(enum.IntEnum):
+class InterfaceFlags(IntEnum):
     # include/uapi/linux/if.h
-
-    UP = 1 << 0
-    BROADCAST = 1 << 1
-    DEBUG = 1 << 2
-    LOOPBACK = 1 << 3
-    POINTOPOINT = 1 << 4
-    # DRV_RUNNING = defs.IFF_DRV_RUNNING
-    NOARP = 1 << 7
-    PROMISC = 1 << 8
-    ALLMULTI = 1 << 9
-    # DRV_OACTIVE = defs.IFF_DRV_OACTIVE
-    # SIMPLEX = defs.IFF_SIMPLEX
-    # LINK0 = defs.IFF_LINK0
-    # LINK1 = defs.IFF_LINK1
-    # LINK2 = defs.IFF_LINK2
-    MULTICAST = 1 << 12
-    # CANTCONFIG = defs.IFF_CANTCONFIG
-    # PPROMISC = defs.IFF_PPROMISC
-    # MONITOR = defs.IFF_MONITOR
-    # STATICARP = defs.IFF_STATICARP
-    # DYING = defs.IFF_DYING
-    # RENAMING = defs.IFF_RENAMING
+    UP = 1 << 0  # sysfs
+    BROADCAST = 1 << 1  # volatile
+    DEBUG = 1 << 2  # sysfs
+    LOOPBACK = 1 << 3  # volatile
+    POINTOPOINT = 1 << 4  # volatile
+    NOTRAILERS = 1 << 5  # sysfs
+    RUNNING = 1 << 6  # volatile
+    NOARP = 1 << 7  # sysfs
+    PROMISC = 1 << 8  # sysfs
+    ALLMULTI = 1 << 9  # sysfs
+    MASTER = 1 << 10  # volatile
+    SLAVE = 1 << 11  # volatile
+    MULTICAST = 1 << 12  # sysfs
+    PORTSEL = 1 << 13  # sysfs
+    AUTOMEDIA = 1 << 14  # sysfs
+    DYNAMIC = 1 << 15  # sysfs
+    LOWER_UP = 1 << 16
+    DORMANT = 1 << 17
+    ECHO = 1 << 18
 
 
-class InterfaceLinkState(enum.IntEnum):
+class InterfaceV6Flags(IntEnum):
+    # include/uapi/linux/if_addr.h
+    TEMPORARY = 0x01
+    NODAD = 0x02
+    OPTIMISTIC = 0x04
+    DADFAILED = 0x08
+    HOMEADDRESS = 0x10
+    DEPRECATED = 0x20
+    TENTATIVE = 0x40
+    PERMANENT = 0x80
+    MANAGETEMPADDR = 0x100
+    NOPREFIXROUTE = 0x200
+    MCAUTOJOIN = 0x400
+    STABLE_PRIVACY = 0x800
+
+
+class InterfaceLinkState(IntEnum):
     LINK_STATE_UNKNOWN = 0
     LINK_STATE_DOWN = 1
     LINK_STATE_UP = 2
 
 
-class NeighborDiscoveryFlags(enum.IntEnum):
+class NeighborDiscoveryFlags(IntEnum):
     PERFORMNUD = 0
     ACCEPT_RTADV = 0
     PREFER_SOURCE = 0

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -3,7 +3,7 @@ from pyroute2 import NDB
 
 from .address import AddressFamily, AddressMixin
 from .bridge import BridgeMixin
-from .bits import InterfaceFlags, InterfaceLinkState
+from .bits import InterfaceFlags, InterfaceV6Flags, InterfaceLinkState
 from .lagg import LaggMixin
 from .utils import bitmask_to_set, INTERNAL_INTERFACES, run
 from .vlan import VlanMixin
@@ -68,11 +68,10 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
 
     @property
     def nd6_flags(self):
-        return set()
-
-    @nd6_flags.setter
-    def nd6_flags(self, value):
-        pass
+        return bitmask_to_set(
+            self.iprinfo.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS'),
+            InterfaceV6Flags
+        )
 
     @property
     def link_state(self):

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -65,10 +65,15 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
 
     @property
     def nd6_flags(self):
-        with IPRoute() as ipr:
-            dev = ipr.get_links(ifname=self.orig_name)[0]
-            v6flags = dev.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS') or 0
-            return bitmask_to_set(v6flags, InterfaceV6Flags)
+        try:
+            with IPRoute() as ipr:
+                dev = ipr.get_links(ifname=self.orig_name)[0]
+                v6flags = dev.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS') or 0
+                return bitmask_to_set(v6flags, InterfaceV6Flags)
+        except Exception:
+            # these flags aren't currently used anywwhere and are a "feature complete"
+            # addition so don't crash here and instead be safe
+            return set()
 
     @property
     def link_state(self):

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -1,4 +1,3 @@
-import logging
 from pyroute2 import NDB, IPRoute
 
 from .address import AddressFamily, AddressMixin
@@ -9,8 +8,6 @@ from .utils import bitmask_to_set, INTERNAL_INTERFACES, run
 from .vlan import VlanMixin
 from .vrrp import VrrpMixin
 from .ethernet_settings import EthernetHardwareSettings
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["Interface"]
 


### PR DESCRIPTION
This does a few minor things.

1. `InterfaceCapability` class was unused so remove it
2. add 3 more flags to `InterfaceFlags` that were missing
3. add `InterfaceV6Flags` class
4. clean up `bits.py`

Original PR: https://github.com/truenas/middleware/pull/9262
Jira URL: https://jira.ixsystems.com/browse/NAS-116835