### PR TITLE
Do not show ix-chart app in latest updated apps

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -16,7 +16,9 @@ class AppService(Service):
         """
         return filter_list(
             await self.middleware.call(
-                'app.available', [['last_update', '!=', None]], {'order_by': ['-last_update']}
+                'app.available', [
+                    ['last_update', '!=', None], ['name', '!=', 'ix-chart'],
+                ], {'order_by': ['-last_update']}
             ), filters, options
         )
 


### PR DESCRIPTION
## Context

`ix-chart` is a special app and it should not be shown in Recently Updated Apps section as it will confuse users - it is used for deploying docker images and is not a normal app per se.