### PR TITLE
NAS-121917 / 23.10 / Do not create swap partition when swap detected on boot drive

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -223,6 +223,10 @@ class DiskService(Service):
         ])
 
     @private
+    async def create_swap_partition(self):
+        return not (await self.middleware.call('system.is_ha_capable') or await self.swap_boot_partitions_exist())
+
+    @private
     async def swap_redundancy(self):
         group_size = 2
         pools = await self.middleware.call('pool.query', [['status', 'nin', ('OFFLINE', 'FAULTED')]])

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -14,14 +14,14 @@ class PoolService(Service):
         swapgb = (await self.middleware.call('system.advanced.config'))['swapondrive']
         formatted = 0
         await self.middleware.call('pool.remove_unsupported_md_devices_from_disks', disks)
-        is_ha_capable = await self.middleware.call('system.is_ha_capable')
+        create_swap_partition = await self.middleware.call('disk.create_swap_partition')
         len_disks = len(disks)
 
         async def format_disk(arg):
             nonlocal formatted
             disk, config = arg
             swap_size = 0
-            if config['create_swap'] and not is_ha_capable:
+            if config['create_swap'] and create_swap_partition:
                 swap_size = swapgb
             await self.middleware.call('disk.format', disk, config.get('size'), swap_size)
             formatted += 1


### PR DESCRIPTION
## Problem

We don't configure swap on data drives when swap partitions exist on boot drive with recent changes. However we were still creating partitions nevertheless which should not be done as it is no longer required.

## Solution

Check if system is either HA capable or has swap partition on boot pool disks and if either is true we don't create swap partition on data pool disks.

**Note**: This does mean that as the disks will be formatted and swap partition will not be created on them, if for some reason the boot disks are phased out which had swap partitions or if the data pool was exported and imported in another TrueNAS - swap cannot be configured on that data pool disks because the partitions don't exist.