### PR TITLE
NAS-116978 / 22.02.3 / Improve logging for when we disable a directory service (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/health.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/health.py
@@ -98,7 +98,7 @@ class ActiveDirectoryService(Service):
 
         try:
             verrors.check()
-        except Exception:
+        except ValidationErrors:
             await self.middleware.call('activedirectory.direct_update', {"enable": False})
             raise CallError('Automatically disabling ActiveDirectory service due to invalid configuration.',
                             errno.EINVAL)

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -168,6 +168,15 @@ class DirectoryServices(Service):
                 try:
                     res = await self.middleware.call(f'{srv.value}.started')
                     ds_state[srv.value] = DSStatus.HEALTHY.name if res else DSStatus.DISABLED.name
+
+                except CallError as e:
+                    if e.errno == errno.EINVAL:
+                        self.logger.warning('%s: setting service to DISABLED due to invalid config',
+                                            srv.value.upper(), exc_info=True)
+                        ds_state[srv.value] = DSStatus.DISABLED.name
+                    else:
+                        ds_state[srv.value] = DSStatus.FAULTED.name
+
                 except Exception:
                     ds_state[srv.value] = DSStatus.FAULTED.name
 

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1131,7 +1131,7 @@ class LDAPService(TDBWrapConfigService):
         await self.common_validate(ldap, ldap, verrors)
         try:
             verrors.check()
-        except Exception:
+        except ValidationErrors:
             await super().do_update({"enable": False})
             raise CallError('Automatically disabling LDAP service due to invalid configuration.',
                             errno.EINVAL)


### PR DESCRIPTION
During the "started" methods for directory services, which are
used in health checks, we re-run validation on the user's
directory service configuration. If it fails validation, then
we automatically disable the directory service.

This PR more explicitly handles ValidationErrors during
directoryservices.get_state. An errno of EINVAL in CallError
means that we have failed validation and have disabled the service,
and in turn need to reflect this state in the directoryservices
cache.

Original PR: https://github.com/truenas/middleware/pull/9318
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116978