### PR TITLE
NAS-118706 / 22.12 / Do not try to update encryption property on ix-applications dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -267,7 +267,7 @@ class KubernetesService(Service):
         return {
             attr: value
             for attr, value in props.items()
-            if attr not in ('casesensitivity', 'mountpoint')
+            if attr not in ('casesensitivity', 'mountpoint', 'encryption')
         }
 
     @private


### PR DESCRIPTION
## Problem

If user was using an encrypted pool for ix-applications and switches to another pool and tries to switch back to his old pool it would fail with following:
```
Error: [EFAULT] Failed to update properties: ZFSException("cannot set property for 'enc-pool/ix-applications': 'encryption' is readonly")
```

## Solution

Do not try to update encryption properties of k8s datasets as encryption is a create time attribute