### PR TITLE
NAS-114156 / 22.12 / add endpoint specifying if default route will be forcefully removed

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/route.py
+++ b/src/middlewared/middlewared/plugins/network_/route.py
@@ -55,7 +55,7 @@ class RouteService(Service):
         rt = netif.RoutingTable()
         will_be_removed1 = not ifaces and rt.default_route_ipv4
 
-        dbgw = self.middleware.call_sync('network.configuration.config')['ipv4gatewa']
+        dbgw = self.middleware.call_sync('network.configuration.config')['ipv4gateway']
         will_be_removed2 = rt.default_route_ipv4 and (dbgw != rt.default_route_ipv4)
 
         return any((will_be_removed1, will_be_removed2))


### PR DESCRIPTION
Trying to improve configuring the network on a TrueNAS and this endpoint will be used by the webUI to prompt user about the default gateway being removed. Currently unused.