### PR TITLE
NAS-121806 / 23.10 / Install relevant dependencies before running unit tests in CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Deploy
         run: |
+          ./src/freenas/usr/bin/install-dev-tools
           cd src/middlewared ; make reinstall_container
           cp -a /__w/middleware/middleware/src/middlewared/middlewared/pytest /usr/local/lib/python3.11/dist-packages/middlewared/
                


### PR DESCRIPTION
## Context

We should be installing any relevant dependencies required for the testing environment to work before executing unit tests in the CI.