### PR TITLE
NAS-121082 / 23.10 / Fix ups service's extra users

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nut/upsd.users.mako
+++ b/src/middlewared/middlewared/etc_files/local/nut/upsd.users.mako
@@ -7,4 +7,5 @@
 [${user}]
 	password = ${ups_config['monpwd']}
 	upsmon master
-	${ups_config['extrausers']}
+
+${ups_config['extrausers']}


### PR DESCRIPTION
## Problem

UPS extra users are expected to be specified at root level of the configuration file for the user and should not have an indent before. Right now it was following the below format:
```
[upsmon]
	password = abcd
	upsmon master
	[admin]
        password = abcd
        instcmds = all
```

Whereas the correct specification is:

```
[upsmon]
	password = abcd
	upsmon master
	
[admin]
        password = abcd
        instcmds = all
```

## Solution

Correctly render the extra users so they are specified keeping in line with upstream guidelines for NUT.

References:
https://wiki.ipfire.org/addons/nut/detailed
https://wiki.archlinux.org/title/Network_UPS_Tools