### PR TITLE
NAS-106086 / 23.10 / Add support for iSNS servers in scst

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -82,6 +82,10 @@ HANDLER ${handler} {
 
 TARGET_DRIVER iscsi {
     enabled 1
+## Currently SCST only supports one iSNS server
+% if global_config['isns_servers']:
+    iSNSServer ${global_config['isns_servers'][0]}
+% endif
 ## We are supposed to set iSNS server here but unfortunately that is not working
 ## An issue has been opened with scst regarding that and duplicating of target reporting on each new portal
 ## https://sourceforge.net/p/scst/tickets/38/ ( let's please fix this once we hear back from them )

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -44,9 +44,8 @@ class ISCSIGlobalService(SystemServiceService):
         try:
             s.connect((host, port))
             ret = True
-        except Exception as e:
-            self.logger.debug("connection to %s failed with error: %s",
-                              host, e)
+        except Exception:
+            self.logger.debug("connection to %s failed", host, exc_info=True)
             ret = False
         finally:
             s.close()
@@ -164,7 +163,7 @@ class ISCSIGlobalService(SystemServiceService):
             '-attributes', 'iSNSServer=""'
         ], check=False)
         if cp.returncode:
-            self.middleware.logger.warning('Failed to stop active iSNS: %s', cp.stderr.decode())
+            self.logger.warning('Failed to stop active iSNS: %s', cp.stderr.decode())
 
     @accepts()
     async def alua_enabled(self):

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -4,6 +4,7 @@
 
 import os
 import random
+import socket
 import string
 import sys
 from time import sleep
@@ -13,9 +14,9 @@ from pytest_dependency import depends
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test, hostname, ip, pool_name
+from auto_config import dev_test, hostname, ip, isns_ip, pool_name
 from functions import DELETE, GET, POST, PUT, SSH_TEST
-from protocols import iscsi_scsi_connection
+from protocols import iscsi_scsi_connection, isns_connection
 
 from assets.REST.pool import dataset
 from assets.REST.snapshot import snapshot, snapshot_rollback
@@ -245,6 +246,20 @@ def configured_target_to_zvol_extent(target_name, zvol, alias=None):
                                 'extent': extent_config,
                             }
 
+@contextlib.contextmanager
+def isns_enabled(delay=5):
+    payload = {'isns_servers': [isns_ip]}
+    results = PUT(f"/iscsi/global", payload)
+    assert results.status_code == 200, results.text
+    try:
+        yield
+    finally:
+        payload = {'isns_servers': []}
+        results = PUT(f"/iscsi/global", payload)
+        assert results.status_code == 200, results.text
+        if delay:
+            print(f'Sleeping for {delay} seconds after turning off iSNS')
+            sleep(delay)
 
 def TUR(s):
     """
@@ -885,6 +900,7 @@ def test_11_modify_portal(request):
         results = PUT(f"/iscsi/portal/id/{portal_config['id']}", payload)
         assert results.status_code == 200, results.text
 
+
 def test_12_pblocksize_setting(request):
     """
     This tests whether toggling pblocksize has the desired result on READ CAPACITY 16, i.e.
@@ -901,7 +917,7 @@ def test_12_pblocksize_setting(request):
             assert data['lbppbe'] == 3, data
 
             # First let's just change the blocksize to 2K
-            payload = {'blocksize' : 2048}
+            payload = {'blocksize': 2048}
             results = PUT(f"/iscsi/extent/id/{extent_config['id']}", payload)
             assert results.status_code == 200, results.text
 
@@ -911,7 +927,7 @@ def test_12_pblocksize_setting(request):
             assert data['lbppbe'] == 1, data
 
             # Now let's change it back to 512, but also set pblocksize
-            payload = {'blocksize' : 512, 'pblocksize' : True}
+            payload = {'blocksize': 512, 'pblocksize': True}
             results = PUT(f"/iscsi/extent/id/{extent_config['id']}", payload)
             assert results.status_code == 200, results.text
 
@@ -929,7 +945,7 @@ def test_12_pblocksize_setting(request):
             assert data['lbppbe'] == 5, data
 
             # First let's just change the blocksize to 4K
-            payload = {'blocksize' : 4096}
+            payload = {'blocksize': 4096}
             results = PUT(f"/iscsi/extent/id/{extent_config['id']}", payload)
             assert results.status_code == 200, results.text
 
@@ -939,7 +955,7 @@ def test_12_pblocksize_setting(request):
             assert data['lbppbe'] == 2, data
 
             # Now let's also set pblocksize
-            payload = {'pblocksize' : True}
+            payload = {'pblocksize': True}
             results = PUT(f"/iscsi/extent/id/{extent_config['id']}", payload)
             assert results.status_code == 200, results.text
 
@@ -947,6 +963,72 @@ def test_12_pblocksize_setting(request):
             data = s.readcapacity16().result
             assert data['block_length'] == 4096, data
             assert data['lbppbe'] == 0, data
+
+
+def test_13_test_isns(request):
+    """
+    Test ability to register targets with iSNS.
+    """
+    # Will use a more unique target name than usual, just in case several test
+    # runs are hitting the same iSNS server at the same time.
+    _host = socket.gethostname()
+    _rand = ''.join(random.choices(string.digits +
+                                   string.ascii_lowercase,
+                                   k=12))
+    _name_base = f'isnstest:{_host}:{_rand}'
+    _target1 = f'{_name_base}:1'
+    _target2 = f'{_name_base}:2'
+    _initiator = f'iqn.2005-10.org.freenas.ctl:isnstest:{_name_base}:initiator'
+
+    with isns_connection(isns_ip, _initiator) as isns_client:
+        # First let's ensure that the targets are not already present.
+        base_iqns = set(isns_client.list_targets())
+        for _target in [_target1, _target2]:
+            iqn = f'{basename}:{_target}'
+            assert iqn not in base_iqns, iqn
+
+        # Create target1 and ensure it is still not present (because we
+        # haven't switched on iSNS yet).
+        with configured_target_to_file_extent(_target1,
+                                              pool_name,
+                                              dataset_name,
+                                              file_name) as iscsi_config:
+            iqns = set(isns_client.list_targets())
+            iqn = f'{basename}:{_target1}'
+            assert iqn not in iqns, iqn
+
+            # Now turn on the iSNS server
+            with isns_enabled():
+                iqns = set(isns_client.list_targets())
+                iqn = f'{basename}:{_target1}'
+                assert iqn in iqns, iqn
+
+                # Create another target and ensure it shows up too
+                with target(_target2,
+                            [{'portal': iscsi_config['portal']['id']}]
+                            ) as target2_config:
+                    target_id = target2_config['id']
+                    with zvol_dataset(zvol):
+                        with zvol_extent(zvol) as extent_config:
+                            extent_id = extent_config['id']
+                            with target_extent_associate(target_id, extent_id):
+                                iqns = set(isns_client.list_targets())
+                                for _target in [_target1, _target2]:
+                                    iqn = f'{basename}:{_target}'
+                                    assert iqn in iqns, iqn
+
+            # Now that iSNS is disabled again, ensure that our target is
+            # no longer advertised
+            iqns = set(isns_client.list_targets())
+            iqn = f'{basename}:{_target1}'
+            assert iqn not in iqns, iqn
+
+        # Finally let's ensure that neither target is present.
+        base_iqns = set(isns_client.list_targets())
+        for _target in [_target1, _target2]:
+            iqn = f'{basename}:{_target}'
+            assert iqn not in base_iqns, iqn
+
 
 def test_99_teardown(request):
     # Disable iSCSI service
@@ -962,4 +1044,3 @@ def test_99_teardown(request):
     results = GET("/service/?service=iscsitarget")
     assert results.status_code == 200, results.text
     assert results.json()[0]["state"] == "STOPPED", results.text
-

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -1,9 +1,11 @@
 import contextlib
+
 from functions import DELETE, POST
 
-from .smb_proto import SMB
+from .iscsi_proto import iscsi_scsi_connect, iscsi_scsi_connection
+from .iSNSP.client import iSNSPClient
 from .nfs_proto import SSH_NFS
-from .iscsi_proto import iscsi_scsi_connection, iscsi_scsi_connect
+from .smb_proto import SMB
 
 
 @contextlib.contextmanager
@@ -47,3 +49,14 @@ def nfs_share(path, options=None):
     finally:
         result = DELETE(f"/sharing/nfs/id/{id}/")
         assert result.status_code == 200, result.text
+
+@contextlib.contextmanager
+def isns_connection(host, initiator_iqn, **kwargs):
+    c = iSNSPClient(host, initiator_iqn, **kwargs)
+    try:
+        c.connect()
+        c.register_initiator()
+        yield c
+    finally:
+        c.deregister_initiator()
+        c.close()

--- a/tests/protocols/iSNSP/client.py
+++ b/tests/protocols/iSNSP/client.py
@@ -1,0 +1,115 @@
+import socket
+
+from .exceptions import *
+from .packet import *
+
+
+class iSNSPClient(object):
+    def __init__(self, host, initiator_iqn, port=3205):
+        self.host = host
+        if initiator_iqn:
+            self.source = iSNSPAttribute.iSCSIName(initiator_iqn)
+        else:
+            self.source = None
+        self.port = port
+        self.txnid = 1
+        self.sock = None
+
+    def connect(self, timeout=10):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect((self.host, self.port))
+        if timeout:
+            self.sock.settimeout(timeout)
+
+    def close(self):
+        if self.sock:
+            self.sock.close()
+
+    def register_initiator(self, iqn=None):
+        if not self.source:
+            self.source = iSNSPAttribute.iSCSIName(iqn)
+        eid = iSNSPAttribute.EntityIdentifier('')
+        delimiter = iSNSPAttribute.Delimiter()
+        iscsi_name = iSNSPAttribute.iSCSIName(iqn) if iqn else self.source
+        node_type = iSNSPAttribute.iSCSINodeType(2)
+        flags = iSNSPFlags(client=True, first=True, last=True)
+
+        pkt = iSNSPPacket.DevAttrReg(flags, self.txnid, 0,
+                                     [self.source, eid, delimiter, iscsi_name,
+                                      node_type])
+        rpkt = self.send_packet(pkt)
+        if rpkt.function != 'DevAttrRegRsp':
+            raise iSNSPException('Invalid response type', response)
+
+    def list_targets(self, verbose=False):
+        result = []
+        next_iscsi_name = iSNSPAttribute.iSCSIName('')
+        delimiter = iSNSPAttribute.Delimiter()
+        target_node_type = iSNSPAttribute.iSCSINodeType(1)
+        flags = iSNSPFlags(client=True, first=True, last=True)
+        while True:
+            pkt = iSNSPPacket.DevGetNext(flags, self.txnid, 0,
+                                         [self.source,
+                                          next_iscsi_name,
+                                          delimiter,
+                                          target_node_type])
+            try:
+                rpkt = self.send_packet(pkt)
+                if verbose:
+                    for p in rpkt.payload:
+                        print(p)
+                if rpkt.payload[1].tag == 'iSCSI Name':
+                    next_iscsi_name = rpkt.payload[1]
+                    result.append(next_iscsi_name.val)
+                else:
+                    raise iSNSPException('Invalid response attribute', rpkt)
+            except StopIteration:
+                break
+        return result
+
+    def fetch_eids(self, verbose=False):
+        result = []
+        eid = iSNSPAttribute.EntityIdentifier(bytes())
+        delimiter = iSNSPAttribute.Delimiter()
+        flags = iSNSPFlags(client=True, first=True, last=True)
+        while True:
+            pkt = iSNSPPacket.DevGetNext(flags, self.txnid, 0,
+                                         [self.source, eid, delimiter])
+            try:
+                rpkt = self.send_packet(pkt)
+                if verbose:
+                    for p in rpkt.payload:
+                        print(p)
+                if rpkt.payload[1].tag == 'Entity Identifier':
+                    eid = rpkt.payload[1]
+                    result.append(eid)
+                else:
+                    raise iSNSPException('Invalid response attribute', rpkt)
+            except StopIteration:
+                break
+        return result
+
+    def deregister_initiator(self, iqn=None):
+        delimiter = iSNSPAttribute.Delimiter()
+        flags = iSNSPFlags(client=True, first=True, last=True)
+        iscsi_name = iSNSPAttribute.iSCSIName(iqn) if iqn else self.source
+        pkt = iSNSPPacket.DevDereg(flags, self.txnid, 0,
+                                   [self.source, delimiter, iscsi_name])
+        rpkt = self.send_packet(pkt)
+        if rpkt.function != 'DevDeregRsp':
+            raise iSNSPException('Invalid response type', response)
+
+    def send_packet(self, pkt):
+        self.sock.send(pkt.asbytes)
+        data = self.sock.recv(4096)
+        _txnid = self.txnid
+        self.txnid += 1
+        response = iSNSPPacket.from_bytes(data)
+        status = response.payload[0]
+        if status == ResponseStatus.NO_SUCH_ENTRY:
+            raise StopIteration
+        if status != ResponseStatus.SUCCESSFUL:
+            raise iSNSPException('Invalid response', status)
+        if response.txnid != _txnid:
+            raise iSNSPException('Invalid response txnid', response)
+        return response

--- a/tests/protocols/iSNSP/exceptions.py
+++ b/tests/protocols/iSNSP/exceptions.py
@@ -1,0 +1,10 @@
+class iSNSPException(Exception):
+    """
+    Base exception for our iSNSP functions
+    """
+
+
+class MalformedPacketError(iSNSPException):
+    """
+    The iSNSP packet has some sort of issue
+    """

--- a/tests/protocols/iSNSP/packet.py
+++ b/tests/protocols/iSNSP/packet.py
@@ -1,0 +1,503 @@
+import struct
+from dataclasses import dataclass
+from enum import Enum
+from typing import ClassVar, Dict, List, Optional
+
+from .exceptions import MalformedPacketError
+
+
+class ResponseStatus(Enum):
+    SUCCESSFUL = 0
+    UNKNOWN_ERROR = 1
+    MESSAGE_FORMAT_ERROR = 2
+    INVALID_REGISTRATION = 3
+    RESERVED = 4
+    INVALID_QUERY = 5
+    SOURCE_UNKNOWN = 6
+    SOURCE_ABSENT = 7
+    SOURCE_UNAUTHORIZED = 8
+    NO_SUCH_ENTRY = 9
+    VERSION_NOT_SUPPORTED = 10
+    INTERNAL_ERROR = 11
+    BUSY = 12
+    OPTION_NOT_UNDERSTOOD = 13
+    INVALID_UPDATE = 14
+    MESSAGE_NOT_SUPPORTED = 15
+    SCN_EVENT_REJECTED = 16
+    SCN_REGISTRATION_REJECTED = 17
+    ATTRIBUTE_NOT_IMPLEMENTED = 18
+    FC_DOMAIN_ID_NOT_AVAILABLE = 19
+    FC_DOMAIN_ID_NOT_ALLOCATED = 20
+    ESI_NOT_AVAILABLE = 21
+    INVALID_DEREGISTRATION = 22
+    REGISTRATION_FEATURE_NOT_SUPPORTED = 23
+
+
+@dataclass
+class iSNSPFlags(object):
+    client: bool = False
+    server: bool = False
+    auth: bool = False
+    replace: bool = False
+    last: bool = False
+    first: bool = False
+
+    @property
+    def int(self):
+        val = 0
+        val |= 0x8000 if self.client else 0
+        val |= 0x4000 if self.server else 0
+        val |= 0x2000 if self.auth else 0
+        val |= 0x1000 if self.replace else 0
+        val |= 0x0800 if self.last else 0
+        val |= 0x0400 if self.first else 0
+        return val
+
+    @property
+    def asbytes(self):
+        return self.int.to_bytes(2, byteorder='big')
+
+    @classmethod
+    def from_val(cls, val: int):
+        client = (val & 0x8000) == 0x8000
+        server = (val & 0x4000) == 0x4000
+        auth = (val & 0x2000) == 0x2000
+        replace = (val & 0x1000) == 0x1000
+        last = (val & 0x0800) == 0x0800
+        first = (val & 0x0400) == 0x0400
+        return cls(client, server, auth, replace, last, first)
+
+
+@dataclass
+class iSNSPAttribute(object):
+    """
+    This class models a iSNSP attribute which is contained in a iSNSP packet's
+    payload. From RFC 4171:
+
+    Byte   MSb                                        LSb
+    Offset 0                                           31
+           +--------------------------------------------+
+         0 |               Attribute Tag                | 4 Bytes
+           +--------------------------------------------+
+         4 |            Attribute Length (N)            | 4 Bytes
+           +--------------------------------------------+
+         8 |                                            |
+           |              Attribute Value               | N Bytes
+           |                                            |
+           +--------------------------------------------+
+                    Total Length = 8 + N
+    """
+    tag: str     # 4 octets
+    length: int  # 4 octets
+    val: bytes
+
+    tag_map: ClassVar[Dict[int, str]] = {
+        0: 'Delimiter',
+        1: 'Entity Identifier',
+        2: 'Entity Protocol',
+        3: 'Management IP Address',
+        4: 'Timestamp',
+        5: 'Protocol Version Range',
+        6: 'Registration Period',
+        7: 'Entity Index',
+        8: 'Entity Next Index',
+        11: 'Entity ISAKMP Phase-1',
+        12: 'Entity Certificate',
+        16: 'Portal IP Address',
+        17: 'Portal TCP/UDP Port',
+        18: 'Portal Symbolic Name',
+        19: 'ESI Interval',
+        20: 'ESI Port',
+        22: 'Portal Index',
+        23: 'SCN Port',
+        24: 'Portal Next Index',
+        27: 'Portal Security Bitmap',
+        28: 'Portal ISAKMP Phase-1',
+        29: 'Portal ISAKMP Phase-2',
+        31: 'Portal Certificate',
+        32: 'iSCSI Name',
+        33: 'iSCSI Node Type',
+        34: 'iSCSI Alias',
+        35: 'iSCSI SCN Bitmap',
+        36: 'iSCSI Node Index',
+        37: 'WWNN Token',
+        38: 'iSCSI Node Next Index',
+        42: 'iSCSI AuthMethod',
+        48: 'PG iSCSI Name',
+        49: 'PG Portal IP Addr',
+        50: 'PG Portal TCP/UDP Port',
+        51: 'PG Tag (PGT)',
+        52: 'PG Index',
+        53: 'PG Next Index',
+        64: 'FC Port Name WWPN',
+        65: 'Port ID',
+        66: 'FC Port Type',
+        67: 'Symbolic Port Name',
+        68: 'Fabric Port Name',
+        69: 'Hard Address',
+        70: 'Port IP-Address',
+        71: 'Class of Service',
+        72: 'FC-4 Types',
+        73: 'FC-4 Descriptor',
+        74: 'FC-4 Features',
+        75: 'iFCP SCN bitmap',
+        76: 'Port Role',
+        77: 'Permanent Port Name',
+        95: 'FC-4 Type Code',
+        96: 'FC Node Name WWNN',
+        97: 'Symbolic Node Name',
+        98: 'Node IP-Address',
+        99: 'Node IPA',
+        101: 'Proxy iSCSI Name',
+        128: 'Switch Name',
+        129: 'Preferred ID',
+        130: 'Assigned ID',
+        131: 'Virtual_Fabric_ID',
+        256: 'iSNS Server Vendor OUI',
+        2049: 'DD_Set ID',
+        2050: 'DD_Set Sym Name',
+        2051: 'DD_Set Status',
+        2052: 'DD_Set_Next_ID',
+        2065: 'DD_ID',
+        2066: 'DD_Symbolic Name',
+        2067: 'DD_Member iSCSI Index',
+        2068: 'DD_Member iSCSI Name',
+        2069: 'DD_Member FC Port Name',
+        2070: 'DD_Member Portal Index',
+        2071: 'DD_Member Portal IP Addr',
+        2072: 'DD_Member Portal TCP/UDP',
+        2078: 'DD_Features',
+        2079: 'DD_ID Next ID',
+    }
+
+    inv_tag_map: ClassVar[Dict[str, int]] = {v: k for k, v in tag_map.items()}
+    packet_fmt: ClassVar[str] = '!LL'
+    variable_length: ClassVar[List[int]] = [1, 11, 12, 18, 28, 29, 31, 32, 34,
+                                            42, 48, 67, 73, 97, 101, 131, 2050,
+                                            2066, 2068]
+    string_attrs: ClassVar[List[int]] = [1, 18, 32, 34, 48, 67, 73, 97, 101,
+                                         131, 2050, 2066, 2068]
+
+    @property
+    def asbytes(self):
+        tagval = self.inv_tag_map[self.tag]
+        if tagval in self.variable_length:
+            # Were we passed in a string?
+            if isinstance(self.val, str):
+                data = bytearray(self.val, 'utf-8')
+            elif isinstance(self.val, bytes):
+                data = bytearray(self.val)
+            elif isinstance(self.val, bytearray):
+                data = self.val
+            else:
+                raise ValueError('Invalid type for value')
+            # Terminate if necessary
+            if len(data):
+                if data[len(data) - 1] != 0:
+                    data += b'\0'
+            # Pad as necessary
+            while len(data) % 4 != 0:
+                data += b'\0'
+        else:
+            data = self.val
+        self.length = len(data)
+        packet_head = [
+            tagval,
+            self.length,
+        ]
+        encoded_packet = struct.pack(self.packet_fmt, *packet_head)
+        encoded_packet += data
+        return encoded_packet
+
+    @classmethod
+    def from_bytes(cls, packet: bytes):
+        """
+        Given a iSNSP attribute in bytes / wire format return a iSNSPAttribute
+        object.
+        """
+        try:
+            decoded_packet = [
+                field.rstrip(b'\x00') if isinstance(field, bytes) else field
+                for field in struct.unpack(
+                    cls.packet_fmt, packet[:8]
+                )
+            ]
+        except Exception as e:
+            raise MalformedPacketError(f'Unable to parse iSNSP attribute: {e}')
+
+        data = packet[8: 8 + decoded_packet[1]]
+        if decoded_packet[0] in cls.string_attrs:
+            data = data.decode('utf-8').rstrip('\x00')
+        decoded_packet[0] = cls.tag_map[decoded_packet[0]]
+        decoded_packet.append(data)
+        return cls(*decoded_packet)
+
+    @classmethod
+    def Delimiter(cls):
+        """
+        Convenient constructor for a iSNSP Delimiter attr.
+        """
+        return cls(
+            'Delimiter',
+            0,
+            bytes())
+
+    @classmethod
+    def iSCSIName(cls, name):
+        """
+        Convenient constructor for a iSNSP iSCSI Name attr.
+        """
+        return cls(
+            'iSCSI Name',
+            0,
+            name)
+
+    @classmethod
+    def EntityIdentifier(cls, name):
+        """
+        Convenient constructor for a iSNSP Entity Identifier attr.
+        """
+        return cls(
+            'Entity Identifier',
+            0,
+            name)
+
+    @classmethod
+    def PortalIPAddress(cls, name):
+        """
+        Convenient constructor for a iSNSP Portal IP Address attr.
+        """
+        return cls(
+            'Portal IP Address',
+            0,
+            name)
+
+    @classmethod
+    def iSCSINodeType(cls, val):
+        """
+        Convenient constructor for a iSCSI Node Type attr.
+        """
+        return cls(
+            'iSCSI Node Type',
+            4,
+            val.to_bytes(4, byteorder='big'))
+
+
+@dataclass
+class iSNSPPacket(object):
+    """
+    This class models a iSNSP packet. From RFC 4171:
+
+    Byte   MSb                                        LSb
+    Offset 0                   15 16                   31
+           +---------------------+----------------------+
+         0 |   iSNSP VERSION     |    FUNCTION ID       | 4 Bytes
+           +---------------------+----------------------+
+         4 |     PDU LENGTH      |       FLAGS          | 4 Bytes
+           +---------------------+----------------------+
+         8 |   TRANSACTION ID    |    SEQUENCE ID       | 4 Bytes
+           +---------------------+----------------------+
+        12 |                                            |
+           |                PDU PAYLOAD                 | N Bytes
+           |                    ...                     |
+           +--------------------------------------------+
+      12+N | AUTHENTICATION BLOCK (Multicast/Broadcast) | L Bytes
+           +--------------------------------------------+
+                    Total Length = 12 + N + L
+    """
+    version: int        # 2 octets - 0x0001
+    function: str       # 2 octets
+    pdulen: int         # 2 octets
+    flags: iSNSPFlags   # 2 octets
+    txnid: int          # 2 octets - a unique value for each concurrently
+    #                                outstanding request message.
+    seqid: int          # 2 octets - unique value for each PDU within a single
+    #                                transaction.  The SEQUENCE_ID value of the
+    #                                first PDU transmitted in a given iSNS
+    #                                message MUST be zero (0), and each
+    #                                SEQUENCE_ID value in each PDU MUST be
+    #                                numbered sequentially in the order in
+    #                                which the PDUs are transmitted.
+    payload: list[iSNSPAttribute]
+    payload_offset: ClassVar[int] = 12
+    packet_fmt: ClassVar[str] = '!HHHHHH'
+    func_map: ClassVar[Dict[int, str]] = {
+        0x0001: 'DevAttrReg',
+        0x0002: 'DevAttrQry',
+        0x0003: 'DevGetNext',
+        0x0004: 'DevDereg',
+        0x0005: 'SCNReg',
+        0x0006: 'SCNDereg',
+        0x0007: 'SCNEvent',
+        0x0008: 'SCN',
+        0x0009: 'DDReg',
+        0x000A: 'DDDereg',
+        0x000B: 'DDSReg',
+        0x000C: 'DDSDereg',
+        0x000D: 'ESI',
+        0x000E: 'Heartbeat',
+        0x0011: 'RqstDomId',
+        0x0012: 'RlseDomId',
+        0x0013: 'GetDomId',
+        0x8001: 'DevAttrRegRsp',
+        0x8002: 'DevAttrQryRsp',
+        0x8003: 'DevGetNextRsp',
+        0x8004: 'DevDeregRsp',
+        0x8005: 'SCNRegRsp',
+        0x8006: 'SCNDeregRsp',
+        0x8007: 'SCNEventRsp',
+        0x8008: 'SCNRsp',
+        0x8009: 'DDRegRsp',
+        0x800A: 'DDDeregRsp',
+        0x800B: 'DDSRegRsp',
+        0x800C: 'DDSDeregRsp',
+        0x800D: 'ESIRsp',
+        0x8011: 'RqstDomIdRsp',
+        0x8012: 'RlseDomIdRsp',
+        0x8013: 'GetDomIdRsp',
+    }
+
+    ifunc_map: ClassVar[Dict[str, int]] = {v: k for k, v in func_map.items()}
+
+    @property
+    def asbytes(self):
+        payload_bytes = bytes()
+        for attr in self.payload:
+            payload_bytes += attr.asbytes
+        self.pdulen = len(payload_bytes)
+        packet_head = [
+            self.version,
+            self.ifunc_map[self.function],
+            self.pdulen,
+            self.flags.int,
+            self.txnid,
+            self.seqid,
+        ]
+        encoded_packet = struct.pack(self.packet_fmt, *packet_head)
+        encoded_packet += payload_bytes
+        return encoded_packet
+
+    @property
+    def msg_type(self) -> Optional[str]:
+        if msg_type_option := self.options.by_code(53):
+            return list(msg_type_option.value.values())[0]
+        else:
+            return None
+
+    @classmethod
+    def from_bytes(cls, packet: bytes):
+        """
+        Given a iSNSP packet in bytes / wire format return a iSNSPPacket
+        object.
+        """
+        try:
+            decoded_packet = [
+                field.rstrip(b'\x00') if isinstance(field, bytes) else field
+                for field in struct.unpack(
+                    cls.packet_fmt, packet[: cls.payload_offset]
+                )
+            ]
+        except Exception as e:
+            raise MalformedPacketError(f'Unable to parse iSNSP packet: {e}')
+
+        # Decode the function
+        # decoded_packet[0] = cls.op_map[decoded_packet[0]]
+        decoded_packet[1] = cls.func_map[decoded_packet[1]]
+        flags = iSNSPFlags.from_val(decoded_packet[3])
+        decoded_packet[3] = flags
+
+        # Handle payload
+        _data = packet[cls.payload_offset:]
+        payload = []
+        # If this is a response from the server, then the first part of the
+        # payload is the status.
+        if flags.server:
+            payload.append(ResponseStatus(int.from_bytes(_data[:4], 'big')))
+            _data = _data[4:]
+        while _data:
+            attr = iSNSPAttribute.from_bytes(_data)
+            _data = _data[8 + attr.length:]
+            payload.append(attr)
+        decoded_packet.append(payload)
+
+        return cls(*decoded_packet)
+
+    @classmethod
+    def DevGetNext(
+        cls,
+        flags: iSNSPFlags,
+        txnid: int,
+        seqid: int,
+        payload: list[iSNSPAttribute],
+    ):
+        """
+        Convenient constructor for a iSNSP DevGetNext packet.
+        """
+        return cls(
+            1,
+            'DevGetNext',
+            0,
+            flags,
+            txnid,
+            seqid,
+            payload)
+
+    @classmethod
+    def DevAttrQry(
+        cls,
+        flags: iSNSPFlags,
+        txnid: int,
+        seqid: int,
+        payload: list[iSNSPAttribute],
+    ):
+        """
+        Convenient constructor for a iSNSP DevAttrQry packet.
+        """
+        return cls(
+            1,
+            'DevAttrQry',
+            0,
+            flags,
+            txnid,
+            seqid,
+            payload)
+
+    @classmethod
+    def DevAttrReg(
+        cls,
+        flags: iSNSPFlags,
+        txnid: int,
+        seqid: int,
+        payload: list[iSNSPAttribute],
+    ):
+        """
+        Convenient constructor for a iSNSP DevAttrReg packet.
+        """
+        return cls(
+            1,
+            'DevAttrReg',
+            0,
+            flags,
+            txnid,
+            seqid,
+            payload)
+
+    @classmethod
+    def DevDereg(
+        cls,
+        flags: iSNSPFlags,
+        txnid: int,
+        seqid: int,
+        payload: list[iSNSPAttribute],
+    ):
+        """
+        Convenient constructor for a iSNSP DevDereg packet.
+        """
+        return cls(
+            1,
+            'DevDereg',
+            0,
+            flags,
+            txnid,
+            seqid,
+            payload)

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -32,9 +32,9 @@ if not os.path.exists('config.py'):
 
 error_msg = f"""Usage for %s:
 Mandatory option
-    --ip <###.###.###.###>      - IP of the FreeNAS
-    --password <root password>  - Password of the FreeNAS root user
-    --interface <interface>     - The interface that FreeNAS is run one
+    --ip <###.###.###.###>      - IP of the TrueNAS
+    --password <root password>  - Password of the TrueNAS root user
+    --interface <interface>     - The interface that TrueNAS is run one
 
 Optional option
     --test <test name>          - Test name (Network, ALL)

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -18,6 +18,8 @@ results_xml = f'{workdir}/results/'
 localHome = os.path.expanduser('~')
 dotsshPath = localHome + '/.ssh'
 keyPath = localHome + '/.ssh/test_id_rsa'
+isns_ip='10.234.24.50' # isns01.qe.ixsystems.net
+pool_name = "tank"
 
 ixautomation_dot_conf_url = "https://raw.githubusercontent.com/iXsystems/" \
     "ixautomation/master/src/etc/ixautomation.conf.dist"
@@ -28,19 +30,21 @@ if not os.path.exists('config.py'):
     print(config_file_msg)
     exit(1)
 
-error_msg = """Usage for %s:
+error_msg = f"""Usage for %s:
 Mandatory option
-    --ip <###.###.###.###>     - IP of the FreeNAS
-    --password <root password> - Password of the FreeNAS root user
-    --interface <interface>    - The interface that FreeNAS is run one
+    --ip <###.###.###.###>      - IP of the FreeNAS
+    --password <root password>  - Password of the FreeNAS root user
+    --interface <interface>     - The interface that FreeNAS is run one
 
 Optional option
-    --test <test name>         - Test name (Network, ALL)
-    --vm-name <VM_NAME>        - Name the the Bhyve VM
-    --ha                       - Run test for HA
-    --dev-test                 - Run only the test that are not mark with
-                                 pytestmark skipif dev_test is true.
-    --debug-mode               - Start API tests with middleware debug mode
+    --test <test name>          - Test name (Network, ALL)
+    --vm-name <VM_NAME>         - Name the the Bhyve VM
+    --ha                        - Run test for HA
+    --dev-test                  - Run only the test that are not mark with
+                                  pytestmark skipif dev_test is true.
+    --debug-mode                - Start API tests with middleware debug mode
+    --isns_ip <###.###.###.###> - IP of the iSNS server (default: {isns_ip})
+    --pool <POOL_NAME>          - Name of the ZFS pool (default: {pool_name})
     """ % argv[0]
 
 # if have no argument stop
@@ -60,11 +64,12 @@ option_list = [
     "debug-mode",
     "log-cli-level=",
     "returncode",
+    "isns_ip=",
 ]
 
 # look if all the argument are there.
 try:
-    myopts, args = getopt.getopt(argv[1:], 'aipItk:vx', option_list)
+    myopts, args = getopt.getopt(argv[1:], 'aipItk:vxs', option_list)
 except getopt.GetoptError as e:
     print(str(e))
     print(error_msg)
@@ -111,6 +116,12 @@ for output, arg in myopts:
         callargs.append(arg)
     elif output == '--returncode':
         returncode = True
+    elif output == '--isns_ip':
+        isns_ip = arg
+    elif output == '--pool':
+        pool_name = arg
+    elif output == '-s':
+        callargs.append('-s')
 
 if 'ip' not in locals() and 'passwd' not in locals() and 'interface' not in locals():
     print("Mandatory option missing!\n")
@@ -138,13 +149,14 @@ interface = "{interface}"
 ntpServer = "10.20.20.122"
 localHome = "{localHome}"
 keyPath = "{keyPath}"
-pool_name = "tank"
+pool_name = "{pool_name}"
 ha_pool_name = "ha"
 ha = {ha}
 update = {update}
 dev_test = {dev_test}
 debug_mode = {debug_mode}
 artifacts = "{artifacts}"
+isns_ip = "{isns_ip}"
 """
 
 cfg_file = open("auto_config.py", 'w')


### PR DESCRIPTION
Add iSNS support.

Some additional context ...
### Add iSNS test
- The existing Linux(/FreeBSD) iSNS client software (included in [open-isns](https://github.com/open-iscsi/open-isns)) and MS iSNS server do not play very well together, so implemented a _minimal_ subset of iSNS (client) in python to side-step the issue when running tests.  (Only used in tests.)
- Added parameter `--isns_ip` to _runtest.py_ (with a default value pointing to our MS iSNS server)
- While in there, likewise added `--pool` (defaults to "tank" as was previously hard-coded).  Also allow `-s` to be passed thru to `pytest`.

### Add validate_isns_server
- Previously we were validating the format of the input, but not checking connectivity.  Add this.
- At the moment SCST only supports a single iSNS server, whereas the UI allows multiple.  Have implemented the checks for multiple for now, but will only _use_ the first provided.  This will need to be reconciled at a later time (i.e. either SCST or UI/middleware change).
