### PR TITLE
NAS-117430 / 22.12 / Simplify/Improve VM devices validation

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
@@ -58,17 +58,14 @@ class CDROM(Device):
             # a) Check if libvirt user can access the file
             # b) Change ownership of the file to libvirt user as libvirt would eventually do
             # 3) Check if libvirt user can access the file
-            libvirt_user = self.middleware.call_sync(
-                'user.query', [['username', '=', LIBVIRT_USER]], {'get': True}
-            )
-            libvirt_group = self.middleware.call_sync('group.query', [['group', '=', LIBVIRT_USER]], {'get': True})
+            libvirt_user = self.middleware.call_sync('user.get_user_obj', {"username": LIBVIRT_USER})
             current_owner = os.stat(path)
             is_valid = False
-            if current_owner.st_uid != libvirt_user['uid']:
+            if current_owner.st_uid != libvirt_user['pw_uid']:
                 if self.middleware.call_sync('filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}):
                     is_valid = True
                 else:
-                    os.chown(path, libvirt_user['uid'], libvirt_group['gid'])
+                    os.chown(path, libvirt_user['pw_uid'], libvirt_group['pw_gid'])
             if not is_valid and not self.middleware.call_sync(
                 'filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}
             ):

--- a/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
@@ -70,7 +70,7 @@ class CDROM(Device):
                 else:
                     os.chown(path, libvirt_user['uid'], libvirt_group['gid'])
             if not is_valid and not self.middleware.call_sync(
-                    'filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}
+                'filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}
             ):
                 verrors.add(
                     'attributes.path',

--- a/src/middlewared/middlewared/plugins/vm/devices/device.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/device.py
@@ -1,7 +1,5 @@
 from abc import ABC
 
-from middlewared.schema import Error
-from middlewared.service_exception import ValidationErrors
 from middlewared.utils import osc
 from middlewared.validators import validate_schema
 

--- a/src/middlewared/middlewared/plugins/vm/devices/device.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/device.py
@@ -3,6 +3,7 @@ from abc import ABC
 from middlewared.schema import Error
 from middlewared.service_exception import ValidationErrors
 from middlewared.utils import osc
+from middlewared.validators import validate_schema
 
 
 class Device(ABC):
@@ -86,21 +87,9 @@ class Device(ABC):
         pass
 
     def validate(self, device, old=None, vm_instance=None, update=True):
-        verrors = ValidationErrors()
-        try:
-            device['attributes'] = self.schema.clean(device['attributes'])
-        except Error as e:
-            verrors.add(f'attributes.{e.attribute}', e.errmsg, e.errno)
-
-        try:
-            self.schema.validate(device['attributes'])
-        except ValidationErrors as e:
-            verrors.extend(e)
-
+        verrors = validate_schema(list(self.schema.attrs.values()), device['attributes'])
         verrors.check()
-
         self._validate(device, verrors, old, vm_instance, update)
-
         verrors.check()
 
     def _validate(self, device, verrors, old=None, vm_instance=None, update=True):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -131,3 +131,6 @@ class DISPLAY(Device):
                     verrors.add(f'attributes.{key}', 'Specified display port is already in use')
             else:
                 device['attributes'][key] = new_ports.pop(0)
+
+        if device['attributes']['bind'] not in self.middleware.call_sync('vm.device.bind_choices'):
+            verrors.add('attributes.bind', 'Requested bind address is not valid')

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -87,3 +87,20 @@ class NIC(Device):
                     ] + self.xml_children()
                 }
             )
+
+    def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
+        nic = device['attributes'].get('nic_attach')
+        if nic:
+            nic_choices = self.middleware.call_sync('vm.device.nic_attach_choices')
+            if nic not in nic_choices:
+                verrors.add('attributes.nic_attach', 'Not a valid choice.')
+            elif nic.startswith('br') and device['attributes']['trust_guest_rx_filters']:
+                verrors.add(
+                    'attributes.trust_guest_rx_filters',
+                    'This can only be set when "nic_attach" is not a bridge device'
+                )
+        if device['attributes']['trust_guest_rx_filters'] and device['attributes']['type'] == 'E1000':
+            verrors.add(
+                'attributes.trust_guest_rx_filters',
+                'This can only be set when "type" of NIC device is "VIRTIO"'
+            )

--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -83,3 +83,14 @@ class PCI(Device):
                 ]
             }
         )
+
+    def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
+        pptdev = device['attributes'].get('pptdev')
+        device_details = self.middleware.call_sync('vm.device.passthrough_device', pptdev)
+        if device_details.get('error'):
+            verrors.add(
+                'attribute.pptdev',
+                f'Not a valid choice. The PCI device is not available for passthru: {device_details["error"]}'
+            )
+        if not self.middleware.call_sync('vm.device.iommu_enabled'):
+            verrors.add('attribute.pptdev', 'IOMMU support is required.')

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -53,6 +53,12 @@ class StorageDevice(Device):
                 f'{vm_instance["name"]} has "{self.identity()}" already configured'
             )
 
+        if device['attributes'].get('physical_sectorsize') and not device['attributes'].get('logical_sectorsize'):
+            verrors.add(
+                'attributes.logical_sectorsize',
+                'This field must be provided when physical_sectorsize is specified.'
+            )
+
 
 class RAW(StorageDevice):
 

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -44,3 +44,12 @@ class USB(Device):
             }
         )
         return device_xml
+
+    def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
+        usb_device = device['attributes']['device']
+        device_details = self.middleware.call_sync('vm.device.usb_passthrough_device', usb_device)
+        if device_details.get('error'):
+            verrors.add(
+                'attribute.device',
+                f'Not a valid choice. The device is not available for USB passthrough: {device_details["error"]}'
+            )

--- a/src/middlewared/middlewared/plugins/vm/devices/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/utils.py
@@ -1,6 +1,6 @@
 import string
 
-from middlewared.plugins.vm.utils import create_element, LIBVIRT_URI, NGINX_PREFIX # noqa
+from middlewared.plugins.vm.utils import create_element, LIBVIRT_URI, LIBVIRT_USER, NGINX_PREFIX # noqa
 
 
 def disk_from_number(number):

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -1,4 +1,4 @@
-from middlewared.plugins.vm.devices import CDROM, DISK, DISPLAY, PCI, RAW
+from middlewared.plugins.vm.devices import CDROM, DISK, DISPLAY, RAW
 from middlewared.utils import Nid
 
 from .supervisor_base import VMSupervisorBase

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -299,6 +299,10 @@ class VMDeviceService(CRUDService):
             return False
 
     @private
+    async def validate_path_field(self, verrors, schema, path):
+        await check_path_resides_within_volume(verrors, self.middleware, schema, path)
+
+    @private
     async def validate_device(self, device, old=None, vm_instance=None, update=True):
         # We allow vm_instance to be passed for cases where VM devices are being updated via VM and
         # the device checks should be performed with the modified vm_instance object not the one db holds

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 
 import middlewared.sqlalchemy as sa
 
@@ -10,7 +9,7 @@ from middlewared.service import CallError, CRUDService, private
 from middlewared.utils import run
 from middlewared.async_validators import check_path_resides_within_volume
 
-from .devices import CDROM, DISK, NIC, PCI, RAW, DISPLAY, USB # noqa
+from .devices import CDROM, DISK, NIC, PCI, RAW, DISPLAY, USB
 
 
 RE_PPTDEV_NAME = re.compile(r'([0-9]+/){2}[0-9]+')
@@ -27,6 +26,16 @@ class VMDeviceModel(sa.Model):
 
 
 class VMDeviceService(CRUDService):
+
+    DEVICES = {
+        'CDROM': CDROM,
+        'RAW': RAW,
+        'DISK': DISK,
+        'NIC': NIC,
+        'PCI': PCI,
+        'DISPLAY': DISPLAY,
+        'USB': USB,
+    }
 
     ENTRY = Patch(
         'vmdevice_create', 'vm_device_entry',
@@ -284,7 +293,7 @@ class VMDeviceService(CRUDService):
     @private
     async def validate_device(self, device, old=None, update=True):
         vm_instance = await self.middleware.call('vm.get_instance', device['vm'])
-        device_obj = getattr(sys.modules[__name__], device['dtype'])(device, self.middleware)
+        device_obj = self.DEVICES[device['dtype']](device, self.middleware)
         await self.middleware.run_in_thread(device_obj.validate, device, old, vm_instance, update)
 
         return device


### PR DESCRIPTION
This PR adds following changes:

1. Move devices validation to their respective classes and simplify `vm.device` plugin.
2. Fix `DISK` device validation to correctly validate passed parameters.
3. Validate display devices bind attribute.
4. Remove unused endpoints in vm.plugin service.