### PR TITLE
NAS-117074 / 22.02.4 / Fix kubernetes token issue (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -1,10 +1,15 @@
-import os
 import asyncio
+import contextlib
+import os
+import re
 
 from middlewared.service import CallError
 from middlewared.utils import run
 
 from .base import SimpleService
+
+
+RE_TOKEN_FORMAT = re.compile(r'^K10.+:.+:.*')
 
 
 class KubernetesService(SimpleService):
@@ -58,8 +63,25 @@ class KubernetesService(SimpleService):
         await self.middleware.call('service.start', 'docker')
         await self._systemd_unit('cni-dhcp', 'start')
 
-    async def _start_linux(self):
-        await super()._start_linux()
+        # It is possible server/token got misconfigured somehow ( we have had reports that on unclean shutdown the file
+        # is empty or malformed, in this case we should remove the token as it's generated automatically by k3s again
+        # and it's not useful to us as well per se as it's used for multi-node cluster )
+
+        await self.middleware.run_in_thread(
+            self.check_server_token, (await self.middleware.call('kubernetes.config'))['dataset']
+        )
+
+    def check_server_token(self, k8s_dataset):
+        token_path = os.path.join('/mnt', k8s_dataset, 'k3s/server/token')
+        with contextlib.suppress(FileNotFoundError):
+            with open(token_path, 'r') as f:
+                token = f.read().strip()
+
+            if not RE_TOKEN_FORMAT.findall(token):
+                os.unlink(token_path)
+
+    async def start(self):
+        await super().start()
         timeout = 40
         # First time when k8s is started, it takes a bit more time to initialise itself properly
         # and we need to have sleep here so that after start is called post_start is not dismissed


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x afe755333443a7f3f279ab66803c27e51d4093d2

## Problem

Recently we have seen some users who had malformed k3s server token when their server was shutdown unexpectedly i.e power loss.
I have not been able to locate exact reason why it got malformed in such cases but this results in kubernetes not working when the server is rebooted.

## Solution

The fix is quite straight forward, after investigation I found that the token is generally used to join multiple nodes and is used in encrypting bootstrap data of k3s which is used for joining nodes which does not apply to us.
If k3s had generated this token once, and the file is removed, k3s generates it again correctly which workarounds the problem of the token being malformed and the file being empty in some cases.

Original PR: https://github.com/truenas/middleware/pull/9499
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117074