### PR TITLE
NAS-121017 / 22.12.3 / fix disk.retaste and, hopefully, SCALE HA failover events (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -11,7 +11,7 @@ from middlewared.utils import filter_list
 from middlewared.service import Service, job, accepts
 from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Bool, Int
-from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
+# from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
 
@@ -448,7 +448,8 @@ class FailoverEventsService(Service):
             except Exception as e:
                 if e.errno == errno.ENOENT:
                     try_again = True
-                    logger.warning('Failed importing %r using cachefile so trying without it.', vol['name'])
+                    # logger.warning('Failed importing %r using cachefile so trying without it.', vol['name'])
+                    logger.warning('Failed importing %r with ENOENT, trying again.', vol['name'])
                 else:
                     vol['error'] = str(e)
                     failed.append(vol)
@@ -465,6 +466,10 @@ class FailoverEventsService(Service):
                     vol['error'] = str(e)
                     failed.append(vol)
                     continue
+
+                # TODO: come back and fix this once we figure out how to properly manage zpool cachefile
+                # (i.e. we need a cachefile per zpool, and not a global one)
+                """
                 try:
                     # make sure the zpool cachefile property is set appropriately
                     self.run_call(
@@ -472,6 +477,7 @@ class FailoverEventsService(Service):
                     )
                 except Exception:
                     logger.warning('Failed to set cachefile property for %r', vol['name'], exc_info=True)
+                """
 
             logger.info('Successfully imported %r', vol['name'])
 
@@ -660,7 +666,7 @@ class FailoverEventsService(Service):
                 os.fsync(f.fileno())  # be EXTRA sure it goes straight to disk
 
         # setup the zpool cachefile
-        self.run_call('failover.zpool.cachefile.setup', 'BACKUP')
+        # self.run_call('failover.zpool.cachefile.setup', 'BACKUP')
 
         # export zpools in a thread and set a timeout to
         # to `self.ZPOOL_EXPORT_TIMEOUT`.


### PR DESCRIPTION
This does 2 primary things:
1. in `disk.retaste` method, I now call `BLKRRPART` which tells kernel to force reread partition tables on the disk. (I also log any type of errors that might occur while I'm there)
2. Remove the `disk.retaste` call on failover event since that seems to have caused all of the problems that we've been experiencing.

Original PR: https://github.com/truenas/middleware/pull/10918
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121017