### PR TITLE
NAS-118309 / 22.12 / disk_resize: Rescan SAS disks after resize

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -148,6 +148,9 @@ sas|scsi)
 		sg_format --format --quick /dev/${dev}
 	fi
 
+	# Tell the kernel to refresh the device properties.
+	echo 1 > /sys/block/${dev}/device/rescan
+
 	if [ ${err} -eq 0 ]; then
 		echo "Resize completed successfully."
 	else


### PR DESCRIPTION
It's been observed that sometimes Linux doesn't notice when a disk is resized.  Forcing a rescan of the device ensures the kernel updates its size.