### PR TITLE
NAS-120304 / 22.12.2 / Increase private docker images password length to 4096 (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/images.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/images.py
@@ -97,7 +97,7 @@ class DockerImagesService(CRUDService):
             Dict(
                 'docker_authentication',
                 Str('username', required=True),
-                Str('password', required=True),
+                Str('password', required=True, max_length=4096),
                 default=None,
                 null=True,
             ),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x cdbb28f47894a189dc40446c5af65570ac3e2ea7

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x cadd7d8b757f6c0923a12ff5ae178cb594154ac2



Original PR: https://github.com/truenas/middleware/pull/10801
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120304