### PR TITLE
NAS-120066 / 23.10 / fix websocket drop on scale HA failover event

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -495,14 +495,6 @@ class FailoverEventsService(Service):
         logger.info('Configuring system dataset')
         self.run_call('systemdataset.setup')
 
-        # Write the certs to disk based on what is written in db.
-        logger.info('Configuring SSL')
-        self.run_call('etc.generate', 'ssl')
-
-        # Now we restart the appropriate services to ensure it's using correct certs.
-        logger.info('Configuring HTTP')
-        self.run_call('service.restart', 'http')
-
         # now we restart the services, prioritizing the "critical" services
         logger.info('Restarting critical services.')
         self.run_call('failover.events.restart_services', {'critical': True})


### PR DESCRIPTION
This change was added back in 11.2 days because we had a situation where generating a certificate on one controller, would not propagate that certificate to the other controller. I have confirmed that this is no longer a problem so we can remove these calls.

More importantly, however, is that by removing these calls it prevents the webUI from showing the login screen, allowing a user to log on, and then seemingly some random time later the screen going back to the login screen forcing the user to re-login.

This was happening because we were restarting nginx which is what the websocket connections get proxied through from the webUI side of things.