### PR TITLE
NAS-117921 / 22.12 / add `reinstall_container` make argument

### DIFF
--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -28,4 +28,6 @@ migrate:
 
 reinstall: stop_service clean install install_client install_test migrate start_service
 
+# this is to be called in github actions running in a container (no systemd (pid 1))
+# so it's the same as `reinstall` but without the start/stop{_service} calls
 reinstall_container: clean install install_client install_test migrate

--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -27,3 +27,5 @@ migrate:
 	migrate
 
 reinstall: stop_service clean install install_client install_test migrate start_service
+
+reinstall_container: clean install install_client install_test migrate


### PR DESCRIPTION
Add a `make reinstall_container` argument to the `Makefile` that will be called in github actions to run our unit tests. The container in github has no PID 1 so starting/stopping systemd services fail (as expected) so this does same as `make reinstall` but without the stopping and starting of the `middlewared` service.