### PR TITLE
NAS-118111 / 22.12-BETA.1 / Fix undefined name in vm/devices.cdrom.py (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
@@ -65,7 +65,7 @@ class CDROM(Device):
                 if self.middleware.call_sync('filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}):
                     is_valid = True
                 else:
-                    os.chown(path, libvirt_user['pw_uid'], libvirt_group['pw_gid'])
+                    os.chown(path, libvirt_user['pw_uid'], libvirt_user['pw_gid'])
             if not is_valid and not self.middleware.call_sync(
                 'filesystem.can_access_as_user', LIBVIRT_USER, path, {'read': True}
             ):


### PR DESCRIPTION
We switched from two separate db queries to a single NSS query for libvirt user, but neglected to change libvirt_group -> libvirt_user.

Original PR: https://github.com/truenas/middleware/pull/9816
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118111