### PR TITLE
reporting: Remove dummy memory-cache statistic

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -131,7 +131,6 @@ class MemoryPlugin(RRDBase):
             ('memory-inactive', 'value', '%name%,UN,0,%name%,IF'),
             ('memory-wired', 'value', '%name%,UN,0,%name%,IF'),
             ('memory-laundry', 'value', '%name%,UN,0,%name%,IF'),
-            ('memory-cache', 'value', '%name%,UN,0,%name%,IF'),
             ('memory-free', 'value', '%name%,UN,0,%name%,IF'),
         )
     else:


### PR DESCRIPTION
The memory-cache statistic reported the size of the virtual memory page
cache queue.  The page cache queue has been removed in favor of the
page laundry queue.  We added a stat for this but failed to remove the
page cache stat, which is now only a dummy stat left for compat and
always reports 0.

Remove the dummy memory-cache statistic.