### PR TITLE
NAS-119893 / 22.12.1 / Fix AD start edge case for when keytab is entirely missing (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -452,6 +452,13 @@ class KerberosService(TDBWrapConfigService):
             )
 
         if has_principal:
+            principals = await self.middleware.call('kerberos.keytab.kerberos_principal_choices')
+            if creds['kerberos_principal'] not in principals:
+                self.logger.debug('Selected kerberos principal [%s] not available in keytab principals: %s. '
+                                  'Regenerating kerberos keytab from configuration file.',
+                                  creds['kerberos_principal'], ','.join(principals))
+                await self.middleware.call('etc.generate', 'kerberos')
+
             cmd.extend(['-k', creds['kerberos_principal']])
             kinit = await run(cmd, check=False)
             if kinit.returncode != 0:


### PR DESCRIPTION
Generate krb5.keytab if necessary during kinit.

Original PR: https://github.com/truenas/middleware/pull/10468
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119893