### PR TITLE
NAS-120428 / 13.0 / Ensure that DOSATTRIB xattr is disabled

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -327,6 +327,7 @@ class SharingSMBService(Service):
             })
 
         conf.update({
+            "ixnas:dosattrib_xattr": "false",
             "nfs4:chown": "true",
             "ea support": "false",
         })


### PR DESCRIPTION
This reverts a change to default parameters that was made between 13.0-U3.1 and 13.0-U4. Initial plan was to normalize how DOS attributes are stored between SCALE and Core (specifically as regards how file ids are generated and used), but upstream has since reverted changes to store a synthesized fileid based on inode birth time. Our temporary plan for now is to switch back to using inode number for this purpose (while evaluating other means of handling these).