### PR TITLE
NAS-119244 / 22.12.2 / add storcli /c<x> show all in debug (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
@@ -2,6 +2,12 @@
 hardware_opt() { echo h; }
 hardware_help() { echo "Dump Hardware Configuration"; }
 hardware_directory() { echo "Hardware"; }
+
+get_hba_ctrl_numbers()
+{
+	storcli show J |jq '.Controllers[0]["Response Data"]["IT System Overview"]' |jq -r '.[]["Ctl"]' 2>/dev/null
+}
+
 hardware_func()
 {
 	section_header "CPU and Memory information"
@@ -40,4 +46,14 @@ hardware_func()
 	section_header "Enclosures (midclt call enclosure.query)"
 	midclt call enclosure.query |jq .
 	section_footer
+
+	section_header = "HBA Information (storcli show)"
+	storcli show
+	section_footer
+
+	for i in $(get_hba_ctrl_numbers); do
+		section_header "storcli /c$i show all"
+		storcli /c$i show all
+		section_footer
+	done
 }


### PR DESCRIPTION
This does 2 things:
1. adds `storcli show`
2. and adds `storcli /c<x> show all` based on number of detected HBAs

This might not have everything compared to CORE's `mprutils` commands, but it's way better than what we're currently doing (nothing).

Original PR: https://github.com/truenas/middleware/pull/10848
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119244