### PR TITLE
NAS-119630 / 22.12.1 / Allow users to download openvpn client configuration (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -179,10 +179,11 @@ class OpenVPN:
         return verrors
 
     @staticmethod
-    async def common_validation(middleware, data, schema, mode):
+    async def common_validation(middleware, data, schema, mode, skip_port_validation=False):
         verrors = ValidationErrors()
 
-        verrors.extend(await validate_port(middleware, f'{schema}.port', data['port'], f'openvpn.{mode}'))
+        if not skip_port_validation:
+            verrors.extend(await validate_port(middleware, f'{schema}.port', data['port'], f'openvpn.{mode}'))
 
         if data['cipher'] and data['cipher'] not in OpenVPN.ciphers():
             verrors.add(
@@ -441,7 +442,7 @@ class OpenVPNServerService(SystemServiceService):
                     self.middleware, {
                         **config,
                         'client_certificate': client_certificate_id
-                    }, '', 'client'
+                    }, '', 'client', True
                 )
             )[0]
             if verrors:


### PR DESCRIPTION
This commit fixes an issue where when downloading a client configuration for openvpn server service, we errored out saying specified port is being used by the server. Now what is actually happening is that the service running is server but as we wanted to download client configuration, the config we wanted to validate was related to the client instead and hence it started checking the specified port in it as well which is invalid. So we now skip port validation when downloading client configuration as that's a no-op.

Original PR: https://github.com/truenas/middleware/pull/10453
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119630