### PR TITLE
NAS-120646 / 23.10 / Allow app dev to specify custom error message for valid_chars

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -115,7 +115,9 @@ def get_schema(variable_details, update, existing=NOT_PROVIDED):
                 # well apart from the range validator we add
                 obj.max_length = range_args['max']
             if 'valid_chars' in schema_details:
-                obj.validators.append(Match(schema_details['valid_chars']))
+                obj.validators.append(Match(
+                    schema_details['valid_chars'], explanation=schema_details.get('valid_chars_error')
+                ))
 
     if schema_class == List:
         obj.items = list(chain.from_iterable(get_schema(i, update) for i in schema_details['items']))


### PR DESCRIPTION
## Context

If app developer uses `valid_chars` attribute to validate a value specified by user, the error is vague i.e does not match pattern.
It does not help tell the user that he needs to follow this specific order to be able to correctly specify the value in question so now the dev can specify a custom error message which will better guide the user on what to input for a field which is being validated by `valid_chars`.