### PR TITLE
NAS-120106 / 22.12.2 / Add some basic detection of misconfigured DNS (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -71,22 +71,77 @@ class ActiveDirectoryService(Service):
             self.logger.warning(f'Failed to update DNS with payload [{payload}]: {e.errmsg}')
 
     @private
+    async def ipaddresses_to_register(self, data, raise_errors=True):
+        validated_ips = []
+
+        if data['clustered']:
+            ips = (await self.middleware.call('smb.bindip_choices')).values()
+        else:
+            ips = [i['address'] for i in (await self.middleware.call('interface.ip_in_use'))]
+
+        if data['bindip']:
+            to_check = set(data['bindip']) & set(ips)
+        else:
+            to_check = set(ips)
+
+        for ip in to_check:
+            try:
+                result = await self.middleware.call('dnsclient.reverse_lookup', {
+                    'addresses': [ip]
+                })
+            except dns.resolver.NXDOMAIN:
+                # This may simply mean entry was not found
+                validated_ips.append(ip)
+
+            except dns.resolver.NoNameservers:
+                self.logger.warning(
+                    'No nameservers configured to handle reverse pointer for %s. '
+                    'Omitting from list of addresses to use for Active Directory purposes.',
+                    ip
+                )
+                continue
+
+            except Exception:
+                # DNS for this IP may be simply wildly misconfigured and time out
+                self.logger.warning(
+                    'Reverse lookup of %s failed, omitting from list '
+                    'of addresses to use for Active Directory purposes.',
+                    ip, exc_info=True
+                )
+                continue
+
+            else:
+                if result[0]['target'] != data['hostname'] and raise_errors:
+                    raise CallError(
+                        f'Reverse lookup of {ip} points to {result[0]["target"]}'
+                        f'rather than our hostname of {data["hostname"]}.',
+                        errno.EINVAL
+                    )
+                validated_ips.append(ip)
+
+        return validated_ips
+
+    @private
     async def register_dns(self, ad, smb, smb_ha_mode):
         if not ad['allow_dns_updates']:
-            return
+            return []
 
         await self.middleware.call('kerberos.check_ticket')
 
         hostname = f'{smb["netbiosname_local"]}.{ad["domainname"]}.'
-        if smb_ha_mode == 'CLUSTERED':
-            vips = (await self.middleware.call('smb.bindip_choices')).values()
-        else:
-            vips = [i['address'] for i in (await self.middleware.call('interface.ip_in_use'))]
+        to_register = await self.ipaddresses_to_register({
+            'bindip': smb['bindip'],
+            'hostname': hostname,
+            'clustered': smb_ha_mode == 'CLUSTERED'
+        })
 
-        smb_bind_ips = smb['bindip'] if smb['bindip'] else vips
-        to_register = set(vips) & set(smb_bind_ips)
-
-        hostname = f'{smb["netbiosname_local"]}.{ad["domainname"]}.'
+        if not to_register:
+            raise CallError(
+                'No server IP addresses passed DNS validation. '
+                'This may indicate an improperly configured reverse zone. '
+                'Review middleware log files for details regarding errors encountered.',
+                errno.EINVAL
+            )
 
         payload = []
 

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -63,6 +63,83 @@ ad_object_list = [
 
 SMB_NAME = "TestADShare"
 
+def remove_dns_entries(payload):
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'dns.nsupdate',
+        'params': [{'ops': payload}]
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+
+
+def cleanup_forward_zone():
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'dnsclient.forward_lookup',
+        'params': [{'names': [f'{hostname}.{AD_DOMAIN}']}]
+    })
+    error = res.get('error')
+
+    if error and error['trace']['class'] == 'NXDOMAIN':
+        # No entry, nothing to do
+        return
+
+    assert error is None, str(error)
+    ips_to_remove = [rdata['address'] for rdata in res['result']]
+
+    payload = []
+    for i in ips_to_remove:
+        addr = ipaddress.ip_address(i)
+        payload.append({
+            'command': 'DELETE',
+            'name': f'{hostname}.{AD_DOMAIN}.',
+            'address': str(addr),
+            'type': 'A' if addr.version == 4 else 'AAAA'
+        })
+
+    remove_dns_entries(payload)
+
+
+def cleanup_reverse_zone():
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'activedirectory.ipaddresses_to_register',
+        'params': [
+            {'hostname': f'{hostname}.{AD_DOMAIN}.', 'clustered': False, 'bindip': []},
+            False
+        ],
+    })
+    error = res.get('error')
+    assert error is None, str(error)
+    ptr_table = {ipaddress.ip_address(i).reverse_pointer: i for i in res['result']}
+
+    res = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'dnsclient.reverse_lookup',
+        'params': [{'addresses': list(ptr_table.values())}],
+    })
+    error = res.get('error')
+    if error and error['trace']['class'] == 'NXDOMAIN':
+        # No entry, nothing to do
+        return
+
+    assert error is None, str(error)
+
+    payload = []
+    for host in res['result']:
+        reverse_pointer = f'{host["name"]}.'
+        assert reverse_pointer in ptr_table, str(ptr_table)
+        addr = ipaddress.ip_address(ptr_table[reverse_pointer])
+        payload.append({
+            'command': 'DELETE',
+            'name': host['target'],
+            'address': str(addr),
+            'type': 'A' if addr.version == 4 else 'AAAA'
+        })
+
+    remove_dns_entries(payload)
+
 
 @pytest.fixture(scope="module")
 def set_ad_nameserver(request):
@@ -114,37 +191,8 @@ def test_02_cleanup_nameserver(request):
     # Now that we have proper kinit as domain admin
     # we can nuke stale DNS entries from orbit.
     #
-    res = make_ws_request(ip, {
-        'msg': 'method',
-        'method': 'dnsclient.forward_lookup',
-        'params': [{'names': [f'{hostname}.{AD_DOMAIN}']}]
-    })
-    error = res.get('error')
-
-    if error and error['trace']['class'] == 'NXDOMAIN':
-        # No entry, nothing to do
-        return
-
-    assert error is None, str(error)
-    ips_to_remove = [rdata['address'] for rdata in res['result']]
-
-    payload = []
-    for i in ips_to_remove:
-        addr = ipaddress.ip_address(i)
-        payload.append({
-            'command': 'DELETE',
-            'name': f'{hostname}.{AD_DOMAIN}.',
-            'address': str(addr),
-            'type': 'A' if addr.version == 4 else 'AAAA'
-        })
-
-    res = make_ws_request(ip, {
-        'msg': 'method',
-        'method': 'dns.nsupdate',
-        'params': [{'ops': payload}]
-    })
-    error = res.get('error')
-    assert error is None, str(error)
+    cleanup_forward_zone()
+    cleanup_reverse_zone()
 
 
 def test_03_get_activedirectory_data(request):


### PR DESCRIPTION
During CI runs it was noted that some jenkins users weren't properly cleaning up after their runs had
completed. This PR expands on previous DNS cleanup "tests" to also look up stale entries via reverse pointers for the current VM's IP address. This cleanup failed due to misconfigured reverse zone in the AD that
the jenkins pipeline was using, and so more robust detection of broken reverse zones was added to
the AD plugin to avoid dynamic updates to networks where this is broken.

Original PR: https://github.com/truenas/middleware/pull/10604
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120106