### PR TITLE
NAS-119619 / 23.10 / Fix scaling apps after restore

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -148,9 +148,10 @@ class ChartReleaseService(Service):
 
         for resource in SCALEABLE_RESOURCES:
             for workload in resources[resource.value]:
-                replica_count = replica_counts[resource.value].get(
+                configured_replica_count = replica_counts[resource.value].get(
                     workload['metadata']['name'], {}
-                ).get('replicas') or replicas
+                ).get('replicas')
+                replica_count = replicas if configured_replica_count is None else configured_replica_count
 
                 current_workload = resources_data[resource.name.lower()].get(workload['metadata']['uid'])
                 if not current_workload or replica_count == current_workload['spec'].get('replicas'):


### PR DESCRIPTION
## Problem

When a backup is restored all apps (including stopped ones) are started automatically.
What happens is that `0` was being treated as boolean false which resulted in falling back to default value when scaling workloads which in most cases is 1.

## Solution

Explicitly make sure that specified value is `None` and only in that case use the configured default value.