### PR TITLE
NAS-116911 / 22.02.3 / Allow LDAP netgroups support (by anodos325)

### DIFF
--- a/src/freenas/etc/nsswitch.conf
+++ b/src/freenas/etc/nsswitch.conf
@@ -11,3 +11,4 @@ services: files
 protocols: files
 rpc: files
 sudoers: files
+netgroup: files ldap

--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -81,6 +81,10 @@
         return ','.join(params)
 
     def parse_host(hostname, gaierrors):
+        if hostname.startswith('@'):
+            # This is a netgroup, skip validation
+            return hostname
+
         try:
             addr = ipaddress.ip_address(hostname)
             return addr.compressed

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -517,7 +517,7 @@ class SharingNFSService(SharingService):
             if share_dev == dev:
                 for host in share["hosts"]:
                     host = dns_cache[host]
-                    if host is None:
+                    if host is None or host.startswith('@'):
                         continue
 
                     try:
@@ -542,6 +542,9 @@ class SharingNFSService(SharingService):
                     used_networks.add(ipaddress.ip_network("::/0"))
 
         for host in set(data["hosts"]):
+            if host.startswith('@'):
+                continue
+
             cached_host = dns_cache[host]
             if cached_host is None:
                 verrors.add(

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -435,10 +435,11 @@ def test_32_check_nfs_share_hosts(request):
 
     "/mnt/dozer/nfs"\
         192.168.0.69(sec=sys,rw,subtree_check)\
-        192.168.0.70(sec=sys,rw,subtree_check)
+        192.168.0.70(sec=sys,rw,subtree_check)\
+        @fakenetgroup(sec=sys,rw,subtree_check)
     """
     depends(request, ["pool_04", "ssh_password"], scope="session")
-    hosts_to_test = ["192.168.0.69", "192.168.0.70"]
+    hosts_to_test = ["192.168.0.69", "192.168.0.70", "@fakenetgroup"]
 
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hosts_to_test})
     assert results.status_code == 200, results.text


### PR DESCRIPTION
Add nsswitch.conf entry for netgroups and allow
netgroups through hosts validation in NFS share
configuration.

Original PR: https://github.com/truenas/middleware/pull/9448
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116911