### PR TITLE
NAS-117360 / 22.02.4 / disk_resize: Don't wait 15 seconds for SAS flash (by freqlabs)

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -145,7 +145,7 @@ sas|scsi)
 	ssd=`sg_vpd -p bdc /dev/${dev} 2>/dev/null | grep -Fc "Non-rotating medium"`
 	if [ ${err} -eq 0 -a ${ssd} -ne 0 -a -n "${size}" ]; then
 		echo "Formatting device."
-		sg_format --format /dev/${dev}
+		sg_format --format --quick /dev/${dev}
 	fi
 
 	if [ ${err} -eq 0 ]; then


### PR DESCRIPTION
By default sg_format gives the user 15 seconds to change their mind.
This is a fully automatic footgun.  Have no mercy.

Original PR: https://github.com/truenas/middleware/pull/9485
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117360