### PR TITLE
chelsio_adapter_config: Match card more precisely

### DIFF
--- a/src/freenas/usr/local/bin/chelsio_adapter_config
+++ b/src/freenas/usr/local/bin/chelsio_adapter_config
@@ -185,7 +185,7 @@ def detect_chelsio_card():
     out = out.split("\n")
     output = []
     for line in out:
-        if re.search("pci.+:.+:.+:4:.+vendor=0x1425", line):
+        if re.search("pci.+:.+:.+:4:.+subvendor=0x1425 subdevice=0x0000", line):
             output.append(line)
 
     for line in output:


### PR DESCRIPTION
The previous code in 12 matched card=0x00001425, which corresponds to
subvendor=0x1425 subdevice=0x0000 in 13.  Replicate the old behavior
exactly rather than matching any card with the Chelsio vendor ID.