### PR TITLE
NAS-119842 / 22.12.1 / only run nvdimm alert on proper m-series (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/nvdimm.py
+++ b/src/middlewared/middlewared/alert/source/nvdimm.py
@@ -46,7 +46,7 @@ class NVDIMMAlertSource(ThreadedAlertSource):
 
     def check_sync(self):
         alerts = []
-        if self.middleware.call_sync('failover.hardware') != 'BHYVE':
+        if self.middleware.call_sync('truenas.get_chassis_hardware').endswith(('M40', 'M50', 'M60')):
             for nvdimm in self.get_ndctl_output():
                 lifetime = 100 - nvdimm['health']['life_used_percentage']
                 alert = None


### PR DESCRIPTION
We have an M30 which does not have an NVDIMM, so only run this alert on the proper m-series platforms.

Original PR: https://github.com/truenas/middleware/pull/10423
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119842