### PR TITLE
NAS-118895 / 22.12 / Handle edge case for missing manifests in helm chart

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
@@ -52,7 +52,7 @@ class ChartReleaseService(Service):
             release_namespace_name = get_namespace(name)
 
             # We don't want manifest files data
-            release.pop('manifest')
+            release.pop('manifest', None)
 
             release.update({
                 'chart_metadata': release.pop('chart')['metadata'],


### PR DESCRIPTION
## Context

If an application's helm chart does not contain any kubernetes resources it will result in middleware not properly able to report what apps are installed as it expects manifests in helm secrets to be always present which is not the case.