### PR TITLE
NAS-117806 / 22.12 / update network configuration domain to match AD one

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -484,6 +484,19 @@ class ActiveDirectoryService(TDBWrapConfigService):
 
         job = None
         if not old['enable'] and new['enable']:
+            ngc = await self.middleware.call('network.configuration.config')
+            if not ngc['domain'] or ngc['domain'] == 'local':
+                try:
+                    await self.middleware.call(
+                        'network.configuration.update',
+                        {'domain': ret['domainname']}
+                    )
+                except CallError:
+                    self.logger.warning(
+                        'Failed to update domain name in network configuration '
+                        'to match active directory value of %s', ret['domainname'], exc_info=True
+                    )
+
             job = (await self.middleware.call('activedirectory.start')).id
 
         elif not new['enable'] and old['enable']:


### PR DESCRIPTION
This PR fixes domain join failures in Samba 4.17 where libads now
more strictly checks that the domain is properly initialized.