### PR TITLE
NAS-116895 / 22.12 / Do not show ix-applications children on any pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2960,11 +2960,8 @@ class PoolDatasetService(CRUDService):
         # needs to be hidden from local webUI. (This is managed by TrueCommander)
         filters.extend([
             ['id', 'rnin', '.glusterfs'],
+            ['id', 'rnin', '/ix-applications/'],
         ])
-
-        k8s_config = await self.middleware.call('kubernetes.config')
-        if k8s_config['dataset']:
-            filters.append(['id', '!^', f'{k8s_config["dataset"]}/'])
 
         return filters
 


### PR DESCRIPTION
This commit adds changes to not add ix-applications children on any pool it might be living on regardless of the pool being configured for apps or not.