### PR TITLE
NAS-116747 / 22.12 / Provide string values for JSON fields that may overflow 2**53 on PiB-scale systems

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -483,12 +483,18 @@ class FilesystemService(Service):
         Int('total_blocks', required=True),
         Int('free_blocks', required=True),
         Int('avail_blocks', required=True),
+        Str('total_blocks_str', required=True),
+        Str('free_blocks_str', required=True),
+        Str('avail_blocks_str', required=True),
         Int('files', required=True),
         Int('free_files', required=True),
         Int('name_max', required=True),
         Int('total_bytes', required=True),
         Int('free_bytes', required=True),
         Int('avail_bytes', required=True),
+        Str('total_bytes_str', required=True),
+        Str('free_bytes_str', required=True),
+        Str('avail_bytes_str', required=True),
     ))
     def statfs(self, path):
         """
@@ -535,7 +541,7 @@ class FilesystemService(Service):
                 continue
             flags.append(flag)
 
-        return {
+        result = {
             'flags': flags,
             'fstype': mntinfo['fs_type'].lower(),
             'source': mntinfo['mount_source'],
@@ -552,6 +558,9 @@ class FilesystemService(Service):
             'free_bytes': st.f_bfree * st.f_frsize,
             'avail_bytes': st.f_bavail * st.f_frsize,
         }
+        for k in ['total_blocks', 'free_blocks', 'avail_blocks', 'total_bytes', 'free_bytes', 'avail_bytes']:
+            result[f'{k}_str'] = str(result[k])
+        return result
 
     @accepts(Str('path'))
     @returns(Bool('paths_acl_is_trivial'))

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -307,6 +307,10 @@ class PoolService(CRUDService):
         Int('free', required=True, null=True),
         Int('freeing', required=True, null=True),
         Str('fragmentation', required=True, null=True),
+        Str('size_str', required=True, null=True),
+        Str('allocated_str', required=True, null=True),
+        Str('free_str', required=True, null=True),
+        Str('freeing_str', required=True, null=True),
         Dict(
             'autotrim',
             required=True,
@@ -544,6 +548,10 @@ class PoolService(CRUDService):
             'free': None,
             'freeing': None,
             'fragmentation': None,
+            'size_str': None,
+            'allocated_str': None,
+            'free_str': None,
+            'freeing_str': None,
             'autotrim': {
                 'parsed': 'off',
                 'rawvalue': 'off',
@@ -568,6 +576,10 @@ class PoolService(CRUDService):
                 'free': info['properties']['free']['parsed'],
                 'freeing': info['properties']['freeing']['parsed'],
                 'fragmentation': info['properties']['fragmentation']['parsed'],
+                'size_str': info['properties']['size']['rawvalue'],
+                'allocated_str': info['properties']['allocated']['rawvalue'],
+                'free_str': info['properties']['free']['rawvalue'],
+                'freeing_str': info['properties']['freeing']['rawvalue'],
                 'autotrim': info['properties']['autotrim'],
             })
 


### PR DESCRIPTION
Some JSON parsers (e.g. the one that is used in the `jq` utility for example) don't parse large values correctly, as a result we have this:
```
      "snapshot_limit": {
        "parsed": 18446744073709552000,
        "rawvalue": "18446744073709551615",
        "value": "none",
        "source": "DEFAULT",
        "source_info": null
      },
```
(the middleware JSON output was correct, but after going through `jq` the `parsed` and `rawvalue` become different).

Clients that know that their JSON parsing is poor can restore the correct ZFS property value using `rawvalue` which is always a string. For other JSON dictionaries that might contain integer values that are too large (this might happen when we start selling petabyte-scale systems) we'll provide `f'{key}_str` values like many other REST APIs do (e.g. Twitter tweet IDs, etc). These are all such values that I was able to find.