### PR TITLE
NAS-117231 / 22.02.3 / Add CTDB event integration (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -102,6 +102,7 @@ class DismissableAlertClass:
 class AlertCategory(enum.Enum):
     APPLICATIONS = "APPLICATIONS"
     CERTIFICATES = "CERTIFICATES"
+    CLUSTERING = "CLUSTERING"
     DIRECTORY_SERVICE = "DIRECTORY_SERVICE"
     HA = "HA"
     HARDWARE = "HARDWARE"
@@ -119,6 +120,7 @@ class AlertCategory(enum.Enum):
 alert_category_names = {
     AlertCategory.APPLICATIONS: "Applications",
     AlertCategory.CERTIFICATES: "Certificates",
+    AlertCategory.CLUSTERING: "Clustering",
     AlertCategory.DIRECTORY_SERVICE: "Directory Service",
     AlertCategory.HA: "High-Availability",
     AlertCategory.HARDWARE: "Hardware",

--- a/src/middlewared/middlewared/alert/source/ctdb.py
+++ b/src/middlewared/middlewared/alert/source/ctdb.py
@@ -1,0 +1,21 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class CtdbInitFailAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.CLUSTERING
+    level = AlertLevel.WARNING
+    title = "CTDB service initialization failed"
+    text = "CTDB service initialization failed: %(errmsg)s"
+
+    async def delete(self, alerts, query):
+        return []
+
+
+class CtdbClusteredServiceAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.CLUSTERING
+    level = AlertLevel.WARNING
+    title = "Clustered service start failed"
+    text = "Clustered service start failed: %(errmsg)s"
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
@@ -6,7 +6,7 @@
         hamode = middleware.call_sync('smb.get_smb_ha_mode')
         if hamode == 'CLUSTERED':
             pnn = middleware.call_sync('ctdb.general.pnn')
-            recmaster = middleware.call_sync('ctdb.general.recovery_masterr')
+            recmaster = middleware.call_sync('ctdb.general.recovery_master')
             if pnn != recmaster:
                 enabled = False
 

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_event.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_event.py
@@ -1,0 +1,118 @@
+import enum
+
+from middlewared.service import job, Service
+
+
+EVENT_FN_MAP = {
+    'INIT': 'event_init',
+    'SETUP': 'event_not_implemented',
+    'STARTUP': 'event_not_implemented',
+    'SHUTDOWN': 'event_not_implemented',
+    'MONITOR': 'event_monitor',
+    'STARTRECOVERY': 'event_recovery',
+    'RECOVERED': 'event_recovery',
+    'TAKEIP': 'event_not_implemented',
+    'RELEASEIP': 'event_not_implemented',
+    'IPREALLOCATED': 'event_ip_reallocated',
+}
+
+
+class CtdbEventType(enum.Enum):
+    INIT = enum.auto()
+    SETUP = enum.auto()
+    STARTUP = enum.auto()
+    SHUTDOWN = enum.auto()
+    MONITOR = enum.auto()
+    STARTRECOVERY = enum.auto()
+    RECOVERED = enum.auto()
+    TAKEIP = enum.auto()
+    RELEASEIP = enum.auto()
+    IPREALLOCATED = enum.auto()
+
+    def get_fn(self):
+        return EVENT_FN_MAP[self.name]
+
+
+class CtdbEventService(Service):
+
+    class Config:
+        namespace = 'ctdb.event'
+        private = True
+
+    def event_ip_reallocated(self, data):
+        """
+        This is notification only. Not an error. Indicates
+        that our public IPs have shifted between nodes.
+
+        We only send out event info from recovery master.
+        """
+        if not self.middleware.call_sync('ctdb.general.is_rec_master'):
+            return
+
+        public_ips = self.middleware.call_sync('ctdb.general.ips')
+        self.middleware.send_event(
+            'ctdb.status', 'CHANGED', fields={'event': data['event'], 'data': public_ips}
+        )
+
+    def event_init(self, data):
+        """
+        This event gets triggered when CTDB is starting.
+        Expected failure mode is when ctdb_shared_volume isn't properly mounted.
+        """
+        ev = data.pop('event')
+        if data['status'] == 'SUCCESS':
+            self.middleware.call_sync('alert.oneshot_delete', 'CtdbInitFail', None)
+        else:
+            self.middleware.call_sync(
+                'alert.oneshot_create',
+                'CtdbInitFail',
+                {'errmsg': data['reason']}
+            )
+
+        self.middleware.send_event(
+            'ctdb.status', 'CHANGED', fields={'event': ev, 'data': data}
+        )
+
+    def event_monitor(self, data):
+        """
+        Failure of a ctdb monitored process to start will cause CTDB to enter
+        UNHEALTHY state.
+
+        This should occur less than monitor interval. Basically the monitor script
+        will only call if the state has changed. Hence we don't need to query alerts here.
+        """
+        ev = data.pop('event')
+        if data['status'] == 'SUCCESS':
+            self.middleware.call_sync('alert.oneshot_delete', 'CtdbClusteredService', None)
+
+        else:
+            self.middleware.call_sync(
+                'alert.oneshot_create',
+                'CtdbClusteredService',
+                {'errmsg': data['reason']}
+            )
+
+        self.middleware.send_event(
+            'ctdb.status', 'CHANGED', fields={'event': ev, 'data': data}
+        )
+
+    def event_recovery(self, data):
+        if not self.middleware.call_sync('ctdb.general.is_rec_master'):
+            return
+
+        ev = data.pop('event')
+        self.middleware.send_event(
+            'ctdb.status', 'CHANGED', fields={'event': ev, 'data': data}
+        )
+
+    def event_not_implemented(self, arg_unused):
+        raise NotImplementedError()
+
+    @job(lock="event_results", transient=True, lock_queue_size=3)
+    def process(self, job, data):
+        ev = CtdbEventType[data['event']]
+        return getattr(self, ev.get_fn())(data)
+
+
+def setup(middleware):
+    middleware.event_register('ctdb.status', 'Sent on cluster status changes.')

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -244,15 +244,9 @@ class CtdbGeneralService(Service):
         if self.this_node is not None:
             return self.this_node
 
-        try:
-            # gluster volume root has inode of 1.
-            # if gluster isn't mounted it will be different
-            # if volume is unhealthy this will fail
-            if os.stat(f'/cluster/{CTDB_VOL}').st_ino != 1:
-                return False
-        except Exception:
-            return False
-
+        # since ctdbd will fail to init if ctdb shared volume is
+        # not mounted, we can skip our normal stat() check for
+        # gluster mountpoint
         self.this_node = ctdb.Client().pnn
         return self.this_node
 
@@ -263,3 +257,7 @@ class CtdbGeneralService(Service):
         Return node number for the recovery master for the cluster.
         """
         return ctdb.Client().recmaster()
+
+    @private
+    def is_rec_master(self):
+        return self.pnn() == self.recovery_master()

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_services.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_services.py
@@ -1,0 +1,120 @@
+import errno
+import fcntl
+import json
+import os
+
+from copy import deepcopy
+from middlewared.plugins.cluster_linux.utils import CTDBConfig
+from middlewared.service import filterable, Service
+from middlewared.service_exception import CallError
+from middlewared.utils import filter_list
+
+CTDB_MONITORED_SERVICES = ['cifs']
+CTDB_SERVICE_DEFAULTS = {srv: {
+    'name': srv,
+    'enable': False,
+    'cluster_state': []
+} for srv in CTDB_MONITORED_SERVICES}
+
+
+class CtdbServicesService(Service):
+
+    class Config:
+        namespace = 'ctdb.services'
+        private = True
+
+    def read_node_specific_status(self, pnn):
+        with open(f'{CTDBConfig.GM_CLUSTERED_SERVICES.value}.{pnn}', 'r') as f:
+            return json.load(f)
+
+    def get_node_service_status(self):
+        out = []
+        for node in self.middleware.call_sync('ctdb.general.listnodes'):
+            try:
+                out.append({'pnn': node['pnn'], 'status': self.read_node_specific_status(node['pnn'])})
+            except FileNotFoundError:
+                out.append({'pnn': node['pnn'], 'status': {}})
+            except json.decoder.JSONDecodeError:
+                self.logger.warning('Service status file for node %d could not be parsed', node['pnn'])
+                out.append({'pnn': node['pnn'], 'status': {}})
+
+        return out
+
+    def get_global_state(self):
+        if not self.middleware.call_sync('ctdb.general.healthy'):
+            raise CallError('Unable to retrieve clustered service state while cluster unhealthy', errno.ENXIO)
+
+        try:
+            with open(CTDBConfig.GM_CLUSTERED_SERVICES.value, 'r') as f:
+                fcntl.lockf(f.fileno(), fcntl.LOCK_SH)
+                try:
+                    cl = json.load(f)
+                finally:
+                    fcntl.lockf(f.fileno(), fcntl.LOCK_UN)
+
+            for srv in CTDB_MONITORED_SERVICES:
+                if srv not in cl:
+                    cl[srv] = deepcopy(CTDB_SERVICE_DEFAULTS[srv])
+
+            return cl
+
+        except FileNotFoundError:
+            pass
+
+        except json.decoder.JSONDecodeError:
+            self.logger.warning('failed to parse clustered services state file', exc_info=True)
+            os.unlink(CTDBConfig.GM_CLUSTERED_SERVICES.value)
+
+        return deepcopy(CTDB_SERVICE_DEFAULTS)
+
+    @filterable
+    def get(self, filters, options):
+        """
+        Get cluster-wide service state for clustered
+        services.
+
+        `enable` service is currently monitored by ctdbd
+        `pnn` indicates the immutable node number.
+        `state` includes following keys:
+        `running` - the service is currently running
+        `last_check` - timestamp (CLOCK_REALTIME) on `pnn` when state last updated
+        `error` - error message from failure (if service isn't running when it should be)
+        """
+        cl = self.get_global_state()
+
+        for node in self.get_node_service_status():
+            for srv in cl.keys():
+                if srv not in node['status']:
+                    cl[srv]['cluster_state'].append({
+                        'pnn': node['pnn'],
+                        'state': 'UNAVAIL'
+                    })
+                    continue
+
+                cl[srv]['cluster_state'].append({
+                    'pnn': node['pnn'],
+                    'state': node['status'][srv]
+                })
+
+        return filter_list(list(cl.values()), filters, options)
+
+    def set(self, srv, enabled):
+        """
+        Private method that enables CTDB monitoring for the specifie
+        service. This enables cluster-wide.
+        """
+        if srv not in CTDB_MONITORED_SERVICES:
+            raise CallError(f'{srv}: not a CTDB monitored service')
+
+        current_state = self.get_global_state()
+
+        if current_state[srv]['enable'] != enabled:
+            current_state[srv]['enable'] = enabled
+            with open(CTDBConfig.GM_CLUSTERED_SERVICES.value, 'w') as f:
+                fcntl.lockf(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    f.write(json.dumps(current_state))
+                    f.flush()
+                    os.fsync(f.fileno())
+                finally:
+                    fcntl.lockf(f.fileno(), fcntl.LOCK_UN)

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -166,6 +166,7 @@ class CTDBConfig(enum.Enum):
     GM_RECOVERY_FILE = os.path.join(CTDB_LOCAL_MOUNT, REC_FILE)
     GM_PRI_IP_FILE = os.path.join(CTDB_LOCAL_MOUNT, PRIVATE_IP_FILE)
     GM_PUB_IP_FILE = os.path.join(CTDB_LOCAL_MOUNT, PUBLIC_IP_FILE)
+    GM_CLUSTERED_SERVICES = os.path.join(CTDB_LOCAL_MOUNT, '.clustered_services')
 
     # ctdb etc config
     CTDB_ETC = '/etc/ctdb'

--- a/src/middlewared/middlewared/scripts/ctdb_events.py
+++ b/src/middlewared/middlewared/scripts/ctdb_events.py
@@ -1,0 +1,302 @@
+#!/usr/bin/python3
+
+import ctdb
+import fcntl
+import json
+import os
+import time
+
+from copy import deepcopy
+from middlewared.client import Client
+from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
+from middlewared.plugins.cluster_linux.ctdb_services import CTDB_SERVICE_DEFAULTS
+
+CTDB_VOL = os.path.join(
+    FuseConfig.FUSE_PATH_BASE.value,
+    CTDBConfig.CTDB_VOL_NAME.value,
+)
+
+CTDB_SERVICE_FILE = f'{CTDB_VOL}/.clustered_services'
+CTDB_RUNDIR = '/var/run/ctdb'
+CTDB_MONITOR_FAILED_SENTINEL = os.path.join(CTDB_RUNDIR, '.monitored_failed')
+
+
+class CtdbEvent:
+
+    def __init__(self, **kwargs):
+        self.logger = kwargs.get('logger')
+        self.client = Client()
+        self.clservices = None
+        self.pnn = -1
+        self.node_status = {}
+        self.init_node_status = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        self.client.close()
+
+    def check_ctdb_shared_volume(self):
+        st = os.stat(CTDB_VOL)
+        if st.st_ino != 1:
+            raise RuntimeError('ctdb shared volume not mounted')
+
+    def load_service_file(self):
+        """
+        There are two separate files we read here:
+        One is cluster-wide service configuration state:
+        /cluster/ctdb_shared_vol/.clustered_services
+
+        This file is read to get configuration, but not
+        updated in the event scripts
+
+        The other is a node-specific service status file
+        /cluster/ctdb_shared_vol/.clustered_services.{pnn}
+
+        This file is updated with current run state of service
+        on every monitoring cycle. This allows any node
+        on the server to see a cached copy of run state
+        of all nodes (based on last monitoring interval).
+        """
+        self.pnn = ctdb.Client().pnn
+        try:
+            with open(CTDB_SERVICE_FILE, 'r') as f:
+                fcntl.lockf(f.fileno(), fcntl.LOCK_SH)
+                try:
+                    self.cl_services = json.load(f)
+                finally:
+                    fcntl.lockf(f.fileno(), fcntl.LOCK_UN)
+
+            try:
+                with open(f'{CTDB_SERVICE_FILE}.{self.pnn}') as f:
+                    self.node_status = json.load(f)
+            except (FileNotFoundError, json.decoder.JSONDecodeError):
+                self.node_status = {}
+
+        except Exception:
+            self.logger.warning('Failed to load clustered services file', exc_info=True)
+            self.cl_services = deepcopy(CTDB_SERVICE_DEFAULTS)
+
+    def init(self):
+        """
+        Raising exception here will prevent ctdb service
+        from starting
+
+        At this point ctdb is not listening on its
+        unix domain socket so any ctdb related commands
+        and python bindings will fail.
+        """
+        self.client.call('core.ping')
+
+        try:
+            self.check_ctdb_shared_volume()
+        except Exception as e:
+            self.client.call('ctdb.event.process', {
+                'event': 'INIT',
+                'status': 'FAILURE',
+                'reason': str(e),
+            })
+
+            raise
+
+        self.client.call('ctdb.event.process', {
+            'event': 'INIT',
+            'status': 'SUCCESS',
+        })
+
+    def setup(self):
+        """
+        This is triggered once aftter the 'init' event
+        has completed.
+
+        Raising exception here will prevent ctdb service
+        from starting
+
+        At this point the ctdb unix domain socket is available.
+        """
+        return
+
+    def startup(self):
+        """
+        This is triggered after the 'setup' event has
+        completed and starts all services managed by ctdb.
+
+        If this fails, CTBDB will retry until it succeeds.
+        There is no limit to the times it retires.
+        """
+        if not self.client.call('system.ready'):
+            return
+
+        if not os.path.exists(CTDB_SERVICE_FILE):
+            return
+
+        self.load_service_file()
+        for srv in self.cl_services.values():
+            if srv['enable']:
+                self.client.call('service.restart', srv['name'])
+
+    def shutdown(self):
+        """
+        This shuts down all services managed by ctdb and is
+        triggered by ctdb shutting down.
+        """
+        return
+
+    def monitor(self):
+        if not self.client.call('system.ready'):
+            self.logger.debug('middlewared is not ready. Skipping monitoring')
+            return
+
+        payload = {
+            'event': 'MONITOR',
+            'status': 'SUCCESS',
+        }
+
+        try:
+            self.check_ctdb_shared_volume()
+        except Exception as e:
+            payload = {
+                'event': 'MONITOR',
+                'status': 'FAILURE',
+                'reason': str(e),
+                'service': 'ctdb_shared_volume',
+            }
+
+        if not payload['status'] == 'FAILURE':
+            self.load_service_file()
+            self.init_node_status = deepcopy(self.node_status)
+            for srv in self.cl_services.values():
+                srvinfo = self.client.call('service.query', [['service', '=', srv['name']]], {'get': True})
+                final_state = 'STOPPED'
+                ts = time.clock_gettime(time.CLOCK_REALTIME)
+                error = None
+
+                if srv['enable']:
+                    if srvinfo['state'] != 'RUNNING':
+                        self.logger.warning('%s: managed service is not running. Attempting to start.',
+                                            srv['name'])
+                        try:
+                            self.client.call('service.start', srv['name'], {'silent': False})
+                            final_state = 'RUNNING'
+                        except Exception as e:
+                            self.logger.warning('%s: failed to start managed service.',
+                                                srv['name'], exc_info=True)
+
+                            error = str(e)
+                            errmsg = f'{srv["name"]}: service failed to start: {e}'
+                            payload = {
+                                'event': 'MONITOR',
+                                'status': 'FAILURE',
+                                'reason': errmsg,
+                                'service': srv['name'],
+                            }
+
+                    else:
+                        final_state = 'RUNNING'
+
+                    if not srvinfo['enable']:
+                        self.client.call('service.update', srvinfo['id'], {'enable': True})
+
+                else:
+                    if srvinfo['enable']:
+                        self.client.call('service.update', srvinfo['id'], {'enable': False})
+
+                    if srvinfo['state'] == 'RUNNING':
+                        self.client.call('service.stop', srv['name'])
+
+                self.node_status[srv['name']] = {
+                    'running': final_state == 'RUNNING',
+                    'last_check': ts,
+                    'error': error
+                }
+
+        try:
+            initial = {k: v['running'] for k, v in self.init_node_status.items()}
+        except Exception:
+            self.logger.warning('Unable to parse initial node status', exc_info=True)
+            initial = {}
+
+        final = {k: v['running'] for k, v in self.node_status.items()}
+
+        if initial and initial != final:
+            # init_node_status may be empty dict if this is first time
+            # through. In this case, we don't need to send a status change event
+            self.client.call('ctdb.event.process', payload)
+
+        if payload['status'] == 'FAILURE' and payload['service'] == 'ctdb_shared_volume':
+            self.client.call('ctdb.event.process', payload)
+            raise RuntimeError(payload['reason'])
+
+        else:
+            with open(f'{CTDB_SERVICE_FILE}.{self.pnn}', 'w') as f:
+                fcntl.lockf(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    f.write(json.dumps(self.node_status))
+                    f.flush()
+                    os.fsync(f.fileno())
+                finally:
+                    fcntl.lockf(f.fileno(), fcntl.LOCK_UN)
+
+    def startrecovery(self):
+        """
+        This event is triggered every time a database recovery process is
+        started. It is rarely used.
+
+        In principle all that is needed here is to pass along to middleware
+        that recovery has started so that notification can be sent to any
+        clustered event subscribers.
+        """
+        try:
+            if not self.client.call('system.ready'):
+                return
+
+            ctdb_status = ctdb.Client().status()
+            self.client.call('ctdb.event.process', {
+                'event': 'STARTRECOVERY', 'status': 'SUCCESS', 'ctdb_status': ctdb_status
+            })
+        except Exception:
+            pass
+
+    def recovered(self):
+        """
+        This event is triggered every time a database recovery process is
+        completed. It is rarely used.
+
+        In principle all that is needed here is to pass along to middleware
+        that recovery has finished so that notification can be sent to any
+        clustered event subscribers.
+        """
+        try:
+            if not self.client.call('system.ready'):
+                return
+
+            ctdb_status = ctdb.Client().status()
+            self.client.call('ctdb.event.process', {
+                'event': 'RECOVERED', 'status': 'SUCCESS', 'ctdb_status': ctdb_status
+            })
+        except Exception:
+            pass
+
+    def takeip(self, iface, address, netmask):
+        return
+
+    def releaseip(self, iface, address, netmask):
+        return
+
+    def updateip(self, old_iface, new_iface, address, netmask):
+        return
+
+    def ipreallocated(self):
+        """
+        This event gets triggered on every node when public IP has changed.
+
+        Failure here causes ip allocation to be retried.
+        """
+        try:
+            if not self.client.call('system.ready'):
+                return
+
+            self.client.call('ctdb.event.process', {'event': 'IPREALLOCATED', 'status': 'SUCCESS'})
+        except Exception:
+            pass


### PR DESCRIPTION
CTDB can be configured to run event scripts at various times /
situations. This commit adds some initial plumbing to pass
these through to middlewared alerts and also subscribers to
ctdb events. The primary ones we are concerned with are:

INIT - add checks that middlewared is healthy and that the
ctdb shared volume is healthy before starting the ctdb process.
If this fails then ctdb will not start.

STARTUP - there are some services that we want to enable / disable
clusterwide. Add support for a special configuration file on
the ctdb_shared_volume that contains services that should always
be running when cluster is healthy. Services here will be restarted
when CTDB finishes starting.

MONITOR - CTDB monitors the services (same as STARTUP) at
configurable intervals and starts the service if it is stopped.
This also checks the status of the CTDB shared volume. Failure
of CTDB shared volume health check will cause CTDB on the node to
become UNHEALTHY. Failure of monitored service in this script
will not degrade CTDB status, but will generate alert / event.
Alert / event will only be triggered on state change based on
sentinel file.

STARTRECOVERY / RECOVERED - This sends events when recovery
operations are started and completed. Should be very infrequent
per documentation. Recovery master only.

IPREALLOCATED - triggered if public IP address changes between
nodes. This will generate an event from recovery master containing
new public IP info.

The actual event script called by CTDB will be located in
Samba repo, but use the CtdbEvent class defined here.

Two new services are added in this PR:
`ctdb.event` - processes events sent from the CTDB daemon, creating
or removing alerts as needed, and sending alerts to TrueCommand.

`ctdb.service` - used for getting basic info about ctdb-managed
services. When ctdb manages services, each node will write basic
status information during the monitoring interval to the ctdb shared
volume.

This is currently not utilized in this PR, but in future can be used to
give cluster-wide state for services through the normal services API.

ctdb.service.set is used to enable ctdb monitoring / management
of supported services. Currently this is limited to the SMB service.

Original PR: https://github.com/truenas/middleware/pull/9418
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117231