### PR TITLE
NAS-117874 / 22.12 / handle disks formatted with Data Integrity Feature (dif)

### DIFF
--- a/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
+++ b/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
@@ -8,7 +8,7 @@ class DifFormattedAlertClass(AlertClass, OneShotAlertClass):
     text = 'Disk(s): %s are formatted with Data Integrity Feature (DIF) which is unsupported.'
 
     async def create(self, disks):
-        return Alert(DifFormattedAlertClass, ', '.join(disks))
+        return Alert(DifFormattedAlertClass, ', '.join(disks), key=None)
 
     async def delete(self, alerts, query):
         return []

--- a/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
+++ b/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
@@ -1,0 +1,22 @@
+from middlewared.alert.base import Alert, AlertSource, AlertClass, AlertCategory, AlertLevel
+from middlewared.alert.schedule import CrontabSchedule
+
+
+class DifFormattedAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.CRITICAL
+    title = 'Disk(s) Are Formatted With Data Integrity Feature (DIF).'
+    text = 'Disk(s): %s are formatted with Data Integrity Feature (DIF) which is unsupported.'
+
+
+class DifFormattedAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=0)  # every 24 hours
+    run_on_backup_node = False
+
+    async def check(self):
+        dif = []
+        for disk, info in filter(lambda x: x[1]['dif'], (await self.middleware.call('device.get_disks')).items()):
+            dif.append(disk)
+
+        if dif:
+            return Alert(DifFormattedAlertClass, ', '.join(dif))

--- a/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
+++ b/src/middlewared/middlewared/alert/source/dif_formatted_disks.py
@@ -1,22 +1,14 @@
-from middlewared.alert.base import Alert, AlertSource, AlertClass, AlertCategory, AlertLevel
-from middlewared.alert.schedule import CrontabSchedule
+from middlewared.alert.base import Alert, AlertClass, AlertCategory, OneShotAlertClass, AlertLevel
 
 
-class DifFormattedAlertClass(AlertClass):
+class DifFormattedAlertClass(AlertClass, OneShotAlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.CRITICAL
     title = 'Disk(s) Are Formatted With Data Integrity Feature (DIF).'
     text = 'Disk(s): %s are formatted with Data Integrity Feature (DIF) which is unsupported.'
 
+    async def create(self, disks):
+        return Alert(DifFormattedAlertClass, ', '.join(disks))
 
-class DifFormattedAlertSource(AlertSource):
-    schedule = CrontabSchedule(hour=0)  # every 24 hours
-    run_on_backup_node = False
-
-    async def check(self):
-        dif = []
-        for disk, info in filter(lambda x: x[1]['dif'], (await self.middleware.call('device.get_disks')).items()):
-            dif.append(disk)
-
-        if dif:
-            return Alert(DifFormattedAlertClass, ', '.join(dif))
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -130,6 +130,8 @@ class DeviceService(Service):
         if disk['serial'] and disk['lunid']:
             disk['serial_lunid'] = f'{disk["serial"]}_{disk["lunid"]}'
 
+        disk['dif'] = self.is_dif_formatted(ctx, {'subsystem': disk['subsystem'], 'hctl': disk['hctl']})
+
         return disk
 
     @private

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -158,7 +158,7 @@ class DeviceService(Service):
 
         try:
             dev = pyudev.Devices.from_path(ctx, f'/sys/class/scsi_disk/{info["hctl"]}')
-        except pyudev.DeviceNotFoundByPathError:
+        except pyudev.DeviceNotFoundAtPathError:
             return dif
         except Exception:
             # logging this is painful because it'll spam so

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -35,7 +35,7 @@ class DeviceService(Service):
                 continue
 
             try:
-                disks[dev.sys_name] = self.get_disk_details(dev, get_partitions)
+                disks[dev.sys_name] = self.get_disk_details(ctx, dev, get_partitions)
             except Exception:
                 self.logger.debug('Failed to retrieve disk details for %s', dev.sys_name, exc_info=True)
 
@@ -79,7 +79,7 @@ class DeviceService(Service):
         return parts
 
     @private
-    def get_disk_details(self, dev, get_partitions=False):
+    def get_disk_details(self, ctx, dev, get_partitions=False):
         is_nvme = dev.sys_name.startswith('nvme')
         blocks = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
         ident = serial = (
@@ -133,6 +133,40 @@ class DeviceService(Service):
         return disk
 
     @private
+    def is_dif_formatted(self, ctx, info):
+        """
+        DIF is a feature added to the SCSI Standard. It adds 8 bytes to the end of each sector on disk.
+        It increases the size of the commonly-used 512-byte disk block from 512 to 520 bytes. The extra bytes comprise
+        the Data Integrity Field (DIF). The basic idea is that the HBA will calculate a checksum value for the data
+        block on writes, and store it in the DIF. The storage device will confirm the checksum on receive, and store
+        the data plus checksum. On a read, the checksum will be checked by the storage device and by the receiving HBA.
+
+        The Data Integrity Extension (DIX) allows this check to move up the stack: the application calculates the
+        checksum and passes it to the HBA, to be appended to the 512 byte data block. This provides a full end-to-end
+        data integrity check.
+
+        With support from the HBA, this means checksums will be computed/verified by the HBA for every block. This is
+        redundant and a waste of bus bandwidth with ZFS. These disks should be reformatted to use a normal sector size
+        without protection information before a pool can be created.
+        """
+        dif = False
+        if (info['subsystem'] != 'scsi') or (info['hctl'].count(':') != 3):
+            # only check scsi devices
+            return dif
+
+        try:
+            dev = pyudev.Devices.from_path(ctx, f'/sys/class/scsi_disk/{info["hctl"]}')
+        except pyudev.DeviceNotFoundByPathError:
+            return dif
+        except Exception:
+            # logging this is painful because it'll spam so
+            # ignore it for now...
+            return dif
+        else:
+            # 0 == disabled, > 0 == enabled
+            return bool(self.safe_retrieval(dev.attributes, 'protection_type', 0, asint=True))
+
+    @private
     def safe_retrieval(self, prop, key, default, asint=False):
         value = prop.get(key)
         if value is not None:
@@ -152,7 +186,7 @@ class DeviceService(Service):
         except pyudev.DeviceNotFoundByNameError:
             return None
 
-        return self.get_disk_details(block_device)
+        return self.get_disk_details(context, block_device)
 
     def _get_type_and_rotation_rate(self, disk_data, device_path):
         if disk_data['rota']:

--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -16,6 +16,9 @@ class DiskService(Service):
         if not dd:
             raise CallError(f'Unable to retrieve disk details for {disk!r}')
 
+        if dd['dif']:
+            raise CallError(f'Disk: {disk!r} is incorrectly formatted with Data Integrity Feature (DIF).')
+
         size = dd['size']
         if not size:
             raise CallError(f'Unable to determine size of {disk!r}')

--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -11,32 +11,38 @@ ZFS_PARTHEX = 'BF01'
 class DiskService(Service):
 
     @private
-    def format(self, disk, swapgb, sync=True):
-        disk_details = self.middleware.call_sync('device.get_disk', disk)
-        if not disk_details:
-            raise CallError(f'Unable to retrieve disk details for {disk}')
-        size = disk_details['size']
+    def validate_disk(self, disk, swapgb):
+        dd = self.middleware.call_sync('device.get_disk', disk)
+        if not dd:
+            raise CallError(f'Unable to retrieve disk details for {disk!r}')
+
+        size = dd['size']
         if not size:
-            self.logger.error(f'Unable to determine size of {disk}')
-        else:
+            raise CallError(f'Unable to determine size of {disk!r}')
+
+        swapsize = swapgb * 1024 * 1024 * 1024
+        if (size - 102400) <= swapsize:
             # The GPT header takes about 34KB + alignment, round it to 100
-            if size - 102400 <= swapgb * 1024 * 1024 * 1024:
-                raise CallError(f'Your disk size must be higher than {swapgb}GB')
+            raise CallError(f'Disk: {disk!r} must be larger than {swapgb}GB')
+
+        sectorsize = dd['sectorsize'] or 512
+        alignment = int(4096 / sectorsize)
+
+        # round up to the nearest whole integral multiple of 128 so next
+        # partition starts at multiple of 128
+        swapsize = int(((swapsize / sectorsize) + 127) / 128) * 128
+
+        return swapsize, alignment
+
+    @private
+    def format(self, disk, swapgb, sync=True):
+        swapsize, alignment = self.validate_disk(disk, swapgb)
 
         job = self.middleware.call_sync('disk.wipe', disk, 'QUICK', sync)
         job.wait_sync()
         if job.error:
             raise CallError(f'Failed to wipe disk {disk}: {job.error}')
 
-        sectorsize = disk_details['sectorsize'] or 512
-
-        # Calculate swap size.
-        swapsize = swapgb * 1024 * 1024 * 1024 / sectorsize
-        # Round up to nearest whole integral multiple of 128
-        # so next partition starts at mutiple of 128.
-        swapsize = (int((swapsize + 127) / 128)) * 128
-
-        alignment = int(4096 / sectorsize)
         if swapsize > 0:
             commands = [
                 ('sgdisk', f'-a{alignment}', f'-n1:128:{swapsize}', f'-t1:{SWAP_PARTHEX}', f'/dev/{disk}'),


### PR DESCRIPTION
1. add new `dif` key to disks details dictionary
2. in `disk.format` raise a `CallError` if disk is formatted with DIF because we do not support it
3. add an alert that warns the user that their drives are formatted with DIF

Very simple scenario (that we've already seen) is that freeBSD ignores this feature altogether in kernel, however, linux kernel does not and will honor it. This means if a zpool is created on freeBSD with disks that are formatted with DIF and then moved to linux and the HBA honors DIF, the zpool will not import. Only way around that scenario is to disable this feature in the HBA driver so the zpool can be imported. However, the proper fix in that scenario is to replace each drive in the zpool 1-by-1 reformatting with DIF disabled. Removing DIF on a drive can take quite a long time because it has to fully erase the entire media.

Having an extra 8 bytes for checksum data (stored at the end of each 512byte sector) is completely unnecessary using ZFS since it does its own checksum calculation (by default) for each block written. DIF is redundant and, more importantly, a waste of bus bandwidth.