### PR TITLE
NAS-117267 / 22.12 / Fix multiple issues with failover.disabled_reasons (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -29,6 +29,7 @@ class FailoverDisabledReasonsService(Service):
         DISAGREE_VIP - Nodes Virtual IP states do not agree.
         MISMATCH_DISKS - The storage controllers do not have the same quantity of disks.
         NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
+        NO_FENCED - Zpools are imported but fenced isn't running.
         """
         reasons = self.middleware.call_sync('failover.disabled.get_reasons', app)
         if reasons != FailoverDisabledReasonsService.LAST_DISABLED_REASONS:


### PR DESCRIPTION
1. `NO_VOLUME` is being returned always on the standby node
2. add a new `NO_FENCED` variable to show when zpools are imported and fenced isn't running (which is pretty bad)

Original PR: https://github.com/truenas/middleware/pull/9439
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117267