### PR TITLE
NAS-118074 / 22.02.4 / stop blocking event loop in auth plugin hook (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -600,11 +600,8 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.random_base32()
 
 
-async def check_permission(middleware, app):
-    """
-    Authenticates connections coming from loopback and from
-    root user.
-    """
+def check_permission(middleware, app):
+    """Authenticates connections coming from loopback and from root user."""
     sock = app.request.transport.get_extra_info('socket')
     if sock.family == socket.AF_UNIX:
         # Unix socket is only allowed for root
@@ -616,7 +613,7 @@ async def check_permission(middleware, app):
         return
 
     # This is an expensive operation, but it is only performed for localhost TCP connections which are rare
-    if process := await middleware.run_in_thread(get_peer_process, remote_addr, remote_port):
+    if process := get_peer_process(remote_addr, remote_port):
         try:
             euid = process.uids().effective
         except psutil.NoSuchProcess:


### PR DESCRIPTION
We're blocking main event loop by calling `get_remote_addr_port`. That function can block in many different obvious and subtle ways. Just convert this hook to be synchronous.

Original PR: https://github.com/truenas/middleware/pull/9792
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118074