### PR TITLE
NAS-116949 / 22.12 / add {add_/delete_}ports methods and use them

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -89,16 +89,11 @@ class InterfaceService(Service):
             sync_interface_opts[member['lagg_physnic']]['skip_mtu'] = True
             members_database.append(member['lagg_physnic'])
 
-        # Remove member configured but not in database
-        for member in (members_configured - set(members_database)):
-            iface.delete_port(member)
+        # Remove member ports configured in bond but do not exist in database
+        iface.delete_ports(list(members_configured - set(members_database)))
 
-        # Add member in database but not configured
-        for member in members_database:
-            if member in members_configured:
-                continue
-
-            iface.add_port(member)
+        # Add member ports that exist in db but not configured in bond
+        iface.add_ports([i for i in members_database if i in members_configured])
 
         for port in iface.ports:
             try:

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/lagg.py
@@ -94,7 +94,10 @@ class LaggMixin:
                     continue
                 else:
                     with ndb.interfaces[self.name] as bond:
-                        bond.add_port(member)
+                        try:
+                            bond.add_port(member)
+                        except Exception:
+                            self.logger.warning('Failed adding %r to %r', member, self.name, exc_inf=True)
 
     def delete_port(self, member_port):
         return self.delete_ports([member_port])


### PR DESCRIPTION
Does 2 things:

1. add `add_ports` method
2. add `delete_ports` method

Both of these take a list of member interfaces for a bond interface and add or delete them respectively in 1 `with NDB()` instantiation which is less expensive. (It also removes `subprocess` usage which is an added bonus)

I kept the `add_port` and `delete_port` methods there just in case something else is using them that I didn't see.