### PR TITLE
NAS-120569 / 23.10 / Cluster - change IPs under fcntl lock

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_ips.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_ips.py
@@ -1,4 +1,9 @@
+import contextlib
+import errno
+import fcntl
+import os
 import pathlib
+import stat
 
 from middlewared.service import Service, CallError
 from middlewared.plugins.cluster_linux.utils import CTDBConfig
@@ -81,6 +86,97 @@ class CtdbIpService(Service):
 
         verrors.check()
 
+    @contextlib.contextmanager
+    def lockfile_open(self, path):
+        # Open the file under a lock. This forces serialization
+        # of write access to the file from all nodes.
+        def ip_file_opener(path, flags):
+            fd = os.open(path, flags, 0o755)
+            st = os.fstat(fd)
+
+            if stat.S_IMODE(st.st_mode) != 0o755:
+                os.fchmod(fd, 0o755)
+
+            if st.st_uid != 0 or st.st_gid != 0:
+                os.fchown(fd, 0, 0)
+
+            return fd
+
+        with open(path, "r+", opener=ip_file_opener) as f:
+            try:
+                fcntl.lockf(f.fileno(), fcntl.LOCK_EX)
+                yield f
+            finally:
+                os.fsync(f.fileno())
+                fcntl.lockf(f.fileno(), fcntl.LOCK_UN)
+
+    def entry_check(self, ip_file, entry):
+        # Scan file for duplicate entry. Ideally this sort
+        # of issue would have been caught during initial validation
+        # but since initial validation isn't performed under a lock,
+        # we are potentially exposed to time of user / time of check issues.
+        for line in ip_file:
+            if line == entry:
+                raise CallError(f'{entry}: entry already exists in file.', errno.EEXIST)
+
+        os.lseek(ip_file.fileno(), 0, os.SEEK_END)
+
+    def create_locked(self, ctdb_file, data, is_private):
+        # in the case of adding a node (private or public),
+        # it _MUST_ be added to the end of the file always
+        with self.lockfile_open(ctdb_file) as f:
+            entry = data['ip'] if is_private else f'{data["ip"]}/{data["netmask"]} {data["interface"]}'
+            self.entry_check(f, entry)
+            f.write(entry + '\n')
+
+    def update_locked(self, schema_name, ctdb_file, data, is_private):
+        enable = data.get('enable', False)
+
+        with self.lockfile_open(ctdb_file) as f:
+            if is_private:
+                address = data['address']
+            else:
+                address = data["public_ip"]
+
+            find_entry = address if not enable else '#' + address
+
+            # read the data first
+            lines = f.read().splitlines()
+
+            # before we truncate the file, let's make sure we don't hit an
+            # unexpected error
+            try:
+                if is_private:
+                    index = lines.index(find_entry)
+                    # on private ip file update, `new_entry` is just the inverse
+                    # of `find_entry`.
+                    # (i.e if find_entry = '192.168.1.150' new_entry = '#192.168.1.150')
+                    new_entry = address if find_entry.startswith('#') else '#' + address
+                else:
+                    # on public ip update, ctdb doesn't return the netmask information
+                    # for the associated ip even though it requires one when creating.
+                    # this means get the index, and simply add a '#' or remove it from
+                    # that entry depending on what the update operation is
+                    index = lines.index(next(i for i in lines if i.startswith(find_entry)))
+                    old_entry = lines[index]
+                    new_entry = '#' + old_entry if not old_entry.startswith('#') else old_entry.split('#')[1]
+
+                # replace our old entry with the new one
+                # if we're deleting a public IP address, remove the entry completely.
+                if schema_name != 'public_delete':
+                    lines[index] = new_entry
+                else:
+                    lines.pop(index)
+            except ValueError as e:
+                raise CallError(f'Failed finding entry in file with error: {e}')
+
+            # now truncate the file since we're rewriting it
+            f.seek(0)
+            f.truncate()
+
+            # finally write it
+            f.write('\n'.join(lines) + '\n')
+
     def update_file(self, data, schema_name):
         """
         Update the ctdb cluster private or public IP file.
@@ -88,7 +184,6 @@ class CtdbIpService(Service):
 
         is_private = schema_name in ('private_create', 'private_update')
         create = schema_name in ('private_create', 'public_create')
-        enable = data.get('enable', False)
 
         if is_private:
             ctdb_file = pathlib.Path(CTDBConfig.GM_PRI_IP_FILE.value)
@@ -158,59 +253,6 @@ class CtdbIpService(Service):
                 raise CallError(f'Failed symlinking {etc_file} to {ctdb_file} with error: {e}')
 
         if create:
-            # in the case of adding a node (private or public),
-            # it _MUST_ be added to the end of the file always
-            with open(ctdb_file, 'a') as f:
-                if is_private:
-                    f.write(data['ip'] + '\n')
-                else:
-                    entry = f'{data["ip"]}/{data["netmask"]} {data["interface"]}'
-                    f.write(entry + '\n')
+            self.create_locked(ctdb_file, data, is_private)
         else:
-            if is_private:
-                address = data['address']
-            else:
-                address = data["public_ip"]
-
-            find_entry = address if not enable else '#' + address
-
-            # no matter what we're doing at this point,
-            # we're going to have to read, truncate,
-            # and rewrite the contents.
-            with open(ctdb_file, 'r+') as f:
-                # read the data first
-                lines = f.read().splitlines()
-
-                # before we truncate the file, let's make sure we don't hit an
-                # unexpected error
-                try:
-                    if is_private:
-                        index = lines.index(find_entry)
-                        # on private ip file update, `new_entry` is just the inverse
-                        # of `find_entry`.
-                        # (i.e if find_entry = '192.168.1.150' new_entry = '#192.168.1.150')
-                        new_entry = address if find_entry.startswith('#') else '#' + address
-                    else:
-                        # on public ip update, ctdb doesn't return the netmask information
-                        # for the associated ip even though it requires one when creating.
-                        # this means get the index, and simply add a '#' or remove it from
-                        # that entry depending on what the update operation is
-                        index = lines.index(next(i for i in lines if i.startswith(find_entry)))
-                        old_entry = lines[index]
-                        new_entry = '#' + old_entry if not old_entry.startswith('#') else old_entry.split('#')[1]
-
-                    # replace our old entry with the new one
-                    # if we're deleting a public IP address, remove the entry completely.
-                    if schema_name != 'public_delete':
-                        lines[index] = new_entry
-                    else:
-                        lines.pop(index)
-                except ValueError as e:
-                    raise CallError(f'Failed finding entry in file with error: {e}')
-
-                # now truncate the file since we're rewriting it
-                f.seek(0)
-                f.truncate()
-
-                # finally write it
-                f.write('\n'.join(lines) + '\n')
+            self.update_locked(schema_name, ctdb_file, data, is_private)


### PR DESCRIPTION
Serialize write access to clustered IP address files via fcntl locks. This helps to avoid time-of-check / time-of-use issues when user is inadvertantly making changes via multiple nodes at once.