### PR TITLE
NAS-120256 / 22.12.2 / clean up pool export (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+
+from middlewared.service import Service, private
+
+
+class PoolService(Service):
+
+    @private
+    def cleanup_after_export(self, poolinfo, opts):
+        if poolinfo['encrypt'] > 0:
+            try:
+                # this is CORE GELI encryption which doesn't exist on SCALE
+                # so it means someone upgraded from CORE to SCALE and their
+                # db has an entry with a GELI based encrypted pool in it so
+                # we'll remove the GELI key files associated with the zpool
+                os.remove(poolinfo['encryptkey'])
+            except Exception:
+                # not fatal, and doesn't really matter since SCALE can't
+                # use this zpool anyways
+                pass
+
+        try:
+            if all((opts['destroy'], opts['cascade'])) and (contents := os.listdir(poolinfo['path'])):
+                if len(contents) == 1 and contents[0] == 'ix-applications':
+                    # This means:
+                    #   1. zpool was destroyed (disks were wiped)
+                    #   2. end-user chose to delete all share configuration associated
+                    #       to said zpool
+                    #   3. somehow ix-applications was the only top-level directory that
+                    #       got left behind
+                    #
+                    # Since all 3 above are true, then we just need to remove this directory
+                    # so we don't leave dangling directory(ies) in /mnt.
+                    # (i.e. it'll leave something like /mnt/tank/ix-application/blah)
+                    shutil.rmtree(poolinfo['path'])
+            else:
+                # remove top-level directory for zpool (i.e. /mnt/tank (ONLY if it's empty))
+                os.rmdir(poolinfo['path'])
+        except FileNotFoundError:
+            # means the pool was exported and the path where the
+            # root dataset (zpool) was mounted was removed
+            return
+        except Exception:
+            self.logger.warning('Failed to remove remaining directories after export', exc_info=True)


### PR DESCRIPTION
Investigating an unrelated problem, I've found many problems with this method. I've fixed the following:
1. pool['encrypt'] logic is calling blocking I/O in the main event loop
2. os.rmdir is blocking I/O for which we were also calling in the main event loop
3. os.rmdir won't recursively remove directories that have contents by design, however, if we export a zpool and the only remaining directory at the top-level of the zpool is `ix-applications`, then we don't need to worry about it and we can recursively remove that since it gets recreated the next time apps plugin is initialized.
4. If an end-user exports a zpool and chooses the option to destroy it, (wipe all the disks associated to said zpool) then we need to wait on `disk.sync_all` since there is potential for the end-user to immediately go back and create a zpool using the same disks and if a new zpool is created using the same disks then there is potential for the webUI to show stale information (because the original `disk.sync_all` hasn't finished)
5. remove f-strings in the logger calls

I've also added some more logging statements to give the end-user a little more of an idea of what's going on when they export a zpool.

Original PR: https://github.com/truenas/middleware/pull/10662
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120256