### PR TITLE
NAS-121330 / 23.10 / fix AttributeError crash in auth plugin

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -115,17 +115,18 @@ class Application:
     def origin(self):
         try:
             sock = self.request.transport.get_extra_info("socket")
-            if sock.family == socket.AF_UNIX:
-                peercred = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize('3i'))
-                pid, uid, gid = struct.unpack('3i', peercred)
-                return UnixSocketOrigin(pid, uid, gid)
-
-            remote_addr, remote_port = get_remote_addr_port(self.request)
-            return TCPIPOrigin(remote_addr, remote_port)
         except AttributeError:
             # self.request.transport can be None by the time this is called
             # on HA systems because remote node could have been rebooted
             return
+
+        if sock.family == socket.AF_UNIX:
+            peercred = sock.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize('3i'))
+            pid, uid, gid = struct.unpack('3i', peercred)
+            return UnixSocketOrigin(pid, uid, gid)
+
+        remote_addr, remote_port = get_remote_addr_port(self.request)
+        return TCPIPOrigin(remote_addr, remote_port)
 
     def register_callback(self, name, method):
         assert name in ('on_message', 'on_close')

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -565,6 +565,8 @@ class AuthService(Service):
 def check_permission(middleware, app):
     """Authenticates connections coming from loopback and from root user."""
     origin = app.origin
+    if origin is None:
+        return
 
     if isinstance(origin, UnixSocketOrigin):
         if origin.uid == 0:


### PR DESCRIPTION
Seen on HA system running latest nightly
```
[2023/04/04 05:47:01] (ERROR) middlewared.call_hook():1227 - Failed to run hook core.on_connect:<function check_permission at 0x7f689f221ca0>(*(), **{'app': <middlewared.main.Application object at 0x7f68792c77c0>})
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1220, in call_hook
    await fut
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1253, in run_in_thread
    return await self.run_in_executor(self.thread_pool_executor, method, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1250, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/auth.py", line 567, in check_permission
    origin = app.origin
  File "/usr/lib/python3.9/functools.py", line 969, in __get__
    val = self.func(instance)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 116, in origin
    sock = self.request.transport.get_extra_info("socket")
AttributeError: 'NoneType' object has no attribute 'get_extra_info'
```