### PR TITLE
NAS-119215 / 23.10 / fix attach_interface

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1852,6 +1852,10 @@ async def configure_http_proxy(middleware, *args, **kwargs):
 
 
 async def attach_interface(middleware, iface):
+    ignore = await middleware.call('interface.internal_interfaces')
+    if any((i.startswith(iface) for i in ignore)):
+        return
+
     if await middleware.call('interface.sync_interface', iface):
         await middleware.call('interface.run_dhcp', iface, False)
 


### PR DESCRIPTION
Seen on an HA system, we're getting log messages from `sync_interface` (for which this function calls) that `ntb0` is not in the database...which is expected. This ignores the "internal interfaces" so we don't generate bogus log messages.