### PR TITLE
NAS-117467 / 22.02.3 / Reuse tdb / ctdb handles (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -6,13 +6,14 @@ from .connection import TDBMixin
 from .schema import SchemaMixin
 from .wrapper import TDBPath
 
-import os
-import json
-import errno
 import ctdb
+import errno
+import json
+import os
+import threading
 
-from contextlib import closing
 from base64 import b64encode, b64decode
+from contextlib import contextmanager
 
 
 class TDBService(Service, TDBMixin, SchemaMixin):
@@ -47,31 +48,33 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         return db.db_id
 
     @private
+    @contextmanager
     def get_connection(self, name, options):
         self.validate_tdb_options(name, options)
 
-        existing = self.handles.get('name')
+        entry = self.handles.setdefault(name, {
+            'name': name,
+            'lock': threading.RLock(),
+            'handle_internal': None,
+            'options': options.copy()
+        })
 
-        if existing:
-            if options != existing['options']:
-                raise CallError(f'{name}: Internal Error - tdb options mismatch', errno.EINVAL)
+        if options != entry['options']:
+            raise CallError(f'{name}: Internal Error - tdb options mismatch', errno.EINVAL)
 
-            if existing['handle']:
-                return existing['handle']
+        with entry['lock']:
+            if entry['handle_internal'] is None:
+                if options['cluster']:
+                    dbid = self._ctdb_get_dbid(name, options)
+                    entry['handle_internal'] = self._get_handle(name, dbid, options, self.logger)
+                else:
+                    entry['handle_internal'] = self._get_handle(name, None, options, self.logger)
 
-        else:
-            self.handles[name] = {
-                'name': name,
-                'options': options.copy()
-            }
+            elif not entry['handle_internal'].validate_handle():
+                entry['handle_internal'].close()
+                entry['handle_internal'] = self._get_handle(name, None, options, self.logger)
 
-        if options['cluster']:
-            dbid = self._ctdb_get_dbid(name, options)
-            handle = self._get_handle(name, dbid, options, self.logger)
-        else:
-            handle = self._get_handle(name, None, options, self.logger)
-
-        return handle
+            yield entry['handle_internal']
 
     @accepts(Dict(
         'tdb-store',
@@ -90,8 +93,6 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         )
     ))
     def store(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-
         if data['tdb-options']['data_type'] == 'JSON':
             tdb_val = json.dumps(data['value'])
         elif data['tdb-options']['data_type'] == 'STRING':
@@ -99,7 +100,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         elif data['tdb-options']['data_type'] == 'BYTES':
             tdb_val = b64decode(data['value']['payload'])
 
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._set(tdb_handle, data['key'], tdb_val)
 
     @accepts(Dict(
@@ -109,9 +110,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def fetch(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             tdb_val = self._get(tdb_handle, data['key'])
 
         if tdb_val is None:
@@ -133,8 +132,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def remove(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._rem(tdb_handle, data['key'])
 
     @accepts(Dict(
@@ -162,9 +160,8 @@ class TDBService(Service, TDBMixin, SchemaMixin):
             'output': [],
             'data_type': data['tdb-options']['data_type']
         }
-        handle = self.get_connection(data['name'], data['tdb-options'])
 
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._traverse(tdb_handle, append_entries, state)
 
         return filter_list(state['output'], data['query-filters'], data['query-options'])
@@ -176,9 +173,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def batch_ops(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             data = self._batch_ops(tdb_handle, data['ops'])
 
         return data
@@ -189,8 +184,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def wipe(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._wipe(tdb_handle)
 
     @accepts(Dict(
@@ -199,8 +193,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def config(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             data = self._config_config(tdb_handle)
 
         return data
@@ -212,8 +205,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def config_update(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._config_update(tdb_handle, data['payload'])
 
         return
@@ -225,8 +217,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def create(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             id = self._create(tdb_handle, data['payload'])
 
         return id
@@ -239,8 +230,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def query(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             data = self._query(tdb_handle, data['query-filters'], data['query-options'])
 
         return data
@@ -253,8 +243,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def update(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             id = self._update(tdb_handle, data['id'], data['payload'])
 
         return id
@@ -266,8 +255,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
         Ref('tdb-options'),
     ))
     def delete(self, data):
-        handle = self.get_connection(data['name'], data['tdb-options'])
-        with closing(handle) as tdb_handle:
+        with self.get_connection(data['name'], data['tdb-options']) as tdb_handle:
             self._delete(tdb_handle, data['id'])
 
         return


### PR DESCRIPTION
During testing there were intermittent failures when stressing
the clustercache interface (ctdb client op would fail with
deadlock avoided). This commit does two primary things:

1) Reuses tdb and ctdb handles (rather than opening / closing
   them on ops).

2) Initializes per-database reentrant lock to prevent multiple
   transactions from being initialized simultaneously.

Original PR: https://github.com/truenas/middleware/pull/9548
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117467