### PR TITLE
NAS-121509 / 22.12.3 / Fix application pool name bug in kubernetes setup (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -350,9 +350,7 @@ class KubernetesService(Service):
     async def create_update_k8s_datasets(self, k8s_ds):
         create_props_default = self.k8s_props_default()
         for dataset_name in await self.kubernetes_datasets(k8s_ds):
-            custom_props = self.kubernetes_dataset_custom_props(
-                ds=dataset_name.rsplit(k8s_ds.split('/', 1)[0])[1].strip('/')
-            )
+            custom_props = self.kubernetes_dataset_custom_props(ds=dataset_name.split('/')[-1])
             # got custom properties, need to re-calculate
             # the update and create props.
             create_props = dict(create_props_default, **custom_props) if custom_props else create_props_default


### PR DESCRIPTION
## Problem
There was a problem with how we removed the pool name from k3s datasets. Essentially we were relying on some custom logic which broke when pool was named `applications` and hence the resulting dataset was malformed i.e `ix-/kubectl` 

## Solution
To address this issue, we remove the complicated logic we had in place and just strip away the pool name cleanly.

Original PR: https://github.com/truenas/middleware/pull/11206
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121509