### PR TITLE
NAS-120022 / 23.10 / Fix single, HA and cluster CI

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -224,7 +224,7 @@ class SupportService(ConfigService):
             if i not in data:
                 raise CallError(f'{i} is required', errno.EINVAL)
 
-        data['version'] = f'{PRODUCT}-{await self.middleware.call("system.version", False)}'
+        data['version'] = f'{PRODUCT}-{await self.middleware.call("system.version_short")}'
         debug = data.pop('attach_debug')
 
         type_ = data.get('type')

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from middlewared.schema import accepts, Bool, returns, Str
 from middlewared.service import CallError, no_auth_required, private, Service
-from middlewared.utils import sw_version, sw_version_is_stable
+from middlewared.utils import sw_info, sw_version_is_stable
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
@@ -74,16 +74,11 @@ class SystemService(Service):
         """
         return "TrueNAS"
 
-    @accepts(Bool('fullname', default=True))
+    @accepts()
     @returns(Str('truenas_version'))
     def version(self, fullname):
-        """Returns software version of the system.
-
-        `full_name`: boolean. If false, will only return the major version
-            without the software product prefix.
-            (i.e. 22.12.0 instead of TrueNAS-SCALE-22.12.0)
-        """
-        return sw_version(fullname=fullname)
+        """Returns the full name of the software version of the system."""
+        return sw_info()['fullname']
 
     @accepts()
     @returns(Str('is_stable'))

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from middlewared.schema import accepts, Bool, returns, Str
 from middlewared.service import CallError, no_auth_required, private, Service
-from middlewared.utils import sw_info, sw_version_is_stable
+from middlewared.utils import sw_info
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
@@ -75,6 +75,12 @@ class SystemService(Service):
         return "TrueNAS"
 
     @accepts()
+    @returns(Str('truenas_version_shortname'))
+    def version_short(self):
+        """Returns the short name of the software version of the system."""
+        return sw_info()['version']
+
+    @accepts()
     @returns(Str('truenas_version'))
     def version(self, fullname):
         """Returns the full name of the software version of the system."""
@@ -86,7 +92,7 @@ class SystemService(Service):
         """
         Returns whether software version of the system is stable.
         """
-        return sw_version_is_stable()
+        return sw_info()['stable']
 
     @no_auth_required
     @accepts()

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -82,7 +82,7 @@ class SystemService(Service):
 
     @accepts()
     @returns(Str('truenas_version'))
-    def version(self, fullname):
+    def version(self):
         """Returns the full name of the software version of the system."""
         return sw_info()['fullname']
 

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -430,7 +430,7 @@ class UpdateService(Service):
             self.logger.info('Deleting dataset %s snapshot %s', dataset, snapshot)
             subprocess.run(['zfs', 'destroy', f'{dataset}@{snapshot}'])
 
-        current_version = self.middleware.call_sync('system.version', False)
+        current_version = self.middleware.call_sync('system.version_short')
         snapshot = f'update--{datetime.utcnow().strftime("%Y-%m-%d-%H-%M")}--{PRODUCT}-{current_version}'
         subprocess.run(['zfs', 'snapshot', f'{dataset}@{snapshot}'])
 

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -258,13 +258,8 @@ def sw_buildtime():
     return sw_info()['buildtime']
 
 
-def sw_version(fullname=True):
-    """
-    `fullname`: bool. If False will return the version of the product
-        without the software name prefix.
-        (i.e. 22.12.0 instead of TrueNAS-SCALE-22.12.0)
-    """
-    return sw_info()['fullname' if fullname else 'version']
+def sw_version():
+    return sw_info()['fullname']
 
 
 def sw_version_is_stable():


### PR DESCRIPTION
Go back to keeping `system.version` a GET request and add a `version_short` method. This fixes integration tests on single, HA and clusters.