### PR TITLE
NAS-120610 / 22.12.2 / Fix AD home shares in SCALE (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
@@ -73,7 +73,14 @@
             if self.name() != 'Base':
                 return pam_line
 
-            return {'primary': [], 'additional': [pam_line]}
+            mkhomedir = self.generate_pam_line(
+                'session',
+                pam_control,
+                self.pam_mkhomedir,
+                pam_args
+            )
+
+            return {'primary': [], 'additional': [pam_line, mkhomedir]}
 
         def pam_password(self, **kwargs):
             pam_path = kwargs.pop('pam_path', self.pam_unix)
@@ -126,8 +133,9 @@
 
         def pam_session(self):
             unix_session = super().pam_session()
+            mkhomedir = super().pam_session(pam_path=self.pam_mkhomedir, pam_control='required')
             wb_session = super().pam_session(pam_path=self.pam_winbind, pam_control='optional')
-            return {'primary': [], 'additional': [unix_session, wb_session]}
+            return {'primary': [], 'additional': [unix_session, mkhomedir, wb_session]}
 
         def pam_password(self):
             args = ["try_first_pass", "krb5_auth", "krb5_ccache_type=FILE"]
@@ -214,6 +222,7 @@
         def pam_session(self):
             entries = [super().pam_session()]
             entries.append(super().pam_session(pam_path=self.pam_ldap, pam_control='optional'))
+            entries.append(super().pam_session(pam_path=self.pam_mkhomedir, pam_control='required'))
             if self.is_kerberized():
                 entries.append(super().pam_session(pam_path=self.pam_krb5, pam_control='optional'))
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1024,6 +1024,11 @@ class SharingSMBService(SharingService):
 
         if do_global_reload:
             await self.middleware.call('smb.initialize_globals')
+            if (await self.middleware.call('activedirectory.get_state')) == 'HEALTHY':
+                await self.middleware.call('activedirectory.synchronize')
+                if data['home']:
+                    await self.middleware.call('idmap.clear_idmap_cache')
+
             await self._service_change('cifs', 'restart')
         else:
             await self._service_change('cifs', 'reload')
@@ -1187,6 +1192,11 @@ class SharingSMBService(SharingService):
 
         if do_global_reload:
             await self.middleware.call('smb.initialize_globals')
+            if (await self.middleware.call('activedirectory.get_state')) == 'HEALTHY':
+                await self.middleware.call('activedirectory.synchronize')
+                if new['home'] or old['home']:
+                    await self.middleware.call('idmap.clear_idmap_cache')
+
             await self._service_change('cifs', 'restart')
         else:
             await self._service_change('cifs', 'reload')
@@ -1304,6 +1314,9 @@ class SharingSMBService(SharingService):
             guest_mapping = await self.middleware.call('smb.getparm', 'map to guest', 'GLOBAL')
             if guest_mapping != 'Bad User':
                 return True
+
+        if data['home']:
+            return True
 
         return False
 


### PR DESCRIPTION
There are several moving parts when configuring the
`homes` share for AD users. This feature relies on
pam_mkhomedir to generate home directories for users
on an as-needed basis. This means that several procedures
need to happen:

1) pam_mkhomedir must be in pam-session block
2) intermediate directories for domain component must exist
   for domains that will authenticate to our server.
3) winbindd configuration must be changed in order for the
   template homedir utilize the homes share.
4) samba must be configured to obey pam restrictions
   (so that pam_mkhomedir will be called when SMB session
   started).
5) winbindd caches must be flushed out so that correct homedir
   is returned in NSS queries.

This feature can be fragile, but has been around since the
days of FreeNAS 9 and so it cannot be completely removed
from the product (but it has been de-emphasized in the GUI).

This PR fixes the items above and adds a test to our CI.

Original PR: https://github.com/truenas/middleware/pull/10837
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120610