### PR TITLE
NAS-116662 / 22.12 / Have persistent swap mirrors

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -137,6 +137,7 @@ class DiskService(Service):
                 'path': swap_device['path'],
                 'encrypted_provider': swap_device['encrypted_provider'],
             }
+            await run('mdadm', '--zero-superblock', '--force', swap_device['path'], encoding='utf8', check=False)
 
         created_swap_devices = []
         for swap_path, data in create_swap_devices.items():

--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -105,7 +105,7 @@ class DiskService(Service):
                     # If something failed here there is no point in trying to create the mirror
                     continue
 
-                swap_path = await self.middleware.call('disk.new_swap_name')
+                swap_path = await self.new_swap_name()
                 if not swap_path:
                     # Which means maximum has been reached and we can stop
                     break
@@ -192,16 +192,17 @@ class DiskService(Service):
         return existing_swap_devices['partitions'] + existing_swap_devices['mirrors'] + created_swap_devices
 
     @private
-    def new_swap_name(self):
+    async def new_swap_name(self):
         """
         Get a new name for a swap mirror
 
         Returns:
             str: name of the swap mirror
         """
+        used_names = [mirror['name'] for mirror in await self.middleware.call('disk.get_swap_mirrors')]
         for i in range(MIRROR_MAX):
             name = f'swap{i}'
-            if not os.path.exists(os.path.join('/dev/md', name)):
+            if name not in used_names:
                 return name
 
     @private

--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -29,6 +29,7 @@ class DiskService(Service):
         mirrors = await self.middleware.call('disk.get_swap_mirrors')
         encrypted_mirrors = {m['encrypted_provider']: m for m in mirrors if m['encrypted_provider']}
         all_partitions = {p['name']: p for p in await self.middleware.call('disk.list_all_partitions')}
+        await self.middleware.call('disk.remove_degraded_mirrors')
 
         for device in await self.middleware.call('disk.get_swap_devices'):
             if device in encrypted_mirrors or device.startswith(('/dev/md', '/dev/mirror/')):

--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -47,7 +47,7 @@ class DiskService(Service):
 
                 real_path = os.path.realpath(array.path)
                 mirror = {
-                    'name': array.name,
+                    'name': array.name.split(':')[-1],
                     'path': array.path,
                     'real_path': real_path,
                     'encrypted_provider': None,

--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -30,6 +30,12 @@ class DiskService(Service):
         if cp.returncode:
             raise CallError(f'Failed to stop mirror {name!r}: {cp.stderr}')
 
+        await run(
+            'mdadm', '--zero-superblock', '--force',
+            *[os.path.join('/dev', provider['name']) for provider in mirror['providers']],
+            encoding='utf8', check=False
+        )
+
     @private
     @filterable
     def get_swap_mirrors(self, filters, options):

--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -11,9 +11,10 @@ class DiskService(Service):
     @private
     async def create_swap_mirror(self, name, options):
         extra = options['extra']
+        await run('mdadm', '--zero-superblock', '--force', *options['paths'], encoding='utf8', check=False)
         cp = await run(
-            'mdadm', '--build', os.path.join('/dev/md', name), f'--level={extra.get("level", 1)}',
-            f'--raid-devices={len(options["paths"])}', *options['paths'], encoding='utf8', check=False,
+            'mdadm', '--create', os.path.join('/dev/md', name), f'--level={extra.get("level", 1)}',
+            f'--raid-devices={len(options["paths"])}', '--meta=1.2', *options['paths'], encoding='utf8', check=False,
         )
         if cp.returncode:
             raise CallError(f'Failed to create mirror {name}: {cp.stderr}')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -42,6 +42,7 @@ class KubernetesService(ConfigService):
         'kubernetes_entry',
         Bool('servicelb', required=True),
         Bool('configure_gpus', required=True),
+        Bool('validate_host_path', required=True),
         Str('pool', required=True, null=True),
         IPAddr('cluster_cidr', required=True, cidr=True, empty=True),
         IPAddr('service_cidr', required=True, cidr=True, empty=True),

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1844,6 +1844,8 @@ class PoolService(CRUDService):
         if os.path.exists(ZPOOL_CACHE_FILE):
             shutil.copy(ZPOOL_CACHE_FILE, zpool_cache_saved)
 
+        # Now finally configure swap to manage any disks which might have been removed
+        self.middleware.call_sync('disk.swaps_configure')
         self.middleware.call_hook_sync('pool.post_import', None)
         job.set_progress(100, 'Pools import completed')
 

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -169,7 +169,10 @@ async def zfs_events(middleware, data):
         # Swap must be configured only on disks being used by some pool,
         # for this reason we must react to certain types of ZFS events to keep
         # it in sync every time there is a change.
-        asyncio.ensure_future(middleware.call('disk.swaps_configure'))
+        if await middleware.call('system.ready'):
+            # We only want to configure swap if system is ready as otherwise when the pools have not been
+            # imported, middleware will remove swap disks as all pools might not have imported
+            asyncio.ensure_future(middleware.call('disk.swaps_configure'))
         if event_id == 'sysevent.fs.zfs.config_sync' and data.get('pool') and data.get('pool_guid'):
             # This event is issued whenever a vdev change is done to a pool
             # Checking pool_guid ensures that we do not do this on creation/deletion of pool as we expect the


### PR DESCRIPTION
This PR adds changes to fix following issues:

1. Have persistent swap mirrors as right now on each reboot, they are re-created which is an expensive process and can slow down boot process.
2. `swaps_configure` was being called numerous times during boot phase when no pool had imported which resulted in the method removing mirrors and re-configuring swap.
3. Correctly get new unused swap mirror name.