### PR TITLE
NAS-117950 / 22.12 / mask ndctl-monitor.service

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -71,6 +71,7 @@ systemctl enable zfs-zed
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 systemctl mask exim4-base.service exim4.service
 systemctl mask uuidd.service uuidd.socket
+systemctl mask ndctl-monitor.service
 
 # We don't use LVM and this service can add significant boot delays
 # on large disk systems


### PR DESCRIPTION
Recent addition of the `ndctl` package installed a service. Mask it since we don't need it.