### PR TITLE
NAS-119666 / 23.10 / Improve kerberos tests

### DIFF
--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -31,7 +31,7 @@ def convert_schema(spec):
     elif t in ('bool', 'boolean'):
         return Bool(name, **spec)
     elif t == 'dict':
-        return Dict(name, **spec)
+        return Dict(name, *spec.get('args', []), **spec.get('kwargs', {}))
     raise ValueError(f'Unknown type: {t}')
 
 

--- a/tests/api2/assets/REST/directory_services.py
+++ b/tests/api2/assets/REST/directory_services.py
@@ -49,8 +49,10 @@ def active_directory(domain, username, password, **kwargs):
 
     sleep(5)
     try:
+        config = results.json()
+        del(config['bindpw'])
         yield {
-            'config': results.json(),
+            'config': config,
             'result': job_status['results']
         }
     finally:

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -32,4 +32,18 @@ def smb_share(path, options=None):
         result = DELETE(f"/sharing/smb/id/{id}/")
         assert result.status_code == 200, result.text
 
+
+@contextlib.contextmanager
+def nfs_share(path, options=None):
+    results = POST("/sharing/nfs/", {
+        "path": path,
+        **(options or {}),
+    })
     assert results.status_code == 200, results.text
+    id = results.json()["id"]
+
+    try:
+        yield id
+    finally:
+        result = DELETE(f"/sharing/nfs/id/{id}/")
+        assert result.status_code == 200, result.text


### PR DESCRIPTION
This PR updates the regression tests for
kerberos when joined to AD. We use new active_directory context manager to ensure proper test cleanup.

Tests are now expanded to included ticket management. After joining AD we re-kinit with a short-lived kerberos ticket and then verify that `kerberos.renew` renews the ticket properly. The tests also validate that our
background job to monitor pending kerberos tickets is reporting the correct information.

During the course of testing, an edge-case was encountered where sysvol replication for the fresh AD account had not ocurred by the time we tried to get a limited kerberos ticket. As a result of this, kerberos.do_kinit was expanded to allow for overriding / hard-coding a particular KDC in the krb5.conf. This is used to temporarily lock us to a single KDC (the one we used to join AD) that that we can reliably kinit. This temporary stub krb5.conf is then cleared when we generate a full krb5.conf file after downgrading our ticket.