### PR TITLE
[Critical] fix: IOMMU groups are indexed from 0

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -107,7 +107,9 @@ class VMDeviceService(Service):
 
         node_info = await self.middleware.call('vm.device.retrieve_node_information', xml)
         error_str = ''
-        if not node_info['iommu_group'].get('number'):
+
+        group = node_info['iommu_group'].get('number')
+        if not isinstance(group, int) or group < 0:
             error_str += 'Unable to determine iommu group\n'
         if any(not node_info['capability'].get(k) for k in ('domain', 'bus', 'slot', 'function')):
             error_str += 'Unable to determine PCI device address\n'


### PR DESCRIPTION
I suggest taking a few basic programming courses. You cannot check an integer value that has a 0 as its valid value like that.
I wasn't into investigating what more can appear there, so I just check if it is int and has `>= 0` value.

https://www.truenas.com/community/threads/issues-with-iommu-groups-for-vm-passtrough.96096/
https://www.truenas.com/community/threads/iommu-group-0-passthrough.99634/

And countless other reports on the forum, Reddit, etc.