### PR TITLE
NAS-117658 / 22.02.4 / fix KeyError for min_memory key (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -130,7 +130,7 @@ class VMService(Service):
         available_memory = await self.get_available_memory(False)
         available_memory_with_overcommit = await self.get_available_memory(True)
         vm_max_memory = vm['memory'] * 1024 * 1024
-        vm_min_memory = vm['min_memory'] * 1024 * 1024 if vm['min_memory'] else None
+        vm_min_memory = vm.get('min_memory', 0) * 1024 * 1024 or None
         vm_requested_memory = vm_min_memory or vm_max_memory
 
         overcommit_required = vm_requested_memory > available_memory


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1272, in nf
    return await func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1140, in nf
    res = await f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/vm_memory_info.py", line 133, in get_vm_memory_info
    vm_min_memory = vm['min_memory'] * 1024 * 1024 if vm['min_memory'] else None
KeyError: 'min_memory'

Original PR: https://github.com/truenas/middleware/pull/9644
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117658