### PR TITLE
NAS-121745 / 23.10 / Fix timezone integration test

### DIFF
--- a/src/middlewared/middlewared/plugins/system_general/timezone.py
+++ b/src/middlewared/middlewared/plugins/system_general/timezone.py
@@ -34,6 +34,5 @@ class SystemGeneralService(Service):
                     zone_name = f'{relpath}/{timezone}'
                 else:
                     zone_name = timezone
-                if 'Etc/GMT' not in zone_name:
-                    timezones[zone_name] = zone_name
+                timezones[zone_name] = zone_name
         return timezones


### PR DESCRIPTION
## Problem

Integration test for timezones was failing https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/API%20Tests%20-%20TrueNAS%20SCALE%20(Incremental)/lastCompletedBuild/testReport/api2/test_490_system_general/test_09_timezone_choices/ in bookworm..in bullseye we don't have `ETC/GMT+X` as valid timezone options.

## Solution

Make sure we recognise `ETC/GMT+X` as valid timezones as they are reported as valid by `timedatectl` and applying them reflects reality as well.