### PR TITLE
NAS-119398 / 23.10 / Fix backup/restore of k8s

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -606,7 +606,7 @@ class ChartReleaseService(CRUDService):
             # If we had pre-install jobs, it's possible we have leftover pods which the job did not remove
             # based on dev specified settings of cleaning it up - let's remove those
             for pod in await self.middleware.call('k8s.pod.query', [['metadata.namespace', '=', namespace]]):
-                owner_references = pod['metadata'].get('owner_references')
+                owner_references = pod['metadata'].get('ownerReferences')
                 if not isinstance(owner_references, list) or all(
                     owner_reference.get('name') not in pre_install_jobs for owner_reference in owner_references
                 ):
@@ -658,7 +658,7 @@ class ChartReleaseService(CRUDService):
         pvc_volume_ds = os.path.join(release_ds, 'volumes')
         for pv in await self.middleware.call(
             'k8s.pv.query', [
-                ['spec.csi.volume_attributes.openebs\\.io/poolname', '=', pvc_volume_ds]
+                ['spec.csi.volumeAttributes.openebs\\.io/poolname', '=', pvc_volume_ds]
             ]
         ):
             await self.middleware.call('k8s.pv.delete', pv['metadata']['name'])

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -246,10 +246,10 @@ class ChartReleaseService(Service):
             for r in await self.middleware.call(
                 f'k8s.{key}.query', [
                     ['metadata.namespace', '=', namespace],
-                    ['metadata', 'rin', 'owner_references'],
+                    ['metadata', 'rin', 'ownerReferences'],
                 ], {'select': ['metadata']}
             ):
-                for owner_reference in filter(lambda o: o.get('uid'), r['metadata']['owner_references'] or []):
+                for owner_reference in filter(lambda o: o.get('uid'), r['metadata']['ownerReferences'] or []):
                     mapping[key][owner_reference['uid']][r['metadata']['uid']] = r
 
         pod_mapping = defaultdict(list)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -218,7 +218,11 @@ class KubernetesService(Service):
                     failed_pv_restores.append(f'Unable to create ZFS Volume for {pvc!r} PVC: {e}')
                     continue
 
+                # We need to safely access claim_ref volume attribute keys as with k8s client api re-write
+                # camel casing which was done by kubernetes asyncio package is not happening anymore
                 pv_spec = pv['pv_details']['spec']
+                claim_ref = pv_spec.get('claim_ref') or pv_spec['claimRef']
+                pv_volume_attrs = pv_spec['csi'].get('volume_attributes') or pv_spec['csi']['volumeAttributes']
                 try:
                     self.middleware.call_sync('k8s.pv.create', {
                         'metadata': {
@@ -229,18 +233,18 @@ class KubernetesService(Service):
                                 'storage': pv_spec['capacity']['storage'],
                             },
                             'claimRef': {
-                                'name': pv_spec['claim_ref']['name'],
-                                'namespace': pv_spec['claim_ref']['namespace'],
+                                'name': claim_ref['name'],
+                                'namespace': claim_ref['namespace'],
                             },
                             'csi': {
                                 'volumeAttributes': {
                                     'openebs.io/poolname': RE_POOL.sub(
-                                        f'{k8s_pool}\\1', pv_spec['csi']['volume_attributes']['openebs.io/poolname']
+                                        f'{k8s_pool}\\1', pv_volume_attrs['openebs.io/poolname']
                                     )
                                 },
-                                'volumeHandle': pv_spec['csi']['volume_handle'],
+                                'volumeHandle': pv_spec['csi'].get('volume_handle') or pv_spec['csi']['volumeHandle'],
                             },
-                            'storageClassName': pv_spec['storage_class_name'],
+                            'storageClassName': pv_spec.get('storage_class_name') or pv_spec['storageClassName'],
                         },
                     })
                 except Exception as e:


### PR DESCRIPTION
## Problem

With kubernetes api client re-write a regression was introduced where upstream kubernetes asyncio package was normalizing fields to snake case which kubernetes API provides as camel case and we had some leftover usages uncovered. This resulted in backups not storing persistent volume state.

## Solution

Cover the snake case usages to correctly retrieve them from the new k8s api and on restore make sure we handle both snake/camel case correctly.