### PR TITLE
NAS-116869 / 22.12 / simplify and speed up interface.query (round 1)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -1,10 +1,10 @@
-from pyroute2 import NDB, IPRoute
+from pyroute2 import NDB
 
-from .address import AddressFamily, AddressMixin
+from .address import AddressMixin
 from .bridge import BridgeMixin
-from .bits import InterfaceFlags, InterfaceV6Flags, InterfaceLinkState
+from .bits import InterfaceFlags, InterfaceV6Flags
 from .lagg import LaggMixin
-from .utils import bitmask_to_set, INTERNAL_INTERFACES, run
+from .utils import bitmask_to_set, INTERNAL_INTERFACES
 from .vlan import VlanMixin
 from .vrrp import VrrpMixin
 from .ethernet_settings import EthernetHardwareSettings
@@ -15,8 +15,14 @@ CLONED_PREFIXES = ["br", "vlan", "bond"] + INTERNAL_INTERFACES
 
 
 class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
-    def __init__(self, name):
-        self.name = name
+    def __init__(self, dev):
+        self.name = dev.get_attr('IFLA_IFNAME')
+        self._mtu = dev.get_attr('IFLA_MTU') or 0
+        self._flags = dev['flags'] or 0
+        self._nd6_flags = dev.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS') or 0
+        self._link_state = f'LINK_STATE_{dev.get_attr("IFLA_OPERSTATE")}'
+        self._link_address = dev.get_attr('IFLA_ADDRESS')
+        self._cloned = any((self.name.startswith(i) for i in CLONED_PREFIXES))
 
     def _read(self, name, type=str):
         return self._sysfs_read(f"/sys/class/net/{self.name}/{name}", type)
@@ -41,55 +47,45 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
 
     @property
     def mtu(self):
-        return self._read("mtu", int)
+        return self._mtu
 
     @mtu.setter
-    def mtu(self, mtu):
-        up = InterfaceFlags.UP in self.flags
-        run(["ip", "link", "set", "dev", self.name, "mtu", str(mtu)])
-        if up:
-            self.down()
-            self.up()
+    def mtu(self, value):
+        with NDB(log='off') as ndb:
+            with ndb.interfaces[self.orig_name] as dev:
+                dev['mtu'] = value
+                if dev['state'] == 'up':
+                    dev['state'] = 'down'
+                    dev['state'] = 'up'
 
     @property
     def cloned(self):
-        for i in CLONED_PREFIXES:
-            if self.orig_name.startswith(i):
-                return True
-
-        return False
+        return self._cloned
 
     @property
     def flags(self):
-        return bitmask_to_set(self._read("flags", lambda s: int(s, base=16)), InterfaceFlags)
+        return bitmask_to_set(self._flags, InterfaceFlags)
 
     @property
     def nd6_flags(self):
-        try:
-            with IPRoute() as ipr:
-                dev = ipr.get_links(ifname=self.orig_name)[0]
-                v6flags = dev.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS') or 0
-                return bitmask_to_set(v6flags, InterfaceV6Flags)
-        except Exception:
-            # these flags aren't currently used anywwhere and are a "feature complete"
-            # addition so don't crash here and instead be safe
-            return set()
+        return bitmask_to_set(self._nd6_flags, InterfaceV6Flags)
 
     @property
     def link_state(self):
-        operstate = self._read("operstate")
-
-        return {
-            "down": InterfaceLinkState.LINK_STATE_DOWN,
-            "up": InterfaceLinkState.LINK_STATE_UP,
-        }.get(operstate, InterfaceLinkState.LINK_STATE_UNKNOWN)
+        return self._link_state
 
     @property
     def link_address(self):
-        try:
-            return list(filter(lambda x: x.af == AddressFamily.LINK, self.addresses)).pop()
-        except IndexError:
-            return None
+        return self._link_address
+
+    @link_address.setter
+    def link_address(self, value):
+        with NDB(log='off') as ndb:
+            with ndb.interfaces[self.orig_name] as dev:
+                dev['address'] = value
+                if dev['state'] == 'up':
+                    dev['state'] = 'down'
+                    dev['state'] = 'up'
 
     def __getstate__(self, address_stats=False, vrrp_config=None):
         state = {
@@ -101,14 +97,14 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             'flags': [i.name for i in self.flags],
             'nd6_flags': [i.name for i in self.nd6_flags],
             'capabilities': [],
-            'link_state': self.link_state.name,
+            'link_state': self.link_state,
             'media_type': '',
             'media_subtype': '',
             'active_media_type': '',
             'active_media_subtype': '',
             'supported_media': [],
             'media_options': None,
-            'link_address': self.link_address.address.address if self.link_address is not None else '',
+            'link_address': self.link_address or '',
             'aliases': [i.__getstate__(stats=address_stats) for i in self.addresses],
             'vrrp_config': vrrp_config,
         }

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -81,29 +81,6 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
     def link_address(self):
         return self._link_address
 
-    @link_address.setter
-    def link_address(self, value):
-        with NDB(log='off') as ndb:
-            with ndb.interfaces[self.orig_name] as dev:
-                upit = False
-                if dev['state'] == 'up':
-                    # gotta take down interface first
-                    dev['state'] = 'down'
-                    upit = True
-
-                dev['address'] = value  # change mac
-
-                if upit:
-                    # only bring it back up if the iface
-                    # was up to begin with
-                    dev['state'] = 'up'
-
-        # NDB() synchronizes state but the instantiation
-        # of this class won't reflect the changed MAC
-        # unless a new instance is created. This is a
-        # cheap way of updating the "state".
-        self._link_address = value
-
     def __getstate__(self, address_stats=False, vrrp_config=None):
         state = {
             'name': self.name,

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -58,6 +58,12 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
                     dev['state'] = 'down'
                     dev['state'] = 'up'
 
+        # NDB() synchronizes state but the instantiation
+        # of this class won't reflect the changed MTU
+        # unless a new instance is created. This is a
+        # cheap way of updating the "state".
+        self._mtu = value
+
     @property
     def cloned(self):
         return self._cloned
@@ -86,6 +92,12 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
                 if dev['state'] == 'up':
                     dev['state'] = 'down'
                     dev['state'] = 'up'
+
+        # NDB() synchronizes state but the instantiation
+        # of this class won't reflect the changed MAC
+        # unless a new instance is created. This is a
+        # cheap way of updating the "state".
+        self._link_address = value
 
     def __getstate__(self, address_stats=False, vrrp_config=None):
         state = {

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -54,9 +54,6 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         with NDB(log='off') as ndb:
             with ndb.interfaces[self.orig_name] as dev:
                 dev['mtu'] = value
-                if dev['state'] == 'up':
-                    dev['state'] = 'down'
-                    dev['state'] = 'up'
 
         # NDB() synchronizes state but the instantiation
         # of this class won't reflect the changed MTU

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -85,9 +85,17 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
     def link_address(self, value):
         with NDB(log='off') as ndb:
             with ndb.interfaces[self.orig_name] as dev:
-                dev['address'] = value
+                upit = False
                 if dev['state'] == 'up':
+                    # gotta take down interface first
                     dev['state'] = 'down'
+                    upit = True
+
+                dev['address'] = value  # change mac
+
+                if upit:
+                    # only bring it back up if the iface
+                    # was up to begin with
                     dev['state'] = 'up'
 
         # NDB() synchronizes state but the instantiation

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,5 +1,5 @@
 import logging
-from pyroute2 import NDB
+from pyroute2 import IPRoute
 
 from .bridge import create_bridge
 from .interface import Interface, CLONED_PREFIXES
@@ -38,5 +38,5 @@ def get_interface(name, safe_retrieval=False):
 
 
 def list_interfaces():
-    with NDB(log="off") as ndb:
-        return {i.ifname: Interface(i.ifname) for i in ndb.interfaces}
+    with IPRoute() as ipr:
+        return {dev.get_attr('IFLA_IFNAME'): Interface(dev) for dev in ipr.get_links()}


### PR DESCRIPTION
This uses `IPRoute` which is very fast and useful for 1-off "scripts" to attain information at the time of the instantiation of the `IPRoute` class.

This also uses `NDB` which synchronizes state with the kernel when a change is made. For example, changing mtu. This also simplifies the logic because we were reading sysfs values to get information when all of it is provided in the `IPRoute` class.

Before my changes, `interface.query` was taking ~0.232 seconds on my VM with 6 NICs and after it takes ~0.157 seconds which is ~33% faster.

There should be no functional change.