### PR TITLE
NAS-120345 / 22.12.2 / need to use IPs of cluster VMs (by yocalebo)

### DIFF
--- a/cluster-tests/init_gluster.py
+++ b/cluster-tests/init_gluster.py
@@ -6,7 +6,7 @@ from helpers import ctdb_healthy
 from exceptions import JobTimeOut
 
 GPD = GLUSTER_PEERS_DNS
-URLS = [f'http://{hostname}/api/v2.0' for hostname in GPD]
+URLS = [f'http://{ip}/api/v2.0' for ip in CLUSTER_IPS]
 
 
 def enable_and_start_service_on_all_nodes():


### PR DESCRIPTION
This fixes cluster API pipeline

Original PR: https://github.com/truenas/middleware/pull/10707
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120345