### PR TITLE
NAS-116295 / 22.12 / Improve VM memory reporting and ZFS ARC management wrt VMs

### DIFF
--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -22,7 +22,7 @@ class SysctlService(Service):
     def get_default_arc_max(self):
         # Default value of arc max on systems
         # https://github.com/truenas/zfs/blob/f38f3a4a3ee430a15fa221ba9fc2b6b8fd17c040/module/os/linux/zfs/arc_os.c#L85
-        return int(psutil.virtual_memory().total / 2)
+        return psutil.virtual_memory().total // 2
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -1,4 +1,5 @@
 import os
+import psutil
 
 from middlewared.service import CallError, Service
 from middlewared.utils import run
@@ -17,6 +18,11 @@ class SysctlService(Service):
         if cp.returncode:
             raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
         return cp.stdout.decode().split('=')[-1].strip()
+
+    def get_default_arc_max(self):
+        # Default value of arc max on systems
+        # https://github.com/truenas/zfs/blob/f38f3a4a3ee430a15fa221ba9fc2b6b8fd17c040/module/os/linux/zfs/arc_os.c#L85
+        return int(psutil.virtual_memory().total / 2)
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -14,12 +14,6 @@ SHUTDOWN_LOCK = asyncio.Lock()
 
 class VMService(Service, VMSupervisorMixin):
 
-    ZFS_ARC_MAX_INITIAL = None
-
-    @private
-    async def get_initial_arc_max(self):
-        return self.ZFS_ARC_MAX_INITIAL
-
     @private
     async def wait_for_libvirtd(self, timeout):
         async def libvirtd_started(middleware):
@@ -112,10 +106,6 @@ class VMService(Service, VMSupervisorMixin):
     async def terminate_timeout(self):
         return max(map(lambda v: v['shutdown_timeout'], await self.middleware.call('vm.query')), default=10)
 
-    @private
-    async def update_zfs_arc_max_initial(self):
-        self.ZFS_ARC_MAX_INITIAL = await self.middleware.call('sysctl.get_arc_max')
-
 
 async def __event_system_ready(middleware, event_type, args):
     """
@@ -129,8 +119,6 @@ async def __event_system_ready(middleware, event_type, args):
             mw.logger.error(f'Stopping VM {vm["name"]} failed: {stop_job.error}')
 
     if args['id'] == 'ready':
-        await middleware.call('vm.update_zfs_arc_max_initial')
-
         await middleware.call('vm.initialize_vms')
 
         # we ignore the 'ready' event on an HA system since the failover event plugin
@@ -154,7 +142,6 @@ async def __event_system_ready(middleware, event_type, args):
 
 
 async def setup(middleware):
-    await middleware.call('vm.update_zfs_arc_max_initial')
     if await middleware.call('system.ready'):
         asyncio.ensure_future(middleware.call('vm.initialize_vms', 5))  # We use a short timeout here deliberately
     middleware.event_subscribe('system', __event_system_ready)

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -19,7 +19,7 @@ class VMService(Service, VMSupervisorMixin):
             raise CallError(f'Cannot guarantee memory for guest {vm["name"]}', errno.ENOMEM)
 
         if memory_details['current_arc_max'] != memory_details['arc_max_after_shrink']:
-            self.middleware.logger.debug(
+            self.logger.debug(
                 'Setting ARC from %s to %s', memory_details['current_arc_max'], memory_details['arc_max_after_shrink']
             )
             await self.middleware.call('sysctl.set_arc_max', memory_details['arc_max_after_shrink'])

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -33,13 +33,12 @@ class VMService(Service, VMSupervisorMixin):
             raise CallError('VM process is running, we won\'t allocate memory')
 
     @private
-    async def teardown_guest_vmemory(self, id):
-        guest_status = await self.middleware.call('vm.status', id)
-        if guest_status.get('state') != 'STOPPED':
+    async def teardown_guest_vmemory(self, vm_id):
+        vm = await self.middleware.call('vm.get_instance', vm_id)
+        if vm['status']['state'] != 'STOPPED':
             return
 
-        vm = await self.middleware.call('datastore.query', 'vm.vm', [('id', '=', id)])
-        guest_memory = vm[0].get('memory', 0) * 1024 * 1024
+        guest_memory = vm['memory'] * 1024 * 1024
         arc_max = await self.middleware.call('sysctl.get_arc_max')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         new_arc_max = min(

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -45,7 +45,7 @@ class VMService(Service, VMSupervisorMixin):
         arc_max = await self.middleware.call('sysctl.get_arc_max')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         new_arc_max = min(
-            await self.middleware.call('vm.get_initial_arc_max'),
+            await self.middleware.call('sysctl.get_default_arc_max'),
             arc_max + guest_memory
         )
         if arc_max != new_arc_max:

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -1,7 +1,7 @@
 import psutil
 
 from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
-from middlewared.service import Service
+from middlewared.service import CallError, Service
 from middlewared.validators import MACAddr
 
 from .devices import NIC
@@ -90,6 +90,67 @@ class VMService(Service):
                         vms_memory_used += vm_max_mem - current_vm_mem
 
         return max(0, total_free - vms_memory_used - swap_used)
+
+    @accepts(Int('vm_id'))
+    @returns(Dict(
+        Int('minimum_memory_requested', description='Minimum memory requested by the VM'),
+        Int('total_memory_requested', description='Maximum / total memory requested by the VM'),
+        Bool('overcommit_required', description='Overcommit of memory is required to start VM'),
+        Bool(
+            'memory_req_fulfilled_after_overcommit',
+            description='Memory requirements of VM are fulfilled if over-committing memory is specified'
+        ),
+        Int('arc_to_shrink', description='Size of ARC to shrink in bytes', null=True),
+        Int('current_arc_max', description='Current size of max ARC in bytes'),
+        Int('arc_max_after_shrink', description='Size of max ARC in bytes after shrinking'),
+        Int(
+            'actual_vm_requested_memory',
+            description='VM memory in bytes to consider when making calculations for available/required memory.'
+                        ' If VM ballooning is specified for the VM, the minimum VM memory specified by user will'
+                        ' be taken into account otherwise total VM memory requested will be taken into account.'
+        ),
+    ))
+    async def get_vm_memory_info(self, vm_id):
+        """
+        Returns memory information for `vm_id` VM if it is going to be started.
+
+        All memory attributes are expressed in bytes.
+        """
+        vm = await self.middleware.call('vm.get_instance', vm_id)
+        if vm['status']['state'] == 'RUNNING':
+            # TODO: Let's add this later as we have a use case in the UI - could be useful to
+            #  show separate info of each VM in the UI moving on
+            raise CallError(f'Unable to retrieve {vm["name"]!r} VM information as it is already running.')
+
+        arc_max = await self.middleware.call('sysctl.get_arc_max')
+        arc_min = await self.middleware.call('sysctl.get_arc_min')
+        shrinkable_arc_max = 0 if arc_max <= arc_min else arc_max - arc_min
+
+        available_memory = await self.get_available_memory(False)
+        available_memory_with_overcommit = await self.get_available_memory(True)
+        vm_max_memory = vm['memory'] * 1024 * 1024
+        vm_min_memory = vm['min_memory'] * 1024 * 1024 if vm['min_memory'] else None
+        vm_requested_memory = vm_min_memory or vm_max_memory
+
+        overcommit_required = vm_requested_memory > available_memory
+        arc_to_shrink = 0
+        if overcommit_required:
+            more_required = vm_requested_memory - available_memory
+            if shrinkable_arc_max < more_required:
+                arc_to_shrink = shrinkable_arc_max
+            else:
+                arc_to_shrink = shrinkable_arc_max - more_required
+
+        return {
+            'minimum_memory_requested': vm_min_memory,
+            'total_memory_requested': vm_max_memory,
+            'overcommit_required': overcommit_required,
+            'arc_to_shrink': arc_to_shrink,
+            'memory_req_fulfilled_after_overcommit': vm_requested_memory < available_memory_with_overcommit,
+            'current_arc_max': arc_max,
+            'arc_max_after_shrink': arc_max - arc_to_shrink,
+            'actual_vm_requested_memory': vm_requested_memory,
+        }
 
     @accepts()
     @returns(Str('mac', validators=[MACAddr(separator=':')]),)

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -102,6 +102,7 @@ class VMService(Service):
         ),
         Int('arc_to_shrink', description='Size of ARC to shrink in bytes', null=True),
         Int('current_arc_max', description='Current size of max ARC in bytes'),
+        Int('arc_min', description='Minimum size of ARC in bytes'),
         Int('arc_max_after_shrink', description='Size of max ARC in bytes after shrinking'),
         Int(
             'actual_vm_requested_memory',
@@ -148,6 +149,7 @@ class VMService(Service):
             'arc_to_shrink': arc_to_shrink,
             'memory_req_fulfilled_after_overcommit': vm_requested_memory < available_memory_with_overcommit,
             'current_arc_max': arc_max,
+            'arc_min': arc_min,
             'arc_max_after_shrink': arc_max - arc_to_shrink,
             'actual_vm_requested_memory': vm_requested_memory,
         }


### PR DESCRIPTION
This PR adds following changes:

1. Fixes a bug on how we deduced available memory for vms. We were taking into account the complete memory of VMs which user had requested disregarding the fact that when we get `free` physical memory, existing used memory of VMs is already accounted there. So we just need to get the memory which the VM `can` consume and is not consuming right now.
2. When starting a VM, `overcommit` to the user actually means forcing the start of the VM even if we don't have enough memory available. In reality what happened is that when it was set, we manipulated the ARC to shrink arc max but the same behaviour was not done when we were calculating `available/free` memory for VMs and we always accounted for ARC. So now if `overcommit` is specified, only then do we consider shrinkable ARC as free memory - otherwise we don't.
3. ARC max was basically a tunable which we were changing on each VM start. Now when middleware started, it cached the value of ARC max and considered that to be the default which we would consider in our calculations when giving back memory on stopping VMs. However this had a fatal flaw, what if middleware was restarted ? It meant that middleware would never know the actual default/initial value of arc max. In Linux, this is basically `total physical memory / 2` and we add that change here.
4. Add an endpoint which would show VM memory related statistics if that VM was to be started. Motivation behind this endpoint is to gather information and show to the user preferably in the UI with a pop-up or something similar when user wants to start a VM that this much memory is being requested and this much is available and if you `overcommit`, we would be doing this with ZFS ARC and this would be the new ZFS ARC value etc.
5. Do not unconditionally always change ZFS ARC if `overcommit` is set. It should only be done selectively based on actual need of the VM.