### PR TITLE
NAS-121558 / 22.12.3 / Fix kubernetes logs assertion error (by Qubad786)

### DIFF
--- a/tests/api2/test_027_kubernetes_logs.py
+++ b/tests/api2/test_027_kubernetes_logs.py
@@ -59,7 +59,7 @@ def test_get_chart_release_logs(request):
 def test_get_chart_exec_result(request):
     depends(request, ['setup_kubernetes'], scope='session')
     release_name = 'test-exec'
-    with official_chart_release('qbittorrent', release_name) as chart_release:
+    with official_chart_release('nginx-proxy-manager', release_name) as chart_release:
         with get_chart_release_pods(release_name, 300) as pods:
             for pod_name, containers in pods.items():
                 for container in containers:


### PR DESCRIPTION
## Problem

`qbittorrent` application has been changed as to how it functions and it now has init container which exits and we don't have logs to follow/assert.

## Solution

Use a different application which solves this problem and has logs streaming which we can test/assert.

Original PR: https://github.com/truenas/middleware/pull/11156
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121558