### PR TITLE
NAS-121909 / 13.0 / fix MINI 3.0 X version 1.0 enclosure mapping

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -31,13 +31,13 @@ MAPPINGS = [
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [
         VersionMapping(re.compile(r"1\.0"), [
-            MappingSlot(1, 1, False),
-            MappingSlot(1, 2, False),
-            MappingSlot(1, 3, False),
-            MappingSlot(1, 4, False),
             MappingSlot(0, 1, False),
             MappingSlot(0, 2, False),
             MappingSlot(0, 3, False),
+            MappingSlot(0, 4, False),
+            MappingSlot(1, 1, False),
+            MappingSlot(1, 2, False),
+            MappingSlot(1, 4, False),
         ]),
     ]),
     ProductMapping(re.compile(r"(TRUE|FREE)NAS-MINI-3.0-X$"), [


### PR DESCRIPTION
This is the correct mapping for the Mini 3.0 X version 1.0 according to internal documentation.