### PR TITLE
NAS-116526 / 22.12 / Add validation for pci devices that are required by host

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -87,10 +87,17 @@ class PCI(Device):
     def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
         pptdev = device['attributes'].get('pptdev')
         device_details = self.middleware.call_sync('vm.device.passthrough_device', pptdev)
-        if device_details.get('error'):
+        if device_details['error']:
             verrors.add(
                 'attribute.pptdev',
                 f'Not a valid choice. The PCI device is not available for passthru: {device_details["error"]}'
             )
+        elif device_details['critical']:
+            verrors.add(
+                'attribute.pptdev',
+                f'{device_details["controller_type"]!r} based PCI devices are critical for system function '
+                'and cannot be used for PCI passthrough'
+            )
+
         if not self.middleware.call_sync('vm.device.iommu_enabled'):
             verrors.add('attribute.pptdev', 'IOMMU support is required.')


### PR DESCRIPTION
## Context

Users can currently configure PCI devices which are critical for host sytsem i.e CPU / RAM etc which results in system crash when user attempts to start VM.

## Solution

Do not allow users to use PCI devices which can be critical for host system usage.