### PR TITLE
NAS-121541 / 22.12.3 / properly validate username field when creating a local user (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Patch, returns, Str
+from middlewared.schema import accepts, Any, Bool, Dict, Int, List, Patch, returns, Str, LocalUsername
 from middlewared.service import (
     CallError, CRUDService, ValidationErrors, item_method, no_auth_required, pass_app, private, filterable, job
 )
@@ -412,7 +412,7 @@ class UserService(CRUDService):
     @accepts(Dict(
         'user_create',
         Int('uid'),
-        Str('username', required=True, max_length=16),
+        LocalUsername('username', required=True),
         Int('group'),
         Bool('group_create', default=False),
         Str('home', default=DEFAULT_HOME_PATH),

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import json
+import string
 import textwrap
 import warnings
 from collections import defaultdict
@@ -192,6 +193,33 @@ class Attribute(object):
         cp = copy.deepcopy(self)
         cp.register = False
         return cp
+
+
+class LocalUsername(Attribute):
+    def to_json_schema(self, parent=None):
+        return {**self._to_json_schema_common(parent), 'type': 'string'}
+
+    def validate(self, value):
+        # see man 8 useradd, specifically the CAVEATS section
+        # NOTE: we are ignoring the man page's recommendation for insistence
+        # upon the starting character of a username be a lower-case letter.
+        # We aren't enforcing this for maximum backwards compatibility
+        val = str(value)
+        val_len = len(val)
+        valid_chars = string.ascii_letters + string.digits + '_' + '-' + '$'
+        valid_start = string.ascii_letters + '_'
+        if val_len <= 0:
+            raise Error(self.name, 'Username must be at least 1 character in length')
+        elif val_len > 32:
+            raise Error(self.name, 'Username cannot exceed 32 characters in length')
+        elif val[0] not in valid_start:
+            raise Error(self.name, 'Username must start with a letter or an underscore')
+        elif '$' in val and val[-1] != '$':
+            raise Error(self.name, 'Username must end with a dollar sign character')
+        elif any((char not in valid_chars for char in val)):
+            raise Error(self.name, f'Valid characters for a username are: {", ".join(valid_chars)!r}')
+
+        return super().validate(val)
 
 
 class Any(Attribute):


### PR DESCRIPTION
WebUI is exclusively doing validation on the username field (with exception of the length). The validation there is out of date and incorrect on SCALE (still makes references to NIS, for example). This adds a new schema class specifically for validating local usernames based on Debian recommendations.

Original PR: https://github.com/truenas/middleware/pull/11119
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121541