### PR TITLE
NAS-117244 / 13.0 / fix subtle regression in generating resolv.conf

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2413,7 +2413,7 @@ class DNSService(Service):
         if domain:
             resolvconf += 'domain {}\n'.format(domain)
         if domains:
-            resolvconf += 'search {}\n'.format(' '.join(domains))
+            resolvconf += 'search {}\n'.format(' '.join([domain] + domains).strip())
 
         resolvconf += self.configure_nameservers(nameservers)
 


### PR DESCRIPTION
The `search` line in `resolv.conf` should also have the `domain` name.

For example
```
domain primary.lan
search primary.lan secondary.lan
```