### PR TITLE
NAS-117400 / 22.02.4 / Fix activedirectory join in cluster (by anodos325)

### DIFF
--- a/cluster-tests/tests/directoryservices/test_001_activedirectory.py
+++ b/cluster-tests/tests/directoryservices/test_001_activedirectory.py
@@ -172,7 +172,7 @@ def test_007_validate_dns_records_added(request):
     payload = {
         'msg': 'method',
         'method': 'dnsclient.forward_lookup',
-        'params': [{"names": [f'truenas.{CLUSTER_ADS["DOMAIN"]}']}],
+        'params': [{"names": [f'{CLUSTER_ADS["NETBIOS"]}.{CLUSTER_ADS["DOMAIN"]}']}],
     }
     res = make_ws_request(CLUSTER_IPS[0], payload)
     assert res.get('error') is None, res

--- a/src/middlewared/middlewared/plugins/tdb/schema.py
+++ b/src/middlewared/middlewared/plugins/tdb/schema.py
@@ -142,8 +142,8 @@ class SchemaMixin:
         tdb_key = f'{tdb_handle.name}_{id}'
 
         ops = [
-            {"action": "SET", "key": tdb_key, "val": json.dumps(data)},
-            {"action": "SET", "key": "hwm", "val": str(id)}
+            {"action": "SET", "key": tdb_key, "val": data},
+            {"action": "SET", "key": "hwm", "val": id}
         ]
         tdb_handle.batch_op(ops)
         tdb_handle.last_read = 0

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -188,7 +188,7 @@ class CTDBWrap(object):
     def __volatile_store(self, key, value):
 
         db_entry = self.hdl.fetch(key)
-        db_entry.store(value.encode())
+        db_entry.store(value)
         db_entry.unlock()
         return
 
@@ -252,7 +252,7 @@ class CTDBWrap(object):
 
     def batch_op(self, ops):
         output = []
-        self.hdl.transaction_start()
+        self.hdl.start_transaction(False)
         self.skip_trans = True
         for op in ops:
             if op["action"] == "SET":
@@ -264,7 +264,7 @@ class CTDBWrap(object):
                 tdb_val = self.get(op["key"])
                 output.append(json.loads(tdb_val))
 
-        self.hdl.transaction_commit()
+        self.hdl.commit_transaction()
         self.skip_trans = False
 
         return output

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1260,7 +1260,7 @@ class TDBWrapCRUDService(CRUDService):
             payload.append({
                 "action": "SET",
                 "key": tdb_key,
-                "val": json.dumps(val),
+                "val": val,
             })
 
         await self.middleware.call('tdb.batch_ops', {


### PR DESCRIPTION
This commit fixes some regressions caused by transitioning from
using ctdb command in subprocess to using python bindings. Regression
wasn't immediately apparent because my test server had some stale
state that caused certain code-paths tonot be followed.

This also removes a hard-coded netbios name in one of the AD
tests so that DNS forward lookup tests will pass where user
has supplied non-default netbios name.

Original PR: https://github.com/truenas/middleware/pull/9506
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117400