### PR TITLE
NAS-116984 / 22.02.3 / Switch to using ctdb client python bindings (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -1,7 +1,8 @@
+import ctdb
 import json
 import os
 
-from middlewared.schema import Dict, Bool
+from middlewared.schema import Bool, Dict, Int, IPAddr, List, returns, Str
 from middlewared.service import CallError, Service, accepts, private, filterable
 from middlewared.utils import run, filter_list
 from middlewared.plugins.cluster_linux.utils import CTDBConfig
@@ -41,18 +42,44 @@ class CtdbGeneralService(Service):
 
     @private
     @filterable
-    async def getdbmap(self, filters, options):
+    def getdbmap(self, filters, options):
         """
         List all clustered TDB databases that the CTDB daemon has attached to.
         """
-        result = await self.middleware.call('ctdb.general.wrapper', ['getdbmap'])
+        result = ctdb.Client().dbmap()
         return filter_list(result['dbmap'], filters, options)
 
     @accepts(Dict(
         'ctdb_status',
         Bool('all_nodes', default=True)
     ))
-    async def status(self, data):
+    @returns(List('ctdb_status', items=[Dict(
+        'ctdb_nodemap_entry',
+        Int('pnn'),
+        Dict(
+            'address',
+            Str('type', enum=['INET', 'INET6']),
+            IPAddr("address"),
+        ),
+        List('flags', items=[Str(
+            'ctdb_status_flag',
+            enum=[
+                'DISCONNECTED',
+                'UNHEALTHY',
+                'INACTIVE',
+                'DISABLED',
+                'STOPPED',
+                'DELETED',
+                'BANNED',
+            ],
+            register=True
+        )]),
+        Int('flags_raw'),
+        Bool('partially_online'),
+        Bool('this_node'),
+        register=True
+    )]))
+    def status(self, data):
         """
         List the status of nodes in the ctdb cluster.
 
@@ -61,35 +88,65 @@ class CtdbGeneralService(Service):
             status of this node.
         """
 
-        command = ['status' if data['all_nodes'] else 'nodestatus']
-        result = await self.middleware.call('ctdb.general.wrapper', command)
-        if result:
-            result = result['nodes'] if not data['all_nodes'] else result['nodemap']['nodes']
+        ctdb_status = ctdb.Client().status()
+        if not data['all_nodes']:
+            for node in ctdb_status['nodemap']['nodes']:
+                if node['this_node']:
+                    return [node]
 
-        return result
+        return ctdb_status['nodemap']['nodes']
 
     @accepts()
-    async def listnodes(self):
+    @returns(List('nodelist', items=[Dict(
+        'ctdb_node',
+        Int('pnn'),
+        Dict(
+            'address',
+            Str('type', enum=['INET', 'INET6']),
+            IPAddr("address"),
+        ),
+        Bool('enabled'),
+        Bool('this_node')
+    )]))
+    def listnodes(self):
         """
         Return a list of nodes in the ctdb cluster.
         """
+        nodelist = ctdb.Client().listnodes()
+        out = []
+        for node in nodelist['nodes']:
+            out.append({
+                'pnn': node.pnn,
+                'address': node.private_address,
+                'enabled': 'DELETED' not in node.flags,
+                'this_node': node.current_node,
+            })
 
-        result = await self.middleware.call('ctdb.general.wrapper', ['listnodes', '-v'])
-        return result['nodelist'] if result else result
+        return out
 
     @accepts(Dict(
         'ctdb_ips',
         Bool('all_nodes', default=True)
     ))
-    async def ips(self, data):
+    @returns(List('ctdb_public_ips', items=[Dict(
+        'ctdb_public_ip',
+        IPAddr('public_ip'),
+        Int('pnn'),
+        List('interfaces', items=[Dict(
+            'ctdb_interface_info',
+            Str('name'),
+            Bool('active'),
+            Bool('available')
+        )]),
+    )]))
+    def ips(self, data):
         """
         Return a list of public ip addresses in the ctdb cluster.
         """
-
-        command = ['ip', 'all'] if data['all_nodes'] else ['ip']
-        return (await self.middleware.call('ctdb.general.wrapper', command))['nodes']
+        return ctdb.Client().ips(data['all_nodes'])
 
     @accepts()
+    @returns(Bool('status'))
     def healthy(self):
         """
         Returns a boolean if the ctdb cluster is healthy.
@@ -117,26 +174,29 @@ class CtdbGeneralService(Service):
             return False
 
         try:
-            status = self.middleware.call_sync('ctdb.general.status', {'all_nodes': True})
+            status = self.status()
         except Exception:
             return False
 
-        return not any(map(lambda x: x['flags_str'] != 'OK', status)) if status else False
+        return not any(map(lambda x: x['flags_raw'] != 0, status)) if status else False
 
     @accepts()
-    async def pnn(self):
+    @returns(Int('pnn'))
+    def pnn(self):
         """
         Return node number for this node. This value should be static for life of cluster.
         """
         if self.this_node is not None:
             return self.this_node
 
-        if not await self.middleware.call('gluster.fuse.is_mounted', {'name': CTDB_VOL}):
-            raise CallError('%s is not fuse mounted locally', CTDB_VOL)
+        try:
+            # gluster volume root has inode of 1.
+            # if gluster isn't mounted it will be different
+            # if volume is unhealthy this will fail
+            if os.stat(f'/cluster/{CTDB_VOL}').st_ino != 1:
+                return False
+        except Exception:
+            return False
 
-        get_pnn = await run(['ctdb', 'pnn'], check=False)
-        if get_pnn.returncode != 0:
-            raise CallError("Failed to get pnn: %s", get_pnn.stderr.decode())
-
-        self.this_node = int(get_pnn.stdout.decode().strip())
+        self.this_node = ctdb.Client().pnn
         return self.this_node

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -61,8 +61,8 @@ class ClusterJob(Service):
             return
 
         node = (await self.middleware.call('ctdb.general.status', {'all_nodes': False}))[0]
-        if node['flags_str'] != 'OK':
-            CallError(f'Cannot reload directory service. Node health: {node["flags_str"]}')
+        if node['flags_raw'] != 0:
+            CallError(f'Cannot reload directory service. Node health: {node["flags"]}')
 
         job_list = await self.list()
         for idx, entry in enumerate(job_list.get(node["pnn"], [])):

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -84,7 +84,7 @@ class ClusterUtils(Service):
     async def time_info(self, job):
         nodes = await self.middleware.call('ctdb.general.status')
         for node in nodes:
-            if not node['flags_str'] == 'OK':
+            if node['flags_raw'] != 0:
                 raise CallError(f'Cluster node {node["pnn"]} is unhealthy. Unable to retrieve time info.')
             if node['this_node']:
                 my_node = node['pnn']


### PR DESCRIPTION
Using the python bindings helps us avoid a significant amount of
subprocess calls during normal clustered operations. This PR
also adds returns decorators for ctdb.general methods.

Original PR: https://github.com/truenas/middleware/pull/9323
Jira URL: https://jira.ixsystems.com/browse/NAS-116984