### PR TITLE
NAS-117416 / 22.12 / add alert for zpools that have USB disks

### DIFF
--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -6,7 +6,7 @@ class PoolUSBDisksAlertClass(AlertClass):
     category = AlertCategory.STORAGE
     level = AlertLevel.WARNING
     title = 'Pool consuming USB disks'
-    text = '%(pool)r is consuming %(disks)r USB disk(s) which is not advised behavior. ' \
+    text = '%(pool)r is consuming %(disks)r USB disk(s) which is not advised. ' \
            'Please replace the disk(s) immediately.'
 
 

--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -6,8 +6,7 @@ class PoolUSBDisksAlertClass(AlertClass):
     category = AlertCategory.STORAGE
     level = AlertLevel.WARNING
     title = 'Pool consuming USB disks'
-    text = '%(pool)r is consuming %(disks)r USB disk(s) which is not advised. ' \
-           'Please replace the disk(s) immediately.'
+    text = '%(pool)r is consuming USB devices %(disks)r which is not recommended.'
 
 
 class PoolDisksChecksAlertSource(AlertSource):
@@ -24,8 +23,8 @@ class PoolDisksChecksAlertSource(AlertSource):
             usb_disks = await self.middleware.call('pool.get_usb_disks', pool['name'])
             if usb_disks:
                 alerts.append(Alert(
-                    PoolDisksChecksAlertSource,
-                    {'pool': pool['name'], 'disks': usb_disks},
+                    PoolUSBDisksAlertClass,
+                    {'pool': pool['name'], 'disks': ', '.join(usb_disks)},
                 ))
 
         return alerts

--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -17,8 +17,11 @@ class PoolDisksChecksAlertSource(AlertSource):
     async def check(self):
         alerts = []
 
-        for pool in await self.middleware.call('pool.query'):
-            usb_disks = await self.middleware.call('pool.get_usb_disks', pool['id'])
+        for pool in filter(
+            lambda p: p['state'] == 'ONLINE',
+            (await self.middleware.call('zfs.pool.query_imported_fast')).values()
+        ):
+            usb_disks = await self.middleware.call('pool.get_usb_disks', pool['name'])
             if usb_disks:
                 alerts.append(Alert(
                     PoolDisksChecksAlertSource,

--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -16,16 +16,9 @@ class PoolDisksChecksAlertSource(AlertSource):
 
     async def check(self):
         alerts = []
-        disks = {disk['name']: disk for disk in await self.middleware.call('disk.query')}
 
         for pool in await self.middleware.call('pool.query'):
-            usb_disks = [
-                disk
-                for disk in filter(
-                    lambda d: d in disks and d['bus'] == 'USB',
-                    await self.middleware.call('pool.get_disks', pool['id'])
-                )
-            ]
+            usb_disks = await self.middleware.call('pool.get_usb_disks', pool['id'])
             if usb_disks:
                 alerts.append(Alert(
                     PoolDisksChecksAlertSource,

--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -1,0 +1,35 @@
+from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.alert.schedule import CrontabSchedule
+
+
+class PoolUSBDisksAlertClass(AlertClass):
+    category = AlertCategory.STORAGE
+    level = AlertLevel.WARNING
+    title = 'Pool consuming USB disks'
+    text = '%(pool)r is consuming %(disks)r USB disk(s) which is not advised behavior. ' \
+           'Please replace the disk(s) immediately.'
+
+
+class PoolDisksChecksAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=0)  # every 24 hours
+    run_on_backup_node = False
+
+    async def check(self):
+        alerts = []
+        disks = {disk['name']: disk for disk in await self.middleware.call('disk.query')}
+
+        for pool in await self.middleware.call('pool.query'):
+            usb_disks = [
+                disk
+                for disk in filter(
+                    lambda d: d in disks and d['bus'] == 'USB',
+                    await self.middleware.call('pool.get_disks', pool['id'])
+                )
+            ]
+            if usb_disks:
+                alerts.append(Alert(
+                    PoolDisksChecksAlertSource,
+                    {'pool': pool['name'], 'disks': usb_disks},
+                ))
+
+        return alerts

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1068,7 +1068,7 @@ class PoolService(CRUDService):
                 lambda d: d in disks and disks[d]['bus'] == 'USB',
                 await self.middleware.call('zfs.pool.get_disks', name)
             )
-        ] if pool_state and pool_state.values()[0]['state'] == 'ONLINE' else []
+        ] if pool_state and list(pool_state.values())[0]['state'] == 'ONLINE' else []
 
     @item_method
     @accepts(Int('id'), Dict(

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1059,11 +1059,16 @@ class PoolService(CRUDService):
         return disks
 
     @private
-    async def get_usb_disks(self, oid):
+    async def get_usb_disks(self, name):
         disks = {disk['name']: disk for disk in await self.middleware.call('disk.query')}
+        pool_state = await self.middleware.call('zfs.pool.query_imported_fast', [name])
+
         return [
-            disk for disk in filter(lambda d: d in disks and disks[d]['bus'] == 'USB', await self.get_disks(oid))
-        ]
+            disk for disk in filter(
+                lambda d: d in disks and disks[d]['bus'] == 'USB',
+                await self.middleware.call('zfs.pool.get_disks', name)
+            )
+        ] if pool_state and pool_state.values()[0]['state'] == 'ONLINE' else []
 
     @item_method
     @accepts(Int('id'), Dict(

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1058,6 +1058,13 @@ class PoolService(CRUDService):
                 disks.extend(await self.middleware.call('zfs.pool.get_disks', pool['name']))
         return disks
 
+    @private
+    async def get_usb_disks(self, oid):
+        disks = {disk['name']: disk for disk in await self.middleware.call('disk.query')}
+        return [
+            disk for disk in filter(lambda d: d in disks and d['bus'] == 'USB', await self.get_disks(oid))
+        ]
+
     @item_method
     @accepts(Int('id'), Dict(
         'options',

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1062,7 +1062,7 @@ class PoolService(CRUDService):
     async def get_usb_disks(self, oid):
         disks = {disk['name']: disk for disk in await self.middleware.call('disk.query')}
         return [
-            disk for disk in filter(lambda d: d in disks and d['bus'] == 'USB', await self.get_disks(oid))
+            disk for disk in filter(lambda d: d in disks and disks[d]['bus'] == 'USB', await self.get_disks(oid))
         ]
 
     @item_method

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -96,11 +96,13 @@ class ZFSPoolService(CRUDService):
                 pools = [i.__getstate__(**state_kwargs) for i in zfs.pools]
         return filter_list(pools, filters, options)
 
-    def query_imported_fast(self):
+    def query_imported_fast(self, name_filters=None):
         # the equivalent of running `zpool list -H -o guid,name` from cli
+        # name_filters will be a list of pool names
         out = {}
+        name_filters = name_filters or []
         with os.scandir('/proc/spl/kstat/zfs') as it:
-            for entry in it:
+            for entry in filter(lambda entry: not name_filters or entry.name in name_filters, it):
                 if not entry.is_dir() or entry.name == '$import':
                     continue
 


### PR DESCRIPTION
This PR adds changes to add an alert for zpools that have USB disks. We saw a user configure apps to point to a zpool using a USB disk that caused dataset creation ( via zfs cli ) to take ~20 seconds and the same dataset on deletion took 1 minute. This caused a cascading set of failures because the zpool was so slow.