### PR TITLE
Be more descriptive about dependencies of an object

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1005,9 +1005,12 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         """
         dependencies = await self.get_dependencies(id, ignored)
         if dependencies:
-            raise CallError(
-                'This object is being used by other objects', errno.EBUSY, {'dependencies': list(dependencies.values())}
-            )
+            dep_err = 'This object is being used by following service(s):\n'
+            for index, dependency in enumerate(dependencies.values()):
+                key = 'service' if dependency['service'] else 'datastore'
+                dep_err += f'{index + 1}) {dependency[key]!r} {key.capitalize()}\n'
+
+            raise CallError(dep_err, errno.EBUSY, {'dependencies': list(dependencies.values())})
 
     @private
     async def get_dependencies(self, id, ignored=None):


### PR DESCRIPTION
This commit adds changes to be more descriptive about services/tables using an object which is going to be deleted.
e.g
```
middlewared.service_exception.CallError: [EBUSY] This object is being used by following service(s):
1) 'system.general' Service
```
