### PR TITLE
NAS-120672 / 22.12.2 / Do not explicitly request multipath support for NVMe. (by amotin)

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -216,7 +216,11 @@ nvme)
 		ucap=`echo "${idctrl}" | awk -F ' +: ' '$1 == "unvmcap" { print $2 }'`
 		size=$((ucap / sector))
 	fi
-	created=`nvme create-ns -s ${size} -c ${size} -f ${lbaf} -m 1 -d 0 ${ctrlr}`
+	mic=`echo "${idctrl}" | awk -F ' +: ' '$1 == "cmic" { print $2 }'`
+	if [ "${mic}" != "0" ]; then
+		mic=1
+	fi
+	created=`nvme create-ns -s ${size} -c ${size} -f ${lbaf} -m ${mic} -d 0 ${ctrlr}`
 	echo "${created}"
 	nsid=`echo "${created}" | awk -F nsid: '{ print $2 }'`
 	if [ -z "${nsid}" ]; then


### PR DESCRIPTION
There are NVMe SSDs that know about multipath, but do not support it. Passing that option makes namespace creation fail with INVALID FIELD status.  Unlike FreeBSD's nvmecontrol nvme is not clever enough to set the default based on NVMe capabilities, so do it manually.

Original PR: https://github.com/truenas/middleware/pull/10832
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120672