### PR TITLE
NAS-121826 / 22.12.3 / add total_capacity to context in usage.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -84,6 +84,7 @@ class UsageService(Service):
         context = {
             'network': self.middleware.call_sync('interface.query'),
             'root_datasets': {},
+            'total_capacity': 0,
             'datasets_total_size': 0,
             'zvols_total_size': 0,
             'zvols': [],
@@ -98,6 +99,9 @@ class UsageService(Service):
                 context['root_datasets'][ds['id']] = ds
                 context['total_datasets'] += 1
                 context['datasets_total_size'] += ds['properties']['used']['parsed']
+                context['total_capacity'] += (
+                    ds['properties']['used']['parsed'] + ds['properties']['available']['parsed']
+                )
             elif ds['type'] == 'VOLUME':
                 context['zvols'].append(ds)
                 context['total_zvols'] += 1
@@ -130,12 +134,7 @@ class UsageService(Service):
         return usage_stats
 
     def gather_total_capacity(self, context):
-        return {
-            'total_capacity': sum(
-                d['properties']['used']['parsed'] + d['properties']['available']['parsed']
-                for d in context['root_datasets'].values()
-            )
-        }
+        return {'total_capacity': context['total_capacity']}
 
     def gather_backup_data(self, context):
         backed = {


### PR DESCRIPTION
We're also iterating over the root_datasets.values() to calculate the total_capacity unnecessarily. We can calculate this value when we're iterating over the datasets when we gather the context which gets passed to all the functions.

Original PR: https://github.com/truenas/middleware/pull/11242
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121826