### PR TITLE
NAS-116870 / 22.12 / Normalise volblocksize attribute for volumes

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3096,7 +3096,7 @@ class PoolDatasetService(CRUDService):
         Str('type', enum=['FILESYSTEM', 'VOLUME'], default='FILESYSTEM'),
         Int('volsize'),  # IN BYTES
         Str('volblocksize', enum=[
-            '512', '1K', '2K', '4K', '8K', '16K', '32K', '64K', '128K',
+            '512', '512B', '1K', '2K', '4K', '8K', '16K', '32K', '64K', '128K',
         ]),
         Bool('sparse'),
         Bool('force_size'),
@@ -3583,8 +3583,8 @@ class PoolDatasetService(CRUDService):
 
                 if 'volblocksize' in data:
 
-                    if data['volblocksize'].isdigit():
-                        block_size = int(data['volblocksize'])
+                    if data['volblocksize'][:3] == '512':
+                        block_size = 512
                     else:
                         block_size = int(data['volblocksize'][:-1]) * 1024
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_recordsize.py
@@ -9,28 +9,29 @@ class PoolDatasetService(Service):
 
     # https://openzfs.github.io/openzfs-docs/Performance%20and%20Tuning/Module%20Parameters.html#zfs-max-recordsize
     # Maximum supported (at time of writing) is 16MB.
-    MAPPING = {
-        1 << 9: '512B',
-        1 << 10: '1K',
-        1 << 11: '2K',
-        1 << 12: '4K',
-        1 << 13: '8K',
-        1 << 14: '16K',
-        1 << 15: '32K',
-        1 << 16: '64K',
-        1 << 17: '128K',
-        1 << 18: '256K',
-        1 << 19: '512K',
-        1 << 20: '1M',
-        1 << 21: '2M',
-        1 << 22: '4M',
-        1 << 23: '8M',
-        1 << 24: '16M',
-    }
+    MAPPING = [
+        (1 << 9, '512'),
+        (1 << 9, '512B'),
+        (1 << 10, '1K'),
+        (1 << 11, '2K'),
+        (1 << 12, '4K'),
+        (1 << 13, '8K'),
+        (1 << 14, '16K'),
+        (1 << 15, '32K'),
+        (1 << 16, '64K'),
+        (1 << 17, '128K'),
+        (1 << 18, '256K'),
+        (1 << 19, '512K'),
+        (1 << 20, '1M'),
+        (1 << 21, '2M'),
+        (1 << 22, '4M'),
+        (1 << 23, '8M'),
+        (1 << 24, '16M'),
+    ]
 
     @accepts()
     @returns(List(items=[Str('recordsize_value')]))
     def recordsize_choices(self):
         with open('/sys/module/zfs/parameters/zfs_max_recordsize') as f:
             val = int(f.read().strip())
-            return [v for k, v in self.MAPPING.items() if k <= val]
+            return [v for k, v in self.MAPPING if k <= val]

--- a/src/middlewared/middlewared/pytest/unit/plugins/pool/test_recordsize_choices.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/pool/test_recordsize_choices.py
@@ -7,4 +7,4 @@ from middlewared.plugins.pool_.dataset_recordsize import PoolDatasetService
 def test_recordsize_choices():
     with patch("middlewared.plugins.pool_.dataset_recordsize.open") as mock:
         mock.return_value = io.StringIO("32768\n")
-        assert PoolDatasetService(None).recordsize_choices() == ["512B", "1K", "2K", "4K", "8K", "16K", "32K"]
+        assert PoolDatasetService(None).recordsize_choices() == ["512", "512B", "1K", "2K", "4K", "8K", "16K", "32K"]


### PR DESCRIPTION
## Problem

It was requested that we had a discrepancy between `recordsize` and `volblocksize` as the former allows specifying `512B` while the latter did not.

## Solution

Allow specifying `512` and `512B` for both `recordsize` and `volblocksize` attrs.