### PR TITLE
NAS-115817 / 22.02.4 / Initialize directory services after system ready event

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -463,6 +463,10 @@ class DSCache(Service):
         This is called from a cronjob every 24 hours and when a user clicks on the
         UI button to 'rebuild directory service cache'.
         """
+        if not await self.middleware.call('system.ready'):
+            self.logger.debug("Skipping directory services cache setup because system not ready.")
+            return
+
         for ds in ['activedirectory', 'ldap']:
             await self.middleware.call('tdb.wipe', {'name': f'{ds}_user'})
             await self.middleware.call('tdb.wipe', {'name': f'{ds}_group'})

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -513,5 +513,14 @@ class DirectoryServices(Service):
         await refresh.wait()
 
 
+async def __directory_services_ready(middleware, event_type, args):
+
+    if args['id'] != 'ready':
+        return
+
+    await middleware.call('directoryservices.initialize')
+
+
 def setup(middleware):
     middleware.event_register('directoryservices.status', 'Sent on directory service state changes.')
+    middleware.event_subscribe('system', __directory_services_ready)


### PR DESCRIPTION
During boot, shift directory services initialialization to occur after the system ready event is sent. This is an angelfish-specific minimal fix.