### PR TITLE
NAS-117684 / 22.02.4 / Separately test basic NFS ops for version 3 and version 4 (by anodos325)

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -30,13 +30,6 @@ dataset = f"{pool_name}/nfs"
 dataset_url = dataset.replace('/', '%2F')
 NFS_PATH = "/mnt/" + dataset
 
-Reason = 'BSD host configuration is missing in ixautomation.conf'
-try:
-    from config import BSD_HOST, BSD_USERNAME, BSD_PASSWORD
-    bsd_host_cfg = pytest.mark.skipif(False, reason=Reason)
-except ImportError:
-    bsd_host_cfg = pytest.mark.skipif(True, reason=Reason)
-
 
 def parse_exports():
     results = SSH_TEST("cat /etc/exports", user, password, ip)
@@ -203,69 +196,20 @@ def test_09_checking_to_see_if_nfs_service_is_running(request):
     assert results.json()[0]["state"] == "RUNNING", results.text
 
 
-@bsd_host_cfg
-def test_11_creating_nfs_mountpoint(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST(f'mkdir -p "{MOUNTPOINT}"',
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
+@pytest.mark.parametrize('vers', [3, 4])
+def test_10_perform_basic_nfs_ops(request, vers):
+    with SSH_NFS(ip, NFS_PATH, vers=vers, user=user, password=password, ip=ip) as n:
+        n.create('testfile')
+        n.mkdir('testdir')
+        contents = n.ls('.')
+        assert 'testdir' in contents
+        assert 'testfile' in contents
 
-
-@bsd_host_cfg
-@pytest.mark.timeout(10)
-def test_12_mounting_nfs(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = f'mount_nfs {ip}:{NFS_PATH} {MOUNTPOINT}'
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_13_creating_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'touch "%s/testfile"' % MOUNTPOINT
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_14_moving_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_15_copying_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_16_deleting_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_17_unmounting_nfs(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_18_removing_nfs_mountpoint(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
+        n.unlink('testfile')
+        n.rmdir('testdir')
+        contents = n.ls('.')
+        assert 'testdir' not in contents
+        assert 'testfile' not in contents
 
 
 def test_19_updating_the_nfs_service(request):
@@ -296,72 +240,6 @@ def test_21_checking_to_see_if_nfs_service_is_enabled(request):
     depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results.text
-
-
-@bsd_host_cfg
-# Now check if we can mount NFS / create / rename / copy / delete / umount
-def test_22_creating_nfs_mountpoint(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-@pytest.mark.timeout(10)
-def test_23_mounting_nfs(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'mount_nfs %s:%s %s' % (ip, NFS_PATH, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_24_creating_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'touch "%s/testfile"' % MOUNTPOINT
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_25_moving_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_26_copying_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_27_deleting_nfs_file(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_28_unmounting_nfs(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
-
-
-@bsd_host_cfg
-def test_29_removing_nfs_mountpoint(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
-    cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
-    assert results['result'] is True, results['output']
 
 
 def test_30_add_second_nfs_path(request):

--- a/tests/protocols.py
+++ b/tests/protocols.py
@@ -560,6 +560,48 @@ class SSH_NFS(NFS):
 
         return
 
+    def mkdir(self, path):
+        mkdir = SSH_TEST(
+            f"mkdir {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if mkdir['result'] == False:
+            raise RuntimeError(mkdir['stderr'])
+
+    def rmdir(self, path):
+        rmdir = SSH_TEST(
+            f"rmdir {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if rmdir['result'] == False:
+            raise RuntimeError(rmdir['stderr'])
+
+    def ls(self, path):
+        ls = SSH_TEST(
+            f"ls {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if ls['result'] == False:
+            raise RuntimeError(ls['stderr'])
+
+        return ls['output']
+
+    def rename(self, src, dst): 
+        mv = SSH_TEST(
+            f"mv {self._localpath}/{path} {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if mv['result'] == False:
+            raise RuntimeError(mv['stderr'])
+
+    def unlink(self, path):
+        rm = SSH_TEST(
+            f"rm {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if rm['result'] == False:
+            raise RuntimeError(rm['stderr'])
+
     def getacl(self, path):
         self.validate(path)
         getfacl = SSH_TEST(


### PR DESCRIPTION
This simplifies / reduces test count and also adds coverage
for basic ops over V4 protocol.

Original PR: https://github.com/truenas/middleware/pull/9639
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117684