### PR TITLE
NAS-118738 / 22.12 / Handle upstream k3s buggy klipper case

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -133,6 +133,38 @@ class KubernetesService(Service):
         except Exception as e:
             raise CallError(f'Failed to configure PV/PVCs support: {e}')
 
+        for loadbalancer_svc in await self.middleware.call('k8s.service.query', [['spec.type', '=', 'LoadBalancer']]):
+            try:
+                await self.middleware.call(
+                    'k8s.service.delete', loadbalancer_svc['metadata']['name'],
+                    {'namespace': loadbalancer_svc['metadata']['namespace']}
+                )
+            except CallError:
+                self.logger.error('Failed to remove %r service', loadbalancer_svc['metadata']['name'], exc_info=True)
+
+        # In some scenarios k3s was not deleting loadbalancer based daemonsets, let's clean up those
+        for daemonset in await self.middleware.call(
+            'k8s.daemonset.query', [['metadata.namespace', '=', 'kube-system'], ['metadata.name', 'rin', 'svclb']]
+        ):
+            try:
+                await self.middleware.call(
+                    'k8s.daemonset.delete', daemonset['metadata']['name'],
+                    {'namespace': daemonset['metadata']['namespace']}
+                )
+            except CallError:
+                self.logger.error('Failed to remove %r daemonset', daemonset['metadata']['name'], exc_info=True)
+
+        # Let helm re-create load balancer services for scaled up apps
+        chart_releases = await self.middleware.call('chart.release.query', [['status', '=', 'DEPLOYING']])
+        bulk_job = await self.middleware.call(
+            'core.bulk', 'chart.release.redeploy', [[r['name']] for r in chart_releases]
+        )
+        for index, status in enumerate(await bulk_job.wait()):
+            if status['error']:
+                self.middleware.logger.error(
+                    'Failed to redeploy %r chart release: %s', chart_releases[index], status['error']
+                )
+
         # Now that k8s is configured, we would want to scale down any deployment/statefulset which might
         # be consuming a locked host path volume
         await self.middleware.call('chart.release.scale_down_resources_consuming_locked_paths')


### PR DESCRIPTION
## Context

Whenever a service of type `LoadBalancer` is created - k3s (when using builtin klipper load balancer) creates a daemonset against it in `kube-system` namespace and whenever the service is deleted (when scaling down app or deleting it) it is responsible for deleting the daemonset so relevant deployed pods by it can be deleted it as well.

## Problem

For some users upgrading from 22.02.4,k3s was not properly deleting older deployed daemonsets even on app deletion (which deletes the service as well) - this meant that old daemonsets with pods were still running for apps which were not present anymore or had been scaled down.

## Solution

We address the problem in the following steps:

1. Delete all `LoadBalancer` type services when bootstrapping cluster
2. Delete any rogue klipper daemonsets left
3. Finally re-deploy apps which weren't stopped so helm can re-create `LoadBalancer` services in question

This happens before apps run so it's safe to pursue and works around upstream k3s issue.

To clarify this bug in k3s is not present anymore in latest 1.25 version available in Bluefin.