### PR TITLE
NAS-119899 / 23.10 / Fix variant of the 256-bit NIST ECC curve

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/utils.py
+++ b/src/middlewared/middlewared/plugins/crypto_/utils.py
@@ -22,7 +22,7 @@ EC_CURVES = [
     'BrainpoolP512R1',
     'BrainpoolP384R1',
     'BrainpoolP256R1',
-    'SECP256K1',
+    'SECP256R1',
     'SECP384R1',
     'SECP521R1',
     'ed25519',


### PR DESCRIPTION
First, this is consistent with the other two NIST curves in the codebase, which use the random ‘r’ variant of the curves, not the Koblitz ‘k' variants. Second, attempting to request a Lets Encrypt certificate with the previous type of secp256k1 fails, with the error message “Error parsing certificate request: x509: unsupported elliptic curve”. Third, the CAB forum says the 256-bit curve must be secp256r1; see section 7.1.3.1.2 of <https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.8.6.pdf>.