### PR TITLE
NAS-120303 / 22.12.2 / fix pblocksize toggling (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -60,6 +60,9 @@ HANDLER ${handler} {
     DEVICE ${extent['name']} {
         filename ${extent['extent_path']}
         blocksize ${extent['blocksize']}
+%       if extent['pblocksize']:
+        lb_per_pb_exp 0
+%       endif
         read_only ${'1' if extent['ro'] else '0'}
         usn ${extent['serial']}
         naa_id ${extent['naa']}


### PR DESCRIPTION
Use the recently added SCST setting `lb_per_pb_exp` to turn off reporting of LOGICAL BLOCKS PER PHYSICAL BLOCK EXPONENT by READ CAPACITY 16 when `pblocksize` is set.

Original PR: https://github.com/truenas/middleware/pull/10818
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120303