### PR TITLE
NAS-121206 / 23.10 / Expand validation of user home directories

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -779,3 +779,18 @@ def test_58_create_new_user_existing_home_path(request):
             'home_create': True,
         })
         assert results.status_code == 422, results.text
+
+
+def test_59_create_user_ro_dataset(request):
+    user_info = {
+        'username': 't1',
+        "full_name": 'T1',
+        'group_create': True,
+        'password': 'test1234',
+        'home_mode': '770',
+        'home_create': True,
+    }
+    with tmp_dataset(pool_name, 'ro_user_ds', {'readonly': 'ON'}) as ds:
+        user_info['home'] = ds['mountpoint']
+        results = POST("/user/", user_info)
+        assert results.status_code == 422, results.text


### PR DESCRIPTION
We should catch following cases and turn them into informative validation errors:

* New home directory doesn't exist and parent directory is on RO dataset
* New home directory doesn't exist and parent directory is immutable
* New home directory exists and is on RO dataset or immutable

Since we're already having to get mount information, this commit adds an additional check for filesystem type in the returned mount info. If any validation errors have been added, then skip more expensive checks using libzfs.