### PR TITLE
NAS-117478 / 22.12 / Revert change to SMB etc generation

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -258,6 +258,7 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'local/rsyncd.conf', 'checkpoint': 'pool_import'}
         ],
         'smb': [
+            {'type': 'mako', 'path': 'local/smb4.conf'},
             {'type': 'mako', 'path': 'security/pam_winbind.conf', 'checkpoint': 'pool_import'},
         ],
         'ctdb': [


### PR DESCRIPTION
This accidentally got deleted, but CI run was successful.
Further investigation of CI pipeline may be warranted.