### PR TITLE
NAS-117858 / 22.02.4 / Relax validation for FreeBSD VFS modules (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1380,10 +1380,7 @@ class SharingSMBService(SharingService):
             'insecure wide links'
         ]
         freebsd_vfs_objects = [
-            'zfsacl',
-            'zfs_space',
             'noacl',
-            'ixnas',
         ]
         for entry in data.splitlines():
             if entry == '' or entry.startswith(('#', ';')):

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -55,7 +55,7 @@ class ShareSchema(RegistrySchema):
                                    'acl_xattr', 'nfs4acl_xattr', 'glusterfs',
                                    'winmsa', 'recycle', 'crossrename', 'zfs_core', 'aio_fbsd', 'io_uring')
 
-            invalid_vfs_objects = ['zfsacl', 'ixnas', 'noacl', 'zfs_space']
+            invalid_vfs_objects = ['noacl']
             cluster_safe_objects = ['catia', 'fruit', 'streams_xattr', 'acl_xattr', 'recycle', 'glusterfs', 'io_ring']
 
             vfs_objects_ordered = []


### PR DESCRIPTION
We have added linux libraries to make these VFS modules work
on SCALE. We can now allow them to pass validation

Original PR: https://github.com/truenas/middleware/pull/9703
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117858