### PR TITLE
NAS-121860 / 13.0 / Fix AttributeError crash

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1044,7 +1044,8 @@ class PoolService(CRUDService):
                     # Use encrypted_provider and not disk because a disk is not a guarantee
                     # to point to correct device if its locked and its not in the system
                     # (e.g. temporarily). See #50291
-                    if disk_name := await self.middleware.call('disk.label_to_disk', prov, False, cache):
+                    provider = prov['encrypted_provider']
+                    if disk_name := await self.middleware.call('disk.label_to_disk', provider, False, cache):
                         for d in filter(lambda x: x['name'] == disk_name, disks_in_db):
                             disk_path = os.path.join('/dev', d['devname'])
                             if await self.middleware.run_in_thread(os.path.exists, disk_path):


### PR DESCRIPTION
This for loop is filtering to ensure the object (dictionary) has an "encrypted_provider" key and value, however, there is a typo that is passing the dict object to the next method instead of the "encrypted_provider" key's value (a string). This causes an AttributeError crash further down the rabbit hole. Excerpt of the traceback
```
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/pool.py", line 1047, in get_disks
    if disk_name := await self.middleware.call('disk.label_to_disk', prov, False, cache):
  File "/usr/local/lib/python3.9/site-packages/middlewared/main.py", line 1279, in call
    return await self._call(
  File "/usr/local/lib/python3.9/site-packages/middlewared/main.py", line 1247, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
  File "/usr/local/lib/python3.9/site-packages/middlewared/main.py", line 1152, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/disk_/disk_info_freebsd.py", line 123, in label_to_disk
    dev = self.label_to_dev(label, geom_scan, cache) or label
  File "/usr/local/lib/python3.9/site-packages/middlewared/plugins/disk_/disk_info_freebsd.py", line 104, in label_to_dev
    if label.endswith('.nop'):
AttributeError: 'dict' object has no attribute 'endswith'
```