### PR TITLE
NAS-118291 / 22.12 / Replication: Only `Same as Source` and `None` retention policies can …

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-10-12_10-41_replication_name_regex_custom_retention_policy.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-10-12_10-41_replication_name_regex_custom_retention_policy.py
@@ -1,0 +1,31 @@
+"""Remove CUSTOM retention policy from replication tasks that use name_regex
+
+Revision ID: f0e551d2defc
+Revises: ae2a519c8b9a
+Create Date: 2022-10-12 10:41:03.028186+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f0e551d2defc'
+down_revision = 'ae2a519c8b9a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        UPDATE storage_replication
+        SET repl_retention_policy = 'NONE',
+            repl_lifetime_unit = NULL,
+            repl_lifetime_value = NULL,
+            repl_lifetimes = '[]'
+        WHERE repl_name_regex IS NOT NULL
+    """)
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -652,6 +652,12 @@ class ReplicationService(CRUDService):
             if data["naming_schema"] or data["also_include_naming_schema"]:
                 verrors.add("name_regex", "Naming regex can't be used with Naming schema")
 
+            if data["retention_policy"] not in ["SOURCE", "NONE"]:
+                verrors.add(
+                    "retention_policy",
+                    "Only `Same as Source` and `None` retention policies can be used with Naming regex",
+                )
+
         if data["retention_policy"] == "CUSTOM":
             if data["lifetime_value"] is None:
                 verrors.add("lifetime_value", "This field is required for custom retention policy")

--- a/tests/api2/test_370_replication.py
+++ b/tests/api2/test_370_replication.py
@@ -210,6 +210,8 @@ def test_00_bootstrap(request, credentials, periodic_snapshot_tasks):
     # name_regex
     (dict(name_regex="manual-.+"), None),
     (dict(direction="PULL", name_regex="manual-.+"), None),
+    (dict(name_regex="manual-.+",
+          retention_policy="CUSTOM", lifetime_value=2, lifetime_unit="WEEK"), "retention_policy"),
 
     # replicate
     (dict(source_datasets=["tank/data", "tank/data/work"], periodic_snapshot_tasks=["data-recursive"], replicate=True,


### PR DESCRIPTION
…be used with Naming regex