### PR TITLE
NAS-119254 / 13.0 / keep references for created asyncio tasks

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -162,7 +162,7 @@ class JobsQueue(object):
     async def run(self):
         while True:
             job = await self.next()
-            asyncio.ensure_future(job.run(self))
+            self.middleware.create_task(job.run(self))
 
 
 class JobsDeque(object):

--- a/src/middlewared/middlewared/plugins/afp.py
+++ b/src/middlewared/middlewared/plugins/afp.py
@@ -1,4 +1,3 @@
-import asyncio
 import enum
 import uuid
 
@@ -362,7 +361,7 @@ async def pool_post_import(middleware, pool):
     Makes sure to reload AFP if a pool is imported and there are shares configured for it.
     """
     if pool is None:
-        asyncio.ensure_future(middleware.call('etc.generate', 'afpd'))
+        middleware.create_task(middleware.call('etc.generate', 'afpd'))
         return
 
     path = f'/mnt/{pool["name"]}'
@@ -372,7 +371,7 @@ async def pool_post_import(middleware, pool):
             ('path', '^', f'{path}/'),
         ])
     ]):
-        asyncio.ensure_future(middleware.call('service.reload', 'afp'))
+        middleware.create_task(middleware.call('service.reload', 'afp'))
 
 
 class AFPFSAttachmentDelegate(LockableFSAttachmentDelegate):

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -214,7 +214,7 @@ async def rclone(middleware, job, cloud_sync, dry_run=False):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        check_cloud_sync = asyncio.ensure_future(rclone_check_progress(job, proc))
+        check_cloud_sync = middleware.create_task(rclone_check_progress(job, proc))
         cancelled_error = None
         try:
             try:

--- a/src/middlewared/middlewared/plugins/device_/devd_events.py
+++ b/src/middlewared/middlewared/plugins/device_/devd_events.py
@@ -94,4 +94,4 @@ async def devd_listen(middleware):
 
 
 def setup(middleware):
-    asyncio.ensure_future(devd_loop(middleware))
+    middleware.create_task(devd_loop(middleware))

--- a/src/middlewared/middlewared/plugins/disk_/hddstandby_force.py
+++ b/src/middlewared/middlewared/plugins/disk_/hddstandby_force.py
@@ -118,7 +118,7 @@ class DiskService(Service):
 
         if spindown_disks:
             logger.trace("Spinning down disks %r", spindown_disks)
-            asyncio.ensure_future(self._spindown_disks(spindown_disks))
+            self.middleware.create_task(self._spindown_disks(spindown_disks))
 
     async def _spindown_disks(self, disks):
         for disk in disks:
@@ -171,4 +171,4 @@ class DiskService(Service):
 
 
 async def setup(middleware):
-    asyncio.ensure_future(middleware.call("disk.update_hddstandby_force"))
+    middleware.create_task(middleware.call("disk.update_hddstandby_force"))

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -38,7 +38,7 @@ class DiskService(Service):
             finally:
                 self.smartctl_args_for_device_lock.release()
 
-        asyncio.ensure_future(update())
+        self.middleware.create_task(update())
 
     @private
     async def smartctl_args(self, disk):

--- a/src/middlewared/middlewared/plugins/disk_/swap_remove.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_remove.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 from middlewared.utils.osc import IS_LINUX
@@ -76,4 +75,4 @@ class DiskService(Service):
 
         # Let consumer explicitly deny swap configuration if desired
         if configure_swap and options.get('configure_swap', True):
-            asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
+            self.middleware.create_task(self.middleware.call('disk.swaps_configure'))

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import time
 import re
@@ -282,7 +281,7 @@ class DiskService(Service, ServiceChangeMixin):
                     ):
                         self.middleware.call_sync('iscsi.extent.delete', extent['id'])
                     if disk['disk_kmip_uid']:
-                        asyncio.ensure_future(self.middleware.call(
+                        self.middleware.create_task(self.middleware.call(
                             'kmip.reset_sed_disk_password', disk['disk_identifier'], disk['disk_kmip_uid']
                         ))
                     self.middleware.call_sync('datastore.delete', 'storage.disk', disk['disk_identifier'], options)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -461,7 +461,7 @@ class EtcService(Service):
 async def __event_system_ready(middleware, event_type, args):
 
     if args['id'] == 'ready':
-        asyncio.ensure_future(middleware.call('etc.generate_checkpoint', 'post_init'))
+        middleware.create_task(middleware.call('etc.generate_checkpoint', 'post_init'))
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -906,7 +906,7 @@ class InterfaceService(CRUDService):
         if options['rollback'] and options['checkin_timeout']:
             loop = asyncio.get_event_loop()
             self._rollback_timer = loop.call_later(
-                options['checkin_timeout'], lambda: asyncio.ensure_future(self.rollback())
+                options['checkin_timeout'], lambda: self.middleware.create_task(self.rollback())
             )
         else:
             self._original_datastores = {}
@@ -2634,7 +2634,7 @@ async def setup(middleware):
     middleware.event_register('network.config', 'Sent on network configuration changes.')
 
     # Configure http proxy on startup and on network.config events
-    asyncio.ensure_future(configure_http_proxy(middleware))
+    middleware.create_task(configure_http_proxy(middleware))
     middleware.event_subscribe('network.config', configure_http_proxy)
 
     # Listen to IFNET events so we can sync on interface attach

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -550,7 +550,7 @@ async def interface_post_sync(middleware):
         nfs = await middleware.call('datastore.query', 'services_services', filters, options)
         if nfs['srv_enable'] and any([i['enabled'] for i in await middleware.call('sharing.nfs.query')]):
             if (await middleware.call('nfs.config'))['bindip']:
-                asyncio.ensure_future(middleware.call('service.restart', 'nfs'))
+                middleware.create_task(middleware.call('service.restart', 'nfs'))
 
 
 async def pool_post_import(middleware, pool):
@@ -558,13 +558,13 @@ async def pool_post_import(middleware, pool):
     Makes sure to reload NFS if a pool is imported and there are shares configured for it.
     """
     if pool is None:
-        asyncio.ensure_future(middleware.call('etc.generate', 'nfsd'))
+        middleware.create_task(middleware.call('etc.generate', 'nfsd'))
         return
 
     path = f'/mnt/{pool["name"]}'
     for share in await middleware.call('sharing.nfs.query'):
         if any(filter(lambda x: x == path or x.startswith(f'{path}/'), share['paths'])):
-            asyncio.ensure_future(middleware.call('service.reload', 'nfs'))
+            middleware.create_task(middleware.call('service.reload', 'nfs'))
             break
 
 

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from middlewared.schema import accepts, Bool, Dict, Int, Str
 from middlewared.service import CallError, job, Service, ValidationErrors
 
@@ -96,4 +94,4 @@ class PoolService(Service):
         enc_disks = [{'disk': options['new_disk'], 'devname': f'{new_devname.removeprefix("/dev/")}'}]
         disk = await self.middleware.call('disk.query', [['devname', '=', options['new_disk']]], {'get': True})
         await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})
-        asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
+        self.middleware.create_task(self.middleware.call('disk.swaps_configure'))

--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -1,4 +1,3 @@
-import asyncio
 import errno
 import os
 
@@ -112,7 +111,7 @@ class PoolService(Service):
         finally:
             # Needs to happen even if replace failed to put back disk that had been
             # removed from swap prior to replacement
-            asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
+            self.middleware.create_task(self.middleware.call('disk.swaps_configure'))
 
         enc_disks = [{'disk': disk['devname'], 'devname': f'{new_devname.removeprefix("/dev/")}'}]
         await self.middleware.call('pool.save_encrypteddisks', oid, enc_disks, {disk['devname']: disk})

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -337,7 +337,7 @@ class ServiceService(CRUDService):
 
 async def __event_service_ready(middleware, event_type, args):
     if args['id'] == 'ready':
-        asyncio.ensure_future(middleware.call('service.check_deprecated_services'))
+        middleware.create_task(middleware.call('service.check_deprecated_services'))
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from middlewared.utils import osc
 
 from middlewared.plugins.service_.services.base import ServiceState, ServiceInterface, SimpleService
@@ -38,7 +36,7 @@ class DiskService(PseudoServiceBase):
 
         # FIXME: Linux
 
-        asyncio.ensure_future(self.middleware.call("service.restart", "collectd"))
+        self.middleware.create_task(self.middleware.call("service.restart", "collectd"))
 
 
 class FailoverService(PseudoServiceBase):
@@ -211,10 +209,10 @@ class SystemService(PseudoServiceBase):
     restartable = True
 
     async def stop(self):
-        asyncio.ensure_future(self.middleware.call("system.shutdown", {"delay": 3}))
+        self.middleware.create_task(self.middleware.call("system.shutdown", {"delay": 3}))
 
     async def restart(self):
-        asyncio.ensure_future(self.middleware.call("system.reboot", {"delay": 3}))
+        self.middleware.create_task(self.middleware.call("system.reboot", {"delay": 3}))
 
 
 class SystemDatasetsService(PseudoServiceBase):
@@ -238,7 +236,7 @@ class SystemDatasetsService(PseudoServiceBase):
         # benefit in waiting for it, since even if it fails it will not
         # tell the user anything useful.
         # Restarting rrdcached will make sure that we start/restart collectd as well
-        asyncio.ensure_future(self.middleware.call("service.restart", "rrdcached"))
+        self.middleware.create_task(self.middleware.call("service.restart", "rrdcached"))
 
 
 class TimeservicesService(PseudoServiceBase):

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import os
 import signal
@@ -33,7 +32,7 @@ class UPSService(SimpleService):
 
     async def after_start(self):
         if await self.middleware.call("service.started", "collectd"):
-            asyncio.ensure_future(self.middleware.call("service.restart", "collectd"))
+            self.middleware.create_task(self.middleware.call("service.restart", "collectd"))
 
     async def before_stop(self):
         await self.middleware.call("ups.dismiss_alerts")
@@ -63,4 +62,4 @@ class UPSService(SimpleService):
 
     async def after_stop(self):
         if await self.middleware.call("service.started", "collectd"):
-            asyncio.ensure_future(self.middleware.call("service.restart", "collectd"))
+            self.middleware.create_task(self.middleware.call("service.restart", "collectd"))

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -280,7 +280,7 @@ class SMARTTestService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        asyncio.ensure_future(self._service_change('smartd', 'restart'))
+        self.middleware.create_task(self._service_change('smartd', 'restart'))
 
         return data
 
@@ -332,7 +332,7 @@ class SMARTTestService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        asyncio.ensure_future(self._service_change('smartd', 'restart'))
+        self.middleware.create_task(self._service_change('smartd', 'restart'))
 
         return await self.query(filters=[('id', '=', id)], options={'get': True})
 
@@ -349,7 +349,7 @@ class SMARTTestService(CRUDService):
             id
         )
 
-        asyncio.ensure_future(self._service_change('smartd', 'restart'))
+        self.middleware.create_task(self._service_change('smartd', 'restart'))
 
         return response
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -5,7 +5,6 @@ from middlewared.service_exception import CallError
 import middlewared.sqlalchemy as sa
 from middlewared.utils import osc, Popen, run
 
-import asyncio
 import codecs
 import enum
 import errno
@@ -1322,7 +1321,7 @@ async def pool_post_import(middleware, pool):
         By the time the post-import hook is called, the smb.configure should have
         already completed and initialized the SMB service.
         """
-        asyncio.ensure_future(middleware.call('sharing.smb.sync_registry'))
+        middleware.create_task(middleware.call('sharing.smb.sync_registry'))
         return
 
     path = f'/mnt/{pool["name"]}'
@@ -1332,7 +1331,7 @@ async def pool_post_import(middleware, pool):
             ('path', '^', f'{path}/'),
         ])
     ]):
-        asyncio.ensure_future(middleware.call('sharing.smb.sync_registry'))
+        middleware.create_task(middleware.call('sharing.smb.sync_registry'))
 
 
 class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -3,7 +3,6 @@ from middlewared.service import CallError, ConfigService, ValidationErrors, job,
 import middlewared.sqlalchemy as sa
 from middlewared.utils import osc, Popen, run
 
-import asyncio
 import errno
 import os
 import shutil
@@ -270,7 +269,7 @@ class SystemDatasetService(ConfigService):
         if await self.__setup_datasets(config['pool'], config['uuid']):
             # There is no need to wait this to finish
             # Restarting rrdcached will ensure that we start/restart collectd as well
-            asyncio.ensure_future(self.middleware.call('service.restart', 'rrdcached'))
+            self.middleware.create_task(self.middleware.call('service.restart', 'rrdcached'))
 
         if not os.path.isdir(SYSDATASET_PATH):
             if os.path.exists(SYSDATASET_PATH):

--- a/src/middlewared/middlewared/plugins/truecommand/__init__.py
+++ b/src/middlewared/middlewared/plugins/truecommand/__init__.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from .enums import Status
 
 
@@ -24,4 +22,4 @@ async def setup(middleware):
     middleware.event_subscribe('system', _event_system)
     if await middleware.call('system.ready'):
         if not await middleware.call('failover.licensed'):
-            asyncio.ensure_future(middleware.call('truecommand.start_truecommand_service'))
+            middleware.create_task(middleware.call('truecommand.start_truecommand_service'))

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 import subprocess
 import time
@@ -130,7 +129,7 @@ class TruecommandService(Service):
             ):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
-                asyncio.ensure_future(self.middleware.call('truecommand.health_check'))
+                self.middleware.create_task(self.middleware.call('truecommand.health_check'))
             else:
                 # start polling iX Portal to see what's up and why we don't have these values set
                 # This can happen in instances where system was polling and then was rebooted,

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -51,7 +51,7 @@ class UsageService(Service):
 
         event_loop.call_later(
             scheduled,
-            lambda: asyncio.ensure_future(self.middleware.call('usage.start'))
+            lambda: self.middleware.create_task(self.middleware.call('usage.start'))
         )
         self.logger.debug(f'Scheduled next run in {round(scheduled)} seconds')
 
@@ -530,7 +530,7 @@ async def setup(middleware):
         random.uniform(1, (
             now.replace(hour=23, minute=59, second=59) - now
         ).total_seconds()),
-        lambda: asyncio.ensure_future(
+        lambda: middleware.create_task(
             middleware.call('usage.start')
         )
     )

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -2421,7 +2421,7 @@ async def __event_system_ready(middleware, event_type, args):
         if not await middleware.call('system.is_freenas') and await middleware.call('failover.licensed'):
             return
 
-        asyncio.ensure_future(middleware.call('vm.start_on_boot'))
+        middleware.create_task(middleware.call('vm.start_on_boot'))
     elif args['id'] == 'shutdown':
         async with SHUTDOWN_LOCK:
             await asyncio_map(
@@ -2494,10 +2494,10 @@ async def setup(middleware):
     if sysctl:
         ZFS_ARC_MAX_INITIAL = sysctl.filter('vfs.zfs.arc.max')[0].value
     if osc.IS_FREEBSD:
-        asyncio.ensure_future(kmod_load())
-    asyncio.ensure_future(middleware.call('pool.dataset.register_attachment_delegate',
-                                          VMFSAttachmentDelegate(middleware)))
+        middleware.create_task(kmod_load())
+    middleware.create_task(middleware.call('pool.dataset.register_attachment_delegate',
+                                           VMFSAttachmentDelegate(middleware)))
 
     if await middleware.call('system.ready'):
-        asyncio.ensure_future(middleware.call('vm.initialize_vms', 2))  # We use a short timeout here deliberately
+        middleware.create_task(middleware.call('vm.initialize_vms', 2))  # We use a short timeout here deliberately
     middleware.event_subscribe('system', __event_system_ready)

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 
 from middlewared.common.attachment import LockableFSAttachmentDelegate
@@ -261,7 +260,7 @@ async def pool_post_import(middleware, pool):
     Makes sure to reload WebDAV if a pool is imported and there are shares configured for it.
     """
     if pool is None:
-        asyncio.ensure_future(middleware.call('etc.generate', 'webdav'))
+        middleware.create_task(middleware.call('etc.generate', 'webdav'))
         return
 
     path = f'/mnt/{pool["name"]}'
@@ -271,7 +270,7 @@ async def pool_post_import(middleware, pool):
             ('path', '^', f'{path}/'),
         ])
     ]):
-        asyncio.ensure_future(middleware.call('service.reload', 'webdav'))
+        middleware.create_task(middleware.call('service.reload', 'webdav'))
 
 
 class WebDAVFSAttachmentDelegate(LockableFSAttachmentDelegate):

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -301,6 +301,7 @@ class Service(object, metaclass=ServiceBase):
 
     This is meant for services that do not follow any standard.
     """
+
     def __init__(self, middleware):
         self.logger = Logger(type(self).__name__).getLogger()
         self.middleware = middleware
@@ -430,7 +431,7 @@ class SystemServiceService(ConfigService):
         if self._config.service_verb_sync:
             await fut
         else:
-            asyncio.ensure_future(fut)
+            self.middleware.create_task(fut)
 
 
 class CRUDService(ServiceChangeMixin, Service):
@@ -1222,7 +1223,7 @@ class CoreService(Service):
           - threaded: run debugger in a new thread instead of event loop
         """
         if options['threaded']:
-            asyncio.ensure_future(self.middleware.run_in_thread(self.__debug, engine, options))
+            self.middleware.create_task(self.middleware.run_in_thread(self.__debug, engine, options))
         else:
             self.__debug(engine, options)
 


### PR DESCRIPTION
According to https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task, references to created tasks should be held until the task terminates.