### PR TITLE
NAS-119762 / 22.12.1 / Fix display devices (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/etc_files/haproxy/haproxy.cfg.mako
+++ b/src/middlewared/middlewared/etc_files/haproxy/haproxy.cfg.mako
@@ -26,7 +26,7 @@ defaults
 frontend vms
     bind ${middleware.call_sync('vm.get_haproxy_uri')}
 % for device in devices:
-    acl PATH_${device['id']} path_beg -i /${device['id']}
+    acl PATH_${device['id']} path_beg -i /${device['id']}/
     use_backend be_${device['id']} if PATH_${device['id']}
 % endfor
 


### PR DESCRIPTION
## Problem

I noticed one of my VMs display device was not working with the regular URL `/vm/display/398/vnc.html?path=vm%2Fdisplay%2F398%2F&autoconnect=1` and was reporting 503. However the VNC client was working properly on `http://NASIP:5900/vnc.html` which meant that there were no issues from VNC client side.

After investigation i found out that nginx was redirecting properly and haproxy was at fault where it was not redirecting to VNC client in question. To sum up, i had another display device whose id was `3` and haproxy was matching the first backend which it saw which was `3` and that VM in question was powered off which resulted in the 503 being reported.

## Solution

Properly match complete id and add a trailing slash `/display_device_id/` so that for ids like `30` or `312` would still match to the correct backend instead of going to `3` backend. Also the URL isn't complete with just the display device id so it wouldn't mean that if trailing slash is not specified the endpoint would not work.

`/vm/display/398/vnc.html?path=vm%2Fdisplay%2F398%2F&autoconnect=1` shows that we have rest of the path coming in after display device id and the fix works nicely.

Original PR: https://github.com/truenas/middleware/pull/10365
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119762