### PR TITLE
NAS-118573 / 22.12 / Update inotify.max_user_watches default value

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -1,3 +1,4 @@
+fs.inotify.max_user_watches = 1024
 kernel.panic = 10
 kernel.panic_on_oops = 1
 kernel.panic_on_io_nmi = 1


### PR DESCRIPTION
## Context

We have received reports where `fs.inotify.max_user_watches` limit of 128 gets low for users deploying a few applications and starts resulting in other failures in the system as system does not have necessary watches anymore.

## Solution

Bump up the default value to `1024` from `128`.