### PR TITLE
properly validate username field when creating a local user

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, returns, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, returns, Str, LocalUsername
 from middlewared.service import (
     CallError, CRUDService, ValidationErrors, no_auth_required, pass_app, private, filterable, job
 )
@@ -423,7 +423,7 @@ class UserService(CRUDService):
     @accepts(Dict(
         'user_create',
         Int('uid'),
-        Str('username', required=True, max_length=16),
+        LocalUsername('username', required=True),
         Int('group'),
         Bool('group_create', default=False),
         Str('home', default=DEFAULT_HOME_PATH),

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -4,7 +4,7 @@ from mock import Mock
 from middlewared.service import job
 from middlewared.service_exception import ValidationErrors
 from middlewared.schema import (
-    accepts, Bool, Cron, Dict, Dir, File, Float, Int, IPAddr, List, Str, URI, UnixPerm,
+    accepts, Bool, Cron, Dict, Dir, File, Float, Int, IPAddr, List, Str, URI, UnixPerm, LocalUsername
 )
 
 

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -779,6 +779,7 @@ def test__uri_schema(test_value, expected_error):
     ('a$', False),
     ('aaa', False),
     ('aAA', False),
+    ('Aaa', False),
 ])
 def test__localusername_schema(value, expected_to_fail):
     @accepts(LocalUsername('username', required=True))

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -768,3 +768,26 @@ def test__uri_schema(test_value, expected_error):
         assert ei.value.errors[0].errmsg == 'Not a valid URI'
     else:
         assert strv(self, test_value) == test_value
+
+
+@pytest.mark.parametrize('value,expected_to_fail', [
+    ('', True),
+    (f'{"a" * 33}', True),
+    (' bad', True),
+    ('a$a', True),
+    ('a!', True),
+    ('a$', False),
+    ('aaa', False),
+    ('aAA', False),
+])
+def test__localusername_schema(value, expected_to_fail):
+    @accepts(LocalUsername('username', required=True))
+    def user(self, data):
+        return data
+
+    self = Mock()
+    if expected_to_fail:
+        with pytest.raises(ValidationErrors):
+            user(self, value)
+    else:
+        assert user(self, value) == value

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -208,7 +208,7 @@ class LocalUsername(Attribute):
         if val_len <= 0:
             raise Error(self.name, 'Username must be at least 1 character in length')
         elif val_len > 32:
-            raise Error(self.name, 'Username cannot exceed 32 chars in length')
+            raise Error(self.name, 'Username cannot exceed 32 characters in length')
         elif val[0] not in valid_start:
             raise Error(self.name, 'Username must start with a lower-case letter or an underscore')
         elif '$' in val and val[-1] != '$':

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -201,6 +201,9 @@ class LocalUsername(Attribute):
 
     def validate(self, value):
         # see man 8 useradd, specifically the CAVEATS section
+        # NOTE: we are ignoring the man page's recommendation for insistence
+        # upon the starting character of a username be a lower-case letter.
+        # We aren't enforcing this for maximum backwards compatibility
         val = str(value)
         val_len = len(val)
         valid_chars = string.ascii_letters + string.digits + '_' + '-' + '$'
@@ -210,7 +213,7 @@ class LocalUsername(Attribute):
         elif val_len > 32:
             raise Error(self.name, 'Username cannot exceed 32 characters in length')
         elif val[0] not in valid_start:
-            raise Error(self.name, 'Username must start with a lower-case letter or an underscore')
+            raise Error(self.name, 'Username must start with a letter or an underscore')
         elif '$' in val and val[-1] != '$':
             raise Error(self.name, 'Username must end with a dollar sign character')
         elif any((char not in valid_chars for char in val)):


### PR DESCRIPTION
WebUI is exclusively doing validation on the username field (with exception of the length). The validation there is out of date and incorrect on SCALE (still makes references to NIS, for example). This adds a new schema class specifically for validating local usernames based on Debian recommendations.