### PR TITLE
NAS-121086 / 22.12.3 / Fix libvirt socket closed edge case when querying VMs (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -96,6 +96,8 @@ class VMService(CRUDService, VMSupervisorMixin):
     @private
     def extend_context(self, rows, extra):
         status = {}
+        if rows:
+            self._check_setup_connection()
         for row in rows:
             status[row['id']] = self.status_impl(row)
         return {'status': status}
@@ -451,6 +453,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             - pid, process id if RUNNING
         """
         vm = self.middleware.call_sync('datastore.query', 'vm.vm', [['id', '=', id]], {'get': True})
+        self._check_setup_connection()
         return self.status_impl(vm)
 
     @private


### PR DESCRIPTION
## Problem

We are seeing another edge case with VMs where if libvirt socket is closed and we try to query VMs it fails as the socket is not re-initialized and we try to update the domain.

## Solution

The failure happens when middleware tries to retrieve status of the VM and covering the usage there making sure that libvirt socket is initialised before we try to retrieve the status of the VM. For performance it is only done once in VM extend context to avoid making the same call - the drawback is that if during the query call libvirt socket fails it will result in a crash but a subsequent VM query call will work.

Original PR: https://github.com/truenas/middleware/pull/10895
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121086