### PR TITLE
NAS-119623 / 22.12.1 / Do not silently `pass` zettarepl startup error (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -1053,7 +1053,7 @@ async def setup(middleware):
     try:
         await middleware.call("zettarepl.start")
     except Exception:
-        pass
+        middleware.logger.error("Unhandled exception during zettarepl startup", exc_info=True)
 
     middleware.register_hook("pool.post_import", pool_configuration_change, sync=True)
     middleware.register_hook("pool.post_export", pool_configuration_change, sync=True)


### PR DESCRIPTION
There were no real possible errors that might be obscured by this `pass`... yet

Original PR: https://github.com/truenas/middleware/pull/10307
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119623