### PR TITLE
NAS-121009 / 22.12.2 / prevent log spam in failover.mismatch_disks (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -429,8 +429,8 @@ class FailoverService(ConfigService):
             try:
                 rd = await self.middleware.call('failover.call_remote', 'failover.get_disks_local')
             except Exception as e:
-                if isinstance(e, CallError) and e.errno == CallError.ENOMETHOD:
-                    # ignore it, just means the other side needs to be upgraded
+                ignore = (CallError.ENOMETHOD, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
+                if isinstance(e, CallError) and e.errno in ignore:
                     return result
                 else:
                     self.logger.error('Unhandled exception in get_disks_local on remote controller', exc_info=True)


### PR DESCRIPTION
This is a particularly "hot" code-path and it's producing quite a bit of log spam on an HA system when other side is rebooted. This prevents, ideally, logs from being generated when that occurs.

Original PR: https://github.com/truenas/middleware/pull/10856
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121009