### PR TITLE
NAS-116508 / 22.12 / Add tests for running as some user

### DIFF
--- a/tests/api2/test_run_as_user_impl.py
+++ b/tests/api2/test_run_as_user_impl.py
@@ -13,8 +13,10 @@ def create_cron_job(owner, ownerGroup, user):
     test_folder = '/tmp/test'
     ssh(f'mkdir {test_folder}')
     ssh(f'chown -R {owner}:{ownerGroup} {test_folder}')
-    cron = call('cronjob.create', {'command': f'touch {test_folder}/test.txt', 'user': user, 'stderr': False,
-                                   'stdout': False})
+    cron = call(
+        'cronjob.create', {
+            'command': f'touch {test_folder}/test.txt', 'user': user, 'stderr': False, 'stdout': False}
+    )
     try:
         yield cron
     finally:
@@ -39,4 +41,4 @@ def test_01_running_as_valid_user():
 def test_02_running_as_invalid_user():
     with create_cron_job(owner='root', ownerGroup='root', user='apps') as cron_job:
         with run_cron_job(cron_job['id']) as job_detail:
-            assert job_detail['results']['error'] is not None, job_detail
+            assert f'"{cron_job["command"]}" exited with 1' in job_detail['results']['error'], job_detail

--- a/tests/api2/test_run_as_user_impl.py
+++ b/tests/api2/test_run_as_user_impl.py
@@ -1,0 +1,42 @@
+import sys
+import os
+from contextlib import contextmanager
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import wait_on_job
+from middlewared.test.integration.utils import call, ssh
+
+
+@contextmanager
+def create_cron_job(owner, ownerGroup, user):
+    test_folder = '/tmp/test'
+    ssh(f'mkdir {test_folder}')
+    ssh(f'chown -R {owner}:{ownerGroup} {test_folder}')
+    cron = call('cronjob.create', {'command': f'touch {test_folder}/test.txt', 'user': user, 'stderr': False,
+                                   'stdout': False})
+    try:
+        yield cron
+    finally:
+        ssh(f'rm -rf {test_folder}')
+
+
+@contextmanager
+def run_cron_job(cron_id):
+    job_id = call('cronjob.run', cron_id)
+    try:
+        yield wait_on_job(job_id, 300)
+    finally:
+        call('cronjob.delete', cron_id)
+
+
+def test_01_running_as_valid_user():
+    with create_cron_job(owner='apps', ownerGroup='apps', user='apps') as cron_job:
+        with run_cron_job(cron_job['id']) as job_detail:
+            assert job_detail['results']['error'] is None
+
+
+def test_02_running_as_invalid_user():
+    with create_cron_job(owner='root', ownerGroup='root', user='apps') as cron_job:
+        with run_cron_job(cron_job['id']) as job_detail:
+            assert job_detail['results']['error'] is not None, job_detail


### PR DESCRIPTION
This commit adds some tests to see if our implementation of running as some user works as intended. The `cronjob` plugin uses the internal implementation we have for running as some X user, so we add some cronjobs to be run as specific users to see if we get desired results.