### PR TITLE
NAS-119782 / 22.12.1 / Shift bootready sentinel to middleware rundir (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 import uuid
 
-from middlewared.utils import run
+from middlewared.utils import BOOTREADY, run
 
 from .utils import FIRST_INSTALL_SENTINEL, lifecycle_conf
 
@@ -46,7 +46,7 @@ async def setup(middleware):
         id=reboot -- Started reboot process\n
         id=shutdown -- Started shutdown process'''))
 
-    if os.path.exists('/tmp/.bootready'):
+    if os.path.exists(BOOTREADY):
         lifecycle_conf.SYSTEM_READY = True
     else:
         await firstboot(middleware)

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -27,7 +27,7 @@ from middlewared.service_exception import (  # noqa
     CallException, CallError, InstanceNotFound, ValidationError, ValidationErrors
 )
 from middlewared.settings import conf
-from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR, osc
+from middlewared.utils import BOOTREADY, filter_list, MIDDLEWARE_RUN_DIR, osc
 from middlewared.utils.debug import get_frame_details, get_threads_stacks
 from middlewared.utils.path import FSLocation, path_location, strip_location_prefix
 from middlewared.logger import Logger, reconfigure_logging, stop_logging
@@ -1697,7 +1697,7 @@ class CoreService(Service):
 
         # Sentinel file to tell we have gone far enough in the boot process.
         # See #17508
-        open('/tmp/.bootready', 'w').close()
+        open(BOOTREADY, 'w').close()
 
         # Send event to middlewared saying we are late enough in the process to call it ready
         self.middleware.call_sync(

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -15,6 +15,7 @@ BUILDTIME = None
 VERSION = None
 MID_PID = None
 MIDDLEWARE_RUN_DIR = '/var/run/middleware'
+BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Service-related sentinel files should be in their respective rundirs.

Original PR: https://github.com/truenas/middleware/pull/10372
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119782