### PR TITLE
NAS-120186 / 23.10 / Wait for app resources to be deleted by helm

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/scale_workload.py
@@ -229,8 +229,6 @@ class ChartReleaseService(Service):
 
     @private
     async def wait_for_pods_to_terminate(self, namespace, extra_filters=None):
-        # wait for release to uninstall properly, helm right now does not support a flag for this but
-        # a feature request is open in the community https://github.com/helm/helm/issues/2378
         while await self.middleware.call(
             'k8s.pod.query', [
                 ['metadata.namespace', '=', namespace],


### PR DESCRIPTION
## Context

Earlier helm did not provide a way to wait for pods deployed by a chart release to be stopped on uninstallation. That feature has been added to helm now and it can now wait for pods to be terminated which were deployed by the chart release.