### PR TITLE
NAS-119829 / 23.10 / Ensure that DNS is updated on domain join

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -8,7 +8,7 @@ from sys import argv, exit
 import os
 import getopt
 import sys
-import random
+import secrets
 import string
 
 workdir = os.getcwd()
@@ -118,7 +118,7 @@ if 'ip' not in locals() and 'passwd' not in locals() and 'interface' not in loca
     exit()
 
 # create random hostname and random fake domain
-digit = ''.join(random.choices(string.digits, k=2))
+digit = ''.join(secrets.choice((string.ascii_uppercase + string.digits)) for i in range(10))
 hostname = f'test{digit}'
 domain = f'test{digit}.nb.ixsystems.com'
 artifacts = f"{workdir}/artifacts/"


### PR DESCRIPTION
Add private internal API endpoint to use nsupdate
to update DNS A and AAAA records for the TrueNAS
server. Use this when joining AD to ensure that
TrueNAS server functions properly in an AD
environment. This PR also extends the IPAddr
schema so that we can optionally filter based
on whether we want to disallow certain types of
IP addresses (like ones reserved for multicast).

Validation in AD plugin is also expanded to check
whether the specified netbios name is already in
use by another server on the network (to prevent
us from clobbering it on domain join).