### PR TITLE
NAS-121153 / 22.12.2 / Shift timing of fenced stop (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -654,10 +654,6 @@ class FailoverEventsService(Service):
 
         logger.warning('Entering BACKUP on "%s".', ifname)
 
-        # we need to stop fenced first
-        logger.warning('Stopping fenced')
-        self.run_call('failover.fenced.stop')
-
         logger.info('Blocking network traffic.')
         fw_drop_job = self.run_call('failover.firewall.drop_all')
         fw_drop_job.wait_sync()
@@ -709,6 +705,10 @@ class FailoverEventsService(Service):
             # now violently reboot
             with open('/proc/sysrq-trigger', 'w') as f:
                 f.write('b')
+
+        # Pools are now exported and so we can make disks available to other controller
+        logger.warning('Stopping fenced')
+        self.run_call('failover.fenced.stop')
 
         # We also remove this file here, because on boot we become BACKUP if the other
         # controller is MASTER. So this means we have no volumes to export which means


### PR DESCRIPTION
As of NAS-121133 storage controllers now poll for getting persistent reservations while becoming VRRP master. This now opens up a window in which to hang onto them on the standby controller a little longer to ensure that pools are fully exported before granting the master access to the disks.

Original PR: https://github.com/truenas/middleware/pull/10941
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121153