### PR TITLE
NAS-119511 / 23.10 / Fix failure backing up apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/backup.py
@@ -61,7 +61,8 @@ class KubernetesService(Service):
                     ['metadata.namespace', '=', chart_release['namespace']]
                 ]
             )
-            for secret in sorted(secrets, key=lambda d: d['metadata']['name']):
+            # We ignore this keeping in line with helm behaviour where the secret malformed is ignored by helm
+            for secret in sorted(secrets, key=lambda d: d['metadata']['name'] and d.get('data')):
                 with open(os.path.join(secrets_dir, secret['metadata']['name']), 'w') as f:
                     f.write(self.middleware.call_sync('k8s.secret.export_to_yaml_internal', secret))
 


### PR DESCRIPTION
## Problem

Sometimes helm secrets get malformed and such secrets are safely ignored by helm and not considered when it fetches history of a chart release. We do this already when we query apps with their history but during backup of chart releases the same consideration was not applied.

## Solution

Ensure the secret is not malformed before making a backup of the secret in question.