### PR TITLE
NAS-121667 / 23.10 / remove __getstate__ for py3.11 compat

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -151,7 +151,7 @@ class InterfaceService(Service):
         # If we have bridge/vlan/lagg not in the database at all
         # it gets destroy, otherwise just bring it down.
         if (name not in cloned_interfaces and
-                self.middleware.call_sync('interface.type', iface.__getstate__()) in [
+                self.middleware.call_sync('interface.type', iface.asdict()) in [
                     InterfaceType.BRIDGE, InterfaceType.LINK_AGGREGATION, InterfaceType.VLAN,
                 ]):
             netif.destroy_interface(name)

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/types.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/types.py
@@ -55,7 +55,7 @@ class LinkAddress(object):
     def __str__(self):
         return self.address
 
-    def __getstate__(self):
+    def asdict(self):
         return {
             'ifname': self.ifname,
             'address': self.address
@@ -100,7 +100,7 @@ class InterfaceAddress(object):
     def __hash__(self):
         return hash((self.af, self.address, self.netmask, self.broadcast, self.dest_address))
 
-    def __getstate__(self, stats=False):
+    def asdict(self, stats=False):
         ret = {
             'type': self.af.name,
             'address': self.address.address if type(self.address) is LinkAddress else str(self.address)

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -91,7 +91,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
     def tx_queues(self):
         return self._txq
 
-    def __getstate__(self, address_stats=False, vrrp_config=None):
+    def asdict(self, address_stats=False, vrrp_config=None):
         state = {
             'name': self.name,
             'orig_name': self.orig_name,
@@ -109,7 +109,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             'supported_media': [],
             'media_options': None,
             'link_address': self.link_address or '',
-            'aliases': [i.__getstate__(stats=address_stats) for i in self.addresses],
+            'aliases': [i.asdict(stats=address_stats) for i in self.addresses],
             'vrrp_config': vrrp_config,
             'rx_queues': self.rx_queues,
             'tx_queues': self.tx_queues,

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/routing.py
@@ -34,7 +34,7 @@ class Route:
         self.scope = scope
         self.preferred_source = preferred_source
 
-    def __getstate__(self):
+    def asdict(self):
         return {
             'network': str(self.network),
             'netmask': str(self.netmask),
@@ -100,11 +100,11 @@ class RouteTable:
     def __eq__(self, other):
         return self.table_id == other.table_id
 
-    def __getstate__(self):
+    def asdict(self):
         return {
             "id": self.table_id,
             "name": self.table_name,
-            "routes": [r.__getstate__() for r in self.routes],
+            "routes": [r.asdict() for r in self.routes],
         }
 
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -190,7 +190,7 @@ class InterfaceService(CRUDService):
                 vrrp_config = self.middleware.call_sync('interfaces.vrrp_config', name)
                 iface_extend_kwargs.update(dict(vrrp_config=vrrp_config))
             try:
-                data[name] = self.iface_extend(iface.__getstate__(**iface_extend_kwargs), configs, ha_hardware)
+                data[name] = self.iface_extend(iface.asdict(**iface_extend_kwargs), configs, ha_hardware)
             except OSError:
                 self.logger.warn('Failed to get interface state for %s', name, exc_info=True)
         for name, config in filter(lambda x: x[0] not in data, configs.items()):
@@ -1827,7 +1827,7 @@ class InterfaceService(CRUDService):
             try:
                 if iface.orig_name.startswith(ignore_nics):
                     continue
-                aliases_list = iface.__getstate__()['aliases']
+                aliases_list = iface.asdict()['aliases']
             except FileNotFoundError:
                 # This happens on freebsd where we have a race condition when the interface
                 # might no longer possibly exist when we try to retrieve data from it

--- a/src/middlewared/middlewared/plugins/network_/route.py
+++ b/src/middlewared/middlewared/plugins/network_/route.py
@@ -38,7 +38,7 @@ class RouteService(Service):
         Get current/applied network routes.
         """
         rtable = netif.RoutingTable()
-        return filter_list([r.__getstate__() for r in rtable.routes], filters, options)
+        return filter_list([r.asdict() for r in rtable.routes], filters, options)
 
     @private
     async def configured_default_ipv4_route(self):
@@ -109,7 +109,7 @@ class RouteService(Service):
                     #       gateway manually (even though dhclient will
                     #       do this for us) it will fail expectedly here.
                     # Either way, let's log the error.
-                    gw = ipv4_gateway.__getstate__()['gateway']
+                    gw = ipv4_gateway.asdict()['gateway']
                     self.logger.error('Failed adding %s as default gateway: %r', gw, e)
             elif ipv4_gateway != routing_table.default_route_ipv4:
                 _from = routing_table.default_route_ipv4.gateway

--- a/src/middlewared/middlewared/plugins/network_/static_routes.py
+++ b/src/middlewared/middlewared/plugins/network_/static_routes.py
@@ -98,14 +98,14 @@ class StaticRouteService(CRUDService):
                 continue
 
             if route not in [default_route_ipv4, default_route_ipv6] and route.gateway is not None:
-                self.logger.debug('Removing route %r', route.__getstate__())
+                self.logger.debug('Removing route %r', route.asdict())
                 try:
                     rt.delete(route)
                 except Exception as e:
                     self.logger.warning('Failed to remove route: %r', e)
 
         for route in new_routes:
-            self.logger.debug('Adding route %r', route.__getstate__())
+            self.logger.debug('Adding route %r', route.asdict())
             try:
                 rt.add(route)
             except Exception as e:

--- a/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/rrd_utils.py
@@ -92,7 +92,7 @@ class RRDBase(object, metaclass=RRDMeta):
     def get_rrd_types(self, identifier):
         return self.rrd_types
 
-    def __getstate__(self):
+    def asdict(self):
         return {
             'name': self.name,
             'title': self.get_title(),

--- a/src/middlewared/middlewared/plugins/reporting/update.py
+++ b/src/middlewared/middlewared/plugins/reporting/update.py
@@ -159,7 +159,7 @@ class ReportingService(ConfigService):
     ))
     def graphs(self, filters, options):
         return filter_list([
-            i.__getstate__() for i in self.__rrds.values() if i.has_data()
+            i.asdict() for i in self.__rrds.values() if i.has_data()
         ], filters, options)
 
     def __rquery_to_start_end(self, query):


### PR DESCRIPTION
Unfortunately, in python3.11-BETA.1 (https://docs.python.org/3.11/whatsnew/changelog.html search for bpo-26579), they introduced a dunder method called getstate for certain built-in objects. This means all the classes that we implemented with a getstate dunder method now collide with the changes introduced in 3.11.

To resolve this, I have renamed those methods to `asdict`. This is a common pattern followed by popular 3rd party python modules and is even implemented by the `dataclasses.dataclass` built-in.