### PR TITLE
NAS-121851 / 23.10 / fix cobia upgrades (again)

### DIFF
--- a/src/freenas/etc/default/kexec.d/truenas
+++ b/src/freenas/etc/default/kexec.d/truenas
@@ -1,16 +1,3 @@
-# Defaults for kexec initscript
-# sourced by /etc/init.d/kexec and /etc/init.d/kexec-load
-
-# Load a kexec kernel (true/false)
-LOAD_KEXEC=true
-
-# Kernel and initrd image
-KERNEL_IMAGE="/vmlinuz"
-INITRD="/initrd.img"
-
-# If empty, use current /proc/cmdline
-APPEND=""
-
 # Load the default kernel from grub config (true/false)
 # if this is set to false, clean reboots will bypass the
 # grub boot menu which prevents upgrades from working


### PR DESCRIPTION
/etc/default/kexec is being overwritten it seems since kexec.service is a sysv generated file. Create a new file "truenas" in /etc/default/kexec.d/ with just the option that we want to enable.