### PR TITLE
NAS-119799 / 22.12.1 / Fix overprovision logic overwriting `disks` variable contents (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -757,9 +757,10 @@ class PoolService(CRUDService):
         verrors.check()
 
         if osize := (await self.middleware.call('system.advanced.config'))['overprovision']:
-            if disks := {disk: osize for disk in sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])}:
+            if log_disks := {disk: osize
+                             for disk in sum([vdev['disks'] for vdev in data['topology'].get('log', [])], [])}:
                 # will log errors if there are any so it won't crash here (this matches CORE behavior)
-                await (await self.middleware.call('disk.resize', disks, True)).wait()
+                await (await self.middleware.call('disk.resize', log_disks, True)).wait()
 
         await self.middleware.call('pool.format_disks', job, disks)
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 559ecaaa6e132d90750eb0b6de679ad5d57cc4a7



Original PR: https://github.com/truenas/middleware/pull/10389
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119799