### PR TITLE
NAS-118328 / 22.12 / Do not encrypt ix-applications dataset 

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -272,7 +272,9 @@ class KubernetesService(Service):
     async def create_update_k8s_datasets(self, k8s_ds):
         create_props_default = self.k8s_props_default()
         for dataset_name in await self.kubernetes_datasets(k8s_ds):
-            custom_props = self.kubernetes_dataset_custom_props(ds=dataset_name.rsplit(k8s_ds)[1].strip('/'))
+            custom_props = self.kubernetes_dataset_custom_props(
+                ds=dataset_name.rsplit(k8s_ds.split('/', 1)[0])[1].strip('/')
+            )
             # got custom properties, need to re-calculate
             # the update and create props.
             create_props = dict(create_props_default, **custom_props) if custom_props else create_props_default
@@ -320,7 +322,10 @@ class KubernetesService(Service):
     @private
     def kubernetes_dataset_custom_props(self, ds: str) -> Dict:
         props = {
-            'k3s/kubelet': {
+            'ix-applications': {
+                'encryption': 'off'
+            },
+            'ix-applications/k3s/kubelet': {
                 'mountpoint': 'legacy'
             }
         }

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -132,6 +132,16 @@ class KubernetesService(ConfigService):
                         f'{schema}.migrate_applications',
                         f'{applications_ds_name(old_data["pool"])!r} does not exist, migration not possible.'
                     )
+                if not verrors and (
+                    await self.middleware.call(
+                        'pool.dataset.get_instance', old_data['pool'], {'extra': {'retrieve_children': False}}
+                    )
+                )['encrypted']:
+                    verrors.add(
+                        f'{schema}.migrate_applications',
+                        f'Source {old_data["pool"]!r} is encrypted and it is not supported '
+                        'migrating encrypted applications data'
+                    )
 
         network_cidrs = set([
             ipaddress.ip_network(f'{ip_config["address"]}/{ip_config["netmask"]}', False)


### PR DESCRIPTION
This PR adds changes to not allow encrypting ix-applications dataset even if parent is encrypted and also not allow migrating ix-applications dataset to another pool if source is encrypted as this results in various edge cases which after discussing with Caleb we have decided not to handle.