### PR TITLE
NAS-121740 / 23.10 / Add changes to allow renaming catalogs for installed apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
@@ -113,7 +113,7 @@ class KubernetesAppMigrationsService(Service):
             elif migration['action'] == 'rename_catalog':
                 for update_app in filter(lambda app: app['catalog'] == migration['old_catalog'], chart_releases):
                     try:
-                        await self.move_app_to_different_catalog(update_app, migration['new_catalog'])
+                        await self.move_app_to_different_catalog(update_app['name'], migration['new_catalog'])
                     except Exception:
                         self.logger.error(
                             'Failed to migrate %r application to %r catalog',

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations.py
@@ -121,6 +121,17 @@ class KubernetesAppMigrationsService(Service):
             }
         })
 
+    async def move_app_to_different_catalog(self, app_name, new_catalog_name):
+        await self.middleware.call('k8s.namespace.update', get_namespace(app_name), {
+            'body': {
+                'metadata': {
+                    'labels': {
+                        'catalog': new_catalog_name,
+                    },
+                }
+            }
+        })
+
     def load_migrations(self, catalog):
         migrations = self.official_migrations() if catalog['label'] == OFFICIAL_LABEL else {}
         migrations_path = os.path.join(catalog['location'], '.migrations')


### PR DESCRIPTION
This PR adds changes to allow changing catalog name for existing apps. So for example if we want to rename the official catalog, we need to make that happen in 2 places i.e available apps and installed apps, for available ones we would be updating the database and for installed we would be writing a migration which would make this work.