### PR TITLE
NAS-117877 / 22.12 / Improve KDC detection during domain join

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -433,7 +433,7 @@ class IdmapDomainService(TDBWrapCRUDService):
 
         try:
             await self.middleware.call('tdb.wipe', {
-                'name': '/var/db/system/samba4/winbindd_idmap.tdb',
+                'name': '/var/db/system/samba4/winbindd_cache.tdb',
                 'tdb-options': {'data_type': 'STRING', 'backend': 'CUSTOM'}
             })
 


### PR DESCRIPTION
Fix passing of domain information to `net ads domain info`
so that we have fewer edge cases with DNS during join
process (give more state info to libads). Use the returned
domain information to generate a stub krb5.conf that we
can use for other kerberos-dependent operations while
intially setting up AD.