### PR TITLE
NAS-121508 / 23.10 / catch Exception class getting libsgio.rotation_rate()

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -221,7 +221,7 @@ class DeviceService(Service):
         try:
             disk = libsgio.SCSIDevice(device_path)
             rotation_rate = disk.rotation_rate()
-        except (OSError, RuntimeError):
+        except Exception:
             if device_path not in self.DISK_ROTATION_ERROR_LOG_CACHE:
                 self.DISK_ROTATION_ERROR_LOG_CACHE.add(device_path)
                 self.logger.error('Ioctl failed while retrieving rotational rate for disk %s', device_path)


### PR DESCRIPTION
I fixed an off-by-one error (and a few other issues) in `libsgio` module. Part of fixing this was raising a proper custom exception. Because of this (we have users that have esoteric hardware (I'm looking at you qnap branded hard drives)), some of our users are missing hard-drives on upgrade from 22.12.1 to 22.12.2. Just catch all exceptions when trying to get rotation rate of a drive. It's not even remotely "critical" information that is necessary for the system to function.