### PR TITLE
NAS-120144 / 23.10 / Improve error reporting when deleting a certificate

### DIFF
--- a/src/middlewared/middlewared/common/attachment/certificate.py
+++ b/src/middlewared/middlewared/common/attachment/certificate.py
@@ -15,6 +15,9 @@ class CertificateAttachmentDelegate:
     async def redeploy(self, cert_id):
         raise NotImplementedError
 
+    async def consuming_cert_human_output(self, cert_id):
+        return self.HUMAN_NAME if self.state(cert_id) else None
+
 
 class CertificateServiceAttachmentDelegate(CertificateAttachmentDelegate, ServiceChangeMixin):
 

--- a/src/middlewared/middlewared/common/attachment/certificate.py
+++ b/src/middlewared/middlewared/common/attachment/certificate.py
@@ -16,7 +16,7 @@ class CertificateAttachmentDelegate:
         raise NotImplementedError
 
     async def consuming_cert_human_output(self, cert_id):
-        return self.HUMAN_NAME if self.state(cert_id) else None
+        return self.HUMAN_NAME if await self.state(cert_id) else None
 
 
 class CertificateServiceAttachmentDelegate(CertificateAttachmentDelegate, ServiceChangeMixin):

--- a/src/middlewared/middlewared/common/attachment/certificate.py
+++ b/src/middlewared/middlewared/common/attachment/certificate.py
@@ -3,6 +3,7 @@ from middlewared.service import ServiceChangeMixin
 
 class CertificateAttachmentDelegate:
 
+    HUMAN_NAME = NotImplementedError
     NAMESPACE = NotImplementedError
 
     def __init__(self, middleware):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
@@ -10,6 +10,10 @@ class ChartReleaseCertificateAttachmentDelegate(CertificateCRUDServiceAttachment
     async def get_filters(self, cert_id):
         return [['resources.truenas_certificates', 'rin', cert_id]]
 
+    async def consuming_cert_human_output(self, cert_id):
+        attachments = await self.attachments(cert_id)
+        return f'{", ".join(app["id"] for app in attachments)!r} {self.HUMAN_NAME}' if attachments else None
+
     async def attachments(self, cert_id):
         return await self.middleware.call(
             f'{self.NAMESPACE}.query', await self.get_filters(cert_id), {'extra': {'retrieve_resources': True}}

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
@@ -52,3 +52,9 @@ class ChartReleaseService(Service):
                     chart_releases.append(chart_release['id'])
                     break
         return chart_releases
+
+
+async def setup(middleware):
+    await middleware.call(
+        'certificate.register_attachment_delegate', ChartReleaseCertificateAttachmentDelegate(middleware)
+    )

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/cert_attachments.py
@@ -4,6 +4,7 @@ from middlewared.service import private, Service
 
 class ChartReleaseCertificateAttachmentDelegate(CertificateCRUDServiceAttachmentDelegate):
 
+    HUMAN_NAME = 'Applications'
     NAMESPACE = 'chart.release'
 
     async def get_filters(self, cert_id):

--- a/src/middlewared/middlewared/plugins/crypto_/attachments.py
+++ b/src/middlewared/middlewared/plugins/crypto_/attachments.py
@@ -19,6 +19,10 @@ class CertificateService(Service):
         return [delegate for delegate in self.delegates if await delegate.state(cert_id)]
 
     @private
+    async def get_attachments(self, cert_id):
+        return list(filter(bool, [await delegate.consuming_cert_human_output(cert_id) for delegate in self.delegates]))
+
+    @private
     async def redeploy_cert_attachments(self, cert_id):
         for delegate in await self.in_use_attachments(cert_id):
             await delegate.redeploy(cert_id)

--- a/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificate_authorities.py
@@ -6,7 +6,6 @@ import middlewared.sqlalchemy as sa
 
 from .cert_entry import get_ca_result_entry
 from .common_validation import _validate_common_attributes, validate_cert_name
-from .dependencies import check_dependencies
 from .key_utils import export_private_key
 from .load_utils import get_serial_from_certificate_safe
 from .query_utils import get_ca_chain, normalize_cert_attrs
@@ -498,7 +497,7 @@ class CertificateAuthorityService(CRUDService):
             }
         """
         await self.get_instance(id)
-        await self.middleware.run_in_thread(check_dependencies, self.middleware, 'CA', id)
+        await self.middleware.call('certificateauthority.check_ca_dependencies', id)
 
         response = await self.middleware.call(
             'datastore.delete',

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -11,7 +11,6 @@ from middlewared.service import CallError, CRUDService, job, private, skip_arg, 
 from middlewared.validators import Email, Range
 
 from .common_validation import _validate_common_attributes, validate_cert_name
-from .dependencies import check_dependencies
 from .cert_entry import CERT_ENTRY
 from .csr import generate_certificate_signing_request
 from .key_utils import export_private_key
@@ -685,9 +684,8 @@ class CertificateService(CRUDService):
                 ]
             }
         """
-        check_dependencies(self.middleware, 'CERT', id)
-
         certificate = self.middleware.call_sync('certificate.get_instance', id)
+        self.middleware.call_sync('certificate.check_cert_deps', id)
 
         if certificate.get('acme') and not certificate['expired']:
             # We won't try revoking a certificate which has expired already

--- a/src/middlewared/middlewared/plugins/crypto_/dependencies.py
+++ b/src/middlewared/middlewared/plugins/crypto_/dependencies.py
@@ -22,11 +22,11 @@ class CertificateAuthorityService(Service):
         await self.middleware.call('certificateauthority.check_dependencies', ca_id)
         chart_releases = await self.middleware.call(
             'chart.release.query', [
-                [f'resources.truenas_certificate_authorities', 'rin', ca_id]
+                ['resources.truenas_certificate_authorities', 'rin', ca_id]
             ], {'extra': {'retrieve_resources': True}}
         )
         if chart_releases:
             raise CallError(
-                f'Certificate Authority cannot be deleted as it is being used by '
+                'Certificate Authority cannot be deleted as it is being used by '
                 f'{", ".join([c["id"] for c in chart_releases])} chart release(s).'
             )

--- a/src/middlewared/middlewared/plugins/crypto_/dependencies.py
+++ b/src/middlewared/middlewared/plugins/crypto_/dependencies.py
@@ -1,12 +1,32 @@
-from middlewared.service import CallError
+from middlewared.service import CallError, Service
+
+
+class CertificateAuthorityService(Service):
+
+    class Config:
+        cli_namespace = 'system.certificate.authority'
+
+    async def check_ca_dependencies(self, ca_id):
+        await self.middleware.call('certificateauthority.check_dependencies', ca_id)
+        chart_releases = await self.middleware.call(
+            'chart.release.query', [
+                [f'resources.truenas_certificate_authorities', 'rin', ca_id]
+            ], {'extra': {'retrieve_resources': True}}
+        )
+        if chart_releases:
+            raise CallError(
+                f'Certificate Authority cannot be deleted as it is being used by '
+                f'{", ".join([c["id"] for c in chart_releases])} chart release(s).'
+            )
 
 
 def check_dependencies(middleware, cert_type, id):
     if cert_type == 'CA':
         key = 'truenas_certificate_authorities'
-        method = 'certificateauthority.check_dependencies'
+        middleware.call_sync('certificateauthority.check_dependencies', id)
     else:
         key = 'truenas_certificates'
+
         method = 'certificate.check_dependencies'
 
     middleware.call_sync(method, id)

--- a/src/middlewared/middlewared/plugins/crypto_/dependencies.py
+++ b/src/middlewared/middlewared/plugins/crypto_/dependencies.py
@@ -1,4 +1,15 @@
-from middlewared.service import CallError, Service
+from middlewared.service import CallError, private, Service
+
+
+class CertificateService(Service):
+
+    @private
+    async def check_cert_deps(self, cert_id):
+        if deps := await self.middleware.call('certificate.get_attachments', cert_id):
+            deps_str = ''
+            for i, svc in enumerate(deps):
+                deps_str += f'{i+1}) {svc}\n'
+            raise CallError(f'Certificate is being used by following service(s):\n{deps_str}')
 
 
 class CertificateAuthorityService(Service):
@@ -6,6 +17,7 @@ class CertificateAuthorityService(Service):
     class Config:
         cli_namespace = 'system.certificate.authority'
 
+    @private
     async def check_ca_dependencies(self, ca_id):
         await self.middleware.call('certificateauthority.check_dependencies', ca_id)
         chart_releases = await self.middleware.call(
@@ -18,24 +30,3 @@ class CertificateAuthorityService(Service):
                 f'Certificate Authority cannot be deleted as it is being used by '
                 f'{", ".join([c["id"] for c in chart_releases])} chart release(s).'
             )
-
-
-def check_dependencies(middleware, cert_type, id):
-    if cert_type == 'CA':
-        key = 'truenas_certificate_authorities'
-        middleware.call_sync('certificateauthority.check_dependencies', id)
-    else:
-        key = 'truenas_certificates'
-
-        method = 'certificate.check_dependencies'
-
-    middleware.call_sync(method, id)
-
-    chart_releases = middleware.call_sync(
-        'chart.release.query', [[f'resources.{key}', 'rin', id]], {'extra': {'retrieve_resources': True}}
-    )
-    if chart_releases:
-        raise CallError(
-            f'Certificate{" Authority" if cert_type == "CA" else ""} cannot be deleted as it is being used by '
-            f'{", ".join([c["id"] for c in chart_releases])} chart release(s).'
-        )

--- a/src/middlewared/middlewared/plugins/ftp_/cert_attachment.py
+++ b/src/middlewared/middlewared/plugins/ftp_/cert_attachment.py
@@ -4,6 +4,7 @@ from middlewared.common.attachment.certificate import CertificateServiceAttachme
 class FTPCertificateAttachment(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'ssltls_certificate'
+    HUMAN_NAME = 'FTP Service'
     SERVICE = 'ftp'
 
 

--- a/src/middlewared/middlewared/plugins/idmap_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/idmap_/cert_attachments.py
@@ -4,6 +4,7 @@ from middlewared.common.attachment.certificate import CertificateCRUDServiceAtta
 class IdmapCertificateAttachmentDelegate(CertificateCRUDServiceAttachmentDelegate):
 
     CERT_FILTER_KEY = 'certificate.id'
+    HUMAN_NAME = 'IDMAP Service'
     NAMESPACE = 'idmap'
 
     async def redeploy(self, cert_id):

--- a/src/middlewared/middlewared/plugins/kmip/attachment.py
+++ b/src/middlewared/middlewared/plugins/kmip/attachment.py
@@ -4,6 +4,7 @@ from middlewared.common.ports import ServicePortDelegate
 
 class KmipCertificateAttachment(CertificateServiceAttachmentDelegate):
 
+    HUMAN_NAME = 'KMIP Service'
     SERVICE = 'kmip'
     SERVICE_VERB = 'start'
 

--- a/src/middlewared/middlewared/plugins/ldap_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/ldap_/cert_attachments.py
@@ -3,6 +3,7 @@ from middlewared.common.attachment.certificate import CertificateServiceAttachme
 
 class LdapCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
+    HUMAN_NAME = 'LDAP Service'
     SERVICE = 'ldap'
     SERVICE_VERB = 'start'
 

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -55,6 +55,7 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
 
 class S3CertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
+    HUMAN_NAME = 'S3 Service'
     SERVICE = 's3'
 
 

--- a/src/middlewared/middlewared/plugins/system/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/system/cert_attachments.py
@@ -4,6 +4,7 @@ from middlewared.common.attachment.certificate import CertificateServiceAttachme
 class SystemGeneralCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'ui_certificate'
+    HUMAN_NAME = 'UI Service'
     NAMESPACE = 'system.general'
     SERVICE = 'http'
 
@@ -11,6 +12,7 @@ class SystemGeneralCertificateAttachmentDelegate(CertificateServiceAttachmentDel
 class SystemAdvancedCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'syslog_tls_certificate'
+    HUMAN_NAME = 'Syslog Service'
     NAMESPACE = 'system.advanced'
     SERVICE = 'syslogd'
 

--- a/src/middlewared/middlewared/plugins/vpn_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/vpn_/cert_attachments.py
@@ -4,6 +4,7 @@ from middlewared.common.attachment.certificate import CertificateServiceAttachme
 class OpenvpnServerCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'server_certificate'
+    HUMAN_NAME = 'OpenVPN Server Service'
     NAMESPACE = 'openvpn.server'
     SERVICE = 'openvpn_server'
 
@@ -11,6 +12,7 @@ class OpenvpnServerCertificateAttachmentDelegate(CertificateServiceAttachmentDel
 class OpenvpnClientCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'client_certificate'
+    HUMAN_NAME = 'OpenVPN Client Service'
     NAMESPACE = 'openvpn.client'
     SERVICE = 'openvpn_client'
 

--- a/src/middlewared/middlewared/plugins/webdav_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/webdav_/cert_attachments.py
@@ -4,6 +4,7 @@ from middlewared.common.attachment.certificate import CertificateServiceAttachme
 class WebdavCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     CERT_FIELD = 'certssl'
+    HUMAN_NAME = 'Webdav Service'
     SERVICE = 'webdav'
 
 


### PR DESCRIPTION
This PR adds changes to be more descriptive about which service is consuming a certificate when deleting a certificate. New changes have the following format:

```
❯ midclt call certificate.check_cert_deps 7
[EFAULT] Certificate is being used by following service(s):
1) 'collabora' Applications
2) OpenVPN Client Service

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 200, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1336, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/crypto_/dependencies.py", line 12, in check_cert_deps
    raise CallError(f'Certificate is being used by following service(s):\n{deps_str}')
middlewared.service_exception.CallError: [EFAULT] Certificate is being used by following service(s):
1) 'collabora' Applications
2) OpenVPN Client Service


❯
❯ midclt call certificate.check_cert_deps 6
[EFAULT] Certificate is being used by following service(s):
1) UI Service

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 200, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1336, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/crypto_/dependencies.py", line 12, in check_cert_deps
    raise CallError(f'Certificate is being used by following service(s):\n{deps_str}')
middlewared.service_exception.CallError: [EFAULT] Certificate is being used by following service(s):
1) UI Service
```