### PR TITLE
NAS-120665 / 22.12.2 / Fix user creation permissions on homedir (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -434,8 +434,8 @@ class UserService(CRUDService):
             try:
                 data['home'] = await self.middleware.run_in_thread(
                     self.setup_homedir,
-                    data['username'],
                     data['home'],
+                    data['username'],
                     home_mode,
                     data['uid'],
                     group['gid'],


### PR DESCRIPTION
Typo in parameters being passed to create user homedir during new user creation caused spurious failure in case when user specified an exising path as a home directory. This fixes the bug and adds some more test coverage for path handling on new user creation.

Original PR: https://github.com/truenas/middleware/pull/10819
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120665