### PR TITLE
NAS-121157 / 23.10 / avoid propagating keepalived restart

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -655,7 +655,7 @@ class FailoverEventsService(Service):
         # which means any VIP that is on this controller will be
         # migrated to the other controller
         logger.info('Transitioning all VIPs off this node')
-        self.run_call('service.restart', 'keepalived')
+        self.run_call('service.restart', 'keepalived', self.HA_PROPAGATE)
 
         # ticket 23361 enabled a feature to send email alerts when an unclean reboot occurrs.
         # TrueNAS HA, by design, has a triggered unclean shutdown.


### PR DESCRIPTION
When we become vrrp_backup we restart the keepalived process through middlewared. For historic reasons, service operations through middleware are propagated to the other storage controller. In this case under the right circumstances, the HA propagation could lead to queued failover events and ping-pong between nodes.