### PR TITLE
fix HA integration test suite

### DIFF
--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -6,6 +6,7 @@ import subprocess
 from middlewared.common.smart.smartctl import get_smartctl_args, smartctl, SMARTCTX
 from middlewared.plugins.smart_.schedule import SMARTD_SCHEDULE_PIECES, smartd_schedule_piece
 from middlewared.schema import Cron
+from middlewared.utils import osc
 from middlewared.utils.asyncio_ import asyncio_map
 
 logger = logging.getLogger(__name__)
@@ -73,11 +74,6 @@ async def render(service, middleware):
         LEFT JOIN tasks_smarttest s ON s.id = sd.smarttest_id OR s.smarttest_all_disks = true
         WHERE disk_togglesmart = 1 AND disk_expiretime IS NULL AND disk_name NOT LIKE 'pmem%'
     """)
-    if await middleware.call("failover.licensed") and (await middleware.call("failover.status") != "MASTER"):
-        # If failover is licensed and we are not a `MASTER` node, only monitor boot pool disks to avoid
-        # reservation conflicts
-        boot_pool_disks = set(await middleware.call("boot.get_disks"))
-        disks = [disk for disk in disks if disk["disk_name"] in boot_pool_disks]
 
     disks = [dict(disk, **smart_config) for disk in disks]
 
@@ -98,7 +94,10 @@ async def render(service, middleware):
     for disk in disks:
         config += get_smartd_config(disk) + "\n"
 
-    path = "/etc/smartd.conf"
+    if osc.IS_FREEBSD:
+        path = "/usr/local/etc/smartd.conf"
+    else:
+        path = "/etc/smartd.conf"
 
     with open(path, "w") as f:
         f.write(config)

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -6,7 +6,6 @@ import subprocess
 from middlewared.common.smart.smartctl import get_smartctl_args, smartctl, SMARTCTX
 from middlewared.plugins.smart_.schedule import SMARTD_SCHEDULE_PIECES, smartd_schedule_piece
 from middlewared.schema import Cron
-from middlewared.utils import osc
 from middlewared.utils.asyncio_ import asyncio_map
 
 logger = logging.getLogger(__name__)
@@ -94,10 +93,5 @@ async def render(service, middleware):
     for disk in disks:
         config += get_smartd_config(disk) + "\n"
 
-    if osc.IS_FREEBSD:
-        path = "/usr/local/etc/smartd.conf"
-    else:
-        path = "/etc/smartd.conf"
-
-    with open(path, "w") as f:
+    with open("/etc/smartd.conf", "w") as f:
         f.write(config)

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -679,6 +679,9 @@ class FailoverEventsService(Service):
         logger.info('Regenerating cron')
         self.run_call('etc.generate', 'cron')
 
+        logger.info('Stopping smartd')
+        self.run_call('service.stop', 'smartd', self.HA_PROPAGATE)
+
         logger.info('Stopping rrdcached')
         self.run_call('service.stop', 'rrdcached', self.HA_PROPAGATE)
 


### PR DESCRIPTION
This breaks HA on our BHYVE vms in a miserable yet fascinating way. BHYVE boot drives don't support SMART and running `failover.status` this early in the boot process will always be 100% truthy for `!= MASTER`. This means we generate an empty /etc/smartd.conf file. However, the failure isn't immediate. The failure happens when we try to create a zpool and the system dataset tries to migrate to the new zpool, we fail because smartd service fails to restart because of empty file. This causes 700+ tests to fail.

For now, we just need to revert this commit and think of something else since it was trying to fix a bunch of scsi reservation console messages on the standby controller during boot.