### PR TITLE
NAS-117061 / 22.02.2.1 / fix small memory leak in netif.list_interfaces() (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,4 +1,3 @@
-import logging
 from pyroute2 import IPRoute
 
 from .bridge import create_bridge
@@ -6,8 +5,6 @@ from .interface import Interface, CLONED_PREFIXES
 from .lagg import AggregationProtocol, create_lagg
 from .utils import run
 from .vlan import create_vlan
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["AggregationProtocol", "create_vlan", "create_interface", "destroy_interface", "get_interface",
            "list_interfaces", "CLONED_PREFIXES"]

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,5 +1,5 @@
 import logging
-from pyroute2 import NDB
+from pyroute2 import IPRoute
 
 from .bridge import create_bridge
 from .interface import Interface, CLONED_PREFIXES
@@ -38,5 +38,9 @@ def get_interface(name, safe_retrieval=False):
 
 
 def list_interfaces():
-    with NDB(log="off") as ndb:
-        return {i.ifname: Interface(i.ifname) for i in ndb.interfaces}
+    info = dict()
+    with IPRoute() as ipr:
+        for dev in ipr.get_links():
+            name = dev.get_attr('IFLA_IFNAME')
+            info[name] = Interface(name)
+    return info


### PR DESCRIPTION
Fix small (200 - 900 bytes each time this is called) memory leak in `netif.list_interfaces()`. I'm already doing this on master but there were other improvements that were included there so this is the compromise for stable/angelfish branch.

Original PR: https://github.com/truenas/middleware/pull/9354
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117061