### PR TITLE
NAS-118444 / 22.12 / add MISMATCH_VERSIONS to failover.disabled.reasons

### DIFF
--- a/src/freenas/usr/local/sbin/hactl
+++ b/src/freenas/usr/local/sbin/hactl
@@ -24,6 +24,7 @@ class StatusEnum(enum.Enum):
 class DisabledEnum(enum.Enum):
     NO_CRITICAL_INTERFACES = 'No network interfaces are marked critical for failover.'
     MISMATCH_DISKS = 'The quantity of disks do not match between the nodes.'
+    MISMATCH_VERSIONS = 'TrueNAS software versions do not match between storage controllers.'
     DISAGREE_VIP = 'Nodes Virtual IP states do not agree.'
     NO_LICENSE = 'Other node has no license.'
     NO_FAILOVER = 'Administratively Disabled.'

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -29,6 +29,7 @@ class FailoverDisabledReasonsService(Service):
         NO_LICENSE - Other storage controller has no license.
         DISAGREE_VIP - Nodes Virtual IP states do not agree.
         MISMATCH_DISKS - The storage controllers do not have the same quantity of disks.
+        MISMATCH_VERSIONS - TrueNAS software versions do not match between storage controllers.
         NO_CRITICAL_INTERFACES - No network interfaces are marked critical for failover.
         NO_FENCED - Zpools are imported but fenced isn't running.
         REM_FAILOVER_ONGOING - Other node is currently processing a failover event.
@@ -102,6 +103,11 @@ class FailoverDisabledReasonsService(Service):
 
             if not self.middleware.call_sync('failover.call_remote', 'failover.licensed'):
                 reasons.add('NO_LICENSE')
+
+            lsw = self.middleware.call_sync('system.version')
+            rsw = self.middleware.call_sync('failover.call_remote', 'system.version')
+            if lsw != rsw:
+                reasons.add('MISMATCH_VERSIONS')
 
             args = [
                 [["method", "in", ["failover.events.vrrp_master", "failover.events.vrrp_backup"]]],


### PR DESCRIPTION
We already raise an alert in the webUI but we don't in `failover.disabled.reasons` which doesn't make any logical sense.