### PR TITLE
NAS-118459 / 22.12 / Fix and enhance recycle test

### DIFF
--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -17,6 +17,7 @@ from time import sleep
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, DELETE, SSH_TEST, cmd_test, send_file
+from utils import create_dataset
 from auto_config import ip, pool_name, password, user, hostname, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
@@ -341,21 +342,43 @@ def test_041_verify_smb_getparm_vfs_objects_share(request, vfs_object):
 
 
 def test_042_recyclebin_functional_test(request):
-    with smb_connection(
-        host=ip,
-        share=SMB_NAME,
-        username='shareuser',
-        password='testing',
-    ) as c:
-        fd = c.create_file('testfile.txt', 'w')
-        c.write(fd, b'foo')
-        c.close(fd, True)
+    with create_dataset(f'{dataset}/subds', {'share_type': 'SMB'}):
+        with smb_connection(
+            host=ip,
+            share=SMB_NAME,
+            username='shareuser',
+            password='testing',
+        ) as c:
+            # Our recycle repository should be auto-created on connect.
+            fd = c.create_file('testfile.txt', 'w')
+            c.write(fd, b'foo')
+            c.close(fd, True)
 
-        # Above close op also deleted the file and so
-        # we expect file to now exist in the user's .recycle directory
-        fd = c.create_file('./recycle/shareuser/testfile.txt', 'r')
-        val = c.read(fd, 0, 3)
-        assert val == b'foo'
+            # Above close op also deleted the file and so
+            # we expect file to now exist in the user's .recycle directory
+            fd = c.create_file('.recycle/shareuser/testfile.txt', 'r')
+            val = c.read(fd, 0, 3)
+            c.close(fd)
+            assert val == b'foo'
+
+            # re-open so that we can set DELETE_ON_CLOSE
+            # this verifies that SMB client can purge file from recycle bin
+            c.close(c.create_file('.recycle/shareuser/testfile.txt', 'w'), True)
+            assert c.ls('.recycle/shareuser/') == []
+
+            # nested datasets get their own recycle bin to preserve atomicity of
+            # rename op.
+            fd = c.create_file('subds/testfile2.txt', 'w')
+            c.write(fd, b'boo')
+            c.close(fd, True)
+
+            fd = c.create_file('subds/.recycle/shareuser/testfile2.txt', 'r')
+            val = c.read(fd, 0, 3)
+            c.close(fd)
+            assert val == b'boo'
+
+            c.close(c.create_file('subds/.recycle/shareuser/testfile2.txt', 'w'), True)
+            assert c.ls('subds/.recycle/shareuser/') == []
 
 
 @windows_host_cred


### PR DESCRIPTION
Add tests to validate:
1. files purged when deleted from recycle paths
2. per-dataset recycle bins are automatically created

This also fixes typo in path for original refactor of recycle test.