### PR TITLE
NAS-119360 / 23.10 / Remove old k3s/kubelet snapshots

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/migrations/0002_k3s_snapshots.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/migrations/0002_k3s_snapshots.py
@@ -1,0 +1,13 @@
+import os
+
+from middlewared.service import CallError
+
+
+def migrate(middleware):
+    k8s_config = middleware.call_sync('kubernetes.config')
+    kubelet_ds = os.path.join(k8s_config['dataset'], 'k3s/kubelet')
+    for snapshot in middleware.call_sync('zfs.snapshot.query', [['id', 'rin', f'{kubelet_ds}@']]):
+        try:
+            middleware.call_sync('zfs.snapshot.delete', snapshot['id'], {'recursive': True})
+        except CallError as e:
+            middleware.logger.error('Failed to delete %r snapshot: %r', snapshot['id'], e)


### PR DESCRIPTION
## Context

`ix-applications/k3s/kubelet` snapshots are not required and not used when restoring kubernetes cluster. Changes have been made which add a kubernetes infra migration to remove any old snapshots of `kubelet` dataset.