### PR TITLE
NAS-116808 / 22.02.3 / Improve IPMI password validation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -277,6 +277,12 @@ class Path(Str):
         return os.path.normpath(value.strip())
 
 
+class Password(Str):
+    def __init__(self, *args, **kwargs):
+        self.private = True
+        super().__init__(*args, **kwargs)
+
+
 class Dataset(Path):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('empty', False)


### PR DESCRIPTION
This addresses a couple of issues with IPMI password validation

1) The webui lists password complexity requirements that are
   not validated within middleware before sending payload
   through ipmitool.

2) Password length of 20 characters is enforced in middleware,
   but this value exceeds that supported by some ipmi implementations.

The first item is problematic because the error messages from ipmitool
for passwords that lack sufficient complexity are less than helpful
("Request data field length limit exceeded").

The second item is also incredibly problematic because on some
devices a password of more than 16 characters will be silently
truncated to 16 characters.

This PR shifts validation to the middleware schema by introducing
two changes:

a) Password() schema type. This currently only hardcodes 'private'
key, but the guiding principal is that we can start shifting
places where we are handling passwords to have a common schema
so that it is simpler to identify and audit where middleware is
handling passwords.

b) PasswordComplexity validator. This checks for presence of required
categories of characters in the password. It includes optional argument
to specify the count of these categories that must be present in the
password.

Original PR: https://github.com/truenas/middleware/pull/9251
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116808