### PR TITLE
NAS-116872 / 13.0 / fix MINI XL+ top drive-bay mapping

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -64,7 +64,7 @@ MAPPINGS = [
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-XL\+$"), [
         VersionMapping(re.compile(".*"), [
-            MappingSlot(1, 5, False),
+            MappingSlot(1, 6, False),
             MappingSlot(0, 1, False),
             MappingSlot(0, 2, False),
             MappingSlot(0, 3, False),
@@ -73,7 +73,6 @@ MAPPINGS = [
             MappingSlot(0, 6, False),
             MappingSlot(0, 7, False),
             MappingSlot(0, 8, False),
-            MappingSlot(1, 6, False),
         ]),
     ]),
     ProductMapping(re.compile(r"TRUENAS-R10$"), [


### PR DESCRIPTION
2 problems:

1. we had a total of 10 drives being mapped when MINI XL+ only has 9 drives on front
2. the first drive being mapped was off by one

Confirmed with QE that this fixes the webUI problem of not showing the top SSD bay