### PR TITLE
NAS-119906 / 13.0 / Backport extra kerberos realm id validation

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -367,6 +367,13 @@ class ActiveDirectoryService(ConfigService):
 
     @private
     async def common_validate(self, new, old, verrors):
+        if new['kerberos_realm'] and new['kerberos_realm'] != old['kerberos_realm']:
+            if not await self.middleware.call('kerberos.realm.query', [("id", "=", new['kerberos_realm'])]):
+                verrors.add(
+                    'activedirectory_update.kerberos_realm',
+                    'Invalid Kerberos realm id. Realm does not exist.'
+                )
+
         if not new["enable"]:
             return
 


### PR DESCRIPTION
This was added to SCALE whilst writing clustering for AD and not backported to 13.