### PR TITLE
NAS-121304 / 23.10 / Improve logging in workflow for UI

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -317,7 +317,8 @@ class AuthService(Service):
     @throttle(seconds=2, condition=throttle_condition)
     @accepts(Str('username'), Str('password'))
     @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
-    async def check_user(self, username, password):
+    @pass_app()
+    async def check_user(self, app, username, password):
         """
         Verify username and password
         """
@@ -410,11 +411,12 @@ class AuthService(Service):
     @throttle(seconds=2, condition=throttle_condition)
     @accepts(Str('username'), Str('password'))
     @returns(Bool('two_factor_auth_enabled', description='Is `true` if 2FA is enabled'))
-    async def two_factor_auth(self, username, password):
+    @pass_app()
+    async def two_factor_auth(self, app, username, password):
         """
-        Returns true if two factor authorization is required for authorizing user's login.
+        Returns true if two-factor authorization is required for authorizing user's login.
         """
-        return await self.check_user(username, password) and (
+        return await self.check_user(app, username, password) and (
             await self.middleware.call('auth.twofactor.config')
         )['enabled'] and (
             await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -13,17 +13,13 @@ from middlewared.auth import (SessionManagerCredentials, UserSessionManagerCrede
 from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, Patch, returns, Str
 from middlewared.service import (
     Service, filterable, filterable_returns, filter_list, no_auth_required,
-    pass_app, private, cli_private, CallError, throttle,
+    pass_app, private, cli_private, CallError,
 )
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils.nginx import get_peer_process
 from middlewared.utils.origin import UnixSocketOrigin, TCPIPOrigin
 from middlewared.utils.crypto import generate_token
-
-
-def throttle_condition(middleware, app, *args, **kwargs):
-    return app is None or (app and app.authenticated), None
 
 
 class TokenManager:
@@ -405,10 +401,8 @@ class AuthService(Service):
         }
 
     @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts(Str('username'), Str('password'))
     @returns(Bool('two_factor_auth_enabled', description='Is `true` if 2FA is enabled'))
-    @pass_app()
     async def two_factor_auth(self, app, username, password):
         """
         Returns true if two-factor authorization is required for authorizing user's login.

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -313,12 +313,9 @@ class AuthService(Service):
         if errors:
             raise CallError("\n".join(["Unable to terminate all sessions:"] + errors))
 
-    @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts(Str('username'), Str('password'))
     @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
-    @pass_app()
-    async def check_user(self, app, username, password):
+    async def check_user(self, username, password):
         """
         Verify username and password
         """
@@ -416,7 +413,7 @@ class AuthService(Service):
         """
         Returns true if two-factor authorization is required for authorizing user's login.
         """
-        return await self.check_user(app, username, password) and (
+        return await self.check_user(username, password) and (
             await self.middleware.call('auth.twofactor.config')
         )['enabled'] and (
             await self.middleware.call(


### PR DESCRIPTION
This PR adds changes so UI can consume the following workflow for logging in users:

1. Users present a login screen where username/password is only asked
2. UI calls `auth.two_factor_auth` where UI passes credentials and endpoint will return if the user has 2FA configured. It will only say 2FA is configured when the credentials are good and 2FA is actually configured.
3. Based on step 2 output, UI will show a new screen where it will ask for OTP
4. With/without OTP, after step 3 - UI will finally call `auth.login` to login the said user