### PR TITLE
NAS-119920 / 23.10 / Fix sysdataset move

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/wsdd.conf.mako
@@ -12,12 +12,9 @@
                 enabled = False
 
     smb_config = middleware.call_sync('smb.config')
-    if smb_config['bindip']:
-        interfaces = config['bind_ip']
-    else:
-        # We use bindip_choices because this is cluster-aware and will
-        # give ctdb public IPs
-        interfaces = list(middleware.call_sync('smb.bindip_choices').values())
+
+    # We use bindip_choices because this is cluster-aware and will give ctdb public IPs
+    interfaces = smb_config['bindip'] or list(middleware.call_sync('smb.bindip_choices').values())
 
     conf = {
         'realm': middleware.call_sync('smb.getparm', 'realm', 'GLOBAL'),

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -581,7 +581,7 @@ class SystemDatasetService(ConfigService):
         flags = '-f' if not self.middleware.call_sync('failover.licensed') else '-l'
         for dataset, name in reversed(self.__get_datasets(pool, uuid)):
             try:
-                subprocess.run(['umount', flags, dataset])
+                subprocess.run(['umount', flags, dataset], check=True, capture_output=True)
             except subprocess.CalledProcessError as e:
                 stderr = e.stderr.decode()
                 if 'no mount point specified' in stderr:
@@ -684,6 +684,8 @@ class SystemDatasetService(ConfigService):
                 restart.append('idmap')
             if self.middleware.call_sync('service.started', 'nmbd'):
                 restart.append('nmbd')
+            if self.middleware.call_sync('service.started', 'wsdd'):
+                restart.append('wsdd')
 
             try:
                 self.middleware.call_sync('cache.put', 'use_syslog_dataset', False)


### PR DESCRIPTION
Wsdd can now have an open handle on its log file and so we need to toggle the service while moving around the system dataset.

This PR also fixes error handling for unmounting
filesystems during system dataset move.