### PR TITLE
23.10 / remove license requirement on k8s passthrough mode

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -142,9 +142,6 @@ class KubernetesService(ConfigService):
                 'System is not licensed to use Applications'
             )
 
-        if data['passthrough_mode'] and not await self.middleware.call('system.license'):
-            verrors.add(f'{schema}.passthrough_mode', 'Can only be enabled on licensed iX enterprise hardware')
-
         if data['pool'] and not await self.middleware.call('pool.query', [['name', '=', data['pool']]]):
             verrors.add(f'{schema}.pool', 'Please provide a valid pool configured in the system.')
 


### PR DESCRIPTION
While I 100% agree that "passthrough mode" should not exposed to normal end users directly in the GUI. Locking this behind enterprise hardware requirements, has no technical reasoning at all behind it. At the same time, it's already trivial to remove this needless requirement manually for people with the knowhow to even make the API call.

iX has always been clear that it only puts OS features and API calls behind a license if it's technically required.

**TLDR**
This limit isn't technically needed, it makes no sense for gatekeeping novice users AND it seems to be in contrast/violation of expected iX policies regarding licensing.

This is not likely to be used much at all, because the knowhow required to even correctly deploy this hidden gem, is huge.
Basically: lets keep it security through obscurity please.