### PR TITLE
NAS-121269 / 22.12.3 / Add non-default parameter to retrieve SID info (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -896,7 +896,8 @@ class UserService(CRUDService):
         'get_user_obj',
         Str('username', default=None),
         Int('uid', default=None),
-        Bool('get_groups', default=False)
+        Bool('get_groups', default=False),
+        Bool('sid_info', default=False),
     ))
     @returns(Dict(
         'user_information',
@@ -907,19 +908,33 @@ class UserService(CRUDService):
         Int('pw_uid'),
         Int('pw_gid'),
         List('grouplist'),
+        Dict('sid_info'),
         register=True,
     ))
     async def get_user_obj(self, data):
         """
         Returns dictionary containing information from struct passwd for the user specified by either
         the username or uid. Bypasses user cache.
+
+        Supports the following additional parameters:
+        `get_groups` - retrieve group list for the specified user.
+
+        NOTE: results will not include nested groups for Active Directory users
+
+        `sid_info` - retrieve SID and domain information for the user
+
+        NOTE: in some pathological scenarios this may make the operation hang until
+        the winbindd request timeout has been reached if the winbindd connection manager
+        has not yet marked the domain as offline. The TrueNAS middleware is more aggressive
+        about marking AD domains as FAULTED and so it may be advisable to first check the
+        Active Directory service state prior to batch operations using this option.
         """
         verrors = ValidationErrors()
         if not data['username'] and data['uid'] is None:
             verrors.add('get_user_obj.username', 'Either "username" or "uid" must be specified')
         verrors.check()
         return await self.middleware.call(
-            'dscache.get_uncached_user', data['username'], data['uid'], data['get_groups']
+            'dscache.get_uncached_user', data['username'], data['uid'], data['get_groups'], data['sid_info']
         )
 
     @item_method

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1095,6 +1095,8 @@ class IdmapDomainService(TDBWrapCRUDService):
                 return f'S-1-22-{1 if id == IDType.USER else 2}-{unixid}'
 
             return None
+        except wbclient.WBCError as e:
+            raise CallError(str(e), WBCErr[e.error_code], e.error_code)
 
         return self._pyuidgid_to_dict(entry)['sid']
 

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -242,10 +242,19 @@ def test_07_enable_leave_activedirectory(request):
 
 
         # Verify that idmapping is working
-        results = POST("/user/get_user_obj/", {'username': AD_USER})
+        results = POST("/user/get_user_obj/", {'username': AD_USER, 'sid_info': True})
         assert results.status_code == 200, results.text
         assert results.json()['pw_name'] == AD_USER, results.text
-        domain_users_id = results.json()['pw_gid']
+        pw = results.json()
+        domain_users_id = pw['pw_gid']
+
+        # Verify winbindd information
+        assert pw['sid_info'] is not None, results.text
+        assert not pw['sid_info']['sid'].startswith('S-1-22-1-'), results.text
+        assert pw['sid_info']['domain_information']['domain'] != 'LOCAL', results.text
+        assert pw['sid_info']['domain_information']['domain_sid'] is not None, results.text
+        assert pw['sid_info']['domain_information']['online'], results.text
+        assert pw['sid_info']['domain_information']['activedirectory'], results.text
 
         res = make_ws_request(ip, {
             'msg': 'method',


### PR DESCRIPTION
This commit adds support for a non-default option to retrieve SID information from winbindd. This may be used to definitively identify whether the user is from AD, a local SMB user, or a local non-SMB user.

Original PR: https://github.com/truenas/middleware/pull/11027
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121269