### PR TITLE
NAS-117391 / 22.12 / Remove redundant dataset.query

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -284,12 +284,9 @@ class iSCSITargetExtentService(SharingService):
             device = os.path.join('/dev', disk)
 
             zvol_name = zvol_path_to_name(device)
-            zvol = await self.middleware.call('pool.dataset.query', [['id', '=', zvol_name]])
-            if not zvol:
-                verrors.add(f'{schema_name}.disk', f'Volume {zvol_name!r} does not exist')
-
             if not os.path.exists(device):
                 verrors.add(f'{schema_name}.disk', f'Device {device!r} for volume {zvol_name!r} does not exist')
+
         elif extent_type == 'FILE':
             if not path:
                 verrors.add(f'{schema_name}.path', 'This field is required')


### PR DESCRIPTION
There's not really a way for a path to be a zvol and not located
in /dev/zvol. Existence check is enough and saves us from an
additional pool.dataset.query.