### PR TITLE
NAS-121387 / 23.10 / fix hook_license_update

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/configure.py
+++ b/src/middlewared/middlewared/plugins/failover_/configure.py
@@ -1,0 +1,55 @@
+from middlewared.service import Service
+
+HA_LICENSE_CACHE_KEY = 'LICENSED_FOR_HA'
+
+
+class FailoverConfigureService(Service):
+
+    class Config:
+        namespace = 'failover.configure'
+        private = True
+
+    def license(self, dser_lic):
+        """
+            1. cache locally whether or not this is a HA license
+            2. if this is a HA license:
+                --ensure we populate IP of heartbeat iface for remote node
+                --ensure we tell remote node to populate IP of heartbeat iface for local node
+                --copy the license file to the remote node
+                --invalidate the license cache on the remote node
+                --enable/disable systemd services on the remote node
+        """
+        is_ha = bool(dser_lic.system_serial_ha)
+        self.middleware.call_sync('cache.put', HA_LICENSE_CACHE_KEY, is_ha)
+        if is_ha:
+            try:
+                self.middleware.call_sync('failover.ensure_remote_client')
+            except Exception:
+                # this is fatal because we can't determine what the remote ip address
+                # is to so any failover.call_remote calls will fail
+                self.logger.error('Failed to determine remote heartbeat IP address', exc_info=True)
+                return
+
+            try:
+                self.middleware.call_sync('failover.call_remote', 'failover.ensure_remote_client')
+            except Exception:
+                # this is not fatal, so no reason to return early
+                # it just means that any "failover.call_remote" calls initiated from the remote node
+                # will fail but that shouldn't be happening anyways
+                self.logger.warning('Remote node failed to determine this nodes heartbeat IP address', exc_info=True)
+
+            try:
+                self.middleware.call_sync('failover.send_small_file', self.middleware.call_sync('system.license_path'))
+            except Exception:
+                self.logger.warning('Failed to sync database to remote node', exc_info=True)
+                return
+
+            try:
+                self.middleware.call_sync('failover.call_remote', 'cache.pop', [HA_LICENSE_CACHE_KEY])
+            except Exception:
+                self.logger.warning('Failed to invalidate license cache on remote node', exc_info=True)
+
+            try:
+                self.middleware.call_sync('failover.call_remote', 'etc.generate', ['rc'])
+            except Exception:
+                self.logger.warning('etc.generate failed on standby', exc_info=True)

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -179,11 +179,9 @@ class SystemService(Service):
     @accepts(Str('license'))
     @returns()
     def license_update(self, license):
-        """
-        Update license file.
-        """
+        """Update license file"""
         try:
-            License.load(license)
+            dser_license = License.load(license)
         except Exception:
             raise CallError('This is not a valid license.')
 
@@ -197,6 +195,8 @@ class SystemService(Service):
         SystemService.PRODUCT_TYPE = None
         if self.middleware.call_sync('system.is_enterprise'):
             Path('/data/truenas-eula-pending').touch(exist_ok=True)
+
+        self.middleware.call_sync('failover.configure.license', dser_license)
         self.middleware.run_coroutine(
             self.middleware.call_hook('system.post_license_update', prev_product_type=prev_product_type), wait=False,
         )

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -11,11 +11,14 @@ __all__ = ["client", "host", "password", "session", "url", "websocket_url"]
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True):
+def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None):
     if auth is undefined:
         auth = ("root", password())
 
-    with Client(f"ws://{host()}/websocket", py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+    if host_ip is None:
+        host_ip = host()
+
+    with Client(f"ws://{host_ip}/websocket", py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
         if auth is not None:
             logged_in = c.call("auth.login", *auth)
             if auth_required:


### PR DESCRIPTION
The `failover.licensed` endpoint reads the license file from disk, deserializes it and then checks to see if this is an HA license. Since this endpoint is called _EVERYWHERE_ we moved to caching the return of this endpoint years ago. This has exposed a bug in the `hook_license_update` method that gets called when an HA license is updated via our API.

We send the license file to the other controller, but that is not enough to cache the license into memory. We must call the appropriate hook on the remote controller as well. However, after investigation, I realized that this hook would cause a recursion loop. Now I remove that hook and explicitly setup the license on the other controller. Also, while I'm here, fix a false log message to reflect reality.