### PR TITLE
add R50B nvme mapping and fix many issues

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/rseries_nvme.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/rseries_nvme.py
@@ -1,41 +1,104 @@
+import re
+
 import sysctl
 from middlewared.service import Service, private
 
 
 class EnclosureService(Service):
+    RE_PCI = re.compile(r'pci([0-9]+)')
+    RE_PCIB = re.compile(r'pcib([0-9]+)')
+
     @private
-    def rseries_nvme_enclosures(self, product):
-        slot_to_nvd = {}
+    def map_nvme(self, product, nvme_slots):
         for nvme, nvd in self.middleware.call_sync('disk.nvme_to_nvd_map', True).items():
+            pci = sysctl.filter(f'dev.nvme.{nvme}.%parent')[0].value
+            m = re.match(self.RE_PCI, pci)
+            if not m:
+                continue
+
+            pcib = sysctl.filter(f'dev.pci.{m.group(1)}.%parent')[0].value
+            m = re.match(self.RE_PCIB, pcib)
+            if not m:
+                continue
+
+            pnpinfo = sysctl.filter(f'dev.pcib.{m.group(1)}.%pnpinfo')[0].value
+            bridge_ids = ['vendor=0x8086 device=0xa190', 'vendor=0x8086 device=0x2030', 'vendor=0x8086 device=0x2031']
+            if not any(string in pnpinfo for string in bridge_ids):
+                continue
+
             try:
-                location = sysctl.filter(f'dev.nvme.{nvme}.%location')[0].value
-                if 'PC01.BR1A.OCL' in location:
-                    slot = 1
-                elif 'PC01.BR1B.OCL' in location:
-                    slot = 2
-                elif 'PC00.RP01.PXSX' in location:
-                    slot = 3
-                else:
-                    continue
-                slot_to_nvd[slot] = f'nvd{nvd}'
+                location = sysctl.filter(f'dev.pcib.{m.group(1)}.%location')[0].value
+                if product == 'TRUENAS-R50B':
+                    if '_SB_.PC03.BR3A' in location:
+                        slot = 49
+                    elif '_SB_.PC00.RP01' in location:
+                        slot = 50
+                    else:
+                        continue
+                elif product == 'TRUENAS-R50':
+                    if 'PC01.BR1A.OCL' in location:
+                        slot = 49
+                    elif 'PC01.BR1B.OCL' in location:
+                        slot = 50
+                    elif 'PC00.RP01.PXSX' in location:
+                        slot = 51
+                    else:
+                        continue
+
+                nvme_slots[slot] = f'nvd{nvd}'
             except Exception:
                 self.logger.error('Failed to map /dev/nvme%s device', nvme, exc_info=True)
                 continue
 
-        try:
-            model = product.split('-')[1]
-        except IndexError:
-            # SMBIOS is mistagged so default to 'R50'
-            # since (at the time of writing this) is
-            # the only r-series hardware that has an
-            # nvme enclosure
-            model = 'R50'
+    @private
+    def format_nvme_slots(self, nvme_slots):
+        elements = {'Array Device Slot': {}}
+        for slot, nvme in nvme_slots.items():
+            if nvme is not None:
+                status = 'OK'
+                value_raw = 16777216
+                dev = nvme
+            else:
+                status = 'Not Installed'
+                value_raw = 83886080
+                dev = ''
 
-        return self.middleware.call_sync(
-            'enclosure.fake_nvme_enclosure',
-            f'{model.lower()}_nvme_enclosure',
-            f'{model} NVMe enclosure',
-            f'{model}',
-            3,
-            slot_to_nvd
-        )
+            elements['Array Device Slot'][slot] = {
+                'descriptor': f'Disk #{slot}',
+                'status': status,
+                'value': 'None',
+                'value_raw': value_raw,
+                'dev': dev,
+                'original': {
+                    'enclosure_id': None,
+                    'number': None,
+                    'slot': None,
+                }
+            }
+
+        return elements
+
+    @private
+    def rseries_nvme_enclosures(self, product):
+        if product == 'TRUENAS-R50':
+            info = [
+                'r50_nvme_enclosure',
+                'R50 NVMe enclosure',
+                'R50',
+                3,
+            ]
+            nvme_slots = {49: None, 50: None, 51: None}
+        elif product == 'TRUENAS-R50B':
+            info = [
+                'r50b_nvme_enclosure',
+                'R50B NVMe enclosure',
+                'R50B',
+                2,
+            ]
+            nvme_slots = {49: None, 50: None}
+        else:
+            # should never get here
+            return []
+
+        self.map_nvme(product, nvme_slots)
+        return self.format_nvme_slots(nvme_slots)


### PR DESCRIPTION
Many problems found and fixed.

1. we didn't even have R50B rear nvme drive bay mapping support for CORE
2. while I was adding R50B nvme drive bay mapping, I discovered that the current logic would not work
3. the `fake_nvme_enclosures` method is returning the old enclosure information format (before I rewrote everything) so the nvme drive bay doesn't match the head-unit/jbod information.
4. the `fake_nvme_enclosures` method had an extra `0` digit for the `value_raw` data when the nvme device wasn't installed in one of the slots (even though it's not used)
5. R50 and R50B rear nvme drive bay mapping has _never_ worked on 13 because the webUI expects the rear nvme drive bays to be concatenated to the head-unit's drive bays....even though the mseries rear nvme drive bay mapping doesn't do this.... Anyways, I've made it so that the head-unit `Array Device Slot` dictionary gets updated with the rear nvme drive bays.
6. rear nvme drives on the r-series do not support drive light identification so ensure we account for that if someone tries to set the slot status for those slots
7. Finally, after discussion with mav, we need to map rear nvme drive bays on the r50 series systems like we do on the m-series. We now map the slots based on the parent bus ACPI handle ID instead of the nvme acpi handle ID (which is not guaranteed to exist as we learned on the R50B).