### PR TITLE
NAS-117376 / 22.12 / Remove port from portal configuration in issci

### DIFF
--- a/src/freenas/etc/systemd/system/scst.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/scst.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=/etc/scst.env

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
@@ -20,7 +20,7 @@ def upgrade():
     conn = op.get_bind()
 
     with op.batch_alter_table('services_iscsitargetglobalconfiguration', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('iscsi_listen_port', sa.INTEGER(), nullable=False))
+        batch_op.add_column(sa.Column('iscsi_listen_port', sa.INTEGER(), nullable=False, server_default='3260'))
 
     listen_port = None
     all_ports = set()
@@ -39,6 +39,10 @@ def upgrade():
     conn.execute("UPDATE services_iscsitargetglobalconfiguration SET iscsi_listen_port = ?", listen_port)
 
     with op.batch_alter_table('services_iscsitargetportalip', schema=None) as batch_op:
+        batch_op.create_index(
+            'services_iscsitargetportalip_iscsi_target_portalip_ip', ['iscsi_target_portalip_ip'], unique=True
+        )
+        batch_op.drop_index('services_iscsitargetportalip_iscsi_target_portalip_ip__iscsi_target_portalip_port')
         batch_op.drop_column('iscsi_target_portalip_port')
 
 

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
@@ -1,0 +1,46 @@
+"""
+Migrate iSCSI Portal IPs
+
+Revision ID: 14899f89b885
+Revises: 3ac384af617f
+Create Date: 2022-07-27 01:00:58.755371+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '14899f89b885'
+down_revision = '3ac384af617f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    with op.batch_alter_table('services_iscsitargetglobalconfiguration', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('iscsi_listen_port', sa.INTEGER(), nullable=False))
+
+    listen_port = None
+    all_ports = set()
+    for row in map(dict, conn.execute("SELECT * FROM services_iscsitargetportalip").fetchall()):
+        all_ports.add(row['iscsi_target_portalip_port'])
+        if row['iscsi_target_portalip_ip'] == '0.0.0.0':
+            listen_port = row['iscsi_target_portalip_port']
+            break
+    else:
+        if len(all_ports) == 1:
+            listen_port = all_ports.pop()
+
+    if listen_port is None:
+        listen_port = 3260
+
+    conn.execute("UPDATE services_iscsitargetglobalconfiguration SET iscsi_listen_port = ?", listen_port)
+
+    with op.batch_alter_table('services_iscsitargetportalip', schema=None) as batch_op:
+        batch_op.drop_column('iscsi_target_portalip_port')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-07-27_01-00_portal_ips.py
@@ -2,7 +2,7 @@
 Migrate iSCSI Portal IPs
 
 Revision ID: 14899f89b885
-Revises: 3ac384af617f
+Revises: 75d84034adcb
 Create Date: 2022-07-27 01:00:58.755371+00:00
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 
 revision = '14899f89b885'
-down_revision = '3ac384af617f'
+down_revision = '75d84034adcb'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -50,7 +50,6 @@
             extent['t10_dev_id'] = extent['serial'].ljust(31 - len(extent['serial']), ' ')
 
     # FIXME: SSD is not being reflected in the initiator, please look into it
-    # FIXME: Authorized networks for initiators has not been implemented yet, please look for alternatives in SCST
 
     target_hosts = middleware.call_sync('iscsi.host.get_target_hosts')
     hosts_iqns = middleware.call_sync('iscsi.host.get_hosts_iqns')
@@ -119,7 +118,6 @@ TARGET_DRIVER iscsi {
                 address = '*'
             else:
                 address = (f'[{addr["ip"]}]' if ':' in addr['ip'] else addr['ip'])
-                # FIXME: SCST does not seem to respect port values for portals, please look for alternatives
 
             group_initiators = initiators[group['initiator']]['initiators'] if group['initiator'] else []
             if not has_per_host_access:

--- a/src/middlewared/middlewared/etc_files/scst.env.mako
+++ b/src/middlewared/middlewared/etc_files/scst.env.mako
@@ -1,0 +1,4 @@
+<%
+    global_config = middleware.call_sync('iscsi.global.config')
+%>\
+ISCSID_OPTIONS="-p ${global_config['listen_port']}}"

--- a/src/middlewared/middlewared/etc_files/scst.env.mako
+++ b/src/middlewared/middlewared/etc_files/scst.env.mako
@@ -1,4 +1,4 @@
 <%
     global_config = middleware.call_sync('iscsi.global.config')
 %>\
-ISCSID_OPTIONS="-p ${global_config['listen_port']}}"
+ISCSID_OPTIONS="-p ${global_config['listen_port']}"

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -166,7 +166,7 @@ class EtcService(Service):
         ],
         'scst': [
             {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'},
-            {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import'},
+            {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import', 'mode': 0o744},
         ],
         'scst_targets': [
             {'type': 'mako', 'path': 'initiators.allow', 'checkpoint': 'pool_import'},

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -165,7 +165,8 @@ class EtcService(Service):
             {'type': 'py', 'path': 'generate_ssl_certs'},
         ],
         'scst': [
-            {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'}
+            {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'},
+            {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import'},
         ],
         'scst_targets': [
             {'type': 'mako', 'path': 'initiators.allow', 'checkpoint': 'pool_import'},

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -17,6 +17,7 @@ class ISCSIGlobalModel(sa.Model):
     iscsi_isns_servers = sa.Column(sa.Text())
     iscsi_pool_avail_threshold = sa.Column(sa.Integer(), nullable=True)
     iscsi_alua = sa.Column(sa.Boolean(), default=False)
+    iscsi_listen_port = sa.Column(sa.Integer(), nullable=False, default=3260)
 
 
 class ISCSIGlobalService(SystemServiceService):
@@ -38,6 +39,7 @@ class ISCSIGlobalService(SystemServiceService):
         'iscsiglobal_update',
         Str('basename'),
         List('isns_servers', items=[Str('server')]),
+        Int('listen_port', validators=[Range(min=1025, max=65535)], default=3260),
         Int('pool_avail_threshold', validators=[Range(min=1, max=99)], null=True),
         Bool('alua'),
         update=True

--- a/src/middlewared/middlewared/plugins/iscsi_/portal.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/portal.py
@@ -4,7 +4,6 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.schema import accepts, Dict, Int, IPAddr, List, Patch, Str
 from middlewared.service import CRUDService, private, ValidationErrors
-from middlewared.validators import Range
 
 from .utils import AUTHMETHOD_LEGACY_MAP
 

--- a/src/middlewared/middlewared/plugins/iscsi_/portal.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/portal.py
@@ -21,9 +21,7 @@ class ISCSIPortalModel(sa.Model):
 class ISCSIPortalIPModel(sa.Model):
     __tablename__ = 'services_iscsitargetportalip'
     __table_args__ = (
-        sa.Index('services_iscsitargetportalip_iscsi_target_portalip_ip__iscsi_target_portalip_port',
-                 'iscsi_target_portalip_ip', 'iscsi_target_portalip_port',
-                 unique=True),
+        sa.Index('services_iscsitargetportalip_iscsi_target_portalip_ip', 'iscsi_target_portalip_ip', unique=True),
     )
 
     id = sa.Column(sa.Integer(), primary_key=True)

--- a/src/middlewared/middlewared/plugins/iscsi_/portal.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/portal.py
@@ -172,7 +172,7 @@ class ISCSIPortalService(CRUDService):
 
     async def __save_listen(self, pk, new, old=None):
         """
-        Update database with a set new listen IP tuples.
+        Update database with new listen IPs.
         It will delete no longer existing addresses and add new ones.
         """
         new_listen_set = set([tuple(i.items()) for i in new])


### PR DESCRIPTION
In SCALE, scst does not support specifying ports on portal level unlike freebsd. Scst only allows port to be configured for `iscsi-scst` daemon and then this port configuration is applied to all portals defined.

This PR introduces a migration moving port configuration to global iscsi configuration and updating relevant usages.