### PR TITLE
NAS-119833 / 23.10 / Enable Nvidia GPU sharing for Apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -137,16 +137,16 @@ GPU_CONFIG = {
             'namespace': 'kube-system'
         },
         'data': {
-            'nvdefault.yaml': '''|
+            'nvdefault.yaml': """|
                 version: v1
-                sharing: 
-                  timeSlicing: 
-                  renameByDefault: false
-                  failRequestsGreaterThanOne: true
-                  resources: 
+                sharing:
+                  timeSlicing:
+                    renameByDefault: false
+                    failRequestsGreaterThanOne: true
+                    resources:
                     - name: nvidia.com/gpu
                       replicas: 5
-                '''
+                """
         }
     },
 }

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -138,15 +138,15 @@ GPU_CONFIG = {
         },
         'data': {
             'nvdefault.yaml': """|
-                version: v1
-                sharing:
-                  timeSlicing:
-                    renameByDefault: false
-                    failRequestsGreaterThanOne: true
-                    resources:
-                    - name: nvidia.com/gpu
-                      replicas: 5
-                """
+version: v1
+sharing:
+  timeSlicing:
+    renameByDefault: false
+    failRequestsGreaterThanOne: true
+    resources:
+    - name: nvidia.com/gpu
+      replicas: 5
+"""
         }
     },
 }

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -137,9 +137,16 @@ GPU_CONFIG = {
             'namespace': 'kube-system'
         },
         'data': {
-            'nvdefault.yaml': '''{version: v1, sharing: { timeSlicing: { renameByDefault:
-                false, failRequestsGreaterThanOne: true, resources: [{"name":
-                "nvidia.com/gpu", "replicas": 5}]}}}'''
+            'nvdefault.yaml': '''|
+                version: v1
+                sharing: 
+                  timeSlicing: 
+                  renameByDefault: false
+                  failRequestsGreaterThanOne: true
+                  resources: 
+                    - name: nvidia.com/gpu
+                      replicas: 5
+                '''
         }
     },
 }


### PR DESCRIPTION
In contrast to Intel, the Nvidia device plugin, only accepts device sharing configuration via a configfile.
This is the vital component to support multiple Apps using the same (supported) Nvidia GPU.

As the existing code did not allow the creation, updating and removal of configmaps, this PR adds a section to define said configmaps.

To prevent confusion between the config(maps) and the (device)plugin daemonset, things have been renamed accordingly. As the previous (device)plugin daemonsets where named "config".