### PR TITLE
NAS-121779 / 23.10 / Stream app's events on app status changes

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -106,6 +106,9 @@ class ChartReleaseService(Service):
             self.middleware.send_event(
                 'chart.release.query', 'CHANGED', id=name, fields=cached_chart_release['data']
             )
+            self.middleware.send_event(
+                'chart.release.events', 'CHANGED', id=name, fields={'events': await self.events(name)}
+            )
 
     @private
     async def poll_chart_release_status(self, name):
@@ -133,5 +136,6 @@ async def chart_release_event(middleware, event_type, args):
 
 async def setup(middleware):
     middleware.event_subscribe('kubernetes.events', chart_release_event)
+    middleware.event_register('chart.release.events', 'Application deployment events')
     if await middleware.call('kubernetes.validate_k8s_setup', False):
         middleware.create_task(middleware.call('chart.release.refresh_events_state'))


### PR DESCRIPTION
## Context

It has been requested by UI team to stream app's events so that they can be dynamically updated on the UI instead of UI polling for them.
Now whenever an app's status changes we will be sending an event with with app's k8s events - unfortunately kubernetes does not provide for streaming these objects directly so polling is not a good solution but this one should work reasonably well.