### PR TITLE
NAS-121397 / 13.0 / add legacy ARM status information for NVDIMM

### DIFF
--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -14,19 +14,35 @@ class NVDIMMAlertClass(AlertClass):
     products = ('ENTERPRISE',)
 
 
-class NVDIMMLifetimeWarningAlertClass(AlertClass):
+class NVDIMMESLifetimeWarningAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.WARNING
-    title = 'NVDIMM Memory Module Lifetime Is Less Than 20%'
-    text = 'NVDIMM: "%(dev)s" Memory Module Remaining Lifetime is %(value)d%%.'
+    title = 'NVDIMM Energy Source Lifetime Is Less Than 20%'
+    text = 'NVDIMM Energy Source Remaining Lifetime for %(dev)s is %(value)d%%.'
     products = ('ENTERPRISE',)
 
 
-class NVDIMMLifetimeCriticalAlertClass(AlertClass):
+class NVDIMMESLifetimeCriticalAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.CRITICAL
+    title = 'NVDIMM Energy Source Lifetime Is Less Than 10%'
+    text = 'NVDIMM Energy Source Remaining Lifetime for %(dev)s is %(value)d%%.'
+    products = ('ENTERPRISE',)
+
+
+class NVDIMMMemoryModLifetimeWarningAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
+    title = 'NVDIMM Memory Module Lifetime Is Less Than 20%'
+    text = 'NVDIMM Memory Module Remaining Lifetime for %(dev)s is %(value)d%%.'
+    products = ('ENTERPRISE',)
+
+
+class NVDIMMMemoryModLifetimeCriticalAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.CRITICAL
     title = 'NVDIMM Memory Module Lifetime Is Less Than 10%'
-    text = 'NVDIMM: "%(dev)s" Memory Module Remaining Lifetime is %(value)d%%.'
+    text = 'NVDIMM Memory Module Remaining Lifetime for %(dev)s is %(value)d%%.'
     products = ('ENTERPRISE',)
 
 
@@ -92,15 +108,15 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
                     ))
 
         if (val := int(nvdimm['nvm_lifetime'].rstrip('%'))) < 20:
-            alert = NVDIMMLifetimeWarningAlertClass if val > 10 else NVDIMMLifetimeCriticalAlertClass
-            alerts.append(Alert(alert, {'dev': 'NVM Lifetime', 'value': val}))
+            alert = NVDIMMMemoryModLifetimeWarningAlertClass if val > 10 else NVDIMMMemoryModLifetimeCriticalAlertClass
+            alerts.append(Alert(alert, {'dev': dev, 'value': val}))
 
         if nvdimm['index'] == 0 and (val := int(nvdimm['es_lifetime'].rstrip('%'))) < 20:
             # we only check this value for the 0th slot nvdimm since M60 has 2 and the way
             # they're physically cabled, prevents monitoring the 2nd nvdimm's energy source
             # (it always reports -1%)
-            alert = NVDIMMLifetimeWarningAlertClass if val > 10 else NVDIMMLifetimeCriticalAlertClass
-            alerts.append(Alert(alert, {'dev': 'NVM Energy Source', 'value': val}))
+            alert = NVDIMMESLifetimeWarningAlertClass if val > 10 else NVDIMMESLifetimeCriticalAlertClass
+            alerts.append(Alert(alert, {'dev': dev, 'value': val}))
 
         if (run_fw := nvdimm['running_firmware']) is not None:
             if run_fw not in nvdimm['qualified_firmware']:

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -11,7 +11,7 @@ class NVDIMMAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'There Is An Issue With NVDIMM'
     text = 'NVDIMM: "%(dev)s" is reporting "%(value)s" with status "%(status)s".'
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
 
 
 class NVDIMMLifetimeWarningAlertClass(AlertClass):
@@ -19,7 +19,7 @@ class NVDIMMLifetimeWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'NVDIMM Memory Module Lifetime Is Less Than 20%'
     text = 'NVDIMM: "%(dev)s" Memory Module Remaining Lifetime is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
 
 
 class NVDIMMLifetimeCriticalAlertClass(AlertClass):
@@ -27,7 +27,7 @@ class NVDIMMLifetimeCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'NVDIMM Memory Module Lifetime Is Less Than 10%'
     text = 'NVDIMM: "%(dev)s" Memory Module Remaining Lifetime is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
 
 
 class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
@@ -35,7 +35,7 @@ class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Invalid NVDIMM Firmware Version'
     text = f'NVDIMM: "%(dev)s" is running invalid firmware. {WEBUI_SUPPORT_FORM}'
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
     proactive_support = True
 
 
@@ -47,7 +47,7 @@ class NVDIMMRecommendedFirmwareVersionAlertClass(AlertClass):
         'NVDIMM: "%(dev)s" is running firmware version "%(rv)s" which can be upgraded to '
         f'"%(uv)s". {WEBUI_SUPPORT_FORM}'
     )
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
     proactive_support = True
 
 
@@ -56,13 +56,13 @@ class OldBiosVersionAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'Old BIOS Version'
     text = f'This system is running an old BIOS version. {WEBUI_SUPPORT_FORM}'
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
     proactive_support = True
 
 
 class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
     schedule = IntervalSchedule(datetime.timedelta(minutes=5))
-    products = ('SCALE_ENTERPRISE',)
+    products = ('ENTERPRISE',)
 
     def produce_alerts(self, nvdimm, alerts, old_bios):
         persistency_restored = 0x4

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -127,6 +127,12 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
                     {'dev': dev, 'rv': run_fw, 'uv': nvdimm['recommended_firmware']}
                 ))
 
+        if 'NOT_ARMED' in nvdimm['state_flags']:
+            alerts.append(Alert(
+                NVDIMMAlertClass,
+                {'dev': dev, 'value': 'ARM_STATUS', 'status': 'NOT ARMED'}
+            ))
+
         if not old_bios_alert_already_generated and nvdimm['old_bios']:
             alerts.append(Alert(OldBiosVersionAlertClass))
             old_bios_alert_already_generated = True

--- a/src/middlewared/middlewared/plugins/hardware_/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware_/m_series_nvdimm.py
@@ -146,7 +146,7 @@ class MseriesNvdimmService(Service):
     def state_flags(self, nvindex):
         try:
             fl = sysctl.filter(f'dev.nvdimm.{nvindex}.flags')[0].value
-            state_flags = fl.strip('<')[-1].rstrip('>').split(',')
+            state_flags = fl.split('<')[-1].rstrip('>').split(',')
         except Exception:
             state_flags = []
 


### PR DESCRIPTION
A sysctl was added to 13 to allow us to parse the "legacy" nvdimms for arm status information (like we do in SCALE). This keeps core in feature parity with SCALE. While I'm here, this fixes the fact that these alerts would not run on 13 because of a copy and paste error when doing a cherry-pick from SCALE in a previous commit.