### PR TITLE
NAS-117436 / 22.02.4 / stop running file IO in main event loop (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -110,7 +110,7 @@ class IPMISELAlertSource(AlertSource):
     )
 
     async def check(self):
-        if not has_ipmi():
+        if not await self.middleware.run_in_thread(has_ipmi):
             return
 
         return await self._produce_alerts_for_ipmitool_output(await ipmitool(["-c", "sel", "elist"]))
@@ -173,7 +173,7 @@ class IPMISELSpaceLeftAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(minutes=5))
 
     async def check(self):
-        if not has_ipmi():
+        if not await self.middleware.run_in_thread(has_ipmi):
             return
 
         return self._produce_alert_for_ipmitool_output(await ipmitool(["sel", "info"]))


### PR DESCRIPTION
Working on another ticket I saw that this specific alert was blocking the main event loop. `has_ipmi` calls `os.path.exists` 3 times which calls `os.stat` 3 times which can block event loop (especially prevalent  on slow boot disks).

Original PR: https://github.com/truenas/middleware/pull/9531
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117436