### PR TITLE
AUTO-237 / 22.12.1 / Backport Adding new vm and vm.device API tests from #10181

### DIFF
--- a/tests/api2/test_540_vm.py
+++ b/tests/api2/test_540_vm.py
@@ -6,25 +6,19 @@
 import pytest
 import sys
 import os
+from time import sleep
+from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, PUT, DELETE, wait_on_job
 from auto_config import dev_test, ha
-from middlewared.test.integration.assets.pool import dataset
 
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for development testing')
 
-global vmware_query, real_device
-vmware_query = None
-message = "This system does not support virtualization."
-payload = {
-    'name': 'nested_vm',
-    'memory': 250,
-    'autostart': False,
-}
-results = POST('/vm/', payload, controller_a=ha)
-support_virtualization = False if message in results.text else True
+support_virtualization = GET('/vm/supports_virtualization/', controller_a=ha).json()
+
+bootloader = {'UEFI': 'UEFI', 'UEFI_CSM': 'Legacy BIOS'}
 
 
 @pytest.fixture(scope='module')
@@ -32,15 +26,80 @@ def data():
     return {}
 
 
-def test_01_looking_vm_flags():
+def test_01_verify_machine_supports_virtualization():
+    results = GET('/vm/supports_virtualization/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), bool), results.text
+
+
+def test_02_get_virtualization_details():
+    results = GET('/vm/virtualization_details/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+    assert isinstance(results.json()['supported'], bool), results.text
+
+
+def test_03_get_vm_flags():
     results = GET('/vm/flags/')
     assert results.status_code == 200, results.text
-    assert isinstance(results.json(), dict) is True, results.text
+    assert isinstance(results.json(), dict), results.text
+
+
+def test_04_get_vm_cpu_model_choices():
+    results = GET('/vm/cpu_model_choices/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+    assert results.json()['EPYC'] == 'EPYC', results.json()
 
 
 # Only run if the system support virtualization
 if support_virtualization:
-    def test_02_creating_vm(data):
+
+    @pytest.mark.parametrize('dkey', list(bootloader.keys()))
+    def test_05_verify_vm_bootloader_options(dkey):
+        results = GET('/vm/bootloader_options/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert bootloader[dkey] == results.json()[dkey]
+
+    def test_06_get_available_memory_for_vms(data):
+        results = POST('/vm/get_available_memory/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), int), results.text
+
+    # /vm/guest_architecture_and_machine_choices
+    @pytest.mark.parametrize('dkey', ['i686', 'x86_64'])
+    def test_07_verify_vm_guest_architecture_and_machine_choices(dkey):
+        results = GET('/vm/guest_architecture_and_machine_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert isinstance(results.json()[dkey], list), results.text
+
+    def test_08_verify_maximum_supported_vcpus():
+        results = GET('/vm/maximum_supported_vcpus/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), int), results.text
+
+    @pytest.mark.parametrize('dkey', ['port', 'web'])
+    def test_09_get_vm_port_wizard(dkey):
+        results = GET('/vm/port_wizard/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert isinstance(results.json()[dkey], int), results.text
+
+    def test_10_get_random_mac():
+        results = GET('/vm/random_mac/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), str), results.text
+
+    def test_12_get_resolution_choices():
+        results = GET('/vm/resolution_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['1920x1080'] == '1920x1080', results.text
+
+    @pytest.mark.dependency(name='CREATE_VM')
+    def test_13_creating_vm(data):
         global payload
         payload = {
             'name': 'vmtest',
@@ -52,39 +111,164 @@ if support_virtualization:
         }
         results = POST('/vm/', payload)
         assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
         data['vmid'] = results.json()['id']
 
-    def test_03_get_vm_query(data):
+    def test_13_get_vm_query(data, request):
+        depends(request, ['CREATE_VM'])
         results = GET(f'/vm/?id={data["vmid"]}')
         assert results.status_code == 200, results.text
-        assert isinstance(results.json(), list) is True, results.text
+        assert isinstance(results.json(), list), results.text
         global vmware_query
         vmware_query = results
 
     @pytest.mark.parametrize('dkey', ['name', 'description', 'vcpus', 'memory',
                                       'bootloader', 'autostart'])
-    def test_04_look_vm_query_(dkey):
+    def test_14_look_vm_query_(dkey, request):
+        depends(request, ['CREATE_VM'])
         assert vmware_query.json()[0][dkey] == payload[dkey], vmware_query.text
 
-    def test_05_start_vm(data):
+    def test_15_get_vm_memory_info(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_vm_memory_info/', data["vmid"])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    def test_16_start_vm(data, request):
+        depends(request, ['CREATE_VM'])
         results = POST(f'/vm/id/{data["vmid"]}/start/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), type(None)), results.text
 
-    def test_06_vm_status(data):
+    def test_17_verify_vm_status_is_running(data, request):
+        depends(request, ['CREATE_VM'])
         results = POST(f'/vm/id/{data["vmid"]}/status/')
         assert results.status_code == 200, results.text
-        status = results.json()
-        assert isinstance(status, dict), results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'RUNNING', results.text
+        assert isinstance(results.json()['pid'], int), results.text
+        assert results.json()['domain_state'] == 'RUNNING', results.text
 
-    def test_07_stop_vm(data):
+    def test_18_get_vm_console_name(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_console/', data['vmid'])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), str), results.text
+        assert results.json() == f'{data["vmid"]}_vmtest'
+
+    def test_19_get_vm_memory_usage(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_memory_usage/', data["vmid"])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), int), results.text
+
+    def test_20_get_vm_memory_info_on_started_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_vm_memory_info/', data["vmid"])
+        assert results.status_code == 422, results.text
+
+    def test_21_get_vm_log_file_path(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/log_file_path/', data["vmid"])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), str), results.text
+        assert f'{data["vmid"]}_vmtest' in results.json()
+
+    @pytest.mark.parametrize('dkey', ['RNP', 'PRD', 'RPRD'])
+    def test_22_verify_vm_bootloader_options(dkey):
+        results = GET('/vm/get_vmemory_in_use/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert isinstance(results.json()[dkey], int), results.text
+
+    def test_23_get_vm_instance(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_instance/', {'id': data["vmid"]})
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['name'] == 'vmtest', results.json()
+
+    def test_24_get_vm_display_devices(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST('/vm/get_display_devices/', data["vmid"])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), list), results.text
+
+    def test_25_suspend_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/suspend')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), type(None)), results.text
+        sleep(1)
+
+    def test_26_verify_vm_status_is_suspended(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/status/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'SUSPENDED', results.text
+        assert isinstance(results.json()['pid'], int), results.text
+        assert results.json()['domain_state'] == 'PAUSED', results.text
+
+    def test_27_resume_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/resume')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), type(None)), results.text
+        sleep(1)
+
+    def test_28_verify_vm_status_is_running_after_resuming(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/status/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'RUNNING', results.text
+        assert isinstance(results.json()['pid'], int), results.text
+        assert results.json()['domain_state'] == 'RUNNING', results.text
+
+    def test_29_restart_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/restart')
+        assert results.status_code == 200, results.text
+        job_status = wait_on_job(results.json(), 180)
+        assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+        sleep(1)
+
+    def test_30_verify_vm_status_is_running_after_restarting(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/status/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'RUNNING', results.text
+        assert isinstance(results.json()['pid'], int), results.text
+        assert results.json()['domain_state'] == 'RUNNING', results.text
+
+    def test_31_stop_vm(data, request):
+        depends(request, ['CREATE_VM'])
         results = POST(f'/vm/id/{data["vmid"]}/stop/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), int), results.text
         job_status = wait_on_job(results.json(), 180)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    def test_08_update_vm(data):
+    def test_32_poweroff_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/poweroff/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), type(None)), results.text
+        sleep(1)
+
+    def test_33_verify_vm_status_is_stopped_and_shutoff(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/status/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'STOPPED', results.text
+        assert isinstance(results.json()['pid'], type(None)), results.text
+        assert results.json()['domain_state'] == 'SHUTOFF', results.text
+
+    def test_34_update_vm(data, request):
+        depends(request, ['CREATE_VM'])
         global payload
         payload = {
             'memory': 768,
@@ -93,27 +277,47 @@ if support_virtualization:
         assert results.status_code == 200, results.text
         assert GET(f'/vm?id={data["vmid"]}').json()[0]['memory'] == 768
 
-    def test_09_get_vm_query(data):
-        results = GET(f'/vm/?id={data["vmid"]}')
-        assert results.status_code == 200, results.text
-        assert isinstance(results.json(), list) is True, results.text
-        global vmware_query
-        vmware_query = results
-
     @pytest.mark.parametrize('dkey', ['memory'])
-    def test_10_look_vm_query_(dkey):
-        assert vmware_query.json()[0][dkey] == payload[dkey], vmware_query.text
-
-    def test_11_delete_vm(data):
-        results = DELETE(f'/vm/id/{data["vmid"]}/')
+    def test_35_get_vm_query(data, dkey, request):
+        depends(request, ['CREATE_VM'])
+        results = GET(f'/vm/id/{data["vmid"]}')
         assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()[dkey] == payload[dkey], results.text
 
+    @pytest.mark.dependency(name='CLONED_VM')
+    def test_36_clone_a_vm(data, request):
+        depends(request, ['CREATE_VM'])
+        results = POST(f'/vm/id/{data["vmid"]}/clone/', 'vmtest2')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), bool), results.text
+        data['vmid2'] = GET('/vm/?name=vmtest2').json()[0]['id']
 
-def test_12_vm_disk_choices(request):
-    with dataset('test zvol', {
-        'type': 'VOLUME',
-        'volsize': 1024000,
-    }) as ds:
-        results = GET('/vm/device/disk_choices')
-        assert isinstance(results.json(), dict) is True
-        assert results.json().get(f'/dev/zvol/{ds.replace(" ", "+")}') == f'{ds}'
+    def test_37_verify_cloned_vm_status_is_stopped(data, request):
+        depends(request, ['CLONED_VM'])
+        results = POST(f'/vm/id/{data["vmid2"]}/status/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['state'] == 'STOPPED', results.text
+        assert isinstance(results.json()['pid'], type(None)), results.text
+        assert results.json()['domain_state'] == 'SHUTOFF', results.text
+
+    def test_38_get_the_clone_vm_console_name(data, request):
+        depends(request, ['CLONED_VM'])
+        results = POST('/vm/get_console/', data['vmid2'])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), str), results.text
+        assert results.json() == f'{data["vmid2"]}_vmtest2'
+
+    def test_39_get_memory_usage_on_stopped_vm(data, request):
+        depends(request, ['CLONED_VM'])
+        results = POST('/vm/get_memory_usage/', data["vmid2"])
+        assert results.status_code == 422, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    @pytest.mark.parametrize('vmid', ['vmid', 'vmid2'])
+    def test_40_delete_vms(data, vmid, request):
+        depends(request, ['CREATE_VM'])
+        results = DELETE(f'/vm/id/{data[vmid]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), bool), results.text

--- a/tests/api2/test_540_vm.py
+++ b/tests/api2/test_540_vm.py
@@ -45,15 +45,13 @@ def test_03_get_vm_flags():
     assert isinstance(results.json(), dict), results.text
 
 
-def test_04_get_vm_cpu_model_choices():
-    results = GET('/vm/cpu_model_choices/')
-    assert results.status_code == 200, results.text
-    assert isinstance(results.json(), dict), results.text
-    assert results.json()['EPYC'] == 'EPYC', results.json()
-
-
 # Only run if the system support virtualization
 if support_virtualization:
+    def test_04_get_vm_cpu_model_choices():
+        results = GET('/vm/cpu_model_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['EPYC'] == 'EPYC', results.json()
 
     @pytest.mark.parametrize('dkey', list(bootloader.keys()))
     def test_05_verify_vm_bootloader_options(dkey):
@@ -67,7 +65,6 @@ if support_virtualization:
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), int), results.text
 
-    # /vm/guest_architecture_and_machine_choices
     @pytest.mark.parametrize('dkey', ['i686', 'x86_64'])
     def test_07_verify_vm_guest_architecture_and_machine_choices(dkey):
         results = GET('/vm/guest_architecture_and_machine_choices/')

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+# Author: Eric Turgeon
+# License: BSD
+
+import pytest
+import sys
+import os
+from pytest_dependency import depends
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import GET, POST, PUT, DELETE
+from auto_config import dev_test, ha, pool_name, ip
+from middlewared.test.integration.assets.pool import dataset
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason='Skip for development testing')
+
+support_virtualization = GET('/vm/supports_virtualization/', controller_a=ha).json()
+DISK_DATASET = f'{pool_name}/disks'
+DISK_DATASET_URL = DISK_DATASET.replace('/', '%2F')
+DISK_DATASET_PATH = f'/mnt/{DISK_DATASET}'
+CDROM_DATASET = f'{pool_name}/cdrom'
+CDROM_DATASET_URL = CDROM_DATASET.replace('/', '%2F')
+CDROM_DATASET_PATH = f'/mnt/{CDROM_DATASET}'
+DEVICE = {'disk_id': 'DISK', 'display_id': 'DISPLAY', 'cdrom_id': 'CDROM'}
+
+
+@pytest.fixture(scope='module')
+def data():
+    return {}
+
+
+def test_01_vm_disk_choices(request):
+    depends(request, ["pool_04"], scope="session")
+    with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1024000}) as ds:
+        results = GET('/vm/device/disk_choices')
+        assert isinstance(results.json(), dict), results.json()
+        assert results.json().get(f'/dev/zvol/{ds.replace(" ", "+")}') == f'{ds}'
+
+
+@pytest.mark.parametrize('bind', ['0.0.0.0', '::', ip])
+def test_02_verify_vm_device_bind_choices(bind):
+    results = GET('/vm/device/bind_choices/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+    assert results.json()[bind] == bind, results.text
+
+
+def test_03_verify_vm_device_iommu_enabled_return_a_boolean():
+    results = GET('/vm/device/iommu_enabled/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), bool), results.text
+
+
+def test_04_get_vm_device_iotype_choices():
+    results = GET('/vm/device/iotype_choices/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+    assert results.json()['NATIVE'] == 'NATIVE', results.text
+
+
+def test_05_verify_vm_device_nic_attach_choices():
+    interface_results = GET('/interface/')
+    assert interface_results.status_code == 200, interface_results.text
+    assert isinstance(interface_results.json(), list), interface_results.text
+
+    nic_results = GET('/vm/device/nic_attach_choices/')
+    assert nic_results.status_code == 200, nic_results.text
+    assert isinstance(nic_results.json(), dict), nic_results.text
+
+    for interface in interface_results.json():
+        assert nic_results.json()[interface['name']] == interface['name'], nic_results.text
+
+
+def test_06_get_vm_device_usb_controller_choices():
+    results = GET('/vm/device/usb_controller_choices/')
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+    assert results.json()['qemu-xhci'] == 'qemu-xhci', results.text
+
+
+# Only run if the system support virtualization
+if support_virtualization:
+
+    def test_07_get_vm_passthrough_device_choices():
+        results = GET('/vm/device/passthrough_device_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    def test_08_get_vm_device_pptdev_choices():
+        results = GET('/vm/device/pptdev_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    def test_09_get_vm_device_usb_passthrough_choices():
+        results = GET('/vm/device/usb_passthrough_choices/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    @pytest.mark.dependency(name='DISK_CDROM_DATASET')
+    def test_10_create_dataset_for_disk_and_cdrom(request):
+        depends(request, ["pool_04"], scope="session")
+        results = POST("/pool/dataset/", payload={"name": DISK_DATASET})
+        assert results.status_code == 200, results.text
+
+        results = POST("/pool/dataset/", payload={"name": CDROM_DATASET})
+        assert results.status_code == 200, results.text
+
+    @pytest.mark.dependency(name='VM_FOR_DEVICE')
+    def test_11_creating_a_vm_for_device_testing(data, request):
+        depends(request, ["DISK_CDROM_DATASET"])
+        global payload
+        payload = {
+            'name': 'devicetest',
+            'description': 'desc',
+            'vcpus': 1,
+            'memory': 512,
+            'bootloader': 'UEFI',
+            'autostart': False,
+        }
+        results = POST('/vm/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        data['vmid'] = results.json()['id']
+
+    @pytest.mark.dependency(name='DISK_DEVICE')
+    def test_12_create_a_disk_device(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        payload = {
+            'dtype': 'DISK',
+            'vm': data['vmid'],
+            'attributes': {'path': DISK_DATASET_PATH}
+        }
+        results = POST('/vm/device/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        data['disk_id'] = results.json()['id']
+
+    def test_13_verify_disk_device_by_id(data, request):
+        depends(request, ["DISK_DEVICE"])
+        results = GET(f'/vm/device/id/{data["disk_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['dtype'] == 'DISK', results.text
+        assert results.json()['vm'] == data["vmid"], results.text
+        assert results.json()['attributes']['path'] == DISK_DATASET_PATH, results.text
+
+    @pytest.mark.dependency(name='DISPLAY_DEVICE')
+    def test_14_create_a_display_device(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        payload = {
+            'dtype': 'DISPLAY',
+            'vm': data['vmid'],
+            'attributes': {'resolution': '1920x1080'}
+        }
+        results = POST('/vm/device/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        data['display_id'] = results.json()['id']
+
+    def test_15_verify_diplay_device_by_id(data, request):
+        depends(request, ["DISPLAY_DEVICE"])
+        results = GET(f'/vm/device/id/{data["display_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['dtype'] == 'DISPLAY', results.text
+        assert results.json()['vm'] == data["vmid"], results.text
+        assert results.json()['attributes']['resolution'] == '1920x1080', results.text
+
+    @pytest.mark.dependency(name='CDROM_DEVICE')
+    def test_16_create_a_cdrom_device(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        payload = {
+            'dtype': 'CDROM',
+            'vm': data["vmid"],
+            'attributes': {'path': CDROM_DATASET_PATH}
+        }
+        results = POST('/vm/device/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        data['cdrom_id'] = results.json()['id']
+
+    def test_17_verify_cdrom_device_by_id(data, request):
+        depends(request, ["CDROM_DEVICE"])
+        results = GET(f'/vm/device/id/{data["cdrom_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['dtype'] == 'CDROM', results.text
+        assert results.json()['vm'] == data["vmid"], results.text
+        assert results.json()['attributes']['path'] == CDROM_DATASET_PATH, results.text
+
+    def test_18_verify_vm_device_list(request):
+        depends(request, ["DISK_DEVICE"])
+        results = GET('/vm/device/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), list), results.text
+        assert len(results.json()) > 0, results.text
+
+    @pytest.mark.parametrize('device_id', list(DEVICE.keys()))
+    def test_19_get_vm_device_instance(data, device_id, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        results = POST('/vm/device/get_instance/', {'id': data[device_id]})
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['dtype'] == DEVICE[device_id], results.text
+        assert results.json()['vm'] == data["vmid"], results.text
+
+    def test_20_get_vm_display_devices(data, request):
+        depends(request, ["DISPLAY_DEVICE"])
+        results = POST('/vm/get_display_devices/', data["vmid"])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), list), results.text
+        assert results.json()[0]['vm'] == data["vmid"], results.json()
+
+    def test_21_get_usb_passthrough_device_info(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        usb_devices = list(GET('/vm/device/usb_passthrough_choices/').json().keys())
+        results = POST('/vm/device/usb_passthrough_device/', usb_devices[0])
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    def test_22_change_display_resolution(data, request):
+        depends(request, ["DISPLAY_DEVICE"])
+        payload = {
+            'attributes': {'resolution': '1280x720'}
+        }
+        results = PUT(f'/vm/device/id/{data["display_id"]}/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['attributes']['resolution'] == '1280x720', results.text
+        assert results.json()['vm'] == data["vmid"], results.json()
+
+    def test_23_verify_display_resolution(data, request):
+        depends(request, ["DISPLAY_DEVICE"])
+        results = GET(f'/vm/device/id/{data["display_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['attributes']['resolution'] == '1280x720', results.text
+        assert results.json()['vm'] == data["vmid"], results.json()
+
+    @pytest.mark.dependency(name='NIC_DEVICE')
+    def test_24_create_a_nic_device(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        payload = {
+            'dtype': 'NIC',
+            'vm': data["vmid"],
+            'attributes': {}
+        }
+        results = POST('/vm/device/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        data['nic_id'] = results.json()['id']
+
+    def test_25_verify_nic_device_by_id(data, request):
+        depends(request, ["NIC_DEVICE"])
+        results = GET(f'/vm/device/id/{data["nic_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['dtype'] == 'NIC', results.text
+        assert results.json()['vm'] == data["vmid"], results.text
+
+    def test_26_add_a_nic_attach_nic_device(data, request):
+        depends(request, ["NIC_DEVICE"])
+        global nic_list
+        nic_list = list(GET('/vm/device/nic_attach_choices/').json().keys())
+        payload = {
+            'attributes': {'nic_attach': nic_list[0]}
+        }
+        results = PUT(f'/vm/device/id/{data["nic_id"]}/', payload)
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+
+    def test_27_verify_nic_device_nic_attach_attributes(data, request):
+        depends(request, ["NIC_DEVICE"])
+        results = GET(f'/vm/device/id/{data["nic_id"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), dict), results.text
+        assert results.json()['attributes']['nic_attach'] == nic_list[0], results.text
+
+    @pytest.mark.parametrize('device_id', list(DEVICE.keys()))
+    def test_28_delete_devices(device_id, data, request):
+        depends(request, ["DISK_DEVICE"])
+        results = DELETE(f'/vm/device/id/{data[device_id]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), bool), results.text
+
+    def test_29_verify_vm_device_list_is_not_empty_before_deleting_the_vm(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        results = GET(f'/vm/device/?vm={data["vmid"]}')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), list), results.text
+        assert len(results.json()) > 0, results.text
+
+    def test_30_delete_the_vm(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        results = DELETE(f'/vm/id/{data["vmid"]}/')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), bool), results.text
+
+    def test_31_verify_vm_device_list_is_empty_after_deleting_the_vm(data, request):
+        depends(request, ["VM_FOR_DEVICE"])
+        results = GET(f'/vm/device/?vm={data["vmid"]}')
+        assert results.status_code == 200, results.text
+        assert isinstance(results.json(), list), results.text
+        assert len(results.json()) == 0, results.text
+
+    def test_32_delete_disk_and_cdrom_dataset(request):
+        depends(request, ["DISK_CDROM_DATASET"])
+        results = DELETE(f"/pool/dataset/id/{DISK_DATASET_URL}/")
+        assert results.status_code == 200, results.text
+
+        results = DELETE(f"/pool/dataset/id/{CDROM_DATASET_URL}/")
+        assert results.status_code == 200, results.text


### PR DESCRIPTION
* Combine VM test 9 and 10 and change query to use /vm/id/{id}

* Adding new vm API tests

verify_vm_bootloader_options
get_available_memory_for_vms
get_vm_console_name
get_vm_memory_usage
get_vm_memory_info_on_started_vm
verify_vm_status_is_running
verify_vm_bootloader_options
verify_vm_status_is_stopped
clone_a_vm
get_the_clone_vm_console_name
get_vm_memory_info_on_stopped_vm

improved delete_vms

* Changed the detection of supported virtualization

* Adding more vm API tests

verify_machine_supports_virtualization
get_virtualization_details
verify_vm_guest_architecture_and_machine_choices
verify_maximum_supported_vcpus
get_vm_port_wizard
get_random_mac
get_resolution_choices
get_vm_log_file_path
suspend_vm
verify_vm_status_is_suspended
resume_vm
verify_vm_status_is_running_after_resuming
restart_vm
verify_vm_status_is_running_after_restarting
poweroff_vm
verify_cloned_vm_status_is_stopped

* Created test_543_vm_device.py and moved vm_disk_choices in it

Also added

* Adding vm test to get cpu model

* Adding get_instance and get_display_devices in test_540_vm.py

* Adding test to create vm DISK and DISPALY device.

* Adding verify_vm_device_bind_choices and verify_vm_device_list

* Adding CDROM device and /vm/device/get_instance/ tests

* Adding more vm.device API test

Added a second dataset for cdrom
Added the test below:
verify_vm_device_iommu_enabled_return_a_boolean
get_vm_device_iotype_choices
verify_vm_device_nic_attach_choices
get_vm_passthrough_device_choices
get_vm_device_pptdev_choices
get_vm_device_usb_controller_choices
get_vm_device_usb_controller_choices
verify_disk_device_by_id
verify_diplay_device_by_id
verify_cdrom_device_by_id
get_usb_passthrough_device_info
change_display_resolution
create_a_nic_device
add_a_nic_attach_nic_device
delete device test

* Adding more vm device test

verify_nic_device_by_id
verify_nic_device_nic_attach_attributes
verify_vm_device_list_is_not_empty_before_deleting_the_vm verify_vm_device_list_is_empty_after_deleting_the_vm

* Added verify_display_resolution and moved some test out of support vm

I also added test dependency in test_543_vm_device.py

* Added test_15_get_vm_memory_info and fixed test 20

Also added test dependencies in test_540_vm.py