### PR TITLE
NAS-118014 / 22.02.4 / fix failover.get_ips (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -290,26 +290,8 @@ class FailoverService(ConfigService):
     @returns(List('ips', items=[Str('ip')]))
     @pass_app()
     async def get_ips(self, app):
-        """
-        Get a list of IPs for which the webUI can be accessed.
-        """
-        data = await self.middleware.call('system.general.config')
-        v4addrs = data['ui_address']
-        v6addrs = data['ui_v6address']
-        all_ip4 = '0.0.0.0' in v4addrs
-        all_ip6 = '::' in v6addrs
-
-        addrs = []
-        if all_ip4 or all_ip6:
-            for i in await self.middleware.call('interface.query', [('failover_vhid', '!=', None)]):
-                # user can bind to a single v4 address but all v6 addresses
-                # or vice versa
-                addrs.extend([
-                    x['address'] for x in i.get('failover_virtual_aliases', [])
-                    if (x['type'] == 'INET' and all_ip4) or (x['type'] == 'INET6' and all_ip6)
-                ])
-
-        return [i for i in set(addrs + v4addrs + v6addrs) if i not in ('0.0.0.0', '::')]
+        """Get a list of IPs for which the webUI can be accessed."""
+        return await self.middleware.call('system.general.get_ui_urls')
 
     @accepts()
     @returns(Bool())

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -288,7 +288,7 @@ class FailoverService(ConfigService):
     @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(List('ips', items=[Str('ip')]))
-    @pass_app()
+    @pass_app(rest=True)
     async def get_ips(self, app):
         """Get a list of IPs for which the webUI can be accessed."""
         return await self.middleware.call('system.general.get_ui_urls')

--- a/tests/api2/test_014_failover_related.py
+++ b/tests/api2/test_014_failover_related.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+from functions import GET
+from auto_config import ha
+
+
+if ha:
+    def test_01_test_failover_get_ips():
+        results = GET('/failover/get_ips', controller_a=ha)
+        assert results.status_code == 200, results.text
+        rv = results.json()
+        assert (isinstance(rv, list) and rv), rv


### PR DESCRIPTION
Noticed when working on other issues. `midcli` isn't showing the IP addresses of the webUI on HA systems. This fixes that problem since `system.general.get_ui_urls` is written for HA systems already.

Original PR: https://github.com/truenas/middleware/pull/9765
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118014