### PR TITLE
NAS-121702 / 23.10 / Fix install-dev-tools

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -9,6 +9,8 @@ PACKAGES=(
     python3-babel
     # Integration and unit test utils, python package management
     python3-pip
+    python3-pyfakefs
+    python3-pyotp
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-dependency
@@ -24,11 +26,9 @@ PACKAGES=(
 PIP_PACKAGES=(
     asyncmock
     asynctest
-    pyfakefs
-    pyotp
 )
 
 chmod +x /usr/bin/apt*
 apt update
 apt install -y "${PACKAGES[@]}"
-pip install "${PIP_PACKAGES[@]}"
+pip install --break-system-packages "${PIP_PACKAGES[@]}"


### PR DESCRIPTION
## Problem

With python3.11 pip does not allow installing packages and errors out saying the packages are managed externally by the debian environment i.e
```
error: externally-managed-environment

× This environment is externally managed
```

## Solution

List of pip packages has been refined to bring in packages with apt which are available in debian repositories and pip is provided with a force flag which will still force install those packages which we are not able to find with apt.