### PR TITLE
NAS-118150 / 22.02.4 / properly catch libzfs EZFS_NOENT errno on failover

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -13,6 +13,8 @@ from middlewared.service import Service, job, accepts
 from middlewared.schema import Dict, Bool, Int
 from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
+from libzfs import Error as libzfs_errnos
+
 
 logger = logging.getLogger('failover')
 
@@ -383,7 +385,10 @@ class FailoverEventsService(Service):
             try:
                 self.run_call('zfs.pool.import_pool', vol['guid'], options, any_host, cachefile, new_name)
             except Exception as e:
-                if e.errno == errno.ENOENT:
+                error = next((i.name for i in libzfs_errnos if i.value == e.errno), '')
+                if error == 'NOENT' or e.errno == errno.ENOENT:
+                    # NOENT when cachefile exists and zpool isn't found from contents in cachefile
+                    # ENONENT when the cachefile doesn't exist on disk
                     logger.warning('Failed importing %r using cachefile so trying without it.', vol['name'])
                     try_again = True
                 else:


### PR DESCRIPTION
Nothing is ever easy.

`EZFS_NOENT` (`NOENT`) with error code `2009` is raised when the zpool doesn't get found from the contents of the cachefile
`ENOENT` with error code `2` is raised when the cachefile doesn't exist on disk