### PR TITLE
NAS-121245 / 22.12.3 / Add more verbose error message for wrong name (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -476,6 +476,17 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'security policies, one may be required to pre-generate a kerberos keytab '
                         'and upload to TrueNAS server for use during join process.'
                     )
+                elif msg.endswith('not found in Kerberos database while getting initial credentials'):
+                    # KRB5KDC_ERR_C_PRINCIPAL_UNKNOWN
+                    if method == "activedirectory.bindpw":
+                        method = "activedirectory.bindname"
+
+                    msg = (
+                        "Client's credentials were not found on remote domain controller. The most "
+                        "common reasons for the domain controller to return this response is due to a "
+                        "typo in the service account name or the service or the computer account being "
+                        "deleted from Active Directory."
+                    )
 
                 if not msg:
                     # failed to parse, re-raise original error message


### PR DESCRIPTION
Make it clearer to end-user when they've typoed the username they're using to bind to active directory.

Original PR: https://github.com/truenas/middleware/pull/11014
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121245