### PR TITLE
NAS-116773 / 22.12 / Sort chart release events

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -45,7 +45,12 @@ class ChartReleaseService(Service):
         """
         Returns kubernetes events for `release_name` Chart Release.
         """
-        return await self.middleware.call('k8s.event.query', [], {'extra': {'namespace': get_namespace(release_name)}})
+        return await self.middleware.call(
+            'k8s.event.query', [], {
+                'extra': {'namespace': get_namespace(release_name)},
+                'order_by': ['metadata.creation_timestamp']
+            }
+        )
 
     @private
     async def refresh_events_state(self, chart_release_name=None):

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -196,7 +196,7 @@ def filter_list(_list, filters=None, options=None):
                 reverse = True
             else:
                 reverse = False
-            rv = sorted(rv, key=lambda x: x[o], reverse=reverse)
+            rv = sorted(rv, key=lambda x: get(x, o), reverse=reverse)
 
     if options.get('get') is True:
         try:


### PR DESCRIPTION
## Context

We sort chart release events now to make sure that we report them in the correct order i.e in the order they were created.