### PR TITLE
NAS-119157 / 22.12 / Fix catalog creation

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -205,3 +205,7 @@ class CatalogService(Service):
             'certificate_authorities': await self.middleware.call('chart.release.certificate_authority_choices'),
             'system.general.config': await self.middleware.call('system.general.config'),
         }
+
+    @private
+    def retrieve_train_names(self, location, all_trains=True, trains_filter=None):
+        return retrieve_train_names(location, all_trains, trains_filter)


### PR DESCRIPTION
## Context

`retrieve_train_names` had been removed from catalog plugin whereas there was an active usage consuming the endpoint when a new catalog was created.