### PR TITLE
NAS-117614 / 22.12 / Isolate middlewared run files in a dedicated directory

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -1,6 +1,6 @@
 from . import ejson as json
 from .protocol import DDPProtocol
-from .utils import ProgressBar
+from .utils import MIDDLEWARE_RUN_DIR, ProgressBar
 from collections import defaultdict, namedtuple, Callable
 from threading import Event as TEvent, Lock, Thread
 from ws4py.client.threadedclient import WebSocketClient
@@ -302,7 +302,7 @@ class Client(object):
         self._py_exceptions = py_exceptions
         self._event_callbacks = defaultdict(list)
         if uri is None:
-            uri = 'ws+unix:///var/run/middlewared.sock'
+            uri = f'ws+unix://{MIDDLEWARE_RUN_DIR}/middlewared.sock'
         self._closed = Event()
         self._connected = Event()
         self._ws = WSClient(

--- a/src/middlewared/middlewared/client/utils.py
+++ b/src/middlewared/middlewared/client/utils.py
@@ -1,6 +1,9 @@
 import sys
 
 
+MIDDLEWARE_RUN_DIR = '/var/run/middleware'
+
+
 class Struct:
     """
     Simpler wrapper to access using object attributes instead of keys.

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -45,7 +45,7 @@ from zettarepl.zettarepl import create_zettarepl
 from middlewared.client import Client, ClientException
 from middlewared.logger import reconfigure_logging, setup_logging
 from middlewared.service import CallError, Service
-from middlewared.utils import start_daemon_thread
+from middlewared.utils import MIDDLEWARE_RUN_DIR, start_daemon_thread
 from middlewared.utils.cgroups import move_to_root_cgroups
 from middlewared.utils.size import format_size
 import middlewared.utils.osc as osc
@@ -165,7 +165,7 @@ class ZettareplProcess:
                 handler.addFilter(LongStringsFilter())
                 handler.addFilter(ReplicationTaskLoggingLevelFilter(default_level))
 
-            c = Client('ws+unix:///var/run/middlewared-internal.sock', py_exceptions=True)
+            c = Client(f'ws+unix://{MIDDLEWARE_RUN_DIR}/middlewared-internal.sock', py_exceptions=True)
             c.subscribe('core.reconfigure_logging', lambda *args, **kwargs: reconfigure_logging())
 
             definition = Definition.from_data(self.definition, raise_on_error=False)

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -27,7 +27,7 @@ from middlewared.service_exception import (  # noqa
     CallException, CallError, InstanceNotFound, ValidationError, ValidationErrors
 )
 from middlewared.settings import conf
-from middlewared.utils import filter_list, osc
+from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR, osc
 from middlewared.utils.debug import get_frame_details, get_threads_stacks
 from middlewared.logger import Logger, reconfigure_logging, stop_logging
 from middlewared.job import Job
@@ -40,7 +40,7 @@ PeriodicTaskDescriptor = namedtuple("PeriodicTaskDescriptor", ["interval", "run_
 get_or_insert_lock = asyncio.Lock()
 LOCKS = defaultdict(asyncio.Lock)
 THREADING_LOCKS = defaultdict(threading.Lock)
-MIDDLEWARE_STARTED_SENTINEL_PATH = "/var/run/middlewared-started"
+MIDDLEWARE_STARTED_SENTINEL_PATH = os.path.join(MIDDLEWARE_RUN_DIR, "middlewared-started")
 
 
 def lock(lock_str):

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -14,6 +14,7 @@ from middlewared.utils.threading import start_daemon_thread  # noqa
 BUILDTIME = None
 VERSION = None
 MID_PID = None
+MIDDLEWARE_RUN_DIR = '/var/run/middleware'
 
 logger = logging.getLogger(__name__)
 

--- a/src/middlewared/middlewared/worker.py
+++ b/src/middlewared/middlewared/worker.py
@@ -8,6 +8,7 @@ import setproctitle
 
 from . import logger
 from .common.environ import environ_update
+from .utils import MIDDLEWARE_RUN_DIR
 from .utils.plugins import LoadPluginsMixin
 import middlewared.utils.osc as osc
 from .utils.service.call import MethodNotFoundError, ServiceCallMixin
@@ -30,7 +31,7 @@ class FakeMiddleware(LoadPluginsMixin, ServiceCallMixin):
 
     def _call(self, name, serviceobj, methodobj, params=None, app=None, pipes=None, job=None):
         try:
-            with Client('ws+unix:///var/run/middlewared-internal.sock', py_exceptions=True) as c:
+            with Client(f'ws+unix://{MIDDLEWARE_RUN_DIR}/middlewared-internal.sock', py_exceptions=True) as c:
                 self.client = c
                 job_options = getattr(methodobj, '_job', None)
                 if job and job_options:
@@ -131,7 +132,7 @@ def reconfigure_logging(mtype, **message):
 
 
 def receive_events():
-    c = Client('ws+unix:///var/run/middlewared-internal.sock', py_exceptions=True)
+    c = Client(f'ws+unix://{MIDDLEWARE_RUN_DIR}/middlewared-internal.sock', py_exceptions=True)
     c.subscribe('core.environ', lambda *args, **kwargs: environ_update(kwargs['fields']))
     c.subscribe('core.reconfigure_logging', reconfigure_logging)
 


### PR DESCRIPTION
## Context

It was requested that we isolate middleware related files under a dedicated directory under `/var/run`. The same is advised by [FHS standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html) when a program is to use multiple sentinel files.