### PR TITLE
NAS-121828 / 22.12.3 / Improve usage.py some more (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -195,13 +195,7 @@ class UsageService(Service):
     async def gather_rsyncmod_stats(self, context):
         return {
             'rsyncmod': {
-                'enabled': (
-                    await self.middleware.call(
-                        'service.query',
-                        [['service', '=', 'rsync']],
-                        {'get': True, 'extra': {'include_state': False}}
-                    )
-                )['enable'],
+                'enabled': [i for i in context['services'] if i['service'] == 'rsync'][0]['enable'],
                 'rsync_modules': await self.middleware.call('rsyncmod.query', [], {'count': True}),
             }
         }


### PR DESCRIPTION
- we already capture service information in context so there is no reason to service.query again in the gather_rsyncmod_stats() method so use the context['services'] key instead
- "type" is a builtin for python and it's not best practice to overwrite those so change it to _type
- simplify, remove unnecessary newlines, and remove an unnecessary variable in gather_pools()

Original PR: https://github.com/truenas/middleware/pull/11244
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121828