### PR TITLE
NAS-117181 / 22.02.3 / Allow setting UID 0 for new users (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -374,7 +374,7 @@ class UserService(CRUDService):
                                                       [('group', '=', 'builtin_users')],
                                                       {'get': True}))['id'])
 
-        if not data.get('uid'):
+        if data.get('uid') is None:
             data['uid'] = await self.get_next_uid()
 
         # Is this a new directory or not? Let's not nuke existing directories,


### PR DESCRIPTION
There are some cases where administrator may wish to create another user with uid 0.

Original PR: https://github.com/truenas/middleware/pull/9395
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117181