### PR TITLE
NAS-119351 / 23.10 / Sanitse app errors from manual helm template catches

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -18,7 +18,7 @@ class ChartReleaseService(Service):
     @private
     def helm_action(self, chart_release, chart_path, config, tn_action):
         args = ['-f']
-        CLEANUPREGEX = re.compile(r'^Error: .[)]: ')
+        CLEANUPREGEX = re.compile(r'^Error: .+[)]: ')
         
         if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
             args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -19,7 +19,7 @@ class ChartReleaseService(Service):
     def helm_action(self, chart_release, chart_path, config, tn_action):
         args = ['-f']
         CLEANUPREGEX = re.compile(r'^Error: .+[)]: ')
-        
+
         if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
             args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -18,6 +18,8 @@ class ChartReleaseService(Service):
     @private
     def helm_action(self, chart_release, chart_path, config, tn_action):
         args = ['-f']
+        CLEANUPREGEX = re.compile(r'^Error: .[)]: ')
+        
         if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
             args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
 
@@ -44,8 +46,7 @@ class ChartReleaseService(Service):
             if cp.returncode:
                 errmsg = stderr.decode()
                 if tn_action == 'upgrade' or tn_action == 'install':
-                    cleanupregex = re.compile(r'^Error: .[)]: ')
-                    errmsg = re.sub(cleanupregex, '', errmsg, 1)
+                    errmsg = re.sub(CLEANUPREGEX, '', errmsg, 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 
         self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -45,8 +45,7 @@ class ChartReleaseService(Service):
             )
             stderr = cp.communicate()[1]
             if cp.returncode:
-                errmsg = stderr.decode()
-                errmsg = re.sub(RE_ERRCLEANUP, '', errmsg, 1)
+                errmsg = re.sub(RE_ERRCLEANUP, '',  stderr.decode(), 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 
         self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -45,7 +45,7 @@ class ChartReleaseService(Service):
             )
             stderr = cp.communicate()[1]
             if cp.returncode:
-                errmsg = re.sub(RE_ERRCLEANUP, '',  stderr.decode(), 1)
+                errmsg = re.sub(RE_ERRCLEANUP, '', stderr.decode(), 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 
         self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -9,6 +9,8 @@ from middlewared.service import CallError, private, Service
 
 from .utils import get_namespace
 
+RE_ERRCLEANUP = re.compile(r'^Error: .+[)]: ')
+
 
 class ChartReleaseService(Service):
 
@@ -18,7 +20,6 @@ class ChartReleaseService(Service):
     @private
     def helm_action(self, chart_release, chart_path, config, tn_action):
         args = ['-f']
-        CLEANUPREGEX = re.compile(r'^Error: .+[)]: ')
 
         if os.path.exists(os.path.join(chart_path, 'ix_values.yaml')):
             args.extend([os.path.join(chart_path, 'ix_values.yaml'), '-f'])
@@ -46,7 +47,7 @@ class ChartReleaseService(Service):
             if cp.returncode:
                 errmsg = stderr.decode()
                 if tn_action == 'upgrade' or tn_action == 'install':
-                    errmsg = re.sub(CLEANUPREGEX, '', errmsg, 1)
+                    errmsg = re.sub(RE_ERRCLEANUP, '', errmsg, 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 
         self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -44,7 +44,7 @@ class ChartReleaseService(Service):
             if cp.returncode:
                 errmsg = stderr.decode()
                 if tn_action == 'upgrade' or tn_action == 'install':
-                    cleanupregex = re.compile(r'^Error: .+?[)]: ')
+                    cleanupregex = re.compile(r'^Error: .+[)]: ')
                     errmsg = re.sub(cleanupregex, '', errmsg, 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -44,7 +44,7 @@ class ChartReleaseService(Service):
             if cp.returncode:
                 errmsg = stderr.decode()
                 if tn_action == 'upgrade' or tn_action == 'install':
-                    cleanupregex = re.compile(r'^Error: .+[)]: ')
+                    cleanupregex = re.compile(r'^Error: .[)]: ')
                     errmsg = re.sub(cleanupregex, '', errmsg, 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/helm.py
@@ -46,8 +46,7 @@ class ChartReleaseService(Service):
             stderr = cp.communicate()[1]
             if cp.returncode:
                 errmsg = stderr.decode()
-                if tn_action == 'upgrade' or tn_action == 'install':
-                    errmsg = re.sub(RE_ERRCLEANUP, '', errmsg, 1)
+                errmsg = re.sub(RE_ERRCLEANUP, '', errmsg, 1)
                 raise CallError(f'Failed to {tn_action} App: {errmsg}')
 
         self.middleware.call_sync('chart.release.clear_chart_release_portal_cache', chart_release)


### PR DESCRIPTION
**Background**

With Helm templating, we can design custom faults and error messages, for example: If users enter the wrong input or settings cannot be combined.

With the current App-template Common rework by @stavros-k , the Apps will (likely) more heavily include these errors, to give as many user-friendly hints on how-to-fix common issues.

Hence it's crucial that those errors are displayed in a way that is as "not scary" as possible for the end-user


**Current Behavior**

Currently these would, for example, display like this:
```
[EFAULT] Failed to install chart release: Error: INSTALLATION FAILED: execution error at (plex/templates/deployment.yaml:1:3): Invalid hostpath /mnt/media_box. Path must be a valid path under a given pool e.g `/mnt/tank/somepath` is valid whereas `/mnt` or `/mnt/tank` are invalid examples.
```

This input is not clear (enough) and needlessly technical for the end user. 


**Wanted Behavior**
As these errors are generated with "user clarity" in mind. it would be prefered if the sentence here would be as clear as possible and leave any relevant technical details under `More info...`.


**Applied Changes**

To accomplice this this PR does:

- This rephrases `chart release` to `app`

- Removes `Error: INSTALLATION FAILED: execution error at (plex/templates/deployment.yaml:1:3): ` in above example. The format should be the same in other cases and is verified other types of helm errors.

- It does not change more than one (the first) match of the regex, so we don't by accident delete parts of custom errors for example.

- In case there is nothing to clean up, the original message is displayed unaltered

- In case the cleanup goes wrong, it does not touch the traceback available under `More info...`

- I've verified that this code portion is not covered by unittests yet.


**Potential other solutions**

1. Do so on the GUI side
   *pros:* This has the benefit of not altering the middleware and also being able to remove the `[EFAULT]` portion. 
   *cons:* It would require altering this in multiple places to counter all cases where something is upgraded/changed/installed and does not include GUI ran updates for example

