### PR TITLE
NAS-121910 / 13.0 / fix regression and edge-case crash in disk.sync_all

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -175,6 +175,7 @@ class DiskService(Service, ServiceChangeMixin):
 
             found_ident = next(disk_xml.iterfind(f'.//config[ident="{_ident}"]/../../name'), None)
             if found_ident is not None:
+                _lunid = _lunid.replace('"', '%22')  # replace double-quote with utf8 url encoded value
                 found_lunid = next(disk_xml.iterfind(f'.//config[lunid="{_lunid}"]/../../name'), None)
                 if found_lunid is not None:
                     # means the identifier and lunid given to us

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -1,7 +1,6 @@
 import os
 import time
 import re
-import shlex
 from datetime import datetime, timedelta
 
 from middlewared.schema import accepts, Str
@@ -176,7 +175,7 @@ class DiskService(Service, ServiceChangeMixin):
 
             found_ident = next(disk_xml.iterfind(f'.//config[ident="{_ident}"]/../../name'), None)
             if found_ident is not None:
-                found_lunid = next(disk_xml.iterfind(f'.//config[lunid={shlex.quote(_lunid)}]/../../name'), None)
+                found_lunid = next(disk_xml.iterfind(f'.//config[lunid="{_lunid}"]/../../name'), None)
                 if found_lunid is not None:
                     # means the identifier and lunid given to us
                     # matches a disk on the system so just return


### PR DESCRIPTION
This does 2 things primarily.
1. revert https://github.com/truenas/middleware/pull/11139 since it caused a regression preventing disk.sync_all to function which means disks to not get properly written to db
2. fix the original problem that the offending commit tried to do by replacing double-quotes with utf8 url encoded value

We do this already in this function up a few lines with single-quotes. The predicate that gets passed to the xml function must be surrounded by double-quotes but escaping that double-quote the traditional way does not work. Replacing double-quotes with the utf8 encoded value is sufficient. Furthermore, this is an edge-case bug so don't expect it to be hit that often in the wild.