### PR TITLE
NAS-117442 / 22.02.4 / fix test_cluster_path_snapshot test (by yocalebo)

### DIFF
--- a/cluster-tests/tests/cloudsync/test_cloudsync.py
+++ b/cluster-tests/tests/cloudsync/test_cloudsync.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.client import ClientException
+from middlewared.client import ClientException, ValidationErrors
 from middlewared.test.integration.assets.cloud_sync import *
 
 from config import CLUSTER_INFO, CLUSTER_IPS
@@ -46,7 +46,7 @@ def test_invalid_cluster_path():
 
 
 def test_cluster_path_snapshot():
-    with pytest.raises(ClientException) as e:
+    with pytest.raises(ValidationErrors) as e:
         with local_s3_task({
             "path": CLUSTER_PATH,
             "snapshot": True


### PR DESCRIPTION
This raises `ValidationErrors` instead of `ClientException`

Original PR: https://github.com/truenas/middleware/pull/9542
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117442