### PR TITLE
NAS-119780 / 13.0 / fix crash during pool expansion

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/expand.py
+++ b/src/middlewared/middlewared/plugins/pool_/expand.py
@@ -100,8 +100,13 @@ class PoolService(Service):
 
     async def _resize_disk(self, part_data, encrypted_pool, geli_resize):
         partition_number = part_data['partition_number']
-        if not part_data['disk'].startswith(('nvd', 'vtbd', 'pmem')):
-            await run('camcontrol', 'reprobe', part_data['disk'])
+        if part_data['disk'].startswith(('da', 'ada', 'nda', 'sdda', 'cd')):
+            try:
+                await run('camcontrol', 'reprobe', part_data['disk'])
+            except Exception:
+                # this isn't fatal
+                self.logger.warning('Failed to camcontrol reprobe {part_data["disk"]!r}', exc_info=True)
+
         await run('gpart', 'recover', part_data['disk'])
         await run('gpart', 'resize', '-a', '4k', '-i', str(partition_number), part_data['disk'])
 

--- a/src/middlewared/middlewared/plugins/pool_/expand.py
+++ b/src/middlewared/middlewared/plugins/pool_/expand.py
@@ -105,7 +105,7 @@ class PoolService(Service):
                 await run('camcontrol', 'reprobe', part_data['disk'])
             except Exception:
                 # this isn't fatal
-                self.logger.warning('Failed to camcontrol reprobe {part_data["disk"]!r}', exc_info=True)
+                self.logger.warning(f'Failed to camcontrol reprobe {part_data["disk"]!r}', exc_info=True)
 
         await run('gpart', 'recover', part_data['disk'])
         await run('gpart', 'resize', '-a', '4k', '-i', str(partition_number), part_data['disk'])


### PR DESCRIPTION
Fix 2 primary problems:
1. only run `camcontrol reprobe` on disks that use CAM subsystem
2. don't crash here, log a warning and move on