### PR TITLE
Fix pods logs repetition in watch

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
@@ -104,7 +104,7 @@ class KubernetesPodLogsFollowTailEventSource(EventSource):
                 async with self.watch.stream(
                     context['core_api'].read_namespaced_pod_log, name=pod, container=container,
                     namespace=release_data['namespace'], tail_lines=tail_lines, limit_bytes=limit_bytes,
-                    timestamps=True,
+                    timestamps=True, _request_timeout=1800
                 ) as stream:
                     async for event in stream:
                         # Event should contain a timestamp in RFC3339 format, we should parse it and supply it


### PR DESCRIPTION
## Problem

`kubernetes_asyncio` package repeats logs after default timeout of k8s request completes as it makes a repeated call to k8s api server. So if we are watching pod logs for example in the UI or with middleware events, we would see pod logs repeating every 5-10 minutes as the new API call it makes get old logs as well.

## Solution

As this issue is by design of how `kubernetes_asyncio` watches logs in realtime, there are limited options. Following options made sense:

1. Keep a cache of logs and when the request is made again invalidate old logs by cache as we had already fed them to consumer.
2. Increase timeout of the request as what happens is that when the k8s client makes request to k8s api, it gets logs up till now and any other which are generated until `timeout` is reached, so we can increase the timeout to 1h or 30m which seems like a more reasonable limit for watching logs - this way new API request is not initiated and we don't see older logs repeated as the request is valid for the specified `timeout` duration.

Point 1 seems reasonable but for apps which have lots of logs coming in will mean we would be increasing memory usage which does not seem reasonable. Point 2 seems more reasonable, it does not make the problem go away but setting it to 30 minutes does improve the situation from usability point of view.