### PR TITLE
NAS-118885 / 22.12-RC.1 / Run through full directory services initialization on failover (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -474,6 +474,9 @@ class FailoverEventsService(Service):
         logger.info('Restarting critical services.')
         self.run_call('failover.events.restart_services', {'critical': True})
 
+        # setup directory services. This is backgrounded job
+        self.run_call('directoryservices.setup')
+
         logger.info('Allowing network traffic.')
         fw_accept_job = self.run_call('failover.firewall.accept_all')
         fw_accept_job.wait_sync()


### PR DESCRIPTION
When node becomes master, run through full directory services initialization method. This is potentially a long-running job and so we can just keep it in the background.

Original PR: https://github.com/truenas/middleware/pull/10075
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118885