### PR TITLE
TE-167 / 22.12.1 / Fixing changing disk['size'] from string to int in optimal_disk_usage

### DIFF
--- a/tests/api2/test_boot_format.py
+++ b/tests/api2/test_boot_format.py
@@ -5,7 +5,7 @@ def test_optimal_disk_usage():
     disk = call('disk.get_unused')[0]
     swap_size = 1024 * 1024 * 1024
     data_size = (
-        disk['size'] -
+        int(disk['size']) -
         1 * 1024 * 1024 -  # BIOS boot
         512 * 1024 * 1024 -  # EFI
         swap_size -


### PR DESCRIPTION
To avoid this error `TypeError: unsupported operand type(s) for -: 'str' and 'int'`