### PR TITLE
NAS-118599 / 22.12 / Do not expose MIXED case sensitivity as user choice

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3141,7 +3141,7 @@ class PoolDatasetService(CRUDService):
         Inheritable(Str('checksum', enum=ZFS_CHECKSUM_CHOICES)),
         Inheritable(Str('readonly', enum=['ON', 'OFF'])),
         Inheritable(Str('recordsize'), has_default=False),
-        Inheritable(Str('casesensitivity', enum=['SENSITIVE', 'INSENSITIVE', 'MIXED']), has_default=False),
+        Inheritable(Str('casesensitivity', enum=['SENSITIVE', 'INSENSITIVE']), has_default=False),
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
         Inheritable(Str('acltype', enum=['OFF', 'NFSV4', 'POSIX']), has_default=False),
         Str('share_type', default='GENERIC', enum=['GENERIC', 'SMB']),


### PR DESCRIPTION
Our product does not make use of MIXED case sensitive option due to implementation being specific to the illumos kernel SMB server, and so it does not make sense to expose it as an option. For case of TrueNAS, MIXED is identical to SENSITIVE.