### PR TITLE
NAS-119873 / 23.10 / Fix image update header parsing

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
@@ -58,9 +58,9 @@ def parse_auth_header(header: str):
     parts = header.split()
     if len(parts) > 1:
         for part in parts[1].split(','):
-            key, value = part.split('=')
-            if key in adapter:
-                results[adapter[key]] = value.strip('"')
+            key_value = part.split('=')
+            if len(key_value) == 2 and key_value[0] in adapter:
+                results[adapter[key_value[0]]] = key_value[1].strip('"')
     return results
 
 


### PR DESCRIPTION
I have not been able to reproduce this but saw the following traceback in a debug and fixed appropriately:
```
future: <Task finished name='Task-6148' coro=<Middleware.call() done, defined at /usr/lib/python3/dist-packages/middlewared/main.py:1362> exception=ValueError('not enough values to unpack (expected 2, got 1)')>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1368, in call
    return await self._call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1317, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/update_alerts.py", line 34, in check_update
    await self.check_update_for_image(tag, image)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/update_alerts.py", line 58, in check_update_for_image
    self.IMAGE_CACHE[tag] = await self.compare_id_digests(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/update_alerts.py", line 74, in compare_id_digests
    digest = await self._get_repo_digest(registry, image_str, tag_str)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/client.py", line 137, in _get_repo_digest
    response = await self._get_manifest_response(
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/client.py", line 119, in _get_manifest_response
    auth_data = parse_auth_header(error.headers[DOCKER_AUTH_HEADER])
  File "/usr/lib/python3/dist-packages/middlewared/plugins/container_runtime_interface/client.py", line 61, in parse_auth_header
    key, value = part.split('=')
ValueError: not enough values to unpack (expected 2, got 1)
```