### PR TITLE
NAS-120193 / 23.10 / Fix cleanup of DNS reverse zone

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -269,6 +269,8 @@ class ActiveDirectoryService(Service):
             })])
         except dns.resolver.NXDOMAIN:
             raise CallError(f'DNS forward lookup of [{netbios_name}] failed.', errno.ENOENT)
+        except dns.resolver.NoNameservers as e:
+            raise CallError(f'DNS forward lookup of netbios name failed: {e}', errno.EFAULT)
 
         ips_in_use = set([x['address'] for x in await self.middleware.call('interface.ip_in_use')])
 

--- a/src/middlewared/middlewared/plugins/network_/dns.py
+++ b/src/middlewared/middlewared/plugins/network_/dns.py
@@ -155,7 +155,7 @@ class DNSService(Service):
 
                 tmpfile.write(directive.encode())
                 if entry['do_ptr']:
-                    ptrs.append(addr.reverse_pointer)
+                    ptrs.append((addr.reverse_pointer, entry['name']))
 
             if ptrs:
                 # additional newline means "send"
@@ -164,13 +164,14 @@ class DNSService(Service):
                 tmpfile.write(b'\n')
 
                 for ptr in ptrs:
+                    reverse_pointer, name = ptr
                     directive = ' '.join([
                         'update',
                         entry['command'].lower(),
-                        ptr,
+                        reverse_pointer,
                         str(entry['ttl']),
                         'PTR',
-                        entry['name'],
+                        name,
                         '\n'
                     ])
                     tmpfile.write(directive.encode())

--- a/tests/api2/assets/REST/directory_services.py
+++ b/tests/api2/assets/REST/directory_services.py
@@ -25,6 +25,10 @@ def clear_ad_info():
         "createcomputer": "",
         "kerberos_realm": None,
     })
+    assert results.status_code == 200, results.text
+    if not results.json().get('job_id'):
+        return
+
     job_status = wait_on_job(results.json()['job_id'], 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
@@ -44,6 +48,9 @@ def clear_ldap_info():
         "disable_freenas_cache": False,
         "certificate": None,
     })
+    if not results.json().get('job_id'):
+        return
+
     job_status = wait_on_job(results.json()['job_id'], 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -112,7 +112,7 @@ def cleanup_reverse_zone():
     })
     error = res.get('error')
     assert error is None, str(error)
-    ptr_table = {ipaddress.ip_address(i).reverse_pointer: i for i in res['result']}
+    ptr_table = {f'{ipaddress.ip_address(i).reverse_pointer}.': i for i in res['result']}
 
     res = make_ws_request(ip, {
         'msg': 'method',
@@ -128,7 +128,7 @@ def cleanup_reverse_zone():
 
     payload = []
     for host in res['result']:
-        reverse_pointer = f'{host["name"]}.'
+        reverse_pointer = host["name"]
         assert reverse_pointer in ptr_table, str(ptr_table)
         addr = ipaddress.ip_address(ptr_table[reverse_pointer])
         payload.append({


### PR DESCRIPTION
* Fix trailing dot on ptr record string in DNS test
* Handle SERVFAIL while looking up netbiosname
* Fix formatting of messages to delete ptr records when
  deleting multiple incorrect ones.