### PR TITLE
NAS-117058 / 22.12 / Include "df -T" for SMB share paths in debug output

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
@@ -104,6 +104,8 @@ smb_func()
 			getfacl -n "${cifs_path}"
 		fi
 		printf "\n"
+		df -T "${cifs_path}"
+		printf "\n"
 	done
 	section_footer
 


### PR DESCRIPTION
This will allow quickly determining underlying dataset
for SMB shares  when reviewing debug info in tickets.