### PR TITLE
NAS-119810 / 23.10 / Change IPMI sensor matching for generating alerts

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -124,12 +124,12 @@ class IPMISELAlertSource(AlertSource):
             record for record in records
             if (
                 (
-                    any(record.sensor.startswith(f"{sensor} #0x")
+                    any(record.sensor.startswith(sensor)
                         for sensor in self.IPMI_SENSORS) or
-                    any(record.sensor.startswith(f"{sensor} #0x") and record.event == event
+                    any(record.sensor.startswith(sensor) and record.event == event
                         for sensor, event in self.IPMI_EVENTS_WHITELIST)
                 ) and
-                not any(record.sensor.startswith(f"{sensor} #0x") and record.event == event
+                not any(record.sensor.startswith(sensor) and record.event == event
                         for sensor, event in self.IPMI_EVENTS_BLACKLIST)
             )
         ]


### PR DESCRIPTION
When using 'elist', as opposed to 'list', ipmitool generates a more detailed description of the sensor, but omits the number from the name. This means that on a system where all the sensors are described, virtually no alert is ever generated. This commit fixes the problem.