### PR TITLE
NAS-120616 / 23.10 / Added support for wildcarded NFS hostnames

### DIFF
--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -4,6 +4,7 @@
     import os
     from pathlib import Path
     from contextlib import suppress
+    from middlewared.plugins.nfs_.utils import get_domain, leftmost_has_wildcards, get_wildcard_domain
 
     def do_map(share, map_type, map_ids):
         output = []
@@ -83,6 +84,10 @@
     def parse_host(hostname, gaierrors):
         if hostname.startswith('@'):
             # This is a netgroup, skip validation
+            return hostname
+
+        if leftmost_has_wildcards(hostname):
+            # This is a wildcarded name, skip validation
             return hostname
 
         try:

--- a/src/middlewared/middlewared/plugins/nfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/nfs_/utils.py
@@ -1,0 +1,36 @@
+import re
+
+RE_DOMAIN_WILDCARD = re.compile(r'\*|\?|\[|\]')
+
+
+def get_domain(hostname):
+    """
+    return the 'domain' part of the hostname
+    e.g. gruff.billy.goat will return 'gruff'
+    and  gruffbillygoat will return None
+    """
+    lst = hostname.split('.', 1)
+    if len(lst) > 1:
+        return lst[1]
+    return None
+
+
+def leftmost_has_wildcards(hostname):
+    """
+    A bool that returns True if the left most level contains wildcards
+    """
+    return bool(RE_DOMAIN_WILDCARD.search(hostname.split('.')[0]))
+
+
+def get_wildcard_domain(hostname):
+    """
+    If the left most level of the supplied hostname contains valid wildcard characters
+       and there is more than one level in the name,
+    then return the domain part.
+    e.g. asdf-* will return None
+         asdf-*.example.com will return example.com
+         fred.example.com will return None
+    """
+    if leftmost_has_wildcards(hostname):
+        return get_domain(hostname)
+    return None

--- a/src/middlewared/middlewared/plugins/nfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/nfs_/utils.py
@@ -6,7 +6,7 @@ RE_DOMAIN_WILDCARD = re.compile(r'\*|\?|\[|\]')
 def get_domain(hostname):
     """
     return the 'domain' part of the hostname
-    e.g. gruff.billy.goat will return 'gruff'
+    e.g. gruff.billy.goat will return 'billy.goat'
     and  gruffbillygoat will return None
     """
     lst = hostname.split('.', 1)

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -317,6 +317,7 @@ def test_32_check_nfs_share_hosts(request, hostlist, ExpectedToPass):
     - Dashes are allowed, but a level cannot start or end with a dash, '-'
     - Only the left most level may contain special characters: '*','?' and '[]'
     """
+    depends(request, ["pool_04", "ssh_password"], scope="session")
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hostlist})
     if ExpectedToPass:
         assert results.status_code == 200, results.text


### PR DESCRIPTION
See `man 5 exports` for list of valid wildcards.
Rules:
* Wildcards are allowed only in the left most level
* If the name is multiple levels, the levels below must be resolvable

Updated _exports.mako_ to allow wildcards.
Extended test 32 in _test_300_nfs.py_ to include wildcard hostnames.
Fixed a few `flake8` complaints.