### PR TITLE
NAS-120153 / 13.0 / fix ValueError crash in enclosure plugin on 13

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
@@ -119,7 +119,7 @@ class Enclosure(object):
                 if da:
                     parsed[slot].update({'dev': da[0]})
                 else:
-                    parsed[slot].update(element['dev'])
+                    parsed[slot].update({'dev': ''})
 
             final[element_type[0]].update(parsed)
 


### PR DESCRIPTION
Seen on some internal hardware. This exposed a typo that causes a ValueError crash.