### PR TITLE
NAS-119702 / 22.12.1 / Add nameserver checks for activedirectory plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/active_directory.py
+++ b/src/middlewared/middlewared/alert/source/active_directory.py
@@ -3,6 +3,7 @@ import logging
 from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource
 from middlewared.alert.schedule import CrontabSchedule, IntervalSchedule
 from middlewared.plugins.directoryservices import DSStatus
+from middlewared.service_exception import CallError
 
 log = logging.getLogger("activedirectory_check_alertmod")
 
@@ -36,6 +37,15 @@ class ActiveDirectoryDomainHealthAlertSource(AlertSource):
             return Alert(
                 ActiveDirectoryDomainHealthAlertClass,
                 {'verrs': str(e)},
+                key=None
+            )
+
+        try:
+            await self.middleware.call("activedirectory.check_nameservers")
+        except CallError as e:
+            return Alert(
+                ActiveDirectoryDomainHealthAlertClass,
+                {'verrs': e.errmsg},
                 key=None
             )
 

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -420,6 +420,18 @@ class ActiveDirectoryService(TDBWrapConfigService):
                 )
 
             try:
+                await self.middleware.call(
+                    'activedirectory.check_nameservers',
+                    new['domainname'],
+                    new['site']
+                )
+            except CallError as e:
+                raise ValidationError(
+                    'activedirectory.domainname',
+                    e.errmsg
+                )
+
+            try:
                 await self.validate_credentials(new, domain_info['KDC server'])
             except CallError as e:
                 if new['kerberos_principal']:


### PR DESCRIPTION
Some users may get confused about their AD domain name and how to configure DNS when TrueNAS is joined to active directory.

This merge request attempts to take some of the burden off of the administrator by:

1. Validating that each of our configured nameservers can successfully look up relevant SRV records for our AD domain. This will hopefully reduce occurance of administrators putting non-AD nameservers (e.g. Google) in their resolv.conf.

2. Validating that each of the nameservers can actually resolve our AD domain name. This will hopefully catch users doing something like setting the FQDN of a domain controller as the active directory domain name.

3. Incorporating nameserver checks into our hourly AD health alert checks.

Original PR: https://github.com/truenas/middleware/pull/10351
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119702