### PR TITLE
NAS-121450 / 23.10 / mask ndctl-monitor.service

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -69,6 +69,7 @@ systemctl enable zfs-zed
 systemctl mask libvirtd.socket libvirtd-ro.socket libvirtd-admin.socket libvirtd-tls.socket libvirtd-tcp.socket
 systemctl mask exim4-base.service exim4.service exim4-base.timer
 systemctl mask uuidd.service uuidd.socket
+systemctl mask ndctl-monitor.service
 
 # mdmonitor.service in particular causes mdadm to send emails to the MAILADDR line
 # in /etc/mdadm/mdadm.conf. By default, that's the root account, so end-users are


### PR DESCRIPTION
In Cobia (based on bookworm), we're bringing in proper ndctl package since it has Mav's fixes. The package adds this service which needs to be masked since it will error If a system doesn't have an NVDIMM.