### PR TITLE
NAS-120273 / 22.12.1 / Skip container image pull tests temporarily (by Qubad786)

### DIFF
--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -98,13 +98,15 @@ if not ha:
         assert isinstance(results.json(), dict), results.text
         assert results.json()['enable_image_updates'] is False, results.text
 
-    def test_04_get_pull_container_image():
+    def test_04_container_image_query():
         results = GET('/container/image/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), list), results.text
 
     @skip_container_image
     @pytest.mark.dependency(name='pull_private_image')
+    @pytest.mark.skip(reason='IX network drops network connection routinely.Sometimes, image is not pulled '
+                             'successfully.Skipping test until it is fixed')
     def test_05_pull_a_private_container_image(request):
         depends(request, ['setup_kubernetes'], scope='session')
         payload = {
@@ -155,6 +157,8 @@ if not ha:
         assert results.json()['enable_image_updates'] is True, results
 
     @pytest.mark.dependency(name='pull_public_image')
+    @pytest.mark.skip(reason='IX network drops network connection routinely.Sometimes, image is not pulled '
+                             'successfully.Skipping test until it is fixed')
     def test_10_pull_a_public_container_image(request):
         depends(request, ['setup_kubernetes'], scope='session')
         payload = {


### PR DESCRIPTION
## Context

iX network is experiencing network issues so essentially tests where we pull container images more or less fail routinely and after discussion with Caleb we have decided to skip them until the underlying network problem has been fixed.

Original PR: https://github.com/truenas/middleware/pull/10675
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120273