### PR TITLE
NAS-117328 / 22.02.4 / Fixes an empty line in SMB share presets (by undsoft)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -155,7 +155,7 @@ class SMBSharePreset(enum.Enum):
             'ixnas:zfs_auto_homedir=true' if osc.IS_FREEBSD else 'zfs_core:zfs_auto_create=true'
         ])
     }, "cluster": False}
-    READ_ONLY = {"verbose": "Read-only share", "params": {
+    READ_ONLY = {"verbose_name": "Read-only share", "params": {
         'ro': True,
         'shadowcopy': False,
         'auxsmbconf': '',


### PR DESCRIPTION
Look ma, I'm a middleware developer now.

Original PR: https://github.com/truenas/middleware/pull/9476
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117328