### PR TITLE
NAS-120091 / 22.12.1 / fix ssh_credentials regression in replication (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -489,7 +489,7 @@ class ReplicationService(CRUDService):
         if verrors:
             raise verrors
 
-        if "ssh_credentials" in data:
+        if data.get("ssh_credentials") is not None:
             data["ssh_credentials"] = await self.middleware.call(
                 "keychaincredential.get_of_type", data["ssh_credentials"], "SSH_CREDENTIALS",
             )


### PR DESCRIPTION
Introduced in ef76438b9f58911966a63a9df802a6d347a48bba and caught in integration tests.
```
                try:
>                   call("replication.run_onetime", {
                        "direction": "PUSH",
                        "transport": "LOCAL",
                        "source_datasets": [src],
                        "target_dataset": f"{pool}/dst",
                        "recursive": True,
                        "also_include_naming_schema": ["%Y-%m-%d-%H-%M-%S"],
                        "retention_policy": "NONE",
                        "replicate": True,
                        "readonly": "IGNORE",
                        "exclude_mountpoint_property": exclude_mountpoint_property
                    }, job=True)

        if job['state'] != 'SUCCESS':
            if job['exc_info'] and job['exc_info']['type'] == 'VALIDATION':
>               raise ValidationErrors(job['exc_info']['extra'])
E               middlewared.client.client.ValidationErrors: [EINVAL] id: null not allowed

Original PR: https://github.com/truenas/middleware/pull/10596
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120091