### PR TITLE
NAS-121795 / 23.10 / fix cobia upgrades

### DIFF
--- a/src/freenas/etc/default/kexec
+++ b/src/freenas/etc/default/kexec
@@ -1,0 +1,19 @@
+# Defaults for kexec initscript
+# sourced by /etc/init.d/kexec and /etc/init.d/kexec-load
+
+# Load a kexec kernel (true/false)
+LOAD_KEXEC=true
+
+# Kernel and initrd image
+KERNEL_IMAGE="/vmlinuz"
+INITRD="/initrd.img"
+
+# If empty, use current /proc/cmdline
+APPEND=""
+
+# Load the default kernel from grub config (true/false)
+# if this is set to false, clean reboots will bypass the
+# grub boot menu which prevents upgrades from working
+# because the new boot environment doesnt get booted into
+# (even though the upgrade applied and was activated)
+USE_GRUB_CONFIG=true


### PR DESCRIPTION
We've noticed that "reboot" command is bypassing the grub boot menu. Because of this fact, on upgrade, the upgrade isn't booted into. Even though there is a new boot environment with the new upgrade and that new boot environment is even "activated" (according to zectl list output). This has something to do with kexec. Fortunately, there seems to be a relatively safe and easy work-around to fix this by using USE_GRUB_CONFIG=true.