### PR TITLE
NAS-120015 / 23.10 / Fix KeyError when validating USB device

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -29,7 +29,7 @@ class USB(Device):
             null=True,
         ),
         Str('controller_type', empty=False, default='nec-xhci', enum=USB_CONTROLLER_CHOICES),
-        Str('device', empty=False, null=True),
+        Str('device', empty=False, null=True, default=None),
     )
 
     @property


### PR DESCRIPTION
## Context

There are 2 ways a USB device can be located:
1) Specifying USB slot
2) Specifying USB product/vendor id

If user specifies (2) only, we get `KeyError` because it is expected that `device` is always specified. We should default to `None` for both schema types(already do so for 2nd case when it's not specified) as that is handled gracefully in the validation changes.