### PR TITLE
NAS-121677 / 23.10 / fix async_validators.py:resolve_hostnames()

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -87,9 +87,8 @@ async def resolve_hostname(middleware, verrors, name, hostname):
             return False
 
     try:
-        result = await asyncio.wait_for(middleware.create_task(
-            middleware.run_in_thread(resolve_host_name_thread, hostname)
-        ), 5, loop=asyncio.get_event_loop())
+        aw = middleware.create_task(middleware.run_in_thread(resolve_host_name_thread, hostname))
+        result = await asyncio.wait_for(aw, timeout=5)
     except asyncio.futures.TimeoutError:
         result = False
 


### PR DESCRIPTION
Python 3.10 removed the loop kwarg to asyncio.wait_for so by upgrading to python3.11, this raises an error. To my pleasant surprise, this is the only place that I could find where we passed a loop kwarg to asyncio.wait_for.