### PR TITLE
NAS-121426 / 22.12.3 / Prevent `The specified key, name, or identifier /vmfs/volumes/f7f8aa8… (by themylogin)

### DIFF
--- a/tests/api2/test_vmware.py
+++ b/tests/api2/test_vmware.py
@@ -73,7 +73,7 @@ def datastore(si):
     else:
         raise RuntimeError(f"ESX host {VCENTER_ESX_HOST} not found")
 
-    with dataset("vm") as ds:
+    with dataset(f"vm_{random_string()}") as ds:
         with nfs_share(ds) as share:
             ssh(f"chmod 777 /mnt/{ds}")
 


### PR DESCRIPTION
…6-01a205f5 already exists.`

Original PR: https://github.com/truenas/middleware/pull/11098
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121426