### PR TITLE
NAS-119409 / 22.12.1 / mask mdadm and mdmonitor services (by yocalebo)

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -72,6 +72,7 @@ systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd
 systemctl mask exim4-base.service exim4.service exim4-base.timer
 systemctl mask uuidd.service uuidd.socket
 systemctl mask ndctl-monitor.service
+systemctl mask mdadm.service mdmonitor.service
 
 # We don't use LVM and this service can add significant boot delays
 # on large disk systems

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -72,6 +72,12 @@ systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd
 systemctl mask exim4-base.service exim4.service exim4-base.timer
 systemctl mask uuidd.service uuidd.socket
 systemctl mask ndctl-monitor.service
+
+# mdmonitor.service in particular causes mdadm to send emails to the MAILADDR line
+# in /etc/mdadm/mdadm.conf. By default, that's the root account, so end-users are
+# getting unnecessary emails about these devices. Since middlewared service is
+# solely responsible for managing md devices there is no reason to run this monitor
+# service. This prevents unnecessary emails from being sent out.
 systemctl mask mdadm.service mdmonitor.service
 
 # We don't use LVM and this service can add significant boot delays


### PR DESCRIPTION
This is causing confusing (and unnecessarily alarming) email messages to users. Middlewared process is solely responsible for managing md devices, so disable these services so unnecessary emails aren't sent.

Original PR: https://github.com/truenas/middleware/pull/10250
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119409