### PR TITLE
NAS-117382 / 22.12 / Handle case of non-existent path during smbconf generation

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -298,6 +298,12 @@ class ShareSchema(RegistrySchema):
 
         try:
             acltype = entry.middleware.call_sync('filesystem.path_get_acltype', data_in['path'])
+        except FileNotFoundError:
+            entry.middleware.logger.warning(
+                "%s: path does not exist. This is unexpected situation and "
+                "may indicate a failure of pool import.", data_in["path"]
+            )
+            raise ValueError(f"{data_in['path']}: path does not exist")
         except OSError:
             entry.middleware.logger.warning(
                 "%s: failed to determine acltype for path.",


### PR DESCRIPTION
If check for ACL type on path fails during smb.conf generation,
raise a ValueError, which indicates to caller of reg_addshare
that there is a fatal configuration error in the share.

Original in this failure case was disabling ACL support while
I think more appropriate response is to remove the share.