### PR TITLE
NAS-116907 / 22.12 / Fix off-by-one and statically map Well-Known SIDs

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -15,6 +15,45 @@ from middlewared.plugins.smb import SMBCmd, WBCErr
 SID_LOCAL_USER_PREFIX = "S-1-22-1-"
 SID_LOCAL_GROUP_PREFIX = "S-1-22-2-"
 
+"""
+See MS-DTYP 2.4.2.4
+
+Most of these groups will never be used on production servers.
+We are statically assigning IDs (based on idmap low range)
+to cover edge cases where users may have decided to copy data
+from a local Windows server share (for example) and preserve
+the existing Security Descriptor. We want the mapping to be
+consistent so that ZFS replication of TrueNAS server A to
+TrueNAS server B will result in same effective permissions
+for users and groups with no unexpected elevation of permissions.
+
+Entries may be appended to this list. Ordering is used to determine
+the GID assigned to the builtin.
+Once a new entry has been appended, the corresponding padding
+in smb/_groupmap.py should be decreased
+"""
+WELL_KNOWN_SIDS = [
+    {"name": "NULL", "sid": "S-1-0-0", "set": False},
+    {"name": "EVERYONE", "sid": "S-1-1-0", "set": True},
+    {"name": "LOCAL", "sid": "S-1-2-0", "set": True},
+    {"name": "CONSOLE_LOGON", "sid": "S-1-2-1", "set": True},
+    {"name": "CREATOR_OWNER", "sid": "S-1-3-0", "set": True},
+    {"name": "CREATOR_GROUP", "sid": "S-1-3-1", "set": True},
+    {"name": "OWNER_RIGHTS", "sid": "S-1-3-4", "set": True},
+    {"name": "DIALUP", "sid": "S-1-5-1", "set": True},
+    {"name": "NETWORK", "sid": "S-1-5-2", "set": True},
+    {"name": "BATCH", "sid": "S-1-5-3", "set": True},
+    {"name": "INTERACTIVE", "sid": "S-1-5-4", "set": True},
+    {"name": "SERVICE", "sid": "S-1-5-6", "set": True},
+    {"name": "ANONYMOUS", "sid": "S-1-5-7", "set": True},
+    {"name": "AUTHENTICATED_USERS", "sid": "S-1-5-11", "set": True},
+    {"name": "TERMINAL_SERVER_USER", "sid": "S-1-5-13", "set": True},
+    {"name": "REMOTE_AUTHENTICATED_LOGON", "sid": "S-1-5-14", "set": True},
+    {"name": "LOCAL_SYSTEM", "sid": "S-1-5-18", "set": True},
+    {"name": "LOCAL_SERVICE", "sid": "S-1-5-19", "set": True},
+    {"name": "NETWORK_SERVICE", "sid": "S-1-5-20", "set": True},
+]
+
 
 class DSType(enum.Enum):
     """
@@ -950,6 +989,30 @@ class IdmapDomainService(TDBWrapCRUDService):
             rv = {"id_type": "USER", "id": uid}
 
         return rv
+
+    @private
+    @filterable
+    async def builtins(self, filters, options):
+        out = []
+        idmap_backend = await self.middleware.call("smb.getparm", "idmap config * : backend", "GLOBAL")
+        if idmap_backend != "tdb":
+            """
+            idmap_autorid and potentially other allocating idmap backends may be used for
+            the default domain.
+            """
+            return []
+
+        idmap_range = await self.middleware.call("smb.getparm", "idmap config * : range", "GLOBAL")
+        low_range = int(idmap_range.split("-")[0].strip())
+        for idx, entry in enumerate(WELL_KNOWN_SIDS):
+            finalized_entry = entry.copy()
+            finalized_entry.update({
+                'id': idx,
+                'gid': low_range + 3 + idx
+            })
+            out.append(finalized_entry)
+
+        return filter_list(out, filters, options)
 
     @private
     async def id_to_name(self, id, id_type):

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -12,6 +12,8 @@ import struct
 # Output format may change between this and final version accepted
 # upstream, but Samba project has standardized on following version format
 GROUPMAP_JSON_VERSION = {"major": 0, "minor": 1}
+WINBINDD_AUTO_ALLOCATED = ['S-1-5-32-544', 'S-1-5-32-545', 'S-1-5-32-546']
+WINBINDD_WELL_KNOWN_PADDING = 100
 
 
 class SMBService(Service):
@@ -179,6 +181,32 @@ class SMBService(Service):
         await self.batch_groupmap(payload)
 
     @private
+    def initialize_idmap_tdb(self, low_range):
+        tdb_path = f'{SMBPath.STATEDIR.platform()}/winbindd_idmap.tdb'
+        tdb_flags = tdb.DEFAULT
+        open_flags = os.O_CREAT | os.O_RDWR
+
+        try:
+            tdb_handle = tdb.Tdb(tdb_path, 0, tdb_flags, open_flags, 0o644)
+        except Exception:
+            self.logger.warning("Failed to create winbindd_idmap.tdb", exc_info=True)
+            return None
+
+        try:
+            for key, val in [
+                (b'IDMAP_VERSION\x00', 2),
+                (b'USER HWM\x00', low_range),
+                (b'GROUP HWM\x00', low_range)
+            ]:
+                tdb_handle.store(key, struct.pack("<L", val))
+        except Exception:
+            self.logger.warning('Failed to initialize winbindd_idmap.tdb', exc_info=True)
+            tdb_handle.close()
+            return None
+
+        return tdb_handle
+
+    @private
     def validate_groupmap_hwm(self, low_range):
         """
         Middleware forces allocation of GIDs for Users, Groups, and Administrators
@@ -186,41 +214,75 @@ class SMBService(Service):
         high-water mark to avoid conflicts with these and remove any mappings that
         conflict. Winbindd will regenerate the removed ones as-needed.
         """
+        def add_key(tdb_handle, gid, sid):
+            gid_val = f'GID {gid}\x00'.encode()
+            sid_val = f'{sid}\x00'.encode()
+            tdb_handle.store(gid_val, sid_val)
+            tdb_handle.store(sid_val, gid_val)
+
+        def remove_key(tdb_handle, key, reverse):
+            tdb_handle.delete(key)
+            if reverse:
+                tdb_handle.delete(reverse)
+
         must_reload = False
+        len_wb_groups = len(WINBINDD_AUTO_ALLOCATED)
+        builtins = self.middleware.call_sync('idmap.builtins')
 
         try:
             tdb_handle = tdb.open(f"{SMBPath.STATEDIR.platform()}/winbindd_idmap.tdb")
         except FileNotFoundError:
-            return must_reload
+            tdb_handle = self.initialize_idmap_tdb(low_range)
+            if not tdb_handle:
+                return False
 
         try:
+            tdb_handle.transaction_start()
             group_hwm_bytes = tdb_handle.get(b'GROUP HWM\00')
             hwm = struct.unpack("<L", group_hwm_bytes)[0]
-            if hwm < low_range + 2:
-                tdb_handle.transaction_start()
-                new_hwm_bytes = struct.pack("<L", low_range + 2)
+            if hwm < low_range + len_wb_groups + len(builtins):
+                hwm = low_range + len_wb_groups + len(builtins) + WINBINDD_WELL_KNOWN_PADDING
+                new_hwm_bytes = struct.pack("<L", hwm)
                 tdb_handle.store(b'GROUP HWM\00', new_hwm_bytes)
-                tdb_handle.transaction_commit()
-                self.middleware.call_sync('idmap.snapshot_samba4_dataset')
                 must_reload = True
 
             for key in tdb_handle.keys():
                 # sample key: b'GID 9000020\x00'
-                if key[:3] == b'GID' and int(key.decode()[4:-1]) < (low_range + 2):
+                if key[:3] == b'GID' and int(key.decode()[4:-1]) < (low_range + len_wb_groups):
                     reverse = tdb_handle.get(key)
-                    tdb_handle.transaction_start()
-                    tdb_handle.delete(key)
-                    tdb_handle.delete(reverse)
-                    tdb_handle.transaction_commit()
-                    if not must_reload:
-                        self.middleware.call_sync('idmap.snapshot_samba4_dataset')
+                    remove_key(tdb_handle, key, reverse)
                     must_reload = True
 
+            for entry in builtins:
+                if not entry['set']:
+                    continue
+
+                sid_key = f'{entry["sid"]}\x00'.encode()
+                val = tdb_handle.get(f'{entry["sid"]}\x00'.encode())
+                if val is None or val.decode() != f'GID {entry["gid"]}\x00':
+                    if sid_key in tdb_handle.keys():
+                        self.logger.debug(
+                            "incorrect sid mapping detected %s -> %s"
+                            "replacing with %s -> %s",
+                            entry['sid'], val.decode()[4:-1] if val else "None",
+                            entry['sid'], entry['gid']
+                        )
+                        remove_key(tdb_handle, f'{entry["sid"]}\x00'.encode(), val)
+
+                    add_key(tdb_handle, entry['gid'], entry['sid'])
+                    must_reload = True
+
+            tdb_handle.transaction_commit()
+
         except Exception as e:
+            tdb_handle.transaction_cancel()
             self.logger.warning("TDB maintenace failed: %s", e)
 
         finally:
             tdb_handle.close()
+
+        if must_reload:
+            self.middleware.call_sync('idmap.snapshot_samba4_dataset')
 
         return must_reload
 


### PR DESCRIPTION
A recent fix for case where we were erroneously purging winbindd
idmap tdb entries introduced an off-by-one error that was caught
by our CI. This PR fixes this issue and also introduces a static
mapping for S-1-3-4 (Owner Rights). The static mapping is to
ensure that in at least normal case of non-clustered server where
users may wish to utilize this special ACE to manage permissions
granted by virtue of being a file's owner we will make sure that
this ACE is consistently evaluated on replication targets.