### PR TITLE
NAS-118416 / 22.12 / impose limit on max length of pool name

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -607,7 +607,7 @@ class PoolService(CRUDService):
 
     @accepts(Dict(
         'pool_create',
-        Str('name', required=True),
+        Str('name', max_length=50, required=True),
         Bool('encryption', default=False),
         Str('deduplication', enum=[None, 'ON', 'VERIFY', 'OFF'], default=None, null=True),
         Str('checksum', enum=[None] + ZFS_CHECKSUM_CHOICES, default=None, null=True),


### PR DESCRIPTION
Pool name counts toward max dataset name limit, hence, we should encourage users toward shorter names to
maximize usable characters for nested datasets.