### PR TITLE
NAS-121881 / 22.12.3 / Fix flapping enclosure alerts (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -23,6 +23,8 @@ class EnclosureStatusAlertSource(AlertSource):
     run_on_backup_node = False
     bad = ('critical', 'noncritical', 'unknown', 'unrecoverable', 'not installed')
 
+    bad_elements = []
+
     async def should_report(self, enclosure, element):
         should_report = True
         if element['status'].lower() in self.bad and element['value'] != 'None':
@@ -43,23 +45,43 @@ class EnclosureStatusAlertSource(AlertSource):
         return should_report
 
     async def check(self):
-        alerts = []
+        good_enclosures = []
+        bad_elements = []
         for enc in await self.middleware.call('enclosure.query'):
-            healthy = True
-            for ele in sum([e['elements'] for e in enc['elements']], []):
-                if await self.should_report(enc, ele):
-                    healthy = False
-                    alerts.append(Alert(EnclosureUnhealthyAlertClass, args=[
-                        enc['name'],
-                        ele['name'],
-                        ele['status'],
-                        ele['value'],
-                        ele['value_raw'],
-                    ]))
+            good_enclosures.append([enc['number'], enc['name']])
 
-            if healthy:
-                # we've iterated all elements of a given enclosure and nothing
-                # was reported as unhealthy
-                alerts.append(Alert(EnclosureHealthyAlertClass, args=[enc['name']]))
+            for element_type, element_values in enc['elements'].items():
+                for slot, value in element_values.items():
+                    if await self.should_report(enc, value):
+                        args = [
+                            enc['number'],
+                            enc['name'],
+                            value['descriptor'],
+                            slot,
+                            hex(slot),
+                            value['status']
+                        ]
+                        for i, (another_args, count) in enumerate(self.bad_elements):
+                            if another_args == args:
+                                bad_elements.append((args, count + 1))
+                                break
+                        else:
+                            bad_elements.append((args, 1))
+
+        self.bad_elements = bad_elements
+
+        alerts = []
+        for args, count in bad_elements:
+            # We only report unhealthy enclosure elements if they were unhealthy 5 probes in a row (1 probe = 1 minute)
+            if count >= 5:
+                try:
+                    good_enclosures.remove(args[:2])
+                except ValueError:
+                    pass
+
+                alerts.append(Alert(EnclosureUnhealthyAlertClass, args=args))
+
+        for args in good_enclosures:
+            alerts.append(Alert(EnclosureHealthyAlertClass, args=args))
 
         return alerts


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 38d01a1bf8dca9e2a94177d76490070dec54b736

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4c0bc47e12995e8967b525cc1d99bc323d3c0f3c

Enclosure elements can "flap" (i.e. report a bad status but then be cleared almost immediately). The alert that is flapping is a particular problem in and of itself. However, this fixes the scenario so that we wait a bit before we raise an alert to the end-user.

Original PR: https://github.com/truenas/middleware/pull/11260
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121881