### PR TITLE
NAS-119903 / 22.12.1 / Improve teardown after krb+nfs4 test module done (by anodos325)

### DIFF
--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -53,14 +53,16 @@ test_flags = {
 
 @pytest.fixture(scope="module")
 def kerberos_config(request):
-    payload = {"v4_krb": True}
+    results = PUT("/nfs/", {"v4_krb": True})
     results = PUT("/nfs/", payload)
     assert results.status_code == 200, results.text
     try:
         yield (request, results.json())
     finally:
-        payload = {"v4_krb": False}
-        results = PUT("/nfs/", payload)
+        results = POST('/service/stop/', {'service': 'nfs'})
+        assert results.status_code == 200, results.text
+
+        results = PUT("/nfs/", {"v4_krb": False})
         assert results.status_code == 200, results.text
 
 


### PR DESCRIPTION
We should ensure that NFS service is stopped when we are done.

Original PR: https://github.com/truenas/middleware/pull/10476
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119903