### PR TITLE
NAS-120608 / 23.10 / fix alert being generated on user caused failover

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_sync.py
+++ b/src/middlewared/middlewared/alert/source/failover_sync.py
@@ -8,11 +8,17 @@ class FailoverSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
     level = AlertLevel.CRITICAL
     title = "Automatic Sync to Peer Failed"
     text = (
-        "Failed to sync configuration information to standby storage "
-        "controller. Use Sync to Peer on the System/Failover page to "
-        "perform a manual sync."
+        "Tried for %(mins)d minutes to sync configuration information to "
+        "the standby storage controller but failed. Use Sync to Peer on the "
+        "System/Failover page to try and perform a manual sync."
     )
     products = ("SCALE_ENTERPRISE",)
+
+    async def create(self, args):
+        return Alert(FailoverSyncFailedAlertClass, {'mins': args['mins']})
+
+    async def delete(self, alerts, query):
+        return []
 
 
 class FailoverKeysSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -37,8 +37,8 @@ class FailoverDatastoreService(Service):
         self.failure = True
         try:
             self.send()
-        except Exception:
-            self.logger.warning('Error sending database to remote node on first replication failure')
+        except Exception as e:
+            self.logger.warning('Error sending database to remote node on first replication failure: %r', e)
 
             def send_retry():
                 set_thread_name('failover_datastore')
@@ -65,7 +65,6 @@ class FailoverDatastoreService(Service):
                         pass
 
                     if raise_alert_time <= 0 and self.failure:
-                        self.middleware.call_sync('alert.oneshot_delete', 'FailoverSyncFailed', None)
                         self.middleware.call_sync('alert.oneshot_create', 'FailoverSyncFailed', {'mins': total_mins})
                         raise_alert_time = RAISE_ALERT_SYNC_RETRY_TIME
 

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -37,6 +37,8 @@ class FailoverDatastoreService(Service):
         try:
             self.send()
         except Exception:
+            self.logger.warning('Error sending database to remote node on first replication failure')
+
             def send_retry():
                 set_thread_name('failover_datastore')
 


### PR DESCRIPTION
The following scenario caused the alert to be generated during QE test cycle.
1. controller A is master controller
2. user initiates a failover via the webUI
3. controller B takes over as master and generates this alert

This alert shouldn't be generated since, almost always, a failover means a controller has been rebooted. This changes the logic just a bit to only generate this alert if we fail to sync the database after 20mins since some of the hardware platforms we sell can take roughly that amount of time to boot up.