### PR TITLE
NAS-117066 / 22.12 / Add pwenc service for cluster

### DIFF
--- a/cluster-tests/tests/clustercache/test_001_base_clustercache_tests.py
+++ b/cluster-tests/tests/clustercache/test_001_base_clustercache_tests.py
@@ -1,0 +1,243 @@
+import pytest
+
+from config import CLUSTER_IPS
+from pytest_dependency import depends
+from time import sleep
+from utils import make_ws_request
+
+
+@pytest.mark.dependency(name='CLUSTERCACHE_WORKING')
+@pytest.mark.parametrize('ip', CLUSTER_IPS)
+def test_001_put_get_query_pop(ip, request):
+    """
+    This validates that all basic operations work
+    on all nodes.
+    """
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': ["FOO", {"test": "things"}]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is None, res
+
+    payload_haskey = {
+        'msg': 'method',
+        'method': 'clustercache.has_key',
+        'params': ["FOO"]
+    }
+    res = make_ws_request(ip, payload_haskey)
+    assert res.get('error') is None, res
+    assert res['result'] is True
+
+    payload_get = {
+        'msg': 'method',
+        'method': 'clustercache.get',
+        'params': ["FOO"]
+    }
+    res = make_ws_request(ip, payload_get)
+    assert res.get('error') is None, res
+    assert res['result'] == {"test": "things"}
+
+    payload_query = {
+        'msg': 'method',
+        'method': 'clustercache.query',
+        'params': [[['key', '=', 'FOO']]]
+    }
+    res = make_ws_request(ip, payload_query)
+    assert res.get('error') is None, res
+    assert len(res['result']) == 1
+
+    payload_pop = {
+        'msg': 'method',
+        'method': 'clustercache.pop',
+        'params': ["FOO"]
+    }
+    res = make_ws_request(ip, payload_pop)
+    assert res.get('error') is None, res
+    assert res['result'] == {"test": "things"}
+
+    payload_haskey = {
+        'msg': 'method',
+        'method': 'clustercache.has_key',
+        'params': ["FOO"]
+    }
+    res = make_ws_request(ip, payload_haskey)
+    assert res.get('error') is None, res
+    assert res['result'] is False
+
+
+def test_002_expired_timed_request(request):
+    """
+    Expired entries should be visible in `has_key`
+    but raise exception and remove entry on `get`.
+    """
+    depends(request, ['CLUSTERCACHE_WORKING'])
+    ip = CLUSTER_IPS[0]
+
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': ["TEST_ENTRY_TIMED", {"test": "things"}, 3]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is None, res
+
+    sleep(5)
+
+    payload_haskey = {
+        'msg': 'method',
+        'method': 'clustercache.has_key',
+        'params': ['TEST_ENTRY_TIMED']
+    }
+    res = make_ws_request(ip, payload_haskey)
+    assert res.get('error') is None, res
+    assert res['result'] is True
+
+    payload_get = {
+        'msg': 'method',
+        'method': 'clustercache.get',
+        'params': ['TEST_ENTRY_TIMED']
+    }
+    res = make_ws_request(ip, payload_get)
+    assert res.get('error') is not None, res
+    assert 'has expired' in res['error']['reason'], res
+
+    payload_haskey = {
+        'msg': 'method',
+        'method': 'clustercache.has_key',
+        'params': ['TEST_ENTRY_TIMED']
+    }
+    res = make_ws_request(ip, payload_haskey)
+    assert res.get('error') is None, res
+    assert res['result'] is False
+
+
+def test_003_create_flag(request):
+    """
+    clustercache.put should fail with KeyError
+    if CREATE specified and entry already exists.
+    After failing, check that original
+    entry exists with correct value.
+    """
+    depends(request, ['CLUSTERCACHE_WORKING'])
+    ip = CLUSTER_IPS[0]
+
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': [
+            'TEST_ENTRY_CREATE',
+            {'test': 'things'},
+            0,
+            {'flag': 'CREATE'}
+        ]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is None, res
+
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': [
+            'TEST_ENTRY_CREATE',
+            {'test': 'things2'},
+            0,
+            {'flag': 'CREATE'}
+        ]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is not None, res
+
+    payload_pop = {
+        'msg': 'method',
+        'method': 'clustercache.pop',
+        'params': ['TEST_ENTRY_CREATE']
+    }
+    res = make_ws_request(ip, payload_pop)
+    assert res.get('error') is None, res
+    assert res['result'] == {'test': 'things'}
+
+
+def test_004_update_flag(request):
+    """
+    clustercache.put should fail with KeyError
+    if UPDATE specied and entry does not exist.
+    """
+    depends(request, ['CLUSTERCACHE_WORKING'])
+    ip = CLUSTER_IPS[0]
+
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': [
+            'TEST_ENTRY_UPDATE',
+            {'test': 'things'},
+            0,
+            {'flag': 'UPDATE'}
+        ]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is not None, res
+
+
+@pytest.mark.dependency(name='PRIVATE_CREATED')
+def test_005_create_private_entry(request):
+    """
+    Private entries are encrypted before being written / sent
+    of the wire. Middlewared transparently decrypts.
+    This test creates the private entry that will be
+    checked in subsequent tests.
+    """
+    depends(request, ['CLUSTERCACHE_WORKING'])
+    ip = CLUSTER_IPS[0]
+
+    payload_put = {
+        'msg': 'method',
+        'method': 'clustercache.put',
+        'params': [
+            'TEST_ENTRY_PRIVATE',
+            {'test': 'things'},
+            0,
+            {'private': True}
+        ]
+    }
+    res = make_ws_request(ip, payload_put)
+    assert res.get('error') is None, res
+
+
+@pytest.mark.parametrize('ip', CLUSTER_IPS)
+def test_006_create_private_entry(ip, request):
+    """
+    All nodes should be able to read data and see
+    entry as private
+    """
+    depends(request, ['PRIVATE_CREATED'])
+
+    payload_query = {
+        'msg': 'method',
+        'method': 'clustercache.query',
+        'params': [
+            [['key', '=', 'TEST_ENTRY_PRIVATE']],
+            {'get': True}
+        ]
+    }
+    res = make_ws_request(ip, payload_query)
+    assert res.get('error') is None, res
+
+    assert res['result']['value'] == {'test': 'things'}, res
+    assert res['result']['private'] is True, res
+
+
+def test_007_remove_private_entry(request):
+    depends(request, ['PRIVATE_CREATED'])
+    ip = CLUSTER_IPS[0]
+
+    payload_pop = {
+        'msg': 'method',
+        'method': 'clustercache.pop',
+        'params': ['TEST_ENTRY_PRIVATE']
+    }
+    res = make_ws_request(ip, payload_pop)
+    assert res.get('error') is None, res
+    assert res['result'] == {'test': 'things'}

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -104,6 +104,11 @@ class CtdbSharedVolumeService(Service):
             wait_id = await self.middleware.call('core.job_wait', fuse_mount_job[0]['id'])
             await wait_id.wait()
 
+        # Initialize clustered secrets
+        if not await self.middleware.call('clpwenc.check'):
+            self.logger.debug('Generating clustered pwenc secret')
+            await self.middleware.call('clpwenc.generate_secret')
+
         # The peers in the TSP could be using dns names while ctdb
         # only accepts IP addresses. This means we need to resolve
         # the hostnames of the peers in the TSP to their respective

--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -1,50 +1,85 @@
 import base64
+import fcntl
 import os
+import threading
 
+from contextlib import contextmanager
 from Cryptodome.Cipher import AES
 from Cryptodome.Util import Counter
 
+from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 from middlewared.service import Service
-
+from middlewared.service_exception import CallError
+from middlewared.utils.path import pathref_open
 
 PWENC_BLOCK_SIZE = 32
 PWENC_FILE_SECRET = os.environ.get('FREENAS_PWENC_SECRET', '/data/pwenc_secret')
 PWENC_PADDING = b'{'
 PWENC_CHECK = 'Donuts!'
 
+CLPWENC_PATH = os.path.join(
+    FuseConfig.FUSE_PATH_BASE.value,
+    CTDBConfig.CTDB_VOL_NAME.value,
+)
+
 
 class PWEncService(Service):
 
     secret = None
+    secret_path = PWENC_FILE_SECRET
+    lock = threading.RLock()
 
     class Config:
         private = True
 
     def file_secret_path(self):
-        return PWENC_FILE_SECRET
+        return self.secret_path
 
-    def generate_secret(self, reset_passwords=True):
-        secret = os.urandom(PWENC_BLOCK_SIZE)
-        with open(PWENC_FILE_SECRET, 'wb') as f:
-            os.fchmod(f.fileno(), 0o600)
-            f.write(secret)
-        self.reset_secret_cache()
+    def _reset_passwords(self):
+        for table, field in (
+            ('directoryservice_activedirectory', 'ad_bindpw'),
+            ('directoryservice_ldap', 'ldap_bindpw'),
+            ('services_dynamicdns', 'ddns_password'),
+            ('services_webdav', 'webdav_password'),
+            ('services_ups', 'ups_monpwd'),
+            ('system_email', 'em_pass'),
+        ):
+            self.middleware.call_sync('datastore.sql', f'UPDATE {table} SET {field} = \'\'')
 
+    @staticmethod
+    def _secret_opener(path, flags):
+        with pathref_open(os.path.dirname(path), force=True, mode=0o755) as secret_path:
+            return os.open(os.path.basename(path), flags, dir_fd=secret_path)
+
+    def _reset_pwenc_check_field(self):
         settings = self.middleware.call_sync('datastore.config', 'system.settings')
         self.middleware.call_sync('datastore.update', 'system.settings', settings['id'], {
             'stg_pwenc_check': self.encrypt(PWENC_CHECK),
         })
 
-        if reset_passwords:
-            for table, field in (
-                ('directoryservice_activedirectory', 'ad_bindpw'),
-                ('directoryservice_ldap', 'ldap_bindpw'),
-                ('services_dynamicdns', 'ddns_password'),
-                ('services_webdav', 'webdav_password'),
-                ('services_ups', 'ups_monpwd'),
-                ('system_email', 'em_pass'),
-            ):
-                self.middleware.call_sync('datastore.sql', f'UPDATE {table} SET {field} = \'\'')
+    @contextmanager
+    def _lock_secrets(self, fd):
+        with self.lock:
+            fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                yield fd
+            finally:
+                fcntl.lockf(fd, fcntl.LOCK_UN)
+
+    def generate_secret(self, reset_passwords=True):
+        secret = os.urandom(PWENC_BLOCK_SIZE)
+        with open(self.secret_path, 'wb', opener=self._secret_opener) as f:
+            with self._lock_secrets(f.fileno()):
+                os.fchmod(f.fileno(), 0o600)
+                f.write(secret)
+                f.flush()
+                os.fsync(f.fileno())
+
+                self.reset_secret_cache()
+                self._reset_pwenc_check_field()
+
+                if reset_passwords:
+                    self._reset_passwords()
 
     def check(self):
         try:
@@ -58,7 +93,7 @@ class PWEncService(Service):
     @classmethod
     def get_secret(cls):
         if cls.secret is None:
-            with open(PWENC_FILE_SECRET, 'rb') as f:
+            with open(cls.secret_path, 'rb', opener=cls._secret_opener) as f:
                 cls.secret = f.read()
 
         return cls.secret
@@ -74,32 +109,119 @@ class PWEncService(Service):
         return decrypt(encrypted, _raise)
 
 
+class CLPWEncService(PWEncService):
+
+    class Config:
+        private = True
+
+    secret = None
+    secret_path = os.path.join(
+        CLPWENC_PATH,
+        '.cluster_private',
+        'clpwenc_secret'
+    )
+
+    def _reset_passwords(self):
+        return
+
+    @staticmethod
+    def _secret_opener(path, flags):
+        with pathref_open(CLPWENC_PATH, force=True, mode=0o755) as ctdb_path:
+            st = os.fstat(ctdb_path)
+            if st.st_ino != 1:
+                raise CallError(
+                    f'Unexpected inode number on {CLPWENC_PATH}. '
+                    'This strongly indicates that the ctdb shared volume '
+                    'is no longer mounted.'
+                )
+
+            with pathref_open(
+                ".cluster_private", mode=0o700, dir_fd=ctdb_path, mkdir=True
+            ) as priv:
+                return os.open(os.path.basename(path), flags, dir_fd=priv)
+
+    @contextmanager
+    def check_file(self, flags):
+        def opener(path, flags):
+            with pathref_open(CLPWENC_PATH, force=True, mode=0o755) as ctdb_path:
+                st = os.fstat(ctdb_path)
+                if st.st_ino != 1:
+                    raise CallError(
+                        f'Unexpected inode number on {CLPWENC_PATH}. '
+                        'This strongly indicates that the ctdb shared volume '
+                        'is no longer mounted.'
+                    )
+
+                with pathref_open('.cluster_private', force=True, mode=0o700, dir_fd=ctdb_path) as priv:
+                    return os.open(path, flags, dir_fd=priv)
+
+        out_file = open('.check_file', flags, opener=opener)
+        try:
+            yield out_file
+        finally:
+            out_file.close()
+
+    def check(self):
+        with self.check_file('r') as f:
+            data = f.read()
+
+        return self.decrypt(data) == PWENC_CHECK
+
+    def _reset_pwenc_check_field(self):
+        with self.check_file('w') as f:
+            f.write(self.encrypt(PWENC_CHECK))
+
+    def generate_secret(self, reset_passwords=True):
+        if not self.middleware.call_sync('ctdb.general.healthy'):
+            raise CallError('Cluster is unhealthy. Refusing to generate secret')
+
+        super().generate_secret()
+
+    def encrypt(self, data):
+        return encrypt(data, True)
+
+    def decrypt(self, encrypted, _raise=False):
+        return decrypt(encrypted, _raise, True)
+
+
 async def setup(middleware):
     if not await middleware.call('pwenc.check'):
         middleware.logger.debug('Generating new pwenc secret')
         await middleware.call('pwenc.generate_secret')
 
 
-def encrypt(data):
+def encrypt(data, cluster=False):
     data = data.encode('utf8')
 
     def pad(x):
         return x + (PWENC_BLOCK_SIZE - len(x) % PWENC_BLOCK_SIZE) * PWENC_PADDING
 
     nonce = os.urandom(8)
-    cipher = AES.new(PWEncService.get_secret(), AES.MODE_CTR, counter=Counter.new(64, prefix=nonce))
+    if cluster:
+        enc_service = CLPWEncService
+    else:
+        enc_service = PWEncService
+
+    cipher = AES.new(enc_service.get_secret(), AES.MODE_CTR, counter=Counter.new(64, prefix=nonce))
     encoded = base64.b64encode(nonce + cipher.encrypt(pad(data)))
     return encoded.decode()
 
 
-def decrypt(encrypted, _raise=False):
+def decrypt(encrypted, _raise=False, cluster=False):
     if not encrypted:
         return ''
+
+    if cluster:
+        enc_service = CLPWEncService
+    else:
+        enc_service = PWEncService
+
     try:
         encrypted = base64.b64decode(encrypted)
         nonce = encrypted[:8]
         encrypted = encrypted[8:]
-        cipher = AES.new(PWEncService.get_secret(), AES.MODE_CTR, counter=Counter.new(64, prefix=nonce))
+
+        cipher = AES.new(enc_service.get_secret(), AES.MODE_CTR, counter=Counter.new(64, prefix=nonce))
         return cipher.decrypt(encrypted).rstrip(PWENC_PADDING).decode('utf8')
     except Exception:
         if _raise:

--- a/src/middlewared/middlewared/utils/path.py
+++ b/src/middlewared/middlewared/utils/path.py
@@ -1,11 +1,15 @@
 # -*- coding=utf-8 -*-
+import errno
 import fcntl
 import logging
 import os
+import stat
+
+from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["is_child", "pathref_reopen"]
+__all__ = ["is_child", "pathref_open", "pathref_reopen"]
 
 
 def pathref_reopen(fd_in: int, flags: int, **kwargs) -> int:
@@ -22,6 +26,77 @@ def pathref_reopen(fd_in: int, flags: int, **kwargs) -> int:
         os.close(fd_in)
 
     return fd_out
+
+
+@contextmanager
+def pathref_open(path: str, **kwargs) -> int:
+    """
+    Get O_PATH open for specified `path`. Supports following kwargs:
+
+    `dir_fd` - fileno for open of to use as dir_fd for open of path.
+
+    `expected_mode` - expected permissions on open of `path`. If
+    the `force` kwarg is also set then the file's permissions
+    will be changed to the specified value. Otherwise ValueError
+    will be raised on permissions mismatch.
+
+    `force` - If path is a symbolic link, then the symlink will be
+    removed and replaced with a directory. In case of mismatch
+    between expected_mode and stat() output, chmod(2) will be called.
+
+    `mkdir` - if `path` does not exist, then it will be created.
+    """
+    dir_fd = kwargs.get('dir_fd')
+    flags = os.O_PATH | os.O_NOFOLLOW | kwargs.get('additional_flags', 0)
+    expected_mode = kwargs.get('mode')
+    force = kwargs.get('force')
+    mkdir = kwargs.get('mkdir', False)
+    fd = -1
+
+    try:
+        fd = os.open(path, flags | os.O_NOFOLLOW, dir_fd=dir_fd)
+    except FileNotFoundError:
+        if not mkdir:
+            raise
+
+        os.mkdir(path, expected_mode or 0o755, dir_fd=dir_fd)
+    except OSError as e:
+        # open will fail with ELOOP if last component is symlink
+        # due to O_NOFOLLOW
+        if e.errno != errno.ELOOP or not force:
+            raise
+
+        os.unlink(path, dir_fd=dir_fd)
+        os.mkdir(path, expected_mode or 0o755, dir_fd=dir_fd)
+        fd = os.open(path, flags, dir_fd=dir_fd)
+
+    st = os.fstat(fd)
+
+    if not stat.S_ISDIR(st.st_mode):
+        os.close(fd)
+        raise NotADirectoryError(path)
+
+    if expected_mode and stat.S_IMODE(st.st_mode) != expected_mode:
+        if not force:
+            raise ValueError(
+                f'{stat.S_IMODE(st.st_mode)} does not match expected mode: '
+                f'{expected_mode}, and "force" was not specified.'
+            )
+
+        try:
+            tmp_fd = pathref_reopen(fd, os.O_DIRECTORY, dir_fd=dir_fd)
+            try:
+                os.fchmod(tmp_fd, expected_mode)
+            finally:
+                os.close(tmp_fd)
+        except Exception:
+            os.close(fd)
+            raise
+
+    try:
+        yield fd
+    finally:
+        os.close(fd)
 
 
 def is_child(child: str, parent: str):


### PR DESCRIPTION
Conventional pwenc service has node-specific secrets file. There
are times when we need to encrypt contents of clustered cache
or other shared data between nodes. This adds a clustered
pwenc module using secret stored in private directory of
ctdb_shared_volume. The clustercache plugin already was designed
for eventual inclusion of private data. This PR enables that
support and is a step in preparing for clustered local user
info.