### PR TITLE
NAS-120672 / 13.0 / Do not explicitly request multipath support for NVMe.

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -243,7 +243,7 @@ nvme)
 	fi
 
 	echo "Creating new namespace."
-	nsid=`nvmecontrol ns create -s ${size} -f ${lbaf} -n 1 -d 0 ${ctrlr} | awk '/namespace [0-9]+ created/ { print $2 }'`
+	nsid=`nvmecontrol ns create -s ${size} -f ${lbaf} -d 0 ${ctrlr} | awk '/namespace [0-9]+ created/ { print $2 }'`
 	if [ -z "${nsid}" ]; then
 		echo "Namespace creation failed"
 		exit 1


### PR DESCRIPTION
There are NVMe SSDs that know about multipath, but do not support it. Passing that option makes namespace creation fail with INVALID FIELD status.  nvmecontrol sets the default based on NVMe capabilities.