### PR TITLE
NAS-118139 / 22.12 / Catalogs need to be synced after restoring k8s backup

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -285,4 +285,10 @@ class KubernetesService(Service):
                 chart_release['replica_counts'], True,
             )
 
+        job.set_progress(99, 'Syncing catalogs')
+        sync_job = self.middleware.call_sync('catalog.sync_all')
+        sync_job.wait_sync()
+        if sync_job.error:
+            self.logger.error('Failed to sync catalogs after restoring kubernetes backup')
+
         job.set_progress(100, f'Restore of {backup_name!r} backup complete')


### PR DESCRIPTION
This commit fixes an issue where catalogs were not synced after restorking k8s backup and this leads to no catalogs actually being present on disk and creating a chart release subsequently is destined to fail as the catalogs have not been synced from github because catalogs dataset was nuked and started afresh.