### PR TITLE
NAS-120955 / 23.10 / Ensure required cgroup controllers are always present before starting apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -430,10 +430,10 @@ class KubernetesService(Service):
                     'ApplicationsConfigurationFailed',
                     {'error': e.errmsg},
                 )
-            else:
-                await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
             raise
+
+        await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -198,6 +198,9 @@ class KubernetesService(Service):
 
     @private
     def ensure_cgroups_are_setup(self):
+        # Logic copied over from kubernetes
+        # https://github.com/kubernetes/kubernetes/blob/08fbe92fa76d35048b4b4891b41fc6912e689cc7/
+        # pkg/kubelet/cm/cgroup_manager_linux.go#L238
         supported_controllers = {'cpu', 'cpuset', 'memory', 'hugetlb', 'pids'}
         cgroup_root_path = '/sys/fs/cgroup'
         system_supported_controllers_path = os.path.join(cgroup_root_path, 'cgroup.controllers')

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -4,7 +4,6 @@ import os
 import re
 
 from middlewared.plugins.kubernetes_linux.k8s.config import remove_initialized_config
-from middlewared.service import CallError
 from middlewared.utils import run
 
 from .base import SimpleService

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -39,20 +39,7 @@ class KubernetesService(SimpleService):
         )
 
     async def before_start(self):
-        try:
-            await self.middleware.call('kubernetes.validate_k8s_fs_setup')
-        except CallError as e:
-            if e.errno != CallError.EDATASETISLOCKED:
-                await self.middleware.call(
-                    'alert.oneshot_create',
-                    'ApplicationsConfigurationFailed',
-                    {'error': e.errmsg},
-                )
-            else:
-                await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
-
-            raise
-
+        await self.middleware.call('kubernetes.before_start_check')
         await self.mount_kubelet_dataset()
         await self.clear_chart_releases_cache()
 


### PR DESCRIPTION
This PR adds changes to ensure that required cgroup controllers are always present before attempting to start apps. We have been seeing this issue for various users where apps refused to work and kubernetes was not really giving us any good information wrt why it fails to start. It has been isolated that it is a kernel/systemd issue and not related to apps and OS team is working on isolating/diagnosing that appropriately. For now these changes will ensure we refuse to start apps and also raise an alert for apps when an attempt is made to start them outlining why it did not start.