### PR TITLE
NAS-119403 / 22.12.1 / fix alembic migration syntax error (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2022-03-01_14-40_simplify_network_interfaces.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2022-03-01_14-40_simplify_network_interfaces.py
@@ -30,7 +30,7 @@ def create_new_entries(old_entry):
 
         # we'll write the ipv6 address to the network_alias table
         alias_entry['alias_interface_id'] = old_entry['id']
-        alias_entry['alias_address'] = old_entry['int_ipv6address'],
+        alias_entry['alias_address'] = old_entry['int_ipv6address']
         alias_entry['alias_address_b'] = old_entry['int_ipv6address_b']
         alias_entry['alias_vip'] = old_entry['int_vipv6address']
         alias_entry['alias_version'] = 6


### PR DESCRIPTION
This causes the value to be a tuple so when we try to do an `INSERT` it fails with syntax error.

Original PR: https://github.com/truenas/middleware/pull/10240
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119403