### PR TITLE
NAS-120593 / 22.12.2 / add support for enclosure.sync_disk on R30 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -207,9 +207,15 @@ class EnclosureService(CRUDService):
     @accepts(Str("enclosure_id"), Int("slot"), Str("status", enum=["CLEAR", "FAULT", "IDENTIFY"]))
     def set_slot_status(self, enclosure_id, slot, status):
         enclosure, element = self._get_slot(lambda element: element["slot"] == slot, [["id", "=", enclosure_id]])
-        ses_slot = self._get_ses_slot(enclosure, element)
-        if not ses_slot.device_slot_set(status.lower()):
-            raise CallError("Error setting slot status")
+        if enclosure_id == 'r30_nvme_enclosure':
+            # TODO this is an all NVMe system and drive identify is done
+            # exclusively via ipmi raw commands....this will need its own
+            # implementation
+            pass
+        else:
+            ses_slot = self._get_ses_slot(enclosure, element)
+            if not ses_slot.device_slot_set(status.lower()):
+                raise CallError("Error setting slot status")
 
     @private
     def sync_disk(self, id, enclosure_info=None):


### PR DESCRIPTION
2 things done here:
1. `enclosure.set_slot_status` needs to be a NO-OP on R30 until the drive identification implementation can be done. It requires a separate module completely since identifying the nvme drives is done via ipmi raw commands which is something we don't have
2. `disk.query` returns slot information for each disk but `disk.sync_all` stores the namespace device of nvme drives (i.e. nvme1n1). `def map_r30` was returning the root character device (/dev/nvme1) instead of the 1st namespace device (/dev/nvme1n1) which is the only we use. This prevented `disk.query` from showing the enclosure slot mapping information which is required by the front-end team to map the drives to enclosure slots in the enclosure management section of the webUI.

Original PR: https://github.com/truenas/middleware/pull/10793
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120593