### PR TITLE
NAS-117673 / 22.12 / enforce minimum zfs passphrase length

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -604,7 +604,7 @@ class PoolService(CRUDService):
             Bool('generate_key', default=False),
             Int('pbkdf2iters', default=350000, validators=[Range(min=100000)]),
             Str('algorithm', default='AES-256-GCM', enum=ZFS_ENCRYPTION_ALGORITHM_CHOICES),
-            Str('passphrase', default=None, null=True, empty=False, private=True),
+            Str('passphrase', default=None, null=True, validators=[Range(min=8)], empty=False, private=True),
             Str('key', default=None, null=True, validators=[Range(min=64, max=64)], private=True),
             register=True
         ),


### PR DESCRIPTION
Saw this error in a recent debug.
```
[2022/08/12 05:03:22] (ERROR) ZFSDatasetService.load_key():765 - Failed to load key for tank/parent/child
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/zfs.py", line 763, in load_key
    ds.load_key(**options)
  File "libzfs.pyx", line 411, in libzfs.ZFS.__exit__
  File "/usr/lib/python3/dist-packages/middlewared/plugins/zfs.py", line 763, in load_key
    ds.load_key(**options)
  File "libzfs.pyx", line 3724, in libzfs.ZFSDataset.load_key
  File "libzfs.pyx", line 3721, in libzfs.ZFSDataset.load_key_common
libzfs.ZFSException: 2072: Passphrase too short (min 8)