### PR TITLE
NAS-118866 / 22.12 / Handle edge case of retrieving active apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -155,7 +155,7 @@ class KubernetesService(Service):
                 self.logger.error('Failed to remove %r daemonset', daemonset['metadata']['name'], exc_info=True)
 
         # Let helm re-create load balancer services for scaled up apps
-        chart_releases = await self.middleware.call('chart.release.query', [['status', '=', 'DEPLOYING']])
+        chart_releases = await self.middleware.call('chart.release.query', [['status', 'in', ('ACTIVE', 'DEPLOYING')]])
         bulk_job = await self.middleware.call(
             'core.bulk', 'chart.release.redeploy', [[r['name']] for r in chart_releases]
         )


### PR DESCRIPTION
When k8s cluster boots, it's possible that started apps aren't all deploying at the stage when we choose to redeploy those - some might still be active despite taints and be in terminating phase. We should still make sure we redeploy those as otherwise loadbalancer service won't be recreated.