### PR TITLE
NAS-120096 / 23.10 / Fix normalization of datasets 

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -201,29 +201,11 @@ class PoolDatasetService(Service):
                 'snapshots_count': True,
             }
         }
-        collapsed = []
         datasets = self.middleware.call_sync('pool.dataset.query', [], options)
-        mntinfo = getmntinfo()
-        info = self.build_details(mntinfo)
+        mnt_info = getmntinfo()
+        info = self.build_details(mnt_info)
         for dataset in datasets:
-            self.collapse_dataset_rewrite(dataset, info, mntinfo)
-
-        for i in collapsed:
-            atime, case, readonly = self.get_mntinfo(i, mntinfo)
-            i['locked'] = i['locked']
-            i['atime'] = atime
-            i['casesensitive'] = case
-            i['readonly'] = readonly
-            i['thick_provisioned'] = any((i['reservation']['value'], i['refreservation']['value']))
-            i['nfs_shares'] = self.get_nfs_shares(i, info['nfs'])
-            i['smb_shares'] = self.get_smb_shares(i, info['smb'])
-            i['iscsi_shares'] = self.get_iscsi_shares(i, info['iscsi'])
-            i['vms'] = self.get_vms(i, info['vm'])
-            i['apps'] = self.get_apps(i, info['app'])
-            i['replication_tasks_count'] = self.get_repl_tasks_count(i, info['repl'])
-            i['snapshot_tasks_count'] = self.get_snapshot_tasks_count(i, info['snap'])
-            i['cloudsync_tasks_count'] = self.get_cloudsync_tasks_count(i, info['cloud'])
-            i['rsync_tasks_count'] = self.get_rsync_tasks_count(i, info['rsync'])
+            self.collapse_datasets(dataset, info, mnt_info)
 
         return datasets
 
@@ -246,16 +228,10 @@ class PoolDatasetService(Service):
         dataset['rsync_tasks_count'] = self.get_rsync_tasks_count(dataset, info['rsync'])
 
     @private
-    def collapse_dataset_rewrite(self, dataset, info, mnt_info):
+    def collapse_datasets(self, dataset, info, mnt_info):
         self.normalize_dataset(dataset, info, mnt_info)
         for child in dataset.get('children', []):
-            self.collapse_dataset_rewrite(child, info, mnt_info)
-
-    @private
-    def collapse_datasets(self, dataset, collapsed):
-        collapsed.append(dataset)
-        for child in dataset.get('children', []):
-            self.collapse_datasets(child, collapsed)
+            self.collapse_datasets(child, info, mnt_info)
 
     @private
     def get_mount_info(self, path, mntinfo):


### PR DESCRIPTION
This PR addresses an issue where a user reported encrypted properties were not being correctly reported in the UI which on investigation i found that we were first building a mapping of all datasets and then performing an additional loop to normalize the dataset which was redundant and we were making some mistake with the references of the objects being maintained which resulted in the dataset not properly reflecting it's normalized properties.
I have not investigated the actual reference issue but just not maintaining that mapping and normalizing in one iteration fixes the issue reasonably.

<img width="1216" alt="Screenshot 2023-05-01 at 10 07 30 PM" src="https://user-images.githubusercontent.com/17968138/235503141-1b199d6d-5986-42a6-a240-885f131e3e9f.png">

Left one outlines the one without fix and the right one with the fix.