### PR TITLE
NAS-117377 / 22.02.3 / Fix clustered filesystem test

### DIFF
--- a/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
+++ b/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
@@ -411,7 +411,7 @@ def test_015_filesystem_statfs(ip, request):
     data = res.json()
 
     assert data['fstype'] == 'fuse.glusterfs'
-    assert data['source'] == CLUSTER_INFO['GLUSTER_VOLUME']
+    assert data['source'] == f'localhost:/{CLUSTER_INFO["GLUSTER_VOLUME"]}'
 
 
 def test_050_remove_test_files(request):


### PR DESCRIPTION
At some point after writing the initial version of this test
filesystem.statfs was refactored to use a common method for
querying /proc/self/mountinfo. The end result is that
the mount source returned by middleware now has a 'localhost:/'
prefix.

(cherry picked from commit a1d8ac9a67c948d8704996ce242f4c64ff99f6d1)
(cherry picked from commit b498bfa24b3485405192f272d185505d3e100a99)