### PR TITLE
NAS-117501 / 22.12 / disk_resize: Don't trigger udev events for NVMe

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -228,8 +228,7 @@ nvme)
 		exit 1
 	fi
 
-	echo "Rescanning namespaces."
-	udevadm trigger -w ${ctrlr}
+	echo "Verifying namespace."
 	nsize=$((`nvme id-ns -n ${nsid} ${ctrlr} | awk -F ' +: ' '$1 == "nsze" { print $2}'`))
 	if [ ${nsize} -eq ${size} ]; then
 		echo "Resize completed successfully."


### PR DESCRIPTION
Work around a bug in the Linux kernel for multipath NVMe devices.

The kernel uses GENHD_FL_HIDDEN to hide controllers from userspace, but
it's not hidden enough.  Udev sees the device, but it never handles
uevents, so it never settles when triggered.

Skip the triggering, we shouldn't need it.