### PR TITLE
NAS-119703 / 23.10 / Fix ix volume filtering in host path validation

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -35,7 +35,7 @@ class ChartReleaseService(Service):
             lambda attachment: attachment['type'] not in allowed_service_types,
             await self.middleware.call('pool.dataset.attachments_with_path', path)
         ):
-            if attachment_entry['service'] == 'Kubernetes' and is_ix_volume_path(
+            if attachment_entry['service'].lower() == 'kubernetes' and is_ix_volume_path(
                 path, (await self.middleware.call('kubernetes.config'))['dataset']
             ):
                 continue

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -100,7 +100,8 @@ def is_ix_volume_path(path: str, dataset: str) -> bool:
     if not path.startswith(release_path):
         return False
 
-    app_path = path.replace(release_path, '')
+    # path -> /mnt/pool/ix-applications/releases/plex/volumes/ix-volumes/
+    app_path = path.replace(release_path, '').removeprefix('/').split('/', 1)[0]
     return path.startswith(os.path.join(release_path, app_path, 'volumes/ix_volumes/'))
 
 


### PR DESCRIPTION
## Context

With upcoming changes removing validation in containerd and relying on middleware instead - ix volumes were not properly filtered out and resulted in those app mounts not mounting ix volumes.