### PR TITLE
NAS-116989 / 22.12 / Fix `ix-wait-on-disks.service` not being installed

### DIFF
--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -21,6 +21,7 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-syncdisks
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-swap
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-update
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-wait-on-disks
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-zfs
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=snmp-agent
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=truenas


### PR DESCRIPTION
@yocalebo is 22.02 backport needed?