### PR TITLE
Fix restarting vm integration test

### DIFF
--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -26,7 +26,7 @@ def test_restart_vm_on_dataset_unlock(zvol):
         call("pool.dataset.lock", ds, job=True)
 
         if zvol:
-            device = {"dtype": "DISK", "attributes": {"path": f"/dev/zvol/{ds}/child"}}
+            device = {"dtype": "DISK", "attributes": {"path": f"/dev/zvol/{ds}"}}
         else:
             device = {"dtype": "RAW", "attributes": {"path": f"/mnt/{ds}/child"}}
 


### PR DESCRIPTION
## Problem

In the scenario when dataset is `zvol` we are to consume that directly as it cannot further have children and integration test fails.

## Solution

Consume the `zvol` directly instead of specifying a child for that zvol.