### PR TITLE
On our HA VM (bhyve) drives are S.M.A.R.T.-capable so it can start successfully

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -63,10 +63,12 @@ def test_00_firstboot_checks():
     for srv in services:
         if srv['service'] == 'smartd':
             assert srv['enable'] is True, str(srv)
+            if not ha:
+                # On our HA VM (bhyve) drives are S.M.A.R.T.-capable so it can start successfully.
+                assert srv['state'] == 'STOPPED', str(srv)
         else:
             assert srv['enable'] is False, str(srv)
-
-        assert srv['state'] == 'STOPPED', str(srv)
+            assert srv['state'] == 'STOPPED', str(srv)
 
 
 def test_01_Configuring_ssh_settings_for_root_login():


### PR DESCRIPTION
I think this is fine. These drives could have been real physical drives forwarded to the VM, if they are SMART-capable we should be monitoring them.
```
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sda, opened	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sda, [HGST     HUS724040ALS640  0001], lu id: 0x5000cca05c9f9d17, S/N: PCJUT79X, 10.7 GB	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sda, does not support SMART Self-Test Log.	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sda, is SMART capable. Adding to "monitor" list.	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sdb, opened	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sdb, [HGST     HUS724040ALS640  0001], lu id: 0x5000cca05c9f9d18, S/N: PCJUT7EX, 10.7 GB	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sdb, does not support SMART Self-Test Log.	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sdb, is SMART capable. Adding to "monitor" list.	
Dec  5 06:16:28 truenas smartd[3090]: Monitoring 0 ATA/SATA, 2 SCSI/SAS and 0 NVMe devices	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sda, state written to /var/lib/smartmontools/smartd.HGST-HUS724040ALS640-PCJUT79X.scsi.state	
Dec  5 06:16:28 truenas smartd[3090]: Device: /dev/sdb, state written to /var/lib/smartmontools/smartd.HGST-HUS724040ALS640-PCJUT7EX.scsi.state
```