### PR TITLE
NAS-121023 / 23.10 / Improve user homedir validation errors

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -29,7 +29,7 @@ async def check_path_resides_within_volume(verrors, middleware, name, path):
         rv['is_mountpoint'] = os.path.ismount(path)
         return rv
 
-    loc = path_location(name)
+    loc = path_location(path)
 
     if loc == 'EXTERNAL':
         verrors.add(name, "Path is external to TrueNAS.")

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -428,10 +428,41 @@ def test_37_homedir_testfile_create(request):
 @pytest.mark.dependency(name="HOMEDIR2_EXISTS")
 def test_38_homedir_move_new_directory(request):
     depends(request, ["HOMEDIR_EXISTS"])
-    payload = {
-        "home": f'/mnt/{dataset}/new_home',
-    }
-    results = PUT(f"/user/id/{user_id}", payload)
+
+    # Validation of autocreation of homedir during path update
+    with tmp_dataset(pool_name, os.path.join('test_homes', 'ds2')) as ds:
+        results = PUT(f'/user/id/{user_id}', {'home': ds['mountpoint'], 'home_create': True})
+        assert results.status_code == 200, results.text
+
+        results = GET('/core/get_jobs/?method=user.do_home_copy')
+        assert results.status_code == 200, results.text
+        job_status = wait_on_job(results.json()[-1]['id'], 180)
+        assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+
+        results = POST('/filesystem/stat/', os.path.join(ds['mountpoint'], 'testuser2'))
+        assert results.status_code == 200, results.text
+        assert results.json()['uid'] == next_uid, results.txt
+
+        # now kick the can down the road to the root of our pool
+        results = PUT(f'/user/id/{user_id}', {'home': os.path.join('/mnt', pool_name), 'home_create': True})
+        assert results.status_code == 200, results.text
+
+        results = GET('/core/get_jobs/?method=user.do_home_copy')
+        assert results.status_code == 200, results.text
+        job_status = wait_on_job(results.json()[-1]['id'], 180)
+        assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+
+        results = POST('/filesystem/stat/', os.path.join('/mnt', pool_name, 'testuser2'))
+        assert results.status_code == 200, results.text
+        assert results.json()['uid'] == next_uid, results.txt
+
+    new_home = f'/mnt/{dataset}/new_home'
+    results = SSH_TEST(f'mkdir {new_home}', user, password, ip)
+    assert results['result'] is True, results['output']
+
+    # Validation of changing homedir to existing path without
+    # autocreation of subdir for user.
+    results = PUT(f"/user/id/{user_id}", {"home": new_home})
     assert results.status_code == 200, results.text
 
     results = GET('/core/get_jobs/?method=user.do_home_copy')
@@ -439,8 +470,9 @@ def test_38_homedir_move_new_directory(request):
     job_status = wait_on_job(results.json()[-1]['id'], 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
-    results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home')
+    results = POST('/filesystem/stat/', new_home)
     assert results.status_code == 200, results.text
+    assert results.json()['uid'] == next_uid, results.txt
 
 
 @pytest.mark.parametrize('to_test', home_files.keys())
@@ -726,6 +758,17 @@ def test_58_create_new_user_existing_home_path(request):
             'group_create': True,
             'password': 'test1234',
             'home': user['home'],
+            'home_create': True,
+        })
+        assert results.status_code == 422, results.text
+
+        # Attempting to create a user with non-existing path
+        results = POST('/user/', {
+            'username': 't2',
+            'full_name': 't2',
+            'group_create': True,
+            'password': 'test1234',
+            'home': os.path.join(user['home'], 'canary'),
             'home_create': True,
         })
         assert results.status_code == 422, results.text


### PR DESCRIPTION
Give explicit guidance in validation error messages about non-existent homedirs and also run homedir path through our standard method of path validation (to catch any more subtle errors in the path).

This also fixes an error where non-existent home directories were bypassing validation and error was being caught by filesystem plugin.

The PR also addresses issues where validation for user creation and update could potentially block main loop by running the homedir validation in a separate thread.

New tests were added to validate the following behavior:

1) Update of user to change home directory to an existing path.
   We check that path owner changed to user in question.

2) Creation of user with non-existing home directory base dir fails
   with a Validation Error.

3) Update of user to change home directory to new base and create
   new directory works and sets ownership correctly.