### PR TITLE
NAS-121746 / 23.10 / Switch tests to use truenas repo for python-scsi and cython-iscsi

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,5 +8,5 @@ pyvmomi==7.0.3
 requests
 websocket-client>=1.4.2
 pyotp
-PYSCSI
-cython-iscsi
+cython-iscsi @ git+https://github.com/truenas/cython-iscsi.git@tester
+PYSCSI @ git+https://github.com/truenas/python-scsi.git@tester


### PR DESCRIPTION
This is required to pickup a version of `python-scsi` that provides a valid initiator name.