### PR TITLE
NAS-120210 / 23.10 / fix enclosure mapping on MINI-R

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -86,10 +86,10 @@ MAPPINGS = [
             MappingSlot(0, 5, False),
             MappingSlot(0, 6, False),
             MappingSlot(0, 7, False),
-            MappingSlot(1, 3, False),
-            MappingSlot(1, 4, False),
-            MappingSlot(1, 5, False),
             MappingSlot(1, 6, False),
+            MappingSlot(1, 5, False),
+            MappingSlot(1, 4, False),
+            MappingSlot(1, 3, False),
         ]),
     ]),
     ProductMapping(re.compile(r"TRUENAS-R10$"), [


### PR DESCRIPTION
Slots 9-12 need to be reversed to match physical slot map.