### PR TITLE
NAS-119839 / 23.10 / prevent console error log spam

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1025,6 +1025,8 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             )
         )
 
+    console_error_counter = 0
+
     def _console_write(self, text, fill_blank=True, append=False):
         """
         Helper method to write the progress of middlewared loading to the
@@ -1033,6 +1035,15 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         There are some cases where loading will take a considerable amount of time,
         giving user at least some basic feedback is fundamental.
         """
+        console_error_log_max = 3
+        if self.console_error_counter == console_error_log_max:
+            # sigh, truenas is installed on "gamer" hardware which
+            # is miserable. The amount of quirks seen on this style
+            # of hardware is astounding really. If we continually
+            # fail to log to console, there is no reason to spam
+            # our log file with it.
+            return
+
         # False means we are running in a terminal, no console needed
         self.logger.trace('_console_write %r', text)
         if self.__console_io is False:
@@ -1044,6 +1055,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             try:
                 self.__console_io = open('/dev/console', 'w')
             except Exception:
+                self.console_error_counter += 1
                 return
             try:
                 # We need to make sure we only try to write to console one time
@@ -1075,9 +1087,15 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             self.__console_io.flush()
             return writes
         except OSError:
+            self.console_error_counter += 1
             self.logger.debug('Failed to write to console', exc_info=True)
         except Exception:
+            self.console_error_counter += 1
             pass
+
+        # be sure and reset error counter after we successfully log
+        # to the console
+        self.console_error_counter = 0
 
     def __notify_startup_progress(self):
         systemd_notify(f'EXTEND_TIMEOUT_USEC={SYSTEMD_EXTEND_USECS}')


### PR DESCRIPTION
Seen on a user that ran their truenas on "gamer" hardware. We constantly spammed log files with Input/Output error when we tried to flush the console messages.