### PR TITLE
NAS-119680 / 22.12.1 / Initialize use_default_domain to False on AD tests (by anodos325)

### DIFF
--- a/tests/api2/assets/REST/directory_services.py
+++ b/tests/api2/assets/REST/directory_services.py
@@ -36,6 +36,7 @@ def active_directory(domain, username, password, **kwargs):
         'bindname': username,
         'bindpw': password,
         "kerberos_principal": "",
+        "use_default_domain": False,
         'enable': True,
         **kwargs
     }


### PR DESCRIPTION
This is not automatically cleared up when leaving AD so a little more state that should be cleaned when joining.

Original PR: https://github.com/truenas/middleware/pull/10346
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119680