### PR TITLE
NAS-118844 / 13.0 / Apply user specified DNS configuration when syncing interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2026,6 +2026,8 @@ class InterfaceService(CRUDService):
         if wait_dhcp and dhclient_aws:
             await asyncio.wait(dhclient_aws, timeout=30)
 
+        await self.middleware.call('dns.sync')
+
         try:
             # We may need to set up routes again as they may have been removed while changing IPs
             await self.middleware.call('route.sync')


### PR DESCRIPTION
## Problem

During boot, we are not applying user specified DNS configuration which results in networking breaking for some users and they need to make some changes to DNS configuration so middleware can actually reflect the configuration to reality.
This happens when interfaces are configured to use DHCP but with static IP configuration the problem is not reproducible anymore.

## Solution

During syncing interfaces, apply DNS configuration keeping in line with how we do it in SCALE. Motivation for this change is that dhclient potentially modifies the DNS configuration when it runs and we need to sync it back to reality after that happens so user specified DNS configuration is applied. Similar to what is done in https://github.com/truenas/middleware/pull/8365/commits/58f6750b7f8b7eaf56f71d7e35ae3ba8f3456ccf.