### PR TITLE
NAS-118567 / 22.12 / Allow migrating applications when encrypted

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/migrate.py
@@ -12,7 +12,7 @@ from .utils import applications_ds_name, MIGRATION_NAMING_SCHEMA
 class KubernetesService(Service):
 
     @private
-    async def migrate_ix_applications_dataset(self, job, config, old_config):
+    async def migrate_ix_applications_dataset(self, job, config, old_config, migration_options):
         new_pool = config['pool']
         backup_name = f'backup_to_{new_pool}_{datetime.utcnow().strftime("%F_%T")}'
         job.set_progress(30, 'Creating kubernetes cluster backup')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -196,7 +196,7 @@ class KubernetesService(ConfigService):
                         # Now let's add some validation for destination
                         destination_root_ds = await self.middleware.call(
                             'pool.dataset.get_instance', data['pool'], {
-                                'extra': {'retrieve_children': False}, 'get': True,
+                                'extra': {'retrieve_children': False}
                             }
                         )
                         if not destination_root_ds['encrypted']:
@@ -389,9 +389,8 @@ class KubernetesService(ConfigService):
         migrate = config.get('migrate_applications')
 
         await self.validate_data(config, 'kubernetes_update', old_config)
-
+        migration_options = config.pop('migration_options', {})
         if len(set(old_config.items()) ^ set(config.items())) > 0:
-            migration_options = config.pop('migration_options')
             await self.middleware.call('chart.release.clear_update_alerts_for_all_chart_releases')
             if migrate and config['pool'] != old_config['pool']:
                 job.set_progress(

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -98,7 +98,7 @@ class KubernetesService(ConfigService):
             verrors.add(f'{schema}.pool', 'Please provide a valid pool configured in the system.')
 
         if data.pop('migrate_applications', False):
-            migration_options = data['migration_options']
+            migration_options = data.get('migration_options', {})
             if data['pool'] == old_data['pool']:
                 verrors.add(
                     f'{schema}.migrate_applications',


### PR DESCRIPTION
This PR adds changes to allow migration of encrypted ix-applications dataset. However it enforces that destination pool's root dataset must be KEY encrypted and when the migration completes, ix-applications dataset would be inheriting encryption properties of destination's root dataset.