### PR TITLE
NAS-117957 / 13.0 / fix IndexError in netcli when create/delete laggs

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -969,7 +969,7 @@ def create_lagg_interface():
     lagg_index = 0
     lagg_interfaces = LAGGInterface.objects.all()
     for li in lagg_interfaces:
-        lagg_index = int(re.split('([0-9]+)$', str(li.lagg_interface))[1]) + 1
+        lagg_index = int(re.split('([0-9]+)$', li.lagg_interface.int_interface)[1]) + 1
 
     lagg_proto = get_lagg_proto()
     if not lagg_proto:
@@ -1050,7 +1050,7 @@ def delete_lagg_interface():
         print()
 
         for idx, li in enumerate(lagg_interfaces):
-            lagg_index = int(re.split('([0-9]+)$', str(li.lagg_interface))[1]) + 1
+            lagg_index = int(re.split('([0-9]+)$', li.lagg_interface.int_interface)[1]) + 1
             lagg_map[idx + 1] = li
 
             print("%d) lagg%s" % (idx + 1, re.split('([0-9]+)$', str(li.lagg_interface))[1]))


### PR DESCRIPTION
`str(li.lagg_interface)` returns the `int_name` column if the end-user has filled it in. This is a free-hand "description" field that can contain whatever the user wants.

`re.split` is expecting to split the string on a number....so if the user had typed in something like `10g lagg for blah` in the `int_name`, this would crash with an `IndexError` exception because we're expecting the interface name to end with a number.

To fix this use the `int_interface` column which is enforced via our schema to always end with a number.