### PR TITLE
NAS-119610 / 23.10 / Remove unnecessary method

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -560,7 +560,7 @@ class Job:
         job.progress = job_dict['progress']
         job.result = job_dict['result']
         job.error = job_dict['error']
-        job.error = job_dict['exception']
+        job.exception = job_dict['exception']
         job.state = State.__members__[job_dict['state']]
         job.time_started = job_dict['time_started']
         job.time_finished = job_dict['time_finished']

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -431,29 +431,6 @@ class FilesystemService(Service):
             self.middleware.call_sync('pwenc.reset_secret_cache')
         return True
 
-    @private
-    @accepts(
-        Str('path'),
-        Dict(
-            'options',
-            Int('offset'),
-            Int('maxlen'),
-        ),
-    )
-    def file_get_contents(self, path, options):
-        """
-        Get contents of a file `path` in base64 encode.
-
-        DISCLAIMER: DO NOT USE THIS FOR BIG FILES (> 500KB).
-        """
-        if not os.path.exists(path):
-            return None
-        with open(path, 'rb') as f:
-            if options.get('offset'):
-                f.seek(options['offset'])
-            data = binascii.b2a_base64(f.read(options.get('maxlen'))).decode().strip()
-        return data
-
     @accepts(Str('path'))
     @returns()
     @job(pipes=["output"])

--- a/src/middlewared/middlewared/test/integration/utils/ssh.py
+++ b/src/middlewared/middlewared/test/integration/utils/ssh.py
@@ -13,8 +13,7 @@ __all__ = ["ssh"]
 
 
 def ssh(command, check=True, complete_response=False, _ip=None):
-    _ip = _ip if _ip is not None else ip
-    result = SSH_TEST(command, user, password, ip)
+    result = SSH_TEST(command, user, password, _ip or ip)
     if check:
         assert result["result"] is True, f"stdout: {result['output']}\nstderr: {result['stderr']}"
     return result if complete_response else result["output"]

--- a/src/middlewared/middlewared/test/integration/utils/ssh.py
+++ b/src/middlewared/middlewared/test/integration/utils/ssh.py
@@ -1,5 +1,3 @@
-# -*- coding=utf-8 -*-
-import logging
 import os
 import sys
 
@@ -11,12 +9,11 @@ try:
 except ImportError:
     pass
 
-logger = logging.getLogger(__name__)
-
 __all__ = ["ssh"]
 
 
-def ssh(command, check=True, complete_response=False):
+def ssh(command, check=True, complete_response=False, _ip=None):
+    _ip = _ip if _ip is not None else ip
     result = SSH_TEST(command, user, password, ip)
     if check:
         assert result["result"] is True, f"stdout: {result['output']}\nstderr: {result['stderr']}"

--- a/tests/api2/test_snmp_agent.py
+++ b/tests/api2/test_snmp_agent.py
@@ -1,12 +1,10 @@
-import base64
-import os
 import re
 import subprocess
 import tempfile
 
 import pytest
 
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, ssh, host
 
 from auto_config import dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
@@ -18,21 +16,24 @@ def snmpd_running():
     yield
 
 
-def test_freenas_mib(snmpd_running):
-    with tempfile.NamedTemporaryFile(suffix=".txt") as f:
-        f.write(base64.b64decode(
-            call("filesystem.file_get_contents", "/usr/local/share/snmp/mibs/TRUENAS-MIB.txt").encode("ascii")
-        ))
+def test_truenas_mib_elements(snmpd_running):
+    mib_file = "/usr/local/share/snmp/mibs/TRUENAS-MIB.txt"
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        lines = ssh(f'cat {mib_file}')
+        assert lines
+
+        f.writelines(lines)
         f.flush()
 
         snmp = subprocess.run(
-            f"snmpwalk -v2c -c public -m {f.name} {os.environ['MIDDLEWARE_TEST_IP']} "
+            f"snmpwalk -v2c -c public -m {f.name} {host()} "
             "1.3.6.1.4.1.50536",
             shell=True,
             capture_output=True,
             text=True,
         )
         assert snmp.returncode == 0, snmp.stderr
-
-    assert "TRUENAS-MIB::zpoolName.1 = STRING: boot-pool\n" in snmp.stdout
-    assert re.search(r"^TRUENAS-MIB::zfsArcSize\.0 = Gauge32: ([1-9][0-9]+)\n", snmp.stdout, re.MULTILINE), snmp.stdout
+        assert "TRUENAS-MIB::zpoolName.1 = STRING: boot-pool\n" in snmp.stdout
+        assert re.search(
+            r"^TRUENAS-MIB::zfsArcSize\.0 = Gauge32: ([1-9][0-9]+)\n", snmp.stdout, re.MULTILINE
+        ), snmp.stdout


### PR DESCRIPTION
Remove `filesystem.file_get_contents` since it doesn't have any type of validation and doesn't mix well with our rootless login functionality. This was a private method (only available across websocket connections) and was only used in our integration test suite, so I've fixed those tests accordingly.