### PR TITLE
NAS-118808 / 22.12 / Fix port delegate test

### DIFF
--- a/tests/api2/test_port_delegates.py
+++ b/tests/api2/test_port_delegates.py
@@ -22,8 +22,9 @@ PAYLOAD = (
 @pytest.mark.parametrize('config_method,method,keys,payload', PAYLOAD)
 def test_port_delegate_validation_with_invalid_ports(config_method, method, keys, payload):
     in_use_ports = []
+    namespace = config_method.rsplit('.', 1)[0]
     for entry in call('port.get_in_use'):
-        in_use_ports.extend(filter(lambda i: i > 1024, entry['ports']))
+        in_use_ports.extend(filter(lambda i: i > 1024 and entry['namespace'] != namespace, entry['ports']))
 
     assert in_use_ports != [], 'No in use ports retrieved'
 


### PR DESCRIPTION
This commit adds changes to not account for existing service's own ports when determining used ports so that we can choose invalid ports and ensure an exception is raised.