### PR TITLE
NAS-120590 / 22.12.2 / call device.settle_udev_events in failover plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -14,7 +14,6 @@ from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Bool, Int
 from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
-from middlewared.scripts.wait_on_disks import main as wait_for_disk_events_to_settle
 
 logger = logging.getLogger('failover')
 
@@ -404,11 +403,7 @@ class FailoverEventsService(Service):
         retaste_job.wait_sync()
 
         logger.info('Waiting for disk events to settle')
-        try:
-            wait_for_disk_events_to_settle(max_wait=3.0, interval=1.0)
-        except Exception:
-            # better safe than sorry
-            self.logger.error('Unexpected failure waiting on disk events to settle', exc_info=True)
+        self.run_call('device.settle_udev_events')
 
         # set the progress to IMPORTING
         job.set_progress(None, description='IMPORTING')


### PR DESCRIPTION
`udevadm settle` seems to be the most fault tolerant mechanism for properly waiting on disk events (in this scenario) to complete.

Original PR: https://github.com/truenas/middleware/pull/10788
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120590