### PR TITLE
NAS-118255 / 22.12 / Improve libvirt connection health check

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/connection.py
+++ b/src/middlewared/middlewared/plugins/vm/connection.py
@@ -44,10 +44,14 @@ class LibvirtConnectionMixin:
             # if we handle this to ensure that system recognises libvirt  connection
             # is no longer active and a new one should be initiated.
             return (
-                self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive()
-                and isinstance(self.LIBVIRT_CONNECTION.listAllDomains(), list)
+                self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive() and
+                isinstance(self.LIBVIRT_CONNECTION.listAllDomains(), list)
             )
         return False
+
+    def _list_domains(self):
+        with contextlib.suppress(libvirt.libvirtError):
+            return {domain.name(): domain.state() for domain in self.LIBVIRT_CONNECTION.listAllDomains()}
 
     def _is_connection_alive(self):
         return self._is_kvm_supported() and self._is_libvirt_connection_alive()

--- a/src/middlewared/middlewared/plugins/vm/connection.py
+++ b/src/middlewared/middlewared/plugins/vm/connection.py
@@ -43,7 +43,10 @@ class LibvirtConnectionMixin:
             # We see isAlive call failed for a user in NAS-109072, it would be better
             # if we handle this to ensure that system recognises libvirt  connection
             # is no longer active and a new one should be initiated.
-            return self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive()
+            return (
+                self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive()
+                and isinstance(self.LIBVIRT_CONNECTION.listAllDomains(), list)
+            )
         return False
 
     def _is_connection_alive(self):

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -95,6 +95,7 @@ class VMService(Service, VMSupervisorMixin):
             'connected': self._is_connection_alive(),
             'connection_initialised': bool(self.LIBVIRT_CONNECTION),
             'domains': list(self.vms.keys()),
+            'libvirt_domains': self._list_domains() if self.LIBVIRT_CONNECTION else None,
         }
 
     @private


### PR DESCRIPTION
This PR adds changes to improve libvirt connection health check logic. Earlier we were calling on libvirt's `isAlive` method to determine if the socket is active or not and performing necessary actions - however we have been seeing that it is likely not enough and libvirt errors out when we try to get state of some domain.

As we don't have a good reproduction case to determine if these changes will address the issue, i think this is a good best effort moving forward and we can further enhance/improve the connection health logic if there still seems to be some case where we might be missing out.