### PR TITLE
NAS-118535 / 22.12 / Handle invalid json case for apps config

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -220,10 +220,14 @@ class KubernetesService(Service):
         clean_start = True
         if os.path.exists(config_path):
             with open(config_path, 'r') as f:
-                on_disk_config = json.loads(f.read())
-            clean_start = not all(
-                config[k] == on_disk_config.get(k) for k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
-            )
+                try:
+                    on_disk_config = json.loads(f.read())
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    clean_start = not all(
+                        config[k] == on_disk_config.get(k) for k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
+                    )
 
         if clean_start and self.middleware.call_sync(
             'zfs.dataset.query', [['id', '=', config['dataset']]], {


### PR DESCRIPTION
## Problem

A user had an empty `config.json` file which is not possible from middleware side but with likely manual changes we can run into that case which results in kubernetes update operation failing as we always expect the file to contain valid json.

## Solution

Gracefully handle the case where the file may not contain valid JSON.