### PR TITLE
NAS-120030 / 22.12.1 / Alter default for netbios-ns on fresh installs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-14_13-26_add_service_announcments.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-14_13-26_add_service_announcments.py
@@ -21,7 +21,7 @@ def upgrade():
     with op.batch_alter_table('network_globalconfiguration', schema=None) as batch_op:
         batch_op.add_column(sa.Column('gc_service_announcement', sa.Text(), nullable=True))
 
-    defaults = '{"mdns": true, "wsd": true, "netbios": false}'
+    defaults = '{"mdns": true, "wsd": true, "netbios": true}'
     op.execute(f"UPDATE network_globalconfiguration SET gc_service_announcement = \'{defaults}\'")
 
     with op.batch_alter_table('network_globalconfiguration', schema=None) as batch_op:


### PR DESCRIPTION
This has especially been problematic during the SCALE release cycle. New users are not familiar with details of how computers appear in Network screen in various Windows versions and some legacy embedded devices and so get confused when TrueNAS isn't visible in them.

Original PR: https://github.com/truenas/middleware/pull/10561
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120030