### PR TITLE
NAS-121133 / 22.12.2 / Fix failover via rebooting active controller (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1285,8 +1285,6 @@ async def _event_system(middleware, event_type, args):
 
         if await middleware.call('keyvalue.get', 'HA_UPGRADE', False):
             middleware.send_event('failover.upgrade_pending', 'ADDED', id='BACKUP', fields={'pending': True})
-    elif args['id'] == 'shutdown':
-        await middleware.call('failover.fenced.stop', True)
 
 
 def remote_status_event(middleware, *args, **kwargs):


### PR DESCRIPTION
When systemd is handling reboot of an HA server, a race condition may be exposed whereby fenced is stopped before pool is exported. This can result in the now-passive controller halting IO to the zpool and hanging in a state that requires server reset in order to recover. This PR makes a couple of minor changes:

1) On active (rebooting) controller, we no longer stop the fenced
   process when processing a shutdown event in middleware.

2) On standby (becoming active) controller, we poll the fenced for
   remote node for up to 10 seconds (repeating if other side has
   fenced running) to give time for fenced to stop / controller
   reboot.

Original PR: https://github.com/truenas/middleware/pull/10937
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121133