### PR TITLE
NAS-118244 / 22.12 / Remove unsupported/user configured md mirrors

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -37,6 +37,7 @@ class DiskService(Service):
                 in_use_disks_exported[in_use_disk] = i['name']
 
         unused = []
+        unsupported_md_devices_mapping = await self.middleware.call('disk.get_disks_to_unsupported_md_devices_mapping')
         serial_to_disk = defaultdict(list)
         for i in await self.middleware.call(
             'datastore.query', 'storage.disk', [['disk_expiretime', '=', None]], {'prefix': 'disk_'}
@@ -50,6 +51,9 @@ class DiskService(Service):
             # was imported so we'll mark this disk specially so that end-user
             # can be warned appropriately
             i['exported_zpool'] = in_use_disks_exported.get(i['name'])
+            # User might have unsupported md devices configured and a single disk might have multiple
+            # partitions which are being used by different md devices so this value will be a list or null
+            i['unsupported_md_devices'] = unsupported_md_devices_mapping.get(i['name'])
 
             serial_to_disk[(i['serial'], i['lunid'])].append(i)
             unused.append(i)

--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -1,6 +1,8 @@
+import collections
+import contextlib
 import glob
 import os
-import contextlib
+import pyudev
 
 from middlewared.service import CallError, filterable, private, Service
 from middlewared.utils import filter_list, run
@@ -25,28 +27,32 @@ class DiskService(Service):
         if mirror['encrypted_provider']:
             await self.middleware.call('disk.remove_encryption', mirror['encrypted_provider'])
 
-        path = mirror['path']
-        cp = await run('mdadm', '--stop', path, check=False, encoding='utf8')
-        if cp.returncode:
-            raise CallError(f'Failed to stop mirror {name!r}: {cp.stderr}')
+        await self.stop_md_device(mirror['path'])
+        await self.clean_superblocks_on_md_device([p['name'] for p in mirror['providers']], True)
 
-        await run(
-            'mdadm', '--zero-superblock', '--force',
-            *[os.path.join('/dev', provider['name']) for provider in mirror['providers']],
-            encoding='utf8', check=False
-        )
+    @private
+    async def stop_md_device(self, path, raise_exception=True):
+        cp = await run('mdadm', '--stop', path, check=False, encoding='utf8')
+        if cp.returncode and raise_exception:
+            raise CallError(f'Failed to stop md device {path!r}: {cp.stderr}')
+
+    @private
+    async def clean_superblocks_on_md_device(self, devices, force):
+        await run(*(
+            ['mdadm', '--zero-superblock'] + (['--force'] if force else []) + [
+                os.path.join('/dev', device) for device in devices
+            ]
+        ), check=False, encoding='utf8')
 
     @private
     @filterable
-    def get_swap_mirrors(self, filters, options):
-        mirrors = []
+    def get_md_devices(self, filters, options):
+        md_devices = []
+        context = pyudev.Context()
         with contextlib.suppress(FileNotFoundError):
             for array in os.scandir('/dev/md'):
-                if not array.name.split(':')[-1].startswith('swap'):
-                    continue
-
                 real_path = os.path.realpath(array.path)
-                mirror = {
+                md_device = {
                     'name': array.name.split(':')[-1],
                     'path': array.path,
                     'real_path': real_path,
@@ -54,16 +60,40 @@ class DiskService(Service):
                     'providers': [],
                 }
                 if enc_path := glob.glob(f'/sys/block/dm-*/slaves/{real_path.split("/")[-1]}'):
-                    mirror['encrypted_provider'] = os.path.join('/dev', enc_path[0].split('/')[3])
+                    md_device['encrypted_provider'] = os.path.join('/dev', enc_path[0].split('/')[3])
 
-                for provider in os.scandir(os.path.join('/sys/block', mirror['real_path'].split('/')[-1], 'slaves')):
+                for provider in os.scandir(os.path.join('/sys/block', md_device['real_path'].split('/')[-1], 'slaves')):
+                    provider_data = {'name': provider.name, 'id': provider.name, 'disk': provider.name}
+
                     partition = os.path.join('/sys/class/block', provider.name, 'partition')
                     if os.path.exists(partition):
-                        provider_data = {'name': provider.name, 'id': provider.name}
-                        with open(partition, 'r') as f:
-                            provider_data['disk'] = provider.name.rsplit(f.read().strip(), 1)[0].strip()
-                        mirror['providers'].append(provider_data)
+                        # This means provider is a partition and not complete disk
+                        with contextlib.suppress(pyudev.DeviceNotFoundByNameError):
+                            device = pyudev.Devices.from_name(context, 'block', provider.name)
+                            parent = device.find_parent('block')
+                            if parent is not None:
+                                provider_data['disk'] = parent.sys_name
 
-                mirrors.append(mirror)
+                    md_device['providers'].append(provider_data)
 
-        return filter_list(mirrors, filters, options)
+                md_devices.append(md_device)
+
+        return filter_list(md_devices, filters, options)
+
+    @private
+    @filterable
+    def get_swap_mirrors(self, filters, options):
+        filters.append(['name', 'rin', 'swap'])
+        return self.get_md_devices(filters, options)
+
+    @private
+    async def get_unsupported_md_devices(self):
+        return await self.middleware.call('disk.get_md_devices', [['name', 'rnin', 'swap']])
+
+    @private
+    async def get_disks_to_unsupported_md_devices_mapping(self):
+        md_device_disk_mapping = collections.defaultdict(list)
+        for md_device in await self.get_unsupported_md_devices():
+            for provider in md_device['providers']:
+                md_device_disk_mapping[provider['disk']].append(md_device['name'])
+        return md_device_disk_mapping

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -14,6 +14,7 @@ class PoolService(Service):
         await self.middleware.call('disk.sed_unlock_all')
         swapgb = (await self.middleware.call('system.advanced.config'))['swapondrive']
         formatted = 0
+        await self.middleware.call('pool.remove_unsupported_md_devices_from_disks', disks)
 
         async def format_disk(arg):
             nonlocal formatted

--- a/src/middlewared/middlewared/plugins/pool_/md_mirrors.py
+++ b/src/middlewared/middlewared/plugins/pool_/md_mirrors.py
@@ -1,0 +1,20 @@
+from middlewared.service import private, Service
+
+
+class PoolService(Service):
+
+    @private
+    async def remove_unsupported_md_devices_from_disks(self, disks):
+        to_remove_md_devices = set()
+        md_devices = {
+            device['name']: device for device in await self.middleware.call('disk.get_unsupported_md_devices')
+        }
+        disks_md_devices_mapping = await self.middleware.call('disk.get_disks_to_unsupported_md_devices_mapping')
+        for disk in filter(lambda d: d in disks_md_devices_mapping, disks):
+            to_remove_md_devices.update(disks_md_devices_mapping[disk])
+
+        for md_device in to_remove_md_devices:
+            await self.middleware.call('disk.stop_md_device', md_devices[md_device]['path'], False)
+            await self.middleware.call(
+                'disk.clean_superblocks_on_md_device', [p['name'] for p in md_devices[md_device]['providers']], False
+            )

--- a/tests/api2/test_unsupported_md_devices.py
+++ b/tests/api2/test_unsupported_md_devices.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import pytest
+import sys
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from middlewared.test.integration.utils import call, ssh
+
+
+MD_DEVICE_NAME = 'mddevicetest'
+MD_DEVICE_MIRROR_LENGTH = 2
+
+
+def create_md_device(md_mirror_name, disks):
+    if len(disks) < MD_DEVICE_MIRROR_LENGTH:
+        pytest.skip(f'Skipping as at least {MD_DEVICE_MIRROR_LENGTH} unused disks are required')
+
+    for disk in disks[:MD_DEVICE_MIRROR_LENGTH]:
+        call('disk.wipe', disk['name'], 'QUICK', job=True)
+
+    md_device_disks = [f'/dev/{disks[i]["name"]}' for i in range(MD_DEVICE_MIRROR_LENGTH)]
+    ssh(
+        f'mdadm --create /dev/md/{md_mirror_name} {" ".join(md_device_disks)} --level=1 '
+        f'--raid-devices={MD_DEVICE_MIRROR_LENGTH} --meta=1.2 --force',
+    )
+
+
+def destroy_md_device(mirror_name):
+    md_device = call('disk.get_md_devices', [['name', '=', mirror_name]], {'get': True})
+    call('disk.stop_md_device', md_device['path'], False)
+    call('disk.clean_superblocks_on_md_device', [p['name'] for p in md_device['providers']], False)
+
+
+def test_pool_creation_with_md_device_used_disks(request):
+    disks = call('disk.get_unused')
+    create_md_device(MD_DEVICE_NAME, disks)
+
+    error = None
+    try:
+        pool = call('pool.create', {
+            'name': 'testmd',
+            'encryption': False,
+            'allow_duplicate_serials': True,
+            'topology': {
+                'data': [
+                    {'type': 'STRIPE', 'disks': [disk['devname'] for disk in disks[:MD_DEVICE_MIRROR_LENGTH]]},
+                ],
+            },
+        }, job=True)
+    except Exception as e:
+        error = e
+    else:
+        call('pool.export', pool['id'], job=True)
+
+    assert error is None, f'Unable to create pool on md device disks: {error!r}'
+
+
+def test_disk_unused_correctly_reports_user_configured_md_device(request):
+    disks = call('disk.get_unused')
+    try:
+        create_md_device(MD_DEVICE_NAME, disks)
+        to_check_disks = [disk['name'] for disk in disks[:MD_DEVICE_MIRROR_LENGTH]]
+        for disk in call('disk.get_unused'):
+            if disk['name'] in to_check_disks and disk['unsupported_md_devices'] == [MD_DEVICE_NAME]:
+                to_check_disks.remove(disk['name'])
+
+        assert to_check_disks == [], f'{", ".join(to_check_disks)!r} disks not ' \
+                                     f'correctly reported as being used by md devices'
+    finally:
+        destroy_md_device(MD_DEVICE_NAME)


### PR DESCRIPTION
## Problem

Some users might have had their own md devices configured either on disks which were in use by some other system before or might do it manually.
This causes problems when we try to create a pool with those as it is going to fail with EBUSY error.

## Solution

The solution to the problem is two fold:
1. Allow users to see in the UI that a disk is being used by an unsupported md mirror
2. Remove the mirrors which are using disks which user specified in pool creation/update or disk replace/attach

This also fixes a bug where system reported actual disk of a partition device being consumed by a md mirror not accounting for different partitioning schemes.