### PR TITLE
NAS-117302 / 22.12 / Integrate `disk_resize` script (overprovision)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -34,8 +34,8 @@ class DiskService(Service):
         Bool('sync', default=True),
         Bool('raise_error', default=False)
     )
-    @job(lock='disk_resize')
     @returns()
+    @job(lock='disk_resize')
     async def resize(self, job, data, sync, raise_error):
         """
         Takes a list of disks. Each list entry is a dict that requires a key, value pair.

--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -74,11 +74,11 @@ class DiskService(Service):
                 self.logger.info('Successfully resized %r', disk['name'])
                 success.append(disk['name'])
 
-        if sync:
-            if len(data) > 1:
+        if sync and success:
+            if len(success) > 1:
                 await (await self.middleware.call('disk.sync_all')).wait()
             else:
-                await self.middleware.call('disk.sync', data[0]['name'])
+                await self.middleware.call('disk.sync', success[0]['name'])
 
         if failures:
             err = f'Failure resizing: {", ".join(failures)}'

--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -84,7 +84,7 @@ class DiskService(Service):
             if len(success) > 1:
                 await (await self.middleware.call('disk.sync_all')).wait()
             else:
-                await self.middleware.call('disk.sync', success[0]['name'])
+                await self.middleware.call('disk.sync', success[0])
 
         if failures:
             err = f'Failure resizing: {", ".join(failures)}'

--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -12,17 +12,15 @@ class DiskService(Service):
     @private
     async def resize_impl(self, disk):
         cmd = ['disk_resize', disk['name']]
+        err = f'DISK: {disk["name"]!r}'
         if disk['size']:
+            err += f' SIZE: {disk["size"]} gigabytes'
             cmd.append(f'{disk["size"]}G')
 
         cp = await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8')
         if cp.returncode != 0:
-            err = f'DISK: {disk["name"]!r}'
-            if disk['size']:
-                err += f' SIZE: {disk["size"]} gigabytes'
             err += f' ERROR: {cp.stdout}'
-
-            raise OSError(cp.returncode, os.sterror(cp.returncode), err)
+            raise OSError(cp.returncode, os.strerror(cp.returncode), err)
 
     @accepts(
         List('disks', required=True, items=[

--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -1,0 +1,67 @@
+import os
+import asyncio
+import subprocess
+
+from middlewared.utils import run
+from middlewared.service import Service, CallError, private, accepts, returns, job
+from middlewared.schema import Dict, Str, Int, List, Bool
+
+
+class DiskService(Service):
+
+    @private
+    async def resize_impl(self, disk):
+        cmd = ['disk_resize', disk['name']]
+        if disk['size']:
+            cmd.append(f'{disk["size"]}G')
+
+        cp = await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8')
+        if cp.returncode != 0:
+            err = f'DISK: {disk["name"]!r}'
+            if disk['size']:
+                err += f' SIZE: {disk["size"]} gigabytes'
+            err += f' ERROR: {cp.stdout}'
+
+            raise OSError(cp.returncode, os.sterror(cp.returncode), err)
+
+    @accepts(
+        List('disks', required=True, items=[
+            Dict(
+                Str('name', required=True),
+                Int('size', required=False, default=None),
+            )
+        ]),
+        Bool('raise_error', default=False)
+    )
+    @job(lock='disk_resize')
+    @returns()
+    async def resize(self, job, data, raise_error):
+        """
+        Takes a list of disks. Each list entry is a dict that requires a key, value pair.
+        `name`: string (the name of the disk (i.e. sda))
+        `size`: integer (given in gigabytes)
+        `raise_error`: boolean
+            when true, will raise a `CallError` if any failures occur
+            when false, will will log the errors if any failures occur
+
+        NOTE:
+            if `size` is given, the disk with `name` will be resized
+                to `size` (overprovision).
+            if `size` is not given, the disk with `name` will be resized
+                to it's original size (unoverprovision).
+        """
+        # since it's a list of disks, we could have received duplicate
+        # key,value pairs so ensure we don't try to run `disk_resize` on
+        # the same disk by removing duplicates
+        disks = [i for idx, i in enumerate(data) if i not in data[idx + 1]]
+        exceptions = await asyncio.gather(*[self.resize_impl(disk) for disk in disks], return_exceptions=True)
+        failures = []
+        for _, exc in filter(lambda x: isinstance(x[1], OSError), zip(disks, exceptions)):
+            failures.append(str(exc))
+
+        if failures:
+            err = f'Failure resizing: {", ".join(failures)}'
+            if raise_error:
+                raise CallError(err)
+            else:
+                self.logger.error(err)

--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -73,7 +73,7 @@ class DiskService(Service):
         exceptions = await asyncio.gather(*[self.resize_impl(disk) for disk in data], return_exceptions=True)
         failures = []
         success = []
-        for disk, exc in zip(disks, exceptions):
+        for disk, exc in zip(data, exceptions):
             if isinstance(exc, Exception):
                 failures.append(str(exc))
             else:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -738,7 +738,7 @@ class PoolService(CRUDService):
         if osize := (await self.middleware.call('system.advanced.config'))['overprovision']:
             if disks := {disk: osize for disk in sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])}:
                 # will log errors if there are any so it won't crash here (this matches CORE behavior)
-                await (await self.middleware.call('disk.resize', disks)).wait()
+                await (await self.middleware.call('disk.resize', disks, True)).wait()
 
         await self.middleware.call('pool.format_disks', job, disks)
 


### PR DESCRIPTION
`disk_resize` was recently made to work on SCALE so this PR does the following:

1. create new `disk.resize` endpoint that takes a list of disks to be overprovisioned (or unoverprovisioned)
2. protect it with a lock so we don't clobber another instance of `disk_resize` for a particular disk
3. call it on pool.create