### PR TITLE
NAS-121087 / 22.12.3 / Make `user.shell_choices` accept group IDs to prevent showing TrueNAS… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -260,6 +260,14 @@ class PrivilegeService(CRUDService):
         return gids
 
     @private
+    async def privileges_for_groups(self, groups_key, group_ids):
+        group_ids = set(group_ids)
+        return [
+            privilege for privilege in await self.middleware.call('datastore.query', 'account.privilege')
+            if set(privilege[groups_key]) & group_ids
+        ]
+
+    @private
     async def compose_privilege(self, privileges):
         compose = {
             'allowlist': [],

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -68,10 +68,7 @@ class AuthService(Service):
 
     @private
     async def common_authenticate(self, username, groups_key, groups):
-        privileges = [
-            privilege for privilege in await self.middleware.call('datastore.query', 'account.privilege')
-            if set(privilege[groups_key]) & groups
-        ]
+        privileges = await self.middleware.call('privilege.privileges_for_groups', groups_key, groups)
         if not privileges:
             return None
 

--- a/tests/api2/test_account_shell_choices.py
+++ b/tests/api2/test_account_shell_choices.py
@@ -1,0 +1,135 @@
+import pytest
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.account import group, user
+from middlewared.test.integration.utils import call
+
+
+def test_shell_choices_has_no_privileges():
+    with group({
+        "name": "test_no_privileges",
+    }) as g:
+        assert "/usr/bin/cli" not in call("user.shell_choices", None, [g["id"]])
+
+
+def test_shell_choices_has_privileges():
+    with group({
+        "name": "test_has_privileges",
+    }) as g:
+        privilege = call("privilege.create", {
+            "name": "Test",
+            "local_groups": [g["gid"]],
+            "ds_groups": [],
+            "allowlist": [{"method": "CALL", "resource": "system.info"}],
+            "web_shell": False,
+        })
+        try:
+            assert "/usr/bin/cli" in call("user.shell_choices", None, [g["id"]])
+        finally:
+            call("privilege.delete", privilege["id"])
+
+
+@pytest.mark.parametrize("group_payload", [
+    lambda g: {"group": g["id"]},
+    lambda g: {"group_create": True, "groups": [g["id"]]},
+])
+def test_cant_create_user_with_cli_shell_without_privileges(group_payload):
+    with group({
+        "name": "test_no_privileges",
+    }) as g:
+        with pytest.raises(ValidationErrors) as ve:
+            with user({
+                "username": "test",
+                "full_name": "Test",
+                "home": f"/nonexistent",
+                "password": "test1234",
+                "shell": "/usr/bin/cli",
+                **group_payload(g),
+            }):
+                pass
+
+        assert ve.value.errors[0].attribute == "user_create.shell"
+
+
+@pytest.mark.parametrize("group_payload", [
+    lambda g: {"group": g["id"]},
+    lambda g: {"group_create": True, "groups": [g["id"]]},
+])
+def test_can_create_user_with_cli_shell_with_privileges(group_payload):
+    with group({
+        "name": "test_no_privileges",
+    }) as g:
+        privilege = call("privilege.create", {
+            "name": "Test",
+            "local_groups": [g["gid"]],
+            "ds_groups": [],
+            "allowlist": [{"method": "CALL", "resource": "system.info"}],
+            "web_shell": False,
+        })
+        try:
+            with user({
+                "username": "test",
+                "full_name": "Test",
+                "home": f"/nonexistent",
+                "password": "test1234",
+                "shell": "/usr/bin/cli",
+                **group_payload(g),
+            }):
+                pass
+        finally:
+            call("privilege.delete", privilege["id"])
+
+
+@pytest.mark.parametrize("group_payload", [
+    lambda g: {"group": g["id"]},
+    lambda g: {"groups": [g["id"]]},
+])
+def test_cant_update_user_with_cli_shell_without_privileges(group_payload):
+    with group({
+        "name": "test_no_privileges",
+    }) as g:
+        with user({
+            "username": "test",
+            "full_name": "Test",
+            "home": f"/nonexistent",
+            "password": "test1234",
+            "group_create": True,
+        }) as u:
+            with pytest.raises(ValidationErrors) as ve:
+                call("user.update", u["id"], {
+                    "shell": "/usr/bin/cli",
+                    **group_payload(g),
+                })
+
+            assert ve.value.errors[0].attribute == "user_update.shell"
+
+
+@pytest.mark.parametrize("group_payload", [
+    lambda g: {"group": g["id"]},
+    lambda g: {"groups": [g["id"]]},
+])
+def test_can_update_user_with_cli_shell_with_privileges(group_payload):
+    with group({
+        "name": "test_no_privileges",
+    }) as g:
+        privilege = call("privilege.create", {
+            "name": "Test",
+            "local_groups": [g["gid"]],
+            "ds_groups": [],
+            "allowlist": [{"method": "CALL", "resource": "system.info"}],
+            "web_shell": False,
+        })
+        try:
+            with user({
+                "username": "test",
+                "full_name": "Test",
+                "home": f"/nonexistent",
+                "password": "test1234",
+                "group_create": True,
+            }) as u:
+                call("user.update", u["id"], {
+                    "shell": "/usr/bin/cli",
+                    **group_payload(g),
+                })
+        finally:
+            call("privilege.delete", privilege["id"])


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 98cabb24b230bfdf8e61f3a22cd44cffca0651e1

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3e8e94c011197b3af0e6460747fc372f8a4a09f2

… CLI for non-privileged users

Original PR: https://github.com/truenas/middleware/pull/10955
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121087