### PR TITLE
NAS-120980 / 22.12.3 / Add MAX_EXTENT_NAME_LEN for iSCSI (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -14,6 +14,8 @@ from middlewared.service import CallError, private, SharingService, ValidationEr
 from middlewared.utils.size import format_size
 from middlewared.validators import Range
 
+from .utils import MAX_EXTENT_NAME_LEN
+
 
 class iSCSITargetExtentModel(sa.Model):
     __tablename__ = 'services_iscsitargetextent'
@@ -66,7 +68,7 @@ class iSCSITargetExtentService(SharingService):
 
     @accepts(Dict(
         'iscsi_extent_create',
-        Str('name', required=True),
+        Str('name', required=True, max_length=MAX_EXTENT_NAME_LEN),
         Str('type', enum=['DISK', 'FILE'], default='DISK'),
         Str('disk', default=None, null=True),
         Str('serial', default=None, null=True),

--- a/src/middlewared/middlewared/plugins/iscsi_/utils.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/utils.py
@@ -6,3 +6,6 @@ AUTHMETHOD_LEGACY_MAP = bidict.bidict({
     'CHAP': 'CHAP',
     'CHAP Mutual': 'CHAP_MUTUAL',
 })
+
+# Currently SCST has this limit (scst_vdisk_dev->name)
+MAX_EXTENT_NAME_LEN = 64


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fbf9a05c8696a87d4991576ab36e369b56ac734a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 6254f72dd006f7fed44e616d82397ff938762002

Currently the underlying iSCSI target code has a limitation wrt the maximum length of the extent name (64).  Enforce a check in middleware to prevent an invalid SCST configuration.


Original PR: https://github.com/truenas/middleware/pull/11105
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120980