### PR TITLE
NAS-120644 / 22.12.2 / Compare casefolded strings for hostnames (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -111,7 +111,7 @@ class ActiveDirectoryService(Service):
                 continue
 
             else:
-                if result[0]['target'] != data['hostname'] and raise_errors:
+                if result[0]['target'].casefold() != data['hostname'].casefold() and raise_errors:
                     raise CallError(
                         f'Reverse lookup of {ip} points to {result[0]["target"]}'
                         f'rather than our hostname of {data["hostname"]}.',


### PR DESCRIPTION
Resolver result may have different case than what we expected (for example manually added DNS entries rather than our dynamic updates).

Original PR: https://github.com/truenas/middleware/pull/10807
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120644