### PR TITLE
NAS-121524 / 23.10 / Be sure and wipe cluster config on factory reset

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -168,12 +168,12 @@ class ClusterUtils(Service):
         return files, dirs
 
     @private
-    @job(lock='teardown_cluster', lock_queue_size=1)
-    def teardown_cluster(self, job):
+    @job(lock='wipe_config', lock_queue_size=1)
+    def wipe_config(self, job):
         """
         This can be called on its own after all the gluster volumes
         have been stopped and deleted (including the ctdb shared volume).
-        However, this is called by ctdb.shared.volume.teardown to maintain
+        NOTE: this is called by ctdb.shared.volume.teardown to maintain
         backwards compatbility with TrueCommand.
         """
         files, dirs = self.state_to_be_removed()

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -255,14 +255,18 @@ class ConfigService(Service):
         If `reboot` is true this job will reboot the system after its completed with a delay of 10
         seconds.
         """
-        job.set_progress(0, 'Replacing database file')
+        job.set_progress(5, 'Removing cluster information (if any)')
+        cjob = self.middleware.call_sync('ctdb.shared.volume.teardown', True)
+        cjob.wait_sync()
+
+        job.set_progress(15, 'Replacing database file')
         shutil.copy('/data/factory-v1.db', FREENAS_DATABASE)
 
-        job.set_progress(10, 'Running database upload hooks')
+        job.set_progress(25, 'Running database upload hooks')
         self.middleware.call_hook_sync('config.on_upload', FREENAS_DATABASE)
 
         if self.middleware.call_sync('failover.licensed'):
-            job.set_progress(30, 'Sending database to the other node')
+            job.set_progress(35, 'Sending database to the other node')
             try:
                 self.middleware.call_sync('failover.send_small_file', FREENAS_DATABASE)
 


### PR DESCRIPTION
We need to ensure that we wipe all cluster related configuration files if an end-user chooses to wipe the system to factory defaults.