### PR TITLE
NAS-120200 / 23.10 / Fix random API test failure

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/apps.py
+++ b/src/middlewared/middlewared/test/integration/assets/apps.py
@@ -1,11 +1,16 @@
 import contextlib
+import time
 
 from middlewared.test.integration.utils import call
 
 
 @contextlib.contextmanager
-def chart_release(payload: dict):
+def chart_release(payload: dict, wait_until_active: bool = False):
     release_data = call('chart.release.create', payload, job=True)
+    if wait_until_active:
+        while release_data['status'] != 'ACTIVE':
+            time.sleep(15)
+            release_data = call('chart.release.get_instance', release_data['id'])
     try:
         yield release_data
     finally:

--- a/tests/api2/test_026_kubernetes_backup_chart_releases.py
+++ b/tests/api2/test_026_kubernetes_backup_chart_releases.py
@@ -19,7 +19,7 @@ from middlewared.test.integration.utils import file_exists_and_perms_check
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
-backup_release_name = 'backupplex'
+backup_release_name = 'backuppostgres'
 
 # Read all the test below only on non-HA
 if not ha:
@@ -254,17 +254,17 @@ if not ha:
 
         with catalog({
             'force': True,
-            'preferred_trains': ['stable'],
-            'label': 'TRUECHARTS',
-            'repository': 'https://github.com/truecharts/catalog.git',
+            'preferred_trains': ['test-apps'],
+            'label': 'TESTAPPS',
+            'repository': 'https://github.com/Qubad786/test_catalog.git',
             'branch': 'main'
         }) as catalog_info:
             with chart_release({
                 'catalog': catalog_info['label'],
-                'item': 'plex',
+                'item': 'postgres',
                 'release_name': backup_release_name,
-                'train': 'stable',
-            }) as chart_release_info:
+                'train': 'test-apps',
+            }, wait_until_active=True) as chart_release_info:
                 with backup() as backup_name:
                     app_info = call(
                         'chart.release.get_instance', chart_release_info['id'], {'extra': {'retrieve_resources': True}}


### PR DESCRIPTION
## Problem

Sometimes backup integrity test https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/API%20Tests%20-%20TrueNAS%20SCALE%20(Incremental)/11855/testReport/junit/api2/test_026_kubernetes_backup_chart_releases/test_25_backup_structure/ fails randomly. Reasoning for that failure is that we are not waiting for an app to be active which would make sure relevant PVCs have been created and rather we just move ahead with taking a backup right away. This results in assertion failing randomly where if the PVC had not been created at the time of the backup but had been created by k8s at the time we read the filesystem contents of the backup.

## Solution
Test should wait for an app to become ACTIVE before taking a backup as that would mean that relevant PVCs would have been created.