### PR TITLE
NAS-120190 / 23.10 / Add simplified API for granting ids access to path

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -594,6 +594,15 @@ class Job:
 
         return await subjob.wait(raise_error=True)
 
+    def wrap_sync(self, subjob):
+        if subjob.wrapped is not None:
+            raise RuntimeError(f"Job {subjob!r} is already wrapped by {subjob.wrapped!r}")
+
+        self.set_progress(**subjob.progress)
+        subjob.wrapped = self
+
+        return subjob.wait_sync(raise_error=True)
+
     def cleanup(self):
         if self.logs_path:
             try:

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -816,12 +816,18 @@ class FilesystemService(Service, ACLBase):
         return acl
 
     def add_to_acl(self, job, data):
+        init_path = data['path']
+        verrors = ValidationErrors()
+        self._common_perm_path_validate('filesystem.add_to_acl', data, verrors)
+        verrors.check()
+
         if os.listdir(data['path']) and not data['options']['force']:
             raise CallError(
                 f'{data["path"]}: path contains existing data '
                 'and `force` was not specified', errno.EPERM
             )
 
+        data['path'] = init_path
         current_acl = self.getacl(data['path'])
         acltype = ACLType[current_acl['acltype']]
 


### PR DESCRIPTION
This simplified API is for charts use to allow chart to specify uids / gids that need access to a given host path.