### PR TITLE
NAS-118019 / 22.02.4 / Prohibit trailing spaces in ZFS dataset names (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3160,6 +3160,11 @@ class PoolDatasetService(CRUDService):
 
         if '/' not in data['name']:
             verrors.add('pool_dataset_create.name', 'You need a full name, e.g. pool/newdataset')
+        elif data['name'][-1] == ' ':
+            verrors.add(
+                'pool_dataset_create.name',
+                'Trailing spaces are not permitted in dataset names'
+            )
         else:
             parent_name = data['name'].rsplit('/', 1)[0]
             if data['create_ancestors']:


### PR DESCRIPTION
Trailing spaces are illegal characters over SMB protocol. Since
we sometimes have dataset mountpoints exposed over SMB, we should
prevent this.

Original PR: https://github.com/truenas/middleware/pull/9768
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118019