### PR TITLE
NAS-119919 / 23.10 / Fix regex for retrieving valid usb passthrough choices

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -10,7 +10,7 @@ from .devices.usb import USB_CONTROLLER_CHOICES
 from .utils import get_virsh_command_args
 
 
-RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+$')
+RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+(_\d)*$')
 
 
 class VMDeviceService(Service):


### PR DESCRIPTION
This commit fixes an issue where if a USB hub is being used, the naming scheme for the devices change from usb_5_1 to usb_5_1_1 / usb_5_1_2.