### PR TITLE
NAS-119044 / 22.12 / Add endpoint to check service configuration prior to start

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -136,6 +136,16 @@ class ServiceService(CRUDService):
 
         await self.middleware.call('service.generate_etc', service_object)
 
+        try:
+            await service_object.check_configuration()
+        except CallError:
+            if options['silent']:
+                self.logger.warning('%s: service failed configuration check',
+                                    service_object.name, exc_info=True)
+                return False
+
+            raise
+
         await service_object.before_start()
         await service_object.start()
         state = await service_object.get_state()

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -12,6 +12,9 @@ class ServiceInterface:
     async def get_state(self):
         raise NotImplementedError
 
+    async def check_configuration(self):
+        pass
+
     async def start(self):
         raise NotImplementedError
 

--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -1,4 +1,8 @@
+import errno
+import os
+
 from .base import SimpleService
+from middlewared.service_exception import CallError
 
 
 class NFSService(SimpleService):
@@ -8,6 +12,15 @@ class NFSService(SimpleService):
     etc = ["nfsd"]
 
     systemd_unit = "nfs-server"
+
+    async def check_configuration(self):
+        if not await self.middleware.run_in_thread(os.path.exists, '/etc/exports'):
+            raise CallError(
+                'At least one configured and available NFS export is required '
+                'in order to start the NFS service. Check the NFS share configuration '
+                'and availability of any paths currently being exported.',
+                errno.EINVAL
+            )
 
     async def systemd_extra_units(self):
         return ["rpc-statd"]


### PR DESCRIPTION
Various services have conditions that must be satisfied prior to starting the service. Since webui is reporting on start failures now, also allow presenting clear reasons why the service won't be started if it's horribly misconfigured or state is broken.