### PR TITLE
NAS-117217 / 22.12 / fix migration failure upgrading from core to scale (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
@@ -38,7 +38,7 @@ def upgrade():
             new_sql = new_sql.rstrip().rstrip(')').rstrip().rstrip(',') + '\n)'
         elif re.match(r'CREATE TABLE "(.+)" \("id" integer (NOT NULL |)PRIMARY KEY AUTOINCREMENT,', sql):
             continue
-        elif re.match(r'CREATE TABLE ?(.+) \(\s+id integer NOT NULL PRIMARY KEY AUTOINCREMENT,', sql):
+        elif re.match(r'CREATE TABLE (.+) \(\s+id integer NOT NULL PRIMARY KEY AUTOINCREMENT,', sql):
             # saw this on 12.0-U8 core machine upgrading to scale
             """
             CREATE TABLE account_bsdgroupmembership (

--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
@@ -50,7 +50,7 @@ def upgrade():
                 'CREATE TABLE sqlite_sequence',
                 'CREATE TABLE alembic_version',
                 'CREATE TABLE "storage_disk"',
-            ))
+            )), sql
             continue
 
         index_sqls = []

--- a/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
+++ b/src/middlewared/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py
@@ -38,6 +38,13 @@ def upgrade():
             new_sql = new_sql.rstrip().rstrip(')').rstrip().rstrip(',') + '\n)'
         elif re.match(r'CREATE TABLE "(.+)" \("id" integer (NOT NULL |)PRIMARY KEY AUTOINCREMENT,', sql):
             continue
+        elif re.match(r'CREATE TABLE ?(.+) \(\s+id integer NOT NULL PRIMARY KEY AUTOINCREMENT,', sql):
+            # saw this on 12.0-U8 core machine upgrading to scale
+            """
+            CREATE TABLE account_bsdgroupmembership (
+                    id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+            """
+            continue
         else:
             assert sql.startswith((
                 'CREATE TABLE sqlite_sequence',


### PR DESCRIPTION
User failed to upgrade from core to scale because of
```
  File "/usr/lib/python3/dist-packages/alembic/runtime/migration.py", line 522, in run_migrations
    step.migration_fn(**kw)
  File "/usr/lib/python3/dist-packages/middlewared/alembic/versions/22.02/2021-01-20_10-19_autoincrement.py", line 40, in upgrade
    assert sql.startswith((
AssertionError
```

Got a copy of users database and ran that upgrade function in isolation and reproduced the same crash here:
```
Traceback (most recent call last):
  File "sqlthings.py", line 66, in <module>
    upgrade()
  File "sqlthings.py", line 39, in upgrade
    )), sql
AssertionError: CREATE TABLE account_bsdgroupmembership (
        id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
        bsdgrpmember_group_id INTEGER NOT NULL,
        bsdgrpmember_user_id INTEGER NOT NULL,
        CONSTRAINT fk_account_bsdgroupmembership_bsdgrpmember_group_id_account_bsdgroups FOREIGN KEY(bsdgrpmember_group_id) REFERENCES account_bsdgroups (id) ON DELETE CASCADE,
        CONSTRAINT fk_account_bsdgroupmembership_bsdgrpmember_user_id_account_bsdusers FOREIGN KEY(bsdgrpmember_user_id) REFERENCES account_bsdusers (id) ON DELETE CASCADE
)
```

Seems the `accounts_bsdgroupmembership` table doesn't match the expected regex.

Fix this by adding another regex check to account for tables like this.

Also, I'm printing the `sql` line when we raise an assertion error so the `/data/update.failed` log message is a little more useful.

Original PR: https://github.com/truenas/middleware/pull/9451
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117217