### PR TITLE
NAS-118772 / 22.12 / Fix ctdb assertions due to open handles

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -23,3 +23,4 @@ class CtdbService(SimpleService):
     async def after_stop(self):
         await self.middleware.call('smb.reset_smb_ha_mode')
         await self.middleware.call('etc.generate', 'smb')
+        await self.middleware.call('tdb.close_cluster_handles')

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -151,12 +151,13 @@ class CTDBWrap(object):
         super().__init__()
 
     def validate_handle(self):
-        return True
+        return self.hdl is not None
 
     def close(self):
         # Closing last reference to pyctdb_client_ctx will
         # TALLOC_FREE() any talloc'ed memory under the handle.
         del(self.hdl)
+        self.hdl = None
         return
 
     def __persistent_fetch(self, tdb_key):


### PR DESCRIPTION
When ctdbd is being stopped we should close out all client handles otherwise stale references in g_lock.tdb will cause ctdbd to panic on start.