### PR TITLE
NAS-120000 / 22.12.1 / fix KeyError crash in kubernetes/update.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -134,12 +134,8 @@ class KubernetesService(ConfigService):
                 'System is not licensed to use Applications'
             )
 
-        license = await self.middleware.call('system.license')
-        if data['passthrough_mode'] and (not license or '-MINI-' in license['system_product']):
-            verrors.add(
-                f'{schema}.passthrough_mode',
-                'Can only be enabled on licensed iX enterprise hardware'
-            )
+        if data['passthrough_mode'] and not await self.middleware.call('system.license'):
+            verrors.add(f'{schema}.passthrough_mode', 'Can only be enabled on licensed iX enterprise hardware')
 
         if data['pool'] and not await self.middleware.call('pool.query', [['name', '=', data['pool']]]):
             verrors.add(f'{schema}.pool', 'Please provide a valid pool configured in the system.')


### PR DESCRIPTION
1. `system_product` key does not exist in the license object.
2. passthrough mode is limited to only our enterprise hardware that comes with a license

Original PR: https://github.com/truenas/middleware/pull/10540
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120000