### PR TITLE
NAS-119237 / 23.10 / Correctly retrieve attachments of a path

### DIFF
--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -91,6 +91,7 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
 
     async def query(self, path, enabled, options=None):
         results = []
+        options = options or {}
         check_path_child_of_resource = options.get('check_path_child_of_resource', False)
         for resource in await self.middleware.call(
             f'{self.namespace}.query', await self.get_query_filters(enabled, options)

--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -133,6 +133,11 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
         if share_path == path:
             return True
 
+        # We want to make sure we cover following cases:
+        # 1) When parent of configured path is specified we return true
+        # 2) When configured path itself is specified we return true
+        # 3) When path is child of configured path, we return true as the path
+        #    is being consumed by service in question
         return await self.middleware.call('filesystem.is_child', share_path, path)
 
     async def start(self, attachments):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -33,7 +33,7 @@ class ChartReleaseService(Service):
         in_use_attachments = []
         for attachment_entry in filter(
             lambda attachment: attachment['type'] not in allowed_service_types,
-            await self.middleware.call('pool.dataset.attachments_with_path', path)
+            await self.middleware.call('pool.dataset.attachments_with_path', path, True)
         ):
             if attachment_entry['service'].lower() == 'kubernetes' and is_ix_volume_path(
                 path, (await self.middleware.call('kubernetes.config'))['dataset']

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -217,7 +217,7 @@ class ChartReleaseService(Service):
 
         if attachments := {
             attachment['type']
-            for attachment in await self.middleware.call('pool.dataset.attachments_with_path', path)
+            for attachment in await self.middleware.call('pool.dataset.attachments_with_path', path, True)
             if attachment['type'].lower() not in ['kubernetes', 'chart releases']
         }:
             verrors.add(schema_name, f"The path '{path}' is already attached to service(s): {', '.join(attachments)}.")

--- a/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
@@ -36,13 +36,13 @@ class PoolDatasetService(Service):
         return []
 
     @private
-    async def attachments_with_path(self, path, check_path_child_of_attachment=False):
+    async def attachments_with_path(self, path, check_parent=False):
         result = []
         if isinstance(path, str) and not path.startswith('/mnt/'):
-            self.logger.warning('%s: uexpected path not located within pool mountpoint', path)
+            self.logger.warning('%s: unexpected path not located within pool mountpoint', path)
 
         if path:
-            options = {'check_path_child_of_resource': check_path_child_of_attachment}
+            options = {'check_parent': check_parent}
             for delegate in self.attachment_delegates:
                 attachments = {'type': delegate.title, 'service': delegate.service, 'attachments': []}
                 for attachment in await delegate.query(path, True, options):

--- a/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_attachments.py
@@ -36,15 +36,16 @@ class PoolDatasetService(Service):
         return []
 
     @private
-    async def attachments_with_path(self, path):
+    async def attachments_with_path(self, path, check_path_child_of_attachment=False):
         result = []
         if isinstance(path, str) and not path.startswith('/mnt/'):
             self.logger.warning('%s: uexpected path not located within pool mountpoint', path)
 
         if path:
+            options = {'check_path_child_of_resource': check_path_child_of_attachment}
             for delegate in self.attachment_delegates:
                 attachments = {'type': delegate.title, 'service': delegate.service, 'attachments': []}
-                for attachment in await delegate.query(path, True):
+                for attachment in await delegate.query(path, True, options):
                     attachments['attachments'].append(await delegate.get_attachment_name(attachment))
                 if attachments['attachments']:
                     result.append(attachments)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1846,8 +1846,8 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
         await reg_sync.wait()
         await self.middleware.call('service.reload', 'mdns')
 
-    async def is_child_of_path(self, resource, path, check_path_child_of_resource):
-        return await super().is_child_of_path(resource, path, check_path_child_of_resource) if resource.get(
+    async def is_child_of_path(self, resource, path, check_parent):
+        return await super().is_child_of_path(resource, path, check_parent) if resource.get(
             self.path_field
         ) else False
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1846,8 +1846,10 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
         await reg_sync.wait()
         await self.middleware.call('service.reload', 'mdns')
 
-    async def is_child_of_path(self, resource, path):
-        return await super().is_child_of_path(resource, path) if resource.get(self.path_field) else False
+    async def is_child_of_path(self, resource, path, check_path_child_of_resource):
+        return await super().is_child_of_path(resource, path, check_path_child_of_resource) if resource.get(
+            self.path_field
+        ) else False
 
 
 async def setup(middleware):

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from pytest_dependency import depends
+
+sys.path.append(os.getcwd())
+
+from middlewared.test.integration.assets.nfs import nfs_share
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, client
+
+
+PARENT_DATASET = 'test_parent'
+CHILD_DATASET = f'{PARENT_DATASET}/child_dataset'
+
+
+def test_attachment_with_child_path(request):
+    depends(request, ['pool_04'], scope='session')
+    with dataset(PARENT_DATASET) as parent_dataset:
+        parent_path = f'/mnt/{parent_dataset}'
+        assert call('pool.dataset.attachments_with_path', parent_path) == []
+
+        with nfs_share(parent_dataset):
+            attachments = call('pool.dataset.attachments_with_path', parent_path)
+            assert len(attachments) > 0, attachments
+            assert attachments[0]['type'] == 'NFS Share', attachments
+
+            with dataset(CHILD_DATASET) as child_dataset:
+                child_path = f'/mnt/{child_dataset}'
+                call('sharing.nfs.create', {'path': child_path})
+                attachments = call('pool.dataset.attachments_with_path', child_path)
+                assert len(attachments) > 0, attachments
+                assert attachments[0]['type'] == 'NFS Share', attachments

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -28,7 +28,6 @@ def test_attachment_with_child_path(request):
 
             with dataset(CHILD_DATASET) as child_dataset:
                 child_path = f'/mnt/{child_dataset}'
-                call('sharing.nfs.create', {'path': child_path})
                 attachments = call('pool.dataset.attachments_with_path', child_path)
                 assert len(attachments) > 0, attachments
                 assert attachments[0]['type'] == 'NFS Share', attachments

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -29,5 +29,8 @@ def test_attachment_with_child_path(request):
             with dataset(CHILD_DATASET) as child_dataset:
                 child_path = f'/mnt/{child_dataset}'
                 attachments = call('pool.dataset.attachments_with_path', child_path)
-                assert len(attachments) > 0, attachments
+                assert len(attachments) == 0, attachments
+
+                attachments = call('pool.dataset.attachments_with_path', child_path, True)
+                assert len(attachments) == 1, attachments
                 assert attachments[0]['type'] == 'NFS Share', attachments


### PR DESCRIPTION
This commit adds changes to also cover the scenario where we might be provided with a path which is child of configured path and in that case we should be correctly retrieving the attachment in question.