### PR TITLE
NAS-118362 / 22.12 / dramatically optimize retrieving drive temps

### DIFF
--- a/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
@@ -1,28 +1,3 @@
-# Copyright 2018 iXsystems, Inc.
-# All rights reserved
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted providing that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
-#####################################################################
 import traceback
 
 import collectd
@@ -31,45 +6,21 @@ from middlewared.client import Client, CallTimeout
 
 READ_INTERVAL = 300.0
 
-collectd.info('Loading "disktemp" python plugin')
 
-
-class DiskTemp(object):
-    initialized = False
-
+class DiskTemp():
     def config(self, config):
         pass
 
     def init(self):
         collectd.info('Initializing "disktemp" plugin')
-        try:
-            with Client() as c:
-                self.disks = c.call('disk.disks_for_temperature_monitoring')
-                self.powermode = c.call('smart.config')['powermode']
-        except Exception:
-            collectd.error(traceback.format_exc())
-        else:
-            self.initialized = True
 
     def read(self):
-        if not self.initialized:
-            self.init()
-
-        if not self.initialized:
-            return
-
-        if not self.disks:
-            return
-
         try:
             with Client() as c:
-                temperatures = c.call('disk.temperatures', self.disks, self.powermode)
-
-            for disk, temp in temperatures.items():
-                if temp is not None:
+                for disk, temp in filter(lambda x: x[1] is not None, c.call('disk.read_temps').items()):
                     self.dispatch_value(disk, 'temperature', temp, data_type='temperature')
         except CallTimeout:
-            collectd.error("Timeout collecting disk temperatures")
+            pass
         except Exception:
             collectd.error(traceback.format_exc())
 

--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -4,7 +4,10 @@ import re
 import subprocess
 import time
 import math
+import pathlib
+import contextlib
 
+import pyudev
 import async_timeout
 
 from middlewared.common.smart.smartctl import SMARTCTL_POWERMODES
@@ -154,6 +157,84 @@ class DiskService(Service):
                 return None
 
         return dict(zip(names, await asyncio_map(temperature, names, 8)))
+
+    @private
+    def read_sata_or_sas_disk_temps(self, disks):
+        rv = {}
+        with contextlib.suppress(FileNotFoundError):
+            for i in pathlib.Path('/var/lib/smartmontools').iterdir():
+                # TODO: throw this into multiple threads since we're reading data from disk
+                # to make this really go brrrrr (even though it only takes ~0.2 seconds on 439 disk system)
+                if i.is_file() and i.suffix == '.csv':
+                    if serial := next((k for k in disks if i.as_posix().find(k) != -1), None):
+                        with open(i.as_posix()) as f:
+                            for line in f:
+                                # iterate to the last line in the file without loading all of it
+                                # into memory since `smartd` could have written 1000's (or more)
+                                # of lines to the file
+                                pass
+
+                            if (ft := line.split('\t')) and (temp := list(filter(lambda x: 'temperature' in x, ft))):
+                                try:
+                                    temp = temp[-1].split(';')[1]
+                                except IndexError:
+                                    continue
+                                else:
+                                    if temp.isdigit():
+                                        rv[disks[serial]] = int(temp)
+
+        return rv
+
+    @private
+    def read_nvme_temps(self, disks):
+        # we store nvme disks in db with their namespaces (i.e. nvme1n1, nvme2n1, etc)
+        # but the hwmon sysfs sensors structure references the nvme devices via nvme1, nvme2
+        # so we simply take first 5 chars so they map correctly
+        nvme_disks = {v[:5]: v for v in disks.values() if v.startswith('nvme')}
+        rv = {}
+        ctx = pyudev.Context()
+        for i in filter(lambda x: x.parent.sys_name in nvme_disks, ctx.list_devices(subsystem='hwmon')):
+            if temp := i.attributes.get('temp1_input'):
+                try:
+                    # https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
+                    # temperature is reported in millidegree celsius so must convert back to celsius
+                    # we also round to nearest whole number for backwards compatbility
+                    rv[nvme_disks[i.parent.sys_name]] = round(int(temp.decode()) * 0.001)
+                except Exception:
+                    # if this fails the caller of this will subprocess out to smartctl and try to
+                    # get the temperature for the drive so dont crash here
+                    continue
+
+        return rv
+
+    @private
+    def read_temps(self):
+        """
+        The main consumer of this endpoint is the disktemp.py collectd python plugin
+        which polls and calls this method every 300 seconds (5 mins). The way we configure
+        the smartd.conf, the temperature will be written to disk in csv file format for each
+        drive. However, smartd only supports writing temp information for sata/sas drives at
+        the moment. Luckily, the kernel (via the hwmon interface) reports nvme drive temperatures
+        (if the nvme drive supports it). This means we can get all drive temperatures quite quickly.
+        However, if we can't get a drive temperature using these methods for whatever reason then
+        we will fall back to subprocessing out to smartctl and trying to parse the temperature.
+        """
+        disks = {
+            i['serial']: i['name'] for i in self.middleware.call_sync('datastore.query', 'storage.disk', [
+                ['serial', '!=', ''],
+                ['togglesmart', '=', True],
+                ['hddstandby', '=', 'Always On'],
+            ], {'prefix': 'disk_'})
+        }
+        temps = self.read_sata_or_sas_disk_temps(disks)
+        temps.update(self.read_nvme_temps(disks))
+
+        for disk in set(disks.values()) - set(temps.keys()):
+            # try to subprocess and run smartctl for any disk that we didn't get the temp
+            # for using the much quicker methods
+            temps.update({disk: self.middleware.call_sync('disk.temperature_uncached', disk, 'never')})
+
+        return temps
 
     @private
     def get_temp_value(self, value):


### PR DESCRIPTION
This does a few things:

1. retrieve SATA/SAS drive temps via the various csv files that `smartd` writes into `/var/lib/smartmontools` directory
2. If nvme drive supports it, the kernel will report the temp
3. make the `disktemp` collectd plugin use the new `disk.read_temps` method

On a system with 432 disks, retrieving drive temps takes ~0.2 seconds with this method. Before the changes this was taking many minutes because we're `subprocess`'ing out to `smartctl` and then parsing the stdout. What I've done is added an entry function `read_temps` that gets the drive temps by reading from kernel or reading from files off disk (as explained above). As a precautionary measure, I fall back as a last resort to `subprocess`'ing out to `smartctl` if we're unable to retrieve drive temps.

These changes are especially important on systems with many hundreds of hard drives.