### PR TITLE
NAS-121633 / 23.10 / don't generate ctdb unless glusterd is enabled

### DIFF
--- a/src/middlewared/middlewared/etc_files/ctdb.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb.conf.mako
@@ -3,6 +3,11 @@
     from middlewared.plugins.cluster_linux.utils import CTDBConfig
     from pathlib import Path
 
+    filters = ['srv_service', '=', 'glusterd']
+    opts = {'get': True}
+    if not middleware.call_sync('datastore.query', 'services.services', filters, opts)['srv_enable']:
+        raise FileShouldNotExist()
+
     r_file = CTDBConfig.REC_FILE.value
     p_dir = CTDBConfig.PER_DB_DIR.value
     s_dir = CTDBConfig.STA_DB_DIR.value


### PR DESCRIPTION
ctdb api endpoints makes the assumption that the glusterd service is started. ctdb.conf needs to be gated on whether or not glusterd is enabled.