### PR TITLE
NAS-117234 / 22.12 / Use mktemp for creating temporary directory

### DIFF
--- a/tests/api2/test_run_as_user_impl.py
+++ b/tests/api2/test_run_as_user_impl.py
@@ -10,8 +10,7 @@ from middlewared.test.integration.utils import call, ssh
 
 @contextmanager
 def create_cron_job(owner, ownerGroup, user):
-    test_folder = '/tmp/test'
-    ssh(f'mkdir {test_folder}')
+    test_folder = ssh('mktemp -d').strip()
     ssh(f'chown -R {owner}:{ownerGroup} {test_folder}')
     cron = call(
         'cronjob.create', {


### PR DESCRIPTION
Fix for https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/API%20Tests%20-%20TrueNAS%20SCALE%20(Incremental)/lastCompletedBuild/testReport/api2/test_024_container/test_pruning_existing_chart_release_images/