### PR TITLE
NAS-121912 / 13.0 / Expect Enter an option instead of https:// in boot.exp

### DIFF
--- a/tests/boot.exp
+++ b/tests/boot.exp
@@ -8,18 +8,7 @@ set PID [spawn vm console "$vm"]
 send_user "Spawned PID: $PID \n"
 
 expect {
-  "https://" {
-    sleep .5
-    exit 0
-  }
-
-  "login:" {
-    sleep .5
-  }
-}
-
-expect {
-  "https://" {
+  "Enter an option from 1-11:" {
     sleep .5
     exit 0
   }


### PR DESCRIPTION
This will fix the boot issue for 13.1. It should now affect the 13.0 boot since it is how it is set up for the 13.0 and 13.1 HA boot.

There is a https:// in the boot of 13.1.
```
---<<BOOT>>---
Copyright (c) 1992-2021 The FreeBSD Project.
Copyright (c) 1979, 1980, 1983, 1986, 1988, 1989, 1991, 1992, 1993, 1994
	The Regents of the University of California. All rights reserved.
FreeBSD is a registered trademark of The FreeBSD Foundation.
FreeBSD 13.2-RELEASE truenas/13.1-stable-d0c24e376 TRUENAS amd64
FreeBSD clang version 14.0.5 (https://greset/: standard error: Inappropriate ioctl for device
```