### PR TITLE
NAS-117001 / 22.12 / Add initial support for mDNS in cluster

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -200,3 +200,11 @@ class CtdbGeneralService(Service):
 
         self.this_node = ctdb.Client().pnn
         return self.this_node
+
+    @accepts()
+    @returns(Int('recmaster'))
+    def recovery_master(self):
+        """
+        Return node number for the recovery master for the cluster.
+        """
+        return ctdb.Client().recmaster()


### PR DESCRIPTION
For sake of simplicity for now, only advertise mDNS with clustered
netbios name for the interfaces used as public addresses on the
recovery master in the cluster.