### PR TITLE
NAS-121696 / 23.10 / Properly cover the case where parent of VM disk device is encrypted

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -58,14 +58,15 @@ class PoolDatasetService(Service):
                 if not path:
                     continue
 
-                if (
-                    (
-                        dataset['type'] == 'FILESYSTEM' and
-                        (mountpoint := dataset_mountpoint(dataset)) and
-                        path.startswith(mountpoint + '/')
-                    ) or
-                    (dataset['type'] == 'VOLUME' and zvol_name_to_path(dataset['name']) == path)
-                ):
+                unlock = False
+                if dataset['type'] == 'FILESYSTEM' and (mountpoint := dataset_mountpoint(dataset)):
+                    unlock = path.startswith(mountpoint + '/') or path.startswith(
+                        zvol_name_to_path(dataset['name']) + '/'
+                    )
+                elif dataset['type'] == 'VOLUME' and zvol_name_to_path(dataset['name']) == path:
+                    unlock = True
+
+                if unlock:
                     result.append(vm)
                     break
 


### PR DESCRIPTION
## Problem
We have encountered a use case where the parent dataset is locked, but its child dataset is being used as a disk by a virtual machine (VM). This scenario has not been addressed before. The dataset logic checks for a mount path like `/mnt/tank/enc` in the pool, but the path on the VM is in the form of a zvol, such as `/zvol/tank/enc/vm-vol`.

## Solution
To resolve this issue, we need to verify whether the zvol disk is a child of the unlocked dataset or not. If it is a child, then we should restart the VM.