### PR TITLE
NAS-120252 / 23.10 / Allow specifying acls for apps

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/acl.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/acl.py
@@ -16,7 +16,10 @@ class ChartReleaseService(Service):
         failures = []
         for status, acl_path in zip(bulk_job.result, acls_to_apply):
             if status['error']:
-                failures.append(acl_path)
+                failures.append((acl_path, status['error']))
 
         if failures:
-            raise CallError(f'Failed to apply ACLs to the following paths: {", ".join(failures)!r}')
+            err_str = 'Failed to apply ACLs to the following paths: \n'
+            for index, entry in enumerate(failures):
+                err_str += f'{index + 1}) {entry[0]}: {entry[1]}\n'
+            raise CallError(err_str)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/acl.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/acl.py
@@ -1,0 +1,22 @@
+from middlewared.service import CallError, private, Service
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    async def apply_acls(self, acls_to_apply):
+        bulk_job = await self.middleware.call(
+            'core.bulk', 'filesystem.add_to_acl', [[acls_to_apply[acl_path]] for acl_path in acls_to_apply],
+        )
+        await bulk_job.wait()
+
+        failures = []
+        for status, acl_path in zip(bulk_job.result, acls_to_apply):
+            if status['error']:
+                failures.append(acl_path)
+
+        if failures:
+            raise CallError(f'Failed to apply ACLs to the following paths: {", ".join(failures)!r}')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -340,7 +340,7 @@ class ChartReleaseService(CRUDService):
             'chart.release.validate_values', item_details, values, update, release_data,
         )
         return await self.middleware.call(
-            'chart.release.get_normalised_values', dict_obj, values, update, {
+            'chart.release.get_normalized_values', dict_obj, values, update, {
                 'release': {
                     'name': release_ds.split('/')[-1],
                     'dataset': release_ds,
@@ -352,7 +352,7 @@ class ChartReleaseService(CRUDService):
 
     @private
     async def perform_actions(self, context):
-        for action in context['actions']:
+        for action in sorted(context['actions'], key=lambda d: 0 if d['method'] == 'update_volumes_for_release' else 1):
             await self.middleware.call(f'chart.release.{action["method"]}', *action['args'])
 
     @accepts(

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -15,6 +15,7 @@ REF_MAPPING = {
     'definitions/certificate': 'certificate',
     'definitions/certificateAuthority': 'certificate_authorities',
     'normalize/interfaceConfiguration': 'interface_configuration',
+    'normalize/acl': 'acl',
     'normalize/ixVolume': 'ix_volume',
 }
 
@@ -27,30 +28,30 @@ class ChartReleaseService(Service):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for method in REF_MAPPING.values():
-            assert isinstance(getattr(self, f'normalise_{method}'), Callable) is True
+            assert isinstance(getattr(self, f'normalize_{method}'), Callable) is True
 
     @private
-    async def get_normalised_values(self, dict_obj, values, update, context):
+    async def get_normalized_values(self, dict_obj, values, update, context):
         for k in RESERVED_NAMES:
             # We reset reserved names from configuration as these are automatically going to
             # be added by middleware during the process of normalising the values
             values[k[0]] = k[1]()
 
         for attr in filter(lambda v: v.name in values, dict_obj.attrs.values()):
-            values[attr.name] = await self.normalise_question(attr, values[attr.name], update, values, context)
+            values[attr.name] = await self.normalize_question(attr, values[attr.name], update, values, context)
 
         return values, context
 
     @private
-    async def normalise_question(self, question_attr, value, update, complete_config, context):
+    async def normalize_question(self, question_attr, value, update, complete_config, context):
         if value is None and isinstance(question_attr, (Dict, List)):
             # This shows that the value provided has been explicitly specified as null and if validation
-            # was okay with it, we shouldn't try to normalise it
+            # was okay with it, we shouldn't try to normalize it
             return value
 
         if isinstance(question_attr, Dict) and not isinstance(question_attr, Cron):
             for attr in filter(lambda v: v.name in value, question_attr.attrs.values()):
-                value[attr.name] = await self.normalise_question(
+                value[attr.name] = await self.normalize_question(
                     attr, value[attr.name], update, complete_config, context
                 )
 
@@ -58,17 +59,17 @@ class ChartReleaseService(Service):
             for index, item in enumerate(value):
                 _, attr = get_list_item_from_value(item, question_attr)
                 if attr:
-                    value[index] = await self.normalise_question(attr, item, update, complete_config, context)
+                    value[index] = await self.normalize_question(attr, item, update, complete_config, context)
 
         for ref in filter(lambda k: k in REF_MAPPING, question_attr.ref):
             value = await self.middleware.call(
-                f'chart.release.normalise_{REF_MAPPING[ref]}', question_attr, value, complete_config, context
+                f'chart.release.normalize_{REF_MAPPING[ref]}', question_attr, value, complete_config, context
             )
 
         return value
 
     @private
-    async def normalise_interface_configuration(self, attr, value, complete_config, context):
+    async def normalize_interface_configuration(self, attr, value, complete_config, context):
         assert isinstance(attr, Dict) is True
         name = get_network_attachment_definition_name(
             context['release']['name'], len(complete_config['ixExternalInterfacesConfiguration'])
@@ -108,14 +109,16 @@ class ChartReleaseService(Service):
         return value
 
     @private
-    async def normalise_ix_volume(self, attr, value, complete_config, context):
+    async def normalize_ix_volume(self, attr, value, complete_config, context):
         # Let's allow ix volume attr to be a string as well making it easier to define a volume in questions.yaml
         assert isinstance(attr, (Dict, Str)) is True
 
         if isinstance(attr, Dict):
             vol_data = {'name': value['datasetName'], 'properties': value.get('properties') or {}}
+            acl_dict = value.get('aclEntries', {})
         else:
             vol_data = {'name': value, 'properties': {}}
+            acl_dict = None
         ds_name = vol_data['name']
 
         action_dict = next((d for d in context['actions'] if d['method'] == 'update_volumes_for_release'), None)
@@ -129,15 +132,18 @@ class ChartReleaseService(Service):
         else:
             # We already have this in action dict, let's not add a duplicate
             return value
-
+        host_path = os.path.join(context['release']['path'], 'volumes/ix_volumes', ds_name)
         complete_config['ixVolumes'].append({
-            'hostPath': os.path.join(context['release']['path'], 'volumes/ix_volumes', ds_name),
+            'hostPath': host_path,
         })
 
+        if acl_dict:
+            acl_dict['path'] = host_path
+            await self.normalize_acl(Dict(), acl_dict, complete_config, context)
         return value
 
     @private
-    async def normalise_certificate(self, attr, value, complete_config, context):
+    async def normalize_certificate(self, attr, value, complete_config, context):
         assert isinstance(attr, Int) is True
 
         if not value:
@@ -148,7 +154,7 @@ class ChartReleaseService(Service):
         return value
 
     @private
-    async def normalise_certificate_authorities(self, attr, value, complete_config, context):
+    async def normalize_certificate_authorities(self, attr, value, complete_config, context):
         assert isinstance(attr, Int) is True
 
         if not value:
@@ -157,5 +163,25 @@ class ChartReleaseService(Service):
         complete_config['ixCertificateAuthorities'][value] = await self.middleware.call(
             'certificateauthority.get_instance', value
         )
+
+        return value
+
+    @private
+    async def normalize_acl(self, attr, value, complete_config, context):
+        assert isinstance(attr, Dict) is True
+
+        if not value or any(not value[k] for k in ('entries', 'path')):
+            return value
+
+        if (action_dict := next((d for d in context['actions'] if d['method'] == 'apply_acls'), None)) is None:
+            context['actions'].append({
+                'method': 'apply_acls',
+                'args': [{value['path']: value}],
+            })
+        elif value['path'] not in action_dict['args'][-1]:
+            action_dict['args'][-1][value['path']] = value
+        else:
+            # We already have this in action dict, let's not add a duplicate
+            return value
 
         return value

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -5,9 +5,9 @@ import subprocess
 import stat as pystat
 from pathlib import Path
 
-from middlewared.utils.path import FSLocation, path_location
-from middlewared.service import private, CallError, ValidationErrors, Service
 from middlewared.plugins.chart_releases_linux.utils import is_ix_volume_path
+from middlewared.service import private, CallError, ValidationErrors, Service
+from middlewared.utils.path import FSLocation, path_location
 from .acl_base import ACLBase, ACLType
 
 

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from middlewared.utils.path import FSLocation, path_location
 from middlewared.service import private, CallError, ValidationErrors, Service
+from middlewared.plugins.chart_releases_linux.utils import is_ix_volume_path
 from .acl_base import ACLBase, ACLType
 
 
@@ -91,7 +92,8 @@ class FilesystemService(Service, ACLBase):
             )
 
         apps_dataset = self.middleware.call_sync('kubernetes.config')['dataset']
-        if apps_dataset and st['realpath'].startswith(f'/mnt/{apps_dataset}'):
+        if apps_dataset and st['realpath'].startswith(f'/mnt/{apps_dataset}')\
+                and not is_ix_volume_path(st['realpath'], apps_dataset):
             verrors.add(
                 f'{schema}.path',
                 f'Changes to permissions of ix-applications dataset are not permitted: {path}.'

--- a/tests/api2/test_chart_release_acl_apply.py
+++ b/tests/api2/test_chart_release_acl_apply.py
@@ -1,0 +1,124 @@
+import contextlib
+import os
+import sys
+
+from pytest_dependency import depends
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+
+from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.assets.apps import chart_release
+from middlewared.test.integration.assets.catalog import catalog
+
+USER_ID = 568
+TEST_DIR = 'test_dir_for_acl'
+
+
+def path_exists(path: str) -> bool:
+    with contextlib.suppress(Exception):
+        return call('filesystem.stat', path) is not None
+    return False
+
+
+def path_is_dir(path: str) -> bool:
+    with contextlib.suppress(Exception):
+        return call('filesystem.stat', path)['type'] == 'DIRECTORY'
+    return False
+
+
+@contextlib.contextmanager
+def hostpath_dir(path: str):
+    if not path_exists(path):
+        call('filesystem.mkdir', path)
+
+    try:
+        yield path
+    finally:
+        ssh(f'rm -rf {path}')
+
+
+def test_01_ix_volumes_normalization(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    with catalog({
+        'force': True,
+        'preferred_trains': ['tests'],
+        'label': 'ACLTEST',
+        'repository': 'https://github.com/truenas/charts.git',
+        'branch': 'acl-tests'
+    }) as catalog_obj:
+        with chart_release({
+            'catalog': catalog_obj['label'],
+            'item': 'syncthing',
+            'release_name': 'syncthing',
+            'train': 'tests',
+            'values': {'appVolumeMounts': {'config': {'hostPathEnabled': False}}},
+        }) as chart_release_obj:
+            for path in chart_release_obj['config']['ixVolumes']:
+                assert path_exists(path['hostPath']) is True
+                assert path_is_dir(path['hostPath']) is True
+
+
+def test_02_acl_normalization_with_ix_volumes(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+
+    with catalog({
+        'force': True,
+        'preferred_trains': ['tests'],
+        'label': 'ACLTEST',
+        'repository': 'https://github.com/truenas/charts.git',
+        'branch': 'acl-tests'
+    }) as catalog_obj:
+        with chart_release({
+            'catalog': catalog_obj['label'],
+            'item': 'syncthing-with-acl',
+            'release_name': 'syncthing-with-acl',
+            'train': 'tests',
+            'values': {
+                'appVolumeMounts': {
+                    'config': {
+                        'testDataset': {
+                            'datasetName': 'ix-syncthing_test',
+                            'aclEntries': {'entries': [{'id_type': 'USER', 'id': USER_ID, 'access': 'READ'}]}
+                        },
+                        'hostPathEnabled': False,
+                    }
+                }
+            }
+        }) as chart_release_obj:
+            for path in chart_release_obj['config']['ixVolumes']:
+                assert path_exists(path['hostPath']) is True
+                assert path_is_dir(path['hostPath']) is True
+                assert any(
+                    acl['id'] == USER_ID and acl['perms']['READ'] for acl in call(
+                        'filesystem.getacl', path['hostPath']
+                    )['acl']
+                ) is path['hostPath'].endswith('syncthing_test')
+
+
+def test_03_acl_normalization(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+
+    k8s_pool = call('kubernetes.config')['pool']
+    with hostpath_dir(os.path.join('/mnt', k8s_pool, 'acl-test-dir-hostpath')) as tmp_dir:
+        with catalog({
+            'force': True,
+            'preferred_trains': ['tests'],
+            'label': 'ACLTEST',
+            'repository': 'https://github.com/truenas/charts.git',
+            'branch': 'acl-tests'
+        }) as catalog_obj:
+            with chart_release({
+                'catalog': catalog_obj['label'],
+                'item': 'syncthing-with-acl',
+                'release_name': 'syncthing-with-acl-host',
+                'train': 'tests',
+                'values': {
+                    'aclEntries': [{
+                        'path': tmp_dir,
+                        'entries': [{'id_type': 'USER', 'id': USER_ID, 'access': 'READ'}]
+                    }],
+                }
+            }):
+                assert any(
+                    acl['id'] == USER_ID and acl['perms']['READ'] for acl in call('filesystem.getacl', tmp_dir)['acl']
+                ) is True


### PR DESCRIPTION
## Context

`filesystem.add_to_acl` has been added to allow app devs to correctly specify ACLs for host paths. A feature `normalize/acl` has been added which app devs can specify to consume the new feature.