### PR TITLE
NAS-119396 / 22.12.1 / Update AMD device plugin image tag (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/images.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/images.py
@@ -201,6 +201,7 @@ class DockerImagesService(CRUDService):
 
         images.extend([
             'nvidia/k8s-device-plugin:1.0.0-beta6',
+            'rocm/k8s-device-plugin:1.18.0',
             'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0',
             'k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0',
             'k8s.gcr.io/sig-storage/csi-resizer:v1.1.0',

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -99,7 +99,7 @@ GPU_CONFIG = {
                         {'key': 'CriticalAddonsOnly', 'operator': 'Exists'},
                     ],
                     'containers': [{
-                        'image': 'rocm/k8s-device-plugin',
+                        'image': 'rocm/k8s-device-plugin:1.18.0',
                         'name': 'amdgpu-dp-cntr',
                         'securityContext': {'allowPrivilegeEscalation': False, 'capabilities': {'drop': ['ALL']}},
                         'volumeMounts': [


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 5087d1ad73ce801a3b4aaf6dc7da3ed71f226082

## Context

We were using `latest` tag for AMD device plugin image which many users have reported as not working and being broken.
Multiple users have confirmed that with `1.18.0` image tag AMD gpu is recognized by kubernetes which is not the case otherwise.

Original PR: https://github.com/truenas/middleware/pull/10312
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119396