### PR TITLE
NAS-119707 / 23.10 / fix applying sysctl tunables on upgrade from 22.02

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-01-13_17-44_fix_tunable_type.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-01-13_17-44_fix_tunable_type.py
@@ -1,0 +1,25 @@
+"""upper-case tun_type column in system_tunable table
+
+Revision ID: d81ede53eb14
+Revises: 82ad1e72a7f0
+Create Date: 2023-01-13 17:44:37.982722+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd81ede53eb14'
+down_revision = '82ad1e72a7f0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute('UPDATE system_tunable SET tun_type = "SYSCTL" where tun_type = "sysctl"')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/tunables.py
+++ b/src/middlewared/middlewared/plugins/tunables.py
@@ -99,13 +99,12 @@ class TunableService(CRUDService):
             if data['var'] not in await self.middleware.call('tunable.get_sysctls'):
                 verrors.add('tunable_create.var', f'Sysctl {data["var"]!r} does not exist in kernel.', errno.ENOENT)
 
-        if data['type'] == 'UDEV':
-            if 'truenas' in data['var']:
-                verrors.add(
-                    'tunable_create.var',
-                    'Udev rules with `truenas` in their name are not allowed.',
-                    errno.EPERM,
-                )
+        if data['type'] == 'UDEV' and 'truenas' in data['var']:
+            verrors.add(
+                'tunable_create.var',
+                'Udev rules with `truenas` in their name are not allowed.',
+                errno.EPERM,
+            )
 
         verrors.check()
 


### PR DESCRIPTION
In Angelfish we were writing the `tun_type` column in lower-case but this plugin was fixed in Bluefin and that subtle (confusing) detail was missed. This makes it so that anyone upgrading from 22.02 with sysctl tunables set will be recognized and applied on upgrade to 22.12.1+