### PR TITLE
NAS-117144 / 22.12 / Fix api docs not respecting port properly when redirecting

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -196,7 +196,7 @@ http {
 
         location /api/docs {
             proxy_pass http://127.0.0.1:6000/api/docs;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Scheme $scheme;
             proxy_set_header X-Script-Name /api/docs;


### PR DESCRIPTION
## Context

Api docs were getting redirected in case of missing forward slash, but was missing port in case user had it changed. Changing the `$host` changing it to `$host_port` makes it accommodate ports in case of ports in url.