### PR TITLE
NAS-119789 / 22.12.1 / Shift more middleware-related sentinels to rundir (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -65,7 +65,7 @@ class CrashReporting(object):
 
     def __init__(self):
         if sw_version_is_stable():
-            self.sentinel_file_path = '/tmp/.crashreporting_disabled'
+            self.sentinel_file_path = f'{MIDDLEWARE_RUN_DIR}/.crashreporting_disabled'
         else:
             self.sentinel_file_path = '/data/.crashreporting_disabled'
         self.logger = logging.getLogger('middlewared.logger.CrashReporting')
@@ -94,7 +94,7 @@ class CrashReporting(object):
             bool: True if crash reporting is disabled, False otherwise.
         """
         # Allow report to be disabled via sentinel file or environment var,
-        # if FreeNAS current train is STABLE, the sentinel file path will be /tmp/,
+        # if TrueNAS current train is STABLE, the sentinel file path will be /var/run/middleware/,
         # otherwise it's path will be /data/ and can be persistent.
 
         if not self.enabled_in_settings:

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -853,7 +853,7 @@ class PreparedCall:
 
 class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
-    CONSOLE_ONCE_PATH = '/tmp/.middlewared-console-once'
+    CONSOLE_ONCE_PATH = f'{MIDDLEWARE_RUN_DIR}/.middlewared-console-once'
 
     def __init__(
         self, loop_debug=False, loop_monitor=True, debug_level=None,


### PR DESCRIPTION
We should try to keep middleware-state-related items in /var/run/middleware rather than in /tmp

Original PR: https://github.com/truenas/middleware/pull/10381
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119789