### PR TITLE
NAS-121028 / 22.12.3 / add create_and_prepare_ws() (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -715,8 +715,9 @@ class ShellApplication(object):
         self.middleware = middleware
 
     async def ws_handler(self, request):
-        ws = web.WebSocketResponse()
-        await ws.prepare(request)
+        ws, prepared = await self.middleware.create_and_prepare_ws(request)
+        if not prepared:
+            return ws
 
         if not await self.middleware.ws_can_access(request, ws):
             return ws
@@ -1604,9 +1605,25 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
         return serviceobj, methodobj
 
-    async def ws_handler(self, request):
+    async def create_and_prepare_ws(self, request):
         ws = web.WebSocketResponse()
-        await ws.prepare(request)
+        prepared = False
+        try:
+            await ws.prepare(request)
+            prepared = True
+        except ConnectionResetError:
+            # happens when we're preparing a new session
+            # and during the time we prepare, the server
+            # is stopped/killed/restarted etc. Ignore these
+            # to prevent log spam
+            pass
+
+        return ws, prepared
+
+    async def ws_handler(self, request):
+        ws, prepared = await self.create_and_prepare_ws(request)
+        if not prepared:
+            return ws
 
         if not await self.ws_can_access(request, ws):
             return ws


### PR DESCRIPTION
Noticed when I was troubleshooting an unrelated issue. I often do `systemctl restart middlewared`. This can finish before a `ws.prepare(request)` returns. When this happens, a `ConnectionRefusedError` is raised and looks pretty nasty in the logs. This PR accounts for this scenario.

Original PR: https://github.com/truenas/middleware/pull/10863
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121028