### PR TITLE
NAS-118421 / 22.12 / Add validation to ensure server/client certs are specified for openvpn services

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/openvpn/client/openvpn_client.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/client/openvpn_client.conf.mako
@@ -6,7 +6,10 @@
 
 	config = middleware.call_sync('openvpn.client.config')
 	root_ca = middleware.call_sync('certificateauthority.query', [['id', '=', config['root_ca']]], {'get': True})
-	client_cert = middleware.call_sync('certificate.query', [['id', '=', config['client_certificate']]], {'get': True})
+	if config['client_certificate']:
+		client_cert = middleware.call_sync('certificate.query', [['id', '=', config['client_certificate']]], {'get': True})
+	else:
+		client_cert = None
 %>\
 client
 % if IS_LINUX:
@@ -24,8 +27,10 @@ group ${"nobody" if IS_FREEBSD else "nogroup"}
 persist-key
 persist-tun
 ca ${root_ca['certificate_path']}
+% if client_cert:
 cert ${client_cert['certificate_path']}
 key ${client_cert['privatekey_path']}
+% endif
 verb 3
 remote-cert-tls server
 % if config['compression']:

--- a/src/middlewared/middlewared/etc_files/local/openvpn/client/openvpn_client.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/client/openvpn_client.conf.mako
@@ -12,13 +12,9 @@
 		client_cert = None
 %>\
 client
-% if IS_LINUX:
+
 dev ${config['interface']}
 dev-type ${config['device_type'].lower()}
-% else:
-dev ${config['device_type'].lower()}
-#dev-type ${config['device_type'].lower()} -FIXME: This does not work, it is an openvpn issue in FreeBSD
-% endif
 proto ${config['protocol'].lower()}
 port ${config['port']}
 remote ${config['remote']}

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -203,7 +203,9 @@ class OpenVPN:
                 f'{mode}_certificate': None,
             })
         else:
-            for k in filter(lambda k: not data.get(k), ('root_ca', f'{mode}_certificate')):
+            for k in filter(
+                lambda k: not data.get(k), ['root_ca'] + ([] if mode == 'client' else ['server_certificate'])
+            ):
                 verrors.add(
                     f'{schema}.{k}',
                     'This is required'

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -476,6 +476,7 @@ class OpenVPNServerService(SystemServiceService):
     @accepts(
         Patch(
             'openvpn_server_entry', 'openvpn_server_update',
+            ('add', Bool('remove_certificates', default=False)),
             ('rm', {'name': 'id'}),
             ('rm', {'name': 'interface'}),
             ('attr', {'update': True}),
@@ -651,6 +652,7 @@ class OpenVPNClientService(SystemServiceService):
     @accepts(
         Patch(
             'openvpn_client_entry', 'openvpn_client_update',
+            ('add', Bool('remove_certificates', default=False)),
             ('rm', {'name': 'id'}),
             ('rm', {'name': 'interface'}),
             ('attr', {'update': True}),

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -197,6 +197,18 @@ class OpenVPN:
                 'Please specify a valid authentication_algorithm.'
             )
 
+        if data.pop('remove_certificates'):
+            data.update({
+                'root_ca': None,
+                f'{mode}_certificate': None,
+            })
+        else:
+            for k in filter(lambda k: not data.get(k), ('root_ca', f'{mode}_certificate')):
+                verrors.add(
+                    f'{schema}.{k}',
+                    'This is required'
+                )
+
         if data['root_ca']:
             verrors = await OpenVPN.cert_validation(middleware, data, schema, mode, verrors)
 

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -644,16 +644,13 @@ class OpenVPNClientService(SystemServiceService):
             ):
                 raise CallError('Root CA has been revoked. Please select another Root CA.')
 
-        if not config['client_certificate']:
-            raise CallError('Please configure client certificate first.')
-        else:
-            if not await self.middleware.call(
-                'certificate.query', [
-                    ['id', '=', config['client_certificate']],
-                    ['revoked', '=', False]
-                ]
-            ):
-                raise CallError('Client certificate has been revoked. Please select another Client certificate.')
+        if config['client_certificate'] and not await self.middleware.call(
+            'certificate.query', [
+                ['id', '=', config['client_certificate']],
+                ['revoked', '=', False]
+            ]
+        ):
+            raise CallError('Client certificate has been revoked. Please select another Client certificate.')
 
         if not config['remote']:
             raise CallError('Please configure remote first.')


### PR DESCRIPTION
This PR adds changes to force user to specify server/client certs for openvpn services. What happens is that before starting openvpn client/server service, we do check if these are present or not and if not we do not render the configuration file for the service which results in the service not starting, however this does not tell the user what he did wrong.

Why we did not validate this before was to allow users to unset certs in case they wanted to delete them and now for that case we have introduced a new variable which will handle this.

There is also another change, we allow users now to not specify client certificate as with some additional parameters which openvpn supports, it is possible to start openvpn with user credentials which some popular VPN providers like proton VPN provide.