### PR TITLE
NAS-119055 / 23.10 / Add kubernetes passthrough mode

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-12-02_17-20_kubernetes_passthrough_mode.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-12-02_17-20_kubernetes_passthrough_mode.py
@@ -1,0 +1,25 @@
+"""
+Kubernetes passthrough mode
+
+Revision ID: fa4097ef2236
+Revises: dc9ffe67a56f
+Create Date: 2022-12-02 17:20:21.541782+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'fa4097ef2236'
+down_revision = 'dc9ffe67a56f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('passthrough_mode', sa.Boolean(), nullable=False, server_default='1'))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-12-02_17-20_kubernetes_passthrough_mode.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-12-02_17-20_kubernetes_passthrough_mode.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('passthrough_mode', sa.Boolean(), nullable=False, server_default='1'))
+        batch_op.add_column(sa.Column('passthrough_mode', sa.Boolean(), nullable=False, server_default='0'))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -97,7 +97,9 @@ class KubernetesService(Service):
         """
         List existing chart releases backups.
         """
-        if not self.middleware.call_sync('kubernetes.pool_configured'):
+        if not self.middleware.call_sync('kubernetes.pool_configured') or self.middleware.call_sync(
+            'kubernetes.config'
+        )['passthrough_mode']:
             return {}
 
         k8s_config = self.middleware.call_sync('kubernetes.config')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -134,6 +134,13 @@ class KubernetesService(ConfigService):
                 'System is not licensed to use Applications'
             )
 
+        license = await self.middleware.call('system.license')
+        if data['passthrough_mode'] and (not license or '-MINI-' in license['system_product']):
+            verrors.add(
+                f'{schema}.passthrough_mode',
+                'Can only be enabled on licensed iX enterprise hardware'
+            )
+
         if data['pool'] and not await self.middleware.call('pool.query', [['name', '=', data['pool']]]):
             verrors.add(f'{schema}.pool', 'Please provide a valid pool configured in the system.')
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -30,6 +30,7 @@ class KubernetesModel(sa.Model):
     configure_gpus = sa.Column(sa.Boolean(), default=True, nullable=False)
     servicelb = sa.Column(sa.Boolean(), default=True, nullable=False)
     validate_host_path = sa.Column(sa.Boolean(), default=True)
+    passthrough_mode = sa.Column(sa.Boolean(), default=False)
 
 
 class KubernetesService(ConfigService):
@@ -44,6 +45,7 @@ class KubernetesService(ConfigService):
         Bool('servicelb', required=True),
         Bool('configure_gpus', required=True),
         Bool('validate_host_path', required=True),
+        Bool('passthrough_mode', required=True),
         Str('pool', required=True, null=True),
         IPAddr('cluster_cidr', required=True, cidr=True, empty=True),
         IPAddr('service_cidr', required=True, cidr=True, empty=True),
@@ -483,6 +485,9 @@ class KubernetesService(ConfigService):
     @private
     async def validate_k8s_setup(self, raise_exception=True):
         error = None
+        if (await self.middleware.call('kubernetes.config'))['passthrough_mode']:
+            error = 'Kubernetes operations are not allowed with passthrough mode enabled'
+
         if not await self.pool_configured():
             error = 'Please configure kubernetes pool.'
         if not error and not await self.middleware.call('service.started', 'kubernetes'):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_kubernetes.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_kubernetes.py
@@ -28,6 +28,7 @@ async def test_kubernetes_configuration_for_licensed_and_unlicensed_systems(ha_c
         'route_v6_gateway': None,
         'node_ip': '0.0.0.0',
         'configure_gpus': True,
+        'passthrough_mode': False,
         'servicelb': True,
         'validate_host_path': True,
     }

--- a/tests/api2/test_kubernetes_passthrough_test.py
+++ b/tests/api2/test_kubernetes_passthrough_test.py
@@ -1,0 +1,88 @@
+import sys
+import os
+import time
+
+from pytest_dependency import depends
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+from middlewared.test.integration.utils import call, ssh
+from middlewared.service_exception import CallError
+from middlewared.client.client import ClientException
+from auto_config import pool_name
+
+import pytest
+
+
+APP_NAME = 'syncthing'
+
+
+@pytest.mark.dependency(name='default_kubernetes_cluster')
+def test_01_default_kubernetes_cluster(request):
+    depends(request, ['pool_04'], scope='session')
+    config = call('kubernetes.update', {'passthrough_mode': False, 'pool': pool_name}, job=True)
+    assert config['passthrough_mode'] is False
+
+
+@pytest.mark.dependency(name='install_chart_release')
+def test_02_install_chart_release(request):
+    depends(request, ['default_kubernetes_cluster'])
+    payload = {'catalog': 'OFFICIAL', 'item': 'syncthing', 'release_name': APP_NAME, 'train': 'charts'}
+    call('chart.release.create', payload, job=True)
+    assert call('chart.release.get_instance', APP_NAME)['name'] == APP_NAME
+
+
+def test_03_ip_rules_in_default_mode(request):
+    depends(request, ['default_kubernetes_cluster'])
+    assert len(call('kubernetes.iptable_rules')) > 0
+
+
+@pytest.mark.dependency(name='setup_kubernetes_passthrough_mode')
+def test_04_kubernetes_passthrough_mode(request):
+    depends(request, ['default_kubernetes_cluster'])
+    config = call('kubernetes.update', {'passthrough_mode': True}, job=True)
+    assert config['passthrough_mode'] is True
+
+
+def test_05_validate_kubernetes_passthrough_mode(request):
+    depends(request, ['setup_kubernetes_passthrough_mode'])
+    with pytest.raises(CallError) as e:
+        call('kubernetes.validate_k8s_setup')
+        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+
+
+def test_06_query_chart_release(request):
+    depends(request, ['install_chart_release', 'setup_kubernetes_passthrough_mode'])
+    assert call('chart.release.query') == []
+
+
+def test_07_install_chart_release_app(request):
+    depends(request, ['setup_kubernetes_passthrough_mode'])
+    payload = {'catalog': 'OFFICIAL', 'item': 'test-syncthing', 'release_name': 'syncthing', 'train': 'charts'}
+    with pytest.raises(ClientException) as e:
+        call('chart.release.create', payload, job=True)
+        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+
+
+def test_08_create_kubernetes_backup_restore(request):
+    depends(request, ['setup_kubernetes_passthrough_mode'])
+    with pytest.raises(ClientException) as e:
+        call('kubernetes.backup_chart_releases', 'test_backup', job=True)
+        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+
+
+def test_09_ip_rules_in_passthrough_mode(request):
+    depends(request, ['setup_kubernetes_passthrough_mode'])
+    assert len(call('kubernetes.iptable_rules')) == 0
+
+
+@pytest.mark.dependency(name='remove_kubernetes_passthrough_mode')
+def test_10_remove_kubernetes_passthrough_mode(request):
+    depends(request, ['setup_kubernetes_passthrough_mode'])
+    call('kubernetes.update', {'passthrough_mode': False}, job=True)
+
+
+def test_11_validate_cluster(request):
+    depends(request, ['remove_kubernetes_passthrough_mode'])
+    assert call('kubernetes.validate_k8s_setup') is True

--- a/tests/api2/test_kubernetes_passthrough_test.py
+++ b/tests/api2/test_kubernetes_passthrough_test.py
@@ -1,16 +1,15 @@
 import sys
 import os
-import time
 
 from pytest_dependency import depends
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 
-from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils import call
 from middlewared.service_exception import CallError
 from middlewared.client.client import ClientException
-from auto_config import pool_name
+from auto_config import ha, pool_name
 
 import pytest
 
@@ -38,51 +37,52 @@ def test_03_ip_rules_in_default_mode(request):
     assert len(call('kubernetes.iptable_rules')) > 0
 
 
-@pytest.mark.dependency(name='setup_kubernetes_passthrough_mode')
-def test_04_kubernetes_passthrough_mode(request):
-    depends(request, ['default_kubernetes_cluster'])
-    config = call('kubernetes.update', {'passthrough_mode': True}, job=True)
-    assert config['passthrough_mode'] is True
+if ha:
+    @pytest.mark.dependency(name='setup_kubernetes_passthrough_mode')
+    def test_04_kubernetes_passthrough_mode(request):
+        depends(request, ['default_kubernetes_cluster'])
+        config = call('kubernetes.update', {'passthrough_mode': True}, job=True)
+        assert config['passthrough_mode'] is True
 
 
-def test_05_validate_kubernetes_passthrough_mode(request):
-    depends(request, ['setup_kubernetes_passthrough_mode'])
-    with pytest.raises(CallError) as e:
-        call('kubernetes.validate_k8s_setup')
-        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+    def test_05_validate_kubernetes_passthrough_mode(request):
+        depends(request, ['setup_kubernetes_passthrough_mode'])
+        with pytest.raises(CallError) as e:
+            call('kubernetes.validate_k8s_setup')
+            assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
 
 
-def test_06_query_chart_release(request):
-    depends(request, ['install_chart_release', 'setup_kubernetes_passthrough_mode'])
-    assert call('chart.release.query') == []
+    def test_06_query_chart_release(request):
+        depends(request, ['install_chart_release', 'setup_kubernetes_passthrough_mode'])
+        assert call('chart.release.query') == []
 
 
-def test_07_install_chart_release_app(request):
-    depends(request, ['setup_kubernetes_passthrough_mode'])
-    payload = {'catalog': 'OFFICIAL', 'item': 'test-syncthing', 'release_name': 'syncthing', 'train': 'charts'}
-    with pytest.raises(ClientException) as e:
-        call('chart.release.create', payload, job=True)
-        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+    def test_07_install_chart_release_app(request):
+        depends(request, ['setup_kubernetes_passthrough_mode'])
+        payload = {'catalog': 'OFFICIAL', 'item': 'test-syncthing', 'release_name': 'syncthing', 'train': 'charts'}
+        with pytest.raises(ClientException) as e:
+            call('chart.release.create', payload, job=True)
+            assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
 
 
-def test_08_create_kubernetes_backup_restore(request):
-    depends(request, ['setup_kubernetes_passthrough_mode'])
-    with pytest.raises(ClientException) as e:
-        call('kubernetes.backup_chart_releases', 'test_backup', job=True)
-        assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
+    def test_08_create_kubernetes_backup_restore(request):
+        depends(request, ['setup_kubernetes_passthrough_mode'])
+        with pytest.raises(ClientException) as e:
+            call('kubernetes.backup_chart_releases', 'test_backup', job=True)
+            assert e == 'Kubernetes operations are not allowed with passthrough mode enabled'
 
 
-def test_09_ip_rules_in_passthrough_mode(request):
-    depends(request, ['setup_kubernetes_passthrough_mode'])
-    assert len(call('kubernetes.iptable_rules')) == 0
+    def test_09_ip_rules_in_passthrough_mode(request):
+        depends(request, ['setup_kubernetes_passthrough_mode'])
+        assert len(call('kubernetes.iptable_rules')) == 0
 
 
-@pytest.mark.dependency(name='remove_kubernetes_passthrough_mode')
-def test_10_remove_kubernetes_passthrough_mode(request):
-    depends(request, ['setup_kubernetes_passthrough_mode'])
-    call('kubernetes.update', {'passthrough_mode': False}, job=True)
+    @pytest.mark.dependency(name='remove_kubernetes_passthrough_mode')
+    def test_10_remove_kubernetes_passthrough_mode(request):
+        depends(request, ['setup_kubernetes_passthrough_mode'])
+        call('kubernetes.update', {'passthrough_mode': False}, job=True)
 
 
-def test_11_validate_cluster(request):
-    depends(request, ['remove_kubernetes_passthrough_mode'])
-    assert call('kubernetes.validate_k8s_setup') is True
+    def test_11_validate_cluster(request):
+        depends(request, ['remove_kubernetes_passthrough_mode'])
+        assert call('kubernetes.validate_k8s_setup') is True


### PR DESCRIPTION
## Context

It was requested that we allow kubernetes passthrough mode which will disable applications functionality and only expose the bare kubernetes cluster for consumption.