### PR TITLE
NAS-121428 / 22.12.3 / Wipe disk which is getting replaced (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -73,6 +73,7 @@ class PoolService(Service):
                             min_size = min(min_size, size)
 
         swap_disks = [disk['devname']]
+        from_disk = None
         if found[1] and await self.middleware.run_in_thread(os.path.exists, found[1]['path']):
             if from_disk := await self.middleware.call('disk.label_to_disk', found[1]['path'].replace('/dev/', '')):
                 # If the disk we are replacing is still available, remove it from swap as well
@@ -93,6 +94,11 @@ class PoolService(Service):
             job.set_progress(30, 'Replacing disk')
             new_devname = vdev[0].replace('/dev/', '')
             await self.middleware.call('zfs.pool.replace', pool['name'], options['label'], new_devname)
+        except Exception:
+            raise
+        else:
+            if from_disk:
+                await self.middleware.call('disk.wipe', from_disk, 'QUICK')
         finally:
             # Needs to happen even if replace failed to put back disk that had been
             # removed from swap prior to replacement


### PR DESCRIPTION
## Problem

When a disk is replaced we are not wiping it's contents which results in swap partitions still being left there and zpool metadata as well.

## Solution

Once replacing disk is complete we wipe out previous disk which was being used in the pool to ensure no metadata is present on it and partitions are wiped as well.

Original PR: https://github.com/truenas/middleware/pull/11131
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121428