### PR TITLE
NAS-116953 / 22.12 / fix reporting.realtime memory leak (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -1,22 +1,14 @@
-from collections import defaultdict
-import glob
 import psutil
-import re
 import time
 
 import humanfriendly
 
 from middlewared.event import EventSource
-from middlewared.plugins.interface.netif import netif
 from middlewared.schema import Dict, Float, Int
 from middlewared.validators import Range
 
 from .iostat import DiskStats
-
-
-MEGABIT = 131072
-RE_BASE = re.compile(r'([0-9]+)base')
-RE_MBS = re.compile(r'([0-9]+)Mb/s')
+from .ifstat import IfStats
 
 
 class RealtimeEventSource(EventSource):
@@ -129,47 +121,11 @@ class RealtimeEventSource(EventSource):
             "swap": swap,
         }
 
-    def get_interface_speeds(self):
-        speeds = {}
-
-        interfaces = self.middleware.call_sync('interface.query')
-        for interface in interfaces:
-            if m := RE_BASE.match(interface['state']['active_media_subtype']):
-                speeds[interface['name']] = int(m.group(1)) * MEGABIT
-            elif m := RE_MBS.match(interface['state']['active_media_subtype']):
-                speeds[interface['name']] = int(m.group(1)) * MEGABIT
-
-        types = ['BRIDGE', 'LINK_AGGREGATION', 'VLAN']
-        for interface in sorted([i for i in interfaces if i['type'] in types], key=lambda i: types.index(i['type'])):
-            speed = None
-
-            if interface['type'] == 'BRIDGE':
-                member_speeds = [speeds.get(member) for member in interface['bridge_members'] if speeds.get(member)]
-                if member_speeds:
-                    speed = max(member_speeds)
-
-            if interface['type'] == 'LINK_AGGREGATION':
-                port_speeds = [speeds.get(port) for port in interface['lag_ports'] if speeds.get(port)]
-                if port_speeds:
-                    if interface['lag_protocol'] in ['LACP', 'LOADBALANCE', 'ROUNDROBIN']:
-                        speed = sum(port_speeds)
-                    else:
-                        speed = min(port_speeds)
-
-            if interface['type'] == 'VLAN':
-                speed = speeds.get(interface['vlan_parent_interface'])
-
-            if speed:
-                speeds[interface['name']] = speed
-
-        return speeds
-
     def run_sync(self):
         interval = self.arg['interval']
         cp_time_last = None
         cp_times_last = None
-        last_interface_stats = {}
-        last_interface_speeds = {'time': time.monotonic(), 'speeds': self.get_interface_speeds()}
+        last_iface_stats = {}
         last_disk_stats = {}
         internal_interfaces = tuple(self.middleware.call_sync('interface.internal_interfaces'))
 
@@ -240,45 +196,15 @@ class RealtimeEventSource(EventSource):
             data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures')
             data['cpu']['temperature'] = {k: 2732 + int(v * 10) for k, v in data['cpu']['temperature_celsius'].items()}
 
-            # Interface related statistics
-            if last_interface_speeds['time'] < time.monotonic() - self.INTERFACE_SPEEDS_CACHE_INTERVAL:
-                last_interface_speeds.update({
-                    'time': time.monotonic(),
-                    'speeds': self.get_interface_speeds(),
-                })
-            data['interfaces'] = defaultdict(dict)
-            retrieve_stat = {'rx_bytes': 'received_bytes', 'tx_bytes': 'sent_bytes'}
-            stats_time = time.time()
-            for i in glob.glob('/sys/class/net/*/statistics'):
-                iface_name = i.replace('/sys/class/net/', '').split('/')[0]
-                if iface_name.startswith(internal_interfaces):
-                    continue
-
-                iface_obj = netif.get_interface(iface_name, True)
-                data['interfaces'][iface_name] = {
-                    'speed': last_interface_speeds['speeds'].get(iface_name),
-                    'link_state': iface_obj.link_state,
-                }
-                for stat, name in retrieve_stat.items():
-                    with open(f'{i}/{stat}', 'r') as f:
-                        value = int(f.read())
-                    data['interfaces'][iface_name][name] = value
-                    traffic_stats = None
-                    if (
-                        last_interface_stats.get(iface_name) and
-                        name in last_interface_stats[iface_name]
-                    ):
-                        traffic_stats = value - last_interface_stats[iface_name][name]
-                        traffic_stats = int(
-                            traffic_stats / (
-                                stats_time - last_interface_stats[iface_name]['stats_time']
-                            )
-                        )
-                    data['interfaces'][iface_name][f'{retrieve_stat[stat]}_rate'] = traffic_stats
-                last_interface_stats[iface_name] = {
-                    **data['interfaces'][iface_name],
-                    'stats_time': stats_time,
-                }
+            # Interface IO Stats
+            with IfStats(interval, last_iface_stats, internal_interfaces) as ifstat:
+                if not last_iface_stats:
+                    # means this is the first time iface stats are being gathered so
+                    # get the results but don't set anything yet since we need to
+                    # calculate the difference between the iterations
+                    last_iface_stats, new = ifstat
+                else:
+                    last_iface_stats, data['interfaces'] = ifstat
 
             # Disk IO Stats
             if not last_disk_stats:

--- a/src/middlewared/middlewared/plugins/reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/ifstat.py
@@ -69,6 +69,8 @@ class IfStats(object):
                 new_data[nic]['sent_bytes'] = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
                 new_data[nic]['received_bytes_rate'] = new_data[nic]['received_bytes'] / self.interval
                 new_data[nic]['sent_bytes_rate'] = new_data[nic]['sent_bytes'] / self.interval
+                curr_data[nic]['received_bytes_rate'] = rx_bytes / self.interval
+                curr_data[nic]['sent_bytes_rate'] = tx_bytes /self.interval
             else:
                 # nic could have been up and is now down so no reason to do calculation
                 # just fill with zeros
@@ -76,6 +78,7 @@ class IfStats(object):
                 new_data[nic]['sent_bytes'] = 0
                 new_data[nic]['received_bytes_rate'] = 0.0
                 new_data[nic]['sent_bytes_rate'] = 0.0
-
+                curr_data[nic]['received_bytes_rate'] = 0.0
+                curr_data[nic]['sent_bytes_rate'] = 0.0
 
         return curr_data, new_data

--- a/src/middlewared/middlewared/plugins/reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/ifstat.py
@@ -58,27 +58,32 @@ class IfStats(object):
             curr_data[nic]['speed'] = speed
             new_data[nic]['speed'] = speed
 
-            rx_bytes = iodata.bytes_recv
-            tx_bytes = iodata.bytes_sent
-            curr_data[nic]['received_bytes'] = rx_bytes
-            curr_data[nic]['sent_bytes'] = tx_bytes
-
-            # diff between curr_data and self.prev_data
             if link_state == 'LINK_STATE_UP':
-                new_data[nic]['received_bytes'] = rx_bytes - self.prev_data.get(nic, {}).get('received_bytes', 0)
-                new_data[nic]['sent_bytes'] = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
-                new_data[nic]['received_bytes_rate'] = new_data[nic]['received_bytes'] / self.interval
-                new_data[nic]['sent_bytes_rate'] = new_data[nic]['sent_bytes'] / self.interval
+                # diff between curr_data and self.prev_data
+                rx_bytes = iodata.bytes_recv
+                tx_bytes = iodata.bytes_sent
+
+                curr_data[nic]['received_bytes'] = rx_bytes
+                curr_data[nic]['sent_bytes'] = tx_bytes
                 curr_data[nic]['received_bytes_rate'] = rx_bytes / self.interval
-                curr_data[nic]['sent_bytes_rate'] = tx_bytes /self.interval
+                curr_data[nic]['sent_bytes_rate'] = tx_bytes / self.interval
+
+                rx_diff = rx_bytes - self.prev_data.get(nic, {}).get('recevied_bytes', 0)
+                tx_diff = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
+                new_data[nic]['received_bytes'] = rx_diff
+                new_data[nic]['sent_bytes'] = tx_diff
+                new_data[nic]['received_bytes_rate'] = rx_diff / self.interval
+                new_data[nic]['sent_bytes_rate'] = tx_diff / self.interval
             else:
                 # nic could have been up and is now down so no reason to do calculation
-                # just fill with zeros
                 new_data[nic]['received_bytes'] = 0
                 new_data[nic]['sent_bytes'] = 0
                 new_data[nic]['received_bytes_rate'] = 0.0
                 new_data[nic]['sent_bytes_rate'] = 0.0
+
+                curr_data[nic]['received_bytes'] = 0
                 curr_data[nic]['received_bytes_rate'] = 0.0
+                curr_data[nic]['sent_bytes'] = 0
                 curr_data[nic]['sent_bytes_rate'] = 0.0
 
         return curr_data, new_data

--- a/src/middlewared/middlewared/plugins/reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/ifstat.py
@@ -68,7 +68,7 @@ class IfStats(object):
                 curr_data[nic]['received_bytes_rate'] = rx_bytes / self.interval
                 curr_data[nic]['sent_bytes_rate'] = tx_bytes / self.interval
 
-                rx_diff = rx_bytes - self.prev_data.get(nic, {}).get('recevied_bytes', 0)
+                rx_diff = rx_bytes - self.prev_data.get(nic, {}).get('received_bytes', 0)
                 tx_diff = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
                 new_data[nic]['received_bytes'] = rx_diff
                 new_data[nic]['sent_bytes'] = tx_diff

--- a/src/middlewared/middlewared/plugins/reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/ifstat.py
@@ -1,0 +1,72 @@
+from pyroute2.ethtool import Ethtool
+from pyroute2.ethtool.ioctl import NotSupportedError, NoSuchDevice
+from psutil import net_if_stats, net_io_counters
+
+
+class IfStats(object):
+
+    def __init__(self, interval, prev_data, ignore_ifaces):
+        self.interval = interval
+        self.prev_data = prev_data
+        self.ignore = ignore_ifaces
+        self.eth = Ethtool()
+
+    def __enter__(self):
+        return self.read()
+
+    def __exit__(self, _type, _value, _tb):
+        self.eth.close()
+        self.eth = None
+
+    def get_link_state(self, isup):
+        return 'LINK_STATE_UP' if isup else 'LINK_STATE_DOWN'
+
+    def get_link_speed(self, iface):
+        try:
+            speed = self.eth.get_link_mode(iface, with_netlink=False).speed
+        except (NotSupportedError, NoSuchDevice, Exception):
+            # NotSupportedError:
+            # ----running as a VM randomly reports NotSupportedError
+
+            # NoSuchDevice:
+            # ----udevd renames interfaces from "old" names (eth0) to new (enp5s0)
+            # ----[2.283069] r8169 0000:05:00.0 enp5s0: renamed from eth0
+
+            # ----also saw a driver problem with 2.5Gb Realteck card (go figure)
+            # ----[4205.447000] RTL8226 2.5Gbps PHY r8169-500:00: attached PHY driver
+
+            # Exception:
+            # ----catch anything else since this is in reporting plugin
+            speed = None
+
+        return speed
+
+    def read(self):
+        ifs = net_if_stats()
+        ioc = net_io_counters(pernic=True)
+        curr_data = dict()
+        new_data = dict()
+        for nic, iodata in filter(lambda x: x[0] not in self.ignore and x[0] in ifs, ioc.items()):
+            curr_data[nic] = dict()
+            new_data[nic] = dict()
+
+            link_state = self.get_link_state(ifs[nic].isup)
+            curr_data[nic]['link_state'] = link_state
+            new_data[nic]['link_state'] = link_state
+
+            speed = self.get_link_speed(nic)
+            curr_data[nic]['speed'] = speed
+            new_data[nic]['speed'] = speed
+
+            rx_bytes = iodata.bytes_recv
+            tx_bytes = iodata.bytes_sent
+            curr_data[nic]['received_bytes'] = rx_bytes
+            curr_data[nic]['sent_bytes'] = tx_bytes
+
+            # diff between curr_data and self.prev_data
+            new_data[nic]['received_bytes'] = rx_bytes - self.prev_data.get(nic, {}).get('received_bytes', 0)
+            new_data[nic]['sent_bytes'] = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
+            new_data[nic]['received_bytes_rate'] = new_data[nic]['received_bytes'] / self.interval
+            new_data[nic]['sent_bytes_rate'] = new_data[nic]['sent_bytes'] / self.interval
+
+        return curr_data, new_data

--- a/src/middlewared/middlewared/plugins/reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/ifstat.py
@@ -64,9 +64,18 @@ class IfStats(object):
             curr_data[nic]['sent_bytes'] = tx_bytes
 
             # diff between curr_data and self.prev_data
-            new_data[nic]['received_bytes'] = rx_bytes - self.prev_data.get(nic, {}).get('received_bytes', 0)
-            new_data[nic]['sent_bytes'] = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
-            new_data[nic]['received_bytes_rate'] = new_data[nic]['received_bytes'] / self.interval
-            new_data[nic]['sent_bytes_rate'] = new_data[nic]['sent_bytes'] / self.interval
+            if link_state == 'LINK_STATE_UP':
+                new_data[nic]['received_bytes'] = rx_bytes - self.prev_data.get(nic, {}).get('received_bytes', 0)
+                new_data[nic]['sent_bytes'] = tx_bytes - self.prev_data.get(nic, {}).get('sent_bytes', 0)
+                new_data[nic]['received_bytes_rate'] = new_data[nic]['received_bytes'] / self.interval
+                new_data[nic]['sent_bytes_rate'] = new_data[nic]['sent_bytes'] / self.interval
+            else:
+                # nic could have been up and is now down so no reason to do calculation
+                # just fill with zeros
+                new_data[nic]['received_bytes'] = 0
+                new_data[nic]['sent_bytes'] = 0
+                new_data[nic]['received_bytes_rate'] = 0.0
+                new_data[nic]['sent_bytes_rate'] = 0.0
+
 
         return curr_data, new_data


### PR DESCRIPTION
Fix many problems.

1. The code that did `glob.glob` and multiple `with open` for each interface slowly leaked memory. I have no idea why but more importantly is that we can fix this by simply removing that code and use tools that already do the hard work for us.
2. the `speed` of each interface was wrong
3. we were only getting the link state of each interface every 5 minutes but we continued to get the traffic stats on the `interval`?
4. the `received_bytes_rate` and `send_bytes_rate` were calculated incorrectly

My changes move the interface related statistics to its' own module and class. I use a couple different well-known 3rd party python modules that gather these stats using `ioctl` or native C bindings which are vastly faster than what we were doing. More importantly, however, no more memory leak and makes the webUI dashboard more responsive since CPU usage goes way down using these methods.

Original PR: https://github.com/truenas/middleware/pull/9342
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116953