### PR TITLE
NAS-117264 / 22.12 / Updater size estimates seem quite off (by rick-mesta)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/install.py
+++ b/src/middlewared/middlewared/plugins/update_/install.py
@@ -119,5 +119,6 @@ class UpdateService(Service):
         )
 
     def _space_left(self, pool_name):
-        pool = self.middleware.call_sync("zfs.pool.query", [["name", "=", pool_name]], {"get": True})
-        return pool["properties"]["free"]["parsed"]
+        filters = [["name", "=", pool_name]]
+        options = {"get": True, "extra": {"flat": False, "retrieve_children": False, "properties": ["available"]}}
+        return self.middleware.call_sync('zfs.dataset.query', filters, options)['properties']['available']['parsed']


### PR DESCRIPTION
Use zfs.dataset plugin to retreive the zpool equivalent of AVAIL

Original PR: https://github.com/truenas/middleware/pull/9437
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117264