### PR TITLE
NAS-119926 / 23.10 / Improve valid usb device regex

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -10,7 +10,7 @@ from .devices.usb import USB_CONTROLLER_CHOICES
 from .utils import get_virsh_command_args
 
 
-RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+(_\d)*$')
+RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+(?:_\d)*$')
 
 
 class VMDeviceService(Service):


### PR DESCRIPTION
For completeness, making extra `_\d` group as non-capturing so that complete USB device is returned appropriately.