### PR TITLE
NAS-121657 / 23.10 / fix typo in ipmi plugin (preventing passwd change)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -152,7 +152,7 @@ class IPMIService(CRUDService):
         run(get_cmd(['arp', 'generate', 'on']), **options)
 
         if passwd := data.get('password'):
-            cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)
+            cp = run(['ipmitool', 'user', 'set', 'password', '2', passwd], capture_output=True)
             if cp.returncode != 0:
                 err = '\n'.join(cp.stderr.decode().split('\n'))
                 raise CallError(f'Failed setting password: {err!r}')


### PR DESCRIPTION
`get_cmd()` is an inner function that is called to prevent duplicate code since ipmitool commands essentially are prefixed with the same few commands. This isn't true when changing the password but that inner method was mistakenly called when changing the password leading to an invalid command. Remove the call to the inner method.