### PR TITLE
Add ACME DNS support for Google DNS and DigitalOcean

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/digital_ocean.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/digital_ocean.py
@@ -1,5 +1,3 @@
-
-
 import logging
 
 from certbot_dns_digitalocean._internal.dns_digitalocean import _DigitalOceanClient

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/digital_ocean.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/digital_ocean.py
@@ -1,0 +1,41 @@
+
+
+import logging
+
+from certbot_dns_digitalocean._internal.dns_digitalocean import _DigitalOceanClient
+
+from middlewared.schema import accepts, Dict, Str
+from middlewared.service import skip_arg
+
+from .base import Authenticator
+
+
+logger = logging.getLogger(__name__)
+
+
+class DigitalOceanAuthenticator(Authenticator):
+
+    NAME = 'Digital Ocean'
+    PROPAGATION_DELAY = 60
+    SCHEMA = Dict(
+        'Digital Ocean',
+        Str('api_token', empty=False, null=False, title='API Token', required=True),
+    )
+
+    def initialize_credentials(self):
+        self.api_token = self.attributes.get('api_token')
+
+    @staticmethod
+    @accepts(SCHEMA)
+    @skip_arg(count=1)
+    async def validate_credentials(middleware, data):
+        return data
+
+    def _perform(self, domain, validation_name, validation_content):
+        self.get_client().add_txt_record(domain, validation_name, validation_content, 600)
+
+    def get_client(self):
+        return _DigitalOceanClient(self.api_token)
+
+    def _cleanup(self, domain, validation_name, validation_content):
+        self.get_client().del_txt_record(domain, validation_name, validation_content, 600)

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
@@ -3,6 +3,7 @@ import errno
 from middlewared.service_exception import CallError
 
 from .cloudflare import CloudFlareAuthenticator
+from .digital_ocean import DigitalOceanAuthenticator
 from .google import GoogleAuthenticator
 from .ovh import OVHAuthenticator
 from .route53 import Route53Authenticator
@@ -29,6 +30,7 @@ class AuthenticatorFactory:
 auth_factory = AuthenticatorFactory()
 for authenticator in [
     CloudFlareAuthenticator,
+    DigitalOceanAuthenticator,
     GoogleAuthenticator,
     Route53Authenticator,
     OVHAuthenticator,

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/factory.py
@@ -3,6 +3,7 @@ import errno
 from middlewared.service_exception import CallError
 
 from .cloudflare import CloudFlareAuthenticator
+from .google import GoogleAuthenticator
 from .ovh import OVHAuthenticator
 from .route53 import Route53Authenticator
 from .shell import ShellAuthenticator
@@ -28,6 +29,7 @@ class AuthenticatorFactory:
 auth_factory = AuthenticatorFactory()
 for authenticator in [
     CloudFlareAuthenticator,
+    GoogleAuthenticator,
     Route53Authenticator,
     OVHAuthenticator,
     ShellAuthenticator,

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/google.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/google.py
@@ -1,0 +1,41 @@
+
+
+import logging
+
+from certbot_dns_google._internal.dns_google import _GoogleClient
+
+from middlewared.schema import accepts, Dict, File
+from middlewared.service import skip_arg
+
+from .base import Authenticator
+
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleAuthenticator(Authenticator):
+
+    NAME = 'Google DNS'
+    PROPAGATION_DELAY = 60
+    SCHEMA = Dict(
+        'Google',
+        File('service_account_path', empty=False, null=False, title='Path to the service account JSON', required=True),
+    )
+
+    def initialize_credentials(self):
+        self.service_account = self.attributes.get('service_account_path')
+
+    @staticmethod
+    @accepts(SCHEMA)
+    @skip_arg(count=1)
+    async def validate_credentials(middleware, data):
+        return data
+
+    def _perform(self, domain, validation_name, validation_content):
+        self.get_client().add_txt_record(domain, validation_name, validation_content, 600)
+
+    def get_client(self):
+        return _GoogleClient(self.service_account)
+
+    def _cleanup(self, domain, validation_name, validation_content):
+        self.get_client().del_txt_record(domain, validation_name, validation_content, 600)

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/google.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/google.py
@@ -1,5 +1,3 @@
-
-
 import logging
 
 from certbot_dns_google._internal.dns_google import _GoogleClient


### PR DESCRIPTION
Provided by the certbot packages.

NAS-121092 seems to mention the need for Google Domains support as well.

Since the `certbot_dns_google` and `certbot_dns_digitalocean` are available out of the box, I thought I'd kill two birds with one stone.