### PR TITLE
NAS-118093 / 22.02.4 / Dont block event look in check_permission hook

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -620,7 +620,6 @@ def check_permission_impl(app):
                 return
 
 
-
 async def check_permission(middleware, app):
     """Authenticates connections coming from loopback and from root user."""
     sock = app.request.transport.get_extra_info('socket')

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -603,8 +603,11 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.random_base32()
 
 
-def check_permission(middleware, app):
-    """Authenticates connections coming from loopback and from root user."""
+async def check_permission(middleware, app):
+    """
+    Authenticates connections coming from loopback and from
+    root user.
+    """
     sock = app.request.transport.get_extra_info('socket')
     if sock.family == socket.AF_UNIX:
         # Unix socket is only allowed for root
@@ -616,7 +619,7 @@ def check_permission(middleware, app):
         return
 
     # This is an expensive operation, but it is only performed for localhost TCP connections which are rare
-    if process := get_peer_process(remote_addr, remote_port):
+    if process := await middleware.run_in_thread(get_peer_process, remote_addr, remote_port):
         try:
             euid = process.uids().effective
         except psutil.NoSuchProcess:


### PR DESCRIPTION
This is called in the main event loop no matter what so for stable/angelfish I've added a `check_permission_impl` which is called in a thread from `async def check_permission`. A better fix will go into master.