### PR TITLE
NAS-121657 / 22.12.3 / fix typo in ipmi plugin (preventing passwd change) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -152,7 +152,7 @@ class IPMIService(CRUDService):
         run(get_cmd(['arp', 'generate', 'on']), **options)
 
         if passwd := data.get('password'):
-            cp = run(get_cmd(['ipmitool', 'user', 'set', 'password', '2', passwd]), capture_output=True)
+            cp = run(['ipmitool', 'user', 'set', 'password', '2', passwd], capture_output=True)
             if cp.returncode != 0:
                 err = '\n'.join(cp.stderr.decode().split('\n'))
                 raise CallError(f'Failed setting password: {err!r}')


### PR DESCRIPTION
`get_cmd()` is an inner function that is called to prevent duplicate code since ipmitool commands essentially are prefixed with the same few commands. This isn't true when changing the password but that inner method was mistakenly called when changing the password leading to an invalid command. Remove the call to the inner method.

Original PR: https://github.com/truenas/middleware/pull/11186
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121657