### PR TITLE
NAS-120040 / 23.10 / Allow RO access to clustered config if DB healthy

### DIFF
--- a/cluster-tests/tests/directoryservices/test_001_activedirectory.py
+++ b/cluster-tests/tests/directoryservices/test_001_activedirectory.py
@@ -348,6 +348,20 @@ def test_030_test_share_failover(request):
         assert res == b'test_failover'
         tcon.close(fd)
 
+    payload = {
+        'msg': 'method',
+        'method': 'ctdb.general.status',
+    }
+
+    res = make_ws_request(ip, payload)
+    assert res.get('error') is None, res
+    assert res['result']['all_healthy'] is False
+
+    url = f'http://{ip}/api/v2.0/activedirectory/get_state'
+    res = make_request('get', url)
+    assert res.status_code == 200, f'ip: {ip}, res: {res.text}'
+    assert res.json() == 'HEALTHY'
+
 
 def test_031_test_share_failover(request):
     """

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -726,6 +726,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             job.set_progress(95, 'Propagating activedirectory service reload to cluster members')
             cl_reload = await self.middleware.call('clusterjob.submit', 'activedirectory.cluster_reload', 'START')
             await cl_reload.wait()
+            await self.middleware.call('service.restart', 'cifs')
 
         job.set_progress(100, f'Active Directory start completed with status [{ret.name}]')
         await self.middleware.call('service.reload', 'idmap')

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1218,7 +1218,7 @@ class LDAPService(TDBWrapConfigService):
         await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('etc.generate', 'ldap')
         await self.middleware.call('etc.generate', 'pam')
-        await self.middleware.call(f'service.{action.lower}' 'nslcd')
+        await self.middleware.call(f'service.{action.lower()}', 'nslcd')
         await self._service_change('cifs', 'restart')
         await self.middleware.call(f'service.{action.lower()}', 'dscache')
 

--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -21,6 +21,8 @@ class CtdbService(SimpleService):
         await self.middleware.call('etc.generate', 'smb')
 
     async def after_stop(self):
-        await self.middleware.call('smb.reset_smb_ha_mode')
-        await self.middleware.call('etc.generate', 'smb')
+        if not await self.middleware.call('cluster.utils.is_clustered'):
+            await self.middleware.call('smb.reset_smb_ha_mode')
+            await self.middleware.call('etc.generate', 'smb')
+
         await self.middleware.call('tdb.close_cluster_handles')

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -103,6 +103,9 @@ class TDBWrap(object):
 
         return output
 
+    def health(self):
+        return 'OK'
+
     def __init__(self, name, options, logger):
         self.name = str(name)
         tdb_type = options.get('backend', 'PERSISTENT')
@@ -149,6 +152,10 @@ class CTDBWrap(object):
             self.hdl
 
         super().__init__()
+
+    def health(self):
+        db_status = self.hdl.status()
+        return db_status['health']
 
     def validate_handle(self):
         return self.hdl is not None

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -651,13 +651,31 @@ class TDBWrapConfigService(ConfigService):
 
         return status
 
+    @private
+    async def db_healthy(self):
+        try:
+            health = await self.middleware.call("tdb.health", {
+                "name": self._config.service,
+                "tdb-options": self.tdb_options.copy(),
+            })
+        except Exception:
+            self.logger.warning("%s: ctdb volume health status check failed.",
+                                self._config.service, exc_info=True)
+        else:
+            if health == "OK":
+                return True
+
+            self.logger.warning("%s: health status is [%s] returning default value",
+                                self._config.service, health)
+        return False
+
     @accepts()
     async def config(self):
         is_clustered = await self.is_clustered()
         if not is_clustered:
             return await super().config()
 
-        if not await self.cluster_healthy():
+        if not await self.cluster_healthy() and not await self.db_healthy():
             return copy.deepcopy(self.tdb_defaults)
 
         tdb_config = await self.middleware.call("tdb.config", {
@@ -1323,6 +1341,25 @@ class TDBWrapCRUDService(CRUDService):
             'tdb-options': self.tdb_options.copy()
         })
 
+    @private
+    async def db_healthy(self):
+        try:
+            health = await self.middleware.call("tdb.health", {
+                "name": self._config.namespace,
+                "tdb-options": self.tdb_options.copy(),
+            })
+        except Exception:
+            self.logger.warning("%s: ctdb volume health status check failed.",
+                                self._config.service, exc_info=True)
+        else:
+            if health == "OK":
+                return True
+
+            self.logger.warning("%s: health status is [%s] returning default value",
+                                self._config.service, health)
+
+        return False
+
     @filterable
     async def query(self, filters, options):
         is_clustered = await self.is_clustered()
@@ -1330,7 +1367,7 @@ class TDBWrapCRUDService(CRUDService):
             res = await super().query(filters, options)
             return res
 
-        if not await self.cluster_healthy():
+        if not await self.cluster_healthy() and not await self.db_healthy():
             return copy.deepcopy(self.tdb_defaults)
 
         res = await self.middleware.call('tdb.query', {


### PR DESCRIPTION
If cluster is overall unhealthy (nodes missing), some of the nodes may still have a healthy copy of our DBs. Since TC wants to present users with at least some config info in this unhealthy state, we can check on per-db basis whether the data is healthy and return what we have.

Updates will still fail as expected.