### PR TITLE
NAS-120650 / 23.10 / Use standardized check for whether we're clustered

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -57,7 +57,7 @@ class ClusterJob(Service):
     @periodic(3600)
     @job(lock="queue_lock", transient=True)
     async def process_queue(self, job):
-        if not (await self.middleware.call('service.query', [('service', '=', 'glusterd')], {'get': True}))['enable']:
+        if not await self.middleware.call('cluster.utils.is_clustered'):
             return
 
         node = (await self.middleware.call('ctdb.general.status', {'all_nodes': False}))['nodemap']['nodes'][0]


### PR DESCRIPTION
This avoids more expensive check for glusterd status when we're checking for cluster jobs.