### PR TITLE
NAS-121880 / 23.10 / tighten the core dump alerts to critical sharing services only

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -17,33 +17,37 @@ class CoreFilesArePresentAlertClass(AlertClass):
 
 class CoreFilesArePresentAlertSource(AlertSource):
     products = ("SCALE",)
-    ignore_executables = (
-        # Crashes at https://github.com/smartmontools/smartmontools/blob/6cc32bf/smartmontools/knowndrives.cpp#L98
-        # when trying to run `-d sat` against certain drives. This is clearly a memory corruption issue since
-        # allocation/freeing in that class is pretty straightforward. Things like that are very hard to debug.
-        # If it crashes with `-d sat` (which is a first try) we simply run it normally so these segfaults are not
-        # a big deal.
-        "/usr/sbin/smartctl",
-    )
-    ignore_units = (
-        # Unit: "syslog-ng.service" has been core dumping for, literally, years
-        # on freeBSD and now also on linux. The fix is non-trivial and it seems
-        # to be very specific to how we implemented our system dataset. Anyways,
-        # the crash isn't harmful so we ignore it.
-        "syslog-ng.service",
-        # Users are free to run whatever 3rd party software in their "app" that they
-        # so choose. We can't fix all the problems of k3s so ignore them since they're
-        # harmless and only cause unnecessary tickets to be created.
-        "k3s.service",
-    )
+
+    async def should_alert(self, core):
+        if core["corefile"] != "present" or not core["unit"]:
+            # no core file on disk, no investigation
+            # not associated to a unit? probably impossible but better safe than sorry
+            return False
+
+        return core["unit"].startswith((
+            # NFS related service(s)
+            "nfs-blkmap.service",
+            "nfs-idmapd.service",
+            "nfs-mountd.service",
+            "nfsdcld.service",
+            "rpc-statd.service",
+            "rpcbind.service",
+            # SMB related service(s)
+            "smbd.service",
+            "winbind.service",
+            "nmbd.service",
+            "wsdd.service",
+            # SCST related service(s)
+            "scst.service",
+            # ZFS related (userspace) service(s)
+            "zfs-zed.service",
+        ))
 
     async def check(self):
         corefiles = []
-        for coredump in filter(lambda c: c["corefile"] == "present", await self.middleware.call("system.coredumps")):
-            if coredump["exe"] in self.ignore_executables or coredump["unit"] in self.ignore_units:
-                continue
-
-            corefiles.append(f"{coredump['exe']} ({coredump['time']})")
+        for coredump in await self.middleware.call("system.coredumps"):
+            if await self.should_alert(coredump):
+                corefiles.append(f"{coredump['exe']} ({coredump['time']})")
 
         if corefiles:
             return Alert(CoreFilesArePresentAlertClass, {"corefiles": ', '.join(corefiles)})


### PR DESCRIPTION
This tightens the core dump alerts to only our "critical" sharing services. There are too many scenarios where end-users can install/modify 3rd party tools to do things that we could never predict. This hopefully limits the core dump alerts to NFS, iSCSI, SMB, and zed.