### PR TITLE
NAS-117471 / 22.02.4 / Improve AD health checks (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/active_directory/active_directory.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/active_directory/active_directory.sh
@@ -179,6 +179,13 @@ active_directory_func()
 	section_footer
 	fi
 
+	if [ "${enabled}" = "ENABLED" ]
+	then
+	section_header "Active Directory machine account status"
+	midclt call activedirectory.machine_account_status
+	section_footer
+	fi
+
 	#
 	#	Dump results clockskew check
 	#


### PR DESCRIPTION
* Make wbinfo subprocess synchronous
* Add method to use the stored machine account password to get AD
  status.
* Include new machine_account_status in debug

Original PR: https://github.com/truenas/middleware/pull/9552
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117471