### PR TITLE
NAS-117072 / 22.02.3 / Include nftables ruleset in network debug (by freqlabs)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
@@ -133,6 +133,10 @@ network_func()
 	iptables-save -c
 	section_footer
 
+	section_header "Nftables Ruleset (nft -a list ruleset)"
+	nft -a list ruleset
+	section_footer
+
 	section_header "IPVS rules (ipvsadm -L)"
 	ipvsadm -L
 	section_footer


### PR DESCRIPTION
iptables is deprecated in Debian in favor of nftables.  The iptables
commands are configured to use iptables-nft, which wraps nftables in an
iptables command interface for compat.  We should prefer to use nftables
where we have the option.

With this in mind, it is useful to also know the full nftables ruleset
when debugging network issues, in particular with regard to kube-router.

Original PR: https://github.com/truenas/middleware/pull/9360
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117072