### PR TITLE
NAS-120482 / 23.10 / Add last update field to schema

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -34,6 +34,7 @@ class CatalogService(Service):
         Str('latest_version', required=True, null=True),
         Str('latest_app_version', required=True, null=True),
         Str('latest_human_version', required=True, null=True),
+        Str('last_update', required=True, null=True),
         Str('icon_url', required=True, null=True),
     ))
     def get_item_details(self, item_name, options):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -46,6 +46,7 @@ class CatalogService(Service):
                     'healthy_error': False,
                     'latest_version': '1.2.0',
                     'latest_app_version': '1.1.6',
+                    'last_update': '2023-02-01 22:55:31',
                     'icon_url': 'https://www.chia.net/img/chia_logo.svg',
                     'title': 'Chia',
                     'description': 'App description here',


### PR DESCRIPTION
## Context

Last update field has been added to item/item versions in https://github.com/truenas/catalog_validation/pull/35 and this is a followup PR to add the attribute to items schema so it correctly reflects what we return.