### PR TITLE
NAS-121397 / 23.10 / Add nvdimm arm info for legacy NVDIMMs

### DIFF
--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -16,7 +16,7 @@ class NVDIMMAlertClass(AlertClass):
 
 class NVDIMMESLifetimeWarningAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
-    level = AlertLevel.CRITICAL
+    level = AlertLevel.WARNING
     title = 'NVDIMM Energy Source Lifetime Is Less Than 20%'
     text = 'NVDIMM Energy Source Remaining Lifetime for %(dev)s is %(value)d%%.'
     products = ('SCALE_ENTERPRISE',)
@@ -32,7 +32,7 @@ class NVDIMMESLifetimeCriticalAlertClass(AlertClass):
 
 class NVDIMMMemoryModLifetimeWarningAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
-    level = AlertLevel.CRITICAL
+    level = AlertLevel.WARNING
     title = 'NVDIMM Memory Module Lifetime Is Less Than 20%'
     text = 'NVDIMM Memory Module Remaining Lifetime for %(dev)s is %(value)d%%.'
     products = ('SCALE_ENTERPRISE',)

--- a/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
@@ -141,6 +141,15 @@ class MseriesNvdimmService(Service):
 
         return result
 
+    def state_flags(self, nmem):
+        try:
+            with open(f'/sys/bus/nd/devices/{nmem.removeprefix("/dev/")}/nfit/flags') as f:
+                state_flags = f.read().strip().split()
+        except Exception:
+            state_flags = []
+
+        return state_flags
+
     def info(self):
         results = []
         sys = ("TRUENAS-M40", "TRUENAS-M50", "TRUENAS-M60")
@@ -155,7 +164,8 @@ class MseriesNvdimmService(Service):
                     'index': int(nmem[len('/dev/nmem')]),
                     'dev': nmem.removeprefix('/dev/'),
                     'dev_path': nmem,
-                    'specrev': int(specrev.strip())
+                    'specrev': int(specrev.strip()),
+                    'state_flags': self.state_flags(nmem),
                 }
                 info.update(self.health_info(output))
                 info.update(self.vendor_info(output))


### PR DESCRIPTION
SCALE has ability to report armed information for legacy NVDIMMs while CORE did not. This is to add that functionality to SCALE (requested by platform team).

I've fixed ambiguous, very confusing alerts while I'm here.