### PR TITLE
NAS-118781 / 22.12 / Create recovery lock if it doesn't exist

### DIFF
--- a/src/freenas/usr/local/sbin/ctdb_glfs_lock
+++ b/src/freenas/usr/local/sbin/ctdb_glfs_lock
@@ -40,7 +40,18 @@ class GlusterConn:
         return
 
     def take_reclock(self):
-        lock_file = self.glusterhdl.get_root_handle().lookup(self.reclock_path)
+        try:
+            lock_file = self.glusterhdl.get_root_handle().lookup(self.reclock_path)
+        except pyglfs.GLFSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+            lock_file = self.glusterhdl.get_root_handle().create(
+                self.reclock_path,
+                os.O_CREAT | os.O_RDWR,
+                mode = 0o600,
+            )
+
         self.reclock_fd = lock_file.open(os.O_RDWR)
         lock_info = self.reclock_fd.posix_lock(
             fcntl.F_SETLK,


### PR DESCRIPTION
The glusterfs ctdb mutex helper script was failing on fresh install because the reclock file didn't exist. Create it on lookup failure with ENOENT.