### PR TITLE
NAS-120280 / 22.12.2 / Add some validation for query-filters (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql.operators import desc_op, nullsfirst_op, nullslast_op
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, Str
 from middlewared.service import Service
 from middlewared.service_exception import MatchNotFound
+from middlewared.validators import QueryFilters
 
 from .filter import FilterMixin
 from .schema import SchemaMixin
@@ -27,7 +28,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
 
     @accepts(
         Str('name'),
-        List('query-filters', register=True),
+        List('query-filters', items=[List('query-filter')], validators=[QueryFilters()], register=True),
         Dict(
             'query-options',
             Bool('relationships', default=True),

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -585,7 +585,7 @@ class List(EnumMixin, Attribute):
         value = super(List, self).clean(value)
         if value is None:
             return copy.deepcopy(self.default)
-        if not isinstance(value, list):
+        if not isinstance(value, (list, tuple)):
             raise Error(self.name, 'Not a list')
         if not self.empty and not value:
             raise Error(self.name, 'Empty value not allowed')

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -4,11 +4,13 @@ import re
 from urllib.parse import urlparse
 import uuid
 from string import digits, ascii_uppercase, ascii_lowercase, punctuation
+from middlewared.utils import filters
 
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
 RE_MAC_ADDRESS = re.compile(r"^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$")
+validate_filters = filters().validate_filters
 
 
 class Email:
@@ -150,6 +152,11 @@ class Range:
 class Port(Range):
     def __init__(self):
         super().__init__(min=1, max=65535)
+
+
+class QueryFilters:
+    def __call__(self, value):
+        validate_filters(value)
 
 
 class Unique:


### PR DESCRIPTION
`query-filters` are always a list of lists (or in some cases tuples) of the form `[<key>, <op>, <val>]` or `['OR', <list of filters>]`. We should perform some basic schema validation to give users more helpful messages.

Example of unhelpful message:
```
root@truenas[/mnt/dozer/middleware/src/middlewared]# midclt call user.query '["bob"]'
Invalid operation: o
```

Example of more helpful message:
```
root@truenas[~]# midclt call user.query '["bob"]'
[EINVAL] query-filters: Item#0 is not valid per list types: [query-filter] Not a list
```

Original PR: https://github.com/truenas/middleware/pull/10679
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120280