### PR TITLE
NAS-119814 / 23.10 / Add ("Power Supply", "Fully Redundant") to IPMI_EVENTS_BLACKLIST

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -107,6 +107,7 @@ class IPMISELAlertSource(AlertSource):
         ("Redundancy State", "Fully Redundant"),
         ("Processor", "Presence detected"),
         ("Power Supply", "Presence detected"),
+        ("Power Supply", "Fully Redundant"),
     )
 
     async def check(self):


### PR DESCRIPTION
I don't know where "Redundancy State" sensor came from (maybe OEM-specific?), but it's not a standard sensor type. Dell uses a "Power Supply" sensor to indicate the redundancy state.