### PR TITLE
NAS-118955 / 22.12 / Add framework for EXTERNAL paths

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from middlewared.service import ValidationErrors
 from middlewared.plugins.zfs_.utils import ZFSCTL
+from middlewared.utils.path import path_location
 from middlewared.validators import IpAddress
 
 
@@ -27,6 +28,11 @@ async def check_path_resides_within_volume(verrors, middleware, name, path):
         rv['realpath'] = os.path.realpath(path)
         rv['is_mountpoint'] = os.path.ismount(path)
         return rv
+
+    loc = path_location(name)
+
+    if loc == 'EXTERNAL':
+        verrors.add(name, "Path is external to TrueNAS.")
 
     st = await middleware.run_in_thread(get_file_info, path)
     rp = st["realpath"]

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -832,7 +832,7 @@ class CloudSyncService(TaskPathService, TaskStateMixin):
             if limit1["time"] >= limit2["time"]:
                 verrors.add(f"{name}.bwlimit.{i + 1}.time", f"Invalid time order: {limit1['time']}, {limit2['time']}")
 
-        await self.validate_path_field(data, name, verrors, allow_cluster=True)
+        await self.validate_path_field(data, name, verrors, permitted_locations=['LOCAL', 'CLUSTER'])
 
         if data["snapshot"]:
             if data["direction"] != "PUSH":

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -9,6 +9,7 @@ from ipaddress import ip_address
 from dns.exception import DNSException
 from middlewared.plugins.gluster_linux.utils import GlusterConfig
 from middlewared.schema import Bool, returns
+from middlewared.utils.path import CLUSTER_PATH_PREFIX
 from middlewared.service import Service, job, ValidationErrors, private, accepts
 from middlewared.service_exception import CallError
 
@@ -196,7 +197,7 @@ class FuseConfig(enum.Enum):
     the gluster volumes locally.
     """
     FUSE_PATH_BASE = '/cluster'
-    FUSE_PATH_SUBST = 'CLUSTER:'
+    FUSE_PATH_SUBST = CLUSTER_PATH_PREFIX
 
 
 class CTDBConfig(enum.Enum):

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -5,6 +5,7 @@ import subprocess
 import stat as pystat
 from pathlib import Path
 
+from middlewared.utils.path import path_location
 from middlewared.service import private, CallError, ValidationErrors, Service
 from .acl_base import ACLBase, ACLType
 
@@ -31,7 +32,10 @@ class FilesystemService(Service, ACLBase):
             raise CallError(f"acltool [{action}] on path {path} failed with error: [{acltool.stderr.decode().strip()}]")
 
     def _common_perm_path_validate(self, schema, data, verrors):
-        is_cluster = self.middleware.call_sync('filesystem.is_cluster_path', data['path'])
+        loc = path_location(data['path'])
+        if loc == 'EXTERNAL':
+            verrors.add(f'{schema}.path', 'ACL operations on remote server paths are not possible')
+
         try:
             data['path'] = self.middleware.call_sync('filesystem.resolve_cluster_path', data['path'])
         except CallError as e:
@@ -61,7 +65,7 @@ class FilesystemService(Service, ACLBase):
                         'Permissions changes in ZFS control directory (.zfs) are not permitted')
             return
 
-        if is_cluster:
+        if loc == 'CLUSTER':
             return
 
         if any(st['realpath'].startswith(prefix) for prefix in ('/home/admin/.ssh', '/root/.ssh')):
@@ -98,7 +102,13 @@ class FilesystemService(Service, ACLBase):
         """
         Failure with ENODATA in case acltype is supported, but
         acl absent. EOPNOTSUPP means that acltype is not supported.
+
+        raises NotImplementedError for EXTERNAL paths
         """
+
+        if path_location(path) == 'EXTERNAL':
+            raise NotImplementedError
+
         try:
             os.getxattr(path, "system.posix_acl_access")
             return ACLType.POSIX1E.name
@@ -367,6 +377,9 @@ class FilesystemService(Service, ACLBase):
 
     def getacl(self, path, simplified, resolve_ids):
         path = self.middleware.call_sync('filesystem.resolve_cluster_path', path)
+        if path_location(path) == 'EXTERNAL':
+            raise CallError(f'{path} is external to TrueNAS', errno.EXDEV)
+
         if not os.path.exists(path):
             raise CallError('Path not found.', errno.ENOENT)
 

--- a/src/middlewared/middlewared/utils/path.py
+++ b/src/middlewared/middlewared/utils/path.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
 import errno
+import enum
 import fcntl
 import logging
 import os
@@ -9,7 +10,30 @@ from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["belongs_to_tree", "pathref_open", "pathref_reopen", "is_child"]
+__all__ = ["belongs_to_tree", "pathref_open", "pathref_reopen", "is_child", "path_location", "strip_location_prefix"]
+
+EXTERNAL_PATH_PREFIX = 'EXTERNAL:'
+CLUSTER_PATH_PREFIX = 'CLUSTER:'
+
+
+class FSLocation(enum.Enum):
+    CLUSTER = enum.auto()
+    EXTERNAL = enum.auto()
+    LOCAL = enum.auto()
+
+
+def path_location(path):
+    if path.startswith(CLUSTER_PATH_PREFIX):
+        return FSLocation.CLUSTER.name
+
+    if path.startswith(EXTERNAL_PATH_PREFIX):
+        return FSLocation.EXTERNAL.name
+
+    return FSLocation.LOCAL.name
+
+
+def strip_location_prefix(path):
+    return path.lstrip(f'{path_location(path)}:')
 
 
 def belongs_to_tree(dataset: str, root: str, recursive: bool, exclude: [str]):

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+from functions import DELETE, POST
 
 from .smb_proto import SMB
 from .nfs_proto import SSH_NFS
@@ -13,3 +14,21 @@ def smb_connection(**kwargs):
         yield c
     finally:
         c.disconnect()
+
+
+@contextlib.contextmanager
+def smb_share(path, options=None):
+    results = POST("/sharing/smb/", {
+        "path": path,
+        **(options or {}),
+    })
+    assert results.status_code == 200, results.text
+    id = results.json()["id"]
+
+    try:
+        yield id
+    finally:
+        result = DELETE(f"/sharing/smb/id/{id}/")
+        assert result.status_code == 200, result.text
+
+    assert results.status_code == 200, results.text


### PR DESCRIPTION
NFS and SMB support exporting an external path via DFS proxies for case of SMB and NFS referrals in case of NFS.

This PR implements DFS proxy for SMB. External path for share is indicated via special prefix "EXTERNAL:" which alters the share configuration so that it redirects to the server / share in question.