### PR TITLE
NAS-121561 / 23.10 / Reflect maintainers attribute in schema

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -28,6 +28,7 @@ class AppService(Service):
         Bool('healthy', required=True),
         Bool('installed', required=True),
         List('categories', required=True),
+        List('maintainers', required=True),
         Str('name', required=True),
         Str('title', required=True),
         Str('description', required=True),

--- a/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/item_version.py
@@ -26,6 +26,7 @@ class CatalogService(Service):
         'item_details',
         Str('name', required=True),
         List('categories', items=[Str('category')], required=True),
+        List('maintainers', required=True),
         Str('app_readme', null=True, required=True),
         Str('location', required=True),
         Bool('healthy', required=True),

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -57,6 +57,7 @@ class CatalogService(Service):
                     'recommended': False,
                     'title': 'Chia',
                     'description': 'App description here',
+                    'maintainers': [],
                 }
             }
         }


### PR DESCRIPTION
## Context

It was requested by UI team that middleware should provide `maintainers` attribute which UI can present in the new Apps UI design. Changes have been added in `truenas/catalog_validation` and here we update schema to reflect the new attribute.