### PR TITLE
NAS-112093 / 13.0 / Set ashift to 12 for pools which do not have it (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -172,6 +172,17 @@ class BootService(Service):
         """
         return (await self.middleware.call('system.advanced.config'))['boot_scrub']
 
+    @private
+    async def check_update_ashift_property(self):
+        properties = {}
+        if (
+            zfs_pool := await self.middleware.call('zfs.pool.query', [('name', '=', BOOT_POOL_NAME)])
+        ) and zfs_pool[0]['properties']['ashift']['source'] == 'DEFAULT':
+            properties['ashift'] = {'value': '12'}
+
+        if properties:
+            await self.middleware.call('zfs.pool.update', BOOT_POOL_NAME, {'properties': properties})
+
 
 async def setup(middleware):
     global BOOT_POOL_NAME

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -80,7 +80,7 @@ class BootService(Service):
         `expand` option will determine whether the new disk partition will be
                  the maximum available or the same size as the current disk.
         """
-
+        await self.check_update_ashift_property()
         disks = list(await self.get_disks())
         if len(disks) > 1:
             raise CallError('3-way mirror not supported')
@@ -123,6 +123,7 @@ class BootService(Service):
         """
         Detach given `dev` from boot pool.
         """
+        await self.check_update_ashift_property()
         await self.middleware.call('zfs.pool.detach', BOOT_POOL_NAME, dev)
 
     @accepts(Str('label'), Str('dev'))
@@ -130,6 +131,7 @@ class BootService(Service):
         """
         Replace device `label` on boot pool with `dev`.
         """
+        await self.check_update_ashift_property()
         format_opts = {}
         disks = list(await self.get_disks())
         swap_part = await self.middleware.call('disk.get_partition', disks[0], 'SWAP')


### PR DESCRIPTION
This PR adds changes to change `ashift` to `12` if it is at `DEFAULT` value whenever a zfs pool is updated or extended.

Original PR: https://github.com/truenas/middleware/pull/11257
Jira URL: https://ixsystems.atlassian.net/browse/NAS-112093