### PR TITLE
NAS-120071 / 23.10 / Add order_by nulls_first, nulls_last

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -120,12 +120,21 @@ Javascript:
 
 #### Order By
 
-Use the `order_by` option to specify which field determines the sort order.
+Use the `order_by` option to specify which field determines the sort order. Fields must be provided in an
+array of strings.
+
+The following prefixes may be applied to the field name:
+
+`-` reverse sort direction.
+
+`nulls_first:` place any NULL values at head of results list.
+
+`nulls_last:` place any NULL values at tail of results list.
 
 Javascript:
     :::javascript
     {
-      "order_by": "size" // field name
+      "order_by": ["size", "-devname", "nulls_first:-expiretime"]
     }
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -19,6 +19,29 @@ DATA = [
     },
 ]
 
+DATA_WITH_NULL = [
+    {
+        'foo': 'foo1',
+        'number': 1,
+        'list': [1],
+    },
+    {
+        'foo': 'foo2',
+        'number': 2,
+        'list': [2],
+    },
+    {
+        'foo': '_foo_',
+        'number': 3,
+        'list': [3],
+    },
+    {
+        'foo': None,
+        'number': 4,
+        'list': [4],
+    },
+]
+
 COMPLEX_DATA = [
     {
         "timestamp": "2022-11-10T07:40:17.397502-0800",
@@ -188,3 +211,11 @@ def test__filter_list_option_order_by_reverse():
 def test__filter_list_option_select():
     for entry in filter_list(DATA, [], {'select': ['foo']}):
         assert list(entry.keys()) == ['foo']
+
+
+def test__filter_list_option_nulls_first():
+    assert filter_list(DATA_WITH_NULL, [], {'order_by': ['nulls_first:foo']})[0]['foo'] is None
+
+
+def test__filter_list_option_nulls_last():
+    assert filter_list(DATA_WITH_NULL, [], {'order_by': ['nulls_last:foo']})[-1]['foo'] is None


### PR DESCRIPTION
This PR adds "nulls_first:" and "nulls_last:"
handling to filter_list order_by option in order
to make options behavior match what we do with
datastore operations. It also fixes API documentation
errors related to this query-option.