### PR TITLE
NAS-120023 / 22.12.1 / Safely handle health key when checking for min scale version (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items_util.py
@@ -26,7 +26,7 @@ def minimum_scale_version_check_update_impl(
     # missing features and based on that makes the decision. So if something is not already supported
     # we do not want to validate minimum scale version in that case. However, when we want to report to
     # the user as to why exactly the app version is not supported, we need to be able to make that distinction
-    if version_details['healthy'] and version_details['chart_metadata'].get('minimum_scale_version') and (
+    if version_details.get('healthy', True) and version_details['chart_metadata'].get('minimum_scale_version') and (
         not check_supported_key or version_details['supported']
     ):
         try:


### PR DESCRIPTION
This commit fixes an issue when checking already installed app's chart we don't add healthy key because the app was only able to install because of it being healthy already.

Original PR: https://github.com/truenas/middleware/pull/10558
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120023