### PR TITLE
NAS-119339 / 23.10 / Do not allow changing PCI device for active VM

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -101,3 +101,11 @@ class PCI(Device):
 
         if not self.middleware.call_sync('vm.device.iommu_enabled'):
             verrors.add('attribute.pptdev', 'IOMMU support is required.')
+
+        if old and vm_instance and vm_instance['status']['state'] in ACTIVE_STATES and old[
+            'attributes'
+        ].get('pptdev') != pptdev:
+            verrors.add(
+                'attribute.pptdev',
+                'Changing PCI device is not allowed while the VM is active.'
+            )

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -238,15 +238,6 @@ class VMDeviceService(CRUDService):
             if not options['force']:
                 raise
 
-        if device['dtype'] == 'PCI':
-            device_obj = PCI(device, middleware=self.middleware)
-            if await self.middleware.run_in_thread(device_obj.safe_to_reattach):
-                try:
-                    await self.middleware.run_in_thread(device_obj.reattach_device)
-                except CallError:
-                    if not options['force']:
-                        raise
-
         return await self.middleware.call('datastore.delete', self._config.datastore, id)
 
     async def __reorder_devices(self, id, vm_id, order):


### PR DESCRIPTION
## Problem

2 problems were identified with the PCI device logic:

1. A running VM can have it's PCI device updated in database which will mean we won't be able to safely re-attach the old device to host.
2.  When a VM is stopped, we already handle the case where the PCI device is re-attached to host but we were also trying the same on PCI device deletion which is not required and doing it unconditionally there. It should be fine generally but for one user who had a critical PCI device passthrough done - re-attaching the device bricked the system..There have been changes since then already where we disallow passthrough for critical PCI devices.

## Solution

Validation has been added to not allow changing PCI device when a VM is in an active state and re-attaching logic on PCI device deletion has been removed.