### PR TITLE
NAS-118138 / 22.12 / Fix unused disks issue

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -38,7 +38,9 @@ class DiskService(Service):
 
         unused = []
         serial_to_disk = defaultdict(list)
-        for i in await self.middleware.call('datastore.query', 'storage.disk', [], {'prefix': 'disk_'}):
+        for i in await self.middleware.call(
+            'datastore.query', 'storage.disk', [['disk_expiretime', '=', None]], {'prefix': 'disk_'}
+        ):
             if i['name'] in in_use_disks_imported:
                 # exclude disks that are currently in use by imported zpool(s)
                 continue


### PR DESCRIPTION
This commit fixes an issue where we were accounting for disks in `disk.get_unused` which were not present.