### PR TITLE
NAS-116676 / 22.02.3 / Backup/restore k8s cluster when migrating apps to new pool (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -188,6 +188,13 @@ class ChartReleaseService(Service):
         else:
             await self.middleware.call('k8s.storage_class.create', storage_class)
 
+    @private
+    async def recreate_storage_class(self, release_name, volumes_path):
+        storage_class_name = get_storage_class_name(release_name)
+        if await self.middleware.call('k8s.storage_class.query', [['metadata.name', '=', storage_class_name]]):
+            await self.middleware.call('k8s.storage_class.delete', storage_class_name)
+        await self.create_update_storage_class_for_chart_release(release_name, volumes_path)
+
     @accepts(Str('release_name'))
     @returns(Dict(
         Int('available', required=True),

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
@@ -2,6 +2,8 @@ import glob
 import os
 import yaml
 
+from datetime import datetime
+
 from middlewared.service import CallError, private, Service
 
 from .utils import applications_ds_name, MIGRATION_NAMING_SCHEMA
@@ -10,7 +12,31 @@ from .utils import applications_ds_name, MIGRATION_NAMING_SCHEMA
 class KubernetesService(Service):
 
     @private
-    async def migrate_ix_applications_dataset(self, new_pool, old_pool):
+    async def migrate_ix_applications_dataset(self, job, config, old_config):
+        new_pool = config['pool']
+        backup_name = f'backup_to_{new_pool}_{datetime.utcnow().strftime("%F_%T")}'
+        job.set_progress(30, 'Creating kubernetes cluster backup')
+        backup_job = await self.middleware.call('kubernetes.backup_chart_releases', backup_name)
+        await backup_job.wait()
+        if backup_job.error:
+            raise CallError(f'Failed to backup kubernetes cluster: {backup_job.error}')
+
+        try:
+            job.set_progress(40, f'Replicating datasets from {old_config["pool"]!r} to {new_pool!r} pool')
+            await self.replicate_apps_dataset(new_pool, old_config['pool'])
+
+            await self.middleware.call('datastore.update', 'services.kubernetes', old_config['id'], config)
+
+            job.set_progress(70, f'Restoring kubernetes cluster in {new_pool!r} pool')
+            restore_job = await self.middleware.call('kubernetes.restore_backup', backup_name)
+            await restore_job.wait()
+            if restore_job.error:
+                raise CallError(f'Failed to restore kubernetes cluster on the new pool: {restore_job.error}')
+        finally:
+            await self.middleware.call('kubernetes.delete_backup', backup_name)
+
+    @private
+    async def replicate_apps_dataset(self, new_pool, old_pool):
         snap_details = await self.middleware.call(
             'zfs.snapshot.create', {
                 'dataset': applications_ds_name(old_pool),
@@ -39,9 +65,6 @@ class KubernetesService(Service):
             await migrate_job.wait()
             if migrate_job.error:
                 raise CallError(f'Failed to migrate {old_ds} to {new_ds}: {migrate_job.error}')
-
-            # We will make sure that certificate paths point to the newly configured pool
-            await self.middleware.call('kubernetes.update_server_credentials', new_ds)
         finally:
             await self.middleware.call('zfs.snapshot.delete', snap_details['id'], {'recursive': True})
             snap_name = f'{applications_ds_name(new_pool)}@{snap_details["snapshot_name"]}'


### PR DESCRIPTION
## Problem

When we were migrating k8s cluster or restoring it form backup, it's possible in the latter as well that we are now using a new pool instead of the older one. However openebs based storage classes apart from default storage class would still be pointing older pool which will result in new PV's being created on upgrades of apps to use the old pool.

When PV's have been migrated to new pool, they still reference the old pool which results in the PV being mounted from the older pool.

## Solution

1. When we migrate apps to a new pool, we are not able to update PV's CSI spec which specifies the dataset which should be mounted. So now instead of managing each dependency ( and failing to do so for PV's ) on migrating apps, we instead take a backup and restore it in the newer pool.
2. Make sure storage classes and PV's reference the new pool after migration.

Original PR: https://github.com/truenas/middleware/pull/9310
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116676