### PR TITLE
NAS-117907 / 22.12 / Add more error handling for glusterfs and sysdataset

### DIFF
--- a/src/middlewared/middlewared/alert/source/glusterfs.py
+++ b/src/middlewared/middlewared/alert/source/glusterfs.py
@@ -1,0 +1,21 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class GlusterdWorkdirUnavailAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.CLUSTERING
+    level = AlertLevel.CRITICAL
+    title = "Glusterd peer information is unavailable"
+    text = "Glusterd work directory dataset is not mounted."
+
+    async def delete(self, alerts, query):
+        return []
+
+
+class GlusterdUUIDChangedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.CLUSTERING
+    level = AlertLevel.CRITICAL
+    title = "Glusterd UUID changed"
+    text = "Glusterd host UUID changed unexpectedly."
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -7,6 +7,7 @@ import shutil
 from ipaddress import ip_address
 
 from dns.exception import DNSException
+from middlewared.plugins.gluster_linux.utils import GlusterConfig
 from middlewared.schema import Bool, returns
 from middlewared.service import Service, job, ValidationErrors, private, accepts
 from middlewared.service_exception import CallError
@@ -150,6 +151,8 @@ class ClusterUtils(Service):
         """
         files = CTDBConfig.CTDB_FILES_TO_REMOVE.value
         dirs = CTDBConfig.CTDB_DIRS_TO_REMOVE.value
+
+        files.extend(GlusterConfig.FILES_TO_REMOVE.value.copy())
 
         interest = (f'.system/{CTDBConfig.CTDB_VOL_NAME.value}', '.system/glusterd')
         mount_info = self.middleware.call_sync('filesystem.mount_info')

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -65,8 +65,15 @@ def set_gluster_workdir_dataset(dataset_name):
 
 
 def check_glusterd_info():
-    with open(f'{GlusterConfig.WORKDIR.value}/glusterd.info', 'r') as f:
-        current_uuid = f.readline()
+    try:
+        with open(f'{GlusterConfig.WORKDIR.value}/glusterd.info', 'r') as f:
+            current_uuid = f.readline()
+    except FileNotFoundError:
+        if not os.path.exists(GlusterConfig.UUID_BACKUP.value):
+            # Glusterd is most likely starting for the first time.
+            return True
+
+        raise
 
     if not current_uuid.startswith('UUID'):
         raise ValueError(f'Invalid glusterd.info file: {current_uuid}')

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -37,3 +37,47 @@ class GlusterConfig(enum.Enum):
     # nodes are mapped to gluster peers, we cap the max number
     # of gluster peers for now
     MAX_PEERS = 20
+
+    # Path containing dataset name where workdir was located
+    # when the first gluster volume was created. This is
+    # used for a sanity when generating gluster config.
+    WORKDIR_DS_CACHE = '/data/.glusterd_workdir_dataset'
+
+    UUID_BACKUP = '/data/.glusterd_uuid'
+
+    FILES_TO_REMOVE = [
+        WORKDIR_DS_CACHE,
+        UUID_BACKUP
+    ]
+
+
+def get_gluster_workdir_dataset():
+    try:
+        with open(GlusterConfig.WORKDIR_DS_CACHE.value, 'r') as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
+def set_gluster_workdir_dataset(dataset_name):
+    with open(GlusterConfig.WORKDIR_DS_CACHE.value, 'w') as f:
+        f.write(dataset_name)
+
+
+def check_glusterd_info():
+    with open(f'{GlusterConfig.WORKDIR.value}/glusterd.info', 'r') as f:
+        current_uuid = f.readline()
+
+    if not current_uuid.startswith('UUID'):
+        raise ValueError(f'Invalid glusterd.info file: {current_uuid}')
+
+    try:
+        with open(GlusterConfig.UUID_BACKUP.value, 'r') as f:
+            backup_uuid = f.readline()
+
+    except FileNotFoundError:
+        with open(GlusterConfig.UUID_BACKUP.value, 'w') as f:
+            f.write(current_uuid)
+            backup_uuid = current_uuid
+
+    return current_uuid == backup_uuid

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -5,6 +5,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.utils.size import format_size
 from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
+from middlewared.plugins.gluster_linux.utils import get_gluster_workdir_dataset, set_gluster_workdir_dataset
 
 try:
     from middlewared.plugins.cluster_linux.utils import CTDBConfig
@@ -638,6 +639,9 @@ class SystemDatasetService(ConfigService):
             path = SYSDATASET_PATH
 
         self.__mount(_to, config['uuid'], path=path)
+
+        if get_gluster_workdir_dataset() is not None:
+            set_gluster_workdir_dataset(_to)
 
         # context manager handles service stop / restart
         with self.release_system_dataset():


### PR DESCRIPTION
Add new oneshot alert for when the volume under sysdataset is unexpected. This is detected in glusterfs config mako file. Raising FileDoesNotExist here will prevent necessary portion of glusterd config from being generated, preventing glusterd from starting.

Store backup of node's UUID and compare current running UUID with the backup to detect an unexpected change in the before_start() method for glusterd. This will prevent middleware from starting glusterd with the unexpected configuration change, but since this is an unusual situation it will currently require manual intervention and cleanup.