### PR TITLE
NAS-121080 / 23.10 / Remove local.compression test

### DIFF
--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -664,7 +664,6 @@ def test_064_destroying_smb_dataset(request):
     'local.charset',
     'local.convert_string',
     'local.string_case_handle',
-    'local.compression',
     'local.event',
     'local.tevent_req',
     'local.util_str_escape',


### PR DESCRIPTION
This particular local smbtorture test was removed
in Samba 4.18