### PR TITLE
NAS-119386 / 13.0 / Fix and improve devd_listen

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/devd_events.py
+++ b/src/middlewared/middlewared/plugins/device_/devd_events.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import socket
 
 from middlewared.service import private, Service
 

--- a/src/middlewared/middlewared/plugins/device_/devd_events.py
+++ b/src/middlewared/middlewared/plugins/device_/devd_events.py
@@ -31,7 +31,7 @@ async def devd_loop(middleware):
         await asyncio.sleep(1)
 
 
-def parse_devd_message(msg):
+async def parse_devd_message(msg):
     """
     Parse devd messages using "=" char as separator.
     We use the first word before "=" as key and every word minus 1 after "=" as value.
@@ -66,17 +66,13 @@ async def devd_listen(middleware):
                 continue
 
             try:
-                parsed = parse_devd_message(line[1:])
+                parsed = await parse_devd_message(line[1:])
             except Exception:
                 middleware.logger.warn(f'Failed to parse devd message: {line}')
                 continue
-
-            if 'system' not in parsed:
-                continue
-
-            # Lets ignore CAM messages for now
-            if parsed['system'] in ('CAM', 'ACPI'):
-                continue
+            else:
+                if not parsed or 'system' not in parsed or parsed['system'] in ('CAM', 'ACPI'):
+                    continue
 
             if parsed['type'] == 'GEOM::physpath' and parsed.get('devname'):
                 # treat GEOM::physpath as DEVFS (even though it's geom)

--- a/src/middlewared/middlewared/plugins/device_/devd_events.py
+++ b/src/middlewared/middlewared/plugins/device_/devd_events.py
@@ -19,7 +19,7 @@ async def devd_loop(middleware):
     while True:
         DEVD_CONNECTED = False
         try:
-            if not os.path.exists(DEVD_SOCKETFILE):
+            if not await middleware.run_in_thread(os.path.exists, DEVD_SOCKETFILE):
                 middleware.logger.info('devd is not running yet, waiting...')
                 await asyncio.sleep(1)
                 continue


### PR DESCRIPTION
All of the changes that were made to `devd_listen` were authored by @rkojedzinszky. I closed out their PR simply because we didn't want to add these changes to our stable product. However, those changes fixed the possibility of leaking fds so I've brought them back.

The 2 primary benefits of these changes are:
1. fixes the possibility of leaking fd's
2. improves the efficiency of this method by parsing the devd lines in the main event loop

Before these changes there was potential to leak `s` a `socket` fd as well as a `socket.makefile` object. I've simply copied and pasted the original author's changes and added the following improvements.

1. parse devd events in the main event loop (original author credit @rkojedzinszky )
2. remove unused `socket` import
3. stop running blocking IO (`os.path.exists`) in the main event loop
4. converted `parse_devd_message` to an asynchronous function since there is no reason to keep it synchronous