### PR TITLE
NAS-117479 / 22.02.4 / Skipping RAW device to be created (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -109,8 +109,8 @@ class VMService(Service):
                         await self.__clone_zvol(vm['name'], zvol, created_snaps, created_clones)
                     )
                 if item['dtype'] == 'RAW':
-                    item['attributes']['path'] = ''
-                    self.logger.warn('For RAW disk you need copy it manually inside your NAS.')
+                    self.logger.warning('RAW disks must be copied manually. Skipping...')
+                    continue
 
             await self.middleware.call('vm.do_create', vm)
         except Exception as e:
@@ -118,7 +118,7 @@ class VMService(Service):
                 try:
                     await self.middleware.call('zfs.dataset.delete', i)
                 except Exception:
-                    self.logger.warn('Rollback of VM clone left dangling zvol: %s', i)
+                    self.logger.warning('Rollback of VM clone left dangling zvol: %s', i)
             for i in reversed(created_snaps):
                 try:
                     dataset, snap = i.split('@')


### PR DESCRIPTION
### Issue
While cloning VMs, if there is a `RAW` device, it throws error as the path needs to be created manually, so the exception makes remaining devices to be skipped from creation.

### Fix
Skipping `RAW` type devices on cloning VMs.

### Future reference
Exceptions on cloning VMs should be managed appropriately, with proper rollback strategy.

Original PR: https://github.com/truenas/middleware/pull/9559
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117479