### PR TITLE
NAS-117825 / 22.12 / Remove python nslcd client

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
@@ -97,15 +97,6 @@ ldap_func()
 	sc "${NSLCD_CONF}" | grep -iv bindpw
 	section_footer
 
-	#
-	#	Dump nslcd state
-	#
-	if [ "${enabled}" = "ENABLED" ]
-	then
-	section_header "NSLCD health check - midclt call ldap.get_nslcd_status"
-	midclt call ldap.get_nslcd_status | jq
-	section_footer
-
 	section_header "ROOT DSE"
 	midclt call ldap.get_root_DSE | jq
 	section_footer


### PR DESCRIPTION
In TrueNAS 11.3 we transitioned from using SSSD for LDAP integration
to using nss-pam-ldapd. There was some concern at the time that
support may need ability to peek more closely into internal
state of the nslcd daemon to debug connectivity issues. Over the
past years since its adoption nscld has proven to be incredibly
stable and dependable for customers and this feature hasn't been
used. Remove it to reduce code maintenance overhead.