### PR TITLE
NAS-121446 / 23.10 / Fix vm restart on dataset unlock

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -65,7 +65,7 @@ class PoolDatasetService(Service):
                         (mountpoint := dataset_mountpoint(dataset)) and
                         path.startswith(mountpoint + '/')
                     ) or
-                    (dataset['type'] == 'VOLUME' and path.startswith(zvol_name_to_path(dataset['name']) + '/'))
+                    (dataset['type'] == 'VOLUME' and zvol_name_to_path(dataset['name']) == path)
                 ):
                     result.append(vm)
                     break


### PR DESCRIPTION
## Problem

On dataset unlock we were considering/treating zvol associated with a VM as a directory whereas that's not true and the condition will fail resulting in the associated VM to not start.

## Solution

The path can be directly asserted by converting zvol to it's path and getting the path saved in VM device and if it matches we would want to restart the VM in that case.