### PR TITLE
NAS-120277 / 23.10 / Document return type in swagger API endpoints

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -303,6 +303,9 @@ class OpenAPIResource(object):
                     'required': True,
                     'schema': {'type': service_config['datastore_primary_key_type']},
                 })
+            method_returns = method.get('returns') or []
+            if method_returns:
+                opobject['responses']['200'] = self._returns_to_request(methodname, method_returns)
 
         self._paths[f'/{path}'][operation] = opobject
 
@@ -334,6 +337,21 @@ class OpenAPIResource(object):
                 else:
                     schema['items'] = {}
         return schema
+
+    def _returns_to_request(self, methodname, method_returns):
+        method_name = f'return_schema_of_{methodname.replace(".", "_")}'
+
+        for schema in method_returns:
+            self._schemas[method_name] = self._convert_schema(schema)
+
+        json_request = {'schema': {'$ref': f'#components/schemas/{method_name}'}}
+
+        return {
+            'description': 'Response schema:',
+            'content': {
+                'application/json': json_request,
+            }
+        }
 
     def _accepts_to_request(self, methodname, method, schemas):
 


### PR DESCRIPTION
This PR adds ability to document return type of a method in HTTP API swagger docs.

Example screenshot:
<img width="828" alt="Screenshot 2023-02-19 at 8 50 41 PM" src="https://user-images.githubusercontent.com/17968138/219958954-1772a3ab-f5ce-4919-9263-c98a5e606882.png">
