### PR TITLE
NAS-119366 / 22.12.1 / Fix nginx reverse proxy issue for haproxy (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -128,4 +128,4 @@ class VMService(Service):
 
     @private
     async def get_haproxy_uri(self):
-        return 'localhost:700'
+        return '127.0.0.1:700'


### PR DESCRIPTION
## Problem

A user reported that after a reboot of system he couldn't access VM's display via our provided vnc client - however it is available after a restart of nginx.
After some investigation i found that we were binding haproxy to `localhost:700` which resulted in calls to `127.0.0.1:700` ending up saying connection refused from haproxy side.

## Solution

Update haproxy URI to bind itself to `127.0.0.1:700` as that resolves the issue (it is still weird why it works for others though and was not able to narrow that down..). 

Original PR: https://github.com/truenas/middleware/pull/10262
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119366