### PR TITLE
NAS-121058 / 22.12.3 / Only register HA VIPs during AD dynamic DNS updates (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -128,10 +128,14 @@ class ActiveDirectoryService(Service):
             return []
 
         await self.middleware.call('kerberos.check_ticket')
+        if smb_ha_mode == 'UNIFIED' and not smb['bindip']:
+            bindip = await self.middleware.call('smb.bindip_choices')
+        else:
+            bindip = smb['bindip']
 
         hostname = f'{smb["netbiosname_local"]}.{ad["domainname"]}.'
         to_register = await self.ipaddresses_to_register({
-            'bindip': smb['bindip'],
+            'bindip': bindip,
             'hostname': hostname,
             'clustered': smb_ha_mode == 'CLUSTERED'
         })

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -294,6 +294,14 @@ class SMBService(TDBWrapConfigService):
 
             return choices
 
+        elif ha_mode == 'UNIFIED':
+            masters, backup, init = await self.middleware.call('failover.vip.get_states')
+            for master_iface in await self.middleware.call('interface.query', [["id", "in", masters]]):
+                for i in master_iface['failover_virtual_aliases']:
+                    choices[i['address']] = i['address']
+
+            return choices
+
         for i in await self.middleware.call('interface.ip_in_use'):
             choices[i['address']] = i['address']
 


### PR DESCRIPTION
We must restrict SMB bind ips and dynamically registered IP addresses to TrueNAS HA Virtual IPs. Otherwise clients may attempt to connect to the wrong storage node.

Original PR: https://github.com/truenas/middleware/pull/10878
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121058