### PR TITLE
NAS-116982 / 22.12 / Properly handle DNSException from dnsclient

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -4,6 +4,7 @@ import enum
 import time
 from ipaddress import ip_address
 
+from dns.exception import DNSException
 from middlewared.service import Service, job, ValidationErrors
 from middlewared.service_exception import CallError
 
@@ -33,9 +34,9 @@ class ClusterUtils(Service):
 
         try:
             ans = [i['address'] for i in await self.middleware.call('dnsclient.forward_lookup', {"names": [host]})]
-        except Exception as e:
+        except DNSException as e:
             # failed to resolve the hostname
-            result['error'] = e.errmsg
+            result['error'] = e.msg
         else:
             if not ans:
                 # this shouldn't happen....but paranoia plagues me


### PR DESCRIPTION
Observed in testing deliberately broken configuration:

```
File \"/usr/lib/python3/dist-packages/middlewared/plugins/cluster_linux/utils.py\", 
line 38, in _resolve_hostname\n    result['error'] = e.errmsg\nAttributeError: 'NXDOMAIN' 
object has no attribute 'errmsg'\n",
```