### PR TITLE
NAS-117230 / 22.02.4 / Do not accumulate `self._finished.wait()` tasks when doing `job.wrap`

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -354,7 +354,7 @@ class Job:
         if timeout is None:
             await self._finished.wait()
         else:
-            await asyncio.wait_for(asyncio.shield(self._finished.wait()), timeout)
+            await asyncio.wait_for(self._finished.wait(), timeout)
         if raise_error:
             if self.error:
                 if isinstance(self.exc_info[1], CallError):


### PR DESCRIPTION
Current `job.wrap` implementation calls `subjob.wait(timeout=1)` indefinitely (i.e. every second). Each `wait` results in a `self._finished.wait()` task being created, and all these tasks will only finish when the parent job completes. For pool scrubs that can last dozens of even hundreds of thousands of seconds this might be a big issue affecting event loop performance and memory consumption.

`self._finished.wait()` was shielded from cancelling by commit fa845e1a9eb618a4a59aa24a280a97511f78aa50. I see no reason why this task can't be cancelled, it's only a `wait` on `asyncio.Event` and its cancellation should not be affecting anything. @william-gr do you recall what was the original issue? Commit message refers to https://redmine.ixsystems.com/issues/26779

For master branch I'll come up with more efficient `job.wrap` implementation and also address the original issue.