### PR TITLE
NAS-118059 / 22.02.4 / fix blank graphs when UPSBase plugin crashes (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -372,18 +372,22 @@ class UPSBase:
         ups_config = self.middleware.call_sync('ups.config')
         if ups_config['mode'] == 'SLAVE':
             remote_host = os.path.join(RRD_BASE_DIR_PATH, ups_config['remotehost'])
-            files = os.listdir(remote_host)
-            if not any(f.endswith('.rrd') for f in files):
-                remote_host = next(
-                    (
-                        f for f in sorted(
-                            filter(os.path.isdir, map(lambda f: os.path.join(remote_host, f), files)),
-                            key=lambda f: os.path.getmtime(f), reverse=True
-                        )
-                    ),
-                    remote_host
-                )
-            return remote_host
+            try:
+                files = os.listdir(remote_host)
+            except FileNotFoundError:
+                return super()._base_path
+            else:
+                if not any(f.endswith('.rrd') for f in files):
+                    remote_host = next(
+                        (
+                            f for f in sorted(
+                                filter(os.path.isdir, map(lambda f: os.path.join(remote_host, f), files)),
+                                key=lambda f: os.path.getmtime(f), reverse=True
+                            )
+                        ),
+                        remote_host
+                    )
+                return remote_host
         else:
             return super()._base_path
 


### PR DESCRIPTION
`os.listdir(remote_host)` is crashing with the below traceback which is breaking all reporting graphs.
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/reporting/plugins.py", line 393, in get_identifiers
    if all(os.path.exists(os.path.join(self._base_path, f'{self.plugin}-{ups_identifier}', f'{rrd_type.type}.rrd'))
  File "/usr/lib/python3/dist-packages/middlewared/plugins/reporting/plugins.py", line 393, in <genexpr>
    if all(os.path.exists(os.path.join(self._base_path, f'{self.plugin}-{ups_identifier}', f'{rrd_type.type}.rrd'))
  File "/usr/lib/python3/dist-packages/middlewared/plugins/reporting/plugins.py", line 375, in _base_path
    files = os.listdir(remote_host)
FileNotFoundError: [Errno 2] No such file or directory: '/var/db/collectd/rrd/10.10.10.64'
```

Original PR: https://github.com/truenas/middleware/pull/9778
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118059