### PR TITLE
NAS-119518 / 23.10 / Refine whitelisted host paths for apps validation

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -75,19 +75,16 @@ def safe_to_ignore_path(path: str) -> bool:
         return True
 
     for ignore_path in (
-        '/etc/',
-        '/sys/',
-        '/proc/',
-        '/var/lib/kubelet/',
-        '/dev/',
+        '/dev/',  # required by openebs
+        '/etc/group',  # required by netdata
+        '/etc/os-release',  # required by netdata
+        '/etc/passwd',  # required by netdata
+        '/home/keys/',  # required by openebs
         '/mnt/',
-        '/home/keys/',
-        '/run/',
-        '/var/run/',
-        '/var/lock/',
-        '/lock',
-        '/usr/share/zoneinfo',  # allow mounting localtime
-        '/usr/lib/os-release',  # allow mounting /etc/os-release
+        '/proc/',  # required by netdata
+        '/sys/',  # required by netdata
+        '/usr/lib/os-release',  # required by netdata
+        '/var/lib/kubelet/',
     ):
         if path.startswith(ignore_path) or path == ignore_path.removesuffix('/'):
             return True


### PR DESCRIPTION
## Context

In docker we were not able to distinguish between a host path as required by the container itself to function or if it being a user specified host path.

With the change to containerd we can now make that distinction and paths have been updated accordingly so as to narrow down whitelisted paths which were allowed earlier.