### PR TITLE
NAS-121141 / 22.12.3 / Don't disable AD on passive controller (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -273,6 +273,6 @@ class ActiveDirectoryService(Service):
         except dns.resolver.NoNameservers as e:
             raise CallError(f'DNS forward lookup of netbios name failed: {e}', errno.EFAULT)
 
-        ips_in_use = set([x['address'] for x in await self.middleware.call('interface.ip_in_use')])
+        ips_in_use = set((await self.middleware.call('smb.bindip_choices')).keys())
 
         return bool(dns_addresses & ips_in_use)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -295,8 +295,8 @@ class SMBService(TDBWrapConfigService):
             return choices
 
         elif ha_mode == 'UNIFIED':
-            masters, backup, init = await self.middleware.call('failover.vip.get_states')
-            for master_iface in await self.middleware.call('interface.query', [["id", "in", masters]]):
+            master, backup, init = await self.middleware.call('failover.vip.get_states')
+            for master_iface in await self.middleware.call('interface.query', [["id", "in", master + backup]]):
                 for i in master_iface['failover_virtual_aliases']:
                     choices[i['address']] = i['address']
 


### PR DESCRIPTION
The common_validation method for activedirectory plugin gets called during AD status checks. This is a safeguard against radically misconfigured active directory settings as failure will result in the AD service being disabled.

Starting in 22.12 the validation was expanded to also include making sure that forward lookup of our hostname returns ips that are ours. In the HA case though it is expected that failover be enabled and FAULTED when on the standby controller. The status is changed to healthy during a failover event when the data pool along with system dataset and secrets file stored there is imported (and directoryservices.setup is called).

This commit slightly alters the set of IP addresses used for validation when checking whether the name is ours by using smb.bindip_choices rather than interface.ip_in_use.

The former has the following special behavior depending on server configuration:
CLUSTERED - ctdb public IPs
HA - VIPs (both backup and master)
STANDALONE - interface.ip_in_use

Original PR: https://github.com/truenas/middleware/pull/10927
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121141