### PR TITLE
NAS-119833 / 23.10 / Allow time slicing for NVIDIA gpu

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/configmaps.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/configmaps.py
@@ -1,18 +1,13 @@
-from middlewared.service import CRUDService, filterable
-from middlewared.utils import filter_list
+from middlewared.service import CRUDService
 
+from .k8s_base_resources import KubernetesBaseResource
 from .k8s import Configmap
 
 
-class KubernetesSecretService(CRUDService):
+class KubernetesSecretService(KubernetesBaseResource, CRUDService):
+
+    KUBERNETES_RESOURCE = Configmap
 
     class Config:
         namespace = 'k8s.configmap'
         private = True
-
-    @filterable
-    async def query(self, filters, options):
-        options = options or {}
-        label_selector = options.get('extra', {}).get('labelSelector')
-        kwargs = {k: v for k, v in [('labelSelector', label_selector)] if v}
-        return filter_list((await Configmap.query(**kwargs))['items'], filters, options)


### PR DESCRIPTION
## Context

A PR (https://github.com/truenas/middleware/pull/10411) was raised by @Ornias1993 to add timeslicing support recently added to nvidia device plugin.

This continues on those changes and adds support to allow using a single NVIDIA gpu in multiple apps defaulting to 5 apps similar to what we do for AMD.