### PR TITLE
NAS-116933 / 22.12 / Correctly handle serial port for UPS

### DIFF
--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -170,10 +170,9 @@ class UPSService(SystemServiceService):
 
         port = data['port']
         if port:
-            serial_port = os.path.join(
-                '/dev', (await self.middleware.call('system.advanced.config'))['serialport']
-            )
-            if serial_port == port:
+            adv_config = await self.middleware.call('system.advanced.config')
+            serial_port = os.path.join('/dev', adv_config['serialport'])
+            if adv_config['serialconsole'] and serial_port == port:
                 verrors.add(
                     f'{schema}.port',
                     'UPS port must be different then the port specified for '

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -95,7 +95,12 @@ class UPSService(SystemServiceService):
     @accepts()
     @returns(List(items=[Str('port_choice')]))
     async def port_choices(self):
-        ports = [os.path.join('/dev', port['name']) for port in await self.middleware.call('device.get_serials')]
+        adv_config = await self.middleware.call('system.advanced.config')
+        ports = [
+            os.path.join('/dev', port['name'])
+            for port in await self.middleware.call('device.get_serials')
+            if not adv_config['serialconsole'] or adv_config['serialport'] != port['name']
+        ]
         ports.extend(glob.glob('/dev/uhid*'))
         ports.append('auto')
         return ports


### PR DESCRIPTION
This PR adds changes to improve validation when serial port is configured for UPS service and also updates the ups port choices to correctly reflect available ports.