### PR TITLE
NAS-121746 / 22.12.3 / Switch tests to use truenas repo for python-scsi and cython-iscsi (by bmeagherix)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,5 +7,5 @@ pytz
 pyvmomi==7.0.3
 requests
 websocket-client
-PYSCSI
-cython-iscsi
+cython-iscsi @ git+https://github.com/truenas/cython-iscsi.git@tester
+PYSCSI @ git+https://github.com/truenas/python-scsi.git@tester


### PR DESCRIPTION
This is required to pickup a version of `python-scsi` that provides a valid initiator name.

Original PR: https://github.com/truenas/middleware/pull/11184
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121746