### PR TITLE
NAS-116904 / 13.0 / rate limit disk.temperatures endpoint (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from datetime import datetime
 
 import async_timeout
 
@@ -50,6 +51,10 @@ def get_temperature(stdout):
 
 
 class DiskService(Service):
+    temps_result = None
+    temps_probed = datetime.min
+    temp_timeout = 300  # seconds
+
     @private
     async def disks_for_temperature_monitoring(self):
         return [
@@ -105,16 +110,19 @@ class DiskService(Service):
         Returns temperatures for a list of devices (runs in parallel).
         See `disk.temperature` documentation for more details.
         """
-        if len(names) == 0:
-            names = await self.disks_for_temperature_monitoring()
+        now = datetime.now()
+        if (now - self.temps_probed).total_seconds() > self.temp_timeout:
+            if len(names) == 0:
+                names = await self.disks_for_temperature_monitoring()
 
-        async def temperature(name):
-            try:
-                async with async_timeout.timeout(15):
-                    return await self.middleware.call('disk.temperature', name, powermode)
-            except asyncio.TimeoutError:
-                return None
+            async def temperature(name):
+                try:
+                    async with async_timeout.timeout(15):
+                        return await self.middleware.call('disk.temperature', name, powermode)
+                except asyncio.TimeoutError:
+                    return None
 
-        result = dict(zip(names, await asyncio_map(temperature, names, 8)))
+            self.temps_result = dict(zip(names, await asyncio_map(temperature, names, 8)))
+            self.temps_probed = now
 
-        return result
+        return self.temps_result


### PR DESCRIPTION
Investigating an unrelated issue, I found that front-end is calling this method every 2 seconds when in the `View Enclosure` page. (this is on 13 but didn't confirm on scale). What's worse, actually, is that certain webpages became non-responsive because the `disk.temperatures` tasks were stacking up and running before the previous tasks could complete. This caused a domino effect.

Either way, after discussions with William we've decided to rate limit this method to 5mins. `collectd` disk temp plugin probes every 5mins and `smartd` (by default) reads attributes every 30mins. For now, we've settled on 5 minutes to match collectd default.

I've also removed some freeBSD specific code.

Original PR: https://github.com/truenas/middleware/pull/9302
Jira URL: https://jira.ixsystems.com/browse/NAS-116904