### PR TITLE
NAS-121008 / 22.12.2 / catch AttributeError in websocket client (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -339,7 +339,12 @@ class Client:
             raise
 
     def _send(self, data):
-        self._ws.send(json.dumps(data))
+        try:
+            self._ws.send(json.dumps(data))
+        except AttributeError:
+            # happens when other node on HA is rebooted, for example, and there are
+            # running tasks in the event loop (i.e. failover.call_remote failover.get_disks_local)
+            raise ClientException('Unexpected closure of remote connection', errno.ECONNABORTED)
 
     def _recv(self, message):
         _id = message.get('id')


### PR DESCRIPTION
```[2023/03/28 09:43:05] (DEBUG) FailoverService.sync_to_peer():354 - Syncing database to standby controller.
[2023/03/28 09:43:05] (DEBUG) FailoverService.sync_to_peer():357 - Syncing cached encryption keys to standby controller.
[2023/03/28 09:43:06] (DEBUG) FailoverService.sync_to_peer():360 - Syncing zpool cachefile, license, pwenc and authorized_keys files to standby controller.
[2023/03/28 09:43:14] (WARNING) middlewared.client.client._on_error():145 - Websocket client error: WebSocketConnectionClosedException('Connection to remote host was lost.')
[2023/03/28 09:43:14] (ERROR) FailoverService.mismatch_disks():436 - Unhandled exception in get_disks_local on remote controller
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover.py", line 430, in mismatch_disks
    rd = await self.middleware.call('failover.call_remote', 'failover.get_disks_local')
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1393, in call
    return await self._call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1347, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1250, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1324, in nf
    return func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1194, in nf
    res = f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/remote.py", line 257, in call_remote
    return self.CLIENT.call(method, *args, **options)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/remote.py", line 129, in call
    return self.client.call(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/client/client.py", line 463, in call
    self._send({
  File "/usr/lib/python3/dist-packages/middlewared/client/client.py", line 303, in _send
    self._ws.send(json.dumps(data))
AttributeError: 'NoneType' object has no attribute 'send'

Original PR: https://github.com/truenas/middleware/pull/10996
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121008