### PR TITLE
Remove 3 deepcopy(s) from usage.py improving perf and memory consumption

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -15,7 +15,7 @@ class ZFSDatasetService(Service):
         private = True
         process_pool = True
 
-    def path_to_dataset(self, path):
+    def path_to_dataset(self, path, mntinfo=None):
         """
         Convert `path` to a ZFS dataset name. This
         performs lookup through mountinfo.
@@ -29,7 +29,11 @@ class ZFSDatasetService(Service):
         boot_pool = self.middleware.call_sync("boot.pool_name")
 
         st = os.stat(path)
-        mntinfo = getmntinfo(st.st_dev)[st.st_dev]
+        if mntinfo is None:
+            mntinfo = getmntinfo(st.st_dev)[st.st_dev]
+        else:
+            mntinfo = mntinfo[st.st_dev]
+
         ds_name = mntinfo['mount_source']
         if mntinfo['fs_type'] != 'zfs':
             raise CallError(f'{path}: path is not a ZFS filesystem')


### PR DESCRIPTION
There is no reason to use deepcopy in gather_backup_stats. Keeping a set with dataset names allows us to remove the necessity of deepcopy'ing 3 times in this method alone. That's painful.

- allow getmntinfo() to be passed as kwarg to zfs.dataset.path_to_dataset
- capture getmntinfo() in the context variable in usage.py
- remove deepcopy in gather_backup_stats
- remove another unnecessary iteration over all datasets
- remove unnecessary variables and newlines