### PR TITLE
NAS-117163 / 13.0 / add "Not Installed, Swapped" element status for X

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/element_types.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/element_types.py
@@ -225,7 +225,8 @@ ELEMENT_DESC = {
     13: 'reserved [13]',
     14: 'reserved [14]',
     15: 'reserved [15]',
-    17: 'OK, Swapped'
+    17: 'OK, Swapped',
+    21: 'Not Installed, Swapped',
 }
 
 ELEMENT_TYPES = {


### PR DESCRIPTION
Seen on the X series platform. Seems when drives are moved around the `Not Installed, Swapped` status (i.e. 21) likes to show up. This wasn't mapped in the element status dictionary so it showed `UNKNOWN` by design. Add this new key so it returns relevant verbiage.