### PR TITLE
NAS-121088 / 22.12.3 / fix missing readonly property (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -213,6 +213,7 @@ class PoolDatasetService(Service):
             i['locked'] = i['locked']
             i['atime'] = atime
             i['casesensitive'] = case
+            i['readonly'] = readonly
             i['thick_provisioned'] = any((i['reservation']['value'], i['refreservation']['value']))
             i['nfs_shares'] = self.get_nfs_shares(i, info['nfs'])
             i['smb_shares'] = self.get_smb_shares(i, info['smb'])


### PR DESCRIPTION
This was supposed to be fixed in 22.12.1 and I added the `readonly` attribute to the data we gather, however, I never added the key in the response. This means webUI is still trying to probe datasets that are encrypted which raises a CallError. This simply adds it so that the webUI will behave as intended.

Original PR: https://github.com/truenas/middleware/pull/10991
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121088