### PR TITLE
NAS-115869 / 22.02.4 / fix ntp on scale when dhcp is involved (by yocalebo)

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -4,7 +4,8 @@ mkdir -p /var/trash
 for file in \
     /etc/default/inadyn \
     /etc/nsswitch.conf \
-    /lib/systemd/system/smartmontools.service
+    /lib/systemd/system/smartmontools.service \
+    /usr/lib/ntp/ntp-systemd-wrapper
 do
     dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"
 done

--- a/src/freenas/usr/lib/ntp/ntp-systemd-wrapper
+++ b/src/freenas/usr/lib/ntp/ntp-systemd-wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+DAEMON=/usr/sbin/ntpd
+PIDFILE=/var/run/ntpd.pid
+CONFFILE=/etc/ntp.conf
+UGID=$(getent passwd ntp | cut -f 3,4 -d:) || true
+
+exec $DAEMON -p $PIDFILE -c "$CONFFILE" -u "$UGID"


### PR DESCRIPTION
`ntp-systemd-wrapper` is set in the `ExecStart` clause of the `ntp.service` file. The one provided by Debian will check if a ntp dhcp file is present (which is created by default if DHCP hands out a NTP address) and will use that, ignoring the `/etc/ntp.conf` that we have generated.

This overwrites the upstream provided wrapper script with our own ignoring NTP peers provided via DHCP.

Original PR: https://github.com/truenas/middleware/pull/9646
Jira URL: https://ixsystems.atlassian.net/browse/NAS-115869