### PR TITLE
NAS-117624 / 22.12 / Fix vm devices choices

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -61,7 +61,7 @@ class VMDeviceService(CRUDService):
                 ['OR', [['attachment', '=', None], ['attachment.method', '=', 'vm.devices.query']]],
                 ['ro', '=', False],
             ],
-            {}, ['ATTACHMENT']
+            {}, ['ATTACHMENT', 'RO']
         )
 
         for zvol in zvols:

--- a/tests/api2/test_540_vm.py
+++ b/tests/api2/test_540_vm.py
@@ -10,6 +10,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, PUT, DELETE
 from auto_config import dev_test, ha
+from middlewared.test.integration.assets.pool import dataset
+
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for development testing')
 
@@ -104,3 +106,13 @@ if support_virtualization:
     def test_11_delete_vm(data):
         results = DELETE(f'/vm/id/{data["vmid"]}/')
         assert results.status_code == 200, results.text
+
+
+def test_12_vm__disk_choices(request):
+    with dataset('test zvol', {
+        'type': 'VOLUME',
+        'volsize': 1024000,
+    }) as ds:
+        results = GET('/vm/device/disk_choices')
+        assert isinstance(results.json(), dict) is True
+        assert results.json().get(f'/dev/zvol/{ds.replace(" ", "+")}') == f'{ds}'


### PR DESCRIPTION
## Context

`zfs.dataset.unlocked_zvols_fast` requires `RO` additional attribute to retrieve zvol read only status as we are using a filter to explicitly retrieve the results.