### PR TITLE
fix drive removal disk events

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -30,7 +30,7 @@ async def added_disk(middleware, disk_name):
 
 async def remove_disk(middleware, disk_name):
     await middleware.call('geom.cache.invalidate')
-    await middleware.call('disk.sync', disk_name)
+    await (await middleware.call('disk.sync_all')).wait()
     await middleware.call('disk.multipath_sync')
     await middleware.call('alert.oneshot_delete', 'SMART', disk_name)
     # If a disk dies we need to reconfigure swaps so we are not left


### PR DESCRIPTION
`disk.sync` was never written for drives being removed.....I don't know why but either way this is a regression for when a disk is removed. Go back to doing `disk.sync_all`. That call is no where near as expensive as what it used to be.