### PR TITLE
NAS-116482 / 22.12 / Properly support snapshots based extents

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -84,7 +84,7 @@ class iSCSITargetExtentService(SharingService):
         Bool('xen'),
         Str('rpm', enum=['UNKNOWN', 'SSD', '5400', '7200', '10000', '15000'],
             default='SSD'),
-        Bool('ro'),
+        Bool('ro', default=False),
         Bool('enabled', default=True),
         register=True
     ))
@@ -286,6 +286,9 @@ class iSCSITargetExtentService(SharingService):
             zvol_name = zvol_path_to_name(device)
             if not os.path.exists(device):
                 verrors.add(f'{schema_name}.disk', f'Device {device!r} for volume {zvol_name!r} does not exist')
+
+            if '@' in zvol_name and not data['ro']:
+                verrors.add(f'{schema_name}.ro', 'Must be set when disk is a ZFS Snapshot')
 
         elif extent_type == 'FILE':
             if not path:

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -58,8 +58,10 @@ class VMDeviceService(CRUDService):
         """
         out = {}
         zvols = await self.middleware.call(
-            'zfs.dataset.unlocked_zvols_fast',
-            [["OR", [["attachment", "=", None], ["attachment.method", "=", "vm.devices.query"]]]],
+            'zfs.dataset.unlocked_zvols_fast', [
+                ['OR', [['attachment', '=', None], ['attachment.method', '=', 'vm.devices.query']]],
+                ['ro', '=', False],
+            ],
             {}, ['ATTACHMENT']
         )
 


### PR DESCRIPTION
## Problem

ZFS snapshots based extents were not properly supported in `iscsi.extent` service which meant that users could specify snapshots as extents but have them not readyonly which in SCST's case resulted in scst failing to start.
Users were also not able to specify `snapdev` property for Volumes.

## Solution

Properly validate snapshot based extents and allow users to specify `snapdev` property.