### PR TITLE
NAS-117353 / 22.12 / Fix Failover_disks alert typo

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -1,7 +1,7 @@
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 
 TITLE = 'Disks Missing On '
-TEXT = 'Disks with serial %(serial)s present on '
+TEXT = 'Disks with serial %(serials) present on '
 
 
 class DisksAreNotPresentOnStandbyNodeAlertClass(AlertClass):


### PR DESCRIPTION
Typo broke string replacement in webui