### PR TITLE
NAS-121789 / 23.10 / fix hosts file when clustered

### DIFF
--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -10,8 +10,8 @@
 % if network_config['hosts']:
 ${network_config['hosts']}
 % endif
-127.0.0.1	localhost
 127.0.0.1	${hostname}.${domain_name} ${hostname}
+127.0.0.1	localhost
 
 # The following lines are desirable for IPv6 capable hosts
 ::1	localhost ip6-localhost ip6-loopback


### PR DESCRIPTION
Seen on an internal cluster, we had a set of nodes that were not able to be added to a cluster because it kept failing with some obscure message about localhost (this came from gluster).

Long-story short, it was because the localhost entry was the first entry in the /etc/hosts file. Even though forward and reverse look ups were working on this network, the cluster was still failing in an extravagant ways. The moment I moved the localhost entry to the last entry in that file, everything magically started working.