### PR TITLE
NAS-117500 / 22.02.4 / call install-dev-tools before setup_test.py (by yocalebo)

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -17,6 +17,7 @@ install_client:
 	python3 setup_client.py install --single-version-externally-managed --record=/dev/null
 
 install_test:
+	bash install-dev-tools
 	python3 setup_test.py install --single-version-externally-managed --record=/dev/null
 
 migrate:


### PR DESCRIPTION
This installs the dependencies needed for `setup_test.py install`.

Original PR: https://github.com/truenas/middleware/pull/9572
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117500