### PR TITLE
NAS-116920 / 13.0 / Update minio access/secret keys validation

### DIFF
--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -1,6 +1,6 @@
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.schema import accepts, Bool, Dict, Int, Str
-from middlewared.validators import Match, Range, Hostname
+from middlewared.validators import Range, Hostname
 from middlewared.service import SystemServiceService, ValidationErrors, private
 import middlewared.sqlalchemy as sa
 
@@ -54,10 +54,8 @@ class S3Service(SystemServiceService):
         Str('bindip'),
         Int('bindport', validators=[Range(min=1, max=65535)]),
         Int('console_bindport', validators=[Range(min=1, max=65535)]),
-        Str('access_key', validators=[Match("^\w+$", explanation="Should only contain alphanumeric characters")],
-            max_length=20),
-        Str('secret_key', validators=[Match("^\w+$", explanation="Should only contain alphanumeric characters")],
-            max_length=40),
+        Str('access_key', max_length=20),
+        Str('secret_key', max_length=40),
         Bool('browser'),
         Str('storage_path'),
         Int('certificate', null=True),


### PR DESCRIPTION
## Context

Minio does not enforce any validation on access/secret keys apart from lenghts.

This change was introduced to SCALE already in https://github.com/truenas/middleware/pull/8328.