### PR TITLE
NAS-121457 / 22.12.3 / fix regression (from Feb, 2022) for missing disks alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -32,8 +32,8 @@ class FailoverDisksAlertSource(AlertSource):
                 return [Alert(
                     DisksAreNotPresentOnStandbyNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
                 )]
-            if md['missing_remote']:
+            if md['missing_local']:
                 return [Alert(
-                    DisksAreNotPresentOnActiveNodeAlertClass, {'serials': ', '.join(md['missing_remote'])}
+                    DisksAreNotPresentOnActiveNodeAlertClass, {'serials': ', '.join(md['missing_local'])}
                 )]
         return []


### PR DESCRIPTION
Regression introduced on Feb 15th, 2022. This fixes it so the alert properly works.

Original PR: https://github.com/truenas/middleware/pull/11103
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121457