### PR TITLE
NAS-121622 / 23.10 / remove rpc-statd as a systemd extra unit for nfs

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -22,9 +22,6 @@ class NFSService(SimpleService):
                 errno.EINVAL
             )
 
-    async def systemd_extra_units(self):
-        return ["rpc-statd"]
-
     async def after_start(self):
         await self._systemd_unit("rpc-statd", "start")
 


### PR DESCRIPTION
rpc-statd is now marked as a "static" service type. This means it cannot be enabled or disabled manually (since a static service doesn't have an Install section so systemd doesn't know where to put the symlink). For now, remove it from `systemd_extra_units` so we can at least generated rc for systemd on Cobia.