### PR TITLE
NAS-121786 / 23.10 / Get all unsupported md mirrors

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_mirror.py
@@ -3,6 +3,7 @@ import contextlib
 import glob
 import os
 import pyudev
+import re
 
 from middlewared.service import CallError, filterable, private, Service
 from middlewared.utils import filter_list, run
@@ -49,38 +50,63 @@ class DiskService(Service):
         ), check=False, encoding='utf8')
 
     @private
+    def get_md_devices_mapping(self):
+        try:
+            path_mapping = {
+                os.path.realpath(array.path): {
+                    'name': array.name,
+                    'path': array.path,
+                }
+                for array in os.scandir('/dev/md')
+            }
+        except FileNotFoundError:
+            path_mapping = {}
+        with contextlib.suppress(FileNotFoundError):
+            with open('/proc/mdstat', 'r') as f:
+                return [
+                    path_mapping[device_path] if device_path in path_mapping else {
+                        'name': os.path.join(device_path), 'path': device_path,
+                    }
+                    for device_path in map(
+                        lambda d: os.path.join('/dev', d),
+                        re.findall(r'md\d+', f.read())
+                    )
+                ]
+
+        return []
+
+    @private
     @filterable
     def get_md_devices(self, filters, options):
         md_devices = []
         context = pyudev.Context()
-        with contextlib.suppress(FileNotFoundError):
-            for array in os.scandir('/dev/md'):
-                real_path = os.path.realpath(array.path)
-                md_device = {
-                    'name': array.name.split(':')[-1],
-                    'path': array.path,
-                    'real_path': real_path,
-                    'encrypted_provider': None,
-                    'providers': [],
-                }
-                if enc_path := glob.glob(f'/sys/block/dm-*/slaves/{real_path.split("/")[-1]}'):
-                    md_device['encrypted_provider'] = os.path.join('/dev', enc_path[0].split('/')[3])
+        for array in self.get_md_devices_mapping():
+            real_path = os.path.realpath(array['path'])
+            md_device = {
+                'name': array['name'].split(':')[-1],
+                'path': array['path'],
+                'real_path': real_path,
+                'encrypted_provider': None,
+                'providers': [],
+            }
+            if enc_path := glob.glob(f'/sys/block/dm-*/slaves/{real_path.split("/")[-1]}'):
+                md_device['encrypted_provider'] = os.path.join('/dev', enc_path[0].split('/')[3])
 
-                for provider in os.scandir(os.path.join('/sys/block', md_device['real_path'].split('/')[-1], 'slaves')):
-                    provider_data = {'name': provider.name, 'id': provider.name, 'disk': provider.name}
+            for provider in os.scandir(os.path.join('/sys/block', md_device['real_path'].split('/')[-1], 'slaves')):
+                provider_data = {'name': provider.name, 'id': provider.name, 'disk': provider.name}
 
-                    partition = os.path.join('/sys/class/block', provider.name, 'partition')
-                    if os.path.exists(partition):
-                        # This means provider is a partition and not complete disk
-                        with contextlib.suppress(pyudev.DeviceNotFoundByNameError):
-                            device = pyudev.Devices.from_name(context, 'block', provider.name)
-                            parent = device.find_parent('block')
-                            if parent is not None:
-                                provider_data['disk'] = parent.sys_name
+                partition = os.path.join('/sys/class/block', provider.name, 'partition')
+                if os.path.exists(partition):
+                    # This means provider is a partition and not complete disk
+                    with contextlib.suppress(pyudev.DeviceNotFoundByNameError):
+                        device = pyudev.Devices.from_name(context, 'block', provider.name)
+                        parent = device.find_parent('block')
+                        if parent is not None:
+                            provider_data['disk'] = parent.sys_name
 
-                    md_device['providers'].append(provider_data)
+                md_device['providers'].append(provider_data)
 
-                md_devices.append(md_device)
+            md_devices.append(md_device)
 
         return filter_list(md_devices, filters, options)
 


### PR DESCRIPTION
## Problem

We have come across a case where when same disk was used in a pool in the system and then taken out and then put back again in which resulted in not all md devices not showing up in `/dev/md` directory but still showing up as a device under `/dev`.

## Solution

`/proc/mdstat` contains all references of used/unused md devices which we are now using. However that does not get us the custom array name which we specify so we still retrieve that information from `/dev/md` and come up with a complete mapping of supported/un-supported md devices.
This in turn makes sure the logic we already have in place to remove disks from mirrors even if they are un-supported ones work automatically leaving nothing else to be changed. 