### PR TITLE
NAS-117600 / 13.0 / add back recoverable APEI alert

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware_/mca_and_apei_events.py
+++ b/src/middlewared/middlewared/plugins/hardware_/mca_and_apei_events.py
@@ -4,7 +4,7 @@ import sysctl
 from middlewared.service import Service
 
 MCA = re.compile(r'.*MCA:.*(UNCOR).*')
-APEI = re.compile(r'.*APEI.*(Fatal).*')
+APEI = re.compile(r'.*APEI.*(Recoverable|Fatal).*')
 
 
 class HardwareService(Service):
@@ -19,7 +19,7 @@ class HardwareService(Service):
 
     def _parse_msgbuf(self, msgbuf=None):
         """
-        Parse `kern.msgbuf` sysctl for any MCA uncorrectable or APEI fatal events.
+        Parse `kern.msgbuf` sysctl for any MCA uncorrectable or APEI recoverable/fatal events.
         `msgbug` List of strings from kern.msgbuf sysctl output
         """
         if msgbuf is None:

--- a/src/middlewared/middlewared/pytest/unit/plugins/hardware/test_mca_and_apei_events.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/hardware/test_mca_and_apei_events.py
@@ -112,6 +112,59 @@ def test__apei_fatal_memory_event():
     assert events == expected_result
 
 
+def test__apei_recoverable_memory_event():
+    apei_event = ("""
+    APEI Recoverable Memory Error:
+     Error Status: 0x0
+     Physical Address: 0x72aed744c0
+     Physical Address Mask: 0x3fffffffffc0
+     Node: 2
+     Card: 1
+     Module: 0
+     Device: 15
+     Row: 8165
+     Column: 184
+     Memory Error Type: 2
+     Rank Number: 0
+     Card Handle: 0xf
+     Module Handle: 0x1a
+     Bank Group: 3
+     Bank Address: 1
+     Chip Identification: 0
+     Flags: 0x1
+     FRU Text: P2-DIMMB1 232891B6
+    BOGUS LINE
+    """).splitlines()
+
+    expected_result = {
+        'MCA_EVENTS': [],
+        'APEI_EVENTS': [
+            {'APEI Recoverable Memory Error:': {
+                'Error Status': '0x0',
+                'Physical Address': '0x72aed744c0',
+                'Physical Address Mask': '0x3fffffffffc0',
+                'Node': '2',
+                'Card': '1',
+                'Module': '0',
+                'Device': '15',
+                'Row': '8165',
+                'Column': '184',
+                'Memory Error Type': '2',
+                'Rank Number': '0',
+                'Card Handle': '0xf',
+                'Module Handle': '0x1a',
+                'Bank Group': '3',
+                'Bank Address': '1',
+                'Chip Identification': '0',
+                'Flags': '0x1',
+                'FRU Text': 'P2-DIMMB1 232891B6',
+            }},
+        ]
+    }
+    events = OBJ._parse_msgbuf(msgbuf=apei_event)
+    assert events == expected_result
+
+
 def test__apei_fatal_pcie_event():
     apei_event = ("""
     APEI Fatal PCIe Error:


### PR DESCRIPTION
Mav requested this be added back since it's still an uncorrected event that should we notify end-user about.