### PR TITLE
NAS-119928 / 23.10 / Do not report GPUs if their count is 0 in k8s

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -168,7 +168,7 @@ class KubernetesGPUService(Service):
         )['configure_gpus'] else set()
         available_gpus = {}
         for k, v in filter(
-            lambda i: i[0].endswith('/gpu') or i[0].startswith('gpu.intel'),
+            lambda i: (i[0].endswith('/gpu') or i[0].startswith('gpu.intel')) and i[1] != '0',
             node_config['status']['allocatable'].items()
         ):
             available_gpus[k] = v if any(gpu.lower() in k.lower() for gpu in found_gpus) else '0'


### PR DESCRIPTION
K8s will keep on reporting GPUs even if they have been removed from the system. Its not an issue per-se but just a bit confusing as the value for the GPU resource would be 0 which equates to it not being present. So let's filter that out on our end as well.