### PR TITLE
NAS-117500 / 22.12 / call install-dev-tools before setup_test.py

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -17,6 +17,7 @@ install_client:
 	python3 setup_client.py install --single-version-externally-managed --record=/dev/null
 
 install_test:
+	bash install-dev-tools
 	python3 setup_test.py install --single-version-externally-managed --record=/dev/null
 
 migrate:


### PR DESCRIPTION
This installs the dependencies needed for `setup_test.py install`.