### PR TITLE
NAS-117885 / 22.12 / Shift winbindd_cache.tdb path in middleware

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
@@ -100,7 +100,6 @@ ldap_func()
 	section_header "ROOT DSE"
 	midclt call ldap.get_root_DSE | jq
 	section_footer
-	fi
 
 	if [ "${enabled}" = "ENABLED" ] && [ "${has_samba_schema}" = "true" ]
 	then

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -495,8 +495,10 @@ class SMBService(Service):
             await self.middleware.call("clustercache.pop", "PASSDB_LOCK")
 
         if must_remove_cache:
-            if os.path.exists(f'{SMBPath.STATEDIR.platform()}/winbindd_cache.tdb'):
-                os.remove(f'{SMBPath.STATEDIR.platform()}/winbindd_cache.tdb')
+            await self.middleware.call('tdb.wipe', {
+                'name': f'{SMBPath.CACHE_DIR.platform()}/winbindd_cache.tdb',
+                'tdb-options': {'data_type': 'STRING', 'backend': 'CUSTOM'}
+            })
             flush = await run([SMBCmd.NET.value, 'cache', 'flush'], check=False)
             if flush.returncode != 0:
                 self.logger.debug('Attempt to flush cache failed: %s', flush.stderr.decode().strip())


### PR DESCRIPTION
The winbindd_cache.tdb file is stored in Samba's statedir to
facilitate offline logons. Since we don't enable or support
pam offline logons, we can safely move the cache away from
the system dataset to tmpfs. This avoids having potential
for winbindd to block system dataset moves.