### PR TITLE
NAS-119814 / 13.0 / Add ("Power Supply", "Fully Redundant") to IPMI_EVENTS_BLACKLIST (by rapperskull)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -142,6 +142,7 @@ class IPMISELAlertSource(AlertSource):
         ("Redundancy State", "Fully Redundant"),
         ("Processor", "Presence detected"),
         ("Power Supply", "Presence detected"),
+        ("Power Supply", "Fully Redundant"),
     )
 
     async def check(self):


### PR DESCRIPTION
I don't know where "Redundancy State" sensor came from (maybe OEM-specific?), but it's not a standard sensor type. Dell uses a "Power Supply" sensor to indicate the redundancy state.

Original PR: https://github.com/truenas/middleware/pull/10090
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119814