### PR TITLE
NAS-120129 / 23.10 / Simplify nslcd state handling

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -9,6 +9,7 @@ from .mdns import MDNSService
 from .netbios import NetBIOSService
 from .nfs import NFSService
 from .nscd import NSCDService
+from .nslcd import NSSPamLdapdService
 from .openvpn_client import OpenVPNClientService
 from .openvpn_server import OpenVPNServerService
 from .rsync import RsyncService
@@ -64,6 +65,7 @@ all_services = [
     NetBIOSService,
     NFSService,
     NSCDService,
+    NSSPamLdapdService,
     OpenVPNClientService,
     OpenVPNServerService,
     RsyncService,

--- a/src/middlewared/middlewared/plugins/service_/services/nslcd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nslcd.py
@@ -1,0 +1,7 @@
+from .base import SimpleService
+
+
+class NSSPamLdapdService(SimpleService):
+    name = "nslcd"
+
+    systemd_unit = "nslcd"


### PR DESCRIPTION
Move nslcd service handling into standard methods of controlling systemd services, and restart nslcd if needed when checking ldap started state. Middleware LDAP state is determined by using libldap python
bindings, but nslcd proved NSS and PAM LDAP integration.