### PR TITLE
NAS-119357 / 23.10 / Fix regression when setting different quota types on same id(s)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -295,7 +295,7 @@ class PoolDatasetService(Service):
                     verrors.add(f'quotas.{i}.id', 'id for quota_type DATASET must be either "QUOTA" or "REFQUOTA"')
                 else:
                     xid = q['id'].lower()
-                    if xid in quotas:
+                    if any((i.get(xid, False) for i in quotas)):
                         verrors.add(
                             f'quotas.{i}.id',
                             f'Setting multiple values for {xid} for quota_type DATASET is not permitted'

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -287,7 +287,8 @@ class PoolDatasetService(Service):
 
         quotas = {}
 
-        for i, q in enumerate(data):
+        ignore = ('PROJECT', 'PROJECTOBJ')  # TODO: not implemented
+        for i, q in filter(lambda x: x[1]['id'] not in ignore, enumerate(data)):
             quota_type = q['quota_type'].lower()
             if q['quota_type'] == 'DATASET':
                 if q['id'] not in ['QUOTA', 'REFQUOTA']:
@@ -305,7 +306,7 @@ class PoolDatasetService(Service):
                     )
                     continue
 
-            elif q['quota_type'] not in ['PROJECT', 'PROJECTOBJ']:
+            else:
                 if not q['quota_value']:
                     q['quota_value'] = 'none'
 
@@ -331,14 +332,6 @@ class PoolDatasetService(Service):
                         f'quotas.{i}.id',
                         f'Setting {quota_type} quota on {id_type[0]}id [{xid}] is not permitted.'
                     )
-            else:
-                if not q['id'].isdigit():
-                    verrors.add(
-                        f'quotas.{i}.id',
-                        f'{quota_type} {q["id"]} must be a numeric project id.'
-                    )
-                else:
-                    xid = int(q['id'])
 
             quotas[xid] = q
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -292,27 +292,20 @@ class PoolDatasetService(Service):
         for i, q in filter(lambda x: x[1]['id'] not in ignore, enumerate(data)):
             quota_type = q['quota_type'].lower()
             if q['quota_type'] == 'DATASET':
-                if q['id'] not in ['QUOTA', 'REFQUOTA']:
-                    verrors.add(
-                        f'quotas.{i}.id',
-                        'id for quota_type DATASET must be either "QUOTA" or "REFQUOTA"'
-                    )
-                    continue
-
-                xid = q['id'].lower()
-                if xid in quotas:
-                    verrors.add(
-                        f'quotas.{i}.id',
-                        f'Setting multiple values for {xid} for quota_type "DATASET" is not permitted'
-                    )
-                    continue
-
+                if q['id'] not in ('QUOTA', 'REFQUOTA'):
+                    verrors.add(f'quotas.{i}.id', 'id for quota_type DATASET must be either "QUOTA" or "REFQUOTA"')
+                else:
+                    xid = q['id'].lower()
+                    if xid in quotas:
+                        verrors.add(
+                            f'quotas.{i}.id',
+                            f'Setting multiple values for {xid} for quota_type DATASET is not permitted'
+                        )
             else:
                 if not q['quota_value']:
                     q['quota_value'] = 'none'
 
                 xid = None
-
                 id_type = 'user' if quota_type.startswith('user') else 'group'
                 if not q['id'].isdigit():
                     try:
@@ -320,18 +313,14 @@ class PoolDatasetService(Service):
                                                              {f'{id_type}name': q['id']})
                         xid = xid_obj['pw_uid'] if id_type == 'user' else xid_obj['gr_gid']
                     except Exception:
-                        self.logger.debug("Failed to convert %s [%s] to id.", id_type, q['id'], exc_info=True)
-                        verrors.add(
-                            f'quotas.{i}.id',
-                            f'{quota_type} {q["id"]} is not valid.'
-                        )
+                        self.logger.debug('Failed to convert %s [%s] to id.', id_type, q['id'], exc_info=True)
+                        verrors.add(f'quotas.{i}.id', f'{quota_type} {q["id"]} is not valid.')
                 else:
                     xid = int(q['id'])
 
                 if xid == 0:
                     verrors.add(
-                        f'quotas.{i}.id',
-                        f'Setting {quota_type} quota on {id_type[0]}id [{xid}] is not permitted.'
+                        f'quotas.{i}.id', f'Setting {quota_type} quota on {id_type[0]}id [{xid}] is not permitted'
                     )
 
             quotas[xid] = q

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -280,7 +280,8 @@ class PoolDatasetService(Service):
         MAX_QUOTAS = 100
         verrors = ValidationErrors()
         if len(data) > MAX_QUOTAS:
-            verrors.add(
+            # no reason to continue
+            raise ValidationErrors(
                 'quotas',
                 f'The number of user or group quotas that can be set in single API call is limited to {MAX_QUOTAS}.'
             )

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -337,7 +337,8 @@ class PoolDatasetService(Service):
                         f'quotas.{i}.id',
                         f'{quota_type} {q["id"]} must be a numeric project id.'
                     )
-                xid = int(q['id'])
+                else:
+                    xid = int(q['id'])
 
             quotas[xid] = q
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -286,8 +286,7 @@ class PoolDatasetService(Service):
                 f'The number of user or group quotas that can be set in single API call is limited to {MAX_QUOTAS}.'
             )
 
-        quotas = {}
-
+        quotas = []
         ignore = ('PROJECT', 'PROJECTOBJ')  # TODO: not implemented
         for i, q in filter(lambda x: x[1]['id'] not in ignore, enumerate(data)):
             quota_type = q['quota_type'].lower()
@@ -323,7 +322,7 @@ class PoolDatasetService(Service):
                         f'quotas.{i}.id', f'Setting {quota_type} quota on {id_type[0]}id [{xid}] is not permitted'
                     )
 
-            quotas[xid] = q
+            quotas.append({xid: q})
 
         verrors.check()
         if quotas:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota_and_perms.py
@@ -288,7 +288,7 @@ class PoolDatasetService(Service):
 
         quotas = []
         ignore = ('PROJECT', 'PROJECTOBJ')  # TODO: not implemented
-        for i, q in filter(lambda x: x[1]['id'] not in ignore, enumerate(data)):
+        for i, q in filter(lambda x: x[1]['quota_type'] not in ignore, enumerate(data)):
             quota_type = q['quota_type'].lower()
             if q['quota_type'] == 'DATASET':
                 if q['id'] not in ('QUOTA', 'REFQUOTA'):

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -802,16 +802,19 @@ class ZFSDatasetService(CRUDService):
 
     def set_quota(self, ds, quotas):
         properties = {}
-        for xid, quota in quotas.items():
-            quota_type = quota['quota_type'].lower()
-            quota_value = {'value': quota['quota_value']}
-            if quota_type == 'dataset':
-                properties[xid] = quota_value
-            else:
-                properties[f'{quota_type}quota@{xid}'] = quota_value
-        with libzfs.ZFS() as zfs:
-            dataset = zfs.get_dataset(ds)
-            dataset.update_properties(properties)
+        for quota in quotas:
+            for xid, quota_info in quota.items():
+                quota_type = quota_info['quota_type'].lower()
+                quota_value = {'value': quota_info['quota_value']}
+                if quota_type == 'dataset':
+                    properties[xid] = quota_value
+                else:
+                    properties[f'{quota_type}quota@{xid}'] = quota_value
+
+        if properties:
+            with libzfs.ZFS() as zfs:
+                dataset = zfs.get_dataset(ds)
+                dataset.update_properties(properties)
 
     @accepts(
         Str('id'),

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -169,28 +169,63 @@ def test_13_strip_acl_from_dataset(request):
     JOB_ID = result.json()
 
 
-def test_14_setting_dataset_quota(request):
-    depends(request, ["pool_04", "shareuser"], scope="session")
-    gid = str(GET('/group/?group=shareuser').json()[0]['gid'])
-    global results
-    payload = [
-        {'quota_type': 'USER', 'id': 'shareuser', 'quota_value': 0},
-        {'quota_type': 'GROUP', 'id': gid, 'quota_value': 2000000000},
-        {'quota_type': 'DATASET', 'id': 'QUOTA', 'quota_value': 1073741824}
+def test_14_setting_various_quotas(request):
+    depends(request, ['pool_04', 'shareuser'], scope='session')
+    user = group = 'shareuser'
+    user_gid = GET('/group/?group=shareuser').json()[0]['gid']
+    user_uid = GET('/user/?user=shareuser').json()[0]['uid']
+    user_quota_value = 1000000
+    group_quota_value = user_quota_value * 2
+    dataset_quota_value = group_quota_value + 10000
+    dataset_refquota_value = dataset_quota_value + 10000
+
+    set_quota_payload = [
+        {'quota_type': 'USER', 'id': user, 'quota_value': user_quota_value},
+        {'quota_type': 'USEROBJ', 'id': user, 'quota_value': user_quota_value},
+        {'quota_type': 'GROUP', 'id': group, 'quota_value': group_quota_value},
+        {'quota_type': 'GROUPOBJ', 'id': group, 'quota_value': group_quota_value},
+        {'quota_type': 'DATASET', 'id': 'QUOTA', 'quota_value': dataset_quota_value},
+        {'quota_type': 'DATASET', 'id': 'REFQUOTA', 'quota_value': dataset_refquota_value},
     ]
-    results = POST(f'/pool/dataset/id/{dataset_url}/set_quota', payload)
+    results = POST(f'/pool/dataset/id/{dataset_url}/set_quota', set_quota_payload)
     assert results.status_code == 200, results.text
 
-
-def test_15_getting_dataset_quota(request):
-    depends(request, ["pool_04"], scope="session")
-    global results
-    payload = {
+    expected_user_quota_result = {
         'quota_type': 'USER',
+        'id': user_uid,
+        'quota': user_quota_value,
+        'obj_quota': user_quota_value,
+        'name': user
     }
-    results = POST(f'/pool/dataset/id/{dataset_url}/get_quota', payload)
+    results = POST(f'/pool/dataset/id/{dataset_url}/get_quota', {'quota_type': 'USER'})
     assert results.status_code == 200, results.text
-    assert isinstance(results.json(), list), results
+    assert any((i == expected_user_quota_result for i in results.json())), results
+
+    expected_group_quota_result = {
+        'quota_type': 'GROUP',
+        'id': user_gid,
+        'quota': group_quota_value,
+        'obj_quota': group_quota_value,
+        'name': group
+    }
+    results = POST(f'/pool/dataset/id/{dataset_url}/get_quota', {'quota_type': 'GROUP'})
+    assert results.status_code == 200, results.text
+    assert any((i == expected_group_quota_result for i in results.json())), results
+
+    expected_dataset_quota_result = {
+        'quota_type': 'DATASET',
+        'id': dataset,
+        'name': dataset,
+        'quota': dataset_quota_value,
+        'refquota': dataset_refquota_value,
+    }
+    results = POST(f'/pool/dataset/id/{dataset_url}/get_quota', {'quota_type': 'DATASET'})
+    assert results.status_code == 200, results.text
+    for ds_quota in filter(lambda x: x['id'] == expected_dataset_quota_result['id'], results.json()):
+        # the dataset quota that is return includes a used_bytes key that has an actual
+        # filesystem value. We can't predict what that value will ever be at this point
+        # so we just verify all the other keys match what we expect
+        assert all((expected_dataset_quota_result[k] == ds_quota[k] for k in expected_dataset_quota_result))
 
 
 def test_16_verify_job_id_is_successfull(request):

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -173,7 +173,7 @@ def test_14_setting_various_quotas(request):
     depends(request, ['pool_04', 'shareuser'], scope='session')
     user = group = 'shareuser'
     user_gid = GET('/group/?group=shareuser').json()[0]['gid']
-    user_uid = GET('/user/?user=shareuser').json()[0]['uid']
+    user_uid = GET('/user/?username=shareuser').json()[0]['uid']
     user_quota_value = 1000000
     group_quota_value = user_quota_value * 2
     dataset_quota_value = group_quota_value + 10000

--- a/tests/api2/test_pool_dataset_set_quota.py
+++ b/tests/api2/test_pool_dataset_set_quota.py
@@ -24,4 +24,4 @@ def test_errors(request, id, quota_type, error):
         with pytest.raises(ValidationErrors) as ve:
             call("pool.dataset.set_quota", ds, [{"quota_type": quota_type, "id": id, "quota_value": 5242880}])
 
-        assert ve.value.errors[0].errmsg == f"Setting {error} [0] is not permitted."
+        assert ve.value.errors[0].errmsg == f"Setting {error} [0] is not permitted"


### PR DESCRIPTION
Fix setting (for example) a USER and USEROBJ quota for the same uid. We were creating a dictionary object with the key being the `xid` which means the previous entry in the dictionary would be overwritten with whatever the last entry was in the for loop.

Fixes implemented here:
- simplify the for loop by ignoring `PROJECT` and `PROJECTOBJ` quota types since those aren't implemented
- remove unnecessary newlines
- changes `quotas` object to a list of dictionaries so we don't overwrite previous `xid` entries
- improve the integration tests to (ideally) catch this from happening again in the future