### PR TITLE
NAS-116513 / 22.12 / generate serial number for pmem devices

### DIFF
--- a/src/freenas/debian/rules
+++ b/src/freenas/debian/rules
@@ -23,6 +23,7 @@ override_dh_auto_install:
 		cp etc/nsswitch.conf debian/truenas-files/etc/; \
 		cp -a etc/syslog-ng debian/truenas-files/etc/; \
 		cp -a etc/systemd debian/truenas-files/etc/; \
+		cp -a etc/udev debian/truenas-files/etc/; \
 		cp -a root debian/truenas-files/; \
 		mkdir -p debian/truenas-files/conf/base/etc; \
 	"

--- a/src/freenas/etc/udev/rules.d/61-pmem.rules
+++ b/src/freenas/etc/udev/rules.d/61-pmem.rules
@@ -1,0 +1,2 @@
+# make the serial = uuid for pmem devices ticket: NAS-116513
+KERNEL=="pmem*", ENV{DEVTYPE}=="disk", ENV{ID_SERIAL_SHORT}="$attr{uuid}"


### PR DESCRIPTION
Recent commit added nvdimm sync support between controllers and also fixed the uuid attribute. This means we can take the uuid attribute and make it the serial. This adds a udev rule in `/etc/udev/rules.d` (which takes precedence over other rules) to add the `uuid` attribute of the pmem device as the `ID_SERIAL_SHORT` attribute. This allows pmem devices to have a serial number and requires no further changes to `device.get_disks` for example.