### PR TITLE
NAS-117848 / 22.12 / fix ipmi plugin and fix openipmi service

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -70,6 +70,7 @@ systemctl enable zfs-zed
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 systemctl mask exim4-base.service exim4.service
 systemctl mask uuidd.service uuidd.socket
+systemctl mask openipmi.service
 
 # We don't use LVM and this service can add significant boot delays
 # on large disk systems

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -39,6 +39,7 @@ systemctl disable smbd
 systemctl disable winbind
 systemctl disable wsdd
 systemctl disable walinuxagent
+systemctl disable openipmi
 
 # nvidia-persistenced is not respecting vendor preset file so we disable it explicitly
 systemctl disable nvidia-persistenced
@@ -70,7 +71,6 @@ systemctl enable zfs-zed
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 systemctl mask exim4-base.service exim4.service
 systemctl mask uuidd.service uuidd.socket
-systemctl mask openipmi.service
 
 # We don't use LVM and this service can add significant boot delays
 # on large disk systems

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -203,3 +203,12 @@ class IPMIService(CRUDService):
     def clear_sel(self):
         """Clear IPMI system event log."""
         run(['ipmitool', 'sel', 'clear'], stdout=DEVNULL, stderr=DEVNULL)
+
+
+async def setup(middleware):
+    if await middleware.call('system.ready') and (await middleware.call('system.dmidecode_info'))['has-ipmi']:
+        # systemd generates a unit file that doesn't honor presets so when it's started on a system without a
+        # BMC device, it always reports as a failure which is expected since no IPMI device exists. Instead
+        # we check to see if dmidecode reports an ipmi device via type "38" of the SMBIOS spec. It's not
+        # fool-proof but it's the best we got atm.
+        await middleware.call('service.start', 'openipmi')

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -78,7 +78,7 @@ class IPMIService(CRUDService):
                 elif name == 'IP Address Source':
                     data['dhcp'] = False if value == 'Static Address' else True
 
-                result.append(data)
+            result.append(data)
 
         return filter_list(result, filters, options)
 

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -82,79 +82,81 @@ class IPMIService(CRUDService):
 
         return filter_list(result, filters, options)
 
-    @accepts(Int('channel'), Dict(
-        'ipmi_update',
-        IPAddr('ipaddress', v6=False),
-        Str('netmask', validators=[Netmask(ipv6=False, prefix_length=False)]),
-        IPAddr('gateway', v6=False),
-        Password('password', validators=[
-            PasswordComplexity(["ASCII_UPPER", "ASCII_LOWER", "DIGIT", "SPECIAL"], 3),
-            Range(8, 16)
-        ]),
-        Bool('dhcp'),
-        Int('vlan', null=True),
-        register=True
-    ))
-    async def do_update(self, id, data):
+    @accepts(
+        Int('channel'),
+        Dict(
+            'ipmi_update',
+            IPAddr('ipaddress', v6=False),
+            Str('netmask', validators=[Netmask(ipv6=False, prefix_length=False)]),
+            IPAddr('gateway', v6=False),
+            Password('password', validators=[
+                PasswordComplexity(["ASCII_UPPER", "ASCII_LOWER", "DIGIT", "SPECIAL"], 3),
+                Range(8, 16)
+            ]),
+            Bool('dhcp'),
+            Int('vlan', null=True),
+            register=True
+        )
+    )
+    def do_update(self, id, data):
         """
-        Update `id` IPMI Configuration.
+        Update IPMI configuration on channel number `id`.
 
-        `ipaddress` is a valid ip which will be used to connect to the IPMI interface.
-
+        `ipaddress` is an IPv4 address to be assigned to channel number `id`.
         `netmask` is the subnet mask associated with `ipaddress`.
-
-        `dhcp` is a boolean value which if unset means that `ipaddress`, `netmask` and `gateway` must be set.
+        `gateway` is an IPv4 address used by `ipaddress` to reach outside the local subnet.
+        `password` is a password to be assigned to channel number `id`
+        `dhcp` is a boolean. If False, `ipaddress`, `netmask` and `gateway` must be set.
+        `vlan` is an integer representing the vlan tag number.
         """
-
-        if not await self.middleware.call('ipmi.is_loaded'):
-            raise CallError('The ipmi device could not be found')
-
         verrors = ValidationErrors()
-
-        if not data.get('dhcp'):
+        if not self.is_loaded():
+            verrors.add('ipmi.update', f'{IPMI_DEV!r} could not be found')
+        elif id not in self.channels():
+            verrors.add('ipmi.update', f'IPMI channel number {id!r} not found')
+        elif not data.get('dhcp'):
             for k in ['ipaddress', 'netmask', 'gateway']:
                 if not data.get(k):
-                    verrors.add(
-                        f'ipmi_update.{k}',
-                        'This field is required when dhcp is not given'
-                    )
+                    verrors.add(f'ipmi_update.{k}', 'This field is required when dhcp is false.')
+        verrors.check()
 
-        if verrors:
-            raise verrors
+        def get_cmd(cmds):
+            nonlocal id
+            return ['ipmitool', 'lan', 'set', f'{id}'] + cmds
 
-        args = ['ipmitool', 'lan', 'set', str(id)]
-        rv = 0
+        rc = 0
+        options = {'stdout': DEVNULL, 'stderr': DEVNULL}
         if data.get('dhcp'):
-            rv |= (await run(*args, 'ipsrc', 'dhcp', check=False)).returncode
+            rc |= run(get_cmd(id, ['dhcp']), **options).returncode
         else:
-            rv |= (await run(*args, 'ipsrc', 'static', check=False)).returncode
-            rv |= (await run(*args, 'ipaddr', data['ipaddress'], check=False)).returncode
-            rv |= (await run(*args, 'netmask', data['netmask'], check=False)).returncode
-            rv |= (await run(*args, 'defgw', 'ipaddr', data['gateway'], check=False)).returncode
-        rv |= (await run(
-            *args, 'vlan', 'id', str(data['vlan']) if data.get('vlan') else 'off'
-        )).returncode
+            rc |= run(get_cmd(['ipsrc', 'static'], **options)).returncode
+            rc |= run(get_cmd(['ipaddr', data['ipaddress']], **options)).returncode
+            rc |= run(get_cmd(['netmask', data['netmask']], **options)).returncode
+            rc |= run(get_cmd(['defgw', 'ipaddr', data['gateway']], **options)).returncode
 
-        rv |= (await run(*args, 'access', 'on', check=False)).returncode
-        rv |= (await run(*args, 'auth', 'USER', 'MD2,MD5', check=False)).returncode
-        rv |= (await run(*args, 'auth', 'OPERATOR', 'MD2,MD5', check=False)).returncode
-        rv |= (await run(*args, 'auth', 'ADMIN', 'MD2,MD5', check=False)).returncode
-        rv |= (await run(*args, 'auth', 'CALLBACK', 'MD2,MD5', check=False)).returncode
-        # Setting arp have some issues in some hardwares
-        # Do not fail if setting these couple settings do not work
-        # See #15578
-        await run(*args, 'arp', 'respond', 'on', check=False)
-        await run(*args, 'arp', 'generate', 'on', check=False)
-        if data.get('password'):
-            rv |= (await run(
-                'ipmitool', 'user', 'set', 'password', '2', data.get('password'),
-            )).returncode
-        rv |= (await run('ipmitool', 'user', 'enable', '2')).returncode
-        # XXX: according to dwhite, this needs to be executed off the box via
-        # the lanplus interface.
-        # rv |= (await run('ipmitool', 'sol', 'set', 'enabled', 'true', '1')).returncode
-        # )
-        return rv
+        rc |= run(get_cmd(['vlan', 'id', f'{data.get("vlan", "off")}'], **options)).returncode
+
+        rc |= run(get_cmd(['access', 'on'], **options)).returncode
+        rc |= run(get_cmd(['auth', 'USER', 'MD2,MD5'], **options)).returncode
+        rc |= run(get_cmd(['auth', 'OPERATOR', 'MD2,MD5'], **options)).returncode
+        rc |= run(get_cmd(['auth', 'ADMIN', 'MD2,MD5'], **options)).returncode
+        rc |= run(get_cmd(['auth', 'CALLBACK', 'MD2,MD5'], **options)).returncode
+
+        # Apparently tickling these ARP options can "fail" on certain hardware
+        # which isn't fatal so we ignore returncode in this instance. See #15578.
+        run(get_cmd(['arp', 'respond', 'on'], **options))
+        run(get_cmd(['arp', 'generate', 'on'], **options))
+
+        if passwd := data.get('password'):
+            cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)
+            if cp.returncode != 0:
+                raise CallError(f'Failed setting password: {cp.stderr!r}')
+
+        cp = run(get_cmd(['ipmitool', 'user', 'enable', '2']), capture_output=True)
+        if cp.returncode != 0:
+            raise CallError(f'Failed enabling user: {cp.stderr!r}')
+
+        return rc
 
     @accepts(Dict(
         'options',

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -150,11 +150,11 @@ class IPMIService(CRUDService):
         if passwd := data.get('password'):
             cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)
             if cp.returncode != 0:
-                raise CallError(f'Failed setting password: {cp.stderr!r}')
+                raise CallError(f'Failed setting password: {cp.stderr.decode()!r}')
 
-        cp = run(get_cmd(['ipmitool', 'user', 'enable', '2']), capture_output=True)
+        cp = run(['ipmitool', 'user', 'enable', '2'], capture_output=True)
         if cp.returncode != 0:
-            raise CallError(f'Failed enabling user: {cp.stderr!r}')
+            raise CallError(f'Failed enabling user: {cp.stderr.decode()!r}')
 
         return rc
 

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -1,11 +1,11 @@
+import os
+import subprocess
+
 from middlewared.plugins.ipmi_.utils import parse_ipmitool_output
 from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Patch, Password, returns, Str
 from middlewared.service import CallError, CRUDService, filterable, ValidationErrors
 from middlewared.utils import filter_list, run
 from middlewared.validators import Netmask, PasswordComplexity, Range
-
-import os
-import subprocess
 
 channels = []
 

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -8,6 +8,7 @@ from middlewared.utils import filter_list, run
 from middlewared.validators import Netmask, PasswordComplexity, Range
 
 channels = []
+IPMI_DEV = '/dev/ipmi0'
 
 
 class IPMIService(CRUDService):
@@ -24,11 +25,9 @@ class IPMIService(CRUDService):
 
     @accepts()
     @returns(Bool('ipmi_loaded'))
-    async def is_loaded(self):
-        """
-        Returns a boolean true value indicating if ipmi device is loaded.
-        """
-        return os.path.exists('/dev/ipmi0')
+    def is_loaded(self):
+        """Returns a boolean value indicating if `IPMI_DEV` is loaded."""
+        return os.path.exists(IPMI_DEV)
 
     @accepts()
     @returns(List('ipmi_channels', items=[Int('ipmi_channel')]))
@@ -103,7 +102,7 @@ class IPMIService(CRUDService):
         `dhcp` is a boolean value which if unset means that `ipaddress`, `netmask` and `gateway` must be set.
         """
 
-        if not await self.is_loaded():
+        if not await self.middleware.call('ipmi.is_loaded'):
             raise CallError('The ipmi device could not be found')
 
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -150,11 +150,13 @@ class IPMIService(CRUDService):
         if passwd := data.get('password'):
             cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)
             if cp.returncode != 0:
-                raise CallError(f'Failed setting password: {cp.stderr.decode()!r}')
+                err = '\n'.join(cp.stderr.decode().split('\n'))
+                raise CallError(f'Failed setting password: {err!r}')
 
         cp = run(['ipmitool', 'user', 'enable', '2'], capture_output=True)
         if cp.returncode != 0:
-            raise CallError(f'Failed enabling user: {cp.stderr.decode()!r}')
+            err = '\n'.join(cp.stderr.decode().split('\n'))
+            raise CallError(f'Failed enabling user: {err!r}')
 
         return rc
 

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -188,10 +188,13 @@ class IPMIService(CRUDService):
     def query_sel(self, job, filters, options):
         """Query IPMI system extended event log."""
         results = []
+        job.set_progress(50, 'Enumerating extended event log')
         cp = run(['ipmitool', '-c', 'sel', 'elist'], capture_output=True)  # this is slowwww
         if cp.returncode == 0 and cp.stdout:
+            job.set_progress(95, 'Parsing extended event log')
             for record in parse_ipmitool_output(cp.stdout.decode()):
                 results.append(record._asdict())
+            job.set_progress(100, 'Parsing extended event log complete')
 
         return filter_list(results, filters, options)
 

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -1,15 +1,9 @@
-try:
-    from bsd import kld
-except ImportError:
-    kld = None
-
 from middlewared.plugins.ipmi_.utils import parse_ipmitool_output
 from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Patch, Password, returns, Str
 from middlewared.service import CallError, CRUDService, filterable, ValidationErrors
 from middlewared.utils import filter_list, run
 from middlewared.validators import Netmask, PasswordComplexity, Range
 
-import errno
 import os
 import subprocess
 
@@ -202,16 +196,6 @@ class IPMIService(CRUDService):
 
 
 async def setup(middleware):
-
-    try:
-        if kld:
-            kld.kldload('/boot/kernel/ipmi.ko')
-    except OSError as e:
-        # Only skip if not already loaded
-        if e.errno != errno.EEXIST:
-            middleware.logger.warn(f'Cannot load IPMI module: {e}')
-            return
-
     # Scan available channels
     for i in range(1, 17):
         try:

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -129,23 +129,23 @@ class IPMIService(CRUDService):
         if data.get('dhcp'):
             rc |= run(get_cmd(id, ['dhcp']), **options).returncode
         else:
-            rc |= run(get_cmd(['ipsrc', 'static'], **options)).returncode
-            rc |= run(get_cmd(['ipaddr', data['ipaddress']], **options)).returncode
-            rc |= run(get_cmd(['netmask', data['netmask']], **options)).returncode
-            rc |= run(get_cmd(['defgw', 'ipaddr', data['gateway']], **options)).returncode
+            rc |= run(get_cmd(['ipsrc', 'static']), **options).returncode
+            rc |= run(get_cmd(['ipaddr', data['ipaddress']]), **options).returncode
+            rc |= run(get_cmd(['netmask', data['netmask']]), **options).returncode
+            rc |= run(get_cmd(['defgw', 'ipaddr', data['gateway']]), **options).returncode
 
-        rc |= run(get_cmd(['vlan', 'id', f'{data.get("vlan", "off")}'], **options)).returncode
+        rc |= run(get_cmd(['vlan', 'id', f'{data.get("vlan", "off")}']), **options).returncode
 
-        rc |= run(get_cmd(['access', 'on'], **options)).returncode
-        rc |= run(get_cmd(['auth', 'USER', 'MD2,MD5'], **options)).returncode
-        rc |= run(get_cmd(['auth', 'OPERATOR', 'MD2,MD5'], **options)).returncode
-        rc |= run(get_cmd(['auth', 'ADMIN', 'MD2,MD5'], **options)).returncode
-        rc |= run(get_cmd(['auth', 'CALLBACK', 'MD2,MD5'], **options)).returncode
+        rc |= run(get_cmd(['access', 'on']), **options).returncode
+        rc |= run(get_cmd(['auth', 'USER', 'MD2,MD5']), **options).returncode
+        rc |= run(get_cmd(['auth', 'OPERATOR', 'MD2,MD5']), **options).returncode
+        rc |= run(get_cmd(['auth', 'ADMIN', 'MD2,MD5']), **options).returncode
+        rc |= run(get_cmd(['auth', 'CALLBACK', 'MD2,MD5']), **options).returncode
 
         # Apparently tickling these ARP options can "fail" on certain hardware
         # which isn't fatal so we ignore returncode in this instance. See #15578.
-        run(get_cmd(['arp', 'respond', 'on'], **options))
-        run(get_cmd(['arp', 'generate', 'on'], **options))
+        run(get_cmd(['arp', 'respond', 'on']), **options)
+        run(get_cmd(['arp', 'generate', 'on']), **options)
 
         if passwd := data.get('password'):
             cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -56,7 +56,7 @@ class IPMIService(CRUDService):
                 raise CallError(f'Failed to get details from channel {channel}: {cp.stderr}')
 
             data = {'channel': channel, 'id': channel}
-            for line in filter(lambda x: ':' in line, cp.stdout.decode().split('\n')):
+            for line in filter(lambda x: ':' in x, cp.stdout.decode().split('\n')):
                 name, value = line.split(':', 1)
                 if not name:
                     continue

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -27,6 +27,7 @@ from .glusterd import GlusterdService
 from .glustereventsd import GlusterEventsdService
 from .ctdb import CtdbService
 from .idmap import IdmapService
+from .openipmi import OpenIpmiService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
@@ -79,6 +80,7 @@ all_services = [
     LdapService,
     NisService,
     IdmapService,
+    OpenIpmiService,
     KeepalivedService,
     GlusterdService,
     GlusterEventsdService,

--- a/src/middlewared/middlewared/plugins/service_/services/openipmi.py
+++ b/src/middlewared/middlewared/plugins/service_/services/openipmi.py
@@ -1,0 +1,6 @@
+from middlewared.plugins.service_.services.base import SimpleService
+
+
+class LibvirtdService(SimpleService):
+    name = "openipmi"
+    systemd_unit = "openipmi"

--- a/src/middlewared/middlewared/plugins/service_/services/openipmi.py
+++ b/src/middlewared/middlewared/plugins/service_/services/openipmi.py
@@ -1,6 +1,6 @@
 from middlewared.plugins.service_.services.base import SimpleService
 
 
-class LibvirtdService(SimpleService):
+class OpenIpmiService(SimpleService):
     name = "openipmi"
     systemd_unit = "openipmi"

--- a/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/system/test_dmi.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from middlewared.plugins.system_.dmi import SystemService
+from middlewared.plugins.system.dmi import SystemService
 from middlewared.service import Service
 
 
@@ -63,6 +63,15 @@ Base Board Information
         Chassis Handle: 0x0003
         Type: Motherboard
         Contained Object Handles: 0
+
+Handle 0x0014, DMI type 38, 18 bytes
+IPMI Device Information
+        Interface Type: KCS (Keyboard Control Style)
+        Specification Version: 2.0
+        I2C Slave Address: 0x10
+        NV Storage Device: Not Present
+        Base Address: 0x0000000000000CA2 (I/O)
+        Register Spacing: Successive Byte Boundaries
 
 Handle 0x0024, DMI type 16, 23 bytes
 Physical Memory Array
@@ -219,6 +228,86 @@ Base Board Information
 
 """).splitlines()
 
+missing_dmi_type38 = ("""
+# dmidecode 3.3
+Getting SMBIOS data from sysfs.
+SMBIOS 3.2.1 present.
+
+Handle 0x0000, DMI type 0, 26 bytes
+BIOS Information
+        Vendor: American Megatrends Inc.
+        Version: 3.3aV3
+        Release Date: 12/03/2020
+        Address: 0xF0000
+        Runtime Size: 64 kB
+        ROM Size: 32 MB
+        Characteristics:
+                PCI is supported
+                BIOS is upgradeable
+                BIOS shadowing is allowed
+                Boot from CD is supported
+                Selectable boot is supported
+                BIOS ROM is socketed
+                EDD is supported
+                5.25"/1.2 MB floppy services are supported (int 13h)
+                3.5"/720 kB floppy services are supported (int 13h)
+                3.5"/2.88 MB floppy services are supported (int 13h)
+                Print screen service is supported (int 5h)
+                Serial services are supported (int 14h)
+                Printer services are supported (int 17h)
+                ACPI is supported
+                USB legacy is supported
+                BIOS boot specification is supported
+                Targeted content distribution is supported
+                UEFI is supported
+        BIOS Revision: 5.14
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+        Manufacturer: iXsystems
+        Product Name: TRUENAS-M60
+        Version: 0123456789
+        Serial Number: A1-111111
+        UUID: 00000000-0000-0000-0000-3cecef5ee7d6
+        Wake-up Type: Power Switch
+        SKU Number: To be filled by O.E.M.
+        Family: To be filled by O.E.M.
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Supermicro
+        Product Name: X11SPH-nCTPF
+        Version: 1.01
+        Serial Number: 0000000000000
+        Asset Tag: To be filled by O.E.M.
+        Features:
+                Board is a hosting board
+                Board is replaceable
+        Location In Chassis: To be filled by O.E.M.
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+Handle 0x0024, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: System Board Or Motherboard
+        Use: System Memory
+        Error Correction Type: Single-bit ECC
+        Maximum Capacity: 2304 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 4
+
+Handle 0x002C, DMI type 16, 23 bytes
+Physical Memory Array
+        Location: System Board Or Motherboard
+        Use: System Memory
+        Error Correction Type: Single-bit ECC
+        Maximum Capacity: 2304 GB
+        Error Information Handle: Not Provided
+        Number Of Devices: 4
+
+""").splitlines()
+
 
 def test__full_dmi():
     expected_result = {
@@ -230,6 +319,7 @@ def test__full_dmi():
         'system-product-name': 'TRUENAS-M60',
         'system-serial-number': 'A1-111111',
         'system-version': '0123456789',
+        'has-ipmi': True,
     }
     obj = SystemService(Service)
     obj._parse_dmi(full_dmi)
@@ -246,6 +336,7 @@ def test__double_colon_dmi():
         'system-product-name': 'X9DRi-LN4+/X9DR3-LN4+',
         'system-serial-number': '0123456789',
         'system-version': '0123456789',
+        'has-ipmi': False,
     }
     obj = SystemService(Service)
     obj._parse_dmi(double_colon_dmi)
@@ -262,6 +353,7 @@ def test__missing_dmi():
         'system-product-name': '',
         'system-serial-number': '',
         'system-version': '',
+        'has-ipmi': False,
     }
     obj = SystemService(Service)
     obj._parse_dmi(missing_dmi)
@@ -278,6 +370,7 @@ def test__missing_dmi_type1():
         'system-product-name': '',
         'system-serial-number': '',
         'system-version': '',
+        'has-ipmi': False,
     }
     obj = SystemService(Service)
     obj._parse_dmi(missing_dmi_type1)
@@ -294,6 +387,7 @@ def test__missing_dmi_type2():
         'system-product-name': 'Standard PC (Q35 + ICH9, 2009)',
         'system-serial-number': 'Not Specified',
         'system-version': 'pc-q35-5.2',
+        'has-ipmi': False,
     }
     obj = SystemService(Service)
     obj._parse_dmi(missing_dmi_type2)
@@ -310,7 +404,25 @@ def test__missing_dmi_type16():
         'system-product-name': 'Standard PC (Q35 + ICH9, 2009)',
         'system-serial-number': 'Not Specified',
         'system-version': 'pc-q35-5.2',
+        'has-ipmi': False,
     }
     obj = SystemService(Service)
     obj._parse_dmi(missing_dmi_type16)
+    assert obj.CACHE == expected_result
+
+
+def test__missing_dmi_type38():
+    expected_result = {
+        'bios-release-date': date(2020, 12, 3),
+        'ecc-memory': True,
+        'baseboard-manufacturer': 'Supermicro',
+        'baseboard-product-name': 'X11SPH-nCTPF',
+        'system-manufacturer': 'iXsystems',
+        'system-product-name': 'TRUENAS-M60',
+        'system-serial-number': 'A1-111111',
+        'system-version': '0123456789',
+        'has-ipmi': False,
+    }
+    obj = SystemService(Service)
+    obj._parse_dmi(missing_dmi_type38)
     assert obj.CACHE == expected_result


### PR DESCRIPTION
Fix many problems

1. `ipmi` plugin subprocesses too many times to put in the main event loop so it's better to convert the plugin to be non-async
2. we were subprocess'ing 16 times every time middlewared started which is brutal, don't do that
3. we were calling blocking IO in the main event loop
4. `openipmi.service` loads the necessary kernel modules and creates the `/dev/ipmi0` device if a BMC is detected on the system. However, if a BMC doesn't exist the service always reported as failure to systemctl which is expected. Instead, we use dmidecode type 38 from SMBIOS spec to determine if IPMI device exists before we try to start `openipmi.service`
5. dmi functional tests were failing because we refactored the system plugin. The test wasn't updated so importing `system_.dmi` failed
6. add new functional tests for type 38 in `plugins/test_dmi.py`
7. `ipmi.query_sel` was broken and crashed in `TypeError` so fix that and also convert it to a `@job` because it's painfully slow on real hardware with a half-way decent IPMI implementation.