### PR TITLE
NAS-117197 / 22.12 / Duplicate samba behavior when generating krb5.conf from AD info

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf.mako
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.mako
@@ -160,9 +160,9 @@
 % for realm in db_realms:
             ${f'{realm["realm"]}'} = {
                    default_domain = ${realm["realm"]}
-                % if realm["kdc"]:
-                   kdc = ${' '.join(realm["kdc"])}
-                % endif
+                % for k in realm["kdc"]:
+                   kdc = ${k}
+                % endfor
                 % if realm["admin_server"]:
                    admin_server = ${' '.join(realm["admin_server"])}
                 % endif


### PR DESCRIPTION
Samba places kdc entries in separate lines within realm section
of kerberos configuration. Since samba internally only looks
up realm-specific KDCs, we can do likewise and reduce number of
DNS lookups performed during domain join.