### PR TITLE
NAS-119577 / 22.12.1 / Ignore container coredumps in bluefin

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -30,6 +30,7 @@ class CoreFilesArePresentAlertSource(AlertSource):
         # ignore those core dumps
         "containerd.service",
         "docker.service",
+        "k3s.service",
         # Unit: "syslog-ng.service" has been core dumping for, literally, years
         # on freeBSD and now also on linux. The fix is non-trivial and it seems
         # to be very specific to how we implemented our system dataset. Anyways,


### PR DESCRIPTION
## Context

We are ignoring container coredumps but had missed to include `k3s.service` unit to list of ignores as coredumps generated can also report as being generated by `k3s.service`.