### PR TITLE
NAS-120589 / 23.10 / Reflect GPU isolation changes on the system

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -347,3 +347,4 @@ class SystemAdvancedService(ConfigService):
             {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
             {'prefix': self._config.datastore_prefix}
         )
+        await self.middleware.call('boot.update_initramfs')


### PR DESCRIPTION
## Problem

A new endpoint was made available for the UI to consume which was separate from `system.advanced.update` and dedicated solely to allow changing GPU isolation settings. In the endpoint the changes were made in the database to reflect new user configuration but the system settings were not changed to reflect that change.

## Solution

Similar to how we enforce how user supplied GPU isolation settings are applied in `system.advanced.update`, the same should be done for the newer dedicated endpoint.