### PR TITLE
NAS-121034 / 23.10 / generate a udev event after disk has been wiped

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -11,7 +11,8 @@ class DiskService(Service):
 
     @private
     def _wipe(self, data):
-        with open(os.open(f'/dev/{data["dev"]}', os.O_WRONLY | os.O_EXCL), 'wb') as f:
+        disk_path = f'/dev/{data["dev"]}'
+        with open(os.open(disk_path, os.O_WRONLY | os.O_EXCL), 'wb') as f:
             size = os.lseek(f.fileno(), 0, os.SEEK_END)
             if size == 0:
                 # no size means nothing else will work
@@ -51,7 +52,7 @@ class DiskService(Service):
                     os.write(f.fileno(), to_write)
                     data['job'].set_progress(float(f'{i / iterations:.{length}f}') * 100)
 
-        with open(f'/dev/{data["name"]}' 'wb'):
+        with open(disk_path, 'wb'):
             # we overwrote partiton label information by the time
             # we get here so we need to close device and re-open
             # it in write mode to trigger a udev to rescan the

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -51,6 +51,13 @@ class DiskService(Service):
                     os.write(f.fileno(), to_write)
                     data['job'].set_progress(float(f'{i / iterations:.{length}f}') * 100)
 
+        with open(f'/dev/{data["name"]}' 'wb'):
+            # we overwrote partiton label information by the time
+            # we get here so we need to close device and re-open
+            # it in write mode to trigger a udev to rescan the
+            # device for new information
+            pass
+
     @accepts(
         Str('dev'),
         Str('mode', enum=['QUICK', 'FULL', 'FULL_RANDOM'], required=True),

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -1,0 +1,24 @@
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.assets.pool import another_pool
+
+
+def test_disk_wipe_exported_zpool_in_disk_get_unused():
+    tmp_pool_name = used_disks = None
+    with another_pool() as tmp_pool:
+        tmp_pool_name = tmp_pool['name']
+        flat = call('pool.flatten_topology', tmp_pool['topology'])
+        used_disks = [i['disk'] for i in flat if i['type'] == 'DISK']
+
+    # something is way off if neither of these are set
+    assert all((tmp_pool_name, used_disks))
+
+    for disk in filter(lambda x: x['name'] in used_disks, call('disk.get_unused')):
+        # disks should still show as being part of an exported zpool
+        assert disk['exported_zpool'] == tmp_pool_name
+
+        # since we're here we'll wipe the disks
+        call('disk.wipe', disk['name'], 'QUICK', job=True)
+
+    for disk in filter(lambda x: x['name'] in used_disks, call('disk.get_unused')):
+        # now disks should no longer show as being part of the exported zpool
+        assert disk['exported_zpool'] is None


### PR DESCRIPTION
When we wipe partition information from a disk using this method, we must open the device again to trigger udev events so the udev cache for the partition information for the disk that we just wiped is updated to reflect reality. Without these changes, middleware will still show a device as having partition labels on it when it doesn't.