### PR TITLE
NAS-117814 / 22.12 / Fix broken k8s cluster initialization

### DIFF
--- a/src/middlewared/middlewared/etc_files/cni/net.d/kube-router.d/kubeconfig.mako
+++ b/src/middlewared/middlewared/etc_files/cni/net.d/kube-router.d/kubeconfig.mako
@@ -4,6 +4,7 @@
         middleware.logger.debug('Kube-router CNI configuration not generated due to missing credentials.')
         raise FileShouldNotExist()
     kube_router = config['cni_config']['kube_router']
+    cluster_ca = middleware.call_sync('k8s.node.get_cluster_ca')
 %>\
 apiVersion: v1
 clusterCIDR: ${config["cluster_cidr"]}
@@ -12,7 +13,7 @@ clusters:
 - name: cluster
   cluster:
     server: https://127.0.0.1:6443
-    certificate-authority-data: ${kube_router['ca']}
+    certificate-authority-data: ${cluster_ca}
 users:
 - name: kube-router
   user:

--- a/src/middlewared/middlewared/etc_files/cni/net.d/multus.d/multus.kubeconfig.mako
+++ b/src/middlewared/middlewared/etc_files/cni/net.d/multus.d/multus.kubeconfig.mako
@@ -4,6 +4,7 @@
         middleware.logger.debug('Multus CNI configuration not generated due to missing credentials.')
         raise FileShouldNotExist()
     multus = config['cni_config']['multus']
+    cluster_ca = middleware.call_sync('k8s.node.get_cluster_ca')
 %>\
 apiVersion: v1
 kind: Config
@@ -11,7 +12,7 @@ clusters:
 - name: local
   cluster:
     server: https://127.0.0.1:6443
-    certificate-authority-data: ${multus['ca']}
+    certificate-authority-data: ${cluster_ca}
 users:
 - name: multus
   user:


### PR DESCRIPTION
## Problem

We recently updated kubernetes to `1.24` which disabled automatic generations of access tokens for service accounts. How this affected us was that we run CNI ourselves as systemd service (at least for `kube-router` as `multus` does not run as service) - their respective service accounts were created automatically but their respective access tokens were not being generated anymore as k8s had removed that functionality in favour of explicitly creating these..

## Solution

Create access tokens for respective service accounts ourselves