### PR TITLE
NAS-120196 / 22.12.1 / Stop kubernetes/VPN services when moving system dataset (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -670,7 +670,7 @@ class SystemDatasetService(ConfigService):
         simultaneous releases of system dataset.
         """
         with self.sysdataset_release_lock:
-            restart = ['collectd', 'rrdcached', 'syslogd']
+            restart = ['collectd', 'rrdcached', 'syslogd', 'kubernetes', 'openvpn_server', 'openvpn_client']
 
             if self.middleware.call_sync('service.started', 'cifs'):
                 restart.insert(0, 'cifs')

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -685,10 +685,7 @@ class SystemDatasetService(ConfigService):
                 {'name': 'openvpn_server'},
             ]:
                 if self.middleware.call_sync(svc_to_check.get('method', 'service.started'), svc_to_check['name']):
-                    if 'index' in svc_to_check:
-                        restart.insert(svc_to_check['index'], svc_to_check['name'])
-                    else:
-                        restart.append(svc_to_check['name'])
+                    restart.insert(svc_to_check.get('index', len(restart)), svc_to_check['name'])
 
             try:
                 self.middleware.call_sync('cache.put', 'use_syslog_dataset', False)


### PR DESCRIPTION
This PR adds changes to restart k8s/vpn services when system dataset is being moved as otherwise it is potentially possible that the service in question is consuming the logging dataset.

Original PR: https://github.com/truenas/middleware/pull/10635
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120196