### PR TITLE
NAS-118803 / 22.12 / Allow deleting vms when host does not support virtualization

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -357,7 +357,9 @@ class VMService(CRUDService, VMSupervisorMixin):
         """
         async with LIBVIRT_LOCK:
             vm = await self.get_instance(id)
-            await self.middleware.run_in_thread(self._check_setup_connection)
+            # Deletion should be allowed even if host does not support virtualization
+            if self._is_kvm_supported():
+                await self.middleware.run_in_thread(self._check_setup_connection)
             status = await self.middleware.call('vm.status', id)
             force_delete = data.get('force')
             if status['state'] in ACTIVE_STATES:


### PR DESCRIPTION
## Context

We tried setting up libvirt connection when trying to delete a VM if it was not already setup which is going to fail on a host where virtualization is not supported..this can happen in scenarios like user changed hardware settings possibly or imported a configuration into a system which does not support virtualization.

Deleting a VM should still be allowed even if host OS does not support virtualization as it just means we don't have to undefine libvirt domain but libvirt wouldn't be even running on that machine so it should be safe.