### PR TITLE
NAS-118988 / 22.12 / Stop any md mirror which might be present on disk

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -6,6 +6,7 @@ from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 async def added_disk(middleware, disk_name):
     await middleware.call('disk.sync', disk_name)
     await middleware.call('disk.sed_unlock', disk_name)
+    await middleware.call('disk.remove_degraded_mirrors')
     await middleware.call('alert.oneshot_delete', 'SMART', disk_name)
 
 


### PR DESCRIPTION
## Context

When a swap mirror is created, essentially a raid mirror is created which is then encrypted and used for swap. When creating these mirrors we write metadata on the disks so that each time system reboots we don't have to rescan and re-setup the complete mirrors as that can be an expensive operation.

## Problem

In the following scenario:

1. Create a pool with MIRROR vdev having 2 disks
2. Take out 1 disk and attach a new disk in it's place
3. Replace the removed disk with new disk and confirm swap mirror is active as well as pool is ONLINE
4. Take out 1 disk again and re-insert the disk taken out in Step 2
5. Trying to use this disk for any pool will fail

What happens is that during step 1 superblocks were written on the disk and when in step 2 pool was degraded the swap mirror was removed but the removed disk had superblocks which were not wiped. When it is inserted again md automatically creates a raid device because of the present superblocks and we cannot format the disk anymore as its being used by raid.

## Solution

Whenever a disk is inserted we should remove any degraded mirrors which have come into place with the disk being inserted.
To be clear we are not destroying any RAID device in this process but just stopping that mirror which will allow users to use the disk with any pool as destroying superblocks implicitly can potentially cause customer data loss.