### PR TITLE
NAS-121833 / 22.12.3 / Remove 3 deepcopy(s) from usage.py improving perf and memory consumption (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -698,7 +698,7 @@ class ZFSDatasetService(CRUDService):
         if mntinfo is None:
             mntinfo = getmntinfo(st.st_dev)[st.st_dev]
         else:
-            mntinfo = mntinfo(st.st_dev)
+            mntinfo = mntinfo[st.st_dev]
 
         ds_name = mntinfo['mount_source']
         if mntinfo['fs_type'] != 'zfs':

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -681,7 +681,7 @@ class ZFSDatasetService(CRUDService):
         if not ds.encrypted:
             raise CallError(f'{id} is not encrypted')
 
-    def path_to_dataset(self, path):
+    def path_to_dataset(self, path, mntinfo=None):
         """
         Convert `path` to a ZFS dataset name. This
         performs lookup through mountinfo.
@@ -695,7 +695,11 @@ class ZFSDatasetService(CRUDService):
         boot_pool = self.middleware.call_sync("boot.pool_name")
 
         st = os.stat(path)
-        mntinfo = getmntinfo(st.st_dev)[st.st_dev]
+        if mntinfo is None:
+            mntinfo = getmntinfo(st.st_dev)[st.st_dev]
+        else:
+            mntinfo = mntinfo(st.st_dev)
+
         ds_name = mntinfo['mount_source']
         if mntinfo['fs_type'] != 'zfs':
             raise CallError(f'{path}: path is not a ZFS filesystem')


### PR DESCRIPTION
There is no reason to use deepcopy in gather_backup_stats. Keeping a set with dataset names allows us to remove the necessity of deepcopy'ing 3 times in this method alone. That's painful.

- allow getmntinfo() to be passed as kwarg to zfs.dataset.path_to_dataset
- capture getmntinfo() in the context variable in usage.py
- remove deepcopy in gather_backup_stats
- remove another unnecessary iteration over all datasets
- remove unnecessary variables and newlines

Original PR: https://github.com/truenas/middleware/pull/11246
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121833