### PR TITLE
NAS-119364 / 22.12.1 / Fix cluster path handling in attachment delegates (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -130,7 +130,8 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
         await self.middleware.call(f'{self.namespace}.remove_locked_alert', attachment['id'])
 
     async def is_child_of_path(self, resource, path):
-        return is_child(resource[self.path_field], path)
+        share_path = await self.service_class.get_path_field(self.service_class, resource)
+        return is_child(share_path, path)
 
     async def start(self, attachments):
         for attachment in attachments:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -4181,6 +4181,10 @@ class PoolDatasetService(CRUDService):
     @private
     async def attachments_with_path(self, path):
         result = []
+
+        if isinstance(path, str) and not path.startswith('/mnt/'):
+            self.logger.warning('%s: uexpected path not located within pool mountpoint', path)
+
         if path:
             for delegate in self.attachment_delegates:
                 attachments = {"type": delegate.title, "service": delegate.service, "attachments": []}


### PR DESCRIPTION
Plugins containing shares have a special method to retrieve the path underlying the share. This is because in some case the path may be a composite (for instance SMB share path on a glusterfs volume is relative to the root of the volume rather than the root of the local filesystme). In this case self.path_field() returns a string containing the special CLUSTER prefix.

Original PR: https://github.com/truenas/middleware/pull/10227
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119364