### PR TITLE
Added OVH authenticator to list of ACME DNS providers

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
@@ -5,6 +5,7 @@ from middlewared.service_exception import CallError
 from .cloudflare import CloudFlareAuthenticator
 from .route53 import Route53Authenticator
 from .shell import ShellAuthenticator
+from .ovh import OVHAuthenticator
 
 
 class AuthenticatorFactory:
@@ -28,6 +29,7 @@ auth_factory = AuthenticatorFactory()
 for authenticator in [
     CloudFlareAuthenticator,
     Route53Authenticator,
+    OVHAuthenticator,
     ShellAuthenticator,
 ]:
     auth_factory.register(authenticator)

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
@@ -3,9 +3,9 @@ import errno
 from middlewared.service_exception import CallError
 
 from .cloudflare import CloudFlareAuthenticator
+from .ovh import OVHAuthenticator
 from .route53 import Route53Authenticator
 from .shell import ShellAuthenticator
-from .ovh import OVHAuthenticator
 
 
 class AuthenticatorFactory:

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
@@ -1,0 +1,51 @@
+import logging
+
+from lexicon.providers.ovh import ENDPOINTS
+from certbot_dns_ovh._internal.dns_ovh import _OVHLexiconClient
+
+from middlewared.schema import accepts, Dict, Str, ValidationErrors
+from middlewared.service import skip_arg
+
+from .base import Authenticator
+
+
+logger = logging.getLogger(__name__)
+OVH_ENDPOINTS = tuple(ENDPOINTS.keys())
+
+class OVHAuthenticator(Authenticator):
+
+    NAME = 'OVH'
+    PROPAGATION_DELAY = 60
+    SCHEMA = Dict(
+        'OVH',
+        Str('application_key', empty=False, null=False, title='OVH Application Key'),
+        Str('application_secret', empty=False, null=False, title='OVH Application Secret'),
+        Str('consumer_key', empty=False, null=False, title='OVH Consumer Key'),
+        Str('endpoint', empty=False, default='ovh-eu', title='OVH Endpoint', enum=OVH_ENDPOINTS),
+    )
+
+    def initialize_credentials(self):
+        self.application_key = self.attributes.get('application_key')
+        self.application_secret = self.attributes.get('application_secret')
+        self.consumer_key = self.attributes.get('consumer_key')
+        self.endpoint = self.attributes.get('endpoint')
+
+    @staticmethod
+    @accepts(SCHEMA)
+    @skip_arg(count=1)
+    async def validate_credentials(middleware, data):
+        verrors = ValidationErrors()
+        verrors.check()
+        return data
+
+    def _perform(self, domain, validation_name, validation_content):
+        self.get_client().add_txt_record(domain, validation_name, validation_content)
+
+    def get_client(self):
+        return _OVHLexiconClient(
+            self.endpoint, self.application_key, self.application_secret,
+            self.consumer_key, 600,
+        )
+
+    def _cleanup(self, domain, validation_name, validation_content):
+        self.get_client().del_txt_record(domain, validation_name, validation_content)

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
@@ -12,6 +12,7 @@ from .base import Authenticator
 logger = logging.getLogger(__name__)
 OVH_ENDPOINTS = tuple(ENDPOINTS.keys())
 
+
 class OVHAuthenticator(Authenticator):
 
     NAME = 'OVH'

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
@@ -3,7 +3,7 @@ import logging
 from lexicon.providers.ovh import ENDPOINTS
 from certbot_dns_ovh._internal.dns_ovh import _OVHLexiconClient
 
-from middlewared.schema import accepts, Dict, Str, ValidationErrors
+from middlewared.schema import accepts, Dict, Str
 from middlewared.service import skip_arg
 
 from .base import Authenticator

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
@@ -18,10 +18,10 @@ class OVHAuthenticator(Authenticator):
     PROPAGATION_DELAY = 60
     SCHEMA = Dict(
         'OVH',
-        Str('application_key', empty=False, null=False, title='OVH Application Key'),
-        Str('application_secret', empty=False, null=False, title='OVH Application Secret'),
-        Str('consumer_key', empty=False, null=False, title='OVH Consumer Key'),
-        Str('endpoint', empty=False, default='ovh-eu', title='OVH Endpoint', enum=OVH_ENDPOINTS),
+        Str('application_key', empty=False, null=False, title='OVH Application Key', required=True),
+        Str('application_secret', empty=False, null=False, title='OVH Application Secret', required=True),
+        Str('consumer_key', empty=False, null=False, title='OVH Consumer Key', required=True),
+        Str('endpoint', empty=False, default='ovh-eu', title='OVH Endpoint', enum=OVH_ENDPOINTS, required=True),
     )
 
     def initialize_credentials(self):
@@ -34,8 +34,6 @@ class OVHAuthenticator(Authenticator):
     @accepts(SCHEMA)
     @skip_arg(count=1)
     async def validate_credentials(middleware, data):
-        verrors = ValidationErrors()
-        verrors.check()
         return data
 
     def _perform(self, domain, validation_name, validation_content):


### PR DESCRIPTION
I know this is a bit unprompted, but I couldn't get the shell script route to work to add my domain registered at OVH to work with SSL certificates.

The code is more or less identical to the Cloudflare Authenticator, so it should work out of the box. One caveat is that OVH can only guarantee propagation to all DNS within 24 hours, in practice though I haven't had any case happen where propagation wasn't done within the hour.

Any comment / review is greatly appreciated for my first contribution to TrueNAS