### PR TITLE
NAS-120081 / 22.12.2 / fix cachefile error when importing encrypted zpools on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -414,7 +414,8 @@ class ZFSPoolService(CRUDService):
             except libzfs.ZFSInvalidCachefileException:
                 raise CallError('Invalid or missing cachefile', errno.ENOENT)
             except libzfs.ZFSException as e:
-                raise CallError(str(e), e.code)
+                code = errno.ENOENT if e.code == libzfs.Error.NOENT.value else e.code
+                raise CallError(str(e), code)
             else:
                 if found is None:
                     raise CallError(f'Pool {name_or_guid} not found.', errno.ENOENT)


### PR DESCRIPTION
This the final caller in our codebase that tries to import a zpool. When this fails, however, this simply propagates the errors and libzfs specific errnos to the callee. While this is fine in most cases, we have decided that all `libzfs` implementation details need to be handled in `plugins/zfs.py`. When a zpool is imported specifying a zpool cachefile, if the cachefile doesn't have the zpool information or the information is outdated, it will raise an exception with errno set to EZFS_NOENT which has error code 2009. This doesn't map to standard ENOENT error code. This means on a failover event, we don't handle this properly and immediately assume (on first attempt of import of the zpool specifying the cachefile) that this is an uncorrectable error, and we continue on. This breaks our logic there because we want to try 2 times to import zpools on failover event.
1. one time specifying the cachefile (since it can dramatically reduce the zpool import time)
2. if that fails with ENOENT (EZFS_NOENT), we try to import without the zpool cachefile

This changes it so that if the `plugin/zfs.py` plugin fails to import the zpool and raises EZFS_NOENT, we map it back to errno.ENOENT so the callee(s) can handle it appropriately.


Original PR: https://github.com/truenas/middleware/pull/10599
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120081