### PR TITLE
NAS-119037 / 22.12 / Allow listing/restoring backups even if k3s is not running

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -97,7 +97,7 @@ class KubernetesService(Service):
         """
         List existing chart releases backups.
         """
-        if not self.middleware.call_sync('kubernetes.validate_k8s_setup', False):
+        if not self.middleware.call_sync('kubernetes.pool_configured'):
             return {}
 
         k8s_config = self.middleware.call_sync('kubernetes.config')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -32,7 +32,6 @@ class KubernetesService(Service):
         It should be noted that a rollback will be initiated which will destroy any newer snapshots/clones
         of `ix-applications` dataset then the snapshot in question of `backup_name`.
         """
-        self.middleware.call_sync('kubernetes.validate_k8s_setup')
         backup = self.middleware.call_sync('kubernetes.list_backups').get(backup_name)
         if not backup:
             raise CallError(f'Backup {backup_name!r} does not exist', errno=errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -481,8 +481,7 @@ class KubernetesService(ConfigService):
     @private
     async def validate_k8s_setup(self, raise_exception=True):
         error = None
-        k8s_config = await self.middleware.call('kubernetes.config')
-        if not k8s_config['dataset']:
+        if not await self.pool_configured():
             error = 'Please configure kubernetes pool.'
         if not error and not await self.middleware.call('service.started', 'kubernetes'):
             error = 'Kubernetes service is not running.'
@@ -496,6 +495,10 @@ class KubernetesService(ConfigService):
         if error and raise_exception:
             raise CallError(error)
         return not error
+
+    @private
+    async def pool_configured(self):
+        return bool((await self.middleware.call('kubernetes.config'))['dataset'])
 
     @accepts()
     @returns(Str('kubernetes_node_ip', null=True))


### PR DESCRIPTION
## Problem

Listing backups / restoring backups right now validates that kubernetes service is running but due to whatever reason it is possible it is borked at the moment and listing/restoring backup does not rely on an existing running service.

## Solution

It only needs to be validated that kubernetes dataset is configured at the time we want to list/restore backups as listing relies on the filesystem only and restoring actually re-initializes k3s so that is a safe procedure as well.