### PR TITLE
NAS-117245 / 22.12 / Improve `get_remote_addr_port` performance

### DIFF
--- a/tests/api2/test_ip_auth.py
+++ b/tests/api2/test_ip_auth.py
@@ -1,0 +1,25 @@
+import json
+import shlex
+
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import ssh
+
+
+@pytest.mark.parametrize("url", ["127.0.0.1", "127.0.0.1:6000"])
+@pytest.mark.parametrize("root", [True, False])
+def test_tcp_connection_from_localhost(url, root):
+    cmd = f"midclt -u ws://{url}/websocket call auth.sessions '[[\"current\", \"=\", true]]' '{{\"get\": true}}'"
+    if root:
+        assert json.loads(ssh(cmd))["credentials"] == "ROOT_TCP_SOCKET"
+    else:
+        with user({
+            "username": "unprivileged",
+            "full_name": "Unprivileged User",
+            "group_create": True,
+            "home": f"/nonexistent",
+            "password": "test1234",
+        }):
+            result = ssh(f"sudo -u unprivileged {cmd}", check=False, complete_response=True)
+            assert "Not authenticated" in result["stderr"]


### PR DESCRIPTION
`get_peer_process` calls `psutil.net_connections` which runs `readlink` on every file opened
in the system. This is slow when many files are open. To determine whether the other side
of the connection is nginx (which we do most of the time) we only need to check for connections
accepted by nginx's workers which is a much easier job.