### PR TITLE
NAS-118953 / 22.12 / Properly remove mirror with degraded disks

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -27,6 +27,10 @@ class DiskService(Service):
         if mirror['encrypted_provider']:
             await self.middleware.call('disk.remove_encryption', mirror['encrypted_provider'])
 
+        for provider in mirror['providers']:
+            await run('mdadm', mirror['real_path'], '--fail', provider['id'], check=False)
+            await run('mdadm', mirror['real_path'], '--remove', provider['id'], check=False)
+
         await self.stop_md_device(mirror['path'])
         await self.clean_superblocks_on_md_device([p['name'] for p in mirror['providers']], True)
 


### PR DESCRIPTION
## Problem

Following the below steps:

1. Create a pool with 1 MIRROR vdev
2. Remove 1 disk from the MIRROR
3. Insert another one in it's place so we can replace it
4. Try to replace the disk and it will error out with `Device busy` error

What was happening was that we create a swap mirror (provided SWAP is enabled) which will have these 2 disks.
On removal of one disk our logic tries to remove the mirror from swap and then destroy the mirror as it is no longer healthy - however `mdadm` refused to destroy the mirror and kept a reference to the already removed disk and when a disk was inserted again with same name i.e `sdb` and on trying to use the disk or wipe it etc it errored out with `Device busy` error.

## Solution

Before trying to destroy the mirror if we loop over all providers and mark them as failed and remove them individually and then destroy the mirror it works nicely and the disk can be used again. 