### PR TITLE
NAS-121659 / 23.10 / fix xseries B slot identification on SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -71,7 +71,8 @@ class EnclosureDetectionService(Service):
                         if ses_addr == sas_addr:
                             NODE = 'A'
                             break
-                    elif (reg := re.search(HA_HARDWARE.XSERIES_NODEB.value, info)) is not None:
+
+                    if (reg := re.search(HA_HARDWARE.XSERIES_NODEB.value, info)) is not None:
                         ses_addr = hex(int(reg.group(1), 16) - 1)
                         if ses_addr == sas_addr:
                             NODE = 'B'


### PR DESCRIPTION
This cannot be an `elif` branch because we depend on the HBA for determining the slot position on the x-series platform. Without this change, the first `if` branch is true on BOTH controllers but the controller in the physical A slot will only ever properly detect its own position in the head-unit.