### PR TITLE
NAS-120978 / 22.12.3 / Fix all supported controllers not being added to available controllers (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -12,8 +12,10 @@ from middlewared.service import CallError, private, Service
 from middlewared.utils import run
 
 from .k8s.config import reinitialize_config
-from .utils import CGROUP_ROOT_PATH, get_available_controllers_for_consumption, RE_CGROUP_CONTROLLERS
-
+from .utils import (
+    CGROUP_ROOT_PATH, get_available_controllers_for_consumption, RE_CGROUP_CONTROLLERS,
+    update_available_controllers_for_consumption,
+)
 
 START_LOCK = asyncio.Lock()
 
@@ -215,7 +217,7 @@ class KubernetesService(Service):
         available_controllers_for_consumption = get_available_controllers_for_consumption()
         if missing_controllers := needed_controllers - available_controllers:
             # If we have missing controllers, lets try adding them to subtree control
-            pass
+            available_controllers_for_consumption = update_available_controllers_for_consumption(missing_controllers)
 
         missing_controllers = needed_controllers - available_controllers_for_consumption
         if missing_controllers:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -215,7 +215,7 @@ class KubernetesService(Service):
 
         needed_controllers = supported_controllers & available_controllers
         available_controllers_for_consumption = get_available_controllers_for_consumption()
-        if missing_controllers := needed_controllers - available_controllers:
+        if missing_controllers := needed_controllers - available_controllers_for_consumption:
             # If we have missing controllers, lets try adding them to subtree control
             available_controllers_for_consumption = update_available_controllers_for_consumption(missing_controllers)
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -1,7 +1,11 @@
 import os
+import re
+
+from middlewared.service import CallError
 
 
 BACKUP_NAME_PREFIX = 'ix-applications-backup-'
+CGROUP_ROOT_PATH = '/sys/fs/cgroup'
 KUBECONFIG_FILE = '/etc/rancher/k3s/k3s.yaml'
 KUBERNETES_WORKER_NODE_PASSWORD = 'e3d26cefbdf2f81eff5181e68a02372f'
 KUBEROUTER_RULE_PRIORITY = 32764
@@ -10,8 +14,21 @@ KUBEROUTER_TABLE_NAME = 'kube-router'
 MIGRATION_NAMING_SCHEMA = 'ix-app-migrate-%Y-%m-%d_%H-%M'
 NODE_NAME = 'ix-truenas'
 OPENEBS_ZFS_GROUP_NAME = 'zfs.openebs.io'
+RE_CGROUP_CONTROLLERS = re.compile(r'(\w+)\s+')
 UPDATE_BACKUP_PREFIX = 'system-update-'
 
 
 def applications_ds_name(pool):
     return os.path.join(pool, 'ix-applications')
+
+
+def get_available_controllers_for_consumption() -> set:
+    system_available_controllers_path = os.path.join(CGROUP_ROOT_PATH, 'cgroup.subtree_control')
+    try:
+        with open(system_available_controllers_path, 'r') as f:
+            return set(RE_CGROUP_CONTROLLERS.findall(f.read()))
+    except FileNotFoundError:
+        raise CallError(
+            'Unable to determine cgroup controllers which are available for consumption as '
+            f'{system_available_controllers_path!r} does not exist'
+        )

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -40,6 +40,6 @@ def update_available_controllers_for_consumption(to_add_controllers: set) -> set
     # regardless of the update failing
     with contextlib.suppress(FileNotFoundError, OSError):
         with open(CGROUP_AVAILABLE_CONTROLLERS_PATH, 'w') as f:
-            f.write(f'+{" ".join(to_add_controllers)}')
+            f.write(f'{" ".join(map(lambda s: f"+{s}", to_add_controllers))}')
 
     return get_available_controllers_for_consumption()


### PR DESCRIPTION
This PR addresses a regression caused by recent changes where we validate that all supported controllers are actually available for consumption but it did not take into account that on some systems after a reboot not all supported controllers are automatically added to available controllers for consumption. So now we try to do that first and don't error out if that is not happening ( as we have seen for users where `cpuset` refused to become part of available controllers ) as that is handled already and we refuse to start k8s in that case.

Original PR: https://github.com/truenas/middleware/pull/10851
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120978