### PR TITLE
NAS-120644 / 23.10 / Compare casefolded strings for hostnames

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -111,7 +111,7 @@ class ActiveDirectoryService(Service):
                 continue
 
             else:
-                if result[0]['target'] != data['hostname'] and raise_errors:
+                if result[0]['target'].casefold() != data['hostname'].casefold() and raise_errors:
                     raise CallError(
                         f'Reverse lookup of {ip} points to {result[0]["target"]}'
                         f'rather than our hostname of {data["hostname"]}.',


### PR DESCRIPTION
Resolver result may have different case than what we expected (for example manually added DNS entries rather than our dynamic updates).