### PR TITLE
NAS-119214 / 23.10 / ensure keepalived starts after ix-netif.service

### DIFF
--- a/src/freenas/etc/systemd/keepalived.service/override.conf
+++ b/src/freenas/etc/systemd/keepalived.service/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=ix-netif.service
+Wants=ix-netif.service


### PR DESCRIPTION
It's vitally important that keepalived always starts after `ix-netif.service` since middlewared is responsible for setting up the reader side of the FIFO that keepalived writes to. These are the "failover events" that we use to promote/demote ourselves.