### PR TITLE
NAS-117367 / 22.12 / Ensure that required paths are auto-created for clustered pwenc

### DIFF
--- a/src/middlewared/middlewared/utils/path.py
+++ b/src/middlewared/middlewared/utils/path.py
@@ -61,12 +61,13 @@ def pathref_open(path: str, **kwargs) -> int:
     fd = -1
 
     try:
-        fd = os.open(path, flags | os.O_NOFOLLOW, dir_fd=dir_fd)
+        fd = os.open(path, flags, dir_fd=dir_fd)
     except FileNotFoundError:
         if not mkdir:
             raise
 
         os.mkdir(path, expected_mode or 0o755, dir_fd=dir_fd)
+        fd = os.open(path, flags, dir_fd=dir_fd)
     except OSError as e:
         # open will fail with ELOOP if last component is symlink
         # due to O_NOFOLLOW


### PR DESCRIPTION
Remove unnecessary check for `ctdb.general.healthy` from the
clustered generate_secret method. The secret_opener method
for the clustered plugin already checks that the fuse volume
is properly mounted. Only fuse/glusterfs access is required at this
point.

This also adds a missing os.open() call for case where we just
made a non-existent directory in pathref_open() method in
middlewared utils.