### PR TITLE
NAS-121918 / 23.10 / max_tasks_per_child for process pool workers

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1263,6 +1263,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
     def __init_procpool(self):
         self.__procpool = concurrent.futures.ProcessPoolExecutor(
             max_workers=5,
+            max_tasks_per_child=5,
             initializer=functools.partial(worker_init, self.debug_level, self.log_handler)
         )
 


### PR DESCRIPTION
This was introduced in python 3.11 and has been on my radar for awhile. This allows for cleaning up resources that our child processes accumulate during normal operation. I don't expect it to solve the worlds problems, but it's an easy way to "clean up" memory usage on large systems or systems that have a large uptime.

To quote the docs
```
max_tasks_per_child is an optional argument that specifies the maximum number of tasks a single process can execute
before it will exit and be replaced with a fresh worker process. By default max_tasks_per_child is None which means
worker processes will live as long as the pool.