### PR TITLE
NAS-121849 / 23.10 / Fix ix-appilcation dataset split bug

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -348,7 +348,7 @@ class KubernetesService(Service):
     async def create_update_k8s_datasets(self, k8s_ds):
         create_props_default = self.k8s_props_default()
         for dataset_name in await self.kubernetes_datasets(k8s_ds):
-            custom_props = self.kubernetes_dataset_custom_props(ds=dataset_name.split('/')[-1])
+            custom_props = self.kubernetes_dataset_custom_props(ds=dataset_name.split('/', 1)[-1])
             # got custom properties, need to re-calculate
             # the update and create props.
             create_props = dict(create_props_default, **custom_props) if custom_props else create_props_default


### PR DESCRIPTION
## Problem

Because of a typo in the logic in https://github.com/truenas/middleware/pull/11206/commits/fe45c4ffeb64527461fb7f3f027372e4c71b483e we were not properly re-setting custom props of k8s datasets which resulted in various mounting errors.

## Solution

Fix the typo and make sure accurate mapping takes place for the kubernetes datasets we have defined so proper properties can be applied.