### PR TITLE
NAS-120155 / 22.12.3 / point vim.tiny to vim (by yocalebo)

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -46,6 +46,7 @@ systemctl disable nvidia-persistenced
 
 # Update alternatives
 update-alternatives --install "/usr/sbin/sendmail" sendmail "/etc/find_alias_for_smtplib.sh" "10"
+update-alternatives --install "/usr/bin/vim" vim.tiny "/usr/bin/vim.tiny" "10"
 
 # Add nut to dialout group - NAS-110578
 usermod -a -G dialout nut


### PR DESCRIPTION
Platform team asking for vim to be installed but we already ship with vim.tiny. This adds a "vim" command that just points to vim.tiny so we don't have to install, essentially, an identical text editor that we already ship.

Original PR: https://github.com/truenas/middleware/pull/11010
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120155