### PR TITLE
NAS-121074 / 23.10 / fix failover.vip.get_states

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
+++ b/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
@@ -17,31 +17,23 @@ class DetectVirtualIpStates(Service):
         masters, backups = [], []
 
         # get failover group id for `iface`
-        group_id = [
-            group for group, names in groups.items() if ifname in names
-        ][0]
+        group_id = [group for group, names in groups.items() if ifname in names][0]
 
         # get all interfaces in `group_id`
-        ids = [
-            names for group, names in groups.items() if group == group_id
-        ][0]
+        ids = [names for group, names in groups.items() if group == group_id][0]
 
         # need to remove the passed in `ifname` from the list
         ids.remove(ifname)
 
-        # if the user provided VIP(s) is/are missing from the interface
-        # then it's considered "BACKUP" if the interface has the VIP(s)
-        # then it's considered "MASTER"
-        if len(ids):
-            # we can have more than one interface in the failover
-            # group so check the state of the interface
-            for i in ids:
-                iface = netif.get_interface(i)
-                for j in iface.vrrp_config:
-                    if j['state'] == 'MASTER':
-                        masters.append(i)
-                    else:
-                        backups.append(i)
+        # we can have more than one interface in the failover
+        # group so check the state of the interface
+        for i in ids:
+            iface = netif.get_interface(i)
+            for j in iface.vrrp_config:
+                if j['state'] == 'MASTER':
+                    masters.append(i)
+                else:
+                    backups.append(i)
 
         return masters, backups
 
@@ -63,9 +55,7 @@ class DetectVirtualIpStates(Service):
         return masters, backups, inits
 
     async def check_states(self, local, remote):
-
         errors = []
-
         interfaces = set(local[0] + local[1] + remote[0] + remote[1])
         if not interfaces:
             errors.append('There are no failover interfaces')


### PR DESCRIPTION
Primary problem being fixed here is to make sure that the interface being checked actually has carrier. In this particular instance `eno2` was showing as being in `BACKUP` state on the master controller. Checking the other controller, it wasn't showing the VIP either. Investigating a little further, the interface was down. I also cleaned up this plugin while I was here.