### PR TITLE
NAS-117010 / 22.02.3 / Provide more detailed ctdb status (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -60,7 +60,7 @@ class ClusterJob(Service):
         if not (await self.middleware.call('service.query', [('service', '=', 'glusterd')], {'get': True}))['enable']:
             return
 
-        node = (await self.middleware.call('ctdb.general.status', {'all_nodes': False}))[0]
+        node = (await self.middleware.call('ctdb.general.status', {'all_nodes': False}))['nodemap']['nodes'][0]
         if node['flags_raw'] != 0:
             CallError(f'Cannot reload directory service. Node health: {node["flags"]}')
 
@@ -135,7 +135,7 @@ class ClusterJob(Service):
             'status': CLStatus.ACTIVE.name
         }
         await self.wait_for_method(job, method, 10)
-        for node in await self.middleware.call('ctdb.general.status'):
+        for node in (await self.middleware.call('ctdb.general.status'))['nodemap']['nodes']:
             if node['this_node'] or node['pnn'] == -1:
                 continue
             job.set_progress(50, f'Setting job status indicator for node {node["address"]!r}')

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -82,7 +82,7 @@ class ClusterUtils(Service):
 
     @job("cluster_time_info")
     async def time_info(self, job):
-        nodes = await self.middleware.call('ctdb.general.status')
+        nodes = await self.middleware.call('ctdb.general.status')['nodemap']['nodes']
         for node in nodes:
             if node['flags_raw'] != 0:
                 raise CallError(f'Cluster node {node["pnn"]} is unhealthy. Unable to retrieve time info.')


### PR DESCRIPTION
Current recovery info and vnnmap is relevant info for internal
purposes. Since TC isn't currently using this API it's safe to
change. Converting to python bindings changed listnodes output
slightly, revert back to previous output to avoid change in
API return for ctdb.private.ips.query. Add docstring for
ctdb.general.status.

Original PR: https://github.com/truenas/middleware/pull/9339
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117010