### PR TITLE
NAS-121442 / 23.10 / Add resource statistics for apps

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -135,6 +135,7 @@ class ChartReleaseService(CRUDService):
         options = options or {}
         extra = copy.deepcopy(options.get('extra', {}))
         retrieve_schema = extra.get('include_chart_schema')
+        retrieve_stats = extra.get('stats', True)
         get_resources = extra.get('retrieve_resources')
         get_locked_paths = extra.get('retrieve_locked_paths')
         locked_datasets = await self.middleware.call('zfs.dataset.locked_datasets') if get_locked_paths else []
@@ -215,6 +216,10 @@ class ChartReleaseService(CRUDService):
                 'used_ports': ports_used[name],
                 'pod_status': pods_status,
             })
+            if retrieve_stats:
+                release_data['stats'] = await self.middleware.call(
+                    'chart.release.stats_internal', resources[Resources.POD.value][name]
+                )
 
             container_images_normalized = {
                 normalize_image_tag(i_name): {

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/core_api.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/core_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import os.path
 
 from dateutil.parser import parse as datetime_parse
 
@@ -59,6 +60,12 @@ class Node(CoreAPI):
             taints.pop(index)
 
         await cls.update(node_object['metadata']['name'], {'spec': {'taints': taints}})
+
+    @classmethod
+    async def get_stats(cls):
+        return await cls.call(
+            os.path.join(cls.uri(object_name=NODE_NAME), 'proxy/stats/summary'), mode=RequestMode.GET.value
+        )
 
 
 class Service(CoreAPI):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/stats.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/stats.py
@@ -1,0 +1,18 @@
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+from .k8s import Node
+
+
+class KubernetesStatsService(CRUDService):
+
+    class Config:
+        namespace = 'k8s.stats'
+        private = True
+
+    @filterable
+    async def summary(self, filters, options):
+        """
+        Retrieve summary of kubernetes cluster.
+        """
+        return filter_list((await Node.get_stats())['pods'], filters, options)

--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -12,6 +12,7 @@ from middlewared.schema import accepts, Bool, Datetime, Dict, Float, Int, List, 
 from middlewared.service import no_auth_required, pass_app, private, Service, throttle
 from middlewared.utils import sw_buildtime
 
+from .utils import cpu_info
 
 RE_CPU_MODEL = re.compile(r'^model name\s*:\s*(.*)', flags=re.M)
 
@@ -21,11 +22,6 @@ def throttle_condition(middleware, app, *args, **kwargs):
 
 
 class SystemService(Service):
-    CPU_INFO = {
-        'cpu_model': None,
-        'core_count': None,
-        'physical_core_count': None,
-    }
 
     MEM_INFO = {
         'physmem_size': None,
@@ -71,16 +67,16 @@ class SystemService(Service):
         CPU info doesn't change after boot so cache the results
         """
 
-        if self.CPU_INFO['cpu_model'] is None:
-            self.CPU_INFO['cpu_model'] = await self.middleware.call('system.get_cpu_model')
+        if cpu_info.cpu_model is None:
+            cpu_info.cpu_model = await self.middleware.call('system.get_cpu_model')
 
-        if self.CPU_INFO['core_count'] is None:
-            self.CPU_INFO['core_count'] = psutil.cpu_count(logical=True)
+        if cpu_info.core_count is None:
+            cpu_info.core_count = psutil.cpu_count(logical=True)
 
-        if self.CPU_INFO['physical_core_count'] is None:
-            self.CPU_INFO['physical_core_count'] = psutil.cpu_count(logical=False)
+        if cpu_info.physical_core_count is None:
+            cpu_info.physical_core_count = psutil.cpu_count(logical=False)
 
-        return self.CPU_INFO
+        return cpu_info.__dict__
 
     @private
     async def time_info(self):

--- a/src/middlewared/middlewared/plugins/system/utils.py
+++ b/src/middlewared/middlewared/plugins/system/utils.py
@@ -1,6 +1,9 @@
 import enum
 import re
 
+from dataclasses import dataclass
+from typing import Optional
+
 
 DEBUG_MAX_SIZE = 30
 FIRST_INSTALL_SENTINEL = '/data/first-boot'
@@ -10,6 +13,13 @@ RE_KDUMP_CONFIGURED = re.compile(r'current state\s*:\s*(ready to kdump)', flags=
 class VMProvider(enum.Enum):
     AZURE = 'AZURE'
     NONE = 'NONE'
+
+
+@dataclass
+class CPUInfo:
+    cpu_model: Optional[str] = None
+    core_count: Optional[int] = None
+    physical_core_count: Optional[int] = None
 
 
 class Lifecycle:
@@ -22,4 +32,5 @@ class Lifecycle:
         self.SYSTEM_SHUTTING_DOWN = False
 
 
+cpu_info = CPUInfo()
 lifecycle_conf = Lifecycle()


### PR DESCRIPTION
## Context

New Apps UI would like to display some resource statistics for apps to better tell the user how much resources an app is consuming.

I have decided to follow through on 3 types of statistics:

1. CPU usage
2. Memory usage
3. Network usage

Kubernetes provides CPU usage stats in nano cores which when is going to be translated to actual core is something like `1e9 (1,000,000,000) nanocores`. We provide an overall percentage across all system cores that an app might be consuming.

Memory usage stats are provided in bytes are forwarded as such and the same applies to network stats.

It would have been nice if we could stream these statistics as well with an event source but apparently that is not possible from kubernetes side as it is not allowing us to stream all pods statistics so if UI wants to update the stats in realtime - they would need to make repeated calls.