### PR TITLE
NAS-121055 / 22.12.2 / add ipmi.chassis plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -164,30 +164,6 @@ class IPMIService(CRUDService):
 
         return rc
 
-    @accepts(Dict(
-        'options',
-        Int('seconds', default=15, validators=[Range(min=0, max=3600)]),
-        Bool('force', default=False),
-    ))
-    @returns()
-    def identify(self, options):
-        """
-        Turn on chassis identify light.
-
-        `seconds` is an integer representing the number of seconds to leave the chassis identify light turned on.
-            - default is 15 seconds
-            - to turn it off, specify `seconds` as 0
-        `force` is a boolean. When True, turn on chassis identify light indefinitely.
-        """
-        verrors = ValidationErrors()
-        force = options['force']
-        seconds = options["seconds"]
-        if force and seconds:
-            verrors.add('ipmi.identify', f'Seconds: ({seconds}) and Force: ({force}) are exclusive.')
-        verrors.check()
-
-        run(['ipmitool', 'chassis', 'identify', 'force' if force else seconds], stdout=DEVNULL, stderr=DEVNULL)
-
     @filterable
     @filterable_returns(List('events_log', items=[Dict('event', additional_attrs=True)]))
     @job(lock='query_sel', lock_queue_size=3)

--- a/src/middlewared/middlewared/plugins/ipmi_/chassis.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/chassis.py
@@ -1,0 +1,34 @@
+from subprocess import run, DEVNULL, PIPE
+
+from middlewared.service import Service, filterable, filterable_returns
+from middlewared.utils import filter_list
+from middlewared.schema import Str, Dict, accepts, returns
+
+
+class IpmiChassisService(Service):
+
+    class Config:
+        namespace = 'ipmi.chassis'
+        cli_namespace = 'service.ipmi.chassis'
+
+    @filterable
+    @filterable_returns(Dict('chassis_info', additional_attrs=True))
+    def query(self, filters, options):
+        rv = {}
+        out = run(['ipmi-chassis', '--get-chassis-status'], stdout=PIPE, stderr=PIPE).stdout.decode().split('\n')
+        for line in filter(lambda x: x, out):
+            ele, status = line.split(':', 1)
+            rv[ele.strip()] = status.strip()
+
+        return filter_list(rv, filters, options)
+
+    @accepts(Str('verb', default='ON', enum=['ON', 'OFF']))
+    @returns()
+    def identify(self, verb):
+        """
+        Toggle the chassis identify light.
+
+        `verb`: str if 'ON' turn identify light on. if 'OFF' turn identify light off.
+        """
+        verb = 'force' if verb == 'ON' else '0'
+        run(['ipmi-chassis', f'--chassis-identify={verb}'], stdout=DEVNULL, stderr=DEVNULL)


### PR DESCRIPTION
After discussion with webUI team, the current ipmi.identify implementation is clunky and not very user friendly. This adds a new plugin that uses a different tool which is much easier to use (and quicker to respond).

I've also added a `ipmi.chassis.query` method to get the status on whether or not the chassis identify light has been toggled.

Currently, we do not allow user to specify a timeout for when the light turns off. It's either on indefinitely, or off.

Original PR: https://github.com/truenas/middleware/pull/10908
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121055