### PR TITLE
NAS-120012 / 22.12.1 / Add basic time machine share preset (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -134,6 +134,11 @@ class SMBSharePreset(enum.Enum):
         'fsrvp': False,
         'auxsmbconf': '',
     }, "cluster": False}
+    TIMEMACHINE = {"verbose_name": "Basic time machine share", "params": {
+        'path_suffix': '',
+        'timemachine': True,
+        'auxsmbconf': '',
+    }, "cluster": False}
     ENHANCED_TIMEMACHINE = {"verbose_name": "Multi-user time machine", "params": {
         'path_suffix': '%U',
         'timemachine': True,


### PR DESCRIPTION
There are many how-tos out there that give horribly wrong information about setting up a time machine share.

Add a simple preset so that docs can give users
something simpler to do.

Original PR: https://github.com/truenas/middleware/pull/10549
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120012