### PR TITLE
NAS-120104 / 23.10 / Fix random failure in container tests

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -617,6 +617,7 @@ class ChartReleaseService(CRUDService):
 
         job.set_progress(75, f'Waiting for {release_name!r} pods to terminate')
         await self.middleware.call('chart.release.wait_for_pods_to_terminate', get_namespace(release_name))
+        await self.middleware.call('chart.release.wait_for_namespace_to_terminate', get_namespace(release_name))
 
         await self.post_remove_tasks(release_name, job)
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -278,3 +278,11 @@ class ChartReleaseService(Service):
         ]
         if args:
             await self.middleware.call('core.bulk', 'chart.release.scale', args)
+
+    @private
+    async def wait_for_namespace_to_terminate(self, namespace, timeout=300):
+        while timeout > 0 and await self.middleware.call(
+            'k8s.namespace.query', [['metadata.namespace', '=', namespace]]
+        ):
+            await asyncio.sleep(5)
+            timeout -= 5

--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -41,11 +41,10 @@ if not ha:
                 "values": values,
             }, job=True
         )
-        chart_release_data = call("chart.release.get_instance", app_name, {"extra": {"retrieve_resources": True}})
-        for image_tag in chart_release_data["resources"]["container_images"]:
-            while not call("container.image.query", [["repo_tags", "rin", image_tag]]):
-                time.sleep(10)
+        while call("chart.release.get_instance", app_name)["status"] != "ACTIVE":
+            time.sleep(10)
 
+        chart_release_data = call("chart.release.get_instance", app_name, {"extra": {"retrieve_resources": True}})
         assert_images_exist_for_chart_release(chart_release_data)
 
         try:


### PR DESCRIPTION
## Problem

After moving to containerd for CRI we noticed random failures in one of our pruning integration tests in CI.
When an app is deleted, CRI tells k8s that pod is gone but in reality that actually happens usually a second or some part of the second later then it reports that and at this stage namespace hasn't fully terminated. So if we prune unused images as well, app in question's images sometimes might not get pruned because that container had not really terminated.

There was also another case where we were waiting on container images in question to be pulled and then when we pruned images, we expected the app's images to not be pruned but they got pruned because the app was not ACTIVE itself as container itself had not been created yet and only the image had been pulled and in that timeframe we had pruned the image which resulted in k8s pulling that image again.

## Solution

Before considering an app to be deleted, we wait on the namespace to terminate which ensures that no container actually exists now and if we prune after that it correctly removes that app's images. Also for good measure instead of ensuring that container images have been pulled, we wait for the app to state itself as ACTIVE before proceeding with the integration test to ensure that app is actually running as intended and various tests can be run accordingly. 