### PR TITLE
NAS-121418 / 23.10 / Fix certificate delete test

### DIFF
--- a/tests/api2/test_110_certificate.py
+++ b/tests/api2/test_110_certificate.py
@@ -4,8 +4,10 @@
 # License: BSD
 
 import pytest
+import re
 import sys
 import os
+
 from time import sleep
 apifolder = os.getcwd()
 sys.path.append(apifolder)
@@ -74,12 +76,9 @@ def test_03_verify_certificate_delete_failed():
             sleep(5)
         else:
             assert job_status['state'] == 'FAILED', get_job.text
-            try:
-                job_status['exc_info']['extra']['dependencies'][0]['objects']
-                num = 0
-            except KeyError:
-                num = 1
-            assert job_status['exc_info']['extra']['dependencies'][num]['objects'][0]['certificate']['id'] == certificate_id, get_job.text
+            assert bool(re.search(
+                r'Certificate is being used by following service.*IDMAP', job_status['error'], flags=re.DOTALL
+            )) is True, job_status['error']
             break
 
 


### PR DESCRIPTION
With changes to how we properly give out humanised errors when deleting certs which are being consumed by services, those changes broke our certificate deletion test which has been fixed.