### PR TITLE
NAS-120242 / 23.10 / Flush samba gencache after removing user or group

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -715,6 +715,7 @@ class UserService(CRUDService):
 
         await self.middleware.call('datastore.delete', 'account.bsdusers', pk)
         await self.middleware.call('service.reload', 'user')
+        await self.middleware.call('idmap.flush_gencache')
 
         return pk
 
@@ -1566,6 +1567,7 @@ class GroupService(CRUDService):
             await gm_job.wait()
 
         await self.middleware.call('service.reload', 'user')
+        await self.middleware.call('idmap.flush_gencache')
 
         return pk
 


### PR DESCRIPTION
If group is removed from file then NSS query will
fall through to nss_winbind, which may have cached result. In principle, winbind shouldn't be giving
a response here, but fix will be more involved and so for now we will simply flush cached entries on
user or group removal.