### PR TITLE
NAS-118564 / 22.12 / fix iommu number detection

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -107,7 +107,8 @@ class VMDeviceService(Service):
 
         node_info = await self.middleware.call('vm.device.retrieve_node_information', xml)
         error_str = ''
-        if not node_info['iommu_group'].get('number'):
+
+        if node_info['iommu_group'].get('number') is None:
             error_str += 'Unable to determine iommu group\n'
         if any(not node_info['capability'].get(k) for k in ('domain', 'bus', 'slot', 'function')):
             error_str += 'Unable to determine PCI device address\n'


### PR DESCRIPTION
Pointed out by another user, this key can start at 0 which is falsey. Instead, explicitly check for `NoneType`.