### PR TITLE
NAS-121727 / 23.10 / Skip iSCSI CHAP tests for invalid initiatorname values

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -16,7 +16,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import dev_test, hostname, ip, isns_ip, pool_name
 from functions import DELETE, GET, POST, PUT, SSH_TEST
-from protocols import iscsi_scsi_connection, isns_connection
+from protocols import (initiator_name_supported, iscsi_scsi_connection,
+                       isns_connection)
 
 from assets.REST.pool import dataset
 from assets.REST.snapshot import snapshot, snapshot_rollback
@@ -27,6 +28,9 @@ MB_512=512*MB
 
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
+
+skip_invalid_initiatorname = pytest.mark.skipif(not initiator_name_supported(),
+                                                reason="Invalid initiatorname will be presented")
 
 digit = ''.join(random.choices(string.digits, k=2))
 
@@ -543,6 +547,8 @@ def test_04_readwrite16_zvol_extent(request):
         iqn = f'{basename}:{target_name}'
         target_test_readwrite16(ip, iqn)
 
+
+@skip_invalid_initiatorname
 def test_05_chap(request):
     """
     This tests that CHAP auth operates as expected.
@@ -581,6 +587,8 @@ def test_05_chap(request):
                                 with iscsi_scsi_connection(ip, iqn, 0, user, secret) as s:
                                     _verify_inquiry(s)
 
+
+@skip_invalid_initiatorname
 def test_06_mutual_chap(request):
     """
     This tests that Mutual CHAP auth operates as expected.

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -2,11 +2,12 @@ import contextlib
 
 from functions import DELETE, POST
 
-from .iscsi_proto import iscsi_scsi_connect, iscsi_scsi_connection
+from .iscsi_proto import (initiator_name_supported, iscsi_scsi_connect,
+                          iscsi_scsi_connection)
 from .iSNSP.client import iSNSPClient
+from .ms_rpc import MS_RPC
 from .nfs_proto import SSH_NFS
 from .smb_proto import SMB
-from .ms_rpc import MS_RPC
 
 
 @contextlib.contextmanager

--- a/tests/protocols/iscsi_proto.py
+++ b/tests/protocols/iscsi_proto.py
@@ -1,7 +1,19 @@
-import contextlib                                                                                                                                               
+import contextlib
+import inspect
+
 import pyscsi
-from pyscsi.utils import init_device
 from pyscsi.pyscsi.scsi import SCSI
+from pyscsi.utils import init_device
+
+
+def initiator_name_supported():
+    """
+    Returns whether a non-None initiator name may be supplied.
+
+    This can have an impact on what kinds of tests can be run.
+    """
+    return 'initiator_name' in inspect.signature(init_device).parameters
+
 
 def iscsi_scsi_connect(host, iqn, lun=0, user=None, secret=None, target_user=None, target_secret=None):
     """


### PR DESCRIPTION
Currently `python-scsi` presents an **illegal** initiator name when CHAP is in use.  In bookworm `SCST` responds very badly to these illegal values, so skip these tests for now.

FWIW, plan to address two related aspects separately (and in this order):

1. Modify test-runner environment to use a more modern `python-scsi` that does not present an illegal initiator name
2. Robustize `SCST` to reject illegal initiator names.