### PR TITLE
NAS-119434 / 22.12.1 / Resolve symlinks when checking paths (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -1,5 +1,4 @@
 from middlewared.service import ServiceChangeMixin
-from middlewared.utils.path import is_child
 
 
 class FSAttachmentDelegate(ServiceChangeMixin):
@@ -131,7 +130,10 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
 
     async def is_child_of_path(self, resource, path):
         share_path = await self.service_class.get_path_field(self.service_class, resource)
-        return is_child(share_path, path)
+        if share_path == path:
+            return True
+
+        return await self.middleware.call('filesystem.is_child', share_path, path)
 
     async def start(self, attachments):
         for attachment in attachments:

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -1,5 +1,4 @@
 from middlewared.common.attachment import FSAttachmentDelegate
-from middlewared.utils.path import is_child
 
 
 class ChartReleaseFSAttachmentDelegate(FSAttachmentDelegate):
@@ -13,7 +12,8 @@ class ChartReleaseFSAttachmentDelegate(FSAttachmentDelegate):
                 release['status'] == 'STOPPED' if enabled else release['status'] != 'STOPPED'
             ):
                 continue
-            if any(is_child(p, path) for p in release['resources']['host_path_volumes']):
+
+            if await self.middleware.call('filesystem.is_child', release['resources']['host_path_volumes'], path):
                 chart_releases_attached.append({
                     'id': release['name'],
                     'name': release['name'],

--- a/src/middlewared/middlewared/plugins/iscsi_/fs_attachment_delegate.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/fs_attachment_delegate.py
@@ -1,8 +1,4 @@
-import os
-
 from middlewared.common.attachment import LockableFSAttachmentDelegate
-from middlewared.plugins.zfs_.utils import zvol_name_to_path
-from middlewared.utils.path import is_child
 
 from .extents import iSCSITargetExtentService
 
@@ -15,11 +11,6 @@ class ISCSIFSAttachmentDelegate(LockableFSAttachmentDelegate):
 
     async def get_query_filters(self, enabled, options=None):
         return [['type', '=', 'DISK']] + (await super().get_query_filters(enabled, options))
-
-    async def is_child_of_path(self, resource, path):
-        dataset_name = os.path.relpath(path, '/mnt')
-        full_zvol_path = zvol_name_to_path(dataset_name)
-        return is_child(resource[self.path_field], os.path.relpath(full_zvol_path, '/dev'))
 
     async def delete(self, attachments):
         orphan_targets_ids = set()

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -35,7 +35,7 @@ from middlewared.service_exception import InstanceNotFound, ValidationError
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list, run
 from middlewared.utils.asyncio_ import asyncio_map
-from middlewared.utils.path import is_child
+from middlewared.utils.path import is_child_realpath
 from middlewared.utils.size import MB
 from middlewared.validators import Exact, Match, Or, Range, Time
 
@@ -2982,7 +2982,7 @@ class PoolDatasetService(CRUDService):
     def path_in_locked_datasets(self, path, locked_datasets=None):
         if locked_datasets is None:
             locked_datasets = self.middleware.call_sync('zfs.dataset.locked_datasets')
-        return any(is_child(path, d['mountpoint']) for d in locked_datasets if d['mountpoint'])
+        return any(is_child_realpath(path, d['mountpoint']) for d in locked_datasets if d['mountpoint'])
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -893,12 +893,13 @@ class ReplicationFSAttachmentDelegate(FSAttachmentDelegate):
         results = []
         for replication in await self.middleware.call('replication.query', [['enabled', '=', enabled]]):
             if replication['transport'] == 'LOCAL' or replication['direction'] == 'PUSH':
-                if any(is_child(os.path.join('/mnt', source_dataset), path)
-                       for source_dataset in replication['source_datasets']):
+                if await self.middleware.call('filesystem.is_child', [
+                    os.path.join('/mnt', source_dataset) for source_dataset in replication['source_datasets']
+                ], path):
                     results.append(replication)
 
             if replication['transport'] == 'LOCAL' or replication['direction'] == 'PULL':
-                if is_child(os.path.join('/mnt', replication['target_dataset']), path):
+                if await self.middleware.call('filesystem.is_child', os.path.join('/mnt', replication['target_dataset']), path):
                     results.append(replication)
 
         return results

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -3,7 +3,6 @@ import os
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.common.attachment.certificate import CertificateServiceAttachmentDelegate
 from middlewared.common.ports import ServicePortDelegate
-from middlewared.utils.path import is_child
 
 
 class MinioFSAttachmentDelegate(FSAttachmentDelegate):
@@ -15,16 +14,18 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
         results = []
 
         s3_config = await self.middleware.call('s3.config')
-        if not s3_config['storage_path'] or not os.path.exists(s3_config['storage_path']):
+        if not s3_config['storage_path']:
             return []
 
         try:
             s3_ds = await self.middleware.call('zfs.dataset.path_to_dataset', s3_config['storage_path'])
+        except FileNotFoundError:
+            return []
         except Exception:
             self.middleware.logger.warning('%s: failed to look up dataset', s3_config['storage_path'], exc_info=True)
             return []
 
-        if is_child(os.path.join('/mnt', s3_ds), path):
+        if await self.middleware.call('filesystem.is_child', os.path.join('/mnt', s3_ds), path):
             results.append({'id': s3_ds})
 
         return results

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -434,7 +434,7 @@ class PeriodicSnapshotTaskFSAttachmentDelegate(FSAttachmentDelegate):
     async def query(self, path, enabled, options=None):
         results = []
         for task in await self.middleware.call('pool.snapshottask.query', [['enabled', '=', enabled]]):
-            if is_child(os.path.join('/mnt', task['dataset']), path):
+            if await self.middleware.call('filesystem.is_child', os.path.join('/mnt', task['dataset']), path):
                 results.append(task)
 
         return results

--- a/src/middlewared/middlewared/plugins/vm/attachments.py
+++ b/src/middlewared/middlewared/plugins/vm/attachments.py
@@ -5,7 +5,6 @@ from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.common.ports import PortDelegate
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.service import private, Service
-from middlewared.utils.path import is_child
 
 from .utils import ACTIVE_STATES
 
@@ -58,7 +57,7 @@ class VMService(Service):
 
             dataset_path = os.path.join('/mnt', dataset)
             if await determine_recursive_search(recursive, device, datasets):
-                if is_child(path, dataset_path):
+                if await self.middleware.call('filesystem.is_child', path, dataset_path):
                     vms[device['vm']].append(device)
             elif dataset_path == path:
                 vms[device['vm']].append(device)
@@ -93,7 +92,7 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
             if disk.startswith('/dev/zvol'):
                 disk = os.path.join('/mnt', zvol_path_to_name(disk))
 
-            if is_child(disk, path):
+            if await self.middleware.call('filesystem.is_child', disk, path):
                 vm = {
                     'id': device['vm'].get('id'),
                     'name': device['vm'].get('name'),


### PR DESCRIPTION
In most cases, resolving symlinks is rather important for determining whether one path is a child of another.

Original PR: https://github.com/truenas/middleware/pull/10228
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119434