### PR TITLE
NAS-118831 / 22.12-RC.1 / fix fresh installing HA systems (by yocalebo)

### DIFF
--- a/src/freenas/etc/systemd/system/systemd-modules-load.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/systemd-modules-load.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutSec=150s


### PR DESCRIPTION
ntb_pmem driver has a wait time for the other controller of 120 seconds but the default systemd unit timeout is 90 seconds. This means, when freshly installing a scale HA system, systemd can kill the systemd-modules-load service which prevents required kernel modules to be loaded ultimately breaking HA systems. Change timeout for this service to 150 seconds (2 1/2 mins).

Original PR: https://github.com/truenas/middleware/pull/10055
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118831