### PR TITLE
NAS-117911 / 22.02.4 / Ensure SMB share ACL is preserved during various share ops (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -538,6 +538,7 @@ class SystemDatasetService(ConfigService):
             for i in restart:
                 await self.middleware.call('service.stop', i)
 
+            await self.middleware.call('tdb.close_sysdataset_handles')
             yield
         finally:
             await self.middleware.call('cache.pop', 'use_syslog_dataset')

--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.sysdataset import SYSDATASET_PATH
 from middlewared.service import Service, private
 from middlewared.schema import accepts, Bool, Dict, Ref, List, Str, Int
 from middlewared.service_exception import CallError, MatchNotFound
@@ -272,6 +273,17 @@ class TDBService(Service, TDBMixin, SchemaMixin):
     def show_handles(self):
         ret = {h['name']: h['options'] for h in self.handles.values()}
         return ret
+
+    @private
+    def close_sysdataset_handles(self):
+        for name in list(self.handles.keys()):
+            if not name.startswith(SYSDATASET_PATH):
+                continue
+
+            entry = self.handles[name]
+            with entry['lock']:
+                if entry['handle_internal'].validate_handle():
+                    entry['handle_internal'].close()
 
     @private
     async def setup(self):

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -31,7 +31,10 @@ class TDBWrap(object):
         return False
 
     def validate_handle(self):
+        if not os.path.exists(f'/proc/self/fd/{self.opath_fd}'):
+            return False
         # if file has been renamed or deleted from under us, readlink will show different path
+
         return os.readlink(f'/proc/self/fd/{self.opath_fd}') == self.full_path
 
     def get(self, key):
@@ -52,8 +55,9 @@ class TDBWrap(object):
         tdb_key = key.encode()
         if self.options['data_type'] == 'BYTES':
             tdb_key += b"\x00"
-
-        tdb_val = val.encode()
+            tdb_val = val
+        else:
+            tdb_val = val.encode()
 
         self.hdl.store(tdb_key, tdb_val)
 


### PR DESCRIPTION
Background: SMB share ACLs are stored in Samba's share_info.tdb
and are keyed by the prefix 'SECDESC/' followed by the
share name. The primary CLI tool for interacting with the
share ACL is `sharesec` unfortunately because of sharesec's
reliance on libraries within samba that check whether the share
exists, some operations are not possible (like copying to a
non-existent share). Additionally, net_conf (the primary tool
for manipulating share acl entries) deletes share ACL entries
when a share is deleted. libsmbconf has no concept of a
"disabled" share this is implemented in middleware by adding
and removing the share as it is enabled and disabled.
Unfortunately, this results in the share ACL being deleted
and only restored during periodic task to back up the
share ACLs to our db.

Add two new helper functions to smb.sharesec:

1) smb.sharesec.toggle_share: backs up or restores a share's ACL
within share_info.tdb. We do this by creating an entry where
the share_name begins with a `#` character, and copying
ACL contents there. Since this is an invalid character
for a SHARE we don't have to worry about collisions here.

2) smb.sharesec.dup_share_acl: duplicates an existing share
ACL to a new entry. This allows us shift the share ACL
as shares are renamed.

Due to aforementioned limitations of the sharesec command, we
use python tdb bindings to accomplish these tasks. Since
share_info.tdb is on the system dataset, we now explicitly
close any open tdbs during systemdataset move.

Original PR: https://github.com/truenas/middleware/pull/9747
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117911