### PR TITLE
NAS-121516 / 22.12.3 / Fix copy-paste error in glusterfs filesystem doc (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
@@ -245,8 +245,7 @@ class GlusterFilesystemService(Service):
     ))
     def contents(self, data):
         """
-        Remove the glusterfs filesystem object at the specified
-        path relative to the specified parent uuid.
+        Get the contents of a glusterfs filesystem object.
 
         Parameters:
         ----------


### PR DESCRIPTION
The docstring was copy-pasted from unlink function.

Original PR: https://github.com/truenas/middleware/pull/11113
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121516