### PR TITLE
NAS-119810 / 13.0 / fix ipmi sensor matching (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -159,12 +159,12 @@ class IPMISELAlertSource(AlertSource):
             record for record in records
             if (
                 (
-                    any(record.sensor.startswith(f"{sensor} #0x")
+                    any(record.sensor.startswith(sensor)
                         for sensor in self.IPMI_SENSORS) or
-                    any(record.sensor.startswith(f"{sensor} #0x") and record.event == event
+                    any(record.sensor.startswith(sensor) and record.event == event
                         for sensor, event in self.IPMI_EVENTS_WHITELIST)
                 ) and
-                not any(record.sensor.startswith(f"{sensor} #0x") and record.event == event
+                not any(record.sensor.startswith(sensor) and record.event == event
                         for sensor, event in self.IPMI_EVENTS_BLACKLIST)
             )
         ]

--- a/src/middlewared/middlewared/pytest/unit/alert/source/test_ipmi_sel.py
+++ b/src/middlewared/middlewared/pytest/unit/alert/source/test_ipmi_sel.py
@@ -75,18 +75,18 @@ async def test_ipmi_sel_alert_source__works():
     source = IPMISELAlertSource(middleware)
 
     assert await source._produce_alerts_for_ipmitool_output(textwrap.dedent("""\
-        9,04/20/2017,06:03:07,Power Unit #0xca,Failure detected,Asserted
+        26,09/15/2022,15:34:46,Voltage PVPP,Lower Non-recoverable going low,Asserted,Reading 0.12 < Threshold 2.17 Volts
     """)) == [
         Alert(
             IPMISELAlertClass,
             args=dict(
-                sensor="Power Unit #0xca",
-                event="Failure detected",
+                sensor="Voltage PVPP",
+                event="Lower Non-recoverable going low",
                 direction="Asserted",
-                verbose=None
+                verbose="Reading 0.12 < Threshold 2.17 Volts"
             ),
             _key=ANY,
-            datetime=datetime(2017, 4, 20, 6, 3, 7),
+            datetime=datetime(2022, 9, 15, 15, 34, 46),
         )
     ]
 


### PR DESCRIPTION
As pointed out by @rapperskull in PR: https://github.com/truenas/middleware/pull/10089, when calling `ipmitool` with the `elist` command, the hexadecimal value after the sensor name is removed. This fixes the sensor matching logic.

Original PR: https://github.com/truenas/middleware/pull/10399
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119810