### PR TITLE
NAS-118093 / 22.12 / Dont block event look in check_permission hook (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -561,8 +561,11 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.random_base32()
 
 
-def check_permission(middleware, app):
-    """Authenticates connections coming from loopback and from root user."""
+async def check_permission(middleware, app):
+    """
+    Authenticates connections coming from loopback and from
+    root user.
+    """
     sock = app.request.transport.get_extra_info('socket')
     if sock.family == socket.AF_UNIX:
         # Unix socket is only allowed for root
@@ -574,7 +577,7 @@ def check_permission(middleware, app):
         return
 
     # This is an expensive operation, but it is only performed for localhost TCP connections which are rare
-    if process := get_peer_process(remote_addr, remote_port):
+    if process := await middleware.run_in_thread(get_peer_process, remote_addr, remote_port):
         try:
             euid = process.uids().effective
         except psutil.NoSuchProcess:

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -561,23 +561,13 @@ class TwoFactorAuthService(ConfigService):
         return pyotp.random_base32()
 
 
-async def check_permission(middleware, app):
-    """
-    Authenticates connections coming from loopback and from
-    root user.
-    """
-    sock = app.request.transport.get_extra_info('socket')
-    if sock.family == socket.AF_UNIX:
-        # Unix socket is only allowed for root
-        AuthService.session_manager.login(app, UnixSocketSessionManagerCredentials())
-        return
-
-    remote_addr, remote_port = get_remote_addr_port(app.request)
+def check_permission_impl(app):
+    remote_addr, remote_port = get_remote_addr_port(app)
     if not (remote_addr.startswith('127.') or remote_addr == '::1'):
         return
 
     # This is an expensive operation, but it is only performed for localhost TCP connections which are rare
-    if process := await middleware.run_in_thread(get_peer_process, remote_addr, remote_port):
+    if process := get_peer_process(remote_addr, remote_port):
         try:
             euid = process.uids().effective
         except psutil.NoSuchProcess:
@@ -586,6 +576,17 @@ async def check_permission(middleware, app):
             if euid == 0:
                 AuthService.session_manager.login(app, RootTcpSocketSessionManagerCredentials())
                 return
+
+
+async def check_permission(middleware, app):
+    """Authenticates connections coming from loopback and from root user."""
+    sock = app.request.transport.get_extra_info('socket')
+    if sock.family == socket.AF_UNIX:
+        # Unix socket is only allowed for root
+        AuthService.session_manager.login(app, UnixSocketSessionManagerCredentials())
+        return
+
+    await middleware.run_in_thread(check_permission_impl, app)
 
 
 def setup(middleware):


### PR DESCRIPTION
This is called in the main event loop no matter what so for stable/angelfish I've added a `check_permission_impl` which is called in a thread from `async def check_permission`. A better fix will go into master.

Original PR: https://github.com/truenas/middleware/pull/9803
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118093