### PR TITLE
NAS-118387 / 22.12 / Allow USB passthrough based on product/vendor id of USB drives

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
@@ -22,6 +22,10 @@ def upgrade():
     }
 
     for device_id, device_attrs in devices.items():
+        device_attrs.update({
+            'controller_type': 'nec-xhci',
+            'usb': None,
+        })
         device_attrs['usb'] = None
         conn.execute('UPDATE vm_device SET attributes = ? WHERE id = ?', (
             json.dumps(device_attrs), device_id

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
@@ -26,7 +26,6 @@ def upgrade():
             'controller_type': 'nec-xhci',
             'usb': None,
         })
-        device_attrs['usb'] = None
         conn.execute('UPDATE vm_device SET attributes = ? WHERE id = ?', (
             json.dumps(device_attrs), device_id
         ))

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-10-07_21-31_update_usb_pass_through_params.py
@@ -1,0 +1,32 @@
+"""update usb pass through params
+
+Revision ID: d388b0e9a50d
+Revises: 7a74a8933a30
+Create Date: 2022-10-07 21:31:21.541782+00:00
+
+"""
+from alembic import op
+import json
+
+revision = 'd388b0e9a50d'
+down_revision = '7a74a8933a30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    devices = {
+        row['id']: json.loads(row['attributes'])
+        for row in map(dict, conn.execute("SELECT * FROM vm_device WHERE dtype = 'USB'").fetchall())
+    }
+
+    for device_id, device_attrs in devices.items():
+        device_attrs['usb'] = None
+        conn.execute('UPDATE vm_device SET attributes = ? WHERE id = ?', (
+            json.dumps(device_attrs), device_id
+        ))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -87,7 +87,12 @@ class USB(Device):
         if verrors:
             return
 
-        if device['attributes']['device']:
+        if not device['attributes']['device'] and not device['attributes']['usb']:
+            verrors.add(
+                'attributes.device',
+                'Either device or attributes.usb must be specified'
+            )
+        elif device['attributes']['device']:
             self._validate_usb_port(device, verrors)
         else:
             self._validate_usb_details(device, verrors)

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -19,6 +19,7 @@ class USB(Device):
             Str('vendor_id', empty=False, required=True),
             Str('product_id', empty=False, required=True),
             default=None,
+            null=True,
         ),
         Str('controller_type', empty=False, default='nec-xhci', enum=USB_CONTROLLER_CHOICES),
         Str('device', empty=False, null=True),
@@ -56,7 +57,10 @@ class USB(Device):
         if usb_device:
             return self.middleware.call_sync('vm.device.usb_passthrough_device', usb_device)
         else:
-            return self.middleware.call_sync('vm.device.usb_passthrough_device', str(usb_device))
+            return {
+                **self.middleware.call_sync('vm.device.get_basic_usb_passthrough_device_data'),
+                'error': 'Could not find matching device as no usb device has been specified',
+            }
 
     def is_available(self):
         return self.get_details()['available']

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -29,6 +29,10 @@ class USB(Device):
         return self.data['attributes']['device']
 
     @property
+    def controller_type(self):
+        return self.data['attributes']['controller_type']
+
+    @property
     def usb_details(self):
         return self.data['attributes']['usb']
 
@@ -58,8 +62,9 @@ class USB(Device):
         return self.get_details()['available']
 
     def xml_linux(self, *args, **kwargs):
+        controller_mapping = kwargs.pop('controller_mapping')
         details = self.get_details()['capability']
-        device_xml = create_element(
+        return create_element(
             'hostdev', mode='subsystem', type='usb', managed='yes', attribute_dict={
                 'children': [
                     create_element('source', attribute_dict={'children': [
@@ -67,10 +72,12 @@ class USB(Device):
                         create_element('product', id=details['product_id']),
                         create_element('address', bus=details['bus'], device=details['device']),
                     ]}),
+                    create_element('address', type='usb', bus=str(controller_mapping[self.controller_type])),
                 ]
             }
+        ), create_element(
+            'controller', type='usb', model=self.controller_type, index=str(controller_mapping[self.controller_type])
         )
-        return device_xml
 
     def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
         if device['attributes']['device'] and device['attributes']['usb']:

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -5,8 +5,8 @@ from .utils import create_element
 
 
 USB_CONTROLLER_CHOICES = [
-    'piix3-uhci', 'piix4-uhci', 'ehci', 'ich9-ehci1', 'ich9-uhci1', 'ich9-uhci2',
-    'ich9-uhci3', 'vt82c686b-uhci', 'pci-ohci', 'nec-xhci', 'qusb1', 'qemu-xhci',
+    'piix3-uhci', 'piix4-uhci', 'ehci', 'ich9-ehci1',
+    'vt82c686b-uhci', 'pci-ohci', 'nec-xhci', 'qemu-xhci',
 ]
 
 

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -4,6 +4,12 @@ from .device import Device
 from .utils import create_element
 
 
+USB_CONTROLLER_CHOICES = [
+    'piix3-uhci', 'piix4-uhci', 'ehci', 'ich9-ehci1', 'ich9-uhci1', 'ich9-uhci2',
+    'ich9-uhci3', 'vt82c686b-uhci', 'pci-ohci', 'nec-xhci', 'qusb1', 'qemu-xhci',
+]
+
+
 class USB(Device):
 
     schema = Dict(
@@ -14,6 +20,7 @@ class USB(Device):
             Str('product_id', empty=False),
             default=None,
         ),
+        Str('controller_type', empty=False, default='nec-xhci', enum=USB_CONTROLLER_CHOICES),
         Str('device', empty=False, null=True),
     )
 

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -75,8 +75,6 @@ class USB(Device):
                     create_element('address', type='usb', bus=str(controller_mapping[self.controller_type])),
                 ]
             }
-        ), create_element(
-            'controller', type='usb', model=self.controller_type, index=str(controller_mapping[self.controller_type])
         )
 
     def _validate(self, device, verrors, old=None, vm_instance=None, update=True):

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -8,6 +8,12 @@ class USB(Device):
 
     schema = Dict(
         'attributes',
+        Dict(
+            'usb',
+            Str('vendor_id', empty=False),
+            Str('product_id', empty=False),
+            default=None,
+        ),
         Str('device', required=True, empty=False),
     )
 

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -21,6 +21,10 @@ class USB(Device):
     def usb_device(self):
         return self.data['attributes']['device']
 
+    @property
+    def usb_details(self):
+        return self.data['attributes']['usb']
+
     def identity(self):
         return self.usb_device
 
@@ -31,7 +35,13 @@ class USB(Device):
         return self.middleware.call_sync('vm.query', [['id', 'in', [dev['vm'] for dev in devs]]])
 
     def get_details(self):
-        return self.middleware.call_sync('vm.device.usb_passthrough_device', self.usb_device)
+        usb_device = self.usb_device
+        if not usb_device and self.usb_details:
+            usb_device = self.middleware.call_sync('vm.device.get_usb_port_from_usb_details', self.usb_details)
+        if usb_device:
+            return self.middleware.call_sync('vm.device.usb_passthrough_device', usb_device)
+        else:
+            return self.middleware.call_sync('vm.device.usb_passthrough_device', str(usb_device))
 
     def is_available(self):
         return self.get_details()['available']

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -40,7 +40,8 @@ class VMSupervisor(VMSupervisorBase):
         boot_no = Nid(1)
         scsi_device_no = Nid(1)
         usb_controller_no = Nid(1)
-        usb_controllers = {}
+        # nec-xhci is added by default for each domain by libvirt so we update our mapping accordingly
+        usb_controllers = {'nec-xhci': 0}
         virtual_device_no = Nid(1)
         devices = []
         for device in filter(lambda d: d.is_available(), self.devices):
@@ -55,8 +56,9 @@ class VMSupervisor(VMSupervisorBase):
                 if device.controller_type not in usb_controllers:
                     usb_controllers[device.controller_type] = usb_controller_no()
                     device_xml.append(create_element(
-                        'address', type='usb', bus=str(usb_controllers[device.controller_type])
-                    ))
+                        'controller', type='usb', index=str(usb_controllers[device.controller_type]),
+                        model=device.controller_type)
+                    )
                 usb_device_xml = device.xml(controller_mapping=usb_controllers)
                 if isinstance(usb_device_xml, (tuple, list)):
                     device_xml.extend(usb_device_xml)

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -1,6 +1,6 @@
 import shlex
 
-from middlewared.plugins.vm.devices import CDROM, DISK, DISPLAY, RAW
+from middlewared.plugins.vm.devices import CDROM, DISK, DISPLAY, RAW, USB
 from middlewared.utils import Nid
 
 from .supervisor_base import VMSupervisorBase
@@ -48,6 +48,8 @@ class VMSupervisor(VMSupervisorBase):
                 else:
                     disk_no = scsi_device_no()
                 device_xml = device.xml(disk_number=disk_no, boot_number=boot_no())
+            elif isinstance(device, USB):
+                pass
             else:
                 device_xml = device.xml()
             devices.extend(device_xml if isinstance(device_xml, (tuple, list)) else [device_xml])

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -51,9 +51,17 @@ class VMSupervisor(VMSupervisorBase):
                     disk_no = scsi_device_no()
                 device_xml = device.xml(disk_number=disk_no, boot_number=boot_no())
             elif isinstance(device, USB):
+                device_xml = []
                 if device.controller_type not in usb_controllers:
                     usb_controllers[device.controller_type] = usb_controller_no()
-                device_xml = device.xml(controller_mapping=usb_controllers)
+                    device_xml.append(create_element(
+                        'address', type='usb', bus=str(usb_controllers[device.controller_type])
+                    ))
+                usb_device_xml = device.xml(controller_mapping=usb_controllers)
+                if isinstance(usb_device_xml, (tuple, list)):
+                    device_xml.extend(usb_device_xml)
+                else:
+                    device_xml.append(usb_device_xml)
             else:
                 device_xml = device.xml()
             devices.extend(device_xml if isinstance(device_xml, (tuple, list)) else [device_xml])

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_linux.py
@@ -39,6 +39,8 @@ class VMSupervisor(VMSupervisorBase):
     def devices_xml(self):
         boot_no = Nid(1)
         scsi_device_no = Nid(1)
+        usb_controller_no = Nid(1)
+        usb_controllers = {}
         virtual_device_no = Nid(1)
         devices = []
         for device in filter(lambda d: d.is_available(), self.devices):
@@ -49,7 +51,9 @@ class VMSupervisor(VMSupervisorBase):
                     disk_no = scsi_device_no()
                 device_xml = device.xml(disk_number=disk_no, boot_number=boot_no())
             elif isinstance(device, USB):
-                pass
+                if device.controller_type not in usb_controllers:
+                    usb_controllers[device.controller_type] = usb_controller_no()
+                device_xml = device.xml(controller_mapping=usb_controllers)
             else:
                 device_xml = device.xml()
             devices.extend(device_xml if isinstance(device_xml, (tuple, list)) else [device_xml])

--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -63,11 +63,7 @@ class VMDeviceService(Service):
         Retrieve details about `device` USB device.
         """
         await self.middleware.call('vm.check_setup_libvirt')
-        data = {
-            'capability': self.get_capability_keys(),
-            'available': False,
-            'error': None,
-        }
+        data = await self.get_basic_usb_passthrough_device_data()
         cp = await run(get_virsh_command_args() + ['nodedev-dumpxml', device], check=False)
         if cp.returncode:
             data['error'] = cp.stderr.decode()
@@ -84,6 +80,14 @@ class VMDeviceService(Service):
         return {
             **data,
             'available': not data['error'],
+        }
+
+    @private
+    async def get_basic_usb_passthrough_device_data(self):
+        return {
+            'capability': self.get_capability_keys(),
+            'available': False,
+            'error': None,
         }
 
     @accepts()

--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -107,3 +107,13 @@ class VMDeviceService(Service):
             mapping[device] = details
 
         return mapping
+
+    @private
+    async def get_usb_port_from_usb_details(self, usb_data):
+        if any(not usb_data.get(k) for k in ('product_id', 'vendor_id')):
+            raise CallError('Product / Vendor ID must be specified for USBs')
+
+        for device, device_details in (await self.usb_passthrough_choices()).items():
+            capability = device_details['capability']
+            if all(usb_data[k] == capability[k] for k in ('product_id', 'vendor_id')):
+                return device


### PR DESCRIPTION
This PR adds following changes:

1. Allows users to specify either USB identifiers or USB port identifier to do USB passthrough. The former helps when user might be plugging in to a different port and still expecting VM start to work by dynamically identifying the port it is in and passing it through to the VM.
2. Allowing users to specify which type of controller they would like to use for the USB for compatibility reasons.