### PR TITLE
NAS-117525 / 22.02.4 / Remove silent from starting service in custer test

### DIFF
--- a/cluster-tests/tests/smb/test_001_sharing_smb.py
+++ b/cluster-tests/tests/smb/test_001_sharing_smb.py
@@ -77,7 +77,7 @@ def test_004_start_smb_service(ip, request):
     payload = {
         'msg': 'method',
         'method': 'service.start',
-        'params': ['cifs', {'silent': False}]
+        'params': ['cifs']
     }
     res = make_ws_request(ip, payload)
     assert res.get('error') is None, res


### PR DESCRIPTION
That is not supported in angelfish