### PR TITLE
NAS-120081 / 22.12.2 / fix importing zpools on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/retaste.py
+++ b/src/middlewared/middlewared/plugins/disk_/retaste.py
@@ -1,0 +1,48 @@
+import multiprocessing
+
+from pyudev import Context
+
+from middlewared.service import Service, accepts, job
+from middlewared.schema import List, Str
+from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
+from middlewared.plugins.device_.device_info import RE_NVME_PRIV
+
+
+def taste_it(disk):
+    try:
+        with open(disk, 'wb'):
+            return
+    except Exception:
+        pass
+
+
+def retaste_disks_impl(disks: set = None):
+    if disks is None:
+        disks = set()
+        for disk in Context().list_devices(subsystem='block', DEVTYPE='disk'):
+            if disk.sys_name.startswith(DISKS_TO_IGNORE) or RE_NVME_PRIV.match(disk.sys_name):
+                continue
+            disks.add(f'/dev/{disk.sys_name}')
+
+    with multiprocessing.Pool() as p:
+        # we use processes so that these operations are truly
+        # "parrallel" (side-step the GIL) since we have systems
+        # with 1k+ disks. Since this runs, potentially, on failover
+        # event we need to squeeze out every bit of perf we can get
+        p.map(taste_it, disks)
+
+
+class DiskService(Service):
+
+    @accepts(List('disks', required=False, default=None, items=[Str('name', required=True)]))
+    @job(lock='disk_retaste')
+    def retaste(self, job, disks):
+        if disks:
+            # remove duplicates and prefix '/dev' (i.e. /dev/sda, /dev/sdb, etc)
+            disks = set(f'/dev/{i.removeprefix("/dev/")}' for i in disks)
+
+        job.set_progress(85, 'Retasting disks')
+        retaste_disks_impl(disks)
+
+        job.set_progress(100, 'Retasting disks done')
+        return 'SUCCESS'

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -396,6 +396,12 @@ class FailoverEventsService(Service):
         # setup the zpool cachefile
         self.run_call('failover.zpool.cachefile.setup', 'MASTER')
 
+        # retaste the disks so that any new metadata on the disks
+        # can be detected by kernel to allow importing of the zpool(s)
+        logger.info('Retasting disks')
+        retaste_job = self.run_call('disk.retaste')
+        retaste_job.wait_sync()
+
         # set the progress to IMPORTING
         job.set_progress(None, description='IMPORTING')
 

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -763,6 +763,11 @@ class PoolService(CRUDService):
                 await (await self.middleware.call('disk.resize', log_disks, True)).wait()
 
         await self.middleware.call('pool.format_disks', job, disks)
+        if await self.middleware.call('failover.licensed'):
+            try:
+                await self.middleware.call('failover.call_remote', 'disk.retaste')
+            except Exception:
+                self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
 
         options = {
             'feature@lz4_compress': 'enabled',


### PR DESCRIPTION
The standby controller must be made aware of partition changes or zpool import on failover event could fail.

This adds a new method `disk.retaste` that will open the disk(s) in write mode which will causes kernel to detect any partitions on said device so that the `/dev/disk/by-partuuid` sysfs structure is populated correctly. Without the sysfs structure being populated correctly, zpool import will fail to find any zpools because, on SCALE, zpool import does not scan the disks for any metadata.

I use multiprocessing.Pool so that this is truly parallel execution since this runs on our HA hardware which has plenty of CPU cores. On an internal M60 with 1250 disks, this takes ~1.1 seconds to retaste all the disks.

We retaste disks in 2 scenarios:
1. on zpool creation
2. when we're becoming the active controller

Original PR: https://github.com/truenas/middleware/pull/10614
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120081