### PR TITLE
NAS-119985 / 23.10 / Allow splitting up location of pam block info

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/common-account.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-account.mako
@@ -8,9 +8,10 @@
 #
 <%namespace name="pam" file="pam.inc.mako" />\
 <%
-        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx)
+        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx).pam_account()
 %>\
 
-${dsp.pam_account()}
+${'\n'.join(dsp['primary'])}
 account	requisite			pam_deny.so
 account	required			pam_permit.so
+${'\n'.join(dsp['additional'])}

--- a/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
@@ -9,9 +9,10 @@
 
 <%namespace name="pam" file="pam.inc.mako" />\
 <%
-        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx)
+        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx).pam_auth()
 %>\
 
-${dsp.pam_auth()}
+${'\n'.join(dsp['primary'])}
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
+${'\n'.join(dsp['additional'])}

--- a/src/middlewared/middlewared/etc_files/pam.d/common-password.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-password.mako
@@ -17,9 +17,10 @@
 
 <%namespace name="pam" file="pam.inc.mako" />\
 <%
-        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx)
+        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx).pam_password()
 %>\
 
-${dsp.pam_password()}
+${'\n'.join(dsp['primary'])}
 password	requisite			pam_deny.so
 password	required			pam_permit.so
+${'\n'.join(dsp['additional'])}

--- a/src/middlewared/middlewared/etc_files/pam.d/common-session-noninteractive.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-session-noninteractive.mako
@@ -8,20 +8,11 @@
 #
 <%namespace name="pam" file="pam.inc.mako" />\
 <%
-        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx)
+        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx).pam_session()
 %>\
 
-# here are the per-package modules (the "Primary" block)
+${'\n'.join(dsp['primary'])}
 session	[default=1]			pam_permit.so
-# here's the fallback if no module succeeds
 session	requisite			pam_deny.so
-# prime the stack with a positive return value if there isn't one already;
-# this avoids us returning an error just because nothing sets a success code
-# since the modules above will each just jump around
 session	required			pam_permit.so
-# and here are more per-package modules (the "Additional" block)
-session	required	pam_unix.so
-% if dsp.enabled() and dsp.name() != 'NIS':
-${dsp.pam_session()}
-% endif
-# end of pam-auth-update config
+${'\n'.join(dsp['additional'])}

--- a/src/middlewared/middlewared/etc_files/pam.d/common-session.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-session.mako
@@ -8,18 +8,12 @@
 
 <%namespace name="pam" file="pam.inc.mako" />\
 <%
-        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx)
+        dsp = pam.getDirectoryServicePam(middleware=middleware, render_ctx=render_ctx).pam_session()
 %>\
 
-# here are the per-package modules (the "Primary" block)
+${'\n'.join(dsp['primary'])}
 session	[default=1]			pam_permit.so
-# here's the fallback if no module succeeds
 session	requisite			pam_deny.so
-# prime the stack with a positive return value if there isn't one already;
-# this avoids us returning an error just because nothing sets a success code
-# since the modules above will each just jump around
 session	required			pam_permit.so
-# and here are more per-package modules (the "Additional" block)
-${dsp.pam_session()}
-session	optional	pam_systemd.so
-# end of pam-auth-update config
+session	optional			pam_systemd.so
+${'\n'.join(dsp['additional'])}

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1179,11 +1179,11 @@ class LDAPService(TDBWrapConfigService):
             job.set_progress(70, 'Storing LDAP password for SMB configuration')
             await self.middleware.call('smb.store_ldap_admin_password')
 
-        await self._service_change('cifs', 'restart')
         await self.set_state(DSStatus['HEALTHY'])
-        job.set_progress(80, 'Reloading directory service cache.')
+        job.set_progress(80, 'Restarting dependent services')
         cache_job = await self.middleware.call('dscache.refresh')
         await cache_job.wait()
+        await self.middleware.call('directoryservices.restart_dependent_services')
 
         ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
         if ha_mode == 'CLUSTERED':

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -11,13 +11,54 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, is_agent_setup, if_key_listed, SSH_TEST, make_ws_request
-from auto_config import sshKey, user, password, ha
+from auto_config import sshKey, user, password, ha, hostname
+from assets.REST.directory_services import active_directory, ldap, override_nameservers
 from middlewared.test.integration.utils import call
+
+try:
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+except ImportError:
+    Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
+    pytestmark = pytest.mark.skip(reason=Reason)
+
+try:
+    from config import (
+        LDAPBASEDN,
+        LDAPBINDDN,
+        LDAPBINDPASSWORD,
+        LDAPHOSTNAME,
+        LDAPUSER,
+        LDAPPASSWORD
+    )
+except ImportError:
+    Reason = 'LDAP* variable are not setup in config.py'
+    pytestmark = pytest.mark.skipif(True, reason=Reason)
+
 
 if "controller1_ip" in os.environ:
     ip = os.environ["controller1_ip"]
 else:
     from auto_config import ip
+
+
+@pytest.fixture(scope="function")
+def do_ad_connection(request):
+    with override_nameservers(ADNameServer):
+        with active_directory(
+            AD_DOMAIN,
+            ADUSERNAME,
+            ADPASSWORD,
+            netbiosname=hostname,
+        ) as ad:
+            yield (request, ad)
+
+
+@pytest.fixture(scope="function")
+def do_ldap_connection(request):
+    with ldap(LDAPBASEDN, LDAPBINDDN, LDAPBINDPASSWORD, LDAPHOSTNAME,
+        has_samba_schema=True,
+    ) as ldap_conn:
+        yield (request, ldap_conn)
 
 
 def test_00_firstboot_checks():
@@ -121,13 +162,30 @@ def test_07_Ensure_ssh_agent_is_setup(request):
     assert is_agent_setup() is True
 
 
-def test_08_Ensure_ssh_key_is_up(request):
+def test_08_test_ssh_ad(do_ad_connection):
+    cmd = 'ls -la'
+    results = SSH_TEST(cmd, f'{ADUSERNAME}@{AD_DOMAIN}', ADPASSWORD, ip)
+    assert results['result'] is True, results['output']
+
+
+def test_09_test_ssh_ldap(do_ldap_connection):
+    cmd = 'ls -la'
+    results = SSH_TEST(cmd, LDAPUSER, LDAPPASSWORD, ip)
+    assert results['result'] is True, results['output']
+
+
+def test_10_Ensure_ssh_agent_is_setup(request):
+    depends(request, ["ssh_password"])
+    assert is_agent_setup() is True
+
+
+def test_11_Ensure_ssh_key_is_up(request):
     depends(request, ["ssh_password"])
     assert if_key_listed() is True
 
 
 @pytest.mark.dependency(name="set_ssh_key")
-def test_09_Add_ssh_ky_to_root(request):
+def test_12_Add_ssh_ky_to_root(request):
     depends(request, ["ssh_password"])
     payload = {"sshpubkey": sshKey}
     results = PUT("/user/id/1/", payload, controller_a=ha)
@@ -135,7 +193,7 @@ def test_09_Add_ssh_ky_to_root(request):
 
 
 @pytest.mark.dependency(name="ssh_key")
-def test_10_test_ssh_key(request):
+def test_13_test_ssh_key(request):
     depends(request, ["set_ssh_key"])
     cmd = 'ls -la'
     results = SSH_TEST(cmd, user, None, ip)


### PR DESCRIPTION
LDAP PAM account control group was placed in wrong portion of file resulting in SSH tests using local accounts to fail while LDAP was enabled.

This PR also adds testing that SSH with directory services users works as expected