### PR TITLE
NAS-120253 / 22.12.2 / Skip image update check for dangling images (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
@@ -54,13 +54,14 @@ class DockerImagesService(Service, DockerClientMixin):
 
     @private
     async def check_update_for_image(self, tag, image_details):
-        parsed_reference = self.normalize_reference(tag)
-        self.IMAGE_CACHE[tag] = await self.compare_id_digests(
-            image_details,
-            parsed_reference['registry'],
-            parsed_reference['image'],
-            parsed_reference['tag']
-        )
+        if not image_details['dangling']:
+            parsed_reference = self.normalize_reference(tag)
+            self.IMAGE_CACHE[tag] = await self.compare_id_digests(
+                image_details,
+                parsed_reference['registry'],
+                parsed_reference['image'],
+                parsed_reference['tag']
+            )
 
     @private
     async def clear_update_flag_for_tag(self, tag):


### PR DESCRIPTION
## Context

For all downloaded container images we are checking if they have an update available upstream against the same tag. However it is possible with time we end up with dangling images and these are the type of images which will not have an update available against their tag upstream. Hence we should avoid making extra REST calls to do that and default to false for them which is the default behaviour of `IMAGE_CACHE`.

Original PR: https://github.com/truenas/middleware/pull/10665
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120253