### PR TITLE
NAS-120256 / 23.10 / clean up pool export

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from middlewared.schema import accepts, Bool, Dict, Int, returns
-from middlewared.service import CallError, item_method, job, Service, ValidationError
+from middlewared.service import CallError, item_method, job, private, Service, ValidationError
 from middlewared.utils.asyncio_ import asyncio_map
 
 
@@ -13,6 +13,7 @@ class PoolService(Service):
         cli_namespace = 'storage.pool'
         event_send = False
 
+    @private
     def cleanup_after_export(self, poolinfo, opts):
         if poolinfo['encrypt'] > 0:
             try:


### PR DESCRIPTION
Investigating an unrelated problem, I've found many problems with this method. I've fixed the following:
1. pool['encrypt'] logic is calling blocking I/O in the main event loop
2. os.rmdir is blocking I/O for which we were also calling in the main event loop
3. os.rmdir won't recursively remove directories that have contents by design, however, if we export a zpool and the only remaining directory at the top-level of the zpool is `ix-applications`, then we don't need to worry about it and we can recursively remove that since it gets recreated the next time apps plugin is initialized.
4. If an end-user exports a zpool and chooses the option to destroy it, (wipe all the disks associated to said zpool) then we need to wait on `disk.sync_all` since there is potential for the end-user to immediately go back and create a zpool using the same disks and if a new zpool is created using the same disks then there is potential for the webUI to show stale information (because the original `disk.sync_all` hasn't finished)
5. remove f-strings in the logger calls

I've also added some more logging statements to give the end-user a little more of an idea of what's going on when they export a zpool.