### PR TITLE
NAS-121871 / 13.0 / Fix redundant check

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3042,20 +3042,6 @@ class PoolDatasetService(CRUDService):
                 # not getting encryption props from pool/encrypted.
                 unencrypted_parent = check_parent
 
-            if (
-                check_ds := await self.middleware.call('zfs.dataset.query', [['name', '=', check_parent]], {
-                    'get': True,
-                    'extra': {'recursive': False},
-                })
-            ) and check_ds['encrypted'] and data['encryption'] is False and not inherit_encryption_properties:
-                # This was a design decision when native zfs encryption support was added to provide a simple
-                # straight workflow not allowing end users to create unencrypted datasets within an encrypted dataset.
-                verrors.add(
-                    'pool_dataset_create.encryption',
-                    f'Cannot create an unencrypted dataset within an encrypted dataset ({check_parent}).'
-                )
-                break
-
         if data['encryption']:
             if inherit_encryption_properties:
                 verrors.add('pool_dataset_create.inherit_encryption', 'Must be disabled when encryption is enabled.')


### PR DESCRIPTION
This commit removes a redundant check which got invovled with cherry-picking selective commits and is basically doing the same logic which is already above in place