### PR TITLE
NAS-120647 / 23.10 / Add some casefolded filters

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -42,6 +42,8 @@ Javascript:
 | '$' |  x is not None and x.endswith(y) |
 | '!$' |  x is not None and not x.endswith(y) |
 
+Specifing the prefix 'C' will perform a case-insensitive version of the filter, e.g. `C=`.
+
 #### Multiple Filters
 
 We can use `disk.query` with the "type" and "rotationrate" filters to find hard drives with a rotation rate higher than 5400 RPM:

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1002,7 +1002,7 @@ class UserService(CRUDService):
                                                        [('smb', '=', True)] + exclude_filter,
                                                        {'prefix': 'bsdusr_'})
 
-                if any(filter(lambda x: data['username'].casefold() == x['username'].casefold(), smb_users)):
+                if filter_list(smb_users, [['username', 'C=', data['username']]]):
                     verrors.add(
                         f'{schema}.smb',
                         f'Username "{data["username"]}" conflicts with existing SMB user. Note that SMB '
@@ -1613,7 +1613,7 @@ class GroupService(CRUDService):
                                                         [('smb', '=', True)] + exclude_filter,
                                                         {'prefix': 'bsdgrp_'})
 
-                if any(filter(lambda x: data['name'].casefold() == x['group'].casefold(), smb_groups)):
+                if filter_list(smb_groups, [['group', 'C=', data['name']]]):
                     verrors.add(
                         f'{schema}.name',
                         f'Group name "{data["name"]}" conflicts with existing groupmap entry. '

--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -5,6 +5,7 @@ import ipaddress
 import socket
 
 from middlewared.service import CallError, private, Service
+from middlewared.utils import filter_list
 
 
 class SRV(enum.Enum):
@@ -218,7 +219,7 @@ class ActiveDirectoryService(Service):
                     servers.extend(resp)
 
             for name in targets:
-                if not any([lambda resp: resp['name'].casefold() == name.casefold(), servers]):
+                if not filter_list(servers, [['name', 'C=', name]]):
                     raise CallError(
                         f'Forward lookup of "{name}" failed with nameserver {entry["nameserver"]}. '
                         'This may indicate a DNS misconfiguration on the remote nameserver.',

--- a/src/middlewared/middlewared/plugins/activedirectory_/health.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/health.py
@@ -9,6 +9,7 @@ from middlewared.service import private, Service, ValidationErrors
 from middlewared.service_exception import CallError
 from middlewared.plugins.directoryservices import DSStatus
 from middlewared.plugins.idmap_.utils import WBClient, WBCErr
+from middlewared.utils import filter_list
 
 
 class ActiveDirectoryService(Service):
@@ -127,10 +128,9 @@ class ActiveDirectoryService(Service):
             """
             try:
                 our_dc = self.winbind_status()
-                for dc_to_check in res:
-                    thehost = dc_to_check['host']
-                    if thehost.casefold() != our_dc.casefold():
-                        found_dc = thehost
+                other_dcs = filter_list(res, [['host', 'C!=', our_dc]])
+                if other_dcs:
+                    found_dc = other_dcs[0]['host']
             except Exception:
                 self.logger.warning("Failed to retrieve current DC.", exc_info=True)
                 found_dc = res[0]['host']

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1075,12 +1075,7 @@ class KerberosKeytabService(TDBWrapCRUDService):
         Generate list of Kerberos principals that are not the AD machine account.
         """
         ad = await self.middleware.call('activedirectory.config')
-        pruned_list = []
-        for i in keytab_list:
-            if ad['netbiosname'].casefold() not in i['principal'].casefold():
-                pruned_list.append(i)
-
-        return pruned_list
+        return filter_list(keytab_list, [['principal', 'Crnin', ad['netbiosname']]])
 
     @private
     async def _generate_tmp_keytab(self):

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -42,6 +42,29 @@ DATA_WITH_NULL = [
     },
 ]
 
+DATA_WITH_CASE = [
+    {
+        'foo': 'foo',
+        'number': 1,
+        'list': [1],
+    },
+    {
+        'foo': 'Foo',
+        'number': 2,
+        'list': [2],
+    },
+    {
+        'foo': 'foO_',
+        'number': 3,
+        'list': [3],
+    },
+    {
+        'foo': 'bar',
+        'number': 3,
+        'list': [3],
+    },
+]
+
 COMPLEX_DATA = [
     {
         "timestamp": "2022-11-10T07:40:17.397502-0800",
@@ -219,3 +242,43 @@ def test__filter_list_option_nulls_first():
 
 def test__filter_list_option_nulls_last():
     assert filter_list(DATA_WITH_NULL, [], {'order_by': ['nulls_last:foo']})[-1]['foo'] is None
+
+
+def test__filter_list_option_casefold_equals():
+    assert len(filter_list(DATA, [['foo', 'C=', 'Foo1']])) == 1
+
+
+def test__filter_list_option_casefold_starts():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'C^', 'F']])) == 3
+
+
+def test__filter_list_option_casefold_does_not_start():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'C!^', 'F']])) == 1
+
+
+def test__filter_list_option_casefold_ends():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'C$', 'foo']])) == 2
+
+
+def test__filter_list_option_casefold_does_not_end():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'C!$', 'O']])) == 2
+
+
+def test__filter_list_option_casefold_in():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'Cin', 'foo']])) == 2
+
+
+def test__filter_list_option_casefold_rin():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'Crin', 'foo']])) == 3
+
+
+def test__filter_list_option_casefold_nin():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'Cnin', 'foo']])) == 2
+
+
+def test__filter_list_option_casefold_rnin():
+    assert len(filter_list(DATA_WITH_CASE, [['foo', 'Crnin', 'foo']])) == 1
+
+
+def test__filter_list_option_casefold_complex_data():
+    assert len(filter_list(COMPLEX_DATA, [['Authentication.clientAccount', 'C=', 'JOINER']])) == 1


### PR DESCRIPTION
Add special behavior where capital C prefix in filterop performs a casefolded version of
the filter. This is useful in cases where we're dealing with external protocols that are
case-insensitive, and will hopefully lead to fewer bugs related to case-insensitive checks.