### PR TITLE
NAS-117441 / 22.02.3 / Added better support for python virtual environment (by ericbsd)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,24 +6,32 @@ This is the folder of all tests for FreeNAS REST API testing.
 ### Require dependency run
 
 ```
-Python 3.6
-Pytest
-Requests
+Python 3 pip
+samba
+sshpass
+smbclient
+snmpwalk
 ```
 
-### Extra for manual debugging
-
-```
-IPython
-```
-
-### Installing of dependency on FreeBSD/TrueOS/Trident/GhostBSD
+### Installing of dependency on FreeBSD base OS
 
 #### Require packages
-`pkg install python36 py36-pytest py36-requests`
+`pkg install py39-pip samba* sshpass net-snmp`
 
-#### Extra packages
-`pkg install py36-ipython`
+In middleware/tests run the command bellow
+
+`pip install -r requirements.txt`
+
+### Installing of dependency on Debian base OS
+
+#### Require packages
+
+`apt install python3-pip samba smbclient sshpass snmp`
+
+In middleware/tests run the command bellow
+
+`pip3 install -r requirements.txt`
+
 
 ## Running REST API test
 All the test suite is run from runtests.py the usage of runtests.py is as follow:
@@ -56,63 +64,6 @@ Command to run a specific REST API v1.0 or v2.0 test:
 
 `./runtests.py --ip 192.168.2.45 --interface em0 --password testing --api 1.0 --test network`
 
-## Running manual REST API test with IPython
-Once runtest.py is run, it did generate all configuration, and running IPython can be run to debug REST API or just to run manual REST API.
-
-### Example
-```
-ipython-3.6         Fri Sep  7 12:32:12 2018
-Password:
-Python 3.6.6 (default, Jul 30 2018, 22:10:00)
-Type "copyright", "credits" or "license" for more information.
-
-IPython 5.8.0 -- An enhanced Interactive Python.
-?         -> Introduction and overview of IPython's features.
-%quickref -> Quick reference.
-help      -> Python's own help system.
-object?   -> Details about 'object', use 'object??' for extra details.
-
-In [1]: from functions import GET, POST, PUT, DELETE
-
-In [2]: GET("/bootenv/").json()
-Out[2]:
-[{'realname': 'default',
-  'name': 'default',
-  'active': 'NR',
-  'mountpoint': '/',
-  'space': '883.8M',
-  'created': {'$date': 1536319800000},
-  'keep': None,
-  'rawspace': '926877696',
-  'id': 'default'},
- {'realname': 'Initial-Install',
-  'name': 'Initial-Install',
-  'active': '-',
-  'mountpoint': '-',
-  'space': '1.8M',
-  'created': {'$date': 1536319980000},
-  'keep': None,
-  'rawspace': '1024',
-  'id': 'Initial-Install'}]
-
-In [3]: payload = {"name": "bootenv1", "source": "default"}
-
-In [4]: results = POST("/bootenv/", payload)
-
-In [5]: results
-Out[5]: <Response [200]>
-
-In [6]: results.json()
-Out[6]: 'bootenv1'
-
-In [7]: results.text
-Out[7]: '"bootenv1"'
-
-In [8]: results.status_code
-Out[8]: 200
-
-In [9]:
-```
 
 ## How REST API tests should be written?
 

--- a/tests/protocols.py
+++ b/tests/protocols.py
@@ -1,13 +1,23 @@
-from samba.samba3 import libsmb_samba_internal as libsmb
-from samba.dcerpc import security
-from samba.samba3 import param as s3param
-from samba import credentials
+import sys
 import enum
 import subprocess
 import contextlib
 import os
-from samba import NTSTATUSError
 from functions import SSH_TEST
+
+# sys.real_prefix only found in virtualenv
+# if detected set local site-packages to use for samba
+if getattr(sys, "real_prefix", None):
+    major_v = sys.version_info.major
+    minor_v = sys.version_info.minor
+    sys.path.append(f'{sys.real_prefix}/lib/python{major_v}.{minor_v}/site-packages')
+
+from samba.samba3 import libsmb_samba_internal as libsmb
+from samba.dcerpc import security
+from samba.samba3 import param as s3param
+from samba import credentials
+from samba import NTSTATUSError
+
 libsmb_has_rename = 'rename' in dir(libsmb.Conn)
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-dependency
+pytest-rerunfailures
+pytest-timeout
+requests
+websocket-client

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -10,11 +10,7 @@ import getopt
 import sys
 import random
 import string
-from platform import system
 
-major_v = sys.version_info.major
-minor_v = sys.version_info.minor
-version = f"{major_v}" if system() == "Linux" else f"{major_v}.{minor_v}"
 workdir = os.getcwd()
 sys.path.append(workdir)
 workdir = os.getcwd()
@@ -120,7 +116,7 @@ artifacts = f"{workdir}/artifacts/"
 if not os.path.exists(artifacts):
     os.makedirs(artifacts)
 
-cfg_content = f"""#!/usr/bin/env python{version}
+cfg_content = f"""#!{sys.executable}
 
 user = "root"
 password = "{passwd}"
@@ -172,8 +168,12 @@ if verbose:
 if exitfirst:
     callargs.append("-x")
 
+# Use the right python version to start pytest with sys.executable
+# So that we can support virtualenv python pytest.
 call([
-    f"pytest-{version}",
+    sys.executable,
+    '-m',
+    'pytest'
 ] + callargs + [
     "-o", "junit_family=xunit2",
     '--timeout=300',


### PR DESCRIPTION
Pipelines will be changed for using virtualenv so that middleware.test is always at the correct version for all tests.

Since samba can't be installed from pip, I added code to use samba from the local system.

I also updated the Readme to install dependencies.

This is related to the ticket I am working on DOCS-4041

Original PR: https://github.com/truenas/middleware/pull/9537
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117441