### PR TITLE
Replace 'from mock import' with 'from unittest.mock import'

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
+++ b/src/middlewared/middlewared/pytest/unit/common/smart/test_smartctl.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from middlewared.common.smart.smartctl import get_smartctl_args, SMARTCTX
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ldap.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from middlewared.service_exception import ValidationErrors
 from middlewared.schema import (

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
@@ -1,4 +1,4 @@
-from mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from middlewared.plugins.nfs import SharingNFSService
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_ups.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_ups.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 
 from middlewared.plugins.ups import UPSService
 

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from middlewared.service import job
 from middlewared.service_exception import ValidationErrors


### PR DESCRIPTION
More fallout from python 3.9 -> 3.11 transition