### PR TITLE
NAS-121784 / 23.10 / Add apps mapping service

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/apps_mapping.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/apps_mapping.py
@@ -1,0 +1,110 @@
+import json
+import jsonschema
+import os
+
+from middlewared.service import Service
+
+
+MAPPING_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'apps': {
+            'type': 'array',
+            'items': {'type': 'string'},
+        },
+        'services': {
+            'type': 'object',
+            'additionalProperties': False,
+        },
+    },
+}
+
+
+class KubernetesAppMappingService(Service):
+
+    FILENAME = 'apps_mapping.json'
+    MAPPING = None
+
+    class Config:
+        namespace = 'k8s.app.mapping'
+        private = True
+
+    def mapping_file_path(self):
+        return os.path.join(
+            '/mnt', self.middleware.call_sync('kubernetes.config')['dataset'], self.FILENAME
+        )
+
+    def setup(self):
+        if not self.middleware.call_sync('kubernetes.validate_k8s_setup', False):
+            return False
+
+        mapping = {'apps': [], 'services': {}}
+        try:
+            with open(self.mapping_file_path(), 'r') as f:
+                mapping = json.loads(f.read())
+            jsonschema.validate(mapping, MAPPING_SCHEMA)
+        except FileNotFoundError:
+            pass
+        except (json.JSONDecodeError, jsonschema.ValidationError):
+            self.logger.error(
+                'Malformed %r app mapping file found, re-creating', self.mapping_file_path(), exc_info=True
+            )
+
+        mapping['apps'] = [app['id'] for app in self.middleware.call_sync('chart.release.query')]
+        # TODO: Services when added should also remove apps which are no longer there
+        #  also we should do appropriate handling for services when added
+        self.MAPPING = mapping
+
+        self.write_to_file()
+        self.register_services()
+
+        return True
+
+    def write_to_file(self):
+        with open(self.mapping_file_path(), 'w') as f:
+            f.write(json.dumps(self.MAPPING))
+
+    def safe_setup(self):
+        return self.setup() if self.MAPPING is None else True
+
+    def _check(func):
+        def wrapper(self, *args, **kwargs):
+            return func(self, *args, **kwargs) if self.safe_setup() else None
+        return wrapper
+
+    @_check
+    def add_app(self, app):
+        if app not in self.MAPPING['apps']:
+            self.MAPPING['apps'].append(app)
+            self.write_to_file()
+
+    @_check
+    def remove_app(self, app):
+        if app in self.MAPPING['apps']:
+            self.MAPPING['apps'].remove(app)
+            # TODO: Remove this from services as well
+            self.write_to_file()
+
+    @_check
+    def register_services(self):
+        # TODO: Let's do this later once we know how mdns integration looks like
+        pass
+
+    @_check
+    def unregister_services(self):
+        # TODO: Let's do this later once we know how mdns integration looks like
+        pass
+
+
+async def app_post_create_hook(middleware, app):
+    await middleware.call('k8s.app.mapping.add_app', app['id'])
+
+
+async def app_post_delete_hook(middleware, app):
+    await middleware.call('k8s.app.mapping.remove_app', app)
+
+
+async def setup(middleware):
+    await middleware.call('k8s.app.mapping.setup')
+    middleware.register_hook('app.post_create', app_post_create_hook, sync=True)
+    middleware.register_hook('app.post_delete', app_post_delete_hook, sync=True)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -147,6 +147,9 @@ class KubernetesService(Service):
         # Let's run app migrations if any
         await self.middleware.call('k8s.app.migration.run')
 
+        # Let's update app's mapping
+        await self.middleware.call('k8s.app.mapping.setup')
+
         node_config = await self.middleware.call('k8s.node.config')
         await self.middleware.call(
             'k8s.node.remove_taints', [

--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -91,6 +91,7 @@ class KubernetesService(SimpleService):
             self.middleware.logger.error('Failed to remove iptable rules for kubernetes service: %r', e)
 
     async def after_stop(self):
+        await self.middleware.call('k8s.app.mapping.unregister_services')
         await self._systemd_unit('kube-router', 'stop')
         await self._systemd_unit('cni-dhcp', 'stop')
         await self.middleware.call('k8s.cni.cleanup_cni')


### PR DESCRIPTION
## Context

There has been a usecase where we would want to whitelist certain ports on the host wrt mdns which will also be running in as an application. In order to make this work we need to have some sort of state saved wrt installed apps which was not being done anywehere.
After considering possible options we decided to go doing that in a json file in the apps dataset itself as maintaining this in database is quite tricky especially considering you can switch pools etc and you will lose state eventually.

Currently basic workflow has been added which generates the mapping file so we can track installed apps..once Andrew is back i intend to understand how the mdns integration looks like and then implement services integration.