### PR TITLE
NAS-121671 / 23.10 / Use common-account for middleware pam file

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/middleware.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/middleware.mako
@@ -13,6 +13,6 @@
 ${'\n'.join(dsp['primary'])}
 @include common-auth-unix
 %endif
-account	required	pam_deny.so
+@include common-account
 password	required	pam_deny.so
 session	required	pam_deny.so


### PR DESCRIPTION
pam.authenticate will still be gated based on details of common-auth.