### PR TITLE
NAS-118722 / 22.12 / fix inotify resource exhaustion on m50

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -1,4 +1,4 @@
-fs.inotify.max_user_watches = 1024
+fs.inotify.max_user_watches = 8192
 kernel.panic = 10
 kernel.panic_on_oops = 1
 kernel.panic_on_io_nmi = 1


### PR DESCRIPTION
On an m50 HA system running latest nightly, im seeing inotify resource exhaustion out of the gate. Bump this to 8192 which

1. fixes the immediate problem
2. moves us inline with what openSUSE (and I think fedora) does