### PR TITLE
NAS-121443 / 23.10 / fix legacy nvdimm alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -3,7 +3,9 @@ import datetime
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
 
-WEBUI_SUPPORT_FORM = 'Please contact iXsystems Support using the form in System Settings->General->Support'
+WEBUI_SUPPORT_FORM = (
+    'Please contact iXsystems Support using the "File Ticket" button in the System Settings->General->Support form'
+)
 
 
 class NVDIMMAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -127,7 +127,7 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
                 {'dev': dev, 'value': 'ARM STATUS', 'status': 'NOT ARMED'}
             ))
 
-        if (run_fw := nvdimm['running_firmware']):
+        if (run_fw := nvdimm['running_firmware']) is not None:
             if run_fw not in nvdimm['qualified_firmware']:
                 alerts.append(Alert(NVDIMMInvalidFirmwareVersionAlertClass, {'dev': dev}))
             elif run_fw != nvdimm['recommended_firmware']:

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -3,7 +3,7 @@ import datetime
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
 
-WEBUI_SUPPORT_FORM = 'Please contact iXsystems Support using the form in System Settings -> General -> Support'
+WEBUI_SUPPORT_FORM = 'Please contact iXsystems Support using the form in System Settings->General->Support'
 
 
 class NVDIMMAlertClass(AlertClass):
@@ -50,10 +50,7 @@ class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.CRITICAL
     title = 'Invalid NVDIMM Firmware Version'
-    text = (
-        'NVDIMM: "%(dev)s" is running firmware version which can cause data loss if a power outage '
-        f'event occurs. {WEBUI_SUPPORT_FORM}'
-    )
+    text = f'NVDIMM: "%(dev)s" is running invalid firmware. {WEBUI_SUPPORT_FORM}'
     products = ('SCALE_ENTERPRISE',)
     proactive_support = True
 

--- a/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
@@ -50,7 +50,7 @@ class MseriesNvdimmService(Service):
                 'subvendor': '0x3480', 'subdevice': '0x4131', 'subrev_id': '0x01',
                 'part_num': '18ASF2G72PF12G6V21AB',
                 'size': '16GB', 'clock_speed': '2666MHz',
-                'qualified_firmware': ['2.1', '2.2', '2.4', '2.6'],
+                'qualified_firmware': ['2.6'],
                 'recommended_firmware': '2.6',
             },
             '0x2c80_0x4e36_0x31_0x3480_0x4231_0x02': {


### PR DESCRIPTION
After clarification from platform team, we do not need a recommended nvdimm firmware alert for version 2.6. Instead, we need to alert as if it's an invalid firmware. I've left the recommended firmware logic in place in-case we ever have more than 1 qualified firmware for an nvdimm.