### PR TITLE
NAS-120230 / 23.10 / Properly mark a gpu as critical if it is critical to the system

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -167,7 +167,9 @@ class SystemAdvancedService(ConfigService):
                 ))
 
         if data['isolated_gpu_pci_ids']:
-            verrors = await self.validate_gpu_pci_ids(data['isolated_gpu_pci_ids'], verrors, schema)
+            verrors = await self.middleware.call(
+                'system.advanced.validate_gpu_pci_ids', data['isolated_gpu_pci_ids'], verrors, schema
+            )
 
         for invalid_char in ('\n', '"'):
             if invalid_char in data['kernel_extra_options']:
@@ -297,57 +299,3 @@ class SystemAdvancedService(ConfigService):
             'datastore.config', 'system.advanced', {'prefix': self._config.datastore_prefix}
         ))['sed_passwd']
         return passwd if passwd else await self.middleware.call('kmip.sed_global_password')
-
-    @private
-    async def validate_gpu_pci_ids(self, isolated_gpu_pci_ids, verrors, schema):
-        available = set()
-        critical_gpus = set()
-        for gpu in await self.middleware.call('device.get_gpus'):
-            available.add(gpu['addr']['pci_slot'])
-            if gpu['uses_system_critical_devices']:
-                critical_gpus.add(gpu['addr']['pci_slot'])
-
-        provided = set(isolated_gpu_pci_ids)
-        not_available = provided - available
-        cannot_isolate = provided & critical_gpus
-        if not_available:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                f'{", ".join(not_available)} GPU pci slot(s) are not available or a GPU is not configured.'
-            )
-
-        if cannot_isolate:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                f'{", ".join(cannot_isolate)} GPU pci slot(s) consists of devices '
-                'which cannot be isolated from host.'
-            )
-
-        if len(available - provided) < 1:
-            verrors.add(
-                f'{schema}.isolated_gpu_pci_ids',
-                'A minimum of 1 GPU is required for the host to ensure it functions as desired.'
-            )
-
-        return verrors
-
-    @accepts(List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True))
-    @returns()
-    async def update_gpu_pci_ids(self, isolated_gpu_pci_ids):
-        """
-        `isolated_gpu_pci_ids` is a list of PCI ids which are isolated from host system.
-        """
-        verrors = ValidationErrors()
-        if isolated_gpu_pci_ids:
-            verrors = await self.validate_gpu_pci_ids(isolated_gpu_pci_ids, verrors, 'gpu_settings')
-
-        verrors.check()
-
-        await self.middleware.call(
-            'datastore.update',
-            self._config.datastore,
-            (await self.middleware.call('system.advanced.config'))['id'],
-            {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
-            {'prefix': self._config.datastore_prefix}
-        )
-        await self.middleware.call('boot.update_initramfs')

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -1,0 +1,63 @@
+from middlewared.schema import accepts, List, returns, Str
+from middlewared.service import private, Service, ValidationErrors
+
+
+class SystemAdvancedService(Service):
+
+    class Config:
+        namespace = 'system.advanced'
+        cli_namespace = 'system.advanced'
+
+    @accepts(List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True))
+    @returns()
+    async def update_gpu_pci_ids(self, isolated_gpu_pci_ids):
+        """
+        `isolated_gpu_pci_ids` is a list of PCI ids which are isolated from host system.
+        """
+        verrors = ValidationErrors()
+        if isolated_gpu_pci_ids:
+            verrors = await self.validate_gpu_pci_ids(isolated_gpu_pci_ids, verrors, 'gpu_settings')
+
+        verrors.check()
+
+        await self.middleware.call(
+            'datastore.update',
+            'system.advanced',
+            (await self.middleware.call('system.advanced.config'))['id'],
+            {'isolated_gpu_pci_ids': isolated_gpu_pci_ids},
+            {'prefix': 'adv_'}
+        )
+        await self.middleware.call('boot.update_initramfs')
+
+    @private
+    async def validate_gpu_pci_ids(self, isolated_gpu_pci_ids, verrors, schema):
+        available = set()
+        critical_gpus = set()
+        for gpu in await self.middleware.call('device.get_gpus'):
+            available.add(gpu['addr']['pci_slot'])
+            if gpu['uses_system_critical_devices']:
+                critical_gpus.add(gpu['addr']['pci_slot'])
+
+        provided = set(isolated_gpu_pci_ids)
+        not_available = provided - available
+        cannot_isolate = provided & critical_gpus
+        if not_available:
+            verrors.add(
+                f'{schema}.isolated_gpu_pci_ids',
+                f'{", ".join(not_available)} GPU pci slot(s) are not available or a GPU is not configured.'
+            )
+
+        if cannot_isolate:
+            verrors.add(
+                f'{schema}.isolated_gpu_pci_ids',
+                f'{", ".join(cannot_isolate)} GPU pci slot(s) consists of devices '
+                'which cannot be isolated from host.'
+            )
+
+        if len(available - provided) < 1:
+            verrors.add(
+                f'{schema}.isolated_gpu_pci_ids',
+                'A minimum of 1 GPU is required for the host to ensure it functions as desired.'
+            )
+
+        return verrors

--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -7,7 +7,7 @@ from middlewared.schema import accepts, Bool, Dict, List, Ref, returns, Str
 from middlewared.service import CallError, private, Service
 from middlewared.utils import run
 
-from .utils import get_virsh_command_args
+from .utils import get_virsh_command_args, SENSITIVE_PCI_DEVICE_TYPES
 
 
 RE_DEVICE_PATH = re.compile(r'pci_(\w+)_(\w+)_(\w+)_(\w+)')
@@ -19,12 +19,6 @@ RE_PCI_NAME = re.compile(r'^([\w:.]+)\s+')
 class VMDeviceService(Service):
 
     PCI_DEVICES = None
-    SENSITIVE_PCI_DEVICE_TYPES = (
-        'Host bridge',
-        'Bridge',
-        'RAM memory',
-        'SMBus',
-    )
 
     class Config:
         namespace = 'vm.device'
@@ -104,7 +98,7 @@ class VMDeviceService(Service):
                 'vendor': 'Not Available',
             },
             'controller_type': controller_type,
-            'critical': controller_type in self.SENSITIVE_PCI_DEVICE_TYPES,
+            'critical': (k.lower() in controller_type.lower() for k in SENSITIVE_PCI_DEVICE_TYPES),
             'iommu_group': {},
             'available': False,
             'drivers': [],

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -5,6 +5,11 @@ ACTIVE_STATES = ['RUNNING', 'SUSPENDED']
 LIBVIRT_URI = 'qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock'
 LIBVIRT_USER = 'libvirt-qemu'
 NGINX_PREFIX = '/vm/display'
+SENSITIVE_PCI_DEVICE_TYPES = (
+    'Bridge',
+    'memory',
+    'SMBus',
+)
 
 
 def create_element(*args, **kwargs):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_isolation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_isolation.py
@@ -1,0 +1,64 @@
+import pytest
+
+from middlewared.pytest.unit.helpers import load_compound_service
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service_exception import ValidationErrors
+
+
+AVAILABLE_GPUS = [
+    {
+        'addr': {
+            'pci_slot': '0000:09:00.0',
+            'domain': '0000',
+            'bus': '09',
+            'slot': '00'
+        },
+        'description': 'Red Hat, Inc. GPU',
+        'devices': [
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:09:00.0',
+                'vm_pci_slot': 'pci_0000_09_00_0'
+            }
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': False,
+        'available_to_host': False
+    },
+    {
+        'addr': {
+            'pci_slot': '0000:02:00.0',
+            'domain': '0000',
+            'bus': '09',
+            'slot': '00'
+        },
+        'description': 'Red Hat, Inc. GPU',
+        'devices': [
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:02:00.0',
+                'vm_pci_slot': 'pci_0000_02_00_0'
+            }
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': True,
+        'available_to_host': True
+    }
+]
+ADVANCED_SVC = load_compound_service('system.advanced')
+
+
+@pytest.mark.parametrize('gpu_pci_ids,errors', [
+    (['0000:09:00.0'], []),
+    (['0000:09:00.0'], []),
+    (['0000:02:00.0'], ['0000:02:00.0 GPU pci slot(s) consists of devices which cannot be isolated from host.']),
+])
+@pytest.mark.asyncio
+async def test_valid_isolated_gpu(gpu_pci_ids, errors):
+    m = Middleware()
+    m['device.get_gpus'] = lambda *args: AVAILABLE_GPUS
+
+    system_advance_svc = ADVANCED_SVC(m)
+    verrors = ValidationErrors()
+    verrors = await system_advance_svc.validate_gpu_pci_ids(gpu_pci_ids, verrors, 'test')
+    assert [e.errmsg for e in verrors.errors] == errors

--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -2,6 +2,7 @@ import pyudev
 import re
 import subprocess
 
+from middlewared.plugins.vm.utils import SENSITIVE_PCI_DEVICE_TYPES
 from middlewared.service import CallError
 
 
@@ -50,7 +51,7 @@ def get_gpus():
                 'vm_pci_slot': f'pci_{child["PCI_SLOT_NAME"].replace(".", "_").replace(":", "_")}',
             })
             critical |= any(
-                k in child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '').lower() for k in ('host bridge', 'memory')
+                k.lower() in child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '').lower() for k in SENSITIVE_PCI_DEVICE_TYPES
             )
 
         gpus.append({


### PR DESCRIPTION
## Context

Logic where we determine if a gpu is critical for the host to function had been outdated with what we have for PCI devices. The same logic is now used in both places to determine critical devices to make sure that a GPU is properly marked as critical.