### PR TITLE
NAS-118250 / 22.12 / Set minimum protocol to SMB2.02

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -67,7 +67,7 @@ class GlobalSchema(RegistrySchema):
         return val['raw'] == "NT1"
 
     def set_min_protocol(entry, val, data_in, data_out):
-        data_out[entry.smbconf] = {"parsed": "NT1" if val else "SMB2_10"}
+        data_out[entry.smbconf] = {"parsed": "NT1" if val else "SMB2_02"}
         return
 
     def log_level_transform(entry, conf):


### PR DESCRIPTION
Lowering minimum protocol to SMB2.02 (Vista) should be benign. Apparently, this is used by some printer vendors.