### PR TITLE
NAS-117215 / 22.12 / Allow users to trust guest rx filters for interface device

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-07-26_17-20_ipv6_ndp_vms.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-07-26_17-20_ipv6_ndp_vms.py
@@ -1,0 +1,31 @@
+"""
+Allow users to configure NDP for vms
+
+Revision ID: 75d84034adcb
+Revises: 3ac384af617f
+Create Date: 2022-07-26 17:20:58.755371+00:00
+
+"""
+import json
+
+from alembic import op
+
+
+
+revision = '75d84034adcb'
+down_revision = '3ac384af617f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for row in map(dict, conn.execute("SELECT * FROM vm_device WHERE dtype = 'NIC'").fetchall()):
+        config = json.loads(row['attributes'])
+        config['trust_guest_rx_filters'] = False
+        conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (json.dumps(config), row['id']))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -1,7 +1,7 @@
 import random
 
 from middlewared.plugins.interface.netif import netif
-from middlewared.schema import Dict, Str
+from middlewared.schema import Bool, Dict, Str
 from middlewared.service import CallError
 from middlewared.validators import MACAddr
 
@@ -13,8 +13,10 @@ class NIC(Device):
 
     schema = Dict(
         'attributes',
+        Bool('trust_guest_rx_filters', default=False),
         Str('type', enum=['E1000', 'VIRTIO'], default='E1000'),
         Str('nic_attach', default=None, null=True),
+        Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
         Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
     )
 
@@ -78,8 +80,9 @@ class NIC(Device):
                 }
             )
         else:
+            trust_guest_rx_filters = 'yes' if self.data['attributes']['trust_guest_rx_filters'] else 'no'
             return create_element(
-                'interface', type='direct', attribute_dict={
+                'interface', type='direct', trustGuestRxFilters=trust_guest_rx_filters, attribute_dict={
                     'children': [
                         create_element('source', dev=self.nic_attach, mode='bridge')
                     ] + self.xml_children()

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -17,7 +17,6 @@ class NIC(Device):
         Str('type', enum=['E1000', 'VIRTIO'], default='E1000'),
         Str('nic_attach', default=None, null=True),
         Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
-        Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -430,6 +430,16 @@ class VMDeviceService(CRUDService):
                 nic_choices = await self.middleware.call('vm.device.nic_attach_choices')
                 if nic not in nic_choices:
                     verrors.add('attributes.nic_attach', 'Not a valid choice.')
+                elif nic.startswith('br') and device['attributes']['trust_guest_rx_filters']:
+                    verrors.add(
+                        'attributes.trust_guest_rx_filters',
+                        'This can only be set when "nic_attach" is not a bridge device'
+                    )
+            if device['attributes']['trust_guest_rx_filters'] and device['attributes']['type'] == 'E1000':
+                verrors.add(
+                    'attributes.trust_guest_rx_filters',
+                    'This can only be set when "type" of NIC device is "VIRTIO"'
+                )
         elif device.get('dtype') == 'PCI':
             pptdev = device['attributes'].get('pptdev')
             device_details = await self.middleware.call('vm.device.passthrough_device', pptdev)


### PR DESCRIPTION
This PR adds changes to allow users to trust guest rx filters as the default behaviour ( not trusting ) does not allow ipv6 NDP to work in the VMs.