### PR TITLE
TE-172 / 22.12.1 / Moving test_ssh_ldap and test_ssh_ad in test_012_directory_service_ssh

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -11,54 +11,15 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, is_agent_setup, if_key_listed, SSH_TEST, make_ws_request
-from auto_config import sshKey, user, password, ha, hostname
-from assets.REST.directory_services import active_directory, ldap, override_nameservers
+from auto_config import sshKey, user, password, ha
+
 from middlewared.test.integration.utils import call
-
-try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
-except ImportError:
-    Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
-    pytestmark = pytest.mark.skip(reason=Reason)
-
-try:
-    from config import (
-        LDAPBASEDN,
-        LDAPBINDDN,
-        LDAPBINDPASSWORD,
-        LDAPHOSTNAME,
-        LDAPUSER,
-        LDAPPASSWORD
-    )
-except ImportError:
-    Reason = 'LDAP* variable are not setup in config.py'
-    pytestmark = pytest.mark.skipif(True, reason=Reason)
 
 
 if "controller1_ip" in os.environ:
     ip = os.environ["controller1_ip"]
 else:
     from auto_config import ip
-
-
-@pytest.fixture(scope="function")
-def do_ad_connection(request):
-    with override_nameservers(ADNameServer):
-        with active_directory(
-            AD_DOMAIN,
-            ADUSERNAME,
-            ADPASSWORD,
-            netbiosname=hostname,
-        ) as ad:
-            yield (request, ad)
-
-
-@pytest.fixture(scope="function")
-def do_ldap_connection(request):
-    with ldap(LDAPBASEDN, LDAPBINDDN, LDAPBINDPASSWORD, LDAPHOSTNAME,
-        has_samba_schema=True,
-    ) as ldap_conn:
-        yield (request, ldap_conn)
 
 
 def test_00_firstboot_checks():
@@ -161,18 +122,6 @@ def test_06_test_ssh():
 def test_07_Ensure_ssh_agent_is_setup(request):
     depends(request, ["ssh_password"])
     assert is_agent_setup() is True
-
-
-def test_08_test_ssh_ad(do_ad_connection):
-    cmd = 'ls -la'
-    results = SSH_TEST(cmd, f'{ADUSERNAME}@{AD_DOMAIN}', ADPASSWORD, ip)
-    assert results['result'] is True, results['output']
-
-
-def test_09_test_ssh_ldap(do_ldap_connection):
-    cmd = 'ls -la'
-    results = SSH_TEST(cmd, LDAPUSER, LDAPPASSWORD, ip)
-    assert results['result'] is True, results['output']
 
 
 def test_10_Ensure_ssh_agent_is_setup(request):

--- a/tests/api2/test_012_directory_service_ssh.py
+++ b/tests/api2/test_012_directory_service_ssh.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Author: Eric Turgeon
+# License: BSD
+
+import pytest
+from pytest_dependency import depends
+from functions import SSH_TEST
+from auto_config import hostname, ip
+
+from assets.REST.directory_services import active_directory, ldap, override_nameservers
+
+try:
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+except ImportError:
+    Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
+    pytestmark = pytest.mark.skip(reason=Reason)
+
+try:
+    from config import (
+        LDAPBASEDN,
+        LDAPBINDDN,
+        LDAPBINDPASSWORD,
+        LDAPHOSTNAME,
+        LDAPUSER,
+        LDAPPASSWORD
+    )
+except ImportError:
+    Reason = 'LDAP* variable are not setup in config.py'
+    pytestmark = pytest.mark.skipif(True, reason=Reason)
+
+
+@pytest.fixture(scope="function")
+def do_ad_connection(request):
+    with override_nameservers(ADNameServer):
+        with active_directory(
+            AD_DOMAIN,
+            ADUSERNAME,
+            ADPASSWORD,
+            netbiosname=hostname,
+        ) as ad:
+            yield (request, ad)
+
+
+@pytest.fixture(scope="function")
+def do_ldap_connection(request):
+    with ldap(LDAPBASEDN, LDAPBINDDN, LDAPBINDPASSWORD, LDAPHOSTNAME,
+         has_samba_schema=True) as ldap_conn:
+        yield (request, ldap_conn)
+
+
+def test_08_test_ssh_ad(do_ad_connection, request):
+    depends(request, ["ssh_password"], scope="session")
+    cmd = 'ls -la'
+    results = SSH_TEST(cmd, f'{ADUSERNAME}@{AD_DOMAIN}', ADPASSWORD, ip)
+    assert results['result'] is True, results['output']
+
+
+def test_09_test_ssh_ldap(do_ldap_connection, request):
+    depends(request, ["ssh_password"], scope="session")
+    cmd = 'ls -la'
+    results = SSH_TEST(cmd, LDAPUSER, LDAPPASSWORD, ip)
+    assert results['result'] is True, results['output']


### PR DESCRIPTION
Those 2 test fails were failing on HA.

Here are the results now on HA.
[2023-01-27 12:07:42] api2/test_012_directory_service_ssh.py::test_08_test_ssh_ad PASSED [  6%]
[2023-01-27 12:08:11] api2/test_012_directory_service_ssh.py::test_09_test_ssh_ldap PASSED [  6%]