### PR TITLE
NAS-115992 / 22.02.4 / Add plumbing for NFSv4 domain override to idmap config (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/idmapd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/idmapd.conf.mako
@@ -1,11 +1,12 @@
 <%
     config = render_ctx["nfs.config"]
-    if not config["v4"]:
-        raise FileShouldNotExist()
 %>
 
 [General]
 Verbosity = 0
+% if config['v4_domain']:
+Domain = ${config['v4_domain']}
+% endif
 
 [Mapping]
 Nobody-User = nobody


### PR DESCRIPTION
Allow overriding the default NFSv4 domain based on key in the NFS config.
Since there's no real harm in generating this file if NFS is disabled, also remove
check for v4 during generation.

Original PR: https://github.com/truenas/middleware/pull/9688
Jira URL: https://ixsystems.atlassian.net/browse/NAS-115992