### PR TITLE
NAS-119932 / 23.10 / Allow tying app version to SCALE releases

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/features.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/features.py
@@ -5,6 +5,8 @@ import os
 from catalog_validation.items.features import SUPPORTED_FEATURES
 from middlewared.service import CallError, private, Service
 
+from .items_util import minimum_scale_version_check_update_impl
+
 
 class CatalogService(Service):
 
@@ -36,7 +38,29 @@ class CatalogService(Service):
         if not version_details['healthy']:
             raise CallError(version_details['healthy_error'])
 
+        # There will be 2 scenarios now because of which a version might not be supported
+        # 1) Missing features
+        # 2) Minimum scale version check specified
+
+        error_str = ''
         missing_features = set(version_details['required_features']) - SUPPORTED_FEATURES
+        if missing_features:
+            error_str = await self.missing_feature_error_message(missing_features)
+
+        version_check, check_error = minimum_scale_version_check_update_impl(version_details)
+        if not version_check:
+            prefix = '\n\n' if error_str else ''
+            error_str = f'{error_str}{prefix}Catalog item version{" also" if error_str else ""} has ' \
+                        'minimum SCALE version specified '
+            if check_error:
+                error_str += 'which is invalid and system is not able to determine if item version is supported or not.'
+            else:
+                error_str += 'which is newer then current SCALE version.'
+
+        raise CallError(error_str)
+
+    @private
+    async def missing_feature_error_message(self, missing_features):
         try:
             mapping = await self.middleware.call('catalog.get_feature_map')
         except Exception as e:
@@ -55,4 +79,4 @@ class CatalogService(Service):
 
             error_str += f'{index + 1}) {feature}{f"{train_message}" if train_message else ""}\n\n'
 
-        raise CallError(error_str)
+        return error_str

--- a/src/middlewared/middlewared/plugins/catalogs_linux/features.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/features.py
@@ -47,7 +47,7 @@ class CatalogService(Service):
         if missing_features:
             error_str = await self.missing_feature_error_message(missing_features)
 
-        version_check, check_error = minimum_scale_version_check_update_impl(version_details)
+        version_check, check_error = minimum_scale_version_check_update_impl(version_details, False)
         if not version_check:
             prefix = '\n\n' if error_str else ''
             error_str = f'{error_str}{prefix}Catalog item version{" also" if error_str else ""} has ' \

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -7,7 +7,7 @@ from catalog_validation.items.items_util import (
 
 from middlewared.plugins.chart_releases_linux.schema import construct_schema
 from middlewared.plugins.update_.utils import can_update
-from middlewared.utils import manifest_version
+from middlewared.utils import sw_version
 
 
 def get_item_default_values(version_details: dict) -> dict:
@@ -30,8 +30,8 @@ def minimum_scale_version_check_update_impl(
         not check_supported_key or version_details['supported']
     ):
         try:
-            if manifest_version() != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
-                version_details['chart_metadata']['minimum_scale_version'], manifest_version()
+            if sw_version(False) != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
+                version_details['chart_metadata']['minimum_scale_version'], sw_version(False)
             ):
                 return False, False
         except Exception:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -7,7 +7,7 @@ from catalog_validation.items.items_util import (
 
 from middlewared.plugins.chart_releases_linux.schema import construct_schema
 from middlewared.plugins.update_.utils import can_update
-from middlewared.utils import sw_version
+from middlewared.utils import sw_info
 
 
 def get_item_default_values(version_details: dict) -> dict:
@@ -30,8 +30,8 @@ def minimum_scale_version_check_update_impl(
         not check_supported_key or version_details['supported']
     ):
         try:
-            if sw_version(False) != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
-                version_details['chart_metadata']['minimum_scale_version'], sw_version(False)
+            if sw_info()['version'] != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
+                version_details['chart_metadata']['minimum_scale_version'], sw_info()['version']
             ):
                 return False, False
         except Exception:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -53,7 +53,7 @@ def get_item_details(item_location: str, questions_context: dict, options: dict)
     return item_details
 
 
-def get_item_version_details(version_path: str, questions_context: dict, scale_version: str) -> dict:
+def get_item_version_details(version_path: str, questions_context: dict) -> dict:
     return minimum_scale_version_check_update(get_catalog_item_version_details(version_path, questions_context, {
         'default_values_callable': get_item_default_values,
     }))

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -1,3 +1,5 @@
+import typing
+
 from catalog_validation.items.items_util import (
     get_item_details as get_catalog_item_details,
     get_item_version_details as get_catalog_item_version_details,
@@ -12,7 +14,12 @@ def get_item_default_values(version_details: dict) -> dict:
     return construct_schema(version_details, {}, False)['new_values']
 
 
-def minimum_scale_version_check_update(version_details):
+def minimum_scale_version_check_update(version_details: dict) -> dict:
+    version_details['supported'] = minimum_scale_version_check_update_impl(version_details)[0]
+    return version_details
+
+
+def minimum_scale_version_check_update_impl(version_details: dict) -> typing.Tuple[bool, bool]:
     if (
         version_details['healthy'] and version_details['supported'] and version_details['chart_metadata'].get(
             'minimum_scale_version'
@@ -20,15 +27,15 @@ def minimum_scale_version_check_update(version_details):
     ):
         try:
             if manifest_version() != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
-                    version_details['chart_metadata']['minimum_scale_version'], manifest_version()
+                version_details['chart_metadata']['minimum_scale_version'], manifest_version()
             ):
-                version_details['supported'] = False
+                return False, False
         except Exception:
             # In case invalid version string is specified we don't want a traceback here
             # let's just explicitly not support the app version in question
-            version_details['supported'] = False
+            return False, True
 
-    return version_details
+    return True, False
 
 
 def get_item_details(item_location: str, questions_context: dict, options: dict) -> dict:

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -18,9 +18,14 @@ def minimum_scale_version_check_update(version_details):
             'minimum_scale_version'
         )
     ):
-        if manifest_version() != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
-                version_details['chart_metadata']['minimum_scale_version'], manifest_version()
-        ):
+        try:
+            if manifest_version() != version_details['chart_metadata']['minimum_scale_version'] and not can_update(
+                    version_details['chart_metadata']['minimum_scale_version'], manifest_version()
+            ):
+                version_details['supported'] = False
+        except Exception:
+            # In case invalid version string is specified we don't want a traceback here
+            # let's just explicitly not support the app version in question
             version_details['supported'] = False
 
     return version_details

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -19,11 +19,15 @@ def minimum_scale_version_check_update(version_details: dict) -> dict:
     return version_details
 
 
-def minimum_scale_version_check_update_impl(version_details: dict) -> typing.Tuple[bool, bool]:
-    if (
-        version_details['healthy'] and version_details['supported'] and version_details['chart_metadata'].get(
-            'minimum_scale_version'
-        )
+def minimum_scale_version_check_update_impl(
+    version_details: dict, check_supported_key: bool = True
+) -> typing.Tuple[bool, bool]:
+    # `check_supported_key` is used because when catalog validation returns the data it only checks the
+    # missing features and based on that makes the decision. So if something is not already supported
+    # we do not want to validate minimum scale version in that case. However, when we want to report to
+    # the user as to why exactly the app version is not supported, we need to be able to make that distinction
+    if version_details['healthy'] and version_details['chart_metadata'].get('minimum_scale_version') and (
+        not check_supported_key or version_details['supported']
     ):
         try:
             if manifest_version() != version_details['chart_metadata']['minimum_scale_version'] and not can_update(

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from middlewared.service import CallError, private, Service
-from middlewared.utils import sw_version
+from middlewared.utils import sw_info
 
 from .utils import can_update
 from .utils_linux import mount_update
@@ -33,7 +33,7 @@ class UpdateService(Service):
             with open(os.path.join(mounted, "manifest.json")) as f:
                 manifest = json.load(f)
 
-            old_version = sw_version(False)
+            old_version = sw_info()['version']
             new_version = manifest["version"]
             if old_version == new_version:
                 raise CallError(f'You already are using {new_version}')

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from middlewared.service import CallError, private, Service
+from middlewared.utils import manifest_version
 
 from .utils import SCALE_MANIFEST_FILE, can_update
 from .utils_linux import mount_update
@@ -27,15 +28,12 @@ class UpdateService(Service):
         )
 
     def _install(self, path, progress_callback, options=None):
-        with open(SCALE_MANIFEST_FILE) as f:
-            old_manifest = json.load(f)
-
         progress_callback(0, "Reading update file")
         with mount_update(path) as mounted:
             with open(os.path.join(mounted, "manifest.json")) as f:
                 manifest = json.load(f)
 
-            old_version = old_manifest["version"]
+            old_version = manifest_version()
             new_version = manifest["version"]
             if old_version == new_version:
                 raise CallError(f'You already are using {new_version}')

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from middlewared.service import CallError, private, Service
-from middlewared.utils import manifest_version
+from middlewared.utils import sw_version
 
 from .utils import can_update
 from .utils_linux import mount_update
@@ -33,7 +33,7 @@ class UpdateService(Service):
             with open(os.path.join(mounted, "manifest.json")) as f:
                 manifest = json.load(f)
 
-            old_version = manifest_version()
+            old_version = sw_version(False)
             new_version = manifest["version"]
             if old_version == new_version:
                 raise CallError(f'You already are using {new_version}')

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -5,7 +5,7 @@ import os
 from middlewared.service import CallError, private, Service
 from middlewared.utils import manifest_version
 
-from .utils import SCALE_MANIFEST_FILE, can_update
+from .utils import can_update
 from .utils_linux import mount_update
 
 logger = logging.getLogger(__name__)

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 import logging
 import re
 import signal
@@ -266,11 +265,6 @@ def sw_version(fullname=True):
         (i.e. 22.12.0 instead of TrueNAS-SCALE-22.12.0)
     """
     return sw_info()['fullname' if fullname else 'version']
-
-
-@functools.cache
-def manifest_version():
-    return osc.get_app_version()['version']
 
 
 def sw_version_is_stable():

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import re
 import signal
@@ -265,6 +266,11 @@ def sw_version(fullname=True):
         (i.e. 22.12.0 instead of TrueNAS-SCALE-22.12.0)
     """
     return sw_info()['fullname' if fullname else 'version']
+
+
+@functools.cache
+def manifest_version():
+    return osc.get_app_version()['version']
 
 
 def sw_version_is_stable():


### PR DESCRIPTION
This PR adds functionality to be able to specify app version to SCALE releases so for example if an app has specified that it can only be installed on Bluefin or above, Angelfish users should not be able to install or upgrade to that app version.
This essentially adds a baseline version which devs can specify so systems on that version or above that version can proceed with installation or upgrade of the app version in question.