### PR TITLE
NAS-120955 / 22.12.2 / Ensure required cgroup controllers are always present before starting apps (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -198,6 +198,9 @@ class KubernetesService(Service):
 
     @private
     def ensure_cgroups_are_setup(self):
+        # Logic copied over from kubernetes
+        # https://github.com/kubernetes/kubernetes/blob/08fbe92fa76d35048b4b4891b41fc6912e689cc7/
+        # pkg/kubelet/cm/cgroup_manager_linux.go#L238
         supported_controllers = {'cpu', 'cpuset', 'memory', 'hugetlb', 'pids'}
         cgroup_root_path = '/sys/fs/cgroup'
         system_supported_controllers_path = os.path.join(cgroup_root_path, 'cgroup.controllers')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -443,10 +443,10 @@ class KubernetesService(Service):
                     'ApplicationsConfigurationFailed',
                     {'error': e.errmsg},
                 )
-            else:
-                await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
             raise
+
+        await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
 
 async def _event_system(middleware, event_type, args):


### PR DESCRIPTION
This PR adds changes to ensure that required cgroup controllers are always present before attempting to start apps. We have been seeing this issue for various users where apps refused to work and kubernetes was not really giving us any good information wrt why it fails to start. It has been isolated that it is a kernel/systemd issue and not related to apps and OS team is working on isolating/diagnosing that appropriately. For now these changes will ensure we refuse to start apps and also raise an alert for apps when an attempt is made to start them outlining why it did not start.

Original PR: https://github.com/truenas/middleware/pull/10838
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120955