### PR TITLE
NAS-117349 / 13.0 / Load firmware for ice Intel E800 NICs.

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -19,6 +19,9 @@ hw.hptrr.attach_generic=0
 # Possible kernel module locations (in addition to /boot/${kernel})
 module_path="/boot/modules;/usr/local/modules"
 
+# Load firmware for ice Intel E800 NICs.
+ice_ddp_load="YES"
+
 # Load firmware for isp FC cards.
 ispfw_load="YES"
 


### PR DESCRIPTION
Otherwise, the adapter will fall back to a single queue mode with
limited functionality.