### PR TITLE
NAS-118568 / 22.12 / Avoid spamming log files with docker mounts

### DIFF
--- a/src/freenas/etc/logrotate.d/syslog-ng-truenas
+++ b/src/freenas/etc/logrotate.d/syslog-ng-truenas
@@ -10,7 +10,7 @@
 		invoke-rc.d syslog-ng reload > /dev/null
 	endscript
 }
-"/var/log/multus.log" "/var/log/k3s_daemon.log" "/var/log/containerd.log" "/var/log/kube_router.log" {
+"/var/log/multus.log" "/var/log/k3s_daemon.log" "/var/log/containerd.log" "/var/log/kube_router.log" "/var/log/app_mounts.log" {
 	rotate 2
 	size 5M
 	missingok

--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -107,6 +107,17 @@ def generate_svc_filters():
         log { source(s_src); filter(f_kube_router); destination(d_kube_router); };
 
         #####################
+        # filter app mounts messages
+        #####################
+        filter f_app_mounts {
+         program("systemd") and match("mount:" value("MESSAGE")) and match("docker" value("MESSAGE")); or
+         program("systemd") and match("mount:" value("MESSAGE")) and match("kubelet" value("MESSAGE"));
+        };
+        destination d_app_mounts { file("/var/log/app_mounts.log"); };
+        log { source(s_src); filter(f_app_mounts); destination(d_app_mounts); };
+
+
+        #####################
         # filter haproxy messages
         #####################
         filter f_haproxy { program("haproxy");; };
@@ -127,7 +138,7 @@ def generate_syslog_conf(middleware):
         syslog_conf = syslog_conf.replace(
             line, RE_K3S_FILTER.sub(
                 r'\1not filter(f_k3s) and not filter(f_containerd) and not filter(f_haproxy)'
-                r' and not filter(f_kube_router) and ',
+                r' and not filter(f_kube_router) and not filter(f_app_mounts) and ',
                 line
             )
         )


### PR DESCRIPTION
## Problem

In a user debug i observed the following logs:
```
ep 29 08:38:00 truenas systemd[1735527]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63\x2dinit.mount: Succeeded.
Sep 29 08:38:00 truenas systemd[1]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63\x2dinit.mount: Succeeded.
Sep 29 08:38:52 truenas systemd[1735527]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63.mount: Succeeded.
Sep 29 08:38:52 truenas systemd[1]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63.mount: Succeeded.
Sep 29 08:39:12 truenas systemd[1735527]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63.mount: Succeeded.
Sep 29 08:39:12 truenas systemd[1]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-86f9331c0e83a3cc2c23ce5fd2038e2be0bcdf1e5b121e266da1268391bd3b63.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1735527]: run-docker-netns-a8e73d1012ef.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1]: run-docker-netns-a8e73d1012ef.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1735527]: mnt-Data1-ix\x2dapplications-docker-containers-e57a8be3735d9ad5f846fc8f0ae03652d8ea74097afb591be63b13a6061fdebd-mounts-shm.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1]: mnt-Data1-ix\x2dapplications-docker-containers-e57a8be3735d9ad5f846fc8f0ae03652d8ea74097afb591be63b13a6061fdebd-mounts-shm.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1735527]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-a4d01bc1bbd4108a8d2360f51ba1f4718b9ca99a15fb17a41f58762ab6ae5fbd.mount: Succeeded.
Sep 29 08:39:32 truenas systemd[1]: mnt-Data1-ix\x2dapplications-docker-zfs-graph-a4d01bc1bbd4108a8d2360f51ba1f4718b9ca99a15fb17a41f58762ab6ae5fbd.mount: Succeeded.
Sep 29 08:39:41 truenas systemd[1735527]: var-lib-kubelet-pods-5201b64b\x2d3b8a\x2d4a25\x2da49e\x2d5a2dece71d6e-volumes-kubernetes.io\x7eprojected-kube\x2dapi\x2daccess\x2d4wbng.mount: Succeeded.
Sep 29 08:39:41 truenas systemd[1]: var-lib-kubelet-pods-5201b64b\x2d3b8a\x2d4a25\x2da49e\x2d5a2dece71d6e-volumes-kubernetes.io\x7eprojected-kube\x2dapi\x2daccess\x2d4wbng.mount: Succeeded.
```

This spams logs and it becomes difficult to locate meaningful information.

## Solution

Move application mount related logs to a separate file to avoid spamming other log files.