### PR TITLE
NAS-120416 / 23.10 / Handle case when no server is specified for openvpn server service

### DIFF
--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -355,7 +355,7 @@ class OpenVPNServerService(SystemServiceService):
                 'on the same local port without any issues.'
             )
 
-        if ipaddress.ip_address(data['server']).version == 4 and data['netmask'] > 32:
+        if data['server'] and ipaddress.ip_address(data['server']).version == 4 and data['netmask'] > 32:
             verrors.add(
                 f'{schema_name}.netmask',
                 'For IPv4 server addresses please provide a netmask value from 0-32.'

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -299,6 +299,9 @@ class OpenVPNServerService(SystemServiceService):
             ):
                 raise CallError('Root CA has been revoked. Please select another Root CA.')
 
+        if not config['server']:
+            raise CallError('Server attribute must be configured to consume OpenVPN Server service.')
+
         if not config['server_certificate']:
             raise CallError('Please configure server certificate first.')
         else:


### PR DESCRIPTION
This PR handles a case where if you try to make a call like `midclt call openvpn.server.update '{"remove_certificates": true}'` and you don't have openvpn server configured already, it will error out with a ValueError because by default no `server` attribute is configured.