### PR TITLE
NAS-117777 / 22.12 / Create SMB directories before reconfiguring logging

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -330,12 +330,13 @@ class SystemDatasetService(ConfigService):
         await self.middleware.call('etc.generate', 'glusterd')
 
         if mounted:
+            await self.middleware.call('smb.setup_directories')
+
             # There is no need to wait this to finish
             # Restarting rrdcached will ensure that we start/restart collectd as well
             asyncio.ensure_future(self.middleware.call('service.restart', 'rrdcached'))
             asyncio.ensure_future(self.middleware.call('service.restart', 'syslogd'))
 
-            await self.middleware.call('smb.setup_directories')
             # The following should be backgrounded since they may be quite
             # long-running.
             await self.middleware.call('smb.configure', False)


### PR DESCRIPTION
syslogd restart has logic to copy directories into a new syslog dir.
Creating samba's logdir before triggering the syslogd restart
ensures that at least these things are happening in a defined order.