### PR TITLE
NAS-119105 / 22.12 / Do not repeatedly request for logs when following

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/watch.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/watch.py
@@ -14,8 +14,9 @@ class Watch(ClientMixin):
 
     def __init__(
         self, resource: typing.Union[typing.Type[Event], typing.Type[Pod]],
-        resource_uri_args: typing.Optional[dict] = None,
+        resource_uri_args: typing.Optional[dict] = None, recreate: bool = True
     ):
+        self.recreate: bool = recreate
         self.resource: typing.Union[typing.Type[Event], typing.Type[Pod]] = resource
         self.resource_ui_args: typing.Optional[dict] = resource_uri_args or {}
         self._stop: bool = False
@@ -43,3 +44,6 @@ class Watch(ClientMixin):
                             return
 
                         yield self.resource.normalize_data(self.sanitize_data(line, self.resource.STREAM_RESPONSE_TYPE))
+
+            if not self.recreate:
+                break

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/pods.py
@@ -81,7 +81,7 @@ class KubernetesPodLogsFollowTailEventSource(EventSource):
                 ) if self.arg[v]
             }
         }
-        self.watch = Watch(Pod, kwargs)
+        self.watch = Watch(Pod, kwargs, False)
 
         async for event in self.watch.watch():
             # Event should contain a timestamp in RFC3339 format, we should parse it and supply it


### PR DESCRIPTION
## Problem

If a pod has multiple containers in which some containers have been terminated i.e init containers - request to follow logs for such a container will retrieve logs asap and will close the connection but as we recreate the request if it times out / closes, it will continuously fetch same logs and disrupt output plus making lots of un-needed requests.


## Solution

Do not recreate request if the existing request is closed by kubernetes api server staying in line with upstream behaviour of kubernetes python client.
This will result in correctly following logs and for terminated containers just showing the logs and exiting as that's the end for the logs of such a container.