### PR TITLE
NAS-120241 / 22.12.2 / rm @throttle decorator from failover plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -12,9 +12,7 @@ from functools import partial
 
 from middlewared.auth import is_ha_connection, TrueNasNodeSessionManagerCredentials
 from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str, returns, Patch
-from middlewared.service import (
-    job, no_auth_required, pass_app, private, throttle, CallError, ConfigService, ValidationErrors,
-)
+from middlewared.service import job, no_auth_required, pass_app, private, CallError, ConfigService, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.plugins.auth import AuthService
 from middlewared.plugins.config import FREENAS_DATABASE

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -11,7 +11,6 @@ import time
 from functools import partial
 
 from middlewared.auth import is_ha_connection, TrueNasNodeSessionManagerCredentials
-from middlewared.plugins.failover_.utils import throttle_condition
 from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str, returns, Patch
 from middlewared.service import (
     job, no_auth_required, pass_app, private, throttle, CallError, ConfigService, ValidationErrors,
@@ -193,7 +192,6 @@ class FailoverService(ConfigService):
         return await self.middleware.call('failover.internal_interface.detect')
 
     @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(Str())
     @pass_app(rest=True)
@@ -273,7 +271,6 @@ class FailoverService(ConfigService):
         return bool(event)
 
     @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(List('ips', items=[Str('ip')]))
     @pass_app(rest=True)

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -1,5 +1,5 @@
 from middlewared.schema import accepts, returns, List, Str
-from middlewared.service import Service, throttle, pass_app, no_auth_required, private
+from middlewared.service import Service, pass_app, no_auth_required, private
 from middlewared.plugins.interface.netif import netif
 
 

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -1,6 +1,5 @@
 from middlewared.schema import accepts, returns, List, Str
 from middlewared.service import Service, throttle, pass_app, no_auth_required, private
-from middlewared.plugins.failover_.utils import throttle_condition
 from middlewared.plugins.interface.netif import netif
 
 
@@ -13,7 +12,6 @@ class FailoverDisabledReasonsService(Service):
     LAST_DISABLED_REASONS = None
 
     @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(List('reasons', items=[Str('reason')]))
     @pass_app()

--- a/src/middlewared/middlewared/plugins/failover_/utils.py
+++ b/src/middlewared/middlewared/plugins/failover_/utils.py
@@ -1,5 +1,0 @@
-def throttle_condition(middleware, app, *args, **kwargs):
-    # app is None means internal middleware call
-    if app is None or (app and app.authenticated):
-        return True, 'AUTHENTICATED'
-    return False, None


### PR DESCRIPTION
This is believed to be causing `failover.status` to sometimes take many minutes (30+) before it returns. This effects the login page since webUI calls this to determine if HA node or not. We also cache the response and listen for specific events to update the HA status so this is no longer needed. We also have a semaphore on the websocket server side to prevent a large amount of concurrent calls rendering this functionality even more useless.

Original PR: https://github.com/truenas/middleware/pull/10724
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120241