### PR TITLE
NAS-119460 / 23.10 / Fix restoring apps properly

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -89,7 +89,14 @@ class KubernetesService(Service):
 
     @private
     def to_ignore_datasets_on_backup(self, k8s_dataset):
-        return [os.path.join(k8s_dataset, ds_name) for ds_name in ('catalogs', 'docker', 'k3s/kubelet')]
+        return {
+            os.path.join(k8s_dataset, ds_name): ds_props
+            for ds_name, ds_props in {
+                'catalogs': {'mount': True},
+                'docker': {'mount': True},
+                'k3s/kubelet': {'mount': False, 'creation_props': {'mountpoint': 'legacy'}},
+            }.items()
+        }
 
     @accepts()
     @returns(Dict('backups', additional_attrs=True))

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -80,7 +80,7 @@ class KubernetesService(Service):
 
         self.middleware.call_sync(
             'zettarepl.create_recursive_snapshot_with_exclude', k8s_config['dataset'],
-            snap_name, self.to_ignore_datasets_on_backup(k8s_config['dataset'])
+            snap_name, list(self.to_ignore_datasets_on_backup(k8s_config['dataset']))
         )
 
         job.set_progress(100, f'Backup {name!r} complete')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -86,7 +86,7 @@ class KubernetesService(Service):
             self.middleware.call_sync('zfs.dataset.create', {
                 'name': dataset,
                 'type': 'FILESYSTEM',
-                **ds_details.get('creation_props', {}),
+                **({'properties': ds_details['creation_props']} if ds_details.get('creation_props') else {}),
             })
             if ds_details['mount']:
                 self.middleware.call_sync('zfs.dataset.mount', dataset)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -82,9 +82,14 @@ class KubernetesService(Service):
                 'recursive_rollback': True,
             }
         )
-        for dataset in fresh_datasets:
-            self.middleware.call_sync('zfs.dataset.create', {'name': dataset, 'type': 'FILESYSTEM'})
-            self.middleware.call_sync('zfs.dataset.mount', dataset)
+        for dataset, ds_details in fresh_datasets.items():
+            self.middleware.call_sync('zfs.dataset.create', {
+                'name': dataset,
+                'type': 'FILESYSTEM',
+                **ds_details.get('creation_props', {}),
+            })
+            if ds_details['mount']:
+                self.middleware.call_sync('zfs.dataset.mount', dataset)
 
         # FIXME: Remove this sleep, sometimes the k3s dataset fails to umount
         #  After discussion with mav, it sounds like a bug to him in zfs, so until that is fixed, we have this sleep


### PR DESCRIPTION
## Problem

`ix-applications/k3s/kubelet` dataset should have `legacy` mountpoint set but during restoring applications we were not specifying the explicit mountpoint for it which resulted in us not able to mount it at `/var/lib/kubelet` and kubernetes failing to start after restore.


## Solution

Explicitly make sure that `ix-applications/k3s/kubelet` has `legacy` mountpoint set.