### PR TITLE
NAS-119396 / 23.10 / Update AMD device plugin image tag

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/images.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/images.py
@@ -151,7 +151,7 @@ class ContainerImagesService(CRUDService):
         images = [
             'nvcr.io/nvidia/k8s-device-plugin:v0.13.0',
             'docker.io/intel/intel-gpu-initcontainer:0.19.0',
-            'docker.io/rocm/k8s-device-plugin:latest',
+            'docker.io/rocm/k8s-device-plugin:1.18.0',
             'docker.io/rancher/mirrored-coredns-coredns:1.9.1',
             'docker.io/rancher/mirrored-pause:3.6',
             'docker.io/rancher/klipper-lb:v0.3.5',

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -102,7 +102,7 @@ GPU_CONFIG = {
                         {'key': 'CriticalAddonsOnly', 'operator': 'Exists'},
                     ],
                     'containers': [{
-                        'image': 'rocm/k8s-device-plugin',
+                        'image': 'rocm/k8s-device-plugin:1.18.0',
                         'name': 'amdgpu-dp-cntr',
                         'securityContext': {'allowPrivilegeEscalation': False, 'capabilities': {'drop': ['ALL']}},
                         'volumeMounts': [


### PR DESCRIPTION
## Context

We were using `latest` tag for AMD device plugin image which many users have reported as not working and being broken.
Multiple users have confirmed that with `1.18.0` image tag AMD gpu is recognized by kubernetes which is not the case otherwise.