### PR TITLE
NAS-117617 / 22.12 / Allow setting snapdev field for filesystems

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3560,7 +3560,7 @@ class PoolDatasetService(CRUDService):
                 if acltype in ['POSIX', 'OFF'] and to_check.get('aclmode', 'DISCARD') != 'DISCARD':
                     verrors.add(f'{schema}.aclmode', 'Must be set to DISCARD when acltype is POSIX or OFF')
 
-            for i in ('force_size', 'sparse', 'volsize', 'volblocksize', 'snapdev'):
+            for i in ('force_size', 'sparse', 'volsize', 'volblocksize'):
                 if i in data:
                     verrors.add(f'{schema}.{i}', 'This field is not valid for FILESYSTEM')
 


### PR DESCRIPTION
This field is allowed to be set on filesystems by zfs and i believe we should do the same.