### PR TITLE
NAS-117499 / 22.12 / make sure pool.attach waits for disk.sync_all

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -30,4 +30,5 @@ class PoolService(Service):
 
         await asyncio_map(format_disk, disks.items(), limit=16)
 
-        await self.middleware.call('disk.sync_all')
+        disk_sync_job = await self.middleware.call('disk.sync_all')
+        await job.wrap(disk_sync_job)


### PR DESCRIPTION
WebUI team is calling `pool.attach` and waiting for the job to complete, however, `disk.query` isn't showing the new disk that was just attached.

This is because they're calling `disk.query` before the `disk.sync_all` completes. Since they're already waiting on `pool.attach` to complete, go ahead and wrap the `disk.sync_all` in a job.wrap call so that when they call `disk.query` it'll show the newly added disk.