### PR TITLE
NAS-121195 / 23.10 / Sync catalogs if they have not been synced

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -30,6 +30,9 @@ class AppService(Service):
         """
         Retrieve all available applications from all configured catalogs.
         """
+        if not self.middleware.call_sync('catalog.synced'):
+            self.middleware.call_sync('catalog.initiate_first_time_sync')
+
         results = []
         installed_apps = [
             (app['chart_metadata']['name'], app['catalog'], app['catalog_train'])

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -9,6 +9,8 @@ from .utils import pull_clone_repository
 
 class CatalogService(Service):
 
+    SYNCED = False
+
     @accepts()
     @returns()
     @job(lock='sync_catalogs')
@@ -28,6 +30,8 @@ class CatalogService(Service):
             self.middleware.create_task(
                 self.middleware.call('chart.release.chart_releases_update_checks_internal')
             )
+
+        self.SYNCED = True
 
     @accepts(Str('label', required=True))
     @returns()
@@ -70,3 +74,7 @@ class CatalogService(Service):
         return pull_clone_repository(
             catalog['repository'], os.path.dirname(catalog['location']), catalog['branch'],
         )
+
+    @private
+    async def synced(self):
+        return self.SYNCED

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -81,5 +81,5 @@ class CatalogService(Service):
 
     @private
     async def initiate_first_time_sync(self):
-        (await self.middleware.call('catalog.sync', OFFICIAL_LABEL)).wait()
+        await (await self.middleware.call('catalog.sync', OFFICIAL_LABEL)).wait()
         await self.middleware.call('catalog.sync_all')

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -78,3 +78,8 @@ class CatalogService(Service):
     @private
     async def synced(self):
         return self.SYNCED
+
+    @private
+    async def initiate_first_time_sync(self):
+        (await self.middleware.call('catalog.sync', OFFICIAL_LABEL)).wait()
+        await self.middleware.call('catalog.sync_all')

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -82,4 +82,5 @@ class CatalogService(Service):
     @private
     async def initiate_first_time_sync(self):
         await (await self.middleware.call('catalog.sync', OFFICIAL_LABEL)).wait()
+        self.SYNCED = True
         await self.middleware.call('catalog.sync_all')


### PR DESCRIPTION
This PR adds changes to account for the fact that if catalogs have not been synced, we sync them when `app.available` is called. Why this is required is that we don't sync catalogs at all unless user configures apps or navigates to available apps. Earlier `catalog.items` used to account for this and it made sure catalog was synced before we retrieved it's contents but that is not the case anymore as `catalog.items` is not a job anymore.

Earlier, we used to ensure that official catalog is synced in such cases and similar changes have been introduced now so we keep backwards compatibility.