### PR TITLE
NAS-118288 / 22.02.4 / fix behavioral change in api_key.create

### DIFF
--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -76,7 +76,7 @@ class ApiKeyService(CRUDService):
                     Str("method", required=True, enum=["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]),
                     Str("resource", required=True),
                 ),
-            ]),
+            ], default=[{"method": "*", "resource": "*"}]),
             register=True,
         )
     )


### PR DESCRIPTION
This exposed a bug on TrueCommand because they were supposed to be sending all the methods (i.e. `GET`, `POST`, etc) to us. However, they were not and it was silently completing. This meant that the key was created without an `allowlist` which granted all access by default.

This changes it back to so that if `allowlist` isn't provided, we grant access to all methods by default to be backwards compatible. Releases >= 22.12.BETA.2 will have the new behavior that if you do not provide an `allowlist`, we will grant no privileges to follow security best practices.