### PR TITLE
NAS-121594 / 23.10 / fix unhandled exception in vrrp_backup

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -733,7 +733,12 @@ class FailoverEventsService(Service):
         # do something with iscsi service here
 
         logger.info('Syncing encryption keys from MASTER node (if any)')
-        self.run_call('failover.call_remote', 'failover.sync_keys_to_remote_node')
+        try:
+            self.run_call('failover.call_remote', 'failover.sync_keys_to_remote_node')
+        except Exception as e:
+            ignore = (errno.ECONNRESET, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
+            if isinstance(e, CallError) and e.errno not in ignore:
+                logger.warning('Unhandled exception syncing keys from MASTER node', exc_info=True)
 
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'


### PR DESCRIPTION
Again, investigating an unrelated issue and noticed this in the logs on the system I'm investigating. Don't crash right here at the end. This failure scenario is present when an HA system is installed and 1 controller is powered off/removed from the head-unit while the end-user is configuring the A controller for the first time. Initial failover event that is received is BACKUP event, subsequently followed by a MASTER event.