### PR TITLE
NAS-119213 / 22.12 / Globally disable the vfs_fruit zero_file_id parameter (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -13,6 +13,7 @@ DEFAULT_GLOBAL_PARAMETERS = {
     "printing": {"smbconf": "printing", "default": "bsd"},
     "printcap": {"smbconf": "printcap", "default": "/dev/null"},
     "fruit:nfs_aces": {"smbconf": "fruit:nfs_aces", "default": False},
+    "fruit:zero_file_id": {"smbconf": "fruit:zero_file_id", "default": False},
     "disable spoolss": {"smbconf": "disable spoolss", "default": True},
     "dos filemode": {"smbconf": "dos filemode", "default": True},
     "kernel change notify": {"smbconf": "kernel change notify", "default": True},

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -35,6 +35,7 @@ class GlobalSchema(RegistrySchema):
             'max log size': {'parsed': 5120},
             'printcap name': {'parsed': '/dev/null'},
             'fruit:nfs_aces': {'parsed': False},
+            'fruit:zero_file_id': {'parsed': False},
             'restrict anonymous': {'parsed': 0 if guest_enabled else 2},
         })
 


### PR DESCRIPTION
This parameter causes significant regressions in MacOS SMB client stability. The default changed in Samba 4.17 and so we're reverting to pre 4.17 default.

Original PR: https://github.com/truenas/middleware/pull/10157
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119213