### PR TITLE
NAS-119649 / 23.10 / fix and improve user.shell_choices

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1121,7 +1121,7 @@ class UserService(CRUDService):
                 'The "\\n" character is not allowed in a "Full Name".'
             )
 
-        if 'shell' in data and data['shell'] not in await self.middleware.call('user.shell_choices', pk):
+        if 'shell' in data and data['shell'] not in await self.middleware.call('user.shell_choices'):
             verrors.add(
                 f'{schema}.shell', 'Please select a valid shell.'
             )

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -4,7 +4,6 @@ from middlewared.service import (
 )
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run, filter_list
-from middlewared.utils.osc import IS_FREEBSD
 from middlewared.validators import Email
 from middlewared.plugins.smb import SMBBuiltin
 
@@ -288,8 +287,8 @@ class UserService(CRUDService):
         Int('group'),
         Bool('group_create', default=False),
         Str('home', default='/nonexistent'),
-        Str('home_mode', default='700'),
-        Str('shell', default='/bin/csh' if IS_FREEBSD else '/usr/bin/zsh'),
+        Str('home_mode', default='755'),
+        Str('shell', default='/usr/bin/zsh'),
         Str('full_name', required=True),
         Str('email', validators=[Email()], null=True, default=None),
         Str('password', private=True),

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -732,7 +732,7 @@ class UserService(CRUDService):
             '/usr/sbin/nologin': 'nologin'
         }
     ))
-    def shell_choices(self, user_id):
+    def shell_choices(self):
         """Return the available shell choices to be used in `user.create` and `user.update`."""
         shells = {'/usr/sbin/nologin': 'nologin'}
         with open('/etc/shells') as f:

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -287,7 +287,7 @@ class UserService(CRUDService):
         Int('group'),
         Bool('group_create', default=False),
         Str('home', default='/nonexistent'),
-        Str('home_mode', default='755'),
+        Str('home_mode', default='700'),
         Str('shell', default='/usr/bin/zsh'),
         Str('full_name', required=True),
         Str('email', validators=[Email()], null=True, default=None),

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -771,7 +771,9 @@ class UserService(CRUDService):
         if not data['username'] and data['uid'] is None:
             verrors.add('get_user_obj.username', 'Either "username" or "uid" must be specified')
         verrors.check()
-        return await self.middleware.call('dscache.get_uncached_user', data['username'], data['uid'], data['get_groups'])
+        return await self.middleware.call(
+            'dscache.get_uncached_user', data['username'], data['uid'], data['get_groups']
+        )
 
     @item_method
     @accepts(
@@ -1274,7 +1276,9 @@ class GroupService(CRUDService):
     @private
     async def group_extend_context(self, rows, extra):
         mem = {}
-        membership = await self.middleware.call('datastore.query', 'account.bsdgroupmembership', [], {'prefix': 'bsdgrpmember_'})
+        membership = await self.middleware.call(
+            'datastore.query', 'account.bsdgroupmembership', [], {'prefix': 'bsdgrpmember_'}
+        )
         users = await self.middleware.call('datastore.query', 'account.bsdusers')
 
         # uid and gid variables here reference database ids rather than OS uid / gid


### PR DESCRIPTION
1. still referenced `netcli` which has been removed
2. Took a `user_id` argument which is non-intuitive and confusing because that's not the uid, it's the database id. This argument isn't needed anymore
3. remove `IS_FREEBSD` checks in this file
4. simplify the method
5. add proper `@returns` information