### PR TITLE
NAS-119997 / 23.10 / Enable UI/values.yaml configured portals for all catalogs

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -47,7 +47,7 @@ class ChartReleaseService(Service):
         )
         if not os.path.exists(questions_yaml_path):
             return {}
-        if  release_data['config'].get('enableUIPortal'):
+        if release_data['config'].get('enableUIPortal'):
             return self.get_ix_chart_portal(release_data, node_ip)
 
         with open(questions_yaml_path, 'r') as f:

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -47,7 +47,6 @@ class ChartReleaseService(Service):
         )
         if not os.path.exists(questions_yaml_path):
             return {}
-        
         if  release_data['config'].get('enableUIPortal'):
             return self.get_ix_chart_portal(release_data, node_ip)
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -47,8 +47,8 @@ class ChartReleaseService(Service):
         )
         if not os.path.exists(questions_yaml_path):
             return {}
-
-        if release_data['chart_metadata']['name'] == 'ix-chart':
+        
+        if  release_data['config'].get('enableUIPortal'):
             return self.get_ix_chart_portal(release_data, node_ip)
 
         with open(questions_yaml_path, 'r') as f:


### PR DESCRIPTION
This is a rather simple change, that allows other catalogs the same portal-freedom as ix-chart does.