### PR TITLE
Revert "set CPU governor to performance mode always"

### DIFF
--- a/src/middlewared/middlewared/plugins/tunables.py
+++ b/src/middlewared/middlewared/plugins/tunables.py
@@ -179,8 +179,3 @@ class TunableService(CRUDService):
             await self.middleware.call('tunable.reset_sysctl', entry)
         else:
             await self.handle_tunable_change(entry)
-
-
-async def setup(middleware):
-    # make sure we're using all the available power for each cpu core
-    await run(['cpupower', 'frequency-set', '-g', 'performance'], check=False)


### PR DESCRIPTION
This reverts commit 058034a092b8d1d5df55a49c2f0e65dba763e218.

Performance team sees performance improvements almost everywhere....except systems running a different brand of CPU 🙄 We'll work with them to characterize certain aspects and turn this back on in a controlled manner.