### PR TITLE
NAS-119129 / 23.10 / Properly set http/https proxy configuration for docker

### DIFF
--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,2 +1,3 @@
 [Service]
+EnvironmentFile=/etc/docker.env
 LimitCORE=1

--- a/src/middlewared/middlewared/etc_files/docker.env.mako
+++ b/src/middlewared/middlewared/etc_files/docker.env.mako
@@ -1,0 +1,9 @@
+<%
+    config = middleware.call_sync('network.configuration.config')
+%>\
+# Docker Environment file
+
+% if config['httpproxy']:
+HTTP_PROXY="${config['httpproxy']}"
+HTTPS_PROXY="${config['httpproxy']}"
+% endif

--- a/src/middlewared/middlewared/etc_files/systemd/system/docker.service.d/http-proxy.conf.mako
+++ b/src/middlewared/middlewared/etc_files/systemd/system/docker.service.d/http-proxy.conf.mako
@@ -1,8 +1,0 @@
-<%
-    config = middleware.call_sync('network.configuration.config')
-    if not config['httpproxy']:
-        raise FileShouldNotExist()
-%>\
-[Service]
-Environment="HTTP_PROXY=${config['httpproxy']}"
-Environment="HTTPS_PROXY=${config['httpproxy']}"

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -232,7 +232,6 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'default/rrdcached', 'checkpoint': 'pool_import'},
         ],
         'docker': [
-            {'type': 'mako', 'path': 'systemd/system/docker.service.d/http-proxy.conf', 'checkpoint': None},
             {'type': 'mako', 'path': 'docker.env', 'checkpoint': None},
             {'type': 'py', 'path': 'docker', 'checkpoint': None},
         ],

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -233,6 +233,7 @@ class EtcService(Service):
         ],
         'docker': [
             {'type': 'mako', 'path': 'systemd/system/docker.service.d/http-proxy.conf', 'checkpoint': None},
+            {'type': 'mako', 'path': 'docker.env', 'checkpoint': None},
             {'type': 'py', 'path': 'docker', 'checkpoint': None},
         ],
         'motd': [


### PR DESCRIPTION
Earlier logic for specifying http/https proxy for docker to consume was faulty as with the existing changes it was necessary to reload the systemctl daemon as it would not be picking up the newly written/modified proxy configuration systemd unit file override.