### PR TITLE
Bugfix: Allowed schema in openapi docs for {id} routes

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -291,7 +291,7 @@ class OpenAPIResource(object):
                                                  '`extra.retrieve_properties=false` will pass `retrieve_properties` ' \
                                                  'as an extra argument to pool/dataset endpoint.'
             elif accepts and not (operation == 'delete' and method['item_method'] and len(accepts) == 1) and (
-                '{id}' not in path and not method['filterable']
+                not method['filterable']
             ):
                 opobject['requestBody'] = self._accepts_to_request(methodname, method, accepts)
 

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -985,6 +985,8 @@ class Patch(object):
 
         schema = schema.copy()
         schema.name = self.name
+        if hasattr(schema, "title"):
+            schema.title = self.name
         for operation, patch in self.patches:
             if operation == 'replace':
                 # This is for convenience where it's hard sometimes to change attrs in a large dict


### PR DESCRIPTION
Currently the `OpenAPIResource.add_path` method was excluding routes with `{id}` from having their schema generated.

This seems to have been a bug accidentally included in [833fbfb](https://github.com/truenas/middleware/commit/833fbfb520168891f332de8a809ecbc18cff48b0) here:

![id-schema-bug-introduction](https://user-images.githubusercontent.com/12521554/221424299-c303bf09-803f-4463-aa8b-a9ebbe171b6e.png)

Previously, a PUT route with `'{id}'` in the path (and 1 `accepts` arg etc) would:

- Pass the `elif` on line 230
- Fail the `if` on line 231
- End up within the `else` on 244

and as such, would have `opobject['requestBody']` set.

Now such a route fails the `elif` on (new) line 233, and thus doesn't have `opobject['requestBody']` set.

Additionally, the `Patch` class wasn't correctly updating the `title` field, but only the `name` field. This led to it having the same name, and as such, not actually being considered different.

The fix can be seen here in the live API docs (fixed on right):
![id-schema](https://user-images.githubusercontent.com/12521554/221424766-e24f4aba-b57a-4916-b00f-696e0ce99424.png)

Here's the old/new JSONs of the API docs (as `.txt` due to github restrictions) so you can easily see the diff:
[old.txt](https://github.com/truenas/middleware/files/10834223/old.txt)
[new.txt](https://github.com/truenas/middleware/files/10834585/new.txt)