### PR TITLE
NAS-119142 / 22.12.1 / Properly get serial number of virtio disk (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -85,7 +85,8 @@ class DeviceService(Service):
         blocks = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
         ident = serial = (
             self.safe_retrieval(dev.properties, 'ID_SCSI_SERIAL', '') or
-            self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT', '')
+            self.safe_retrieval(dev.properties, 'ID_SERIAL_SHORT', '') or
+            self.safe_retrieval(dev.properties, 'ID_SERIAL', '')
         )
         model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)
         driver = self.safe_retrieval(dev.parent.properties, 'DRIVER', '') if not is_nvme else 'nvme'


### PR DESCRIPTION
## Context

Serial number of virtio disk is available in `ID_SERIAL` attribute which we are not currently retrieving which results in us not able to retrieve serial number of virtio disks.

Original PR: https://github.com/truenas/middleware/pull/10191
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119142