### PR TITLE
NAS-116380 / 22.02.4 / ensure unique ns/gws in network.general.summary (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/general.py
+++ b/src/middlewared/middlewared/plugins/network_/general.py
@@ -55,19 +55,19 @@ class NetworkGeneralService(Service):
                     continue
                 ips[iface['name']][key].append(f'{alias["address"]}/{alias["netmask"]}')
 
-        default_routes = set()
+        default_routes = dict()
         for route in await self.middleware.call('route.system_routes', [('netmask', 'in', ['0.0.0.0', '::'])]):
             # IPv6 have local addresses that don't have gateways. Make sure we only return a gateway
             # if there is one.
             if route['gateway']:
-                default_routes.add(route['gateway'])
+                default_routes[route['gateway']] = None
 
-        nameservers = set()
+        nameservers = dict()
         for ns in await self.middleware.call('dns.query'):
-            nameservers.add(ns['nameserver'])
+            nameservers[ns['nameserver']] = None
 
         return {
             'ips': ips,
-            'default_routes': list(default_routes),
-            'nameservers': list(nameservers),
+            'default_routes': list(default_routes.keys()),
+            'nameservers': list(nameservers.keys()),
         }

--- a/src/middlewared/middlewared/plugins/network_/general.py
+++ b/src/middlewared/middlewared/plugins/network_/general.py
@@ -55,19 +55,19 @@ class NetworkGeneralService(Service):
                     continue
                 ips[iface['name']][key].append(f'{alias["address"]}/{alias["netmask"]}')
 
-        default_routes = []
+        default_routes = set()
         for route in await self.middleware.call('route.system_routes', [('netmask', 'in', ['0.0.0.0', '::'])]):
             # IPv6 have local addresses that don't have gateways. Make sure we only return a gateway
             # if there is one.
             if route['gateway']:
-                default_routes.append(route['gateway'])
+                default_routes.add(route['gateway'])
 
-        nameservers = []
+        nameservers = set()
         for ns in await self.middleware.call('dns.query'):
-            nameservers.append(ns['nameserver'])
+            nameservers.add(ns['nameserver'])
 
         return {
             'ips': ips,
-            'default_routes': default_routes,
-            'nameservers': nameservers,
+            'default_routes': list(default_routes),
+            'nameservers': list(nameservers),
         }


### PR DESCRIPTION
Ensu;re duplicate default gateways and/or nameservers don't show up in the webUI.

Original PR: https://github.com/truenas/middleware/pull/9555
Jira URL: https://ixsystems.atlassian.net/browse/NAS-116380