### PR TITLE
NAS-121269 / 23.10 / Add non-default parameter to retrieve SID info

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1095,6 +1095,8 @@ class IdmapDomainService(TDBWrapCRUDService):
                 return f'S-1-22-{1 if id == IDType.USER else 2}-{unixid}'
 
             return None
+        except wbclient.WBCError as e:
+            raise CallError(str(e), WBCErr[e.error_code], e.error_code)
 
         return self._pyuidgid_to_dict(entry)['sid']
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -150,15 +150,18 @@ def test_05_verify_user_exists(request):
     get_user_obj is a wrapper around the pwd module.
     This check verifies that the user is _actually_ created.
     """
-    results = POST("/user/get_user_obj/", {"username": "testuser"})
+    results = POST("/user/get_user_obj/", {"username": "testuser", "sid_info": True})
     assert results.status_code == 200, results.text
-    if results.status_code == 200:
-        pw = results.json()
-        assert pw['pw_uid'] == next_uid, results.text
-        assert pw['pw_shell'] == SHELL, results.text
-        assert pw['pw_gecos'] == 'Test User', results.txt
-        assert pw['pw_dir'] == '/nonexistent', results.txt
+    pw = results.json()
+    assert pw['pw_uid'] == next_uid, results.text
+    assert pw['pw_shell'] == SHELL, results.text
+    assert pw['pw_gecos'] == 'Test User', results.text
+    assert pw['pw_dir'] == '/nonexistent', results.text
 
+    # At this point, we're not an SMB user
+    assert pw['sid_info'] is not None, results.text
+    assert pw['sid_info']['domain_information']['online'], results.text
+    assert pw['sid_info']['domain_information']['activedirectory'] is False, results.text
 
 def test_06_get_user_info(request):
     depends(request, ["user_02", "user_01"])
@@ -358,8 +361,7 @@ def test_31_creating_user_with_homedir(request):
     user_id = results.json()
     time.sleep(5)
 
-    payload = {"username": "testuser2"}
-    results = POST("/user/get_user_obj/", payload)
+    results = POST("/user/get_user_obj/", {"username": "testuser2", "sid_info": True})
     assert results.status_code == 200, results.text
 
     pw = results.json()
@@ -368,6 +370,11 @@ def test_31_creating_user_with_homedir(request):
     assert pw['pw_uid'] == user_payload['uid'], results.text
     assert pw['pw_shell'] == user_payload['shell'], results.text
     assert pw['pw_gecos'] == user_payload['full_name'], results.text
+
+    # this one is created as an SMB user
+    assert pw['sid_info'] is not None, results.text
+    assert pw['sid_info']['domain_information']['online'], results.text
+    assert pw['sid_info']['domain_information']['activedirectory'] is False, results.text
 
 
 def test_32_verify_post_user_do_not_leak_password_in_middleware_log(request):

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -245,10 +245,19 @@ def test_07_enable_leave_activedirectory(request):
 
 
         # Verify that idmapping is working
-        results = POST("/user/get_user_obj/", {'username': AD_USER})
+        results = POST("/user/get_user_obj/", {'username': AD_USER, 'sid_info': True})
         assert results.status_code == 200, results.text
         assert results.json()['pw_name'] == AD_USER, results.text
-        domain_users_id = results.json()['pw_gid']
+        pw = results.json()
+        domain_users_id = pw['pw_gid']
+
+        # Verify winbindd information
+        assert pw['sid_info'] is not None, results.text
+        assert not pw['sid_info']['sid'].startswith('S-1-22-1-'), results.text
+        assert pw['sid_info']['domain_information']['domain'] != 'LOCAL', results.text
+        assert pw['sid_info']['domain_information']['domain_sid'] is not None, results.text
+        assert pw['sid_info']['domain_information']['online'], results.text
+        assert pw['sid_info']['domain_information']['activedirectory'], results.text
 
         res = make_ws_request(ip, {
             'msg': 'method',


### PR DESCRIPTION
This commit adds support for a non-default option to retrieve SID information from winbindd. This may be used to definitively identify whether the user is from AD, a local SMB user, or a local non-SMB user.