### PR TITLE
NAS-121516 / 23.10 / Fix copy-paste error in glusterfs filesystem doc

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
@@ -245,8 +245,7 @@ class GlusterFilesystemService(Service):
     ))
     def contents(self, data):
         """
-        Remove the glusterfs filesystem object at the specified
-        path relative to the specified parent uuid.
+        Get the contents of a glusterfs filesystem object.
 
         Parameters:
         ----------


### PR DESCRIPTION
The docstring was copy-pasted from unlink function.