### PR TITLE
NAS-120226 / 22.12.1 / fix zpool import on failover events (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -393,8 +393,8 @@ class FailoverEventsService(Service):
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
 
-        # setup the zpool cachefile
-        self.run_call('failover.zpool.cachefile.setup', 'MASTER')
+        # setup the zpool cachefile  TODO: see comment below about cachefile usage
+        # self.run_call('failover.zpool.cachefile.setup', 'MASTER')
 
         # retaste the disks so that any new metadata on the disks
         # can be detected by kernel to allow importing of the zpool(s)
@@ -409,8 +409,12 @@ class FailoverEventsService(Service):
         options = {'altroot': '/mnt'}
         import_options = {'missing_log': True}
         any_host = True
-        cachefile = ZPOOL_CACHE_FILE
-        new_name = None
+        # TODO: maintaing zpool cachefile is very fragile and can
+        # ruin the ability to successfully import a zpool on failover
+        # event.... Until we can truly dig into this problem, we'll
+        # ignore the cache file for now
+        # cachefile = ZPOOL_CACHE_FILE
+        new_name = cachefile = None
         for vol in fobj['volumes']:
             logger.info('Importing %r', vol['name'])
 


### PR DESCRIPTION
Past few days I've investigated random occurrences of zpools being unhealthy after failover event. I've learned
1. using a singular zpool cachefile for all zpools isn't the best idea more than likely
2. managing the zpool cachefile is very fragile and will lead to despair
3. limit the search paths given to zpool import on our HA certified hardware line to lessen the possibility of importing a zpool and have random disks get imported using the raw device instead of the gpt device.

Tested extensively in house with QE team since they were the ones seeing this quite often. After these changes, they've had a singular occurrence of this after my changes. I will push a separate PR to, hopefully, fix the last remaining issue.

Original PR: https://github.com/truenas/middleware/pull/10678
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120226