### PR TITLE
NAS-120259 / 22.12.1 / `gpt_header_size` might vary between sector sizes; do not take it int… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -30,10 +30,10 @@ class DiskService(Service):
 
         swapsize = swapgb * 1024 * 1024 * 1024
         if min_size:
-            leftover = size - gpt_header_size - min_size
-            if leftover < 0:
+            if size < min_size:
                 raise CallError(f'Disk: {disk!r} must be larger than {min_size} bytes')
 
+            leftover = max(0, size - gpt_header_size - min_size)
             if leftover < swapsize:
                 self.logger.warning(
                     'Requested %d bytes for swap and a minimal data partition size of %d bytes, but only %d bytes for '


### PR DESCRIPTION
…o account when validating disks

Original PR: https://github.com/truenas/middleware/pull/10664
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120259