### PR TITLE
prevent boot delays on large disk systems

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -71,6 +71,10 @@ systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd
 systemctl mask exim4-base.service exim4.service
 systemctl mask uuidd.service uuidd.socket
 
+# We don't use LVM and this service can add significan boot delays
+# on large disk systems
+systemctl mask lvm2-monitor.service
+
 systemctl set-default truenas.target
 
 sed -i.bak 's/CHARMAP="ISO-8859-15"/CHARMAP="UTF-8"/' /etc/default/console-setup

--- a/src/freenas/etc/initramfs-tools/conf.d/noresume.conf
+++ b/src/freenas/etc/initramfs-tools/conf.d/noresume.conf
@@ -1,0 +1,4 @@
+# initramfs will try and resume from /dev/dm* devices by default
+# which doesn't apply to us since we don't support suspend/resume
+# functionality
+RESUME=none


### PR DESCRIPTION
2 problems discovered.

1. `lvm2-monitor.service` is miserably slow and scans every disk so disable it entirely because we don't use `lvm` anywhere in our product
2. `initramfs` will try to resume from `/dev/dm*` devices by default which can arbitrarily slow down boot process, but we don't support resume from suspend so disable that functionality as well.