### PR TITLE
TE-405 / 13.0 / Remove env in test 96 of test_130_cloudsync.py

### DIFF
--- a/tests/api2/test_130_cloudsync.py
+++ b/tests/api2/test_130_cloudsync.py
@@ -160,7 +160,7 @@ def test_08_delete_restore_cloudsync(request):
     assert result.status_code == 200, result.text
 
 
-def test_96_delete_cloud_credentials_error(request, env, task):
+def test_96_delete_cloud_credentials_error(request, task):
     depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/cloudsync/credentials/id/{credentials['id']}/")
     assert result.status_code == 422


### PR DESCRIPTION
It is not defined and not use in the step definition.