### PR TITLE
NAS-121130 / 22.12.2 / prevent libads from performing DNS updates (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -841,7 +841,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if ad['createcomputer']:
             cmd.append(f'createcomputer={ad["createcomputer"]}')
 
-        cmd.append(ad['domainname'])
+        cmd.extend(['--no-dns-updates', ad['domainname']])
         netads = await run(cmd, check=False)
         if netads.returncode != 0:
             self.logger.warning("AD JOIN FAILED: %s", netads.stderr.decode())


### PR DESCRIPTION
Beginning in 22.12.0 we began to use nsupdate to perform dynamic DNS updates for active directory. libads with MIT kerberos wouldn't successfully perform these while we were working on the transition to building with MIT kerberos, but it appears that issue is now fixed. This PR prevents libads from performing DNS updates during domain join so that we have finer-grained control over this in middleware.

Original PR: https://github.com/truenas/middleware/pull/10921
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121130