### PR TITLE
NAS-120226 / 22.12.2 / fix zpool import on failover events (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -393,8 +393,8 @@ class FailoverEventsService(Service):
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
 
-        # setup the zpool cachefile
-        self.run_call('failover.zpool.cachefile.setup', 'MASTER')
+        # setup the zpool cachefile  TODO: see comment below about cachefile usage
+        # self.run_call('failover.zpool.cachefile.setup', 'MASTER')
 
         # retaste the disks so that any new metadata on the disks
         # can be detected by kernel to allow importing of the zpool(s)
@@ -409,8 +409,12 @@ class FailoverEventsService(Service):
         options = {'altroot': '/mnt'}
         import_options = {'missing_log': True}
         any_host = True
-        cachefile = ZPOOL_CACHE_FILE
-        new_name = None
+        # TODO: maintaing zpool cachefile is very fragile and can
+        # ruin the ability to successfully import a zpool on failover
+        # event.... Until we can truly dig into this problem, we'll
+        # ignore the cache file for now
+        # cachefile = ZPOOL_CACHE_FILE
+        new_name = cachefile = None
         for vol in fobj['volumes']:
             logger.info('Importing %r', vol['name'])
 

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -2,6 +2,7 @@ import copy
 import errno
 import os
 import subprocess
+import functools
 from collections import defaultdict
 from copy import deepcopy
 
@@ -80,6 +81,15 @@ class ZFSPoolService(CRUDService):
         namespace = 'zfs.pool'
         private = True
         process_pool = True
+
+    @functools.cache
+    def get_search_paths(self):
+        if self.middleware.call_sync('system.is_ha_capable'):
+            # HA capable hardware which means we _ALWAYS_ expect
+            # the zpool to have been created with disks that have
+            # been formatted with gpt type labels on them
+            return ['/dev/disk/by-partuuid']
+        return SEARCH_PATHS
 
     @filterable
     def query(self, filters, options):
@@ -389,8 +399,9 @@ class ZFSPoolService(CRUDService):
 
     @accepts()
     def find_import(self):
+        sp = self.get_search_paths()
         with libzfs.ZFS() as zfs:
-            return [i.__getstate__() for i in zfs.find_import(search_paths=SEARCH_PATHS)]
+            return [i.__getstate__() for i in zfs.find_import(search_paths=sp)]
 
     @accepts(
         Str('name_or_guid'),
@@ -406,8 +417,9 @@ class ZFSPoolService(CRUDService):
     def import_pool(self, name_or_guid, properties, any_host, cachefile, new_name, import_options):
         with libzfs.ZFS() as zfs:
             found = None
+            sp = self.get_search_paths()
             try:
-                for pool in zfs.find_import(cachefile=cachefile, search_paths=SEARCH_PATHS):
+                for pool in zfs.find_import(cachefile=cachefile, search_paths=sp):
                     if pool.name == name_or_guid or str(pool.guid) == name_or_guid:
                         found = pool
                         break


### PR DESCRIPTION
Past few days I've investigated random occurrences of zpools being unhealthy after failover event. I've learned
1. using a singular zpool cachefile for all zpools isn't the best idea more than likely
2. managing the zpool cachefile is very fragile and will lead to despair
3. limit the search paths given to zpool import on our HA certified hardware line to lessen the possibility of importing a zpool and have random disks get imported using the raw device instead of the gpt device.

Tested extensively in house with QE team since they were the ones seeing this quite often. After these changes, they've had a singular occurrence of this after my changes. I will push a separate PR to, hopefully, fix the last remaining issue.

Original PR: https://github.com/truenas/middleware/pull/10678
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120226