### PR TITLE
NAS-117524 / 22.12 / huge optimization to query_for_quota_alert

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -571,16 +571,28 @@ class ZFSDatasetService(CRUDService):
         return filter_list(datasets, filters, options)
 
     def query_for_quota_alert(self):
-        return [
-            {
-                k: v for k, v in dataset['properties'].items()
-                if k in [
-                    "name", "quota", "available", "refquota", "used", "usedbydataset", "mounted", "mountpoint",
-                    "org.freenas:quota_warning", "org.freenas:quota_critical",
-                    "org.freenas:refquota_warning", "org.freenas:refquota_critical"
+        options = {
+            'extra': {
+                'flat': False,
+                'properties': [
+                    'name',
+                    'quota',
+                    'available',
+                    'refquota',
+                    'used',
+                    'usedbydataset',
+                    'mounted',
+                    'mountpoint',
+                    'org.freenas:quota_warning',
+                    'org.freenas:quota_critical',
+                    'org.freenas:refquota_warning',
+                    'org.freenas:refquota_critial',
                 ]
             }
-            for dataset in self.query()
+        }
+        return [
+            {k: v for k, v in i['properties'].items() if k in options['extra']['properties']}
+            for i in self.query([], options)
         ]
 
     @accepts(


### PR DESCRIPTION
On a system with ~1200 datasets, this method was taking ~10 seconds to complete and spiking a CPU core the entire time. After my changes, it takes ~0.9 seconds.

This is a ~91% decrease in time it takes to run this method. (Which, btw, is running every 5minutes in our alert system)

There is no change in functionality, I'm simply using some `extra` flags to `zfs.dataset.query` so we don't enumerate every property of every dataset and only the ones we want.