### PR TITLE
NAS-117663 / 13.0 / Revert "Load vendor's Realtek NIC driver. (#9075)"

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -39,10 +39,6 @@ hpt27xx_load="YES"
 hptnr_load="YES"
 hptrr_load="YES"
 
-# Load vendor's Realtek NIC driver, supporting 2.5G Realtek RTL8125.
-if_re_load="YES"
-if_re_name="/boot/modules/if_re.ko"
-
 # Disable IPv6 link local addresses.  We'll enable this per interface
 # if IPv6 is configured for the interface later on in boot.
 net.inet6.ip6.auto_linklocal="0"


### PR DESCRIPTION
Appears the vendor driver can not handle physically non-contiguous
mbufs, that cause data corruptions with our iSCSI target.  Other
protocols should work fine, but we don't want to risk user data.

This reverts commit 2a15f78a84cb7c19c9be9457a97fa4b9fbaa2fc6.