### PR TITLE
NAS-118957 / 22.12 / Prevent users from sharing root of gluster volume

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1505,6 +1505,9 @@ class SharingSMBService(SharingService):
                 )
             except FileNotFoundError:
                 verrors.add(f'{schema_name}.path', 'Path does not exist.')
+        else:
+            if data.get('path') == '/':
+                verrors.add(f'{schema_name}.path', 'Sharing root of gluster volume is not permitted.')
 
         if data['auxsmbconf']:
             try:


### PR DESCRIPTION
This is generally bad practice as removes ability for administrator to reconfiguration / add more shares for the clustered volume. Preventing sharing root also allows us to potentially store internal metadata in the gluster volume that we don't want file sharing clients to be able to access.