### PR TITLE
NAS-118351 / 22.12 / Disable middleware debug mode being the default

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -10,7 +10,7 @@ Conflicts=reboot.target shutdown.target halt.target
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/middlewared --log-handler=file --disable-debug-mode
+ExecStart=/usr/bin/middlewared --log-handler=file
 TimeoutStartSec=240
 Restart=always
 # SIGTERM will only happen if systemd kills process that timed out booting (it is the only case in which we don't

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1836,7 +1836,7 @@ def main():
     parser.add_argument('--loop-debug', action='store_true')
     parser.add_argument('--trace-malloc', '-tm', action='store', nargs=2, type=int, default=False)
     parser.add_argument('--overlay-dirs', '-o', action='append')
-    parser.add_argument('--disable-debug-mode', action='store_true', default=False)
+    parser.add_argument('--debug-mode', action='store_true', default=False)
     parser.add_argument('--debug-level', choices=[
         'TRACE',
         'DEBUG',
@@ -1871,7 +1871,7 @@ def main():
         with open(pidpath, "w") as _pidfile:
             _pidfile.write(f"{str(os.getpid())}\n")
 
-    conf.debug_mode = not args.disable_debug_mode
+    conf.debug_mode = args.debug_mode
 
     Middleware(
         loop_debug=args.loop_debug,


### PR DESCRIPTION
No one seems to be interested to keep our return value schemas up-to-date, so middleware started in debug mode is unusable. Let's start it normally by default, we'll fix this in the future.