### PR TITLE
NAS-119233 / 23.10 / Set valid keyboard layout if configured one is not supported

### DIFF
--- a/src/middlewared/middlewared/migration/0008_default_keymap.py
+++ b/src/middlewared/middlewared/migration/0008_default_keymap.py
@@ -1,0 +1,10 @@
+async def migrate(middleware):
+    config = await middleware.call('system.general.config')
+    if config['kbdmap'] not in await middleware.call('system.general.kbdmap_choices'):
+        await middleware.call(
+            'datastore.update',
+            'system.settings',
+            config['id'],
+            {'stg_kbdmap': 'us'},
+        )
+        await middleware.call('system.general.set_kbdlayout')

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -264,9 +264,7 @@ class SystemGeneralService(ConfigService):
         )
 
         if config['kbdmap'] != new_config['kbdmap']:
-            await self.middleware.call('etc.generate', 'keyboard')
-            await run(['setupcon'], check=False)
-            await run(['localectl', 'set-keymap', new_config['kbdmap']], check=False)
+            await self.set_kbdlayout(new_config['kbdmap'])
 
         if config['timezone'] != new_config['timezone']:
             await self.middleware.call('zettarepl.update_config', {'timezone': new_config['timezone']})
@@ -292,6 +290,12 @@ class SystemGeneralService(ConfigService):
             await self.middleware.call('system.general.ui_restart', ui_restart_delay)
 
         return await self.config()
+
+    @private
+    async def set_kbdlayout(self, kbdmap='us'):
+        await self.middleware.call('etc.generate', 'keyboard')
+        await run(['setupcon'], check=False)
+        await run(['localectl', 'set-keymap', kbdmap], check=False)
 
     @private
     def set_crash_reporting(self):


### PR DESCRIPTION
## Problem

For a user upgrading from CORE, a keyboard layout was set which was not supported in SCALE.

## Solution

Add a migration to set the default available keyboard layout in SCALE if the already configured keyboard layout is not supported.