### PR TITLE
NAS-120458 / 23.10 / NAS-120458 Avoid parsing dates while reading yaml

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/restore.py
@@ -9,6 +9,7 @@ import yaml
 
 from middlewared.schema import Dict, Bool, returns, Str
 from middlewared.service import accepts, CallError, job, Service
+from middlewared.plugins.kubernetes_linux.yaml import NoDatesFullLoader
 
 
 RE_POOL = re.compile(r'^.*?(/.*)')
@@ -150,14 +151,15 @@ class KubernetesService(Service):
 
             # First we will restore namespace and then the secrets
             with open(os.path.join(r_backup_dir, 'namespace.yaml'), 'r') as f:
-                namespace_body = yaml.load(f.read(), Loader=yaml.FullLoader)
+                namespace_body = yaml.load(f.read(), Loader=NoDatesFullLoader)
                 namespace_body['metadata'].pop('resourceVersion', None)
+
                 self.middleware.call_sync('k8s.namespace.create', {'body': namespace_body})
 
             secrets_dir = os.path.join(r_backup_dir, 'secrets')
             for secret in sorted(os.listdir(secrets_dir)):
                 with open(os.path.join(secrets_dir, secret)) as f:
-                    secret_body = yaml.load(f.read(), Loader=yaml.FullLoader)
+                    secret_body = yaml.load(f.read(), Loader=NoDatesFullLoader)
                     secret_body['metadata'].pop('resourceVersion', None)
                     self.middleware.call_sync(
                         'k8s.secret.create', {

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/yaml.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/yaml.py
@@ -1,5 +1,27 @@
 import yaml
 
+class NoDatesFullLoader(yaml.FullLoader):
+    @classmethod
+    def remove_implicit_resolver(cls, tag_to_remove):
+        """
+        Remove implicit resolvers for a particular tag
+
+        Takes care not to modify resolvers in super classes.
+
+        We want to load datetimes as strings, not dates, because we
+        go on to serialise as json which doesn't have the advanced types
+        of yaml, and leads to incompatibilities down the track.
+        """
+        if not 'yaml_implicit_resolvers' in cls.__dict__:
+            cls.yaml_implicit_resolvers = cls.yaml_implicit_resolvers.copy()
+
+        for first_letter, mappings in cls.yaml_implicit_resolvers.items():
+            cls.yaml_implicit_resolvers[first_letter] = [(tag, regexp) 
+                                                         for tag, regexp in mappings
+                                                         if tag != tag_to_remove]
+
+NoDatesFullLoader.remove_implicit_resolver('tag:yaml.org,2002:timestamp')
+
 
 class SafeDumper(yaml.SafeDumper):
     pass


### PR DESCRIPTION
This is specifically for YAML which is then converted to JSON for delivery to a Kubernetes API endpoint. The YAML parser converts datetime strings into Python datetime objects by default, losing the original formatting, and the JSON library doesn't understand what format it should use to output dates.