### PR TITLE
NAS-119423 / 22.12.1 / Strip trailing '/32' when writing /etc/initiators.allow (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/initiators.allow.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.allow.mako
@@ -1,7 +1,20 @@
 <%
+    import ipaddress
     base_name = middleware.call_sync('iscsi.global.config')['basename']
     targets = middleware.call_sync('iscsi.target.query', [['auth_networks', '!=', []]])
+
+    def parse_auth(auth):
+        s = auth.split('/')
+        if len(s) == 2:
+            try:
+                ipobj = ipaddress.ip_interface(s[0])
+            except ValueError:
+                middleware.logger.warning(f"Invalid IP address: {s[0]}", exc_info=True)
+            else:
+                if (ipobj.version == 4 and s[1] == '32') or (ipobj.version == 6 and s[1] == '128'):
+                    return str(ipobj.ip)
+        return auth
 %>\
 % for target in targets:
-${base_name}:${target['name']} ${', '.join(target['auth_networks'])}
+${base_name}:${target['name']} ${', '.join([parse_auth(auth) for auth in target['auth_networks']])}
 % endfor

--- a/src/middlewared/middlewared/etc_files/initiators.allow.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.allow.mako
@@ -9,7 +9,7 @@
             try:
                 ipobj = ipaddress.ip_interface(s[0])
             except ValueError:
-                middleware.logger.warning(f"Invalid IP address: {s[0]}", exc_info=True)
+                middleware.logger.warning("Invalid IP address: %s", s[0], exc_info=True)
             else:
                 if (ipobj.version == 4 and s[1] == '32') or (ipobj.version == 6 and s[1] == '128'):
                     return str(ipobj.ip)

--- a/src/middlewared/middlewared/etc_files/initiators.allow.mako
+++ b/src/middlewared/middlewared/etc_files/initiators.allow.mako
@@ -4,16 +4,14 @@
     targets = middleware.call_sync('iscsi.target.query', [['auth_networks', '!=', []]])
 
     def parse_auth(auth):
-        s = auth.split('/')
-        if len(s) == 2:
-            try:
-                ipobj = ipaddress.ip_interface(s[0])
-            except ValueError:
-                middleware.logger.warning("Invalid IP address: %s", s[0], exc_info=True)
-            else:
-                if (ipobj.version == 4 and s[1] == '32') or (ipobj.version == 6 and s[1] == '128'):
-                    return str(ipobj.ip)
-        return auth
+        try:
+            ipobj = ipaddress.ip_interface(auth)
+        except ValueError:
+            middleware.logger.warning("Invalid IP address: %s", auth, exc_info=True)
+        else:
+            if ipobj.network.prefixlen in (32, 128):
+                return str(ipobj.ip)
+            return str(ipobj.network)
 %>\
 % for target in targets:
 ${base_name}:${target['name']} ${', '.join([parse_auth(auth) for auth in target['auth_networks']])}

--- a/src/middlewared/middlewared/test/integration/assets/iscsi.py
+++ b/src/middlewared/middlewared/test/integration/assets/iscsi.py
@@ -14,6 +14,7 @@ def target_login_test(portal_ip, target_name):
 
 def target_login_test_linux(portal_ip, target_name):
     try:
+        run_on_runner(['iscsiadm', '-m', 'discovery', '-t', 'sendtargets', '--portal', portal_ip])
         run_on_runner(['iscsiadm', '-m', 'node', '--targetname', target_name, '--portal', portal_ip, '--login'])
     except RunOnRunnerException:
         return False


### PR DESCRIPTION
When writing `/etc/initiators.allow` the netmask should only be included when not dealing with a specific address.

Added some additional tests to further exercise this functionality.

Original PR: https://github.com/truenas/middleware/pull/10324
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119423