### PR TITLE
NAS-121392 / 22.12.3 / Add some more validation for AD-related changes (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -930,6 +930,14 @@ class KerberosKeytabService(TDBWrapCRUDService):
         Delete kerberos keytab by id, and force regeneration of
         system keytab.
         """
+        kt = await self.get_instance(id)
+        if kt['name'] == 'AD_MACHINE_ACCOUNT':
+            if (await self.middleware.call('activedirectory.get_state')) != 'DISABLED':
+                raise CallError(
+                    'Active Directory machine account keytab may not be deleted while '
+                    'the Active Directory service is enabled.'
+                )
+
         await super().do_delete(id)
         if os.path.exists(keytab['SYSTEM'].value):
             os.remove(keytab['SYSTEM'].value)


### PR DESCRIPTION
* Prevent users from manually deleting the AD machine account keytab if the AD service is currently enabled. This keytab is vital to keeping kerberized services working properly.

* Whitelist which AD fields may be changed while service is enabled. This will hopefully encourage users to take maintenance windows before making changes on production servers that may affect clients that are currently connected to the server.

* In some abusive testing support was able to get into a state where libads had cached stale information which led to failures spurious failures when looking up DC and domain information. This commit changes the behavior of related methods so that if the first attempt doesn't succeed, we flush out caches then try again.

Original PR: https://github.com/truenas/middleware/pull/11080
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121392