### PR TITLE
NAS-119356 / 23.10 / Avoid python DeprecationWarning wrt import of Callable.

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -1,24 +1,31 @@
+from collections import defaultdict, namedtuple
+
 from . import ejson as json
 from .protocol import DDPProtocol
-from .utils import MIDDLEWARE_RUN_DIR, undefined, ProgressBar
-from collections import defaultdict, namedtuple, Callable
-from threading import Event as TEvent, Lock, Thread
-from ws4py.client.threadedclient import WebSocketClient
+from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 import argparse
-from base64 import b64decode
 import errno
 import logging
 import os
 import pickle
+import platform
 import pprint
+import random
 import socket
 import sys
 import time
 import uuid
-import random
-import platform
+from base64 import b64decode
+from threading import Event as TEvent
+from threading import Lock, Thread
 
+from ws4py.client.threadedclient import WebSocketClient
 
 try:
     from libzfs import Error as ZFSError

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -1,14 +1,3 @@
-from collections import defaultdict, namedtuple
-
-from . import ejson as json
-from .protocol import DDPProtocol
-from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined
-
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable
-
 import argparse
 import errno
 import logging
@@ -22,11 +11,19 @@ import sys
 import time
 import uuid
 from base64 import b64decode
+from collections import defaultdict, namedtuple
 from threading import Event as TEvent
 from threading import Lock, Thread
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 from ws4py.client.threadedclient import WebSocketClient
 
+from . import ejson as json
+from .protocol import DDPProtocol
+from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined
 try:
     from libzfs import Error as ZFSError
 except ImportError:

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -1,7 +1,6 @@
 import copy
 import json
 import os
-
 try:
     from collections.abc import Callable
 except ImportError:
@@ -9,7 +8,6 @@ except ImportError:
 
 from middlewared.schema import Cron, Dict, Int, List, Str
 from middlewared.service import private, Service
-
 from .schema import get_list_item_from_value
 from .utils import get_network_attachment_definition_name, RESERVED_NAMES
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -2,7 +2,10 @@ import copy
 import json
 import os
 
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 
 from middlewared.schema import Cron, Dict, Int, List, Str
 from middlewared.service import private, Service


### PR DESCRIPTION
Modify import to avoid "DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is
deprecated since Python 3.3, and in 3.10 it will stop working"

Example context:
```
api2/test_480_system_advanced.py:60: AssertionError
=============================== warnings summary ===============================
../env/lib/python3.9/site-packages/middlewared-0.0.0-py3.9.egg/middlewared/client/client.py:4
  /root/jenkins/workspace/TrueNAS_SCALE_-_Unstable/Test_development/API_Tests_-_TrueNAS_SCALE_from_branch_-_Incremental/env/lib/python3.9/site-packages/middlewared-0.0.0-py3.9.egg/middlewared/client/client.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import defaultdict, namedtuple, Callable
```

Used `try ... except ImportError` to preserve existing behavior in case this code is also still being used somewhere with older python.

Also used [isort](https://pycqa.github.io/isort/index.html) to clean up some import ordering.