### PR TITLE
NAS-118705 / 22.12 / No need to validate force flag when starting k8s service

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -369,7 +369,7 @@ class KubernetesService(ConfigService):
         data.pop('dataset')
 
         try:
-            await self.validate_data(data, 'kubernetes', data)
+            await self.validate_data({**data, 'force': True}, 'kubernetes', data)
         except ValidationErrors as e:
             return e
 


### PR DESCRIPTION
There is no need to validate force flag usage when starting k8s service as otherwise bootstrapping new k8s cluster fails