### PR TITLE
NAS-117299 / 22.12 / Add internal endpoint to retrieve host paths being consumed by apps

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -325,7 +325,7 @@ class ChartReleaseService(CRUDService):
             for volume in filter(
                 lambda v: (v.get('host_path') or {}).get('path'), resource['spec']['template']['spec']['volumes'] or []
             ):
-                host_path_volumes.append(copy.deepcopy(volume))
+                host_path_volumes.append(volume['host_path']['path'])
         return host_path_volumes
 
     @private

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -241,10 +241,8 @@ class ChartReleaseService(CRUDService):
                 }
                 if get_locked_paths:
                     release_resources['locked_host_paths'] = [
-                        v['host_path']['path'] for v in release_resources['host_path_volumes']
-                        if await self.middleware.call(
-                            'pool.dataset.path_in_locked_datasets', v['host_path']['path'], locked_datasets
-                        )
+                        v for v in release_resources['host_path_volumes']
+                        if await self.middleware.call('pool.dataset.path_in_locked_datasets', v, locked_datasets)
                     ]
 
                 release_data['resources'] = release_resources

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -15,7 +15,7 @@ class ChartReleaseFSAttachmentDelegate(FSAttachmentDelegate):
                 release['status'] == 'STOPPED' if enabled else release['status'] != 'STOPPED'
             ):
                 continue
-            if any(is_child(p['host_path']['path'], path) for p in release['resources']['host_path_volumes']):
+            if any(is_child(p, path) for p in release['resources']['host_path_volumes']):
                 chart_releases_attached.append({
                     'id': release['name'],
                     'name': release['name'],

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/ix_volumes.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/ix_volumes.py
@@ -45,8 +45,7 @@ class ChartReleaseService(Service):
         if not await self.middleware.call('zfs.dataset.query', [['id', '=', volume_ds]]):
             raise CallError(f'Unable to locate {volume_name!r} volume', errno=errno.ENOENT)
 
-        used_host_path_volumes = {v['host_path'].get('path', '') for v in release['resources']['host_path_volumes']}
-        if os.path.join('/mnt', volume_ds) in used_host_path_volumes:
+        if os.path.join('/mnt', volume_ds) in release['resources']['host_path_volumes']:
             raise CallError(
                 f'{volume_name!r} is configured as a host path volume for a workload, please remove it from workload'
             )

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -295,9 +295,6 @@ class ChartReleaseService(Service):
                 app_resources[app_name].extend(resources_info[app_name])
 
         for app_name in app_resources:
-            apps[app_name] = [
-                volume['host_path']['path']
-                for volume in await self.middleware.call('chart.release.host_path_volumes', app_resources[app_name])
-            ]
+            apps[app_name] = await self.middleware.call('chart.release.host_path_volumes', app_resources[app_name])
 
         return apps

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -286,6 +286,9 @@ class ChartReleaseService(Service):
     @private
     async def get_consumed_host_paths(self):
         apps = {}
+        if not await self.middleware.call('kubernetes.validate_k8s_setup', False):
+            return apps
+
         app_resources = collections.defaultdict(list)
         resources = await self.get_resources_with_workload_mapping({
             'resources': [Resources.DEPLOYMENT.name, Resources.STATEFULSET.name]


### PR DESCRIPTION
This PR adds an optimized / selective version of `chart.release.query` which only retrieves host paths which apps might be consuming.