### PR TITLE
NAS-119727 / 22.12.1 / Do not fail local groupmap sync on broken domains (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -130,9 +130,12 @@ class SMBService(Service):
 
         ad_state = await self.middleware.call('activedirectory.get_state')
         if ad_state == 'HEALTHY':
-            domain_info = await self.middleware.call('idmap.domain_info',
-                                                     'DS_TYPE_ACTIVEDIRECTORY')
-            domain_sid = domain_info['sid']
+            try:
+                domain_info = await self.middleware.call('idmap.domain_info',
+                                                         'DS_TYPE_ACTIVEDIRECTORY')
+                domain_sid = domain_info['sid']
+            except Exception:
+                self.logger.warning('Failed to retrieve idmap domain info', exc_info=True)
 
         """
         Administrators should only have local and domain admins, and a user-


### PR DESCRIPTION
Some users have semi-broken AD domains that on boot are inaccessible. Skip the AD-related component of groupmap synchronization in this case. We can pick it up again once user has fixed their domain.

Another situation where this can happen is if AD
Domain Controller is in VM or app hosted on this
server.

Original PR: https://github.com/truenas/middleware/pull/10417
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119727