### PR TITLE
NAS-119819 / 23.10 / Allow users to enable metrics server in k3s

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-01-20_00-15_k3s_metrics_server.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-01-20_00-15_k3s_metrics_server.py
@@ -1,0 +1,22 @@
+"""Add apps metrics server
+Revision ID: 9c44b7e06dff
+Revises: 2bef686cbf7d
+Create Date: 2023-01-20 00:20:00.702138+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '9c44b7e06dff'
+down_revision = '2bef686cbf7d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('metrics_server', sa.Boolean(), server_default='0', nullable=False))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -35,6 +35,9 @@ def render(service, middleware):
         'max-pods=250',
     ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
+
+    features_mapping = {'servicelb': 'servicelb', 'metrics_server': 'metrics-server'}
+
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({
             'cluster-cidr': config['cluster_cidr'],
@@ -49,7 +52,7 @@ def render(service, middleware):
             'kube-apiserver-arg': kube_api_server_args,
             'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
-            'disable': [] if config['servicelb'] else ['servicelb'],
+            'disable': [features_mapping[feature] for feature in features_mapping if not config[feature]],
         }))
 
     with open('/etc/containerd.json', 'w') as f:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -31,6 +31,7 @@ class KubernetesModel(sa.Model):
     servicelb = sa.Column(sa.Boolean(), default=True, nullable=False)
     validate_host_path = sa.Column(sa.Boolean(), default=True)
     passthrough_mode = sa.Column(sa.Boolean(), default=False)
+    metrics_server = sa.Column(sa.Boolean(), default=False, nullable=False)
 
 
 class KubernetesService(ConfigService):
@@ -44,6 +45,7 @@ class KubernetesService(ConfigService):
         'kubernetes_entry',
         Bool('servicelb', required=True),
         Bool('configure_gpus', required=True),
+        Bool('metrics_server', required=True),
         Bool('validate_host_path', required=True),
         Bool('passthrough_mode', required=True),
         Str('pool', required=True, null=True),
@@ -445,6 +447,9 @@ class KubernetesService(ConfigService):
         `force` is a boolean which can be set to bypass validation which does not allow users to select a pool which
         is potentially corrupt by having a partially initialized ix-applications dataset. In that case the cluster
         would be re-initialized and user would still be able to select such a pool.
+
+        `metrics_server` is a boolean to enable or disable the integrated k3s Metrics Server. This can be set
+        to enabled to enable the user to use of Kubernetes Horizontal/Vertical Pod Autoscalers.
         """
         old_config = await self.config()
         old_config.pop('dataset')


### PR DESCRIPTION
@Ornias1993 opened up a PR adding changes to enable/disable metrics server in k3s which right now is disabled by default. This refactors some changes and upgrades migration to the changes.

https://github.com/truenas/k3s/pull/32 should be merged once this has been merged.