### PR TITLE
NAS-117187 / 22.12 / Fix test_427 regression

### DIFF
--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -138,12 +138,14 @@ def test_002_creating_shareuser_to_test_acls(request):
     assert results.status_code == 200, results.text
     global new_id
     new_id = results.json()
+    groupinfo = GET('/group?group=builtin_administrators').json()[0]
 
     global smbuser_id
     payload = {
         "username": SMB_USER,
         "full_name": "SMB User",
         "group_create": True,
+        "groups": [groupinfo["id"]],
         "password": SMB_PWD,
         "uid": new_id,
     }


### PR DESCRIPTION
A recent acltemplate plugin fix caused a regression in this
test. Ensure that the test user has write_acl permissions to
the test dataset.