### PR TITLE
NAS-118508 / 22.12 / Make sure stopped app stays stopped after editing its config

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -545,6 +545,9 @@ class ChartReleaseService(CRUDService):
 
         await self.middleware.call('chart.release.helm_action', chart_release, chart_path, config, 'update')
 
+        if release_orig['status'] == 'STOPPED':
+            await self.middleware.call('chart.release.scale', chart_release, {'replica_count': 0})
+
         job.set_progress(90, 'Syncing secrets for chart release')
         await self.middleware.call('chart.release.sync_secrets_for_release', chart_release)
         await self.middleware.call('chart.release.refresh_events_state', chart_release)


### PR DESCRIPTION
This commit fixes an issue where when an app was updated, the value specified in it's replica count for deployments/statefulsets was applied overriding user specified setting where if he had stopped the app first and then modified will result in app starting again.