### PR TITLE
NAS-118765 / 22.12-RC.1 / Add handling for MatchNotFound to share_info parsing (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -125,6 +125,9 @@ class ShareSec(CRUDService):
 
                     self.logger.debug('%s: failed to resolve SID to name: %s', acl_entry['ae_who_sid'], e)
 
+                except MatchNotFound:
+                    self.logger.warning('Foreign SID: %r in share ACL that cannot be resolved to name.', acl_entry['ae_who_sid'])
+
             parsed_share_sd['share_acl'].append(acl_entry)
 
         return parsed_share_sd


### PR DESCRIPTION
There are some situations where domain SID for server may change due to administrator action, which causes existing SID entries in share_info.tdb to no longer resolve. Due to switching to python bindings for this, SID lookups can fail with MatchNotFound and so add an additional error message / case for this.

Original PR: https://github.com/truenas/middleware/pull/10078
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118765