### PR TITLE
NAS-118846 / 22.12 / Improve diasbled reasons

### DIFF
--- a/src/freenas/usr/local/sbin/hactl
+++ b/src/freenas/usr/local/sbin/hactl
@@ -35,6 +35,8 @@ class DisabledEnum(enum.Enum):
     NO_FENCED = 'Fenced is not running.'
     REM_FAILOVER_ONGOING = 'Other node is currently processing a failover event.'
     HEALTHY = 'Failover is healthy.'
+    NO_HEARTBEAT_IFACE = 'Local heartbeat interface does not exist.'
+    NO_CARRIER_ON_HEARTBEAT = 'Local heartbeat interfae is down.'
     UNKNOWN = 'UNKNOWN'
 
 


### PR DESCRIPTION
QE was fresh installing an HA machine running SCALE while there was no `ntb0` (heartbeat interface). The reason for the `ntb0` interface missing is unrelated to their testing but these changes are to hopefully warn the end-user that things are not healthy.