### PR TITLE
NAS-119981 / 22.12.1 / Use optimization to avoid getting service state (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -28,7 +28,11 @@ class ClusterUtils(Service):
         `True` means this system is clustered
         `False` means this system is not clustered.
         """
-        return (await self.middleware.call('service.query', [('service', '=', 'glusterd')], {'get': True}))['enable']
+        return (await self.middleware.call(
+            'service.query',
+            [('service', '=', 'glusterd')],
+            {'get': True, 'extra': {'include_state': False}}
+        ))['enable']
 
     @private
     async def _resolve_hostname(self, host, avail_ips):

--- a/src/middlewared/middlewared/plugins/iscsi_/host_injection.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/host_injection.py
@@ -104,6 +104,5 @@ class iSCSIHostsInjectionService(Service):
 
 
 async def setup(middleware):
-    service = await middleware.call("service.query", [["service", "=", "iscsitarget"]], {"get": True})
-    if service["enable"] or service["state"] == "RUNNING":
+    if await middleware.call('service.started_or_enabled', 'iscsitarget'):
         await middleware.call("iscsi.host.injection.start")

--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -27,8 +27,7 @@ class PoolDatasetService(Service):
 
         result = {}
         for k, v in services.items():
-            service = await self.middleware.call('service.query', [['service', '=', k]], {'get': True})
-            if service['enable'] or service['state'] == 'RUNNING':
+            if await self.middleware.call('service.started_or_enabled', k):
                 result[k] = v
 
         check_services = {

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -188,7 +188,11 @@ class UsageService(Service):
         return {
             'rsyncmod': {
                 'enabled': (
-                    await self.middleware.call('service.query', [['service', '=', 'rsync']], {'get': True})
+                    await self.middleware.call(
+                        'service.query',
+                        [['service', '=', 'rsync']],
+                        {'get': True, 'extra': {'include_state': False}}
+                    )
                 )['enable'],
                 'rsync_modules': await self.middleware.call('rsyncmod.query', [], {'count': True}),
             }
@@ -446,7 +450,7 @@ class UsageService(Service):
         return {'pools': pool_list}
 
     async def gather_services(self, context):
-        services = await self.middleware.call('service.query')
+        services = await self.middleware.call('service.query', [], {'extra': {'include_state': False}})
         service_list = []
 
         for s in services:


### PR DESCRIPTION
There are a few places where we only check whether a service is enabled. In this case, we don't need to the full service state.

This PR also simplifies a few checks for whether a service is enabled or running by using the dedicated method `service.started_or_enabled`.

Original PR: https://github.com/truenas/middleware/pull/10522
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119981