### PR TITLE
NAS-117377 / 22.02.4 / Fix clustered filesystem test (by anodos325)

### DIFF
--- a/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
+++ b/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
@@ -411,7 +411,7 @@ def test_015_filesystem_statfs(ip, request):
     data = res.json()
 
     assert data['fstype'] == 'fuse.glusterfs'
-    assert data['source'] == CLUSTER_INFO['GLUSTER_VOLUME']
+    assert data['source'] == f'localhost:/{CLUSTER_INFO["GLUSTER_VOLUME"]}'
 
 
 def test_050_remove_test_files(request):


### PR DESCRIPTION
At some point after writing the initial version of this test
filesystem.statfs was refactored to use a common method for
querying /proc/self/mountinfo. The end result is that
the mount source returned by middleware now has a 'localhost:/'
prefix.

Original PR: https://github.com/truenas/middleware/pull/9493
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117377