### PR TITLE
NAS-118583 / 22.12 / Add API for setting clock

### DIFF
--- a/src/middlewared/middlewared/plugins/system/time.py
+++ b/src/middlewared/middlewared/plugins/system/time.py
@@ -1,0 +1,47 @@
+import subprocess
+import time
+
+from middlewared.schema import accepts, Int
+from middlewared.service import private, Service, ValidationErrors
+from middlewared.service_exception import CallError
+
+MAX_PERMITTED_SLEW = 86400 * 30
+
+
+class SystemService(Service):
+
+    @private
+    @accepts(Int('new_time', required=True))
+    def set_time(self, ts):
+        """
+        This endpoint sets RTC to UTC and then sets the time to the specified
+        value.
+        """
+        verr = ValidationErrors()
+        if ts < 0:
+            verr.add('system_set_time.new_time', 'timestamp must be positive value')
+
+        if abs(ts - time.time()) > MAX_PERMITTED_SLEW:
+            verr.add(
+                'system_set_time.new_time',
+                'new timestamp requires slewing clock more than maximum permitted value of 30 days'
+            )
+
+        verr.check()
+
+        # stop NTP service before making clock changes
+        self.middleware.call_sync('service.stop', 'ntpd')
+
+        # Make sure RTC is set to UTC
+        timedatectl = subprocess.run(['timedatectl', 'set-local-rtc', '0'], capture_output=True, check=False)
+        if timedatectl.returncode:
+            self.middleware.call_sync('service.start', 'ntpd')
+            raise CallError(f'Failed to set RTC to UTC: {timedatectl.stderr.decode()}')
+
+        # Set to our new timestamp
+        timedatectl = subprocess.run(['timedatectl', 'set-time', f'@{int(ts)}'], capture_output=True, check=False)
+        if timedatectl.returncode:
+            self.middleware.call_sync('service.start', 'ntpd')
+            raise CallError(f'Failed to set clock to ({ts}): {timedatectl.stderr.decode()}')
+
+        self.middleware.call_sync('service.start', 'ntpd')

--- a/tests/api2/test_470_system.py
+++ b/tests/api2/test_470_system.py
@@ -9,8 +9,8 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import GET  # , POST
-from auto_config import dev_test
+from functions import GET, make_ws_request # , POST
+from auto_config import dev_test, ip
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -43,3 +43,33 @@ def test_04_check_system_product_type():
 def test_05_check_system_debug():
     results = GET("/system/debug/")
     assert results.status_code == 200, results.text
+
+
+def test_06_check_system_set_time():
+    """
+    This test intentionally slews our clock to be off
+    by 300 seconds and then verifies that it got set
+    """
+    results = GET("/system/info/")
+    assert results.status_code == 200, results.text
+
+    # Convert to seconds
+    datetime = results.json()['datetime']['$date']/1000
+
+    # hop 300 seconds into the past
+    target = datetime - 300
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'system.set_time',
+        'params': [int(target)]
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+
+    results = GET("/system/info/")
+    assert results.status_code == 200, results.text
+    datetime2 = results.json()['datetime']['$date']/1000
+
+    # This is a fudge-factor because NTP will start working
+    # pretty quickly to correct the slew.
+    assert abs(target - datetime2) < 60


### PR DESCRIPTION
This API endpoint is to be used to set the RTC clock to a client-provided unix timestamp. ntpd will be temporarily stopped while making clock adjustment.