### PR TITLE
NAS-117188 / 22.02.3 / `assert_creates_job` integration test helper to ensure that method be…

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/__init__.py
+++ b/src/middlewared/middlewared/test/integration/utils/__init__.py
@@ -1,5 +1,6 @@
 from .call import *  # noqa
 from .client import *  # noqa
+from .job import *  # noqa
 from .mock import *  # noqa
 from .pool import *  # noqa
 from .ssh import *  # noqa

--- a/src/middlewared/middlewared/test/integration/utils/job.py
+++ b/src/middlewared/middlewared/test/integration/utils/job.py
@@ -1,0 +1,26 @@
+# -*- coding=utf-8 -*-
+import contextlib
+import logging
+from types import SimpleNamespace
+
+from .call import call
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["assert_creates_job"]
+
+
+@contextlib.contextmanager
+def assert_creates_job(method):
+    newest_job_id = 0
+    if jobs := call("core.get_jobs"):
+        newest_job_id = jobs[-1]["id"]
+
+    job = SimpleNamespace(id=None)
+    yield job
+
+    jobs = call("core.get_jobs", [["method", "=", method]])
+    if not jobs or jobs[-1]["id"] <= newest_job_id:
+        raise RuntimeError(f"{method} was not started")
+
+    job.id = jobs[-1]["id"]

--- a/tests/api2/test_439_snapshottask_retention.py
+++ b/tests/api2/test_439_snapshottask_retention.py
@@ -2,11 +2,12 @@
 from datetime import datetime
 import os
 import sys
+import time
 
 import pytest
 
 from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import assert_creates_job, call
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
@@ -60,23 +61,25 @@ def test_change_retention(request):
         assert result.json() == {
             ds: ["auto-2021-04-12-06-30-1y"],
         }
+
+        with assert_creates_job("pool.snapshottask.fixate_removal_date") as job:
+            result = PUT(f"/pool/snapshottask/id/{task_id}/", {
+                "naming_schema": "auto-%Y-%m-%d-%H-%M-365d",
+                "fixate_removal_date": True,
+            })
+            assert result.status_code == 200, result.text
     
-        result = PUT(f"/pool/snapshottask/id/{task_id}/", {
-            "naming_schema": "auto-%Y-%m-%d-%H-%M-365d",
-            "fixate_removal_date": True,
-        })
-        assert result.status_code == 200, result.text
-    
-        results = GET("/core/get_jobs/?method=pool.snapshottask.fixate_removal_date")
-        job_status = wait_on_job(results.json()[-1]["id"], 180)
+        job_status = wait_on_job(job.id, 180)
         assert job_status["state"] == "SUCCESS", str(job_status["results"])
+
+        time.sleep(2)  # Successfully set ZFS properties might not update immediately, give them some time
     
         result = GET(f"/zfs/snapshot/?id={ds}@auto-2021-04-12-06-30-1y&extra.retention=true")
         assert result.status_code == 200, result.text
-        assert (
-            [v for k, v in result.json()[0]["properties"].items() if k.startswith("org.truenas:destroy_at_")][0]["value"]
-            == "2021-04-19T06:30:00"
-        )
+        assert result.json()
+        properties = [v for k, v in result.json()[0]["properties"].items() if k.startswith("org.truenas:destroy_at_")]
+        assert properties, result.json()[0]["properties"]
+        assert properties[0]["value"] == "2021-04-19T06:30:00"
         assert result.json()[0]["retention"] == {
             "datetime": {
                 "$date": (datetime(2021, 4, 19, 6, 30) - datetime(1970, 1, 1)).total_seconds() * 1000,
@@ -116,22 +119,24 @@ def test_delete_retention(request):
         assert result.json() == {
             ds: ["auto-2021-04-12-06-30-1y"],
         }
-    
-        result = DELETE(f"/pool/snapshottask/id/{task_id}/", {
-            "fixate_removal_date": True,
-        })
-        assert result.status_code == 200, result.text
-    
-        results = GET("/core/get_jobs/?method=pool.snapshottask.fixate_removal_date")
-        job_status = wait_on_job(results.json()[-1]["id"], 180)
+
+        with assert_creates_job("pool.snapshottask.fixate_removal_date") as job:
+            result = DELETE(f"/pool/snapshottask/id/{task_id}/", {
+                "fixate_removal_date": True,
+            })
+            assert result.status_code == 200, result.text
+
+        job_status = wait_on_job(job.id, 180)
         assert job_status["state"] == "SUCCESS", str(job_status["results"])
+
+        time.sleep(2)  # Successfully set ZFS properties might not update immediately, give them some time
     
         result = GET(f"/zfs/snapshot/?id={ds}@auto-2021-04-12-06-30-1y&extra.retention=true")
         assert result.status_code == 200, result.text
-        assert (
-            [v for k, v in result.json()[0]["properties"].items() if k.startswith("org.truenas:destroy_at_")][0]["value"]
-            == "2021-04-19T06:30:00"
-        )
+        assert result.json()
+        properties = [v for k, v in result.json()[0]["properties"].items() if k.startswith("org.truenas:destroy_at_")]
+        assert properties, result.json()[0]["properties"]
+        assert properties[0]["value"] == "2021-04-19T06:30:00"
         assert result.json()[0]["retention"] == {
             "datetime": {
                 "$date": (datetime(2021, 4, 19, 6, 30) - datetime(1970, 1, 1)).total_seconds() * 1000,


### PR DESCRIPTION
…ing tested creates a new job

with specified method.

Improve debugging in `test_439_snapshottask_retention.py` to better understand why a test might
fail occasionally.

(probably) cover the issue up with `sleep`.