### PR TITLE
NAS-119258 / 23.10 / Disable k3s/kubelet dataset snapshot

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -89,7 +89,7 @@ class KubernetesService(Service):
 
     @private
     def to_ignore_datasets_on_backup(self, k8s_dataset):
-        return [os.path.join(k8s_dataset, ds_name) for ds_name in ('catalogs', 'docker')]
+        return [os.path.join(k8s_dataset, ds_name) for ds_name in ('catalogs', 'docker', 'k3s/kubelet')]
 
     @accepts()
     @returns(Dict('backups', additional_attrs=True))

--- a/tests/api2/test_026_kubernetes_backup_chart_releases.py
+++ b/tests/api2/test_026_kubernetes_backup_chart_releases.py
@@ -7,6 +7,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, DELETE, SSH_TEST, wait_on_job
 from auto_config import ha, dev_test, artifacts, password, ip
+from middlewared.test.integration.utils import call
 
 
 reason = 'Skipping for test development testing'
@@ -59,7 +60,22 @@ if not ha:
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
         backup_name = job_status['results']['result']
 
-    def test_04_get_ix_applications_kubernetes_backup(request):
+    @pytest.mark.dependency(name='check_datasets_to_ignore')
+    def test_04_check_to_ignore_datasets_exist(request):
+        datasets_to_ignore = set(call('kubernetes.to_ignore_datasets_on_backup', call('kubernetes.config')['dataset']))
+
+        assert set(ds['id'] for ds in call(
+            'zfs.dataset.query', [['OR', [['id', '=', directory] for directory in datasets_to_ignore]]]
+        )) == datasets_to_ignore
+
+    def test_05_backup_chart_release(request):
+        depends(request, ['ix_app_backup', 'check_datasets_to_ignore'])
+        datasets_to_ignore = set(call('kubernetes.to_ignore_datasets_on_backup', call('kubernetes.config')['dataset']))
+        datasets = set(snap['dataset'] for snap in call('zfs.snapshot.query', [['id', 'rin', backup_name]]))
+
+        assert datasets_to_ignore.intersection(datasets) == set()
+
+    def test_06_get_ix_applications_kubernetes_backup(request):
         depends(request, ['ix_app_backup'])
         results = GET('/kubernetes/list_backups/')
         assert results.status_code == 200, results.text
@@ -67,7 +83,7 @@ if not ha:
         assert backup_name in results.json(), results.text
 
     @pytest.mark.dependency(name='ix_app_backup_restored')
-    def test_05_restore_ix_applications_kubernetes_backup(request):
+    def test_07_restore_ix_applications_kubernetes_backup(request):
         depends(request, ['ix_app_backup'])
         payload = {
             "backup_name": backup_name,
@@ -80,14 +96,14 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_06_verify_plex_chart_release_still_exist(request):
+    def test_08_verify_plex_chart_release_still_exist(request):
         depends(request, ['release_plex', 'ix_app_backup_restored'])
         results = GET(f'/chart/release/id/{plex_id}/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
 
     @pytest.mark.dependency(name='release_ipfs')
-    def test_07_create_ipfs_chart_release(request):
+    def test_09_create_ipfs_chart_release(request):
         depends(request, ['setup_kubernetes'], scope='session')
         global ipfs_id
         payload = {
@@ -104,7 +120,7 @@ if not ha:
         ipfs_id = job_status['results']['result']['id']
 
     @pytest.mark.dependency(name='my_app_backup')
-    def test_08_create_custom_name_kubernetes_chart_releases_backup(request):
+    def test_10_create_custom_name_kubernetes_chart_releases_backup(request):
         depends(request, ['release_plex', 'release_ipfs'])
         results = POST('/kubernetes/backup_chart_releases/', 'mybackup')
         assert results.status_code == 200, results.text
@@ -112,14 +128,14 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_09_get_custom_name_kubernetes_backup(request):
+    def test_11_get_custom_name_kubernetes_backup(request):
         depends(request, ['my_app_backup'])
         results = GET('/kubernetes/list_backups/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
         assert 'mybackup' in results.json(), results.text
 
-    def test_10_restore_custom_name_kubernetes_backup(request):
+    def test_12_restore_custom_name_kubernetes_backup(request):
         depends(request, ['my_app_backup'])
         payload = {
             "backup_name": 'mybackup',
@@ -129,7 +145,7 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_11_verify_plex_and_ipfs_chart_release_still_exist(request):
+    def test_13_verify_plex_and_ipfs_chart_release_still_exist(request):
         depends(request, ['my_app_backup'])
         results = GET(f'/chart/release/id/{plex_id}/')
         assert results.status_code == 200, results.text
@@ -139,7 +155,7 @@ if not ha:
         assert isinstance(results.json(), dict), results.text
 
     @pytest.mark.dependency(name='my_second_backup')
-    def test_12_create_mysecondbackup_kubernetes_chart_releases_backup(request):
+    def test_14_create_mysecondbackup_kubernetes_chart_releases_backup(request):
         depends(request, ['release_plex', 'release_ipfs'])
         results = POST('/kubernetes/backup_chart_releases/', 'mysecondbackup')
         assert results.status_code == 200, results.text
@@ -147,7 +163,7 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_13_delete_ipfs_chart_release(request):
+    def test_15_delete_ipfs_chart_release(request):
         depends(request, ['release_ipfs'])
         results = DELETE(f'/chart/release/id/{ipfs_id}/')
         assert results.status_code == 200, results.text
@@ -155,7 +171,7 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_14_restore_custom_name_kubernetes_backup(request):
+    def test_16_restore_custom_name_kubernetes_backup(request):
         depends(request, ['my_second_backup'])
         payload = {
             "backup_name": 'mysecondbackup',
@@ -168,7 +184,7 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_15_verify_plex_chart_still_exist_and_ipfs_does_not_exist(request):
+    def test_17_verify_plex_chart_still_exist_and_ipfs_does_not_exist(request):
         depends(request, ['my_app_backup'])
         results = GET(f'/chart/release/id/{plex_id}/')
         assert results.status_code == 200, results.text
@@ -177,20 +193,20 @@ if not ha:
         assert results.status_code == 404, results.text
         assert isinstance(results.json(), dict), results.text
 
-    def test_16_delete_mybackup_kubernetes_backup(request):
+    def test_18_delete_mybackup_kubernetes_backup(request):
         depends(request, ['my_app_backup'])
         results = POST('/kubernetes/delete_backup/', 'mybackup')
         assert results.status_code == 200, results.text
         assert results.json() is None, results.text
 
-    def test_17_delete_ix_applications_kubernetes_backup(request):
+    def test_19_delete_ix_applications_kubernetes_backup(request):
         depends(request, ['ix_app_backup', 'ix_app_backup_restored'])
         results = POST('/kubernetes/delete_backup/', backup_name)
         assert results.status_code == 200, results.text
         assert results.json() is None, results.text
 
     @pytest.mark.dependency(name='k8s_snapshot_regression')
-    def test_18_recreate_mybackup_kubernetes_backup_for_snapshots_regression(request):
+    def test_20_recreate_mybackup_kubernetes_backup_for_snapshots_regression(request):
         depends(request, ['my_app_backup'])
         results = POST('/kubernetes/backup_chart_releases/', 'mybackup')
         assert results.status_code == 200, results.text
@@ -198,19 +214,19 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_19_delete_mybackup_kubernetes_backup(request):
+    def test_21_delete_mybackup_kubernetes_backup(request):
         depends(request, ['k8s_snapshot_regression'])
         results = POST('/kubernetes/delete_backup/', 'mybackup')
         assert results.status_code == 200, results.text
         assert results.json() is None, results.text
 
-    def test_20_delete_mysecondbackup_kubernetes_backup(request):
+    def test_22_delete_mysecondbackup_kubernetes_backup(request):
         depends(request, ['my_second_backup'])
         results = POST('/kubernetes/delete_backup/', 'mysecondbackup')
         assert results.status_code == 200, results.text
         assert results.json() is None, results.text
 
-    def test_21_delete_plex_chart_release(request):
+    def test_23_delete_plex_chart_release(request):
         depends(request, ['release_plex'])
         results = DELETE(f'/chart/release/id/{plex_id}/')
         assert results.status_code == 200, results.text
@@ -218,7 +234,7 @@ if not ha:
         job_status = wait_on_job(results.json(), 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_22_get_k3s_logs():
+    def test_24_get_k3s_logs():
         results = SSH_TEST('journalctl --no-pager -u k3s', 'root', password, ip)
         ks3_logs = open(f'{artifacts}/k3s-scale.log', 'w')
         ks3_logs.writelines(results['output'])


### PR DESCRIPTION
## Context

On backup of kubernetes, we take snapshot of complete ix-applications dataset (except for a few) so that we can rollback the snapshots when a cluster restore is taking place.

Similar to how we ignore some other datasets on backup we should be ignoring `ix-applications/k3s/kubelet` snapshot as it's redundant/useless because we are essentially re-initializing docker.
