### PR TITLE
NAS-121238 / 13.0 / Backport SCALE activedirectory-related fixes to Core

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -164,6 +164,30 @@ class KerberosService(ConfigService):
         return True
 
     @private
+    def generate_stub_config(self, realm, kdc=None):
+        if os.path.exists('/etc/krb5.conf'):
+            return
+
+        def write_libdefaults(krb_file):
+            krb_file.write('[libdefaults]\n')
+            krb_file.write(f'\tdefault_realm = {realm}\n')
+            krb_file.write('\tdns_lookup_realm = false\n')
+            krb_file.write(f'\tdns_lookup_kdc = {"false" if kdc else "true"}\n')
+
+        def write_realms(krb_file):
+            krb_file.write('[realms]\n')
+            krb_file.write(f'\t{realm} =' + '{\n')
+            if kdc:
+                krb_file.write(f'\t\tkdc = {kdc}\n')
+            krb_file.write('\t}\n')
+
+        with open('/etc/krb5.conf', 'w') as f:
+            write_libdefaults(f)
+            write_realms(f)
+            f.flush()
+            os.fsync(f.fileno())
+
+    @private
     async def check_ticket(self):
         valid_ticket = await self._klist_test()
         if not valid_ticket:
@@ -270,8 +294,19 @@ class KerberosService(ConfigService):
 
     @private
     async def do_kinit(self, data):
+        kinit_options = data.get('kinit-options', {})
         dstype = DSType(data['dstype'])
         krb5 = KRB5.platform()
+
+        if override := kinit_options.get('kdc_override'):
+            if override['domain'] is None:
+                raise CallError('Domain missing from KDC override')
+
+            await self.middleware.call(
+                'kerberos.generate_stub_config',
+                override['domain'], override['kdc']
+            )
+
         if data['kerberos_principal']:
             if krb5 == KRB5.MIT:
                 kinit = await run(['kinit', '-r', '7d', '-k', data['kerberos_principal']], check=False)
@@ -804,6 +839,14 @@ class KerberosKeytabService(CRUDService):
         Delete kerberos keytab by id, and force regeneration of
         system keytab.
         """
+        kt = await self.get_instance(id)
+        if kt['name'] == 'AD_MACHINE_ACCOUNT':
+            if (await self.middleware.call('activedirectory.get_state')) != 'DISABLED':
+                raise CallError(
+                    'Active Directory machine account keytab may not be deleted while '
+                    'the Active Directory service is enabled.'
+                )
+
         await self.middleware.call("datastore.delete", self._config.datastore, id)
         if os.path.exists(keytab['SYSTEM'].value):
             os.remove(keytab['SYSTEM'].value)


### PR DESCRIPTION
This backports a fundamental design change to no longer use python bindings into libnet / libads in the activedirectory plugin. This is generally more reliable. Information we were gleaning from the python bindings can be gotten through subprocessing out to net commands. This commit also fixes an edge case where kerberos errors would not be properly turned into ValidationError while checking user-provided passwords.