### PR TITLE
NAS-117245 / 22.02.3 / Improve `get_remote_addr_port` performance (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/utils/nginx.py
+++ b/src/middlewared/middlewared/utils/nginx.py
@@ -1,0 +1,42 @@
+# -*- coding=utf-8 -*-
+import psutil
+from psutil._common import addr
+
+
+def get_peer_process(remote_addr, remote_port):
+    for connection in psutil.net_connections(kind='tcp'):
+        if connection.laddr == addr(remote_addr, remote_port):
+            try:
+                return psutil.Process(connection.pid)
+            except psutil.ProcessNotFound:
+                return None
+
+
+def get_remote_addr_port(request):
+    remote_addr, remote_port = request.transport.get_extra_info("peername")
+    if remote_addr in ["127.0.0.1", "::1"]:
+        try:
+            x_real_remote_addr = request.headers["X-Real-Remote-Addr"]
+            x_real_remote_port = int(request.headers["X-Real-Remote-Port"])
+        except (KeyError, ValueError):
+            pass
+        else:
+            try:
+                with open("/var/run/nginx.pid") as f:
+                    nginx_pid = int(f.read().strip())
+            except Exception:
+                pass
+            else:
+                try:
+                    process = psutil.Process(nginx_pid)
+                except psutil.ProcessNotFound:
+                    pass
+                else:
+                    if process.name() == "nginx":
+                        for worker in process.children():
+                            for connection in worker.connections(kind="tcp"):
+                                if connection.laddr == addr(remote_addr, remote_port):
+                                    remote_addr = x_real_remote_addr
+                                    remote_port = x_real_remote_port
+
+    return remote_addr, remote_port

--- a/tests/api2/test_ip_auth.py
+++ b/tests/api2/test_ip_auth.py
@@ -1,0 +1,25 @@
+import json
+import shlex
+
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import ssh
+
+
+@pytest.mark.parametrize("url", ["127.0.0.1", "127.0.0.1:6000"])
+@pytest.mark.parametrize("root", [True, False])
+def test_tcp_connection_from_localhost(url, root):
+    cmd = f"midclt -u ws://{url}/websocket call auth.sessions '[[\"current\", \"=\", true]]' '{{\"get\": true}}'"
+    if root:
+        assert json.loads(ssh(cmd))["credentials"] == "ROOT_TCP_SOCKET"
+    else:
+        with user({
+            "username": "unprivileged",
+            "full_name": "Unprivileged User",
+            "group_create": True,
+            "home": f"/nonexistent",
+            "password": "test1234",
+        }):
+            result = ssh(f"sudo -u unprivileged {cmd}", check=False, complete_response=True)
+            assert "Not authenticated" in result["stderr"]


### PR DESCRIPTION
`get_peer_process` calls `psutil.net_connections` which runs `readlink` on every file opened
in the system. This is slow when many files are open. To determine whether the other side
of the connection is nginx (which we do most of the time) we only need to check for connections
accepted by nginx's workers which is a much easier job.

Original PR: https://github.com/truenas/middleware/pull/9452
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117245