### PR TITLE
NAS-118197 / 22.12 / Fix k3s logs/exec issue

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -41,6 +41,9 @@ def render(service, middleware):
             'cluster-dns': config['cluster_dns_ip'],
             'data-dir': os.path.join('/mnt', config['dataset'], 'k3s'),
             'node-ip': config['node_ip'],
+            'node-external-ip': ','.join([
+                interface['address'] for interface in middleware.call_sync('interface.ip_in_use', {'ipv6': False})
+            ]),
             'kube-controller-manager-arg': kube_controller_args,
             'kube-apiserver-arg': kube_api_server_args,
             'kubelet-arg': kubelet_args,

--- a/tests/api2/test_027_kubernetes_logs.py
+++ b/tests/api2/test_027_kubernetes_logs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import contextlib
+import os
+from time import sleep
+import pytest
+import sys
+
+from pytest_dependency import depends
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from middlewared.test.integration.utils import call, ssh
+from auto_config import ip
+
+
+@contextlib.contextmanager
+def official_chart_release(chart_name, release_name):
+    payload = {
+        'catalog': 'OFFICIAL',
+        'item': chart_name,
+        'release_name': release_name,
+        'train': 'charts',
+    }
+    chart_release = call('chart.release.create', payload, job=True)
+    try:
+        yield chart_release
+    finally:
+        call('chart.release.delete', release_name, job=True)
+
+
+@contextlib.contextmanager
+def get_chart_release_pods(release_name, timeout=90):
+    status = call('chart.release.pod_status', release_name)
+    time_spend = 0
+    while status.get('status') != 'ACTIVE':
+        if time_spend > timeout:
+            raise Exception("Time out chart release is not in running state")
+        sleep(6)
+        time_spend += 6
+        status = call('chart.release.pod_status', release_name)
+
+    chart_pods = call('chart.release.pod_logs_choices', release_name)
+    yield chart_pods
+
+
+def test_get_chart_release_logs(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    release_name = 'test-logs'
+    with official_chart_release('ipfs', release_name) as chart_release:
+        with get_chart_release_pods(release_name, 100) as pods:
+            for pod_name, containers in pods.items():
+                for container in containers:
+                    logs = call('k8s.pod.get_logs', pod_name, container, chart_release['namespace'])
+                    assert logs != ''
+
+
+def test_get_chart_exec_result(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    release_name = 'test-exec'
+    with official_chart_release('ipfs', release_name) as chart_release:
+        with get_chart_release_pods(release_name, 100) as pods:
+            for pod_name, containers in pods.items():
+                for container in containers:
+                    result = ssh(
+                        f'k3s kubectl exec -n {chart_release["namespace"]} pods/{pod_name} -c {container} -- /bin/ls',
+                        check=False)
+                    assert result != ''


### PR DESCRIPTION
## Problem

With recent upgrade of kubernetes, k3s logs could not be viewed and neither would `exec` work for pods with kubernetes complaining about SSL certificate not containing explicit node IP.

## Solution

K3s generates SSL certificates itself required for functioning of kubernetes but it only by default adds the node IP to the certificate. For users who have selected wildcard ( `0.0.0.0` ) in the settings, the SSL certificate will have a SAN entry for `0.0.0.0` only but the actual node IP would be some IP on one of the interfaces of the system..
This results in failure to see logs or exec in pods. Proposed workflow is to provide all available ips to k3s so it adds explicit SAN entries for each IP available and then for cases like where we are using wildcard IP, the SSL certificate of kubernetes would still contain the actual node IP and users can access logs or exec pods.