### PR TITLE
NAS-119763 / 23.10 / Expand tests for adding kerberos principal

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/krb5.py
+++ b/src/middlewared/middlewared/plugins/nfs_/krb5.py
@@ -104,5 +104,5 @@ class NFSService(Service):
             await self.middleware.call('kerberos.stop')
             await self.middleware.call('kerberos.start')
 
-        await self._service_change("nfs", "restart")
+        await self.middleware.call('service.restart', 'nfs')
         return ret


### PR DESCRIPTION
This ensures that NFS principal in kerberos
keytab is properly visible when LDAP is configured.

This is prep step for adding functional testing for 
krb5+NFS with both AD and LDAP plugins.