### PR TITLE
NAS-120068 / 22.12.2 / Set rdns off during kerberized NFS tests (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -96,6 +96,7 @@ class KRB_LibDefaults(enum.Enum):
     FCACHE_VERSION = ('fcache_version', 'int')
     KRB4_GET_TICKETS = ('krb4_get_tickets', 'boolean')
     FCC_MIT_TICKETFLAGS = ('fcc-mit-ticketflags', 'boolean')
+    RDNS = ('rdns', 'boolean')
 
     def __str__(self):
         return self.value[0]

--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -53,6 +53,11 @@ test_flags = {
 
 @pytest.fixture(scope="module")
 def kerberos_config(request):
+    # DNS in automation domain is often broken.
+    # Setting rdns helps to pass this
+    results = PUT("/kerberos/", {"libdefaults_aux": "rdns = false"})
+    assert results.status_code == 200, results.text
+
     results = PUT("/nfs/", {"v4_krb": True})
     assert results.status_code == 200, results.text
     try:
@@ -62,6 +67,9 @@ def kerberos_config(request):
         assert results.status_code == 200, results.text
 
         results = PUT("/nfs/", {"v4_krb": False})
+        assert results.status_code == 200, results.text
+
+        results = PUT("/kerberos/", {"libdefaults_aux": ""})
         assert results.status_code == 200, results.text
 
 


### PR DESCRIPTION
Our automation network has semi-broken DNS from time to time.

Original PR: https://github.com/truenas/middleware/pull/10587
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120068