### PR TITLE
NAS-117699 / 22.02.4 / Add test for NFS server-side-copy (by anodos325)

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -212,6 +212,11 @@ def test_10_perform_basic_nfs_ops(request, vers):
         assert 'testfile' not in contents
 
 
+def test_11_perform_server_side_copy(request):
+    with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip) as n:
+        n.server_side_copy('ssc1', 'ssc2')
+
+
 def test_19_updating_the_nfs_service(request):
     """
     This test verifies that service can be updated in general,


### PR DESCRIPTION
Test this by running an ad-hoc python script calling
the relevant syscalls.

Original PR: https://github.com/truenas/middleware/pull/9662
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117699