### PR TITLE
NAS-117045 / 22.12 / Resolve minimum memory key error

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -113,7 +113,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         Str('nodeset', default=None, null=True, validators=[NumericSet()]),
         Bool('pin_vcpus', default=False),
         Int('memory', required=True, validators=[Range(min=20)]),
-        Int('min_memory', null=True, validators=[Range(min=20)]),
+        Int('min_memory', null=True, validators=[Range(min=20)], default=None),
         Bool('hyperv_enlightenments', default=False),
         Str('bootloader', enum=list(BOOT_LOADER_OPTIONS.keys()), default='UEFI'),
         Bool('autostart', default=True),


### PR DESCRIPTION
## Problem

`min_memory` is an optional attribute which might or might not be specified and if not specified we fail with a `KeyError`.

## Solution

Safely check existence of `min_memory` attribute in the payload before performing checks on it.