### PR TITLE
NAS-117495 / 22.12 / fix and improve middlewared Makefile

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -1,21 +1,25 @@
-VERSION != cat /etc/version
+export MWPATH=/usr/lib/python3/dist-packages/middlewared
 
+
+stop_service:
+	systemctl stop middlewared
+
+start_service:
+	systemctl restart middlewared
 
 clean:
-	rm -rf build
+	rm -rf $(MWPATH)
 
-reinstall: clean
-	sh -x -c '\
-		path=$$(python3 -c "import sys; sys.path = sys.path[1:]; import middlewared; import os; print(os.path.dirname(middlewared.__spec__.origin))"); \
-		rm -rf $$path; \
-	'
+install:
 	python3 setup.py install --single-version-externally-managed --record=/dev/null
 
-dev: reinstall run
+install_client:
+	python3 setup_client.py install --single-version-externally-managed --record=/dev/null
 
-run:
-	middlewared restart --loop-debug -P --debug-level 'TRACE'
+install_test:
+	python3 setup_test.py install --single-version-externally-managed --record=/dev/null
 
-reinstall-remote:
-	sh -c 'if [ -z "${HOST}" ]; then echo "You need to set HOST"; exit 1; fi;'
-	tar cf - . | ssh root@${HOST} 'cat > /tmp/middleware.tar; set tmpdir=`mktemp -d`; tar xf /tmp/middleware.tar -C $$tmpdir; cd $$tmpdir; make reinstall; service middlewared restart'
+migrate:
+	migrate
+
+reinstall: stop_service clean install install_client install_test migrate start_service


### PR DESCRIPTION
Fix (and improve) the middlewared `Makefile` so that it works on SCALE. QE team is using many different methods across the various CI pipelines to reinstall the middlewared service. Provide a mechanism that allows the QE team to call 1 command during CI builds/tests (`make reinstall`) that will handle all the magic behind the scenes.

This can also be used by middleware developers for testing local changes.