### PR TITLE
NAS-121091 / 23.10 / Add tests for MS-RPC server

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/smb.py
+++ b/src/middlewared/middlewared/test/integration/assets/smb.py
@@ -1,0 +1,25 @@
+# -*- coding=utf-8 -*-
+import contextlib
+import logging
+
+from middlewared.test.integration.utils import call
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["smb_share"]
+
+
+@contextlib.contextmanager
+def smb_share(path, name, options=None):
+    share = call("sharing.smb.create", {
+        "path": path,
+        "name": name,
+        **(options or {})
+    })
+    assert call("service.start", "cifs")
+
+    try:
+        yield share
+    finally:
+        call("sharing.smb.delete", share["id"])
+        call("service.stop", "cifs")

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+import os
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from auto_config import (ip, dev_test, pool_name)
+from functions import GET
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.assets.pool import dataset
+from protocols import MS_RPC
+
+reason = 'Skipping for test development testing'
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason=reason)
+
+SMB_USER = "smbrpcuser"
+SMB_PWD = "smb1234#!@"
+
+@pytest.fixture(scope="module")
+def setup_smb_share(request):
+    with dataset('rpc_test', data={'share_type': 'SMB'}) as ds:
+        with smb_share(os.path.join('/mnt', ds), "RPC_TEST") as s:
+            yield {'dataset': ds, 'share': s}
+
+@pytest.fixture(autouse=True, scope="function")
+def setup_smb_user(request):
+    with user({
+        "username": SMB_USER,
+        "full_name": SMB_USER,
+        "group_create": True,
+        "home": "/nonexistent",
+        "password": SMB_PWD,
+    }) as u:
+        yield u
+
+
+def test_001_net_share_enum(setup_smb_user, setup_smb_share):
+    path = setup_smb_share['share']['path']
+    share_name = setup_smb_share['share']['name']
+
+    with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
+        shares = hdl.shares()
+        # IPC$ share should always be present
+        assert len(shares) == 2, str(shares)
+        assert shares[0]['netname'] == 'IPC$'
+        assert shares[0]['path'] == 'C:\\tmp'
+        assert shares[1]['netname'] == share_name
+        assert shares[1]['path'].replace('\\', '/')[2:] == path
+
+
+def test_002_enum_users(setup_smb_user, setup_smb_share):
+    results = GET('/user', payload={
+        'query-filters': [['username', '=', SMB_USER]],
+        'query-options': {
+            'get': True,
+            'extra': {'additional_information': ['SMB']}
+        }
+    })
+    assert results.status_code == 200, results.text
+    user_info = results.json()
+
+    with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
+        entry = None
+        users = hdl.users()
+        for u in users:
+            if u['user'] != SMB_USER:
+                continue
+
+            entry = u
+            break
+
+        assert entry is not None, str(users)
+        rid = int(user_info['sid'].rsplit('-', 1)[1])
+        assert rid == entry['rid'], str(entry)

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -6,6 +6,7 @@ from .iscsi_proto import iscsi_scsi_connect, iscsi_scsi_connection
 from .iSNSP.client import iSNSPClient
 from .nfs_proto import SSH_NFS
 from .smb_proto import SMB
+from .ms_rpc import MS_RPC
 
 
 @contextlib.contextmanager

--- a/tests/protocols/ms_rpc.py
+++ b/tests/protocols/ms_rpc.py
@@ -1,0 +1,119 @@
+import re
+import subprocess
+
+from collections import namedtuple
+
+RE_SAMR_ENUMDOMAINS = re.compile(r"name:\[(?P<name>\w+)\] idx:\[(?P<idx>\w+)\]")
+RE_SAMR_ENUMDOMUSER = re.compile(r"user:\[(?P<user>\w+)\] rid:\[(?P<rid>\w+)\]")
+
+class MS_RPC():
+    """
+    Thin wrapper around rpcclient. As needed we can use python bindings.
+    and use this to hold state.
+    """
+    def __init__(self, **kwargs):
+        self.user = kwargs.get('username')
+        self.passwd = kwargs.get('password')
+        self.workgroup = kwargs.get('workgroup')
+        self.kerberos = kwargs.get('use_kerberos', False)
+        self.realm = kwargs.get('realm')
+        self.host = kwargs.get('host')
+        self.smb1 = kwargs.get('smb1', False)
+
+    def connect(self):
+        # currently connect() and disconnect() are no-ops
+        # This is placeholder for future python binding usage.
+        return
+
+    def disconnect(self):
+        return
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, tp, value, traceback):
+        self.disconnect()
+
+    def _get_connection_subprocess_args(self):
+        # NOTE: on failure rpcclient will return 1 with error written to stdout
+        args = ['rpcclient']
+        if self.kerberos:
+            args.extend(['--use-kerberos', 'required'])
+        else:
+            args.extend(['-U', f'{self.user}%{self.passwd}'])
+
+        if self.workgroup:
+            args.extend(['-W', self.workgroup])
+
+        if self.realm:
+            args.extend(['--realm', self.realm])
+
+        if self.smb1:
+            args.extend(['-m', 'NT1'])
+
+        args.append(self.host)
+
+        return args
+
+    # SAMR
+    def _parse_samr_results(self, results, regex, to_convert):
+        output = []
+        for line in results.splitlines():
+            if not (m:= regex.match(line.strip())):
+                continue
+
+            entry = m.groupdict()
+            entry[to_convert] = int(entry[to_convert], 16)
+            output.append(entry)
+
+        return output
+
+    def domains(self):
+        cmd = self._get_connection_subprocess_args()
+        cmd.extend(['-c', 'enumdomains'])
+        rpc_proc = subprocess.run(cmd, capture_output=True)
+        if rpc_proc.returncode != 0:
+            raise RuntimeError(rpc_proc.stdout.decode())
+
+        return self._parse_samr_results(
+            rpc_proc.stdout.decode(),
+            RE_SAMR_ENUMDOMAINS,
+            'idx'
+        )
+
+    def users(self):
+        cmd = self._get_connection_subprocess_args()
+        cmd.extend(['-c', 'enumdomusers'])
+        rpc_proc = subprocess.run(cmd, capture_output=True)
+        if rpc_proc.returncode != 0:
+            raise RuntimeError(rpc_proc.stdout.decode())
+
+        return self._parse_samr_results(
+            rpc_proc.stdout.decode(),
+            RE_SAMR_ENUMDOMUSER,
+            'rid'
+        )
+
+    # SRVSVC
+    def shares(self):
+        shares = []
+        entry = None
+
+        cmd = self._get_connection_subprocess_args()
+        cmd.extend(['-c', 'netshareenumall'])
+        rpc_proc = subprocess.run(cmd, capture_output=True)
+        if rpc_proc.returncode != 0:
+            raise RuntimeError(rpc_proc.stdout.decode())
+
+        for idx, line in enumerate(rpc_proc.stdout.decode().splitlines()):
+            k, v = line.strip().split(':', 1)
+
+            # use modulo wrap-around to create new entries based on stdout
+            if idx % 4 == 0:
+                entry = {k: v.strip()}
+                shares.append(entry)
+            else:
+                entry.update({k: v.strip()})
+
+        return shares


### PR DESCRIPTION
This series of tests is just a thin wrapper around rpclient, and is a preliminary step to having formal tests for FSS support.

Right now we only check that shares are properly enumerated via srvsvc endpoint and that users and RIDs are presented as expeceted.