### PR TITLE
NAS-119459 / 23.10 / Do not scale up workloads twice

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/rollback.py
@@ -162,7 +162,7 @@ class ChartReleaseService(Service):
                 break
 
         await self.middleware.call(
-            'chart.release.scale_release_internal', release['resources'], None, scale_stats['before_scale'], True,
+            'chart.release.scale_release_internal', release['resources'], None, scale_stats['before_scale'],
         )
         await self.middleware.call('chart.release.clear_chart_release_portal_cache', release_name)
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -301,7 +301,7 @@ class KubernetesService(Service):
         for chart_release in restored_chart_releases.values():
             self.middleware.call_sync(
                 'chart.release.scale_release_internal', chart_release['resources'], None,
-                chart_release['replica_counts'], True,
+                chart_release['replica_counts'],
             )
 
         job.set_progress(99, 'Syncing catalogs')


### PR DESCRIPTION
## Problem

When an app is scaled down we delete resources such as cronjobs or services. Former is deleted because as the app should be stopped we don't want cronjobs executing still of that app. For `services` it is done so as to stop ipvsadm from spamming console and app consuming port while it is still stopped.

When the app is scaled up, before setting up specific `replica_count` we use helm to re-create the resources we deleted and when that is done - for most charts the deployments or statefulsets have `replicas` specified as 1 as default and the app is scaled to that number but after the resources have been created we still try to scale the workload to the said replica count which results in the following workflow:

1. App is scaled up by the helm
2. We explicitly scale the scaleable resources to the said replica counts again which results in the pods deployed in (1) getting killed (they have had a few seconds of running time in this window) and new pods get created again.

## Solution

Before actually scaling workloads to said replica counts, check the scaleable resource's existing replica value and if it is already set to the specified replica count which user wants do nothing.