### PR TITLE
NAS-118149 / 22.02.4 / Removed log_py_exceptions from middlewared.test.integration.utils.client

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -11,7 +11,7 @@ __all__ = ["client", "host", "session", "url"]
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, py_exceptions=True, log_py_exceptions=True):
+def client(*, auth=undefined, py_exceptions=True):
     if auth is undefined:
         if "NODE_A_IP" in os.environ:
             password = os.environ["APIPASS"]
@@ -20,7 +20,7 @@ def client(*, auth=undefined, py_exceptions=True, log_py_exceptions=True):
 
         auth = ("root", password)
 
-    with Client(f"ws://{host()}/websocket", py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+    with Client(f"ws://{host()}/websocket", py_exceptions=py_exceptions) as c:
         if auth is not None:
             c.call("auth.login", *auth)
         yield c


### PR DESCRIPTION
On Angelfish, log_py_exceptions is not implemented in middlewared.client.Client

It is causing testing using middlewared.test.integration.utils.client to fail with this
```
>       with Client(f"ws://{host()}/websocket", py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
E       TypeError: __init__() got an unexpected keyword argument 'log_py_exceptions'
```

See https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Stable/job/API%20Tests%20-%20TrueNAS%20SCALE%20Angelfish%20(Full%20-%20Nightly%20ISO)/270/testReport/api2/test_007_pool/test_08_test_pool_property_normalization/