### PR TITLE
NAS-118064 / 22.02.4 / cache failover.hardware.detect (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -4,6 +4,7 @@ import re
 from pyudev import Context
 
 from middlewared.service import Service
+from middlewared.utils.functools import cache
 from .ha_hardware import HA_HARDWARE
 
 ENCLOSURES_DIR = '/sys/class/enclosure/'
@@ -17,6 +18,7 @@ class EnclosureDetectionService(Service):
 
     HARDWARE = NODE = 'MANUAL'
 
+    @cache
     def detect(self):
 
         # first check to see if this is a BHYVE instance


### PR DESCRIPTION
This method is expensive but more importantly, it's detecting head-units of our HA capable hardware which shouldn't change dynamically so cache it.

Original PR: https://github.com/truenas/middleware/pull/9783
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118064