### PR TITLE
NAS-119399 / 22.12.1 / Fix "KeyError: 'remove_certificates' not found" exception. (by Jah-On)

### DIFF
--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -196,7 +196,8 @@ class OpenVPN:
                 'Please specify a valid authentication_algorithm.'
             )
 
-        if data.pop('remove_certificates'):
+        if 'remove_certificates' in data:
+            data.pop('remove_certificates')
             data.update({
                 'root_ca': None,
                 f'{mode}_certificate': None,

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -196,8 +196,7 @@ class OpenVPN:
                 'Please specify a valid authentication_algorithm.'
             )
 
-        if 'remove_certificates' in data:
-            data.pop('remove_certificates')
+        if data.pop('remove_certificates', None):
             data.update({
                 'root_ca': None,
                 f'{mode}_certificate': None,


### PR DESCRIPTION
This error occurred when trying to download a client config after selecting the client certificate. The current code does not check if the key exists before popping thus throwing an error when the 'remove_certificates' key is not found.

Original PR: https://github.com/truenas/middleware/pull/10236
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119399