### PR TITLE
Fix json schema for app/infra migration of kubernetes

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
@@ -16,7 +16,7 @@ MIGRATION_MANIFEST_SCHEMA = {
     'patternProperties': {
         '.*': {
             'type': 'array',
-            'items': [{'type': 'string'}],
+            'items': {'type': 'string'},
         },
     },
 }

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/infra_migrations.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/infra_migrations.py
@@ -13,7 +13,7 @@ MIGRATION_MANIFEST_SCHEMA = {
     'properties': {
         'migrations': {
             'type': 'array',
-            'items': [{'type': 'string'}],
+            'items': {'type': 'string'},
         },
     },
     'required': [


### PR DESCRIPTION
## Problem

Json schema validation was failing when we updated to bookworm with the problem being invalid newer json schema being specified for validation.

## Solution

For `array` type objects when `items` is specified as a list it is expected that each item in the value which is to be validated will be mapped with each entry specified in `items` list. If the values are more in either list validation fails..in our case we want all the items to be of type `string` and in that case `items` should not be a list but rather the type we want all of the items to be enforced in the actual value of list.