### PR TITLE
Add openat2() wrapper to filesystem plugin utils

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -9,8 +9,10 @@ from middlewared.service import CallError, Service
 from middlewared.utils import osc
 from middlewared.utils.io import write_if_changed
 from middlewared.utils.mako import get_template
+from middlewared.utils.osc import openat2, ResolveFlags
 
 DEFAULT_ETC_PERMS = 0o644
+RFLAGS = ResolveFlags.RESOLVE_NO_SYMLINKS | ResolveFlags.RESOLVE_NO_XDEV
 
 
 class FileShouldNotExist(Exception):
@@ -401,9 +403,10 @@ class EtcService(Service):
 
     def make_changes(self, full_path, entry, rendered):
         mode = entry.get('mode', DEFAULT_ETC_PERMS)
+        rflags = entry.get('resolve', RFLAGS)
 
         def opener(path, flags):
-            return os.open(path, os.O_CREAT | os.O_RDWR, mode=mode)
+            return openat2(path, os.O_CREAT | os.O_RDWR, mode=mode, resolve=rflags)
 
         outfile_dirname = os.path.dirname(full_path)
         if outfile_dirname != '/etc':

--- a/src/middlewared/middlewared/utils/osc/linux/__init__.py
+++ b/src/middlewared/middlewared/utils/osc/linux/__init__.py
@@ -1,4 +1,5 @@
 from .multiprocessing import *  # noqa
+from .openat2 import * # noqa
 from .os import *  # noqa
 from .user_context import *  # noqa
 from .mount import * # noqa

--- a/src/middlewared/middlewared/utils/osc/linux/openat2.py
+++ b/src/middlewared/middlewared/utils/osc/linux/openat2.py
@@ -1,0 +1,54 @@
+import os
+import ctypes
+from enum import IntFlag
+
+__all__ = ["openat2", "ResolveFlags"]
+
+AT_FDCWD = -100
+
+# See linux/openat2.h
+__NR_openat2 = 437
+
+
+class ResolveFlags(IntFlag):
+    # fcntl.h
+    RESOLVE_NO_XDEV = 0x01
+    RESOLVE_NO_MAGICLINKS = 0x02
+    RESOLVE_NO_SYMLINKS = 0x04
+    RESOLVE_BENEATH = 0x08
+    RESOLVE_IN_ROOT = 0x10
+    RESOLVE_CACHED = 0x20
+    VALID_FLAGS = 0x3f
+
+
+class OpenHow(ctypes.Structure):
+    _fields_ = [
+        ("flags", ctypes.c_uint64),
+        ("mode", ctypes.c_uint64),
+        ("resolve", ctypes.c_uint64)
+    ]
+
+
+def openat2(path, flags, mode=0, resolve=0, dirfd=AT_FDCWD):
+    path = path.encode() if isinstance(path, str) else path
+
+    if invalid_resolve := resolve & ~ResolveFlags.VALID_FLAGS:
+        raise ValueError(f'{hex(invalid_resolve)}: unsupported resolve flags')
+
+    _libc = ctypes.CDLL('libc.so.6', use_errno=True)
+    _func = _libc.syscall
+    _func.restype = ctypes.c_int
+    _func.argstypes = (
+        ctypes.c_uint64,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.POINTER(OpenHow),
+        ctypes.c_uint64
+    )
+    how = OpenHow(flags, mode, resolve)
+    result = _func(__NR_openat2, dirfd, path, ctypes.byref(how), ctypes.sizeof(OpenHow))
+    if result < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    else:
+        return result


### PR DESCRIPTION
This can be used for custom opener for open() in
python. Since it still hasn't been wrapped in glibc we have to use the syscall(2) interface to make
these calls.