### PR TITLE
NAS-121277 / 22.12.3 /  Reduce dependencies on glusterfs fuse mount  (by anodos325)

### DIFF
--- a/cluster-tests/tests/directoryservices/test_001_activedirectory.py
+++ b/cluster-tests/tests/directoryservices/test_001_activedirectory.py
@@ -11,6 +11,7 @@ from time import sleep
 SHARE_FUSE_PATH = f'CLUSTER:{CLUSTER_INFO["GLUSTER_VOLUME"]}/ds_smb_share_01'
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=10)
 @pytest.mark.parametrize('ip', CLUSTER_IPS)
 @pytest.mark.dependency(name='VALID_SMB_BIND_IPS')
 def test_001_validate_smb_bind_ips(ip, request):

--- a/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
+++ b/cluster-tests/tests/filesystem/test_001_base_filesystem_tests.py
@@ -31,10 +31,13 @@ def test_001_volume_is_mounted(ip):
 def test_002_enable_and_start_ssh(ip, request):
     depends(request, ['FS_BASIC_GLUSTER_VOLUME_MOUNTED'])
 
-    payload = {
-        "rootlogin": True,
-    }
-    url = f'http://{CLUSTER_IPS[1]}/api/v2.0/ssh/'
+    url = f'http://{ip}/api/v2.0/user?username=root'
+    res = make_request('get', url)
+    assert res.status_code == 200, res.text
+    root = res.json()[0]
+
+    payload = {"ssh_password_enabled": True}
+    url = f'http://{ip}/api/v2.0/user/id/{root["id"]}'
     res = make_request('put', url, data=payload)
     assert res.status_code == 200, res.text
 

--- a/src/middlewared/middlewared/etc_files/ctdb.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb.conf.mako
@@ -11,11 +11,17 @@
     for i in (p_dir, s_dir, v_dir):
         Path(i).mkdir(parents=True, exist_ok=True)
 
+    try:
+        ctdb_shared_vol_info = middleware.call_sync('ctdb.shared.volume.config')
+    except Exception:
+        middleware.logger.debug('Failed to retrieve ctdb volume information', exc_info=True)
+        raise FileShouldNotExist()
+
     mutex_helper_config = {
         'liveness_timeout': 20,
         'check_interval': 1,
         'reclock_path': r_file,
-        'volume_name': 'ctdb_shared_vol',
+        'volume_name': ctdb_shared_vol_info['volume_name'],
         'volfile_servers': [{'host': '127.0.0.1', 'proto': 'tcp', 'port': 0}],
         'log_file': '/var/log/ctdb/reclock_helper.log',
         'log_level': 1
@@ -27,7 +33,7 @@
     try:
         bricks = middleware.call_sync(
             'gluster.volume.query',
-            [['name', '=', 'ctdb_shared_vol']],
+            [['name', '=', ctdb_shared_vol_info['volume_name']]],
             {'get': True}
         )['bricks']
     except Exception:

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -10,6 +10,7 @@ from dns.exception import DNSException
 from middlewared.plugins.gluster_linux.utils import GlusterConfig
 from middlewared.schema import Bool, returns
 from middlewared.utils.path import CLUSTER_PATH_PREFIX
+from middlewared.utils import MIDDLEWARE_RUN_DIR
 from middlewared.service import Service, job, ValidationErrors, private, accepts
 from middlewared.service_exception import CallError
 
@@ -243,11 +244,10 @@ class CTDBConfig(enum.Enum):
     # local gluster fuse client mount related config
     LOCAL_MOUNT_BASE = FuseConfig.FUSE_PATH_BASE.value
     CTDB_VOL_NAME = 'ctdb_shared_vol'
+    CTDB_VOL_INFO_FILE = f'{MIDDLEWARE_RUN_DIR}/ctdb_vol_info'
     CTDB_LOCAL_MOUNT = os.path.join(LOCAL_MOUNT_BASE, CTDB_VOL_NAME)
-    GM_RECOVERY_FILE = os.path.join(CTDB_LOCAL_MOUNT, REC_FILE)
-    GM_PRI_IP_FILE = os.path.join(CTDB_LOCAL_MOUNT, PRIVATE_IP_FILE)
-    GM_PUB_IP_FILE = os.path.join(CTDB_LOCAL_MOUNT, PUBLIC_IP_FILE)
-    GM_CLUSTERED_SERVICES = os.path.join(CTDB_LOCAL_MOUNT, '.clustered_services')
+
+    CLUSTERED_SERVICES = '.clustered_services'
 
     # ctdb etc config
     CTDB_ETC = '/etc/ctdb'

--- a/src/middlewared/middlewared/plugins/gluster_linux/pyglfs_utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/pyglfs_utils.py
@@ -1,0 +1,106 @@
+import errno
+import fcntl
+import functools
+import pyglfs
+import threading
+
+from contextlib import contextmanager
+from copy import deepcopy
+from middlewared.service_exception import CallError
+
+DEFAULT_GLFS_OPTIONS = {"volfile_servers": None, "translators": []}
+
+
+class GlfsHdl:
+    handles = {}
+
+    def init_volume_mount(self, name, options):
+        """
+        Initialize a pyglfs gluster volume virtual mount.
+        Resources will be automatically deallocated / unmounted
+        when returned object is deallocated.
+        """
+        if not options['volfile_servers']:
+            volfile_servers = [{'host': '127.0.0.1', 'proto': 'tcp', 'port': 0}]
+        else:
+            volfile_servers = options['volfile_servers']
+
+        xlators = []
+
+        # Normalization of values
+        for s in volfile_servers:
+            s['proto'] = s['proto'].lower()
+
+        for entry in options.get('translators', []):
+            xlators.append((entry['xlator_name'], entry['key'], entry['value']))
+
+        kwargs = {
+            'volume_name': name,
+            'volfile_servers': volfile_servers
+        }
+
+        if options.get('translators'):
+            kwargs['translators'] = xlators
+
+        return pyglfs.Volume(**kwargs)
+
+    @contextmanager
+    def get_volume_handle(self, name, options=DEFAULT_GLFS_OPTIONS):
+        """
+        Get / store glusterfs volume handle virtual mount.
+        We want to keep these around because unmount can be rather
+        slow to complete (taking up to 10 seconds in some poorly-resourced VMs).
+
+        If a task is expected to be extremely long-running i.e. a `job` then,
+        it's a better idea to `init_volume_mount()` for a temporary virtual mount
+        and use that (since we're already commited in that case for a non-immediate response).
+        """
+        entry = self.handles.setdefault(name, {
+            'name': name,
+            'lock': threading.RLock(),
+            'handle_internal': None,
+            'options': deepcopy(options)
+        })
+
+        if options != entry['options']:
+            raise CallError(f'{name}: Internal Error - volume options mismatch', errno.EINVAL)
+
+        with entry['lock']:
+            if entry['handle_internal'] is None:
+                entry['handle_internal'] = self.init_volume_mount(name, options)
+
+            yield entry['handle_internal']
+
+
+glfs = GlfsHdl()
+
+
+@contextmanager
+def lock_file_open(object_hdl, open_flags, lock_flags=fcntl.F_WRLCK, blocking=True, mode=None, owners=None):
+    fd = object_hdl.open(open_flags)
+    try:
+        fd.posix_lock(fcntl.F_SETLKW if blocking else fcntl.F_SETLK, fcntl.F_WRLCK)
+        if mode is not None:
+            fd.fchmod(mode)
+
+        if owners is not None:
+            fd.fchown(*owners)
+
+        yield fd
+
+    finally:
+        fd.posix_lock(fcntl.F_SETLK, fcntl.F_UNLCK)
+
+
+def glusterfs_volume(fn):
+    @functools.wraps(fn)
+    def get_volume_handle(*args, **kwargs):
+        with glfs.get_volume_handle(
+            args[1]['volume_name'],
+            args[1].get('gluster-volume-options', DEFAULT_GLFS_OPTIONS)
+        ) as vol:
+            args = list(args)
+            args.insert(1, vol)
+            return fn(*args, **kwargs)
+
+    return get_volume_handle

--- a/src/middlewared/middlewared/scripts/ctdb_events.py
+++ b/src/middlewared/middlewared/scripts/ctdb_events.py
@@ -9,16 +9,12 @@ import time
 
 from copy import deepcopy
 from middlewared.client import Client
-from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
+from middlewared.plugins.cluster_linux.utils import CTDBConfig
 from middlewared.plugins.cluster_linux.ctdb_services import CTDB_SERVICE_DEFAULTS
 from middlewared.service import MIDDLEWARE_STARTED_SENTINEL_PATH
+from pathlib import Path
 
-CTDB_VOL = os.path.join(
-    FuseConfig.FUSE_PATH_BASE.value,
-    CTDBConfig.CTDB_VOL_NAME.value,
-)
-
-CTDB_SERVICE_FILE = f'{CTDB_VOL}/.clustered_services'
+CTDB_VOL_INFO_FILE = CTDBConfig.CTDB_VOL_INFO_FILE.value
 CTDB_RUNDIR = '/var/run/ctdb'
 CTDB_MONITOR_FAILED_SENTINEL = os.path.join(CTDB_RUNDIR, '.monitored_failed')
 
@@ -33,6 +29,8 @@ class CtdbEvent:
         self.pnn = -1
         self.node_status = {}
         self.init_node_status = {}
+        self.ctdb_info = None
+        self.ctdb_service_file = None
 
     def __enter__(self):
         return self
@@ -53,8 +51,13 @@ class CtdbEvent:
             return False
 
     def check_ctdb_shared_volume(self):
-        st = os.stat(CTDB_VOL)
-        if st.st_ino != 1:
+        try:
+            self.ctdb_info = json.loads(Path(CTDB_VOL_INFO_FILE).read_text())
+        except FileNotFoundError:
+            self.ctdb_info = self.client.call('ctdb.shared.volume.config')
+
+        self.ctdb_service_file = os.path.join(self.ctdb_info['mountpoint'], '.clustered_services')
+        if os.stat(os.path.join('/cluster', self.ctdb_info['volume_name'])).st_ino != 1:
             raise RuntimeError('ctdb shared volume not mounted')
 
     def load_service_file(self):
@@ -76,7 +79,7 @@ class CtdbEvent:
         """
         self.pnn = ctdb.Client().pnn
         try:
-            with open(CTDB_SERVICE_FILE, 'r') as f:
+            with open(self.ctdb_service_file, 'r') as f:
                 fcntl.lockf(f.fileno(), fcntl.LOCK_SH)
                 try:
                     self.cl_services = json.load(f)
@@ -84,7 +87,7 @@ class CtdbEvent:
                     fcntl.lockf(f.fileno(), fcntl.LOCK_UN)
 
             try:
-                with open(f'{CTDB_SERVICE_FILE}.{self.pnn}') as f:
+                with open(f'{self.ctdb_service_file}.{self.pnn}') as f:
                     self.node_status = json.load(f)
             except (FileNotFoundError, json.decoder.JSONDecodeError):
                 self.node_status = {}
@@ -151,9 +154,6 @@ class CtdbEvent:
         if not self.init_client():
             return
 
-        if not os.path.exists(CTDB_SERVICE_FILE):
-            return
-
         try:
             self.check_ctdb_shared_volume()
         except Exception as e:
@@ -164,6 +164,9 @@ class CtdbEvent:
             })
 
             raise
+
+        if not os.path.exists(self.ctdb_service_file):
+            return
 
         self.load_service_file()
         for srv in self.cl_services.values():
@@ -280,7 +283,7 @@ class CtdbEvent:
             raise RuntimeError(payload['reason'])
 
         else:
-            with open(f'{CTDB_SERVICE_FILE}.{self.pnn}', 'w') as f:
+            with open(f'{self.ctdb_service_file}.{self.pnn}', 'w') as f:
                 fcntl.lockf(f.fileno(), fcntl.LOCK_EX)
                 try:
                     f.write(json.dumps(self.node_status))


### PR DESCRIPTION
* use python libgfapi bindings to read / write configuration
  files that reside on glusterfs volumes

* shift the cached glusterfs volume handles to a common utils
  class shared between multiple middleware plugins

* remove usage of hard-coded paths under /cluster for clustered
  config and state files

These steps are significant progress toward deprecating the
dedicated ctdb_shared_volume

Original PR: https://github.com/truenas/middleware/pull/11030
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121277