### PR TITLE
NAS-121788 / 22.12.3 / Make DNS timeouts for AD checks configurable (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/health.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/health.py
@@ -107,7 +107,7 @@ class ActiveDirectoryService(Service):
                 SRV.DOMAINCONTROLLER.name,
                 ad['site'],
                 2,
-                ad['timeout'],
+                ad['dns_timeout'],
                 ad['verbose_logging']
             )
             if len(res) == 0:


### PR DESCRIPTION
Pass through the legacy dns_timeout key to our DNS client plugin when doing various AD checks. This potentially allows users to account for really terrible DNS. Since the DNS client ops are not called within a job, timeout should have some validation to prevent setting something too low or too high.

Original PR: https://github.com/truenas/middleware/pull/11208
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121788