### PR TITLE
NAS-119959 / 22.12.1 / fix HA integration suite (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/default/smartmontools.mako
+++ b/src/middlewared/middlewared/etc_files/default/smartmontools.mako
@@ -9,4 +9,4 @@
 #enable_smart="/dev/hda /dev/hdb"
 
 # uncomment to pass additional options to smartd on startup
-smartd_opts="--interval=${config["interval"] * 60} -q nodev"
+smartd_opts="--interval=${config["interval"] * 60} -q never"

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -63,6 +63,11 @@ def get_smartd_schedule(disk):
     ])
 
 
+def write_config(config):
+    with open("/etc/smartd.conf", "w") as f:
+        f.write(config)
+
+
 async def render(service, middleware):
     smart_config = await middleware.call("datastore.query", "services.smart", [], {"get": True})
 
@@ -98,7 +103,4 @@ async def render(service, middleware):
     for disk in disks:
         config += get_smartd_config(disk) + "\n"
 
-    path = "/etc/smartd.conf"
-
-    with open(path, "w") as f:
-        f.write(config)
+    await middleware.run_in_thread(write_config, config)

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -105,9 +105,10 @@ def test_00_firstboot_checks():
     for srv in services:
         if srv['service'] == 'smartd':
             assert srv['enable'] is True, str(srv)
-            if not ha:
-                # On our HA VM (bhyve) drives are S.M.A.R.T.-capable so it can start successfully.
-                assert srv['state'] == 'STOPPED', str(srv)
+            # SMART is started with "-q never" which means it should
+            # always start in all circumstances
+            # (even if there is an invalid (or empty) config)
+            assert srv['state'] == 'RUNNING', str(srv)
         else:
             assert srv['enable'] is False, str(srv)
             assert srv['state'] == 'STOPPED', str(srv)


### PR DESCRIPTION
On BHYVE HA VMs used to run our integration test suite, the boot drive does not support SMART. So `failover.status != MASTER` is always true (since we're initializing HA for the first time AND this is called too early in boot process). This means we will generate an empty `/etc/smartd.conf` which causes a cascade of failures in other parts of our code. Migrating system dataset, formatting a disk etc because those methods try to restart smartd service. Since we generate smartmontools with `-q nodev` it will exit with a returncode and stop the service and we raise an error.

To fix this, set it to `-q never` so that if we try to start smartd with an empty config file OR all the devices in the config file are not able to be monitored via smart, the service will still start, not return a returncode and will continue to monitor the config file for any changes.

Original PR: https://github.com/truenas/middleware/pull/10548
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119959