### PR TITLE
NAS-121275 / 23.10 / Properly have HA licensed systems to consume enterprise apps train

### DIFF
--- a/src/middlewared/middlewared/migration/0007_catalog_enterprise_train.py
+++ b/src/middlewared/middlewared/migration/0007_catalog_enterprise_train.py
@@ -1,7 +1,2 @@
 async def migrate(middleware):
-    if await middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
-        await middleware.call(
-            'catalog.update',
-            await middleware.call('catalog.official_catalog_label'),
-            {'preferred_trains': [await middleware.call('catalog.official_enterprise_train')]}
-        )
+    await middleware.call('catalog.update_train_for_enterprise')

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -325,7 +325,9 @@ class CatalogService(CRUDService):
 
 
 async def enterprise_train_update(middleware, prev_product_type, *args, **kwargs):
-    if await middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
+    if await middleware.call('system.product_type') == 'SCALE_ENTERPRISE' and not await middleware.call(
+        'catalog.query', [['id', '=', OFFICIAL_LABEL], ['preferred_trains', 'rin', OFFICIAL_ENTERPRISE_TRAIN]],
+    ):
         await middleware.call('catalog.update', OFFICIAL_LABEL, {'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]})
 
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -330,16 +330,15 @@ class CatalogService(CRUDService):
     @private
     async def update_train_for_enterprise(self):
         catalog = await self.middleware.call('catalog.get_instance', OFFICIAL_LABEL)
-        if await self.middleware.call(
-            'system.product_type'
-        ) == 'SCALE_ENTERPRISE' and OFFICIAL_ENTERPRISE_TRAIN not in catalog['preferred_trains']:
-            if await self.middleware.call('catalog.can_system_add_catalog'):
+        if await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
+            can_system_add_catalog = await self.can_system_add_catalog()
+            if OFFICIAL_ENTERPRISE_TRAIN not in catalog['preferred_trains'] and can_system_add_catalog:
                 await self.middleware.call(
                     'catalog.update', OFFICIAL_LABEL, {
                         'preferred_trains': catalog['preferred_trains'] + [OFFICIAL_ENTERPRISE_TRAIN]
                     }
                 )
-            else:
+            elif not can_system_add_catalog:
                 await self.middleware.call(
                     'catalog.update', OFFICIAL_LABEL, {
                         'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -176,7 +176,10 @@ class CatalogService(CRUDService):
                 f'{schema}.preferred_trains',
                 'At least 1 preferred train must be specified for a catalog.'
             )
-        if await self.valid_enterprise_catalog_license() and OFFICIAL_ENTERPRISE_TRAIN not in data['preferred_trains']:
+        if (
+            await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE' and
+            OFFICIAL_ENTERPRISE_TRAIN not in data['preferred_trains']
+        ):
             verrors.add(
                 f'{schema}.preferred_trains',
                 f'Enterprise systems must at least have {OFFICIAL_ENTERPRISE_TRAIN!r} train enabled'
@@ -218,7 +221,7 @@ class CatalogService(CRUDService):
                     f'catalog_create.{k}', 'A catalog with same repository/branch already exists', errno=errno.EEXIST
                 )
 
-        if await self.middleware.call('system.is_ha_capable'):
+        if not await self.can_system_add_catalog():
             verrors.add(
                 'catalog_create.label',
                 'Enterprise systems are not allowed to add catalog(s)'
@@ -304,8 +307,17 @@ class CatalogService(CRUDService):
         return ret
 
     @private
-    async def valid_enterprise_catalog_license(self):
-        return await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE'
+    async def can_system_add_catalog(self):
+        if await self.middleware.call('system.product_type') != 'SCALE_ENTERPRISE':
+            return True
+
+        # If system is not HA capable and is not R series, we can add catalog
+        if not await self.middleware.call('system.is_ha_capable') and not (
+            await self.middleware.call('failover.hardware')
+        ).startswith('TRUENAS-R'):
+            return True
+
+        return False
 
     @private
     async def official_catalog_label(self):
@@ -315,12 +327,28 @@ class CatalogService(CRUDService):
     async def official_enterprise_train(self):
         return OFFICIAL_ENTERPRISE_TRAIN
 
+    @private
+    async def update_train_for_enterprise(self):
+        catalog = await self.middleware.call('catalog.get_instance', OFFICIAL_LABEL)
+        if await self.middleware.call(
+            'system.product_type'
+        ) == 'SCALE_ENTERPRISE' and OFFICIAL_ENTERPRISE_TRAIN not in catalog['preferred_trains']:
+            if await self.middleware.call('catalog.can_system_add_catalog'):
+                await self.middleware.call(
+                    'catalog.update', OFFICIAL_LABEL, {
+                        'preferred_trains': catalog['preferred_trains'] + [OFFICIAL_ENTERPRISE_TRAIN]
+                    }
+                )
+            else:
+                await self.middleware.call(
+                    'catalog.update', OFFICIAL_LABEL, {
+                        'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]
+                    }
+                )
+
 
 async def enterprise_train_update(middleware, prev_product_type, *args, **kwargs):
-    if await middleware.call('system.product_type') == 'SCALE_ENTERPRISE' and not await middleware.call(
-        'catalog.query', [['id', '=', OFFICIAL_LABEL], ['preferred_trains', 'rin', OFFICIAL_ENTERPRISE_TRAIN]],
-    ):
-        await middleware.call('catalog.update', OFFICIAL_LABEL, {'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]})
+    await middleware.call('catalog.update_train_for_enterprise')
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -332,17 +332,17 @@ class CatalogService(CRUDService):
         catalog = await self.middleware.call('catalog.get_instance', OFFICIAL_LABEL)
         if await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
             can_system_add_catalog = await self.can_system_add_catalog()
+            preferred_trains = []
             if OFFICIAL_ENTERPRISE_TRAIN not in catalog['preferred_trains'] and can_system_add_catalog:
-                await self.middleware.call(
-                    'catalog.update', OFFICIAL_LABEL, {
-                        'preferred_trains': catalog['preferred_trains'] + [OFFICIAL_ENTERPRISE_TRAIN]
-                    }
-                )
+                preferred_trains = catalog['preferred_trains'] + [OFFICIAL_ENTERPRISE_TRAIN]
             elif not can_system_add_catalog:
+                preferred_trains = [OFFICIAL_ENTERPRISE_TRAIN]
+
+            if preferred_trains:
                 await self.middleware.call(
-                    'catalog.update', OFFICIAL_LABEL, {
-                        'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]
-                    }
+                    'datastore.update', self._config.datastore, OFFICIAL_LABEL, {
+                        'preferred_trains': preferred_trains,
+                    },
                 )
 
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -325,7 +325,7 @@ class CatalogService(CRUDService):
 
 
 async def enterprise_train_update(middleware, prev_product_type, *args, **kwargs):
-    if prev_product_type != 'SCALE_ENTERPRISE' and await middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
+    if await middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
         await middleware.call('catalog.update', OFFICIAL_LABEL, {'preferred_trains': [OFFICIAL_ENTERPRISE_TRAIN]})
 
 


### PR DESCRIPTION
This PR adds following changes:

1. Any machine which is marked as `SCALE_ENTERPRISE` will at least have enterprise train set in it's preferred trains.
2. HA capable machines and R series machines will only have enterprise train set whenever the license is applied and they can then later add on more trains if required.
3. HA capable machines and R series machines cannot add any other catalogs other then OFFICIAL catalog.
4. Machines which are `SCALE_ENTERPRISE` and not ha capable and not R series will have enterprise train in it's preferred trains and will also be able to add other catalogs if required.