### PR TITLE
NAS-118887 / 23.10 / Properly report datastore name for services

### DIFF
--- a/src/middlewared/middlewared/plugins/dyndns.py
+++ b/src/middlewared/middlewared/plugins/dyndns.py
@@ -24,6 +24,7 @@ class DynDNSService(SystemServiceService):
 
     class Config:
         service = "dynamicdns"
+        datastore = "services.dynamicdns"
         datastore_extend = "dyndns.dyndns_extend"
         datastore_prefix = "ddns_"
         cli_namespace = "service.dyndns"

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -56,6 +56,7 @@ class FTPService(SystemServiceService):
 
     class Config:
         service = "ftp"
+        datastore = "services.ftp"
         datastore_prefix = "ftp_"
         datastore_extend = "ftp.ftp_extend"
         cli_namespace = "service.ftp"

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -9,10 +9,6 @@ from middlewared.utils import filter_list, run
 class ISCSIGlobalService(Service):
 
     class Config:
-        datastore_extend = 'iscsi.global.config_extend'
-        datastore_prefix = 'iscsi_'
-        service = 'iscsitarget'
-        service_model = 'iscsitargetglobalconfiguration'
         namespace = 'iscsi.global'
 
     @filterable

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -24,10 +24,10 @@ class ISCSIGlobalModel(sa.Model):
 class ISCSIGlobalService(SystemServiceService):
 
     class Config:
+        datastore = 'services.iscsitargetglobalconfiguration'
         datastore_extend = 'iscsi.global.config_extend'
         datastore_prefix = 'iscsi_'
         service = 'iscsitarget'
-        service_model = 'iscsitargetglobalconfiguration'
         namespace = 'iscsi.global'
         cli_namespace = 'sharing.iscsi.global'
 

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -40,6 +40,7 @@ class NFSService(SystemServiceService):
     class Config:
         service = "nfs"
         service_verb = "restart"
+        datastore = "services.nfs"
         datastore_prefix = "nfs_srv_"
         datastore_extend = 'nfs.nfs_extend'
         cli_namespace = "service.nfs"

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -93,9 +93,9 @@ class RsyncdModel(sa.Model):
 class RsyncdService(SystemServiceService):
 
     class Config:
-        service = "rsync"
-        service_model = 'rsyncd'
-        datastore_prefix = "rsyncd_"
+        datastore = 'services.rsyncd'
+        service = 'rsync'
+        datastore_prefix = 'rsyncd_'
         cli_namespace = 'service.rsync'
 
     ENTRY = Dict(

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -29,6 +29,7 @@ class S3Service(SystemServiceService):
 
     class Config:
         service = "s3"
+        datastore = "services.s3"
         datastore_prefix = "s3_"
         datastore_extend = "s3.config_extend"
         cli_namespace = "service.s3"

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -688,8 +688,8 @@ class SmartModel(sa.Model):
 class SmartService(SystemServiceService):
 
     class Config:
+        datastore = "services.smart"
         service = "smartd"
-        service_model = "smart"
         service_verb_sync = False
         datastore_extend = "smart.smart_extend"
         datastore_prefix = "smart_"

--- a/src/middlewared/middlewared/plugins/snmp.py
+++ b/src/middlewared/middlewared/plugins/snmp.py
@@ -29,6 +29,7 @@ class SNMPService(SystemServiceService):
 
     class Config:
         service = 'snmp'
+        datastore = 'services.snmp'
         datastore_prefix = 'snmp_'
         cli_namespace = 'service.snmp'
 

--- a/src/middlewared/middlewared/plugins/ssh.py
+++ b/src/middlewared/middlewared/plugins/ssh.py
@@ -48,8 +48,8 @@ class SSHModel(sa.Model):
 class SSHService(SystemServiceService):
 
     class Config:
+        datastore = "services.ssh"
         service = "ssh"
-        service_model = "ssh"
         datastore_prefix = "ssh_"
         cli_namespace = 'service.ssh'
 

--- a/src/middlewared/middlewared/plugins/tftp.py
+++ b/src/middlewared/middlewared/plugins/tftp.py
@@ -24,6 +24,7 @@ class TFTPService(SystemServiceService):
 
     class Config:
         service = "tftp"
+        datastore = "services.tftp"
         datastore_prefix = "tftp_"
         cli_namespace = "service.tftp"
 

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -249,8 +249,8 @@ class OpenVPNServerService(SystemServiceService):
     class Config:
         namespace = 'openvpn.server'
         service = 'openvpn_server'
-        service_model = 'openvpnserver'
         service_verb = 'restart'
+        datastore = 'services.openvpnserver'
         datastore_extend = 'openvpn.server.server_extend'
         cli_namespace = 'service.openvpn.server'
 
@@ -545,8 +545,8 @@ class OpenVPNClientService(SystemServiceService):
     class Config:
         namespace = 'openvpn.client'
         service = 'openvpn_client'
-        service_model = 'openvpnclient'
         service_verb = 'restart'
+        datastore = 'services.openvpnclient'
         datastore_extend = 'openvpn.client.client_extend'
         cli_namespace = 'service.openvpn.client'
 

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -169,6 +169,7 @@ class WebDAVModel(sa.Model):
 class WebDAVService(SystemServiceService):
     class Config:
         service = 'webdav'
+        datastore = 'services.webdav'
         datastore_prefix = 'webdav_'
         datastore_extend = 'webdav.upper'
         cli_namespace = 'service.webdav'


### PR DESCRIPTION
## Problem

When deleting certificates, sometimes it is not clear which service is consuming the certificate as the `CRUDService` has `check_dependencies` implementation which checks usages of the database row in question but for `SystemServiceService` children it only reports datastore names as it was not able to map the service name from datastore name which is not intuitive and user can not understand which service is actually consuming the certificate.

## Solution

`SystemServiceService` is special and we are not setting `datastore` variable for that but instead are relying on custom logic where we check for `service_model` or `service` and the name is made up dynamically.

Setting `datastore` in `Config` for `SystemServiceService` children handles the case and `check_dependencies` is able to report the services consuming the certificate accurately.