### PR TITLE
NAS-121718 / 23.10 / add zpool list -o size output to usage.py plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -374,6 +374,7 @@ class UsageService(Service):
             pool_list.append(
                 {
                     'capacity': pd['used']['parsed'] + pd['available']['parsed'],
+                    'raw_capacity': p['size'],
                     'disks': disks,
                     'encryption': bool(p['encrypt']),
                     'l2arc': bool(p['topology']['cache']),


### PR DESCRIPTION
This was requested by the PM team to have the raw zpool capacity (i.e. zpool list -p -o size) output in the usage stats.