### PR TITLE
NAS-119455 / 23.10 / Fix swap creation

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_remove.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_remove.py
@@ -54,6 +54,9 @@ class DiskService(Service):
 
         swap_devices = await self.middleware.call('disk.get_swap_devices')
         for mirror in await self.middleware.call('disk.get_swap_mirrors'):
+            if not set([p['disk'] for p in mirror['providers']]).intersection(set(disks)):
+                continue
+
             devname = mirror['encrypted_provider'] or mirror['real_path']
             if devname in swap_devices:
                 await run('swapoff', devname)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -205,6 +205,7 @@ class PoolService(Service):
         self.middleware.create_task(self.middleware.call('service.restart', 'collectd'))
         await self.middleware.call_hook('pool.post_import', {'passphrase': data.get('passphrase'), **pool})
         await self.middleware.call('pool.dataset.sync_db_keys', pool['name'])
+        self.middleware.create_task(self.middleware.call('disk.swaps_configure'))
         self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)
 
         return True


### PR DESCRIPTION
## Problem

There were 2 problems with swap configuration logic:

1. We were configuring swap after importing a pool
2. When a disk was to be removed from swap in a case like pool export being in progress - we unconditionally were removing configured mirrors which meant that swap devices could not be configured.

## Solution

For (1), we call endpoint to configure swap after a pool import is complete so swap can be configured appropriately. For (2), we make sure that we only unconfigure swap mirrors which are actually using a disk which is to be removed from swap.