### PR TITLE
NAS-116931 / 22.12 / remove duplicate code in interface do_create

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -622,6 +622,9 @@ class InterfaceService(CRUDService):
                 prefix = 'bond'
             elif data['type'] == 'VLAN':
                 prefix = 'vlan'
+            else:
+                # should never be reached because it means our schema is broken
+                raise CallError(f'Invalid interface type: {data["type"]!r}')
 
             name = await self.get_next(prefix)
 


### PR DESCRIPTION
This removes a bunch of duplicate code that was being called in the interface.create endpoint. There is no functional change.