### PR TITLE
NAS-120246 / 23.10 / Edit iSCSI portal

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/portal.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/portal.py
@@ -175,8 +175,9 @@ class ISCSIPortalService(CRUDService):
         Update database with new listen IPs.
         It will delete no longer existing addresses and add new ones.
         """
-        new_listen_set = set([tuple(i.items()) for i in new])
-        old_listen_set = set([tuple(i.items()) for i in old]) if old else set()
+        # We only want to compare 'ip', weed out any 'port' present
+        new_listen_set = set([(('ip', i.get('ip')),) for i in new])
+        old_listen_set = set([(('ip', i.get('ip')),) for i in old]) if old else set()
         for i in new_listen_set - old_listen_set:
             i = dict(i)
             await self.middleware.call(

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -868,6 +868,23 @@ def test_10_target_alias(request):
                     assert targets[A['name']]['alias'] is None, targets[A['name']]['alias']
                     assert targets[B['name']]['alias'] is None, targets[B['name']]['alias']
 
+def test_11_modify_portal(request):
+    """
+    Test that we can modify a target portal.
+    """
+    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    with portal() as portal_config:
+        portal_id = portal_config['id']
+        assert portal_config['comment'] == 'Default portal', portal_config
+        # First just change the comment
+        payload = {'comment' : 'New comment'}
+        results = PUT(f"/iscsi/portal/id/{portal_config['id']}", payload)
+        # Then try to reapply everything
+        payload = {'comment': 'test1', 'discovery_authmethod': 'NONE', 'discovery_authgroup': None, 'listen': [{'ip': '0.0.0.0'}]}
+        # payload = {'comment': 'test1', 'discovery_authmethod': 'NONE', 'discovery_authgroup': None, 'listen': [{'ip': '0.0.0.0'}, {'ip': '::'}]}
+        results = PUT(f"/iscsi/portal/id/{portal_config['id']}", payload)
+        assert results.status_code == 200, results.text
+
 def test_99_teardown(request):
     # Disable iSCSI service
     depends(request, ["iscsi_cmd_00"])


### PR DESCRIPTION
Comparison in `__save_listen` was broken by the presence of `port` in addition to `ip` in the `old` parameter (but missing from `new`).