### PR TITLE
NAS-118222 / 22.12 / Fix keyerror in ACL template domain info lookup

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -201,7 +201,7 @@ class ACLTemplateService(CRUDService):
             return
 
         domain_info = await self.middleware.call('idmap.domain_info', 'DS_TYPE_ACTIVEDIRECTORY')
-        if not domain_info['active directory']:
+        if 'ACTIVE_DIRECTORY' not in domain_info['domain_flags']['parsed']:
             self.logger.warning(
                 '%s: domain is not identified properly as an Active Directory domain.',
                 domain_info['alt_name']


### PR DESCRIPTION
Regression was caused by changes to output format of idmap.domain_info due to change to libwbclient python bindings.