### PR TITLE
NAS-117081 / 22.02.3 / Fix regression in clustered timeinfo (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -82,7 +82,7 @@ class ClusterUtils(Service):
 
     @job("cluster_time_info")
     async def time_info(self, job):
-        nodes = await self.middleware.call('ctdb.general.status')['nodemap']['nodes']
+        nodes = (await self.middleware.call('ctdb.general.status'))['nodemap']['nodes']
         for node in nodes:
             if node['flags_raw'] != 0:
                 raise CallError(f'Cluster node {node["pnn"]} is unhealthy. Unable to retrieve time info.')


### PR DESCRIPTION
Typo in applying change node status output caused regression
in gathering cluster-wide time info. While fixing this I
realized that we could end up with orphaned cluster jobs if
caller timed out, so now we scavenge jobs that have been
expired for more than 10 minutes.

Original PR: https://github.com/truenas/middleware/pull/9363
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117081