### PR TITLE
NAS-116988 / 22.02.3 / Fix `"device": "pmem0p2", "disk": "pmem0p"` in pool topology (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/boot_/boot_loader_linux.py
+++ b/src/middlewared/middlewared/plugins/boot_/boot_loader_linux.py
@@ -11,10 +11,7 @@ from .boot_loader_base import BootLoaderBase
 class BootService(Service, BootLoaderBase):
 
     async def install_loader(self, dev):
-        if "nvme" in dev:
-            partition = f'{dev}p2'
-        else:
-            partition = f'{dev}2'
+        partition = await self.middleware.call('disk.get_partition_for_disk', dev, 2)
 
         await run('grub-install', '--target=i386-pc', f'/dev/{dev}')
         await run('mkdosfs', '-F', '32', '-s', '1', '-n', 'EFI', f'/dev/{partition}')

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -46,10 +46,9 @@ class DeviceService(Service):
         parts = []
         keys = tuple('ID_PART_ENTRY_' + i for i in ('TYPE', 'UUID', 'NUMBER', 'SIZE'))
         parent = dev.sys_name
-        is_nvme_or_pmem = parent.startswith(('nvme', 'pmem'))
         for i in filter(lambda x: all(x.get(k) for k in keys), dev.children):
             part_num = int(i['ID_PART_ENTRY_NUMBER'])
-            part_name = f'{parent}p{part_num}' if is_nvme_or_pmem else f'{parent}{part_num}'
+            part_name = self.middleware.call_sync('disk.get_partition_for_disk', parent, part_num)
             part = {
                 'name': part_name,
                 'id': part_name,

--- a/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_linux.py
@@ -128,15 +128,15 @@ class DiskService(Service, DiskInfoBase):
             return None
         with open(os.path.join('/sys/class/block', part_name, 'partition'), 'r') as f:
             part_num = f.read().strip()
-        if part_name.startswith('nvme'):
-            # nvme partitions would be like nvmen1p1 where disk is nvmen1
+        if part_name.startswith(('nvme', 'pmem')):
+            # nvme/pmem partitions would be like nvmen1p1 where disk is nvmen1
             part_num = f'p{part_num}'
         return part_name.rsplit(part_num, 1)[0].strip()
 
     @private
     def get_partition_for_disk(self, disk, partition):
-        if disk.startswith('nvme'):
-            # This is a hack for nvme disks, however let's please come up with a better way
+        if disk.startswith(('nvme', 'pmem')):
+            # FIXME: This is a hack for nvme/pmem disks, however let's please come up with a better way
             # to link disks with their partitions
             return f'{disk}p{partition}'
         else:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 92fe016aee9a9b04eda0cee2ec86f1e03656b697



Original PR: https://github.com/truenas/middleware/pull/9326
Jira URL: https://jira.ixsystems.com/browse/NAS-116988