### PR TITLE
NAS-120295 / 22.12.2 / Do not raise port conflict error when nobind for openvpn client is set (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -601,7 +601,7 @@ class OpenVPNClientService(SystemServiceService):
         remove_certificates = data['remove_certificates']
 
         verrors, data = await OpenVPN.common_validation(
-            self.middleware, data, schema_name, 'client'
+            self.middleware, data, schema_name, 'client', data['nobind'] is True,
         )
 
         if not remove_certificates:

--- a/src/middlewared/middlewared/plugins/vpn_/attachments.py
+++ b/src/middlewared/middlewared/plugins/vpn_/attachments.py
@@ -16,6 +16,14 @@ class OpenVPNClientServicePortDelegate(ServicePortDelegate):
     port_fields = ['port']
     title = 'Openvpn Client Service'
 
+    async def get_ports_internal(self):
+        await self.basic_checks()
+        config = await self.middleware.call(f'{self.namespace}.config')
+        if config['nobind']:
+            return []
+        else:
+            return [config[k] for k in filter(lambda k: config.get(k), self.port_fields)]
+
 
 async def setup(middleware):
     await middleware.call('port.register_attachment_delegate', OpenVPNServerServicePortDelegate(middleware))


### PR DESCRIPTION
This PR adds changes to not raise a port conflict with openvpn server or any other service if `nobind` is set as that means the `port` field just points to the remove openvpn server's port and not it's own which would be selected dynamically by openvpn ( whichever is not in use ).

Original PR: https://github.com/truenas/middleware/pull/10751
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120295