### PR TITLE
NAS-117049 / 22.12 / improve getting zfs arcstats

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/arcstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/arcstat.py
@@ -4,13 +4,13 @@ class ZfsArcStats(object):
         self.args = args
         self.kwargs = kwargs
 
-    def read():
+    def read(self):
         hits = misses = total = 0
         fhits = fmisses = fmax = fsize = False
         data = {'arc_max_size': 0, 'arc_size': 0, 'cache_hit_ratio': 0.0}
         with open('/proc/spl/kstat/zfs/arcstats') as f:
             for lineno, line in enumerate(f):
-                if line < 2:
+                if lineno < 2:
                     # skip first 2 lines
                     continue
 

--- a/src/middlewared/middlewared/plugins/reporting/arcstats.py
+++ b/src/middlewared/middlewared/plugins/reporting/arcstats.py
@@ -1,0 +1,44 @@
+class ZfsArcStats(object):
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def read():
+        hits = misses = total = 0
+        fhits = fmisses = fmax = fsize = False
+        data = {'arc_max_size': 0, 'arc_size': 0, 'cache_hit_ratio': 0.0}
+        with open('/proc/spl/kstat/zfs/arcstats') as f:
+            for lineno, line in enumerate(f):
+                if line < 2:
+                    # skip first 2 lines
+                    continue
+
+                try:
+                    name, _, value = line.strip().split()
+                except ValueError:
+                    # maybe file format has changed or is malformed?
+                    continue
+
+                if name == 'hits':
+                    hits = int(value)
+                    fhits = True
+                elif name == 'misses':
+                    misses = int(value)
+                    fmisses = True
+                elif name == 'c_max':
+                    data['arc_max_size'] = int(value)
+                    fmax = True
+                elif name == 'size':
+                    data['arc_size'] = int(value)
+                    fsize = True
+
+                if all((fhits, fmisses, fmax, fsize)):
+                    # no reason to iterate entire contents
+                    # if we've got the information we need
+                    break
+
+        if total := (hits + misses):
+            data['cache_hit_ratio'] = hits / total
+
+        return data

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -9,6 +9,7 @@ from middlewared.validators import Range
 
 from .iostat import DiskStats
 from .ifstat import IfStats
+from .arcstat import ZfsArcStats
 
 
 class RealtimeEventSource(EventSource):
@@ -133,26 +134,7 @@ class RealtimeEventSource(EventSource):
             data = {}
 
             # ZFS ARC Size (raw value is in Bytes)
-            hits = 0
-            misses = 0
-            data['zfs'] = {}
-            with open('/proc/spl/kstat/zfs/arcstats') as f:
-                for line in f.readlines()[2:]:
-                    if line.strip():
-                        name, type, value = line.strip().split()
-                        if name == 'hits':
-                            hits = int(value)
-                        if name == 'misses':
-                            misses = int(value)
-                        if name == 'c_max':
-                            data['zfs']['arc_max_size'] = int(value)
-                        if name == 'size':
-                            data['zfs']['arc_size'] = int(value)
-            total = hits + misses
-            if total > 0:
-                data['zfs']['cache_hit_ratio'] = hits / total
-            else:
-                data['zfs']['cache_hit_ratio'] = 0
+            data['zfs'] = ZfsArcStats().read()
 
             # Virtual memory use
             data['memory'] = self.get_memory_info(data['zfs']['arc_size'])

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -60,7 +60,6 @@ class RealtimeEventSource(EventSource):
             Float('cache_hit_ratio'),
         ),
     )
-    INTERFACE_SPEEDS_CACHE_INTERVAL = 300
 
     @staticmethod
     def get_cpu_usages(cp_diff):


### PR DESCRIPTION
Improve getting zfs arcstats in the `reporting.realtime` subscription.

1. Don't `f.readlines()` since that loads the entire contents of the file into a list in memory. We can iterate over the file object which is quite a bit faster and more memory efficient.
2. Keep track of the 4 stats that we're pulling out of the file and then break the for-loop early as to not iterate over the entire contents of the file unnecessarily.
3. move this logic to it's own module like we are doing with `DiskStats` and `IfStats`