### PR TITLE
NAS-121913 / 23.10 / Add app migrations to installed middlewared files

### DIFF
--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -49,7 +49,8 @@ setup(
             get_assets('assets') +
             get_assets('etc_files') +
             get_assets('migration') +
-            get_assets('plugins/kubernetes_linux/migrations')
+            get_assets('plugins/kubernetes_linux/migrations') +
+            get_assets('plugins/kubernetes_linux/app_migrations')
         ),
     },
     include_package_data=True,


### PR DESCRIPTION
## Problem

Support for app migrations was added but the directory which will hold these migrations was not being added to the final middlewared installed files which resulted in kubernetes setup failing as on setup app migrations are executed. This is also resulting in various integration tests to fail.

## Solution

`app_migrations` directory has been added to the list of middlewared installed files.