### PR TITLE
NAS-117155 / 22.02.3 / Fix bug in `ensure_builtins` option for ACL templates (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -162,9 +162,9 @@ class ACLTemplateService(CRUDService):
                 )
 
             if ba_id != -1:
-                data['acl'].append([
+                data['acl'].append(
                     {"tag": "GROUP", "id": ba_id, "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}, "type": "ALLOW"},
-                ])
+                )
             return
 
         has_default_mask = any(filter(lambda x: x["tag"] == "MASK" and x["default"], data['acl']))


### PR DESCRIPTION
During refactoring for TC-related improvements, list.extend
method was changed to list.append, but change was broken
in one place.

Original PR: https://github.com/truenas/middleware/pull/9385
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117155