### PR TITLE
NAS-119838 / 22.12.1 / Add regex validation for product/vendor id (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -1,4 +1,5 @@
 from middlewared.schema import Dict, Str
+from middlewared.validators import Match
 
 from .device import Device
 from .utils import create_element
@@ -16,8 +17,14 @@ class USB(Device):
         'attributes',
         Dict(
             'usb',
-            Str('vendor_id', empty=False, required=True),
-            Str('product_id', empty=False, required=True),
+            Str(
+                'vendor_id', empty=False, required=True, validators=[Match(r'^0x.*')],
+                description='Vendor id must start with "0x" prefix e.g 0x0451'
+            ),
+            Str(
+                'product_id', empty=False, required=True, validators=[Match(r'^0x.*')],
+                description='Product id must start with "0x" prefix e.g 0x16a8'
+            ),
             default=None,
             null=True,
         ),


### PR DESCRIPTION
## Problem

Product/vendor id must be specified starting with `0x` prefix. This is similar to how we report this when displaying USB passthrough choices and how libvirt ingests.

Original PR: https://github.com/truenas/middleware/pull/10527
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119838