### PR TITLE
NAS-121728 / 23.10 / Switch from python 3.9 to 3.11

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Deploy
         run: |
           cd src/middlewared ; make reinstall_container
-          cp -a /__w/middleware/middleware/src/middlewared/middlewared/pytest /usr/local/lib/python3.9/dist-packages/middlewared/
+          cp -a /__w/middleware/middleware/src/middlewared/middlewared/pytest /usr/local/lib/python3.11/dist-packages/middlewared/
                
       - name: Test
         run:
-          pytest-3 -v --disable-pytest-warnings /usr/local/lib/python3.9/dist-packages/middlewared/pytest
+          pytest-3 -v --disable-pytest-warnings /usr/local/lib/python3.11/dist-packages/middlewared/pytest

--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -1,5 +1,5 @@
 export MWPATH1=/usr/lib/python3/dist-packages/middlewared
-export MWPATH2=/usr/local/lib/python3.9/dist-packages/middlewared
+export MWPATH2=/usr/local/lib/python3.11/dist-packages/middlewared
 export BUILD=$(shell pwd)/build
 
 stop_service:


### PR DESCRIPTION
Previously bookworm based CI builds were failing in the `Deploy` phase.

With the updated python paths in this PR, it now fails in the `Test` phase ... so _slight_ progress.


FWIW, the failure is now, e.g.
```
_______________ ERROR collecting unit/plugins/test_datastore.py ________________
/usr/local/lib/python3.11/dist-packages/middlewared/pytest/unit/plugins/test_datastore.py:[19](https://github.com/truenas/middleware/actions/runs/4825763722/jobs/8596936868?pr=11171#step:5:20): in <module>
    from middlewared.pytest.unit.middleware import Middleware
/usr/local/lib/python3.11/dist-packages/middlewared/pytest/unit/middleware.py:4: in <module>
    from asynctest import CoroutineMock, Mock
/usr/local/lib/python3.11/dist-packages/asynctest/__init__.py:[22](https://github.com/truenas/middleware/actions/runs/4825763722/jobs/8596936868?pr=11171#step:5:23): in <module>
    from .case import *
/usr/local/lib/python3.11/dist-packages/asynctest/case.py:54: in <module>
    import asynctest.selector
/usr/local/lib/python3.11/dist-packages/asynctest/selector.py:29: in <module>
    from . import mock
/usr/local/lib/python3.11/dist-packages/asynctest/mock.py:4[28](https://github.com/truenas/middleware/actions/runs/4825763722/jobs/8596936868?pr=11171#step:5:29): in <module>
    class _AwaitEvent:
/usr/local/lib/python3.11/dist-packages/asynctest/mock.py:433: in _AwaitEvent
    @asyncio.coroutine
E   AttributeError: module 'asyncio' has no attribute 'coroutine'
```

Reading https://docs.python.org/3.8/library/asyncio-task.html#asyncio.coroutine

> Deprecated since version 3.8, will be removed in version 3.10: Use [async def](https://docs.python.org/3.8/reference/compound_stmts.html#async-def) instead.

Hmm. https://asynctest.readthedocs.io/en/latest/ => https://github.com/Martiusweb/asynctest which hasn't been updated in several years, and still [contains](https://github.com/Martiusweb/asynctest/blob/master/asynctest/mock.py) e.g

```
    @asyncio.coroutine
    def wait(self, skip=0):
        """
        Wait for await.
        :param skip: How many awaits will be skipped.
                     As a result, the mock should be awaited at least
                     ``skip + 1`` times.
        """
        def predicate(mock):
            return mock.await_count > skip

        return (yield from self.wait_for(predicate))
```

