### PR TITLE
NAS-120391 / 23.10 / Cleanup and improve SentryCrashReporting class

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -3,11 +3,6 @@ from logging.config import dictConfig
 import logging.handlers
 import os
 
-import sentry_sdk
-
-from .utils import sw_version, sw_version_is_stable, MIDDLEWARE_RUN_DIR
-
-
 # markdown debug is also considered useless
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
 # asyncio runs in debug mode but we do not need INFO/DEBUG
@@ -52,89 +47,6 @@ def trace(self, message, *args, **kws):
 
 logging.addLevelName(logging.TRACE, "TRACE")
 logging.Logger.trace = trace
-
-
-class CrashReporting(object):
-    enabled_in_settings = False
-
-    """
-    Pseudo-Class for remote crash reporting
-    """
-
-    def __init__(self):
-        if sw_version_is_stable():
-            self.sentinel_file_path = f'{MIDDLEWARE_RUN_DIR}/.crashreporting_disabled'
-        else:
-            self.sentinel_file_path = '/data/.crashreporting_disabled'
-        self.logger = logging.getLogger('middlewared.logger.CrashReporting')
-        url = 'https://11101daa5d5643fba21020af71900475:d60cd246ba684afbadd479653de2c216@sentry.ixsystems.com/2'
-        query = '?timeout=3'
-        sentry_sdk.init(
-            url + query,
-            release=sw_version(),
-            integrations=[],
-            default_integrations=False,
-        )
-        sentry_sdk.utils.MAX_STRING_LENGTH = 10240
-        # FIXME: remove this when 0.10.3 is released
-        strip_string = sentry_sdk.utils.strip_string
-        sentry_sdk.utils.strip_string = lambda s: strip_string(s, sentry_sdk.utils.MAX_STRING_LENGTH)
-        sentry_sdk.utils.slim_string = sentry_sdk.utils.strip_string
-        sentry_sdk.serializer.strip_string = sentry_sdk.utils.strip_string
-        sentry_sdk.serializer.slim_string = sentry_sdk.utils.strip_string
-
-    def is_disabled(self):
-        """
-        Check the existence of sentinel file and its absolute path
-        against STABLE and DEVELOPMENT branches.
-
-        Returns:
-            bool: True if crash reporting is disabled, False otherwise.
-        """
-        # Allow report to be disabled via sentinel file or environment var,
-        # if TrueNAS current train is STABLE, the sentinel file path will be /var/run/middleware/,
-        # otherwise it's path will be /data/ and can be persistent.
-
-        if not self.enabled_in_settings:
-            return True
-
-        if os.path.exists(self.sentinel_file_path) or 'CRASHREPORTING_DISABLED' in os.environ:
-            return True
-
-        if os.stat(__file__).st_dev != os.stat('/').st_dev:
-            return True
-
-        return False
-
-    def report(self, exc_info, log_files):
-        """"
-        Args:
-            exc_info (tuple): Same as sys.exc_info().
-            request (obj, optional): It is the HTTP Request.
-            sw_version (str): The current middlewared version.
-            t_log_files (tuple): A tuple with log file absolute path and name.
-        """
-        if self.is_disabled():
-            return
-
-        data = {}
-        for path, name in log_files:
-            if os.path.exists(path):
-                with open(path, 'r') as absolute_file_path:
-                    contents = absolute_file_path.read()[-10240:]
-                    data[name] = contents
-
-        self.logger.debug('Sending a crash report...')
-        try:
-            with sentry_sdk.configure_scope() as scope:
-                payload_size = 0
-                for k, v in data.items():
-                    if payload_size + len(v) < 190000:
-                        scope.set_extra(k, v)
-                        payload_size += len(v)
-                sentry_sdk.capture_exception(exc_info)
-        except Exception:
-            self.logger.debug('Failed to send crash report', exc_info=True)
 
 
 class LoggerFormatter(logging.Formatter):

--- a/src/middlewared/middlewared/logging/sentry_crash_reporting.py
+++ b/src/middlewared/middlewared/logging/sentry_crash_reporting.py
@@ -43,7 +43,8 @@ class SentryCrashReporting:
             # disabled via environment variable
             return True
         elif os.stat(__file__).st_dev != os.stat('/').st_dev:
-            # really??
+            # middlewared package directory is remotely mounted
+            # (i.e. done by some developers)
             return True
         else:
             return False

--- a/src/middlewared/middlewared/logging/sentry_crash_reporting.py
+++ b/src/middlewared/middlewared/logging/sentry_crash_reporting.py
@@ -1,0 +1,81 @@
+import os
+import logging
+
+import sentry_sdk
+
+from middlewared.utils import MIDDLEWARE_RUN_DIR, sw_info
+
+DISABLED_SENTINEL = '.crashreporting_disabled'
+DISABLED_KEY = 'CRASHREPORTING_DISABLED'
+MAX_STRING_LEN = 10240
+
+
+class SentryCrashReporting:
+    """Sentry class for reporting crash info to a remote endpoint"""
+    enabled_in_settings = False
+
+    def __init__(self):
+        self.logger = logging.getLogger('middlewared.logging.SentryCrashReporting')
+        self.init_sentry_sdk()
+
+    def init_sentry_sdk(self):
+        dsn = 'https://11101daa5d5643fba21020af71900475:d60cd246ba684afbadd479653de2c216@sentry.ixsystems.com/2'
+        query = '?timeout=3'
+        dsn = f'{dsn}{query}'
+        release = sw_info['fullname']
+        sentry_sdk.init(dsn=dsn, release=release, default_integrations=False)
+        sentry_sdk.utils.MAX_STRING_LENGTH = MAX_STRING_LEN
+
+    def is_disabled(self):
+        """
+        Sentry Crash reporting can be disabled via:
+            1. system_settings table in the db or
+            2. presence of sentifnel file (`DISABLED_SENTINEL`) or
+            3. environment variable (`DISABLED_KEY`)
+        """
+        if not self.enabled_in_settings:
+            # disabed in db
+            return True
+        elif os.path.exists(os.path.join(MIDDLEWARE_RUN_DIR if sw_info()['stable'] else '/data', DISABLED_SENTINEL)):
+            # disabled because of presence of sentinel file
+            return True
+        elif os.environ.get(DISABLED_KEY, False):
+            # disabled via environment variable
+            return True
+        elif os.stat(__file__).st_dev != os.stat('/').st_dev:
+            # really??
+            return True
+        else:
+            return False
+
+    def get_log_file_content(self, log_files):
+        data = dict()
+        for path, name in log_files:
+            try:
+                with open(path) as f:
+                    data[name] = f.read()[-MAX_STRING_LEN:]
+            except FileNotFoundError:
+                continue
+
+        return data
+
+    def report(self, exc_info, log_files):
+        """"
+        Args:
+            exc_info (tuple): Same as sys.exc_info().
+            log_files (tuple): A tuple with log file absolute path and name.
+        """
+        if self.is_disabled():
+            return
+
+        self.logger.debug('Sending a crash report...')
+        try:
+            with sentry_sdk.configure_scope() as scope:
+                payload_size = 0
+                for k, v in self.get_log_file_content(log_files).items():
+                    if payload_size + len(v) < 190000:
+                        scope.set_extra(k, v)
+                        payload_size += len(v)
+                sentry_sdk.capture_exception(exc_info)
+        except Exception:
+            self.logger.debug('Failed to send crash report', exc_info=True)

--- a/src/middlewared/middlewared/logging/sentry_crash_reporting.py
+++ b/src/middlewared/middlewared/logging/sentry_crash_reporting.py
@@ -22,7 +22,7 @@ class SentryCrashReporting:
         dsn = 'https://11101daa5d5643fba21020af71900475:d60cd246ba684afbadd479653de2c216@sentry.ixsystems.com/2'
         query = '?timeout=3'
         dsn = f'{dsn}{query}'
-        release = sw_info['fullname']
+        release = sw_info()['fullname']
         sentry_sdk.init(dsn=dsn, release=release, default_integrations=False)
         sentry_sdk.utils.MAX_STRING_LENGTH = MAX_STRING_LEN
 

--- a/src/middlewared/middlewared/logging/sentry_crash_reporting.py
+++ b/src/middlewared/middlewared/logging/sentry_crash_reporting.py
@@ -52,8 +52,13 @@ class SentryCrashReporting:
         data = dict()
         for path, name in log_files:
             try:
-                with open(path) as f:
-                    data[name] = f.read()[-MAX_STRING_LEN:]
+                with open(path, 'rb') as f:
+                    # seek to offset relative to the end of file
+                    # since we don't want to load the entire contents
+                    # into memory as a single string just to read the
+                    # last `MAX_STRING_LEN` chars...
+                    f.seek(-MAX_STRING_LEN, os.SEEK_END)
+                    data[name] = f.read().decode()
             except FileNotFoundError:
                 continue
 

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -23,6 +23,7 @@ from .utils.service.call import ServiceCallMixin
 from .utils.threading import set_thread_name, IoThreadPoolExecutor
 from .utils.type import copy_function_metadata
 from .webui_auth import addr_in_allowlist, WebUIAuth
+from .logging.sentry_crash_reporting import SentryCrashReporting
 from .worker import main_worker, worker_init
 from .webhooks.cluster_events import ClusterEventsApplication
 from aiohttp import web
@@ -865,7 +866,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             'middlewared', debug_level, log_format
         ).getLogger()
         self.logger.info('Starting %s middleware', sw_version())
-        self.crash_reporting = logger.CrashReporting()
+        self.crash_reporting = SentryCrashReporting()
         self.crash_reporting_semaphore = asyncio.Semaphore(value=2)
         self.loop_debug = loop_debug
         self.loop_monitor = loop_monitor

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -4,7 +4,7 @@ import syslog
 import middlewared.sqlalchemy as sa
 
 from middlewared.async_validators import validate_port
-from middlewared.logger import CrashReporting
+from middlewared.logging.sentry_crash_reporting import SentryCrashReporting
 from middlewared.schema import accepts, Bool, Datetime, Dict, Int, IPAddr, List, Patch, returns, Str
 from middlewared.service import ConfigService, private, ValidationErrors
 from middlewared.utils import run
@@ -302,7 +302,7 @@ class SystemGeneralService(ConfigService):
 
     @private
     def set_crash_reporting(self):
-        CrashReporting.enabled_in_settings = self.middleware.call_sync('system.general.config')['crash_reporting']
+        SentryCrashReporting.enabled_in_settings = self.middleware.call_sync('system.general.config')['crash_reporting']
 
     @accepts()
     @returns(Int('remaining_seconds', null=True))


### PR DESCRIPTION
1. Rename `CrashReporting` to `SentryCrashReporting` to reflect reality
2. Move this class to its own file
3. We're currently running sentry 0.13.2 which means we can get rid of the monkey-patching to work-around a bug we saw in a version < 0.10.3
4. Stop loading, potentially, a large file into memory every time a crash occurs just so we can load the last `MAX_STRING_LEN` chars of the file. Seek to relative end of file, and then read. 