### PR TITLE
NAS-117893 / 13.0 / fix many issues with volume_version alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/volume_version.py
+++ b/src/middlewared/middlewared/alert/source/volume_version.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 from middlewared.alert.schedule import IntervalSchedule
 
 
@@ -9,22 +9,23 @@ class VolumeVersionAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "New Feature Flags Are Available for Pool"
     text = (
-        "New ZFS version or feature flags are available for pool %s. Upgrading pools is a one-time process that can "
+        "New ZFS version or feature flags are available for pool(s) %s. Upgrading pools is a one-time process that can "
         "prevent rolling the system back to an earlier TrueNAS version. It is recommended to read the TrueNAS release "
         "notes and confirm you need the new ZFS feature flags before upgrading a pool."
     )
 
 
-class VolumeVersionAlertSource(ThreadedAlertSource):
+class VolumeVersionAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(minutes=5))
+    run_on_backup_node = False
 
-    def check_sync(self):
-        alerts = []
-        for pool in self.middleware.call_sync("pool.query"):
-            if not self.middleware.call_sync('pool.is_upgraded', pool["id"]):
-                alerts.append(Alert(
-                    VolumeVersionAlertClass,
-                    pool["name"],
-                ))
+    async def check(self):
+        pools_needing_upgrade = []
+        for pool in await self.middleware.call("pool.query"):
+            if not await self.middleware.call("pool.is_upgraded", pool["id"]):
+                pools_needing_upgrade.append(pool["name"])
+
+        if pools_needing_upgrade:
+            return Alert(VolumeVersionAlertClass, ', '.join(pools_needing_upgrade))
 
         return alerts

--- a/src/middlewared/middlewared/alert/source/volume_version.py
+++ b/src/middlewared/middlewared/alert/source/volume_version.py
@@ -27,5 +27,3 @@ class VolumeVersionAlertSource(AlertSource):
 
         if pools_needing_upgrade:
             return Alert(VolumeVersionAlertClass, ', '.join(pools_needing_upgrade))
-
-        return alerts


### PR DESCRIPTION
1. don't run this on standby controller
2. no reason to make this a `ThreadedAlertSource` so convert to `AlertSource` and make it `async`
3. Stop generating an individual alert for each zpool. It's unnecessary and inefficient since these get written to our db. Instead generate a singular alert joining the pools with commas (if there are more than one).