### PR TITLE
NAS-117952 / 22.02.4 / Add initial containers in pod logs choices (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -23,7 +23,9 @@ class ChartReleaseService(Service):
         choices = {}
         for pod in release['resources']['pods']:
             choices[pod['metadata']['name']] = []
-            for container in (pod['status']['container_statuses'] or []):
+            for container in (
+                (pod['status']['container_statuses'] or []) + (pod['status']['init_container_statuses'] or [])
+            ):
                 choices[pod['metadata']['name']].append(container['name'])
 
         return choices


### PR DESCRIPTION
## Problem

Init containers were not being accounted for when we were retrieving containers in a pod.


## Solution

Init containers need to be separately referenced in order to retrieve them properly.

Original PR: https://github.com/truenas/middleware/pull/9834
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117952