### PR TITLE
NAS-119926 / 22.12.1 / Improve valid usb device regex (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -10,7 +10,7 @@ from .devices.usb import USB_CONTROLLER_CHOICES
 from .utils import get_virsh_command_args
 
 
-RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+(_\d)*$')
+RE_VALID_USB_DEVICE = re.compile(r'^usb_\d+_\d+(?:_\d)*$')
 
 
 class VMDeviceService(Service):


### PR DESCRIPTION
For completeness, making extra `_\d` group as non-capturing so that complete USB device is returned appropriately.

Original PR: https://github.com/truenas/middleware/pull/10501
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119926