### PR TITLE
NAS-120666 / 22.12.2 / fix enclosure alerts on SCALE (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -5,7 +5,7 @@ class EnclosureUnhealthyAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.CRITICAL
     title = "Enclosure Status Is Not Healthy"
-    text = "Enclosure %d (%s): %s is %s (%s)."
+    text = "Enclosure (%s): Element \"%s\" is reporting a status of \"%s\" with a value of \"%s\". (raw value \"%s\")"
     products = ("SCALE_ENTERPRISE",)
 
 
@@ -13,7 +13,7 @@ class EnclosureHealthyAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.INFO
     title = "Enclosure Status Is Healthy"
-    text = "Enclosure %d (%s): is healthy."
+    text = "Enclosure (%s) is healthy."
     products = ("SCALE_ENTERPRISE",)
 
 
@@ -21,50 +21,45 @@ class EnclosureStatusAlertSource(AlertSource):
     products = ("SCALE_ENTERPRISE",)
     failover_related = True
     run_on_backup_node = False
+    bad = ('critical', 'noncritical', 'unknown', 'unrecoverable', 'not installed')
+
+    async def should_report(self, enclosure, element):
+        should_report = True
+        if element['status'].lower() in self.bad and element['value'] != 'None':
+            if element['name'] == 'Enclosure':
+                # this is an element that provides an "overview" for all the other elements
+                # i.e. if a power supply element is reporting critical, this will (should)
+                # report critical as well. Sometimes, however, this will constantly report
+                # a bad status, just ignore it #11918
+                should_report = False
+            elif enclosure['name'] == 'ECStream 3U16+4R-4X6G.3 d10c' and element['descriptor'] == '1.8V Sensor':
+                # The 1.8V sensor is bugged on the echostream enclosure (Z-series). The
+                # management chip loses it's mind and claims undervoltage, but scoping
+                # this confirms the voltage is fine. Ignore alerts from this element. #10077
+                should_report = False
+        else:
+            should_report = False
+
+        return should_report
 
     async def check(self):
         alerts = []
-
-        for num, enc in enumerate(await self.middleware.call('enclosure.query')):
+        for enc in await self.middleware.call('enclosure.query'):
             healthy = True
             for ele in sum([e['elements'] for e in enc['elements']], []):
-                if ele['status'] in ['Critical', 'Noncritical', 'Unrecoverable']:
-                    pass
-                elif ele['status'] == 'Not Installed' and ele['name'] in ['Power Supply']:
-                    pass
-                else:
-                    continue
-
-                # Enclosure element is CRITICAL in single head, ignore this for now
-                # See #11918
-                if ele['name'] == 'Enclosure':
-                    continue
-
-                # The 1.8V sensor is bugged on the echostream enclosure.  The
-                # management chip loses it's mind and claims undervoltage, but
-                # scoping this confirms the voltage is fine.
-                # Ignore alerts from this element.
-                # #10077
-                if enc['name'] == 'ECStream 3U16+4R-4X6G.3 d10c':
-                    if ele['descriptor'] == '1.8V Sensor':
-                        continue
-
-                healthy = False
-                alerts.append(Alert(
-                    EnclosureUnhealthyAlertClass,
-                    args=[
-                        num,
+                if await self.should_report(enc, ele):
+                    healthy = False
+                    alerts.append(Alert(EnclosureUnhealthyAlertClass, args=[
                         enc['name'],
-                        f"{ele['name']} {hex(ele['slot'])} {ele['descriptor']}",
+                        ele['name'],
                         ele['status'],
-                        ele['value_raw']
-                    ],
-                ))
+                        ele['value'],
+                        ele['value_raw'],
+                    ]))
 
             if healthy:
-                alerts.append(Alert(
-                    EnclosureHealthyAlertClass,
-                    args=[num, enc['name']],
-                ))
+                # we've iterated all elements of a given enclosure and nothing
+                # was reported as unhealthy
+                alerts.append(Alert(EnclosureHealthyAlertClass, args=[enc['name']]))
 
         return alerts


### PR DESCRIPTION
I traced the logic that was put into this alert back to a commit done in 2019. The changes done back then essentially ignored all alerts for an enclosure. I honestly couldn't deduce what the intended reasoning was for choosing to do it the way it was done. Maybe, it was a simple mistake, who knows? Either way, I've fixed the alerts for enclosures on SCALE with these changes. I referenced the logic that I put into CORE (when I rewrote all of this over there) so this should be mostly feature (and logic) parity.

Tested this by pulling a PSU from an enclosure and ensuring the proper alert was generated.

Original PR: https://github.com/truenas/middleware/pull/10826
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120666