### PR TITLE
NAS-119219 / 22.12 / Make validate_path_field properly location-aware (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -8,6 +8,7 @@ from middlewared.service import (
 import middlewared.sqlalchemy as sa
 from middlewared.utils import Popen, run
 from middlewared.utils.lang import undefined
+from middlewared.utils.path import FSLocation
 from middlewared.utils.plugins import load_modules, load_classes
 from middlewared.utils.python import get_middlewared_dir
 from middlewared.utils.service.task_state import TaskStateMixin
@@ -743,6 +744,7 @@ class CloudSyncService(TaskPathService, TaskStateMixin):
     local_fs_lock_manager = FsLockManager()
     remote_fs_lock_manager = FsLockManager()
     share_task_type = 'CloudSync'
+    allowed_path_types = [FSLocation.CLUSTER, FSLocation.LOCAL]
     task_state_methods = ['cloudsync.sync', 'cloudsync.restore']
 
     class Config:
@@ -832,7 +834,7 @@ class CloudSyncService(TaskPathService, TaskStateMixin):
             if limit1["time"] >= limit2["time"]:
                 verrors.add(f"{name}.bwlimit.{i + 1}.time", f"Invalid time order: {limit1['time']}, {limit2['time']}")
 
-        await self.validate_path_field(data, name, verrors, permitted_locations=['LOCAL', 'CLUSTER'])
+        await self.validate_path_field(data, name, verrors)
 
         if data["snapshot"]:
             if data["direction"] != "PUSH":

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -19,7 +19,7 @@ from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, retur
 from middlewared.service import private, CallError, filterable_returns, filterable, Service, job
 from middlewared.utils import filter_list
 from middlewared.utils.osc import getmntinfo
-from middlewared.utils.path import path_location
+from middlewared.utils.path import FSLocation, path_location, strip_location_prefix
 from middlewared.plugins.filesystem_.acl_base import ACLType
 from middlewared.plugins.zfs_.utils import ZFSCTL
 
@@ -77,7 +77,7 @@ class FilesystemService(Service):
 
     @private
     def is_cluster_path(self, path):
-        return path_location(path) == 'CLUSTER'
+        return path_location(path) is FSLocation.CLUSTER
 
     @private
     def resolve_cluster_path(self, path, ignore_ctdb=False):
@@ -85,21 +85,26 @@ class FilesystemService(Service):
         Convert a "CLUSTER:"-prefixed path to an absolute path
         on the server.
         """
-        if not path.startswith(FuseConfig.FUSE_PATH_SUBST.value):
+        if path_location(path) is not FSLocation.CLUSTER:
             return path
 
-        gluster_volume = path[8:].split("/")[0]
+        try:
+            gluster_volume, volpath = strip_location_prefix(path).split('/', 1)
+        except ValueError:
+            raise CallError(
+                'Cluster paths must be provided with the following format: '
+                f'"{FuseConfig.FUSE_PATH_SUBST.value}<cluster volume name>/<path>". '
+                f'For example: "{FuseConfig.FUSE_PATH_SUBST.value}GLSMB/SHARE"'
+            )
+
         if gluster_volume == CTDBConfig.CTDB_VOL_NAME.value and not ignore_ctdb:
             raise CallError('access to ctdb volume is not permitted.', errno.EPERM)
-        elif not gluster_volume:
-            raise CallError(f'More than the prefix "{FuseConfig.FUSE_PATH_SUBST.value}" must be provided')
 
         is_mounted = self.middleware.call_sync('gluster.fuse.is_mounted', {'name': gluster_volume})
         if not is_mounted:
             raise CallError(f'{gluster_volume}: cluster volume is not mounted.', errno.ENXIO)
 
-        cluster_path = path.replace(FuseConfig.FUSE_PATH_SUBST.value, f'{FuseConfig.FUSE_PATH_BASE.value}/')
-        return cluster_path
+        return os.path.join(FuseConfig.FUSE_PATH_BASE.value, gluster_volume, volpath)
 
     @private
     @filterable
@@ -334,7 +339,7 @@ class FilesystemService(Service):
         in the directory 'data' in the clustered volume `smb01`, the
         path should be specified as `CLUSTER:smb01/data`.
         """
-        if path_location(_path) == 'EXTERNAL':
+        if path_location(_path) is FSLocation.EXTERNAL:
             raise CallError(f'{_path} is external to TrueNAS', errno.EXDEV)
 
         path = pathlib.Path(self.resolve_cluster_path(_path))

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -1,5 +1,5 @@
 from middlewared.plugins.smb_.registry_base import RegObj, RegistrySchema
-from middlewared.utils.path import path_location, strip_location_prefix
+from middlewared.utils.path import FSLocation, path_location, strip_location_prefix
 
 
 FRUIT_CATIA_MAPS = [
@@ -201,13 +201,13 @@ class ShareSchema(RegistrySchema):
         loc = path_location(val)
         path = strip_location_prefix(val)
 
-        if loc == 'EXTERNAL':
+        if loc is FSLocation.EXTERNAL:
             data_out['msdfs root'] = {'parsed': True}
             data_out['msdfs proxy'] = {'parsed': path}
             path = '/var/empty'
 
         path_suffix = data_in["path_suffix"]
-        if path_suffix and loc != 'EXTERNAL':
+        if path_suffix and loc is not FSLocation.EXTERNAL:
             path = '/'.join([path, path_suffix])
 
         data_out['path'] = {"parsed": path}
@@ -302,7 +302,11 @@ class ShareSchema(RegistrySchema):
         if not val:
             data_out['nt acl support'] = {"parsed": False}
 
-        if data_in['cluster_volname']:
+        loc = path_location(data_in['path'])
+        if loc == FSLocation.EXTERNAL:
+            return
+
+        elif data_in['cluster_volname']:
             data_out['vfs objects']['parsed'].append("acl_xattr")
             return
 

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -29,7 +29,7 @@ from middlewared.service_exception import (  # noqa
 from middlewared.settings import conf
 from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR, osc
 from middlewared.utils.debug import get_frame_details, get_threads_stacks
-from middlewared.utils.path import path_location, strip_location_prefix
+from middlewared.utils.path import FSLocation, path_location, strip_location_prefix
 from middlewared.logger import Logger, reconfigure_logging, stop_logging
 from middlewared.job import Job
 from middlewared.pipe import Pipes
@@ -1076,10 +1076,15 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
 class SharingTaskService(CRUDService):
 
     path_field = 'path'
+    allowed_path_types = [FSLocation.LOCAL]
     enabled_field = 'enabled'
     locked_field = 'locked'
     locked_alert_class = NotImplemented
     share_task_type = NotImplemented
+
+    @private
+    async def get_path_field(self, data):
+        return data[self.path_field]
 
     @private
     async def sharing_task_extend_context(self, rows, extra):
@@ -1097,33 +1102,79 @@ class SharingTaskService(CRUDService):
         }
 
     @private
-    async def validate_external_path(self, verrors, name, path):
-        verrors.add(name, 'Service does not allow external paths')
+    async def validate_cluster_path(self, verrors, name, volname, path):
+        if volname not in await self.middleware.call('gluster.volume.list'):
+            verrors.add(name, f'{volname}: cluster volume does not exist.')
+            return
+
+        try:
+            await self.middleware.call('filesystem.stat', f'CLUSTER:{volname}{path}')
+        except CallError as e:
+            if e.errno is errno.ENXIO:
+                verrors.add(name, f'{volname}: cluster volume is not mounted.')
+            elif e.errno is errno.ENOENT:
+                # this is not treated as fatal error in `check_path_resides_within_volume`
+                # but the design decision may need further review
+                pass
+            else:
+                raise
 
     @private
-    async def validate_path_field(self, data, schema, verrors, *, permitted_locations=None):
+    async def validate_external_path(self, verrors, name, path):
+        # Services with external paths must implement their own
+        # validation here because we can't predict what is required.
+        raise NotImplementedError
+
+    @private
+    async def validate_local_path(self, verrors, name, path):
+        await check_path_resides_within_volume(verrors, self.middleware, name, path)
+
+    @private
+    async def validate_path_field(self, data, schema, verrors):
         name = f'{schema}.{self.path_field}'
-        path = data[self.path_field]
+        path = await self.get_path_field(data)
         loc = path_location(path)
 
-        if loc not in (permitted_locations or ['LOCAL']):
-            verrors.add(name, f'{loc}: paths are not allowed.')
+        if loc not in self.allowed_path_types:
+            verrors.add(name, f'{loc.name}: path type is not allowed.')
 
-        elif loc == 'EXTERNAL':
+        elif loc is FSLocation.CLUSTER:
+            try:
+                volname, volpath = strip_location_prefix(path).split('/', 1)
+            except ValueError:
+                verrors.add(name, f'{path}: path within cluster volume must be specified.')
+            else:
+                volpath = os.path.join('/', volpath)
+                await self.validate_cluster_path(verrors, name, volname, volpath)
+
+        elif loc is FSLocation.EXTERNAL:
             await self.validate_external_path(verrors, name, strip_location_prefix(path))
+
+        elif loc is FSLocation.LOCAL:
+            await self.validate_local_path(verrors, name, path)
+
         else:
-            await check_path_resides_within_volume(verrors, self.middleware, name, path)
+            self.logger.error('%s: unknown location type', loc.name)
+            raise NotImplementedError
 
         return verrors
 
     @private
     async def sharing_task_datasets(self, data):
-        return [os.path.relpath(data[self.path_field], '/mnt')]
+        path = await self.get_path_field(data)
+        if path_location(path) is not FSLocation.LOCAL:
+            return []
+
+        return [os.path.relpath(path, '/mnt')]
 
     @private
     async def sharing_task_determine_locked(self, data, locked_datasets):
+        path = await self.get_path_field(data)
+        if path_location(path) is not FSLocation.LOCAL:
+            return False
+
         return await self.middleware.call(
-            'pool.dataset.path_in_locked_datasets', data[self.path_field], locked_datasets
+            'pool.dataset.path_in_locked_datasets', path, locked_datasets
         )
 
     @private
@@ -1192,7 +1243,7 @@ class TaskPathService(SharingTaskService):
 
     @private
     async def human_identifier(self, share_task):
-        return share_task[self.path_field]
+        return await self.get_path_field(share_task)
 
 
 class TDBWrapCRUDService(CRUDService):

--- a/src/middlewared/middlewared/utils/path.py
+++ b/src/middlewared/middlewared/utils/path.py
@@ -24,16 +24,16 @@ class FSLocation(enum.Enum):
 
 def path_location(path):
     if path.startswith(CLUSTER_PATH_PREFIX):
-        return FSLocation.CLUSTER.name
+        return FSLocation.CLUSTER
 
     if path.startswith(EXTERNAL_PATH_PREFIX):
-        return FSLocation.EXTERNAL.name
+        return FSLocation.EXTERNAL
 
-    return FSLocation.LOCAL.name
+    return FSLocation.LOCAL
 
 
 def strip_location_prefix(path):
-    return path.lstrip(f'{path_location(path)}:')
+    return path.lstrip(f'{path_location(path).name}:')
 
 
 def belongs_to_tree(dataset: str, root: str, recursive: bool, exclude: [str]):


### PR DESCRIPTION
Make it so that services that have a path field can optionally allow cluster and external paths by setting allowed_path_locations.

This setting will be evaluated in the plugin's
validate_path_field method. This PR refactors this a bit to allow plugins to more easily override the default validation if necessary.

This PR also prevents us from checking whether non-local (gluserfs or external) paths are on locked datasets, which for obvious reasons would have never worked.

Original PR: https://github.com/truenas/middleware/pull/10155
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119219