### PR TITLE
NAS-118498 / 13.0 / Disable the mdssd rpc daemon

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -128,6 +128,8 @@
                 'unix charset': db['cifs']['unixcharset'],
                 'log level': f"{db['loglevel']} auth_json_audit:3@/var/log/samba4/auth_audit.log",
                 'obey pam restrictions': 'True' if pam_is_required(db) else 'False',
+                'rpc_daemon:mdssd': 'disabled',
+                'rpc_server:mdssvc': 'disabled',
             })
             if osc.IS_FREEBSD:
                 pc.update({'enable web service discovery': 'True'})


### PR DESCRIPTION
Spotlight support via elasticsearch is currently broken and users can override this via auxiliary parameters if they're particularly ambitious.