### PR TITLE
NAS-117137 / 22.12 / add mount_info to sharing plugins

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -785,6 +785,7 @@ class CloudSyncService(TaskPathService):
 
         cloud_sync.pop('job', None)
         cloud_sync.pop(self.locked_field, None)
+        cloud_sync.pop(self.mount_info_field, None)
 
         return cloud_sync
 

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -143,7 +143,8 @@ class iSCSITargetExtentService(SharingService):
         verrors.check()
 
         await self.save(new, 'iscsi_extent_update', verrors)
-        new.pop(self.locked_field)
+        new.pop(self.locked_field, None)
+        new.pop(self.mount_info_field, None)
 
         await self.middleware.call(
             'datastore.update',

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -536,6 +536,7 @@ class SharingNFSService(SharingService):
         data["hosts"] = " ".join(data["hosts"])
         data["security"] = [s.lower() for s in data["security"]]
         data.pop(self.locked_field, None)
+        data.pop(self.mount_info_field, None)
         return data
 
 

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -241,7 +241,8 @@ class RsyncModService(SharingService):
         module.update(data)
 
         module = await self.common_validation(module, 'rsyncmod_update')
-        module.pop(self.locked_field)
+        module.pop(self.locked_field, None)
+        module.pop(self.mount_info_field, None)
 
         await self.middleware.call(
             'datastore.update',
@@ -634,7 +635,8 @@ class RsyncTaskService(TaskPathService):
         data.setdefault('validate_rpath', True)
 
         old = await self.query(filters=[('id', '=', id)], options={'get': True})
-        old.pop(self.locked_field)
+        old.pop(self.locked_field, None)
+        old.pop(self.mount_info_field, None)
         old.pop('job')
 
         new = old.copy()

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1709,6 +1709,7 @@ class SharingSMBService(SharingService):
         data['hostsallow'] = ' '.join(data['hostsallow'])
         data['hostsdeny'] = ' '.join(data['hostsdeny'])
         data.pop(self.locked_field, None)
+        data.pop(self.mount_info_field, None)
         data.pop('path_local', None)
 
         return data

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -115,7 +115,8 @@ class WebDAVSharingService(SharingService):
         await self.validate_data(new, 'webdav_share_update')
 
         if len(set(old.items()) ^ set(new.items())) > 0:
-            new.pop(self.locked_field)
+            new.pop(self.locked_field, None)
+            new.pop(self.mount_info_field, None)
             await self.middleware.call(
                 'datastore.update',
                 self._config.datastore,

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1132,9 +1132,13 @@ class SharingTaskService(CRUDService):
             data[self.mount_info_field] = {}
         else:
             # dataset isn't locked so get mount info
-            data[self.mount_info_field] = await self.middleware.run_in_thread(
-                getmntinfo_from_path, data[self.path_field]
-            )
+            try:
+                data[self.mount_info_field] = await self.middleware.run_in_thread(
+                    getmntinfo_from_path, data[self.path_field]
+                )
+            except Exception:
+                # don't crash here since it'll break sharing.query
+                data[self.mount_info_field] = {}
 
         return data
 

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1128,9 +1128,9 @@ class SharingTaskService(CRUDService):
         data[self.locked_field] = await self.middleware.call(
             f'{self._config.namespace}.sharing_task_determine_locked', data, context['locked_datasets']
         )
-        if data[self.locked_field]:
-            data[self.mount_info_field] = {}
-        else:
+        data[self.mount_info_field] = {}
+
+        if not data[self.locked_field]:
             # dataset isn't locked so get mount info
             try:
                 data[self.mount_info_field] = await self.middleware.run_in_thread(
@@ -1138,7 +1138,7 @@ class SharingTaskService(CRUDService):
                 )
             except Exception:
                 # don't crash here since it'll break sharing.query
-                data[self.mount_info_field] = {}
+                pass
 
         return data
 

--- a/src/middlewared/middlewared/utils/osc/linux/mount.py
+++ b/src/middlewared/middlewared/utils/osc/linux/mount.py
@@ -30,6 +30,16 @@ def __parse_mntent(line, out_dict):
     }})
 
 
+def getmntinfo_from_path(path):
+    """
+    Try to determine the `dev_id` (st_dev) from `path` and then
+    call `getmntinfo` for O(1) lookups since mount info
+    is keyed on `dev_id`.
+    """
+    dev_id = os.stat(path).st_dev
+    return getmntinfo(dev_id=dev_id)[dev_id]
+
+
 def getmntinfo(dev_id=None):
     """
     Get mount information. returns dictionary indexed by dev_t.


### PR DESCRIPTION
This addes `mount_info` key to all sharing plugins. This will be used for the new storage page redesign.