### PR TITLE
Fix middleware import in middleware tests utils

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/iscsi.py
+++ b/src/middlewared/middlewared/test/integration/assets/iscsi.py
@@ -2,13 +2,11 @@ import contextlib
 import json
 import time
 
-from middlewared.utils import osc
-
-from middlewared.test.integration.utils import run_on_runner, RunOnRunnerException
+from middlewared.test.integration.utils import run_on_runner, RunOnRunnerException, IS_LINUX
 
 
 def target_login_test(portal_ip, target_name):
-    if osc.IS_LINUX:
+    if IS_LINUX:
         return target_login_test_linux(portal_ip, target_name)
     else:
         return target_login_test_freebsd(portal_ip, target_name)

--- a/src/middlewared/middlewared/test/integration/utils/__init__.py
+++ b/src/middlewared/middlewared/test/integration/utils/__init__.py
@@ -5,3 +5,4 @@ from .mock import *  # noqa
 from .pool import *  # noqa
 from .ssh import *  # noqa
 from .run import * # noqa
+from .runner import * # noqa

--- a/src/middlewared/middlewared/test/integration/utils/runner.py
+++ b/src/middlewared/middlewared/test/integration/utils/runner.py
@@ -1,0 +1,5 @@
+import platform
+
+SYSTEM = platform.system().upper()
+IS_FREEBSD = SYSTEM == 'FREEBSD'
+IS_LINUX = SYSTEM == 'LINUX'


### PR DESCRIPTION
This commit adds changes to not import anything from middleware package as only middleware.test is installed on runners.