### PR TITLE
NAS-121328 / 22.12.3 / prevent service_remote from spamming logs (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1270,7 +1270,7 @@ async def service_remote(middleware, service, verb, options):
         ])
     except Exception as e:
         ignore = (errno.ECONNRESET, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-        if not (isinstance(e, CallError) and e.errno not in ignore:
+        if isinstance(e, CallError) and e.errno not in ignore:
             middleware.logger.warning(f'Failed to run {verb}({service})', exc_info=True)
 
 

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1269,7 +1269,8 @@ async def service_remote(middleware, service, verb, options):
             f'service.{verb}', [[service, options]]
         ])
     except Exception as e:
-        if not (isinstance(e, CallError) and e.errno in (errno.ECONNREFUSED, errno.ECONNRESET)):
+        ignore = (errno.ECONNRESET, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
+        if not (isinstance(e, CallError) and e.errno not in ignore:
             middleware.logger.warning(f'Failed to run {verb}({service})', exc_info=True)
 
 


### PR DESCRIPTION
We don't want to log a stack trace when the other controller is down in an HA system. It's expected that remote calls will fail.

Original PR: https://github.com/truenas/middleware/pull/11043
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121328