### PR TITLE
 NAS-118941 / 22.12 / fix pool.dataset.internal_dataset_filters

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2967,25 +2967,12 @@ class PoolDatasetService(CRUDService):
     @private
     async def internal_datasets_filters(self):
         # We get filters here which ensure that we don't match an internal dataset
-        filters = []
-        try:
-            sysds = (await self.middleware.call('cache.get', 'SYSDATASET_PATH'))['dataset']
-        except KeyError:
-            sysds = (await self.middleware.call('systemdataset.config'))['basename']
-
-        if sysds:
-            filters.extend([['id', '!=', sysds], ['id', '!^', f'{sysds}/']])
-
-        filters.append(['pool', '!=', await self.middleware.call('boot.pool_name')])
-
-        # top level dataset that stores all things related to gluster config
-        # needs to be hidden from local webUI. (This is managed by TrueCommander)
-        filters.extend([
-            ['id', 'rnin', '.glusterfs'],
+        return [
+            ['pool', '!=', await self.middleware.call('boot.pool_name')],
+            ['id', 'rnin', '/.system'],
+            ['id', 'rnin', '/.glusterfs'],
             ['id', 'rnin', '/ix-applications/'],
-        ])
-
-        return filters
+        ]
 
     @private
     async def is_internal_dataset(self, dataset):


### PR DESCRIPTION
This logic has been broken for a long time. We shouldn't include these datasets for any zpools since they are reserved for internal use only.