### PR TITLE
NAS-119733 / 22.12.1 / Save empty iSCSI target alias as NULL (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -357,4 +357,7 @@ class iSCSITargetService(CRUDService):
         data['mode'] = data['mode'].lower()
         for group in data['groups']:
             group['authmethod'] = AUTHMETHOD_LEGACY_MAP.inv.get(group.pop('authmethod'), 'NONE')
+        if 'alias' in data and not data['alias']:
+            # We may have specified the empty string as alias, store it as NULL
+            data['alias'] = None
         return data

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -357,7 +357,8 @@ class iSCSITargetService(CRUDService):
         data['mode'] = data['mode'].lower()
         for group in data['groups']:
             group['authmethod'] = AUTHMETHOD_LEGACY_MAP.inv.get(group.pop('authmethod'), 'NONE')
-        if 'alias' in data and not data['alias']:
-            # We may have specified the empty string as alias, store it as NULL
+        # If we specified the alias as the empty string, store it as NULL instead to prevent clash 
+        # on UNIQUE in the database.
+        if data.get("alias", None) == "":
             data['alias'] = None
         return data

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -357,7 +357,7 @@ class iSCSITargetService(CRUDService):
         data['mode'] = data['mode'].lower()
         for group in data['groups']:
             group['authmethod'] = AUTHMETHOD_LEGACY_MAP.inv.get(group.pop('authmethod'), 'NONE')
-        # If we specified the alias as the empty string, store it as NULL instead to prevent clash 
+        # If we specified the alias as the empty string, store it as NULL instead to prevent clash
         # on UNIQUE in the database.
         if data.get("alias", None) == "":
             data['alias'] = None


### PR DESCRIPTION
When saving an empty string iSCSI target alias store it as NULL.

The field in the underlying database is unique, so saving as "" is problematic.

Original PR: https://github.com/truenas/middleware/pull/10379
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119733