### PR TITLE
NAS-117307 / 22.12 / Update ixvolumes during pool migration

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
@@ -2,7 +2,7 @@ import errno
 import os
 
 from middlewared.schema import accepts, Str, Ref, returns
-from middlewared.service import CallError, job, Service
+from middlewared.service import CallError, job, private, Service
 
 from .utils import add_context_to_configuration, CONTEXT_KEY_NAME, get_action_context
 
@@ -17,9 +17,14 @@ class ChartReleaseService(Service):
     @job(lock=lambda args: f'chart_release_redeploy_{args[0]}')
     async def redeploy(self, job, release_name):
         """
-        Redeploy will initiate a new rollout of the Helm chart according to upgrade strategy defined by the chart release
-        workloads. A good example for redeploying is updating kubernetes pods with an updated container image.
+        Redeploy will initiate a new rollout of the Helm chart according to upgrade strategy defined by the chart
+        release workloads. A good example for redeploying is updating kubernetes pods with an updated container image.
         """
+        return await job.wrap(await self.middleware.call('chart.release.redeploy_internal', release_name, False))
+
+    @private
+    @job(lock=lambda args: f'chart_release_redeploy_internal_{args[0]}')
+    async def redeploy_internal(self, job, release_name, update_pool=False):
         release = await self.middleware.call('chart.release.get_instance', release_name)
         chart_path = os.path.join(release['path'], 'charts', release['chart_metadata']['version'])
         if not os.path.exists(chart_path):
@@ -35,6 +40,13 @@ class ChartReleaseService(Service):
                 'isUpdate': True,
             }
         }, self.middleware)
+        if update_pool:
+            for index, host_path in enumerate(config.get('ixVolumes', [])):
+                new_pool = release['path'].split('/')[2]
+                # e.g path /mnt/tank/ix-applications/releases/pihole/volumes/ix_volumes/user-data
+                path_under_pool = host_path['hostPath'].split('/', 3)[-1]
+                config['ixVolumes'][index]['hostPath'] = os.path.join('/mnt', new_pool, path_under_pool)
+
         await self.middleware.call('chart.release.helm_action', release_name, chart_path, config, 'update')
 
         job.set_progress(90, 'Syncing secrets for chart release')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -248,7 +248,7 @@ class KubernetesService(Service):
                     'Failed to restore CRD(s) for %r chart release:\n%s', chart_release, '\n'.join(failed_crds)
                 )
 
-            update_jobs.append(self.middleware.call_sync('chart.release.redeploy', chart_release))
+            update_jobs.append(self.middleware.call_sync('chart.release.redeploy_internal', chart_release, True))
 
         for update_job in update_jobs:
             update_job.wait_sync()


### PR DESCRIPTION
### Problem
After migrating ix-applications to a new pool with `kubernetes.update`, ix-volumes continue using the path which points to old pool unless they are edited/modified which is a serious concern.

### Solution
Update ix-volumes in helm configuration when ix-applications is migrated to use the newer pool.
