### PR TITLE
NAS-119007 / 22.12.1 / Present zvol snapshot count in dataset details (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/snapshot_count.py
+++ b/src/middlewared/middlewared/alert/source/snapshot_count.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
 from middlewared.alert.schedule import CrontabSchedule
 
@@ -33,10 +31,10 @@ class SnapshotCountAlertSource(AlertSource):
         max_total = await self.middleware.call("pool.snapshottask.max_total_count")
 
         total = 0
-        datasets = defaultdict(lambda: 0)
-        for snapshot in await self.middleware.call("zfs.snapshot.query", [], {"select": ["name"]}):
-            total += 1
-            datasets[snapshot["name"].split("@")[0]] += 1
+        datasets = await self.middleware.call("zfs.snapshot.count")
+
+        for cnt in datasets.values():
+            total += cnt
 
         if total > max_total:
             return Alert(

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3027,6 +3027,7 @@ class PoolDatasetService(CRUDService):
         retrieve_children = extra.get('retrieve_children', True)
         props = extra.get('properties')
         snapshots = extra.get('snapshots')
+        snapshots_count = extra.get('snapshots_count')
         snapshots_recursive = extra.get('snapshots_recursive')
         return filter_list(
             self.__transform(self.middleware.call_sync(
@@ -3037,6 +3038,7 @@ class PoolDatasetService(CRUDService):
                         'properties': props,
                         'snapshots': snapshots,
                         'snapshots_recursive': snapshots_recursive,
+                        'snapshots_count': snapshots_count,
                         'snapshots_properties': extra.get('snapshots_properties', [])
                     }
                 }

--- a/src/middlewared/middlewared/plugins/pool_/snapshot_count.py
+++ b/src/middlewared/middlewared/plugins/pool_/snapshot_count.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-from middlewared.plugins.zfs_.utils import ZFSCTL
 from middlewared.schema import accepts, returns, Int, Str
 from middlewared.service import Service
 
@@ -16,11 +13,4 @@ class PoolDatasetService(Service):
         """
         Returns snapshot count for specified `dataset`.
         """
-        if mountpoint := self.middleware.call_sync("pool.dataset.mountpoint", dataset, False):
-            zfs_dir = Path(mountpoint) / ".zfs/snapshot"
-            if zfs_dir.is_dir():
-                stat = zfs_dir.stat()
-                if stat.st_ino == ZFSCTL.INO_SNAPDIR:
-                    return stat.st_nlink - 2
-
-        return self.middleware.call_sync("zfs.snapshot.query", [["dataset", "=", dataset]], {"count": True})
+        return self.middleware.call_sync("zfs.snapshot.count", [dataset])[dataset]

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -3,9 +3,11 @@ import enum
 import logging
 import os
 
+from middlewared.service_exception import MatchNotFound
+
 logger = logging.getLogger(__name__)
 
-__all__ = ["zvol_name_to_path", "zvol_path_to_name"]
+__all__ = ["zvol_name_to_path", "zvol_path_to_name", "get_snapshot_count_cached"]
 
 
 class ZFSCTL(enum.IntEnum):
@@ -110,3 +112,135 @@ def unlocked_zvols_fast(options=None, data=None):
     info_level = options or []
     zvols = get_zvols(info_level, data or {})
     return zvols
+
+
+def get_snapshot_count_cached(middleware, lz, datasets, prefetch=False, update_datasets=False, remove_snapshots_changed=False):
+    """
+    Try retrieving snapshot count for dataset from cache if the
+    `snapshots_changed` timestamp hasn't changed. If it has,
+    then retrieve new snapshot count in most optimized way possible
+    and cache new value
+
+    Parameters:
+    ----------
+    middleware - middleware object
+    lz - libzfs handle, e.g. libzfs.ZFS()
+    zhdl - iterable containing dataset information as returned by
+        libzfs.datasets_serialized
+    prefetch - bool - optional performance enhancement to grab entire
+        tdb contents prior to iteration. This reduces count of middleware calls.
+    update_datasets - bool - optional - insert `snapshot_count` key into datasets passed
+        into this method
+    remove_snapshots_changed - bool - remove the snapshots_changed key from dataset properties
+        after processing. This is to hide the fact that we had to retrieve this property to
+        determie whether to return cached value.
+
+    Returns:
+    -------
+    Dict containing following:
+        key (dataset name) : value (int - snapshot count)
+    """
+    def get_mountpoint(zhdl):
+        mp = zhdl['properties'].get('mountpoint')
+        if mp is None:
+            return None
+
+        if mp['parsed'] and mp['parsed'] != 'legacy':
+            return mp['parsed']
+
+        return None
+
+    def entry_get_cnt(zhdl):
+        if mp := get_mountpoint(zhdl):
+            try:
+                st = os.stat(f'{mp}/.zfs/snapshot')
+            except Exception:
+                pass
+            else:
+                if st.st_ino == ZFSCTL.INO_SNAPDIR.value:
+                    return st.st_nlink - 2
+
+        return len(lz.snapshots_serialized(['name'], datasets=[zhdl['name']], recursive=False))
+
+    def get_entry_prefetch(key, tdb_entries):
+        return tdb_entries.get(key, {'changed_ts': None, 'cnt': -1})
+
+    def get_entry_fetch(key, tdb_entries):
+        try:
+            entry = middleware.call_sync('tdb.fetch', {
+                'name': 'snapshot_count',
+                'key': key,
+            })
+        except MatchNotFound:
+            entry = {
+                'changed_ts': None,
+                'cnt': -1
+            }
+        return entry
+
+    def process_entry(out, zhdl, tdb_entries, batch_ops, get_entry_fn):
+        """
+        This method processes the dataset entry and
+        sets new value in tdb file if necessary. Since
+        we may be consuming "flattened" datasets here, there
+        is potential for duplicate entries. Hence, check for
+        whether we've already handled the dataset for this run.
+        """
+        existing_entry = out.get(zhdl['name'])
+        if existing_entry:
+            if update_datasets:
+                zhdl['snapshot_count'] = existing_entry
+
+            if remove_snapshots_changed:
+                zhdl['properties'].pop('snapshots_changed', None)
+
+            return
+
+        changed_ts = zhdl['properties']['snapshots_changed']['parsed']
+        cache_key = f'SNAPCNT%{zhdl["name"]}'
+
+        entry = get_entry_fn(cache_key, tdb_entries)
+
+        if entry['changed_ts'] != changed_ts:
+            entry['cnt'] = entry_get_cnt(zhdl)
+            entry['changed_ts'] = changed_ts
+
+            # There are circumstances in which legacy datasets
+            # may not have this property populated. We don't
+            # want cache insertion with NULL key to avoid
+            # collisions
+            if changed_ts:
+                batch_ops.append({
+                    'action': 'SET',
+                    'key': cache_key,
+                    'val': entry
+                })
+
+        out[zhdl['name']] = entry['cnt']
+        if update_datasets:
+            zhdl['snapshot_count'] = entry['cnt']
+
+        if remove_snapshots_changed:
+            zhdl['properties'].pop('snapshots_changed', None)
+
+    def iter_datasets(out, datasets_in, tdb_entries, batch_ops, get_entry_fn):
+        for ds in datasets_in:
+            process_entry(out, ds, tdb_entries, batch_ops, get_entry_fn)
+            iter_datasets(out, ds.get('children', []), tdb_entries, batch_ops, get_entry_fn)
+
+    tdb_entries = {}
+    out = {}
+    batch_ops = []
+    get_entry_fn = get_entry_fetch
+    if prefetch:
+        tdb_entries = {
+            x['key']: x['val']
+            for x in middleware.call_sync('tdb.entries', {'name': 'snapshot_count'})
+        }
+        get_entry_fn = get_entry_prefetch
+
+    iter_datasets(out, datasets, tdb_entries, batch_ops, get_entry_fn)
+    if batch_ops:
+        middleware.call_sync('tdb.batch_ops', {'name': 'snapshot_count', 'ops': batch_ops})
+
+    return out

--- a/tests/api2/test_snapshot_count_alert.py
+++ b/tests/api2/test_snapshot_count_alert.py
@@ -3,6 +3,7 @@ from pytest_dependency import depends
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, mock
 from auto_config import dev_test
+from time import sleep
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -34,6 +35,7 @@ def test_snapshot_count_alert(request):
                 call("zfs.snapshot.create", {"dataset": ds, "name": f"snap-{i}"})
 
             assert call("alert.run_source", "SnapshotCount") == []
+            sleep(1)
 
             call("zfs.snapshot.create", {"dataset": ds, "name": "snap-10"})
 


### PR DESCRIPTION
This adds a new method zfs.dataset.snapshot_count that maintains a persistent tdb-backed cache of snapshot count for datasets that gets invalidated based on the snapshots_changed timestamp presented by libzfs.

Original PR: https://github.com/truenas/middleware/pull/10161
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119007