### PR TITLE
NAS-120242 / 22.12.2 / Flush samba gencache after removing user or group (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -715,6 +715,7 @@ class UserService(CRUDService):
 
         await self.middleware.call('datastore.delete', 'account.bsdusers', pk)
         await self.middleware.call('service.reload', 'user')
+        await self.middleware.call('idmap.flush_gencache')
 
         return pk
 
@@ -1569,6 +1570,7 @@ class GroupService(CRUDService):
             await gm_job.wait()
 
         await self.middleware.call('service.reload', 'user')
+        await self.middleware.call('idmap.flush_gencache')
 
         return pk
 


### PR DESCRIPTION
If group is removed from file then NSS query will
fall through to nss_winbind, which may have cached result. In principle, winbind shouldn't be giving
a response here, but fix will be more involved and so for now we will simply flush cached entries on
user or group removal.

Original PR: https://github.com/truenas/middleware/pull/10651
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120242