### PR TITLE
NAS-118498 / 22.12 / Disable spotlight-related RPC server

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -7,6 +7,8 @@
 %>
 
 [global]
+    rpc_daemon:mdssd = disabled
+    rpc_server:mdssvc = disabled
     % if failover_status in ('SINGLE', 'MASTER'):
     % if smb_ha_mode == "CLUSTERED":
     clustering = Yes


### PR DESCRIPTION
Until such a time as we officially support spotlight searches, disable the relevant RPC server. End-users can override this setting via auxiliary parameters.