### PR TITLE
Add better net stats to collectd

### DIFF
--- a/src/freenas/usr/local/lib/collectd_pyplugins/ifstat.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/ifstat.py
@@ -1,0 +1,63 @@
+import traceback
+
+import collectd
+from pyroute2 import IPRoute
+
+from middlewared.client import Client
+
+READ_INTERVAL = 1.0
+
+
+class IfStat():
+    ignore = []
+
+    def config(self, config):
+        pass
+
+    def init(self):
+        collectd.info('Initializing "ifstat" python plugin')
+        try:
+            with Client() as c:
+                self.ignore = c.call('interface.internal_interfaces')
+        except Exception:
+            collectd.error(traceback.format_exc())
+
+    def valid_iface(self, dev):
+        ifname = dev.get_attr('IFLA_IFNAME')
+        if ifname is not None and ifname not in self.ignore:
+            return ifname
+
+    def get_stats(self):
+        stats = dict()
+        with IPRoute() as ipr:
+            for i in ipr.dump():
+                if ifname := self.valid_iface(i):
+                    if ifstats := i.get_attr('IFLA_STATS64'):
+                        stats[ifname] = ifstats
+        return stats
+
+    def read(self):
+        try:
+            stats = self.get_stats()
+        except Exception:
+            collectd.error(traceback.format_exc())
+        else:
+            for ifname, ifstats in stats.items():
+                for stat, value in ifstats.items():
+                    self.dispatch_value(ifname, stat, value)
+
+    def dispatch_value(self, ifname, stat, value):
+        val = collectd.Values()
+        val.plugin = 'ifstat'
+        val.plugin_instance = ifname
+        val.type = 'ifstat'
+        val.type_instance = stat
+        val.values = [value]
+        val.meta = {'0': True}
+        val.dispatch(interval=READ_INTERVAL)
+
+
+ifstat = IfStat()
+collectd.register_config(ifstat.config)
+collectd.register_init(ifstat.init)
+collectd.register_read(ifstat.read, READ_INTERVAL)

--- a/src/freenas/usr/share/collectd/types.db.truenas
+++ b/src/freenas/usr/share/collectd/types.db.truenas
@@ -1,1 +1,2 @@
 nfsstat                 value:DERIVE:0:U
+ifstat                  value:DERIVE:0:U

--- a/src/middlewared/middlewared/etc_files/local/collectd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/collectd.conf.mako
@@ -44,7 +44,6 @@ LoadPlugin cpu
 LoadPlugin df
 LoadPlugin disk
 LoadPlugin exec
-LoadPlugin interface
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin processes
@@ -91,18 +90,6 @@ LoadPlugin python
 
 <Plugin "exec">
 	NotificationExec "nobody" "/usr/local/libexec/collectd_alert.py"
-</Plugin>
-
-<Plugin "interface">
-	Interface "lo"
-	Interface "lo0"
-	Interface "ipfw0"
-	Interface "pflog0"
-	Interface "pfsync0"
-	Interface "plip0"
-	Interface "/^usbus/"
-	Interface "/^veth/"
-	IgnoreSelected true
 </Plugin>
 
 <Plugin "rrdcached">
@@ -161,12 +148,15 @@ LoadPlugin python
 	Import "cputemp"
 	Import "disktemp"
 	Import "nfsstat"
+	Import "ifstat"
 
 	<Module "cputemp">
 	</Module>
 	<Module "disktemp">
 	</Module>
 	<Module "nfsstat">
+	</Module>
+	<Module "ifstat">
 	</Module>
 </Plugin>
 

--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -140,32 +140,16 @@ class DiskTempPlugin(RRDBase):
         return ids
 
 
-class InterfacePlugin(RRDBase):
-
-    vertical_label = 'Bits/s'
+class InterfacePacketsPlugin(RRDBase):
+    plugin = 'ifstat'
+    vertical_label = 'Packets'
     rrd_types = (
-        RRDType('if_octets', 'rx', '%name%,8,*', 'rx'),
-        RRDType('if_octets', 'tx', '%name%,8,*', 'tx'),
+        RRDType('ifstat-rx_packets', 'value'),
+        RRDType('ifstat-tx_packets', 'value'),
     )
-    rrd_data_extra = """
-        CDEF:overlap=%name_0%,%name_1%,LT,%name_0%,%name_1%,IF
-        XPORT:overlap:overlap
-    """
 
     def get_title(self):
-        return 'Interface Traffic ({identifier})'
-
-    def get_identifiers(self):
-        ids = []
-        ifaces = [i['name'] for i in self.middleware.call_sync('interface.query')]
-        for entry in glob.glob(f'{self._base_path}/interface-*'):
-            ident = entry.rsplit('-', 1)[-1]
-            if ident not in ifaces:
-                continue
-            if os.path.exists(os.path.join(entry, 'if_octets.rrd')):
-                ids.append(ident)
-        ids.sort(key=RRDBase._sort_disks)
-        return ids
+        return 'Interface Packets ({identifier})'
 
 
 class MemoryPlugin(RRDBase):

--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -152,6 +152,18 @@ class InterfacePacketsPlugin(RRDBase):
         return 'Interface Packets ({identifier})'
 
 
+class InterfaceBitsPlugin(RRDBase):
+    plugin = 'ifstat'
+    vertical_label = 'Bits/s'
+    rrd_types = (
+        RRDType('ifstat-rx_bytes', 'value', '%name%,8,*'),
+        RRDType('ifstat-tx_bytes', 'value', '%name%,8,*'),
+    )
+
+    def get_title(self):
+        return 'Interface Bits/s ({identifier})'
+
+
 class MemoryPlugin(RRDBase):
 
     title = 'Physical memory utilization'

--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -176,6 +176,18 @@ class InterfaceErrorsPlugin(RRDBase):
         return 'Interface Errors ({identifier})'
 
 
+class InterfaceDroppedPlugin(RRDBase):
+    plugin = 'ifstat'
+    vertical_label = 'Dropped'
+    rrd_types = (
+        RRDType('ifstat-rx_dropped', 'value'),
+        RRDType('ifstat-tx_dropped', 'value'),
+    )
+
+    def get_title(self):
+        return 'Interface Dropped ({identifier})'
+
+
 class MemoryPlugin(RRDBase):
 
     title = 'Physical memory utilization'

--- a/src/middlewared/middlewared/plugins/reporting/plugins.py
+++ b/src/middlewared/middlewared/plugins/reporting/plugins.py
@@ -164,6 +164,18 @@ class InterfaceBitsPlugin(RRDBase):
         return 'Interface Bits/s ({identifier})'
 
 
+class InterfaceErrorsPlugin(RRDBase):
+    plugin = 'ifstat'
+    vertical_label = 'Errors'
+    rrd_types = (
+        RRDType('ifstat-rx_errors', 'value'),
+        RRDType('ifstat-tx_errors', 'value'),
+    )
+
+    def get_title(self):
+        return 'Interface Errors ({identifier})'
+
+
 class MemoryPlugin(RRDBase):
 
     title = 'Physical memory utilization'


### PR DESCRIPTION
I'm investigating why `collectd` and `rrdcached` are using almost constant CPU time on a system with a large amount of datasets. As I was investigating, I noticed that the built-in `interface` plugin was lack-luster and furthermore we had not updated the collectd configuration so it was ignoring devices that could never exist on SCALE but also monitoring devices that we wanted to be ignored.

To remedy all of these problems, I've done the following:
1. remove the built-in `interface` module and replaced it with a python plugin called `ifstat`
2. this new plugin gives us quite a bit more data points to be mapped to each interface
3. the `ifstat` plugin now only monitors interfaces that we expect

3 new graphs are added
1. rx/tx packets
2. rx/tx errors
3. rx/tx dropped

1 graph updated
1. rx/tx bits per second