### PR TITLE
NAS-121309 / 23.10 / Update forward_lookup to support A/AAAA records by default

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -209,7 +209,7 @@ class ActiveDirectoryService(Service):
                 try:
                     resp = await self.middleware.call('dnsclient.forward_lookup', {
                         'names': [name],
-                        'record_type': 'SRV',
+                        'record_types': ['SRV'],
                         'dns_client_options': {'nameservers': [entry['nameserver']]}
                     })
                 except dns.resolver.NXDOMAIN:
@@ -245,7 +245,7 @@ class ActiveDirectoryService(Service):
             host = f"{srv_prefix.value}{domain}."
 
         servers = self.middleware.call_sync('dnsclient.forward_lookup', {
-            'names': [host], 'record_type': 'SRV', 'query-options': {'order_by': ['priority', 'weight']}
+            'names': [host], 'record_types': ['SRV'], 'query-options': {'order_by': ['priority', 'weight']}
         })
 
         output = []

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -54,7 +54,7 @@ class ClusterUtils(Service):
                 pass
 
         try:
-            ans = [i['address'] for i in await self.middleware.call('dnsclient.forward_lookup', {"names": [host]})]
+            ans = [i['address'] for i in await self.middleware.call('dnsclient.forward_lookup', {"names": [host], 'record_types': ['A']})]
         except DNSException as e:
             # failed to resolve the hostname
             result['error'] = e.msg

--- a/src/middlewared/middlewared/plugins/dns_client.py
+++ b/src/middlewared/middlewared/plugins/dns_client.py
@@ -57,11 +57,11 @@ class DNSClient(Service):
             List('nameservers', items=[IPAddr("ip")], default=[]),
             Int('lifetime', default=12),
             Int('timeout', default=4),
+            Str('raise_error', default='HOST_FAILURE', enum=['NEVER', 'ANY_FAILURE', 'HOST_FAILURE', 'ALL_FAILURE']),
             register=True
         ),
         Ref('query-filters'),
         Ref('query-options'),
-        Str('raise_error', default='HOST_FAILURE', enum=['NEVER', 'ANY_FAILURE', 'HOST_FAILURE', 'ALL_FAILURE']),
     ))
     @returns(OROperator(
         List(
@@ -120,7 +120,6 @@ class DNSClient(Service):
 
         if (len(data['record_types']) > 1) and (set(single_rtypes) & set(data['record_types'])):
             raise ValidationError(
-                # 'dnclient.mcg_forward_lookup',
                 'dnclient.forward_lookup',
                 f'{single_rtypes} cannot be combined with other rtypes in the same request'
             )
@@ -176,14 +175,14 @@ class DNSClient(Service):
         # ANY   - raise on any failure
         # ALL   - raise if all tests for all 'names' fail
         if failures:
-            if data['raise_error'] == 'HOST_FAILURE':
+            if options['raise_error'] == 'HOST_FAILURE':
                 for h in data['names']:
                     fph = len(failuresPerHost[h]) if failuresPerHost.get(h) is not None else 0
                     if fph == len(data['record_types']):
                         raise failuresPerHost[h][0]
-            elif data['raise_error'] == 'ANY_FAILURE':
+            elif options['raise_error'] == 'ANY_FAILURE':
                 raise failures[0]
-            elif data['raise_error'] == 'ALL_FAILURE':
+            elif options['raise_error'] == 'ALL_FAILURE':
                 if len(data['names']) * len(data['record_types']) == len(failures):
                     raise failures[0]
 

--- a/src/middlewared/middlewared/plugins/dns_client.py
+++ b/src/middlewared/middlewared/plugins/dns_client.py
@@ -108,9 +108,10 @@ class DNSClient(Service):
     async def forward_lookup(self, data):
         """
         Rules: We can combine 'A' and 'AAAA', but 'SRV' and 'CNAME' must be singular.
-        NB1: By default raise_error=True and forward_lookup will return on the _first_ exception.
-             If that is not desired then use raise_error=False
-        NB2: With raise_error=False all results are returned and resolve attempts that
+        NB1: By default record_types is ['A', 'AAAA'] and if selected will return both 'A' and 'AAAA' records
+             for hosts that support both.
+        NB2: By default throw_exception_on is 'host_failure', i.e. raise exception if all tests for a name fail
+        NB3: With throw_exception_on as 'never' all results are returned and resolve attempts that
              generate an exception are returned as an empty list
         """
         single_rtypes = ['CNAME', 'SRV']

--- a/src/middlewared/middlewared/plugins/dns_client.py
+++ b/src/middlewared/middlewared/plugins/dns_client.py
@@ -61,7 +61,7 @@ class DNSClient(Service):
         ),
         Ref('query-filters'),
         Ref('query-options'),
-        Str('throw_exception_on', default='host_failure', enum=['never', 'any_failure', 'host_failure', 'all_failure']),
+        Str('raise_error', default='HOST_FAILURE', enum=['NEVER', 'ANY_FAILURE', 'HOST_FAILURE', 'ALL_FAILURE']),
     ))
     @returns(OROperator(
         List(
@@ -110,8 +110,8 @@ class DNSClient(Service):
         Rules: We can combine 'A' and 'AAAA', but 'SRV' and 'CNAME' must be singular.
         NB1: By default record_types is ['A', 'AAAA'] and if selected will return both 'A' and 'AAAA' records
              for hosts that support both.
-        NB2: By default throw_exception_on is 'host_failure', i.e. raise exception if all tests for a name fail
-        NB3: With throw_exception_on as 'never' all results are returned and resolve attempts that
+        NB2: By default raise_error is 'HOST_FAILURE', i.e. raise exception if all tests for a name fail
+        NB3: With raise_error as 'NEVER' all results are returned and resolve attempts that
              generate an exception are returned as an empty list
         """
         single_rtypes = ['CNAME', 'SRV']
@@ -171,19 +171,19 @@ class DNSClient(Service):
 
                 output.extend(entries)
 
-        # never - squash all failures
-        # host  - raise if all tests for a name fail  (default case)
-        # any   - raise on any failure
-        # all   - raise if all tests for all 'names' fail
+        # NEVER - squash all failures
+        # HOST  - raise if all tests for a name fail  (default case)
+        # ANY   - raise on any failure
+        # ALL   - raise if all tests for all 'names' fail
         if failures:
-            if data['throw_exception_on'] == 'host_failure':
+            if data['raise_error'] == 'HOST_FAILURE':
                 for h in data['names']:
                     fph = len(failuresPerHost[h]) if failuresPerHost.get(h) is not None else 0
                     if fph == len(data['record_types']):
                         raise failuresPerHost[h][0]
-            elif data['throw_exception_on'] == 'any_failure':
+            elif data['raise_error'] == 'ANY_FAILURE':
                 raise failures[0]
-            elif data['throw_exception_on'] == 'all_failure':
+            elif data['raise_error'] == 'ALL_FAILURE':
                 if len(data['names']) * len(data['record_types']) == len(failures):
                     raise failures[0]
 


### PR DESCRIPTION
Input parameters:
* record_type changed to a list of record_types. Default is ['A', 'AAAA']. 'SRV' and 'CNAME' remain singular and cannot be requested in combination with the others. NOTE: With the default record_types selection, hosts that support both IPv4 and IPv6 will return entries for both 'A' and 'AAAA' records.
* Added 'throw_exception_on'. Default to 'host_failure'.  Options are 'never', 'any_failure', 'host_failure', all_failure'. Output parameters and exception reporting behavior (with default selection) remain unchanged.