### PR TITLE
NAS-118117 / 22.02.4 / move gluster fuse mounts to root cgroups (by yocalebo)

### DIFF
--- a/cluster-tests/config.py
+++ b/cluster-tests/config.py
@@ -45,7 +45,9 @@ CLUSTER_LDAP = {
 TIMEOUTS = {
     'FUSE_OP_TIMEOUT': environ.get('FUSE_OP_TIMEOUT', 10),
     'FAILOVER_WAIT_TIMEOUT': environ.get('FAILOVER_WAIT_TIMEOUT', 10),
-    'MONITOR_TIMEOUT': environ.get('MONITOR_TIMEOUT', 20)
+    'MONITOR_TIMEOUT': environ.get('MONITOR_TIMEOUT', 20),
+    'CTDB_IP_TIMEOUT': environ.get('CTDB_IP_TIMEOUT', 20),
+    'VOLUME_TIMEOUT': environ.get('VOLUME_TIMEOUT', 120),
 }
 
 CLEANUP_TEST_DIR = 'tests/cleanup'

--- a/cluster-tests/init_gluster.py
+++ b/cluster-tests/init_gluster.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from config import CLUSTER_INFO, BRICK_PATH, GLUSTER_PEERS_DNS, CLUSTER_IPS, PUBLIC_IPS
+from config import CLUSTER_INFO, BRICK_PATH, GLUSTER_PEERS_DNS, CLUSTER_IPS, PUBLIC_IPS, TIMEOUTS
 from utils import make_request, wait_on_job
 from helpers import ctdb_healthy
 from exceptions import JobTimeOut
@@ -69,7 +69,7 @@ def add_peers():
 
         # wait on the peer to be added
         try:
-            status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 10)
+            status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], TIMEOUTS['CTDB_IP_TIMEOUT'])
         except JobTimeOut:
             assert False, JobTimeOut
         else:
@@ -122,7 +122,7 @@ def create_volume():
 
     # wait on the gluster volume to be created
     try:
-        status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 20)
+        status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], TIMEOUTS['VOLUME_TIMEOUT'])
     except JobTimeOut:
         assert False, JobTimeOut
     else:
@@ -153,7 +153,7 @@ def add_public_ips_to_ctdb():
             }
             res = make_request('post', f'http://{priv_ip}/api/v2.0/ctdb/public/ips', data=payload)
             try:
-                status = wait_on_job(res.json(), priv_ip, 5)
+                status = wait_on_job(res.json(), priv_ip, TIMEOUTS['CTDB_IP_TIMEOUT'])
             except JobTimeOut:
                 assert False, JobTimeOut
             else:

--- a/cluster-tests/tests/gluster/test_volume.py
+++ b/cluster-tests/tests/gluster/test_volume.py
@@ -3,7 +3,7 @@ from time import sleep
 import pytest
 
 from config import CLUSTER_INFO, CLUSTER_IPS, TIMEOUTS
-from utils import make_request, make_ws_request, wait_on_job
+from utils import make_request, make_ws_request, wait_on_job, ssh_test
 from exceptions import JobTimeOut
 from pytest_dependency import depends
 
@@ -106,9 +106,19 @@ def test_05_verify_gluster_volume_is_fuse_mounted(ip, request):
     assert ans.json(), ans.text
 
 
+@pytest.mark.parametrize('ip', CLUSTER_IPS)
+def test_06_verify_gluster_volume_fuse_cgroup(ip, request):
+    # the fuse mounts locally should not be attached to the
+    # parent middlewared process
+    depends(request, ['VERIFY_FUSE_MOUNTED'])
+    rv = ssh_test(ip, 'systemctl status middlewared')
+    assert rv['output'], rv
+    assert '/usr/sbin/glusterfs' not in rv['output'], rv
+
+
 @pytest.mark.parametrize('volume', [GVOL])
 @pytest.mark.dependency(name='STOP_GVOLUME')
-def test_06_stop_gluster_volume(volume, request):
+def test_07_stop_gluster_volume(volume, request):
     depends(request, ['STARTED_GVOLUME'])
     ans = make_request('post', '/gluster/volume/stop', data={'name': volume, 'force': True})
     assert ans.status_code == 200, ans.text
@@ -116,7 +126,7 @@ def test_06_stop_gluster_volume(volume, request):
 
 @pytest.mark.parametrize('ip', CLUSTER_IPS)
 @pytest.mark.dependency(name='VERIFY_FUSE_UMOUNTED')
-def test_07_verify_gluster_volume_is_fuse_umounted(ip, request):
+def test_08_verify_gluster_volume_is_fuse_umounted(ip, request):
     depends(request, ['STOP_GVOLUME'])
 
     total_time_to_wait = 10
@@ -134,13 +144,13 @@ def test_07_verify_gluster_volume_is_fuse_umounted(ip, request):
 
 
 @pytest.mark.parametrize('volume', [GVOL])
-def test_08_delete_gluster_volume(volume, request):
+def test_09_delete_gluster_volume(volume, request):
     depends(request, ['VERIFY_FUSE_UMOUNTED'])
     ans = make_request('delete', f'/gluster/volume/id/{volume}')
     assert ans.status_code == 200, ans.text
     try:
         # wait for it to be deleted
-        status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 120)
+        wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 120)
     except JobTimeOut:
         assert False, JobTimeOut
     else:

--- a/cluster-tests/tests/gluster/test_volume.py
+++ b/cluster-tests/tests/gluster/test_volume.py
@@ -60,7 +60,7 @@ def test_03_create_gluster_volume(volume, request):
 
     # wait on the gluster volume to be created
     try:
-        status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 120)
+        status = wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], TIMEOUTS['VOLUME_TIMEOUT'])
     except JobTimeOut:
         assert False, JobTimeOut
     else:
@@ -150,7 +150,7 @@ def test_09_delete_gluster_volume(volume, request):
     assert ans.status_code == 200, ans.text
     try:
         # wait for it to be deleted
-        wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], 120)
+        wait_on_job(ans.json(), CLUSTER_INFO['NODE_A_IP'], TIMEOUTS['VOLUME_TIMEOUT'])
     except JobTimeOut:
         assert False, JobTimeOut
     else:


### PR DESCRIPTION
Since we fuse mount the gluster volumes locally on each node, we need to make sure we move those child process out from underneath the middlewared cgroup. This prevents the fuse mounts from becoming unmounted when `middlewared` service is restarted for whatever reason.

Original PR: https://github.com/truenas/middleware/pull/9819
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118117