### PR TITLE
NAS-118929 / 22.12 / Allow binding authorization token to its origin (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -605,7 +605,7 @@ class KeychainCredentialService(CRUDService):
 
         with client as c:
             if data.get("token"):
-                if not c.call("auth.token", data["token"]):
+                if not c.call("auth.login_with_token", data["token"]):
                     raise CallError("Invalid token")
             elif data.get("password"):
                 args = [data["admin_username"], data["password"]]

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -16,6 +16,8 @@ from .job import Job
 from .pipe import Pipes
 from .schema import Error as SchemaError
 from .service_exception import adapt_exception, CallError, MatchNotFound, ValidationError, ValidationErrors
+from .utils.nginx import get_remote_addr_port
+from .utils.origin import TCPIPOrigin
 
 
 async def authenticate(middleware, request, method, resource):
@@ -32,7 +34,8 @@ async def authenticate(middleware, request, method, resource):
         token = None
 
     if token is not None:
-        token = await middleware.call('auth.get_token_for_action', token, method, resource)
+        origin = TCPIPOrigin(*await middleware.run_in_thread(get_remote_addr_port, request))
+        token = await middleware.call('auth.get_token_for_action', token, origin, method, resource)
         if token is None:
             raise web.HTTPForbidden()
 

--- a/src/middlewared/middlewared/utils/origin.py
+++ b/src/middlewared/middlewared/utils/origin.py
@@ -1,0 +1,34 @@
+class Origin:
+    def match(self, origin):
+        raise NotImplementedError
+
+    def __str__(self):
+        raise NotImplementedError
+
+
+class UnixSocketOrigin(Origin):
+    def __init__(self, pid, uid, gid):
+        self.pid = pid
+        self.uid = uid
+        self.gid = gid
+
+    def match(self, origin):
+        return self.uid == origin.uid and self.gid == origin.gid
+
+    def __str__(self):
+        return f"UNIX socket (pid={self.pid} uid={self.uid} gid={self.gid})"
+
+
+class TCPIPOrigin(Origin):
+    def __init__(self, addr, port):
+        self.addr = addr
+        self.port = port
+
+    def match(self, origin):
+        return self.addr == origin.addr
+
+    def __str__(self):
+        if ":" in self.addr:
+            return f"[{self.addr}]:{self.port}"
+        else:
+            return f"{self.addr}:{self.port}"

--- a/tests/api2/test_account_privilege_authentication.py
+++ b/tests/api2/test_account_privilege_authentication.py
@@ -29,7 +29,7 @@ def unprivileged_user():
 @pytest.fixture()
 def unprivileged_user_token(unprivileged_user):
     with client(auth=(unprivileged_user.username, unprivileged_user.password)) as c:
-        return c.call("auth.generate_token")
+        return c.call("auth.generate_token", 300, {}, True)
 
 
 @pytest.fixture(scope="module")
@@ -47,7 +47,7 @@ def unprivileged_user_with_web_shell():
 @pytest.fixture()
 def unprivileged_user_with_web_shell_token(unprivileged_user_with_web_shell):
     with client(auth=(unprivileged_user_with_web_shell.username, unprivileged_user_with_web_shell.password)) as c:
-        return c.call("auth.generate_token")
+        return c.call("auth.generate_token", 300, {}, True)
 
 
 def test_websocket_auth_session_list_terminate(unprivileged_user):

--- a/tests/api2/test_auth_token.py
+++ b/tests/api2/test_auth_token.py
@@ -10,13 +10,14 @@ sys.path.append(os.getcwd())
 from functions import GET
 from auto_config import ip
 
-from middlewared.test.integration.utils import call, client
+from middlewared.test.integration.assets.account import unprivileged_user as unprivileged_user_template
+from middlewared.test.integration.utils import call, client, ssh
 from middlewared.test.integration.utils.shell import assert_shell_works
 
 
 @pytest.fixture(scope="module")
 def download_token():
-    return call("auth.generate_token", 300, {"filename": "debug.txz", "job": 1020})
+    return call("auth.generate_token", 300, {"filename": "debug.txz", "job": 1020}, True)
 
 
 def test_download_auth_token_cannot_be_used_for_restful_api_call(download_token):
@@ -50,10 +51,40 @@ def test_download_auth_token_cannot_be_used_for_websocket_auth(download_token):
 @pytest.mark.timeout(30)
 def test_token_created_by_token_can_use_shell():
     with client() as c:
-        token = c.call("auth.generate_token")
+        token = c.call("auth.generate_token", 300, {}, True)
 
         with client(auth=None) as c2:
             assert c2.call("auth.login_with_token", token)
 
-            token2 = c2.call("auth.generate_token")
+            token2 = c2.call("auth.generate_token", 300, {}, True)
             assert_shell_works(token2, "root")
+
+
+@pytest.fixture(scope="module")
+def unprivileged_user():
+    with unprivileged_user_template(
+        username="test",
+        group_name="test",
+        privilege_name="test",
+        allowlist=[{"method": "CALL", "resource": "system.info"}],
+        web_shell=True,
+    ):
+        yield
+
+
+def test_login_with_token_match_origin(unprivileged_user):
+    token = ssh(
+        "sudo -u test midclt -u ws://localhost/websocket -U test -P test1234 call auth.generate_token 300 '{}' true"
+    ).strip()
+
+    with client(auth=None) as c:
+        assert not c.call("auth.login_with_token", token)
+
+
+def test_login_with_token_no_match_origin(unprivileged_user):
+    token = ssh(
+        "sudo -u test midclt -u ws://localhost/websocket -U test -P test1234 call auth.generate_token 300"
+    ).strip()
+
+    with client(auth=None) as c:
+        assert c.call("auth.login_with_token", token)

--- a/tests/api2/test_rest_api_authentication.py
+++ b/tests/api2/test_rest_api_authentication.py
@@ -45,7 +45,7 @@ def token_auth(allowlist):
         web_shell=False,
     ) as t:
         with client(auth=(t.username, t.password)) as c:
-            token = c.call("auth.generate_token")
+            token = c.call("auth.generate_token", 300, {}, True)
             yield dict(anonymous=True, headers={"Authorization": f"Token {token}"})
 
 


### PR DESCRIPTION
We do not always require to match token with its origin (namely, remote IP address) because some use cases (e.g. semiautomatic remote SSH connection setup) will break if we do so.

Original PR: https://github.com/truenas/middleware/pull/10138
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118929