### PR TITLE
NAS-117587 / 22.12 / Fix regression in getgrnam for gid 0

### DIFF
--- a/src/middlewared/middlewared/etc_files/group.mako
+++ b/src/middlewared/middlewared/etc_files/group.mako
@@ -14,6 +14,6 @@
         ])
 
 %>\
-% for group in filter_list(render_ctx['group.query'], [], {'order_by': ['-builtin', 'gid']}):
+% for group in filter_list(render_ctx['group.query'], [], {'order_by': ['-builtin', 'gid', 'group']}):
 ${group['group']}:x:${group['gid']}:${get_usernames(group)}
 % endfor


### PR DESCRIPTION
We added secondary mapping for gid 0 to wheel without verifying
that it was being added in proper order during generation of
/etc/group.