### PR TITLE
NAS-121598 / 13.0 / fix edge-case crash

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -1,6 +1,7 @@
 import os
 import time
 import re
+import shlex
 from datetime import datetime, timedelta
 
 from middlewared.schema import accepts, Str
@@ -175,7 +176,7 @@ class DiskService(Service, ServiceChangeMixin):
 
             found_ident = next(disk_xml.iterfind(f'.//config[ident="{_ident}"]/../../name'), None)
             if found_ident is not None:
-                found_lunid = next(disk_xml.iterfind(f'.//config[lunid="{_lunid}"]/../../name'), None)
+                found_lunid = next(disk_xml.iterfind(f'.//config[lunid={shlex.quote(_lunid)}]/../../name'), None)
                 if found_lunid is not None:
                     # means the identifier and lunid given to us
                     # matches a disk on the system so just return


### PR DESCRIPTION
Seen in the wild, a certain manufacturer is returning double-quotes in the information returned from the disk. This breaks the xml iteration. Use shlex.quote to resolve this.