### PR TITLE
NAS-121363 / 23.10 / Fix filterable return schema and update app.latest endpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -9,14 +9,16 @@ class AppService(Service):
     class Config:
         cli_namespace = 'app'
 
-    @accepts(Int('limit', default=10, validators=[Range(min=1)]))
-    @returns(Ref('available_apps'))
-    async def latest(self, limit):
+    @filterable
+    @filterable_returns(Ref('available_apps'))
+    async def latest(self, filters, options):
         """
-        Retrieve latest updated apps limiting the number by specifying `limit`.
+        Retrieve latest updated apps.
         """
-        return await self.middleware.call(
-            'app.available', [['last_update', '!=', None]], {'order_by': ['-last_update'], 'limit': limit}
+        return filter_list(
+            await self.middleware.call(
+                'app.available', [['last_update', '!=', None]], {'order_by': ['-last_update']}
+            ), filters, options
         )
 
     @filterable

--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -1,7 +1,6 @@
-from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, returns, Str
+from middlewared.schema import accepts, Bool, Dict, List, Ref, returns, Str
 from middlewared.service import filterable, filterable_returns, Service
 from middlewared.utils import filter_list
-from middlewared.validators import Range
 
 
 class AppService(Service):

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -966,6 +966,9 @@ class Ref(object):
         self.resolved = True
         return schema
 
+    def copy(self):
+        return copy.deepcopy(self)
+
 
 class Patch(object):
 


### PR DESCRIPTION
## Problem

It was requested by the UI team that `app.latest` should have the same options as `filterable` so they can retrieve all apps at once and filter/limit as required.

While updating `app.latest` endpoint, `filterable_returns` was broken when `Ref` was used. The problem it turned out to be were 2:
1. `_filterable_schema` attribute which points to schema never got resolved which failed obviously
2. When the same `Ref` object was specified in `OROperator`, ref in the list item did not resolve because the same object was being manipulated when the ref was specified as second entry in the OR operator.

## Solution

Convert `app.latest` to be filterable and fixes for the 2 problems were:

1. Specify the OROperator in `_filterable_schema` so that the schema does get resolved as the same object would be referenced by the returns decorator.
2. Copy the schema object when trying to use the same schema in the `OROperator` usage as then it will resolve nicely.