### PR TITLE
NAS-119889 / 23.10 / bump udev receive queue buffer size to 256MB

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/udev_events.py
+++ b/src/middlewared/middlewared/plugins/device_/udev_events.py
@@ -22,12 +22,14 @@ class DeviceService(Service):
 
 
 def udev_events(middleware):
+    _256MB = 268435456  # for large quantity disk systems (100's or more)
     while True:
         # We always want to keep polling udev, let's log what error we are
-        # seeing and fix them accordingly as we see them
+        # seeing and fix them as we come across them
         try:
             context = pyudev.Context()
             monitor = pyudev.Monitor.from_netlink(context)
+            monitor.set_receive_buffer_size(_256MB)
             monitor.filter_by(subsystem='block')
             monitor.filter_by(subsystem='net')
             for device in iter(monitor.poll, None):


### PR DESCRIPTION
As best as I can tell, when using `libudev` api, kernel receive buffer is initiated to 128MB. However, I've seen this on our internal system with ~1.2k HDDs
```
[2023/01/17 10:53:45] (ERROR) middlewared.udev_events():38 - Polling udev failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/udev_events.py", line 33, in udev_events
    for device in iter(monitor.poll, None):
  File "/usr/lib/python3/dist-packages/pyudev/monitor.py", line 355, in poll
    return self._receive_device()
  File "/usr/lib/python3/dist-packages/pyudev/monitor.py", line 294, in _receive_device
    device_p = self._libudev.udev_monitor_receive_device(self)
  File "/usr/lib/python3/dist-packages/pyudev/_ctypeslib/_errorcheckers.py", line 103, in check_errno_on_null_pointer_return
    raise exception_from_errno(errnum)
OSError: [Errno 105] No buffer space available
```

My running theory is that we're overflowing that queue and causing that crash, so I've bumped it to 256MB. After making these changes, I haven't seen that same error message. Alas, however, I wasn't able to ever reproduce that problem either so...