### PR TITLE
NAS-121457 / 23.10 / fix regression (from Feb, 2022) for missing disks alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -32,8 +32,8 @@ class FailoverDisksAlertSource(AlertSource):
                 return [Alert(
                     DisksAreNotPresentOnStandbyNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
                 )]
-            if md['missing_remote']:
+            if md['missing_local']:
                 return [Alert(
-                    DisksAreNotPresentOnActiveNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
+                    DisksAreNotPresentOnActiveNodeAlertClass, {'serials': ', '.join(md['missing_local'])}
                 )]
         return []


### PR DESCRIPTION
Regression introduced on Feb 15th, 2022. This fixes it so the alert properly works.