### PR TITLE
NAS-119349 / 13.0 / Prevent includes from being written to SMB config

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -409,6 +409,11 @@
                 try:
                     aux_key = param.split("=")[0].strip()
                     aux_val = param.split(aux_key)[1].strip()[1:]
+
+                    if aux_key == 'include':
+                        logger.warning('global SMB config contains invalid include line: %s', param)
+                        continue
+
                     pc.update({aux_key: aux_val})
                 except Exception:
                     logger.debug(f"[global] contains invalid auxiliary parameter: ({param})")

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1057,6 +1057,7 @@ class SharingSMBService(SharingService):
             'cache directory',
             'wide links',
             'insecure wide links',
+            'include',
         ]
         for entry in data.splitlines():
             if entry == '' or entry.startswith(('#', ';')):

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -384,6 +384,11 @@ class SharingSMBService(Service):
                 continue
             try:
                 auxparam, val = param.split('=', 1)
+                if auxparam == 'include':
+                    self.logger.warning('[%s] contains invalid include line: %s',
+                                        data['name'], param)
+                    continue
+
                 """
                 vfs_fruit must be added to all shares if fruit is enabled.
                 Support for SMB2 AAPL extensions is determined on first tcon
@@ -397,6 +402,7 @@ class SharingSMBService(Service):
                     conf['vfs objects'] = await self.order_vfs_objects(vfsobjects)
                 else:
                     conf[auxparam.strip()] = val.strip()
+
             except Exception:
                 self.logger.debug("[%s] contains invalid auxiliary parameter: [%s]",
                                   data['name'], param)


### PR DESCRIPTION
Behavior in this case is unpredictable and hard to ensure for forwards-compatibility. Skip the auxiliary parameter and log its presence in our db.