### PR TITLE
NAS-121443 / 13.0 / fix legacy nvdimm alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -34,10 +34,7 @@ class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.CRITICAL
     title = 'Invalid NVDIMM Firmware Version'
-    text = (
-        'NVDIMM: "%(dev)s" is running firmware version which can cause data loss if a power outage '
-        f'event occurs. {WEBUI_SUPPORT_FORM}'
-    )
+    text = f'NVDIMM: "%(dev)s" is running invalid firmware. {WEBUI_SUPPORT_FORM}'
     products = ('SCALE_ENTERPRISE',)
     proactive_support = True
 
@@ -105,7 +102,7 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
             alert = NVDIMMLifetimeWarningAlertClass if val > 10 else NVDIMMLifetimeCriticalAlertClass
             alerts.append(Alert(alert, {'dev': 'NVM Energy Source', 'value': val}))
 
-        if (run_fw := nvdimm['running_firmware']):
+        if (run_fw := nvdimm['running_firmware']) is not None:
             if run_fw not in nvdimm['qualified_firmware']:
                 alerts.append(Alert(NVDIMMInvalidFirmwareVersionAlertClass, {'dev': dev}))
             elif run_fw != nvdimm['recommended_firmware']:

--- a/src/middlewared/middlewared/plugins/hardware_/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware_/m_series_nvdimm.py
@@ -50,7 +50,7 @@ class MseriesNvdimmService(Service):
                 'subvendor': '0x3480', 'subdevice': '0x4131', 'subrev_id': '0x01',
                 'part_num': '18ASF2G72PF12G6V21AB',
                 'size': '16GB', 'clock_speed': '2666MHz',
-                'qualified_firmware': ['2.1', '2.2', '2.4', '2.6'],
+                'qualified_firmware': ['2.6'],
                 'recommended_firmware': '2.6',
             },
             '0x2c80_0x4e36_0x31_0x3480_0x4231_0x02': {


### PR DESCRIPTION
After clarification from platform team, we do not need a recommended nvdimm firmware alert for version 2.6. Instead, we need to alert as if it's an invalid firmware. I've left the recommended firmware logic in place in-case we ever have more than 1 qualified firmware for an nvdimm.

Original PR: https://github.com/truenas/middleware/pull/11094
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121443