### PR TITLE
NAS-117434 / 22.12 / Fix VM clone failure with display devices

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -106,6 +106,7 @@ class VMService(Service):
                     if 'port' in item['attributes']:
                         dev_dict = await self.middleware.call('vm.port_wizard')
                         item['attributes']['port'] = dev_dict['port']
+                        item['attributes']['web_port'] = dev_dict['web']
                 if item['dtype'] == 'DISK':
                     zvol = zvol_path_to_name(item['attributes']['path'])
                     item['attributes']['path'] = zvol_name_to_path(


### PR DESCRIPTION
## Problem

When a VM is cloned, DISPLAY devices are not updated with newer `web_port` and causes a conflict with old display device.

## Solution

Use a separate unique port for web port in DISPLAY device on cloning a VM.