### PR TITLE
NAS-118681 / 13.0 / Restart LDAP service if enabled on becoming master

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
@@ -616,9 +616,14 @@ class FailoverService(Service):
                 # Now we restart the appropriate services to ensure it's using correct certs.
                 self.run_call('service.restart', 'http')
 
+                # Directory services restart prior to criticial ones
+                # because latter may depend on nsswitch / pam functioning properly
                 if self.run_call('nis.config')['enable']:
                     if not self.run_call('nis.started'):
                         self.run_call('service.restart', 'nis', {'ha_propagate': False})
+
+                elif self.run_call('ldap.config')['enable']:
+                    self.run_call('service.restart', 'ldap', {'ha_propagate': False})
 
                 # restart the critical services first
                 # each service is restarted concurrently and given a timeout value of 15

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1032,11 +1032,6 @@ class LDAPService(ConfigService):
         user_next_index = group_next_index = 100000000
         cache_data = {'users': {}, 'groups': {}}
 
-        if self.middleware.call_sync('cache.has_key', 'LDAP_cache') and not force:
-            raise CallError('LDAP cache already exists. Refusing to generate cache.')
-
-        self.middleware.call_sync('cache.pop', 'LDAP_cache')
-
         if (self.middleware.call_sync('ldap.config'))['disable_freenas_cache']:
             self.middleware.call_sync('cache.put', 'LDAP_cache', cache_data)
             self.logger.debug('LDAP cache is disabled. Bypassing cache fill.')
@@ -1105,4 +1100,5 @@ class LDAPService(ConfigService):
             await self.middleware.call('ldap.fill_cache')
             self.logger.debug('cache fill is in progress.')
             return {'users': {}, 'groups': {}}
+
         return await self.middleware.call('cache.get', 'LDAP_cache')


### PR DESCRIPTION
This also removes logic to skip user / group cache refill on service restart.