### PR TITLE
NAS-116411 / 22.12 / add `pool.dataset.details`

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -49,7 +49,7 @@ class PoolDatasetService(Service):
             i['smb_shares'] = self.get_smb_shares(i, info['smb'])
             i['iscsi_shares'] = self.get_iscsi_shares(i, info['iscsi'])
             i['vms'] = self.get_vms(i, info['vm'])
-            i['apps'] = self.get_apps(i,  info['app'])
+            i['apps'] = self.get_apps(i, info['app'])
             i['replication_tasks_count'] = self.get_repl_tasks_count(i, info['repl'])
             i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, info['snap'])
             i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, info['cloud'])

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -34,33 +34,26 @@ class PoolDatasetService(Service):
                 ]
             }
         }
-
-        mntinfo = getmntinfo()
-        nfsshares = self.middleware.call_sync('sharing.nfs.query')
-        smbshares = self.middleware.call_sync('sharing.smb.query')
-        iscsishares = self.build_iscsi_share_info()
-        repltasks = self.middleware.call_sync('datastore.query', 'storage.replication', [], {'prefix': 'repl_'})
-        snaptasks = self.middleware.call_sync('datastore.query', 'storage.task', [], {'prefix': 'task_'})
-        cldtasks = self.middleware.call_sync('datastore.query', 'tasks.cloudsync')
-        rsynctasks = self.middleware.call_sync('rsynctask.query')
         collapsed = []
-        info = self.middleware.call_sync('pool.dataset.query', filters, options)
-        for dataset in info:
+        datasets = self.middleware.call_sync('pool.dataset.query', filters, options)
+        for dataset in datasets:
             self.collapse_datasets(dataset, collapsed)
 
+        mntinfo = getmntinfo()
+        info = self.build_share_and_task_info(mntinfo)
         for i in collapsed:
             snapshot_count, locked = self.get_snapcount_and_encryption_status(i, mntinfo)
             i['snapshot_count'] = snapshot_count
             i['locked'] = locked
-            i['nfs_shares'] = self.get_nfs_shares(i, nfsshares, mntinfo)
-            i['smb_shares'] = self.get_smb_shares(i, smbshares, mntinfo)
-            i['iscsi_shares'] = self.get_iscsi_shares(i, iscsishares, mntinfo)
-            i['replication_tasks_count'] = self.get_repl_tasks_count(i, repltasks)
-            i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, snaptasks)
-            i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, cldtasks)
-            i['rsync_tasks_count'] = self.get_rsync_tasks_count(i, rsynctasks)
+            i['nfs_shares'] = self.get_nfs_shares(i, info['nfs'])
+            i['smb_shares'] = self.get_smb_shares(i, info['smb'])
+            i['iscsi_shares'] = self.get_iscsi_shares(i, info['iscsi'])
+            i['replication_tasks_count'] = self.get_repl_tasks_count(i, info['repl'])
+            i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, info['snap'])
+            i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, info['cloud'])
+            i['rsync_tasks_count'] = self.get_rsync_tasks_count(i, info['rsync'])
 
-        return info
+        return datasets
 
     @private
     def collapse_datasets(self, dataset, collapsed):
@@ -69,21 +62,67 @@ class PoolDatasetService(Service):
             self.collapse_datasets(child, collapsed)
 
     @private
-    def build_iscsi_share_info(self):
+    def get_mount_info(self, path, mntinfo):
+        mount_info = {}
+        try:
+            devid = os.stat(path).st_dev
+        except Exception:
+            # path deleted/umounted/locked etc
+            pass
+        else:
+            if devid in mntinfo:
+                mount_info = mntinfo[devid]
+
+        return mount_info
+
+    @private
+    def build_share_and_task_info(self, mntinfo):
+        results = {'iscsi': [], 'nfs': [], 'smb': [], 'repl': [], 'snap': [], 'cloud': [], 'rsync': []}
+
+        # iscsi
         t_to_e = self.middleware.call_sync('iscsi.targetextent.query')
         t = {i['id']: i for i in self.middleware.call_sync('iscsi.target.query')}
         e = {i['id']: i for i in self.middleware.call_sync('iscsi.extent.query')}
-
-        iscsi_shares = []
         for i in filter(lambda x: x['target'] in t and t[x['target']]['groups'] and x['extent'] in e, t_to_e):
             """
             1. make sure target's and extent's id exist in the target to extent table
             2. make sure the target has `groups` entry since, without it, it's impossible
                 that it's being shared via iscsi
             """
-            iscsi_shares.append({'extent': e[i['extent']], 'target': t[i['target']]})
+            results['iscsi'].append({
+                'extent': e[i['extent']],
+                'target': t[i['target']],
+                'mount_info': self.get_mount_info(e[i['extent']]['path'], mntinfo),
+            })
 
-        return iscsi_shares
+        # nfs and smb
+        for key in ('nfs', 'smb'):
+            for share in self.middleware.call_sync(f'sharing.{key}.query'):
+                share['mount_info'] = self.get_mount_info(share['path'], mntinfo)
+                results[key].append(share)
+
+        # replication
+        options = {'prefix': 'repl_'}
+        for task in self.middleware.call_sync('datastore.query', 'storage.replication', [], options):
+            # replication can only be configured on a dataset so getting mount info is unnecessary
+            results['repl'].append(task)
+
+        # snapshots
+        for task in self.middleware.call_sync('datastore.query', 'storage.task', [], {'prefix': 'task_'}):
+            # snapshots can only be configured on a dataset so getting mount info is unnecessary
+            results['snap'].append(task)
+
+        # cloud sync
+        for task in self.middleware.call_sync('datastore.query', 'tasks.cloudsync'):
+            task['mount_info'] = self.get_mount_info(task['path'], mntinfo)
+            results['cloud'].append(task)
+
+        # rsync
+        for task in self.middleware.call_sync('rsynctask.query'):
+            task['mount_info'] = self.get_mount_info(task['path'], mntinfo)
+            results['rsync'].append(task)
+
+        return results
 
     @private
     def get_snapcount_and_encryption_status(self, ds, mntinfo):
@@ -117,56 +156,29 @@ class PoolDatasetService(Service):
         return snap_count, locked
 
     @private
-    def get_nfs_shares(self, ds, nfsshares, mntinfo):
+    def get_nfs_shares(self, ds, nfsshares):
         nfs_shares = []
-        found = False
-        for nfsshare in nfsshares:
-            if nfsshare['path'] == ds['mountpoint']:
-                # the share path is the actual dataset
-                found = True
-            else:
-                try:
-                    devid = os.stat(nfsshare['path']).st_dev
-                except Exception:
-                    pass
-                else:
-                    found = devid in mntinfo and mntinfo[devid]['mount_source'] == ds['id']
-
-            if found:
-                nfs_shares.append({
-                    'enabled': nfsshare['enabled'],
-                    'path': nfsshare['path'],
-                })
+        for share in nfsshares:
+            if share['path'] == ds['mountpoint'] or share['mount_info'].get('mount_source') == ds['id']:
+                nfs_shares.append({'enabled': share['enabled'], 'path': share['path']})
 
         return nfs_shares
 
     @private
-    def get_smb_shares(self, ds, smbshares, mntinfo):
+    def get_smb_shares(self, ds, smbshares):
         smb_shares = []
-        found = False
-        for smbshare in smbshares:
-            if smbshare['path'] == ds['mountpoint']:
-                # the share path is the actual dataset
-                found = True
-            else:
-                try:
-                    devid = os.stat(smbshare['path']).st_dev
-                except Exception:
-                    pass
-                else:
-                    found = devid in mntinfo and mntinfo[devid]['mount_source'] == ds['id']
-
-            if found:
+        for share in smbshares:
+            if share['path'] == ds['mountpoint'] or share['mount_info'].get('mount_source') == ds['id']:
                 smb_shares.append({
-                    'enabled': smbshare['enabled'],
-                    'path': smbshare['path'],
-                    'share_name': smbshare['name'],
+                    'enabled': share['enabled'],
+                    'path': share['path'],
+                    'share_name': share['name']
                 })
 
         return smb_shares
 
     @private
-    def get_iscsi_shares(self, ds, iscsishares, mntinfo):
+    def get_iscsi_shares(self, ds, iscsishares):
         iscsi_shares = []
         thick_provisioned = any((ds['reservation']['value'], ds['refreservation']['value']))
         for share in iscsishares:
@@ -178,23 +190,16 @@ class PoolDatasetService(Service):
                     'path': f'/dev/{share["extent"]["path"]}',
                     'thick_provisioned': thick_provisioned,
                 })
-            elif share['extent']['type'] == 'FILE':
+            elif share['extent']['type'] == 'FILE' and share['mount_info'].get('mount_source') == ds['id']:
                 # this isn't common but possible, you can share a "file"
                 # via iscsi which means it's not a dataset but a file inside
                 # a dataset so we need to find the source dataset for the file
-                try:
-                    devid = os.stat(share['extent']['path']).st_dev
-                except Exception:
-                    # this is a regular file so ignore exceptions for now
-                    pass
-                else:
-                    if devid in mntinfo and mntinfo[devid]['mount_source'] == ds['id']:
-                        iscsi_shares.append({
-                            'enabled': share['extent']['enabled'],
-                            'type': 'FILE',
-                            'path': share['extent']['path'],
-                            'thick_provisioned': thick_provisioned,
-                        })
+                iscsi_shares.append({
+                    'enabled': share['extent']['enabled'],
+                    'type': 'FILE',
+                    'path': share['extent']['path'],
+                    'thick_provisioned': thick_provisioned,
+                })
 
         return iscsi_shares
 
@@ -209,13 +214,25 @@ class PoolDatasetService(Service):
         return count
 
     @private
-    def get_cloudsync_tasks_count(self, ds, cldtasks):
-        return len([i for i in cldtasks if i['path'] == ds['mountpoint']])
+    def get_snapshot_tasks_count(self, ds, snaptasks):
+        return len([i for i in snaptasks if i['dataset'] == ds['id']])
 
     @private
-    def get_snapshot_tasks_count(self, ds, snaptasks):
-        return len([i for i in snaptasks if f'/mnt/{i["dataset"]}' == ds['mountpoint']])
+    def get_cloudsync_tasks_count(self, ds, cldtasks):
+        count = 0
+        for i in filter(lambda x: x['direction'] == 'PUSH', cldtasks):
+            # we only care about cloud sync tasks that are configured to push
+            if i['mountpoint'] == ds['mountpoint'] or i['mount_info'].get('mount_source') == ds['id']:
+                count += 1
+
+        return count
 
     @private
     def get_rsync_tasks_count(self, ds, rsynctasks):
-        return len([i for i in rsynctasks if i['path'] == ds['mountpoint']])
+        count = 0
+        for i in filter(lambda x: x['direction'] == 'PUSH', rsynctasks):
+            # we only care about rsync tasks that are configured to push
+            if i['path'] == ds['mountpoint'] or i['mount_info'].get('mount_source') == ds['id']:
+                count += 1
+
+        return count

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -1,0 +1,171 @@
+import os
+
+from middlewared.service import Service, private
+from middlewared.schema import accepts, returns, Dict
+from middlewared.plugins.zfs_.utils import ZFSCTL
+from middlewared.utils.path import belongs_to_tree, is_child
+from middlewared.utils.osc.linux.mount import getmntinfo
+
+
+class PoolDatasetService(Service):
+
+    class Config:
+        namespace = 'pool.dataset'
+
+    @accepts()
+    @returns(Dict('datasets', additional_attrs=True))
+    def details(self):
+        filters = []
+        options = {
+            'extra': {
+                'flat': False,
+                'order_by': 'name',
+                'properties': [
+                    'used',
+                    'available',
+                    'usedbysnapshots',
+                    'usedbydataset',
+                    'usedbychildren',
+                    'refquota',
+                    'quota',
+                    'refreservation',
+                    'reservation',
+                    'mountpoint',
+                    'encryption',
+                ]
+            }
+        }
+
+        mntinfo = getmntinfo()
+        nfsshares = self.middleware.call_sync('sharing.nfs.query')
+        smbshares = self.middleware.call_sync('sharing.smb.query')
+        repltasks = self.middleware.call_sync('datastore.query', 'storage.replication', [], {'prefix': 'repl_'})
+        snaptasks = self.middleware.call_sync('datastore.query', 'storage.task', [], {'prefix': 'task_'})
+        cldtasks = self.middleware.call_sync('datastore.query', 'tasks.cloudsync')
+        collapsed = []
+        info = self.middleware.call_sync('pool.dataset.query', filters, options)
+        for dataset in info:
+            self.collapse_datasets(dataset, collapsed)
+
+        for i in collapsed:
+            snapshot_count, locked = self.get_snapcount_and_encryption_status(i, mntinfo)
+            i['snapshot_count'] = snapshot_count
+            i['locked'] = locked
+            i['nfs_shares'] = self.get_nfs_shares(i, nfsshares, mntinfo)
+            i['smb_shares'] = self.get_smb_shares(i, smbshares, mntinfo)
+            i['replication_tasks_count'] = self.get_repl_tasks_count(i, repltasks)
+            i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, snaptasks)
+            i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, cldtasks)
+
+        return info
+
+    @private
+    def collapse_datasets(self, dataset, collapsed):
+        collapsed.append(dataset)
+        for child in dataset.get('children', []):
+            self.collapse_datasets(child, collapsed)
+
+    @private
+    def get_snapcount_and_encryption_status(self, ds, mntinfo):
+        snap_count = 0
+        locked = False
+        if ds['type'] == 'FILESYSTEM':
+            # FIXME: determining zvol snapshot count requires iterating over
+            # all snapshots for a given zvol and then counting them which is
+            # painful. This will be moot when this is merged upstream
+            # https://github.com/openzfs/zfs/pull/13635
+
+            try:
+                st = os.stat(f'{ds["mountpoint"]}/.zfs/snapshot')
+            except FileNotFoundError:
+                # means that the zfs snapshot dir doesn't exist which
+                # can only happen if the dataset is encrypted and "locked"
+                # (unmounted) or the dataset is unmounted
+                locked = ds['encrypted']
+            else:
+                if st.st_ino == ZFSCTL.INO_SNAPDIR:
+                    # dataset isn't locked and the inode of the snapshot dir
+                    # is what we expect so we're able to determine the snapshot
+                    # count by reading st_nlink
+                    snap_count = st.st_nlink - 2  # (remove 2 for `.` and `..`)
+                else:
+                    # zfs snapshot dir exists but inode doesn't match reality
+                    # which can only happen if dataset is unmounted and the
+                    # same directory structure is created manually
+                    locked = ds['encrypted']
+
+        return snap_count, locked
+
+    @private
+    def get_nfs_shares(self, ds, nfsshares, mntinfo):
+        nfs_shares = []
+        found = False
+        for nfsshare in nfsshares:
+            if nfsshare['path'] == ds['mountpoint']:
+                # the share path is the actual dataset
+                found = True
+            else:
+                try:
+                    devid = os.stat(nfsshare['path']).st_dev
+                except Exception:
+                    pass
+                else:
+                    found = devid in mntinfo and mntinfo[devid]['mount_source'] == ds['id']
+
+            if found:
+                nfs_shares.append({
+                    'enabled': nfsshare['enabled'],
+                    'path': nfsshare['path'],
+                })
+
+        return nfs_shares
+
+    @private
+    def get_smb_shares(self, ds, smbshares, mntinfo):
+        smb_shares = []
+        found = False
+        for smbshare in smbshares:
+            if smbshare['path'] == ds['mountpoint']:
+                # the share path is the actual dataset
+                found = True
+            else:
+                try:
+                    devid = os.stat(smbshare['path']).st_dev
+                except Exception:
+                    pass
+                else:
+                    found = devid in mntinfo and mntinfo[devid]['mount_source'] == ds['id']
+
+            if found:
+                smb_shares.append({
+                    'enabled': smbshare['enabled'],
+                    'path': smbshare['path'],
+                    'share_name': smbshare['name'],
+                })
+
+        return smb_shares
+
+    @private
+    def get_repl_tasks_count(self, ds, repltasks):
+        count = 0
+        for repl in repltasks:
+            if repl['transport'] == 'LOCAL' or repl['direction'] == 'PUSH':
+                if any(
+                    belongs_to_tree(ds, src_ds, repl['recursive'], repl['exclude'])
+                    for src_ds in repl['source_datasets']
+                ):
+                    count += 1
+
+            if repl['transport'] == 'LOCAL' or repl['direction'] == 'PULL':
+                if is_child(ds, repl['target_dataset']):
+                    count += 1
+
+        return count
+
+    @private
+    def get_cloudsync_tasks_count(self, ds, cldtasks):
+        return len([i for i in cldtasks if i['path'] == ds['mountpoint']])
+
+    @private
+    def get_snapshot_tasks_count(self, ds, snaptasks):
+        return len([i for i in snaptasks if f'/mnt/{i["dataset"]}' == ds['mountpoint']])

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -43,6 +43,7 @@ class PoolDatasetService(Service):
         repltasks = self.middleware.call_sync('datastore.query', 'storage.replication', [], {'prefix': 'repl_'})
         snaptasks = self.middleware.call_sync('datastore.query', 'storage.task', [], {'prefix': 'task_'})
         cldtasks = self.middleware.call_sync('datastore.query', 'tasks.cloudsync')
+        rsynctasks = self.middleware.call_sync('rsynctask.query')
         collapsed = []
         info = self.middleware.call_sync('pool.dataset.query', filters, options)
         for dataset in info:
@@ -58,6 +59,7 @@ class PoolDatasetService(Service):
             i['replication_tasks_count'] = self.get_repl_tasks_count(i, repltasks)
             i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, snaptasks)
             i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, cldtasks)
+            i['rsync_tasks_count'] = self.get_rsync_tasks_count(i, rsynctasks)
 
         return info
 
@@ -221,3 +223,7 @@ class PoolDatasetService(Service):
     @private
     def get_snapshot_tasks_count(self, ds, snaptasks):
         return len([i for i in snaptasks if f'/mnt/{i["dataset"]}' == ds['mountpoint']])
+
+    @private
+    def get_rsync_tasks_count(self, ds, rsynctasks):
+        return len([i for i in rsynctasks if i['path'] == ds['mountpoint']])


### PR DESCRIPTION
This will be used by front-end team for storage page redesign. This gathers the information they're after in 1 parent for loop trying to be as optimized as possible.

I've tested this on real hardware with > 1k+ datasets, ~15K snapshots, 90 smb shares, 20 iscsi shares, 36 nfs shares Along with 1 rsync, snapshot, replication and cloudsync task respectively.

When I call this method, it takes ~2.2 seconds which is fast enough since it's been tested against absolute worst case scenario.

On a side-note, I'm querying with `flat: False` and then collapsing the children datasets into a list so a weakref is made so that the original structure of the returned data can be kept in tact because the webUI uses that to expand/collapse the dataset tree. (i.e. show only parent datasets and allow user to drill-down into the child datasets if any exist)


NOTE: I am not determining the zvol snapshot count at this time because it makes this considerably slower. Makes it so slow that this endpoint isn't usable. This will become moot once an upstream openzfs pr is merged which adds the snapshot count as a zfs property. (It has been approved, just not merged)