### PR TITLE
NAS-120563 / 23.10 / Ensure we append path separator in SMB validation

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1476,7 +1476,7 @@ class SharingSMBService(SharingService):
             return
 
         current_acltype = get_acl_type(this_mnt['super_opts'])
-        child_mounts = filter_list(list(mntinfo.values()), [['mountpoint', '^', path]])
+        child_mounts = filter_list(list(mntinfo.values()), [['mountpoint', '^', f'{path}/']])
         for mnt in child_mounts:
             if '@' in mnt['mount_source']:
                 continue

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -13,6 +13,7 @@ from samba import param
 from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.common.listen import SystemServiceListenMultipleDelegate
 from middlewared.schema import Bool, Dict, IPAddr, List, Str, Int, Patch
+from middlewared.schema import Path as SchemaPath
 from middlewared.service import accepts, job, private, SharingService
 from middlewared.service import TDBWrapConfigService, ValidationErrors, filterable
 from middlewared.service_exception import CallError, MatchNotFound
@@ -939,7 +940,7 @@ class SharingSMBService(SharingService):
     @accepts(Dict(
         'sharingsmb_create',
         Str('purpose', enum=[x.name for x in SMBSharePreset], default=SMBSharePreset.DEFAULT_SHARE.name),
-        Str('path', required=True),
+        SchemaPath('path', required=True),
         Str('path_suffix', default=''),
         Bool('home', default=False),
         Str('name', max_length=80, required=True),


### PR DESCRIPTION
When determining whether a mountpoint is a child of the current path, we should append path separator so that we don't generate false-positives in the following case

```
/mnt/dozer/SHARE
/mnt/dozer/SHARE2
```