### PR TITLE
NAS-117263 / 22.02.3 / Add test for disabling ACL auto-inheritance via SMB (by anodos325)

### DIFF
--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -16,6 +16,7 @@ from auto_config import (
     password,
     user,
 )
+from protocols import SMB
 from pytest_dependency import depends
 from time import sleep
 from utils import create_dataset
@@ -285,6 +286,23 @@ def test_006_test_preserve_dynamic_id_mapping(request):
             the_acl = result.json()['acl']
             has_owner_rights = _find_owner_rights(the_acl)
             assert has_owner_rights is True, str(the_acl)
+
+
+def test_007_test_disable_autoinherit(request):
+    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    ds = 'nfs4acl_disable_inherit'
+    path = f'/mnt/{pool_name}/{ds}'
+    with create_dataset(f'{pool_name}/{ds}', {'share_type': 'SMB'}):
+        with smb_share(path, {'name': 'NFS4_INHERIT'}):
+            c = SMB()
+            c.connect(host=ip, share='NFS4_INHERIT', username=SMB_USER, password=SMB_PWD, smb1=False)
+            c.mkdir('foo')
+            sd = c.get_sd('foo')
+            assert 'SEC_DESC_DACL_PROTECTED' not in sd['control']['parsed'], str(sd)
+            c.inherit_acl('foo', 'COPY')
+            sd = c.get_sd('foo')
+            assert 'SEC_DESC_DACL_PROTECTED' in sd['control']['parsed'], str(sd)
+            c.disconnect()
 
 
 def test_099_delete_smb_user(request):


### PR DESCRIPTION
Create temporary dataset and share, make a test dir, getacl
on dataset and verify that PROTECTED is not set, disable
auto-inheritance, verify that PROTECTED is now set.

Original PR: https://github.com/truenas/middleware/pull/9436
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117263