### PR TITLE
NAS-120534 / 22.12.2 / Fix removal of ctdb_shared_volume files during teardown (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -161,7 +161,7 @@ class ClusterUtils(Service):
 
         interest = (f'.system/{CTDBConfig.CTDB_VOL_NAME.value}', '.system/glusterd')
         mount_info = self.middleware.call_sync('filesystem.mount_info')
-        for i in filter(lambda x: x['mountpoint'].endswith(interest), mount_info):
+        for i in filter(lambda x: x['mount_source'].endswith(interest), mount_info):
             dirs.append(i['mountpoint'])
 
         return files, dirs


### PR DESCRIPTION
Typo in how we generated our list of paths to remove caused stale nodes file to exist which triggered issues for QE workflows to involve building / tearing down clusters.

Original PR: https://github.com/truenas/middleware/pull/10762
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120534