### PR TITLE
NAS-121689 / 23.10 / Properly reflect add nvidia runtime class variable

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -9,11 +9,12 @@ except ImportError:
 from middlewared.schema import Cron, Dict, Int, List, Str
 from middlewared.service import private, Service
 from .schema import get_list_item_from_value
-from .utils import get_network_attachment_definition_name, RESERVED_NAMES
+from .utils import CONTEXT_KEY_NAME, get_network_attachment_definition_name, RESERVED_NAMES
 
 REF_MAPPING = {
     'definitions/certificate': 'certificate',
     'definitions/certificateAuthority': 'certificate_authorities',
+    'definitions/gpuConfiguration': 'gpu_configuration',
     'normalize/interfaceConfiguration': 'interface_configuration',
     'normalize/acl': 'acl',
     'normalize/ixVolume': 'ix_volume',
@@ -66,6 +67,16 @@ class ChartReleaseService(Service):
                 f'chart.release.normalize_{REF_MAPPING[ref]}', question_attr, value, complete_config, context
             )
 
+        return value
+
+    @private
+    async def normalize_gpu_configuration(self, attr, value, complete_config, context):
+        assert isinstance(attr, Dict) is True
+        nvidia_attr = {'addNvidiaRuntimeClass': bool(value.get('nvidia.com/gpu'))}
+        try:
+            complete_config[CONTEXT_KEY_NAME].update(nvidia_attr)
+        except KeyError:
+            complete_config[CONTEXT_KEY_NAME] = nvidia_attr
         return value
 
     @private

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -31,7 +31,7 @@ class Resources(enum.Enum):
 
 def get_action_context(release_name):
     return copy.deepcopy({
-        'addNvidiaRuntimeClass': True,
+        'addNvidiaRuntimeClass': False,
         'nvidiaRuntimeClassName': NVIDIA_RUNTIME_CLASS_NAME,
         'operation': None,
         'isInstall': False,
@@ -43,10 +43,13 @@ def get_action_context(release_name):
 
 
 async def add_context_to_configuration(config, context_dict, middleware, release_name):
-    context_dict[CONTEXT_KEY_NAME]['kubernetes_config'] = {
-        k: v for k, v in (await middleware.call('kubernetes.config')).items()
-        if k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
-    }
+    context_dict[CONTEXT_KEY_NAME].update({
+        'kubernetes_config': {
+            k: v for k, v in (await middleware.call('kubernetes.config')).items()
+            if k in ('cluster_cidr', 'service_cidr', 'cluster_dns_ip')
+        },
+        'addNvidiaRuntimeClass': config.get(CONTEXT_KEY_NAME, {}).get('addNvidiaRuntimeClass', False),
+    })
     if 'global' in config:
         config['global'].update(context_dict)
         config.update(context_dict)


### PR DESCRIPTION
## Problem

There were 2 problems with 1 problem being a side-effect of another one..root problem was:

We have an attribute which reflects if nvidia runtime class should be added or not but it was always set which indicated that app developer should always add nvidia runtime even when nvidia gpu was not available.
This problem was being reflected in one of the integration tests we have where the helm chart was updated to reflect the value middleware provides to the app dev if he should add the runtime class or not:
```
Error creating: pods "prune-test1-ix-chart-6c6f674cbb-" is forbidden: pod rejected: RuntimeClass "nvidia" not found
```

## Solution

Fixing the root problem will solve the integration test problem automatically. Now we correctly determine if nvidia runtime class should be added by the app developer or not by seeing if user has actually specified a nvidia gpu to be consumed.