### PR TITLE
NAS-119998 / 23.10 / Allow multiple custom portals

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -107,7 +107,6 @@ class ChartReleaseService(Service):
                 port = ''
             else:
                 port = f':{port}'
-
             stored_portals[name] = [f'{protocol}://{host}{port}/{path}']
 
         return stored_portals


### PR DESCRIPTION
This PR adds support for defining multiple (user and catalog definable) portals in values.yaml/questions.yaml.

It does not touch current code and creates a new dict in values.yaml/questions.yaml to ensure backwards compatibility with older versions of ix-chart.

Basically a quick and dirty example of new layout in values.yaml (or after rendering questions.yaml) will be:
```
iXPortals:
  open:
    enabled: true    # So users/catalog can dynamically enable and disable catalogs
    protocol: http   # Protocol used for the URL
    host: "192.168.10.1"   # Sets the host used for the URL, defaults to nodeIP if not set
    port: 80   # port used for url generation
  admin:
    enabled: true
    protocol: https
    path: "/admin"
    # In this case the host used would be the nodeIP
```

Most of the above settings are optional and all non-bool settings, are parsed to strings.
It also sures the url is sanitised when ports 80 or 443 are used, as that's what browsers and users expect.