### PR TITLE
NAS-120261 / 22.12.1 / Fix tests (by yocalebo)

### DIFF
--- a/tests/api2/test_008_pool.py
+++ b/tests/api2/test_008_pool.py
@@ -183,6 +183,15 @@ def test_08_test_pool_property_normalization(request):
         assert ds['properties']['mountpoint']['value'] != 'legacy', str(ds['properties'])
         assert ds['properties']['sharenfs']['value'] == 'off', str(ds['properties'])
 
+    # the very next test that runs after this one exports the pool that
+    # we re-imported but the database id has changed so we need to update
+    # the global `tp['id']` variable
+    res = make_ws_request(ip, {'msg': 'method', 'method': 'datastore.query', 'params': ['storage.volume']})
+    assert res.get('error') is None
+    assert res['result']
+    for i in filter(lambda x: x['vol_name'] == tp['name'], res['result']):
+        tp['id'] = i['id']
+
 
 def test_09_export_test_pool_with_destroy_true(request):
     depends(request, ["pool_04"])

--- a/tests/api2/test_008_pool.py
+++ b/tests/api2/test_008_pool.py
@@ -191,6 +191,9 @@ def test_08_test_pool_property_normalization(request):
     assert res['result']
     for i in filter(lambda x: x['vol_name'] == tp['name'], res['result']):
         tp['id'] = i['id']
+        break
+    else:
+        assert False, f'zpool with name: {tp["name"]!r} not found'
 
 
 def test_09_export_test_pool_with_destroy_true(request):


### PR DESCRIPTION
Changes introduced here https://github.com/truenas/middleware/pull/10655 exposed the fact that our tests were written with the assumption that sqlite didn't autoincrement columns on insert. Well...turns out it wasn't actually doing that which was breaking cloud-sync tasks so we fixed the autoincrement problem but then it broke these tests.

Fixes employed here:
1. update the global `tp['id']` after we import the zpool since that translates to a database insert which increments the column `id` by design

Original PR: https://github.com/truenas/middleware/pull/10669
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120261