### PR TITLE
NAS-121144 / 22.12.3 / Allow adding FULL_CONTROL to ACL for apps (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -380,7 +380,7 @@ class ACLBase(ServicePartBase):
             'simplified_acl_entry',
             Str('id_type', enum=['USER', 'GROUP'], required=True),
             Int('id', required=True),
-            Str('access', enum=['READ', 'MODIFY'], required=True)
+            Str('access', enum=['READ', 'MODIFY', 'FULL_CONTROL'], required=True)
         )]),
         Dict(
             'options',

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -688,6 +688,8 @@ class FilesystemService(Service, ACLBase):
             if perm == 'READ':
                 return {'READ': True, 'WRITE': False, 'EXECUTE': True}
 
+            raise CallError(f'{perm}: unsupported permissions type for POSIX1E acltype')
+
         def check_acl_for_entry(entry):
             id_type = entry['id_type']
             xid = entry['id']
@@ -786,6 +788,11 @@ class FilesystemService(Service, ACLBase):
 
             if perm == 'READ':
                 return {'BASIC': 'READ'}
+
+            if perm == 'FULL_CONTROL':
+                return {'BASIC': 'FULL_CONTROL'}
+
+            raise CallError(f'{perm}: unsupported permissions type for NFSv4 acltype')
 
         def check_acl_for_entry(entry):
             id_type = entry['id_type']


### PR DESCRIPTION
There are a large category of apps that are extremely poorly designed and will fail to deploy if they are unable to recursively chown paths presented to them.

Although it is debatable about whether one should try to support something so haphazardly developed, we can present a knob for at least NFSv4 acltype to allow administrator to grant chown / chmod rights to these IDs on a per-host-path basis.

Original PR: https://github.com/truenas/middleware/pull/10928
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121144