### PR TITLE
NAS-121787 / 23.10 / Fix middleware reinstalls

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -28,4 +28,6 @@ PIP_PACKAGES=()
 chmod +x /usr/bin/apt*
 apt update
 apt install -y "${PACKAGES[@]}"
-pip install --break-system-packages "${PIP_PACKAGES[@]}"
+if [ "${#PIP_PACKAGES[@]}" -gt 0 ]; then
+    pip install --break-system-packages "${PIP_PACKAGES[@]}"
+fi


### PR DESCRIPTION
pip install won't work with an empty array. Check whether we actually need to install anything before invoking it.