### PR TITLE
NAS-117283 / 22.02.3 / Fix resolve_builtins for case where id is None (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -221,7 +221,7 @@ class ACLTemplateService(CRUDService):
     @private
     async def resolve_names(self, uid, gid, data):
         for ace in data['acl']:
-            if ace['id'] != -1:
+            if ace['id'] not in (-1, None):
                 ace['who'] = await self.middleware.call(
                     'idmap.id_to_name', ace['id'], ace['tag']
                 )


### PR DESCRIPTION
Historically we accepted null and -1 for equivalent of
ACL_UNDEFINED_ID (which is used with NFSv4 SPECIAL entries)
in NFSv4 ACL type. We need handling for this case when
resolving IDs to names.

Original PR: https://github.com/truenas/middleware/pull/9455
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117283