### PR TITLE
NAS-116882 / 22.12 / Fix FS attachment for NFS shares

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -559,6 +559,7 @@ class NFSFSAttachmentDelegate(LockableFSAttachmentDelegate):
     title = 'NFS Share'
     service = 'nfs'
     service_class = SharingNFSService
+    resource_name = 'path'
 
     async def restart_reload_services(self, attachments):
         await self._service_change('nfs', 'reload')


### PR DESCRIPTION
`name` key doesn't exist for NFS.