### PR TITLE
NAS-121064 / 23.10 / fix x controller position detection logic

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -20,10 +20,7 @@ class EnclosureDetectionService(Service):
 
     @cache
     def detect(self):
-
-        # first check to see if this is a BHYVE instance
-        manufacturer = self.middleware.call_sync('system.dmidecode_info')['system-product-name']
-        if manufacturer == 'BHYVE':
+        if self.middleware.call_sync('system.dmidecode_info')['system-product-name'] == 'BHYVE':
             # bhyve host configures a scsi_generic device that when sent an inquiry will
             # respond with a string that we use to determine the position of the node
             ctx = Context()
@@ -32,43 +29,33 @@ class EnclosureDetectionService(Service):
                     model = model.decode().strip() if isinstance(model, bytes) else model.strip()
                     if model == 'TrueNAS_A':
                         self.NODE = 'A'
-                        self.HARDWARE = manufacturer
+                        self.HARDWARE = 'BHYVE'
                         break
                     elif model == 'TrueNAS_B':
                         self.NODE = 'B'
-                        self.HARDWARE = manufacturer
+                        self.HARDWARE = 'BHYVE'
                         break
 
             return self.HARDWARE, self.NODE
 
-        # Gather the PCI address for all enclosurers
-        # detected by the kernel
-        enclosures = self.middleware.call_sync("enclosure.list_ses_enclosures")
-        if not enclosures:
-            # No enclosures detected
-            return self.HARDWARE, self.NODE
-
-        for enc in enclosures:
+        for enc in self.middleware.call_sync("enclosure.list_ses_enclosures"):
             proc = subprocess.run(
                 ['/usr/bin/sg_ses', '-p', 'ed', enc],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-
             if proc.stdout:
                 info = proc.stdout.decode(errors='ignore', encoding='utf8')
 
-                # Identify the Z-series Hardware (Echostream)
                 if re.search(HA_HARDWARE.ZSERIES_ENCLOSURE.value, info):
+                    # Z-series Hardware (Echostream)
                     self.HARDWARE = 'ECHOSTREAM'
                     reg = re.search(HA_HARDWARE.ZSERIES_NODE.value, info)
                     self.NODE = reg.group(1)
                     if self.NODE:
                         break
-
-                # Identify the X-series Hardware (PUMA)
-                # TODO: Verify this works on X-series Hardware
                 elif re.search(HA_HARDWARE.XSERIES_ENCLOSURE.value, info):
+                    # X-series Hardware (PUMA)
                     self.HARDWARE = 'PUMA'
 
                     sas_addr = ''
@@ -85,27 +72,19 @@ class EnclosureDetectionService(Service):
                         if ses_addr == sas_addr:
                             self.NODE = 'A'
                             break
-
-                    if (reg := re.search(HA_HARDWARE.XSERIES_NODEB.value, info)) is not None:
+                    elif (reg := re.search(HA_HARDWARE.XSERIES_NODEB.value, info)) is not None:
                         ses_addr = hex(int(reg.group(1), 16) - 1)
                         if ses_addr == sas_addr:
                             self.NODE = 'B'
                             break
-
-                # Identify the M-series hardware (Echowarp)
-                else:
-                    reg = re.search(HA_HARDWARE.MSERIES_ENCLOSURE.value, info)
-                    if reg:
-                        self.HARDWARE = 'ECHOWARP'
-
-                        # Identify M-series A slot in chassis
-                        if reg.group(2) == 'p':
-                            self.NODE = 'A'
-                            break
-
-                        # Identify M-series B slot in chassis
-                        if reg.group(2) == 's':
-                            self.NODE = 'B'
-                            break
+                elif (reg := re.search(HA_HARDWARE.MSERIES_ENCLOSURE.value, info)) is not None:
+                    # M-series hardware (Echowarp)
+                    self.HARDWARE = 'ECHOWARP'
+                    if reg.group(2) == 'p':
+                        self.NODE = 'A'
+                        break
+                    elif reg.group(2) == 's':
+                        self.NODE = 'B'
+                        break
 
         return self.HARDWARE, self.NODE

--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -71,26 +71,24 @@ class EnclosureDetectionService(Service):
                 elif re.search(HA_HARDWARE.XSERIES_ENCLOSURE.value, info):
                     self.HARDWARE = 'PUMA'
 
-                    # We need to get the SAS address of the SAS expander first
-                    sas_addr_file = ENCLOSURES_DIR + enc.split('/dev/bsg/')[-1] + '/id'
-                    with open(sas_addr_file, 'r') as f:
+                    sas_addr = ''
+                    with open(f'{ENCLOSURES_DIR}{enc.split("/")[-1]}/device/sas_address') as f:
+                        # We need to get the SAS address of the SAS expander first
                         sas_addr = f.read().strip()
 
                     # We then cast the SES address (deduced from SES VPD pages)
                     # to an integer and subtract 1. Then cast it back to hexadecimal.
                     # We then compare if the SAS expander's SAS address
                     # is in the SAS expanders SES address
-                    reg = re.search(HA_HARDWARE.XSERIES_NODEA.value, info)
-                    if reg:
+                    if (reg := re.search(HA_HARDWARE.XSERIES_NODEA.value, info)) is not None:
                         ses_addr = hex(int(reg.group(1), 16) - 1)
-                        if ses_addr in sas_addr:
+                        if ses_addr == sas_addr:
                             self.NODE = 'A'
                             break
 
-                    reg = re.search(HA_HARDWARE.XSERIES_NODEB.value, info)
-                    if reg:
+                    if (reg := re.search(HA_HARDWARE.XSERIES_NODEB.value, info)) is not None:
                         ses_addr = hex(int(reg.group(1), 16) - 1)
-                        if ses_addr in sas_addr:
+                        if ses_addr == sas_addr:
                             self.NODE = 'B'
                             break
 


### PR DESCRIPTION
This fixes 2 primary problems.
1. correctly identify whether the controller is in the `A` or `B` position of the head-unit
2. We were caching the return of this method twice. Once on class and one via the functools.cache decorator.

While I'm here, i've cleaned this method up a bit to make it more concise.