### PR TITLE
NAS-119238 / 23.10 / Ensure app config always has release_name available

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -474,7 +474,7 @@ class ChartReleaseService(CRUDService):
                     'operation': 'INSTALL',
                     'isInstall': True,
                 }
-            }, self.middleware)
+            }, self.middleware, data['release_name'])
 
             await self.middleware.call(
                 'chart.release.create_update_storage_class_for_chart_release',
@@ -548,7 +548,7 @@ class ChartReleaseService(CRUDService):
                 'operation': 'UPDATE',
                 'isUpdate': True,
             }
-        }, self.middleware)
+        }, self.middleware, chart_release)
 
         await self.middleware.call('chart.release.helm_action', chart_release, chart_path, config, 'update')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/redeploy.py
@@ -39,7 +39,7 @@ class ChartReleaseService(Service):
                 'operation': 'UPDATE',
                 'isUpdate': True,
             }
-        }, self.middleware)
+        }, self.middleware, release_name)
         if update_pool:
             for index, host_path in enumerate(config.get('ixVolumes', [])):
                 new_pool = release['path'].split('/')[2]

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -292,7 +292,7 @@ class ChartReleaseService(Service):
                     'preUpgradeRevision': release['version'],
                 }
             }
-        }, self.middleware)
+        }, self.middleware, release_name)
 
         job.set_progress(60, 'Upgrading chart release version')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -37,7 +37,7 @@ def get_action_context(release_name):
     })
 
 
-async def add_context_to_configuration(config, context_dict, middleware):
+async def add_context_to_configuration(config, context_dict, middleware, release_name):
     context_dict[CONTEXT_KEY_NAME]['kubernetes_config'] = {
         k: v for k, v in (await middleware.call('kubernetes.config')).items()
         if k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
@@ -50,6 +50,7 @@ async def add_context_to_configuration(config, context_dict, middleware):
             'global': context_dict,
             **context_dict
         })
+    config['release_name'] = release_name
     return config
 
 


### PR DESCRIPTION
This commit fixes an issue where we might expect release name to be present but in reality that might not be true always. How this started was that UI added release name to top level config dict on creatation of chart releases and additional attrs are not verified for top level dict which meant we might get in an inconsistent state if apps were created via API directly and not specifying release name in top level config dict.