### PR TITLE
NAS-119196 / 23.10 / fix webui dashboard caching issues on HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -123,7 +123,7 @@ class FailoverEventsService(Service):
             wait_id = await self.middleware.call('core.job_wait', jobid)
             await wait_id.wait(raise_error=True)
         except (CallError, KeyError):
-            # `CallErro` means the failover job didn't complete successfully
+            # `CallError` means the failover job didn't complete successfully
             # but we still want to refresh status in this scenario
             # `KeyError` shouldn't be possible but there exists a hypothetical
             # race condition...but we still want to refresh status


### PR DESCRIPTION
The webUI team subscribes to `failover.disabled.reasons` but when the standby controller reboots, the last message they get on the active controller is `{"msg": "changed", "collection": "failover.disabled.reasons", "fields": {"disabled_reasons": ["REM_FAILOVER_ONGOING"]}}`. After the failover job on the standby controller completes, we need to refresh the failover status on the active controller to ensure the webUI team receives an event with an empty (hopefully) `disabled_reasons` field so that the dashboard widget(s) and the HA status icon can reflect reality. Without these changes, rebooting the standby will never show back up on the dashboard which leads to perceiving a false reality.