### PR TITLE
NAS-120253 / 23.10 / Skip image update check for dangling images

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/update_alerts.py
@@ -50,13 +50,14 @@ class ContainerImagesService(Service, CRIClientMixin):
 
     @private
     async def check_update_for_image(self, tag, image_details):
-        parsed_reference = self.normalize_reference(tag)
-        self.IMAGE_CACHE[tag] = await self.compare_id_digests(
-            image_details,
-            parsed_reference['registry'],
-            parsed_reference['image'],
-            parsed_reference['tag']
-        )
+        if not image_details['dangling']:
+            parsed_reference = self.normalize_reference(tag)
+            self.IMAGE_CACHE[tag] = await self.compare_id_digests(
+                image_details,
+                parsed_reference['registry'],
+                parsed_reference['image'],
+                parsed_reference['tag']
+            )
 
     @private
     async def clear_update_flag_for_tag(self, tag):


### PR DESCRIPTION
## Context

For all downloaded container images we are checking if they have an update available upstream against the same tag. However it is possible with time we end up with dangling images and these are the type of images which will not have an update available against their tag upstream. Hence we should avoid making extra REST calls to do that and default to false for them which is the default behaviour of `IMAGE_CACHE`.