### PR TITLE
NAS-116939 / 22.12 / fix regression in bond creation

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -3,7 +3,6 @@ import logging
 import pathlib
 from pyroute2 import NDB
 
-import middlewared.plugins.interface.netif_linux.interface as interface
 from .utils import run
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Looks like `add_port` was instantiating `Interface` class directly which prevents bonds from being properly created. Instead of doing this, just use `pyroute2.NDB` to perform the same procedure which removes necessity to use `subprocess`.