### PR TITLE
Fix failover via rebooting active controller

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1286,10 +1286,6 @@ async def _event_system_ready(middleware, event_type, args):
         middleware.send_event('failover.upgrade_pending', 'ADDED', id='BACKUP', fields={'pending': True})
 
 
-async def _event_system_shutdown(middleware, event_type, args):
-    await middleware.call('failover.fenced.stop', True)
-
-
 def remote_status_event(middleware, *args, **kwargs):
     middleware.call_sync('failover.status_refresh')
 
@@ -1303,7 +1299,6 @@ async def setup(middleware):
         It is expected the client will react by issuing `upgrade_finish` call
         at user will.'''))
     middleware.event_subscribe('system.ready', _event_system_ready)
-    middleware.event_subscribe('system.shutdown', _event_system_shutdown)
     middleware.register_hook('core.on_connect', ha_permission, sync=True)
     middleware.register_hook('interface.pre_sync', interface_pre_sync_hook, sync=True)
     middleware.register_hook('interface.post_sync', hook_setup_ha, sync=True)


### PR DESCRIPTION
When systemd is handling reboot of an HA server, a race condition may be exposed whereby fenced is stopped before pool is exported. This can result in the now-passive controller halting IO to the zpool and hanging in a state that requires server reset in order to recover. This PR makes a couple of minor changes:

1) On active (rebooting) controller, we no longer stop the fenced
   process when processing a shutdown event in middleware.

2) On standby (becoming active) controller, we poll the fenced for
   remote node for up to 10 seconds (repeating if other side has
   fenced running) to give time for fenced to stop / controller
   reboot.