### PR TITLE
NAS-117991 / 22.12 / Use zfs.pool.query_imported_fast in failover.status

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1322,10 +1322,6 @@ def remote_status_event(middleware, *args, **kwargs):
 async def setup(middleware):
     middleware.event_register('failover.setup', 'Sent when failover is being setup.')
     middleware.event_register('failover.status', 'Sent when failover status changes.')
-    middleware.event_register(
-        'failover.disabled.reasons',
-        'Sent when the reasons for failover being disabled have changed.'
-    )
     middleware.event_register('failover.upgrade_pending', textwrap.dedent('''\
         Sent when system is ready and HA upgrade is pending.
 

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -238,10 +238,10 @@ class FailoverService(ConfigService):
             # connection is "up" but the default TCP window hasn't elapsed so
             # the connection remains alive. Without the timeout, this could take
             # 20+ seconds to return which is unacceptable during a failover event.
-            remote_imported = len(await self.middleware.call(
+            remote_imported = await self.middleware.call(
                 'failover.call_remote', 'zfs.pool.query_imported_fast', [], {'timeout': 5}
-            ))
-            if remote_imported <= 1:
+            )
+            if len(remote_imported) <= 1:
                 # getting here means we dont have a pool and neither does remote node
                 return 'ERROR'
             else:

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -98,3 +98,7 @@ class FailoverDisabledReasonsService(Service):
             reasons.add('NO_PONG')
 
         return reasons
+
+
+async def setup(middleware):
+    middleware.event_register('failover.disabled.reasons', 'Sent when failover status reasons change.')

--- a/src/middlewared/middlewared/plugins/failover_/failover_status.py
+++ b/src/middlewared/middlewared/plugins/failover_/failover_status.py
@@ -8,27 +8,63 @@ class DetectFailoverStatusService(Service):
         namespace = 'failover.status'
 
     async def get_local(self, app):
-
-        # Check if we have at least 1 interface with VRRP config
-        interfaces = await self.middleware.call('interface.query')
-        if not any(filter(lambda x: x['state']['vrrp_config'], interfaces)):
+        licensed = await self.middleware.call('failover.licensed')
+        if not licensed:
+            # no HA license so nothing else matters
             return 'SINGLE'
 
-        pools = await self.middleware.call('zfs.pool.query_imported_fast')
-        if len(pools) <= 1:
-            # Check if we have at least 1 pool configured and imported (excluding boot pool)
-            return 'SINGLE'
-        elif (await self.middleware.call('failover.vip.get_states', interfaces))[0]:
-            # Means we have VRRP MASTER interfaces and we have pool(s) imported
+        fenced_running = (await self.middleware.call('failover.fenced.run_info'))['running']
+        only_boot_pool = len((await self.middleware.call('zfs.pool.query_imported_fast'))) <= 1
+        if not fenced_running:
+            if only_boot_pool:
+                # we only have boot pool, fenced is not running, and we're licensed
+                # safe to assume we're the backup node
+                return 'BACKUP'
+            else:
+                # we have at least 1 zpool imported, but fenced is not running and we're licensed
+                # ...that's not good but it's safe to return MASTER. failover.disabled.reasons
+                # will return NO_FENCED will cause alerts and warnings and emails to be sent to
+                # end-user
+                return 'MASTER'
+        elif not only_boot_pool:
+            # we have at least 1 zpool imported, fenced is running, and we're licensed
+            # safe to assume we're the master node
             return 'MASTER'
-        else:
-            failover_events = await self.middleware.call(
-                'core.get_jobs', [('method', '=', 'failover.event.vrrp_master')], {'order_by': ['-id']}
-            )
-            for i in failover_events:
-                if i['state'] == 'RUNNING':
-                    # we're currently becoming master node
-                    return i['progress']['description']
-                elif i['progress']['description'] == 'ERROR':
-                    # last failover failed
-                    return i['progress']['description']
+
+        master_ifaces = backup_ifaces = 0
+        interfaces = await self.middleware.call('interface.query')
+        for iface in filter(lambda x: x['state']['vrrp_config'], interfaces):
+            for ip in iface['state']['vrrp_config']:
+                if ip['state'] == 'MASTER':
+                    master_ifaces += 1
+                else:
+                    backup_ifaces += 1
+
+        if master_ifaces and not backup_ifaces:
+            # all interfaces that are configured for HA are master, safe to assume
+            # this _should_ be the master node. we shouldn't get here on a
+            # healhy HA system because we should be able to determine the status
+            # based on zpools and fenced running
+            return 'MASTER'
+        elif backup_ifaces and not master_ifaces:
+            # all interfaces that are configured for HA are backup, safe to assume
+            # this _should_ be the backup node. we shouldn't get here on a
+            # healhy HA system because we should be able to determine the status
+            # based on zpools and fenced running
+            return 'BACKUP'
+
+        # last ditch effort to determine the status of this node. if there are
+        # no failover events occurring locally and we make it this far, the caller
+        # of this method will check the remote system which is slow...but have no
+        # option at that point. Note: we shouldn't get here ideally because calling
+        # core.get_jobs is not known for being "performant" especially as more jobs
+        # accumulate as uptime increases
+        filters = [('method', '=', 'failover.event.vrrp_master')]
+        options = {'order_by': ['-id']}
+        for i in await self.middleware.call('core.get_jobs', filters, options):
+            if i['state'] == 'RUNNING':
+                # we're currently becoming master node
+                return i['progress']['description']
+            elif i['progress']['description'] == 'ERROR':
+                # last failover failed
+                return i['progress']['description']

--- a/src/middlewared/middlewared/plugins/failover_/failover_status.py
+++ b/src/middlewared/middlewared/plugins/failover_/failover_status.py
@@ -14,34 +14,21 @@ class DetectFailoverStatusService(Service):
         if not any(filter(lambda x: x['state']['vrrp_config'], interfaces)):
             return 'SINGLE'
 
-        # Check if we have at least 1 pool configured and imported
-        pools = await self.middleware.call('pool.query')
-        if not pools:
+        pools = await self.middleware.call('zfs.pool.query_imported_fast')
+        if len(pools) <= 1:
+            # Check if we have at least 1 pool configured and imported (excluding boot pool)
             return 'SINGLE'
-
-        # Check if we have any VRRP MASTER interfaces
-        if (await self.middleware.call('failover.vip.get_states', interfaces))[0]:
-
-            # If we have VRRP MASTER interfaces, ensure none of the zpools
-            # are offline
-            if any(filter(lambda x: x.get('status') != 'OFFLINE', pools)):
-                return 'MASTER'
-
-            # need to check to check 2 things if we get to this point
-            #
-            #   1. check to make sure there isn't an ongoing failover event
-            #
-            #   2. check to make sure that the last failover event didn't
-            #       fail
-            #
+        elif (await self.middleware.call('failover.vip.get_states', interfaces))[0]:
+            # Means we have VRRP MASTER interfaces and we have pool(s) imported
+            return 'MASTER'
+        else:
             failover_events = await self.middleware.call(
-                'core.get_jobs',
-                [('method', '=', 'failover.event.vrrp_master')],
-                {'order_by': ['-id']},
+                'core.get_jobs', [('method', '=', 'failover.event.vrrp_master')], {'order_by': ['-id']}
             )
-
             for i in failover_events:
                 if i['state'] == 'RUNNING':
+                    # we're currently becoming master node
                     return i['progress']['description']
                 elif i['progress']['description'] == 'ERROR':
+                    # last failover failed
                     return i['progress']['description']


### PR DESCRIPTION
Use `zfs.pool.query_imported_fast` which is a vastly more performant way of getting basic zpool information compared to `pool.query` which is exactly what we want in methods like `failover.status` and `failover.status.get_local`