### PR TITLE
NAS-116976 / 22.02.3 / prevent boot delays on large disk systems (by yocalebo)

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -69,7 +69,7 @@ systemctl enable zfs-zed
 # We need to mask libvirtd related sockets so that they don't start automatically
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 
-# We don't use LVM and this service can add significan boot delays
+# We don't use LVM and this service can add significant boot delays
 # on large disk systems
 systemctl mask lvm2-monitor.service
 

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -69,6 +69,10 @@ systemctl enable zfs-zed
 # We need to mask libvirtd related sockets so that they don't start automatically
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 
+# We don't use LVM and this service can add significan boot delays
+# on large disk systems
+systemctl mask lvm2-monitor.service
+
 systemctl set-default truenas.target
 
 sed -i.bak 's/CHARMAP="ISO-8859-15"/CHARMAP="UTF-8"/' /etc/default/console-setup

--- a/src/freenas/etc/initramfs-tools/conf.d/noresume.conf
+++ b/src/freenas/etc/initramfs-tools/conf.d/noresume.conf
@@ -1,0 +1,4 @@
+# initramfs will try and resume from /dev/dm* devices by default
+# which doesn't apply to us since we don't support suspend/resume
+# functionality
+RESUME=none


### PR DESCRIPTION
2 problems discovered.

1. `lvm2-monitor.service` is miserably slow and scans every disk so disable it entirely because we don't use `lvm` anywhere in our product
2. `initramfs` will try to resume from `/dev/dm*` devices by default which can arbitrarily slow down boot process, but we don't support resume from suspend so disable that functionality as well.

Original PR: https://github.com/truenas/middleware/pull/9319
Jira URL: https://jira.ixsystems.com/browse/NAS-116976