### PR TITLE
NAS-116295 / 22.02.4 / Improve VM memory reporting and ZFS ARC management wrt VMs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -22,7 +22,7 @@ class SysctlService(Service):
     def get_default_arc_max(self):
         # Default value of arc max on systems
         # https://github.com/truenas/zfs/blob/f38f3a4a3ee430a15fa221ba9fc2b6b8fd17c040/module/os/linux/zfs/arc_os.c#L85
-        return int(psutil.virtual_memory().total / 2)
+        return psutil.virtual_memory().total // 2
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -1,4 +1,5 @@
 import os
+import psutil
 
 from middlewared.service import CallError, Service
 from middlewared.utils import run
@@ -17,6 +18,11 @@ class SysctlService(Service):
         if cp.returncode:
             raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
         return cp.stdout.decode().split('=')[-1].strip()
+
+    def get_default_arc_max(self):
+        # Default value of arc max on systems
+        # https://github.com/truenas/zfs/blob/f38f3a4a3ee430a15fa221ba9fc2b6b8fd17c040/module/os/linux/zfs/arc_os.c#L85
+        return int(psutil.virtual_memory().total / 2)
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -19,7 +19,7 @@ class VMService(Service, VMSupervisorMixin):
             raise CallError(f'Cannot guarantee memory for guest {vm["name"]}', errno.ENOMEM)
 
         if memory_details['current_arc_max'] != memory_details['arc_max_after_shrink']:
-            self.middleware.logger.debug(
+            self.logger.debug(
                 'Setting ARC from %s to %s', memory_details['current_arc_max'], memory_details['arc_max_after_shrink']
             )
             await self.middleware.call('sysctl.set_arc_max', memory_details['arc_max_after_shrink'])

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -33,13 +33,12 @@ class VMService(Service, VMSupervisorMixin):
             raise CallError('VM process is running, we won\'t allocate memory')
 
     @private
-    async def teardown_guest_vmemory(self, id):
-        guest_status = await self.middleware.call('vm.status', id)
-        if guest_status.get('state') != 'STOPPED':
+    async def teardown_guest_vmemory(self, vm_id):
+        vm = await self.middleware.call('vm.get_instance', vm_id)
+        if vm['status']['state'] != 'STOPPED':
             return
 
-        vm = await self.middleware.call('datastore.query', 'vm.vm', [('id', '=', id)])
-        guest_memory = vm[0].get('memory', 0) * 1024 * 1024
+        guest_memory = vm['memory'] * 1024 * 1024
         arc_max = await self.middleware.call('sysctl.get_arc_max')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         new_arc_max = min(

--- a/src/middlewared/middlewared/plugins/vm/memory.py
+++ b/src/middlewared/middlewared/plugins/vm/memory.py
@@ -45,7 +45,7 @@ class VMService(Service, VMSupervisorMixin):
         arc_max = await self.middleware.call('sysctl.get_arc_max')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         new_arc_max = min(
-            await self.middleware.call('vm.get_initial_arc_max'),
+            await self.middleware.call('sysctl.get_default_arc_max'),
             arc_max + guest_memory
         )
         if arc_max != new_arc_max:

--- a/src/middlewared/middlewared/plugins/vm/vm_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_info.py
@@ -1,11 +1,9 @@
 import ipaddress
-import psutil
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, returns, Str
+from middlewared.schema import accepts, Dict, Int, List, Ref, returns, Str
 from middlewared.service import pass_app, Service
-from middlewared.validators import MACAddr
 
-from .devices import NIC, DISPLAY
+from .devices import DISPLAY
 
 
 class VMService(Service):
@@ -42,89 +40,6 @@ class VMService(Service):
 
         port = next((i for i in range(5900, 65535) if i not in all_ports))
         return {'port': port, 'web': DISPLAY.get_web_port(port)}
-
-    @accepts()
-    @returns(Dict(
-        'vmemory_in_use',
-        Int('RNP', required=True, description='Running but not provisioned'),
-        Int('PRD', required=True, description='Provisioned but not running'),
-        Int('RPRD', required=True, description='Running and provisioned'),
-    ))
-    async def get_vmemory_in_use(self):
-        """
-        The total amount of virtual memory in MB used by guests
-
-            Returns a dict with the following information:
-                RNP - Running but not provisioned
-                PRD - Provisioned but not running
-                RPRD - Running and provisioned
-        """
-        memory_allocation = {'RNP': 0, 'PRD': 0, 'RPRD': 0}
-        guests = await self.middleware.call('datastore.query', 'vm.vm')
-        for guest in guests:
-            status = await self.middleware.call('vm.status', guest['id'])
-            if status['state'] == 'RUNNING' and guest['autostart'] is False:
-                memory_allocation['RNP'] += guest['memory'] * 1024 * 1024
-            elif status['state'] == 'RUNNING' and guest['autostart'] is True:
-                memory_allocation['RPRD'] += guest['memory'] * 1024 * 1024
-            elif guest['autostart']:
-                memory_allocation['PRD'] += guest['memory'] * 1024 * 1024
-
-        return memory_allocation
-
-    @accepts(Bool('overcommit', default=False))
-    @returns(Int('available_memory'))
-    async def get_available_memory(self, overcommit):
-        """
-        Get the current maximum amount of available memory to be allocated for VMs.
-
-        If `overcommit` is true only the current used memory of running VMs will be accounted for.
-        If false all memory (including unused) of runnings VMs will be accounted for.
-
-        This will include memory shrinking ZFS ARC to the minimum.
-
-        Memory is of course a very "volatile" resource, values may change abruptly between a
-        second but I deem it good enough to give the user a clue about how much memory is
-        available at the current moment and if a VM should be allowed to be launched.
-        """
-        # Use 90% of available memory to play safe
-        free = int(psutil.virtual_memory().available * 0.9)
-
-        # swap used space is accounted for used physical memory because
-        # 1. processes (including VMs) can be swapped out
-        # 2. we want to avoid using swap
-        swap_used = psutil.swap_memory().used
-
-        # Difference between current ARC total size and the minimum allowed
-        arc_total = await self.middleware.call('sysctl.get_arcstats_size')
-        arc_min = await self.middleware.call('sysctl.get_arc_min')
-        arc_shrink = max(0, arc_total - arc_min)
-
-        vms_memory_used = 0
-        if overcommit is False:
-            # If overcommit is not wanted its verified how much physical memory
-            # the vm process is currently using and add the maximum memory its
-            # supposed to have.
-            for vm in await self.middleware.call('vm.query'):
-                if vm['status']['state'] == 'RUNNING':
-                    try:
-                        vms_memory_used += await self.middleware.call('vm.get_memory_usage_internal', vm)
-                    except Exception:
-                        self.logger.error('Unable to retrieve %r vm memory usage', vm['name'], exc_info=True)
-                        continue
-
-        return max(0, free + arc_shrink - vms_memory_used - swap_used)
-
-    @accepts()
-    @returns(Str('mac', validators=[MACAddr(separator=':')]),)
-    def random_mac(self):
-        """
-        Create a random mac address.
-
-        Returns:
-            str: with six groups of two hexadecimal digits
-        """
-        return NIC.random_mac()
 
     @accepts(
         Int('id'),

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -44,10 +44,15 @@ class VMService(Service):
         """
         Get the current maximum amount of available memory to be allocated for VMs.
 
-        If `overcommit` is true only the current used memory of running VMs will be accounted for.
-        If false all memory (including unused) of running VMs will be accounted for.
+        In case of `overcommit` being `true`, calculations are done in the following manner:
+        1. If a VM has requested 10G but is only consuming 5G, only 5G will be counted
+        2. System will consider shrinkable ZFS ARC as free memory ( shrinkable ZFS ARC is current ZFS ARC
+           minus ZFS ARC minimum )
 
-        This will include memory shrinking ZFS ARC to the minimum.
+        In case of `overcommit` being `false`, calculations are done in the following manner:
+        1. Complete VM requested memory will be taken into account regardless of how much actual physical
+           memory the VM is consuming
+        2. System will not consider shrinkable ZFS ARC as free memory
 
         Memory is of course a very "volatile" resource, values may change abruptly between a
         second but I deem it good enough to give the user a clue about how much memory is
@@ -65,6 +70,7 @@ class VMService(Service):
         arc_total = await self.middleware.call('sysctl.get_arcstats_size')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         arc_shrink = max(0, arc_total - arc_min)
+        total_free = free + arc_shrink if overcommit else free
 
         vms_memory_used = 0
         if overcommit is False:
@@ -83,7 +89,7 @@ class VMService(Service):
                     if vm_max_mem > current_vm_mem:
                         vms_memory_used += vm_max_mem - current_vm_mem
 
-        return max(0, free + arc_shrink - vms_memory_used - swap_used)
+        return max(0, total_free - vms_memory_used - swap_used)
 
     @accepts()
     @returns(Str('mac', validators=[MACAddr(separator=':')]), )

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -1,0 +1,93 @@
+import psutil
+
+from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
+from middlewared.service import Service
+from middlewared.validators import MACAddr
+
+from .devices import NIC
+
+
+class VMService(Service):
+
+    @accepts()
+    @returns(Dict(
+        'vmemory_in_use',
+        Int('RNP', required=True, description='Running but not provisioned'),
+        Int('PRD', required=True, description='Provisioned but not running'),
+        Int('RPRD', required=True, description='Running and provisioned'),
+    ))
+    async def get_vmemory_in_use(self):
+        """
+        The total amount of virtual memory in MB used by guests
+
+            Returns a dict with the following information:
+                RNP - Running but not provisioned
+                PRD - Provisioned but not running
+                RPRD - Running and provisioned
+        """
+        memory_allocation = {'RNP': 0, 'PRD': 0, 'RPRD': 0}
+        guests = await self.middleware.call('datastore.query', 'vm.vm')
+        for guest in guests:
+            status = await self.middleware.call('vm.status', guest['id'])
+            if status['state'] == 'RUNNING' and guest['autostart'] is False:
+                memory_allocation['RNP'] += guest['memory'] * 1024 * 1024
+            elif status['state'] == 'RUNNING' and guest['autostart'] is True:
+                memory_allocation['RPRD'] += guest['memory'] * 1024 * 1024
+            elif guest['autostart']:
+                memory_allocation['PRD'] += guest['memory'] * 1024 * 1024
+
+        return memory_allocation
+
+    @accepts(Bool('overcommit', default=False))
+    @returns(Int('available_memory'))
+    async def get_available_memory(self, overcommit):
+        """
+        Get the current maximum amount of available memory to be allocated for VMs.
+
+        If `overcommit` is true only the current used memory of running VMs will be accounted for.
+        If false all memory (including unused) of runnings VMs will be accounted for.
+
+        This will include memory shrinking ZFS ARC to the minimum.
+
+        Memory is of course a very "volatile" resource, values may change abruptly between a
+        second but I deem it good enough to give the user a clue about how much memory is
+        available at the current moment and if a VM should be allowed to be launched.
+        """
+        # Use 90% of available memory to play safe
+        free = int(psutil.virtual_memory().available * 0.9)
+
+        # swap used space is accounted for used physical memory because
+        # 1. processes (including VMs) can be swapped out
+        # 2. we want to avoid using swap
+        swap_used = psutil.swap_memory().used
+
+        # Difference between current ARC total size and the minimum allowed
+        arc_total = await self.middleware.call('sysctl.get_arcstats_size')
+        arc_min = await self.middleware.call('sysctl.get_arc_min')
+        arc_shrink = max(0, arc_total - arc_min)
+
+        vms_memory_used = 0
+        if overcommit is False:
+            # If overcommit is not wanted its verified how much physical memory
+            # the vm process is currently using and add the maximum memory its
+            # supposed to have.
+            for vm in await self.middleware.call('vm.query'):
+                if vm['status']['state'] == 'RUNNING':
+                    try:
+                        vms_memory_used += await self.middleware.call('vm.get_memory_usage_internal', vm)
+                    except Exception:
+                        self.logger.error('Unable to retrieve %r vm memory usage', vm['name'], exc_info=True)
+                        continue
+
+        return max(0, free + arc_shrink - vms_memory_used - swap_used)
+
+    @accepts()
+    @returns(Str('mac', validators=[MACAddr(separator=':')]), )
+    def random_mac(self):
+        """
+        Create a random mac address.
+
+        Returns:
+            str: with six groups of two hexadecimal digits
+        """
+        return NIC.random_mac()

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -102,6 +102,7 @@ class VMService(Service):
         ),
         Int('arc_to_shrink', description='Size of ARC to shrink in bytes', null=True),
         Int('current_arc_max', description='Current size of max ARC in bytes'),
+        Int('arc_min', description='Minimum size of ARC in bytes'),
         Int('arc_max_after_shrink', description='Size of max ARC in bytes after shrinking'),
         Int(
             'actual_vm_requested_memory',
@@ -148,6 +149,7 @@ class VMService(Service):
             'arc_to_shrink': arc_to_shrink,
             'memory_req_fulfilled_after_overcommit': vm_requested_memory < available_memory_with_overcommit,
             'current_arc_max': arc_max,
+            'arc_min': arc_min,
             'arc_max_after_shrink': arc_max - arc_to_shrink,
             'actual_vm_requested_memory': vm_requested_memory,
         }


### PR DESCRIPTION
This PR adds following changes:

1. Fixes a bug on how we deduced available memory for vms. We were taking into account the complete memory of VMs which user had requested disregarding the fact that when we get `free` physical memory, existing used memory of VMs is already accounted there. So we just need to get the memory which the VM `can` consume and is not consuming right now.
2. When starting a VM, `overcommit` to the user actually means forcing the start of the VM even if we don't have enough memory available. In reality what happened is that when it was set, we manipulated the ARC to shrink arc max but the same behaviour was not done when we were calculating `available/free` memory for VMs and we always accounted for ARC. So now if `overcommit` is specified, only then do we consider shrinkable ARC as free memory - otherwise we don't.
3. ARC max was basically a tunable which we were changing on each VM start. Now when middleware started, it cached the value of ARC max and considered that to be the default which we would consider in our calculations when giving back memory on stopping VMs. However this had a fatal flaw, what if middleware was restarted ? It meant that middleware would never know the actual default/initial value of arc max. In Linux, this is basically `total physical memory / 2` and we add that change here.
4. Add an endpoint which would show VM memory related statistics if that VM was to be started. Motivation behind this endpoint is to gather information and show to the user preferably in the UI with a pop-up or something similar when user wants to start a VM that this much memory is being requested and this much is available and if you `overcommit`, we would be doing this with ZFS ARC and this would be the new ZFS ARC value etc.
5. Do not unconditionally always change ZFS ARC if `overcommit` is set. It should only be done selectively based on actual need of the VM.

Original PR: https://github.com/truenas/middleware/pull/9445
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116295