### PR TITLE
NAS-118092 / 22.12 / Properly terminate Web Shell and it's children (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -802,24 +802,25 @@ class ShellApplication(object):
         return ws
 
     async def worker_kill(self, t_worker):
-        # If connection has been closed lets make sure shell is killed
-        if t_worker.shell_pid:
-            with contextlib.suppress(psutil.NoSuchProcess):
-                shell = psutil.Process(t_worker.shell_pid)
-                to_terminate = [shell] + shell.children(recursive=True)
+        def worker_kill_impl():
+            # If connection has been closed lets make sure shell is killed
+            if t_worker.shell_pid:
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    shell = psutil.Process(t_worker.shell_pid)
+                    to_terminate = [shell] + shell.children(recursive=True)
 
-                for p in to_terminate:
-                    with contextlib.suppress(psutil.NoSuchProcess):
-                        p.terminate()
-                gone, alive = psutil.wait_procs(to_terminate, timeout=2)
+                    for p in to_terminate:
+                        with contextlib.suppress(psutil.NoSuchProcess):
+                            p.terminate()
+                    gone, alive = psutil.wait_procs(to_terminate, timeout=2)
 
-                for p in alive:
-                    with contextlib.suppress(psutil.NoSuchProcess):
-                        p.kill()
+                    for p in alive:
+                        with contextlib.suppress(psutil.NoSuchProcess):
+                            p.kill()
 
-        # Wait thread join in yet another thread to avoid event loop blockage
-        # There may be a simpler/better way to do this?
-        await self.middleware.run_in_thread(t_worker.join)
+            t_worker.join()
+
+        await self.middleware.run_in_thread(worker_kill_impl)
 
 
 class PreparedCall:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -62,6 +62,7 @@ import urllib.parse
 import uuid
 import tracemalloc
 
+import psutil
 from systemd.daemon import notify as systemd_notify
 
 from . import logger
@@ -803,23 +804,18 @@ class ShellApplication(object):
     async def worker_kill(self, t_worker):
         # If connection has been closed lets make sure shell is killed
         if t_worker.shell_pid:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                shell = psutil.Process(t_worker.shell_pid)
+                to_terminate = [shell] + shell.children(recursive=True)
 
-            try:
-                pid_waiter = osc.PidWaiter(self.middleware, t_worker.shell_pid)
+                for p in to_terminate:
+                    with contextlib.suppress(psutil.NoSuchProcess):
+                        p.terminate()
+                gone, alive = psutil.wait_procs(to_terminate, timeout=2)
 
-                os.kill(t_worker.shell_pid, signal.SIGTERM)
-
-                # If process has not died in 2 seconds, try the big gun
-                if not await pid_waiter.wait(2):
-                    os.kill(t_worker.shell_pid, signal.SIGKILL)
-
-                    # If process has not died even with the big gun
-                    # There is nothing else we can do, leave it be and
-                    # release the worker thread
-                    if not await pid_waiter.wait(2):
-                        t_worker.die()
-            except ProcessLookupError:
-                pass
+                for p in alive:
+                    with contextlib.suppress(psutil.NoSuchProcess):
+                        p.kill()
 
         # Wait thread join in yet another thread to avoid event loop blockage
         # There may be a simpler/better way to do this?


### PR DESCRIPTION
Sometimes when `/usr/bin/login` (which is a master pid for our Web Shell) is terminated, shell (and its children) stays alive. Let's terminate the entire process tree.

(cherry picked from commit 2a0d8af8bc99d3516d9c06e1a4404ed8de6cd033)

Original PR: https://github.com/truenas/middleware/pull/9799
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118092