### PR TITLE
NAS-117655 / 22.02.4 / Directly query ldap config while validating AD config (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -246,8 +246,8 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if not new["enable"]:
             return
 
-        ds_state = await self.middleware.call('directoryservices.get_state')
-        if ds_state['ldap'] != 'DISABLED':
+        ldap_enabled = (await self.middleware.call('ldap.config'))['enable']
+        if ldap_enabled:
             verrors.add(
                 "activedirectory_update.enable",
                 "Active Directory service may not be enabled while LDAP service is enabled."


### PR DESCRIPTION
LDAP configuration is now clustered and so we can safely get config
directly to determine whether or not there is a service setting
conflict between AD and LDAP.

Original PR: https://github.com/truenas/middleware/pull/9681
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117655