### PR TITLE
NAS-118480 / 22.12 / Configure kuberouter logs destination in sylog-ng cfg file

### DIFF
--- a/src/freenas/etc/logrotate.d/syslog-ng-truenas
+++ b/src/freenas/etc/logrotate.d/syslog-ng-truenas
@@ -10,7 +10,7 @@
 		invoke-rc.d syslog-ng reload > /dev/null
 	endscript
 }
-"/var/log/multus.log" "/var/log/k3s_daemon.log" "/var/log/containerd.log" {
+"/var/log/multus.log" "/var/log/k3s_daemon.log" "/var/log/containerd.log" "/var/log/kube_router.log" {
 	rotate 2
 	size 5M
 	missingok

--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -100,6 +100,13 @@ def generate_svc_filters():
         log { source(s_src); filter(f_containerd); destination(d_containerd); };
 
         #####################
+        # filter kube-router messages
+        #####################
+        filter f_kube_router { program("kube-router"); };
+        destination d_kube_router { file("/var/log/kube_router.log"); };
+        log { source(s_src); filter(f_kube_router); destination(d_kube_router); };
+
+        #####################
         # filter haproxy messages
         #####################
         filter f_haproxy { program("haproxy");; };
@@ -119,7 +126,9 @@ def generate_syslog_conf(middleware):
     ):
         syslog_conf = syslog_conf.replace(
             line, RE_K3S_FILTER.sub(
-                r'\1not filter(f_k3s) and not filter(f_containerd) and not filter(f_haproxy) and ', line
+                r'\1not filter(f_k3s) and not filter(f_containerd) and not filter(f_haproxy)'
+                r' and not filter(f_kube_router) and ',
+                line
             )
         )
 


### PR DESCRIPTION
## Context

We want `kube-router`to log errors to a separate file so we update syslog-ng configuration to filter out `kube-router` program logs to separate files to not spam other files.