### PR TITLE
NAS-117584 / 22.12 / fix Makefile MWPATH

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -1,5 +1,6 @@
-export MWPATH=/usr/lib/python3/dist-packages/middlewared
-
+export MWPATH1=/usr/lib/python3/dist-packages/middlewared
+export MWPATH2=/usr/local/lib/python3.9/dist-packages/middlewared
+export BUILD=$(shell pwd)/build
 
 stop_service:
 	systemctl stop middlewared
@@ -8,7 +9,9 @@ start_service:
 	systemctl restart middlewared
 
 clean:
-	rm -rf $(MWPATH)
+	rm -rf $(MWPATH1)*
+	rm -rf $(MWPATH2)*
+	rm -rf $(BUILD)
 
 install:
 	python3 setup.py install --single-version-externally-managed --record=/dev/null


### PR DESCRIPTION
This didn't work when you ran `make reinstall` 2 or more times on the same machine. The reason why is 3 fold.

1. on fresh installation middlewared is installed in `/usr/lib/python3/dist-packages`, but when `python3 setup.py` is called, it reinstalls in `/usr/local/lib/python3.9/dist-packages`
2. `python3 setup.py` byte-compiles the modules in the current directory into a directory named `build` and would copy any modules already there to the new location. Even if those modules no longer existed upstream.
3. We weren't removing the proper directories