### PR TITLE
NAS-119515 / 22.12.2 / fix hot-spare not auto-detaching after replace (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -93,14 +93,6 @@ class PoolService(Service):
             job.set_progress(30, 'Replacing disk')
             new_devname = vdev[0].replace('/dev/', '')
             await self.middleware.call('zfs.pool.replace', pool['name'], options['label'], new_devname)
-            try:
-                vdev = await self.middleware.call('zfs.pool.get_vdev', pool['name'], options['label'])
-                if vdev['status'] not in ('ONLINE', 'DEGRADED'):
-                    job.set_progress(80, 'Detaching old disk')
-                    # If we are replacing a faulted disk, kick it right after replace is initiated.
-                    await self.middleware.call('zfs.pool.detach', pool['name'], options['label'])
-            except Exception:
-                self.logger.warning('Failed to detach device with label %r', options['label'], exc_info=True)
         finally:
             # Needs to happen even if replace failed to put back disk that had been
             # removed from swap prior to replacement


### PR DESCRIPTION
This was added over 4 years ago for freeBSD based product. It is now, currently, interfering with the proper operation of zed and zfsd on CORE and SCALE respectively.

Original PR: https://github.com/truenas/middleware/pull/10839
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119515