### PR TITLE
NAS-117711 / 13.0 / Increase vfs.zfs.zfetch.max_distance to 64MB.

### DIFF
--- a/src/autotune/files/autotune.py
+++ b/src/autotune/files/autotune.py
@@ -241,7 +241,7 @@ def guess_vfs_zfs_vdev_sync_write_max_active():
 
 
 def guess_vfs_zfs_zfetch_max_distance():
-    return 32 * MiB
+    return 64 * MiB
 
 
 def main(argv):


### PR DESCRIPTION
This reflects the new default value in ZFS after my recent speculative
prefetcher improvements.