### PR TITLE
NAS-121794 / 23.10 / Behavior of python enum.Flags has changed between 3.9 and 3.11.

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/debug.py
+++ b/src/middlewared/middlewared/plugins/nfs_/debug.py
@@ -6,7 +6,7 @@ import os
 import enum
 
 
-class NFSDBG(enum.Flag):
+class NFSDBG(enum.Enum):
     # include/uapi/linux/nfs_fs.h
     NONE = 0x0000
     VFS = 0x0001


### PR DESCRIPTION
Changing `enum.Flags` to `enum.Enum` restores expected behavior.

```
# ---------- python 3.9 --------------
>>> import enum
>>> class NFSDBG(enum.Flag):
...     # include/uapi/linux/nfs_fs.h
...     NONE = 0x0000
...     VFS = 0x0001
...     DIRCACHE = 0x0002
...     LOOKUPCACHE = 0x0004
...     PAGECACHE = 0x0008
...     PROC = 0x0010
...     XDR = 0x0020
...     FILE = 0x0040
...     ROOT = 0x0080
...     CALLBACK = 0x0100
...     CLIENT = 0x0200
...     MOUNT = 0x0400
...     FSCACHE = 0x0800
...     PNFS = 0x1000
...     PNFS_LD = 0x2000
...     STATE = 0x4000
...     XATTR_CACHE = 0x8000
...     ALL = 0xFFFF
...
>>> [x.name for x in NFSDBG]
['NONE', 'VFS', 'DIRCACHE', 'LOOKUPCACHE', 'PAGECACHE', 'PROC', 'XDR', 'FILE', 'ROOT', 'CALLBACK', 'CLIENT', 'MOUNT', 'FSCACHE', 'PNFS', 'PNFS_LD', 'STATE', 'XATTR_CACHE', 'ALL']
```
```
# ------- python 3.11 -------
>>> import enum
>>> class NFSDBG(enum.Flag):
...     # include/uapi/linux/nfs_fs.h
...     NONE = 0x0000
...     VFS = 0x0001
...     DIRCACHE = 0x0002
...     LOOKUPCACHE = 0x0004
...     PAGECACHE = 0x0008
...     PROC = 0x0010
...     XDR = 0x0020
...     FILE = 0x0040
...     ROOT = 0x0080
...     CALLBACK = 0x0100
...     CLIENT = 0x0200
...     MOUNT = 0x0400
...     FSCACHE = 0x0800
...     PNFS = 0x1000
...     PNFS_LD = 0x2000
...     STATE = 0x4000
...     XATTR_CACHE = 0x8000
...     ALL = 0xFFFF
...
>>> [x.name for x in NFSDBG]
['VFS', 'DIRCACHE', 'LOOKUPCACHE', 'PAGECACHE', 'PROC', 'XDR', 'FILE', 'ROOT', 'CALLBACK', 'CLIENT', 'MOUNT', 'FSCACHE', 'PNFS', 'PNFS_LD', 'STATE', 'XATTR_CACHE']

```
