### PR TITLE
NAS-121924 / 22.12.3 / fix un-awaited coroutine in account.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1197,7 +1197,7 @@ class UserService(CRUDService):
 
         if 'home' in data:
             if await self.middleware.run_in_thread(self.validate_homedir_path, verrors, schema, data, users):
-                check_path_resides_within_volume(verrors, self.middleware, schema, data['home'])
+                await check_path_resides_within_volume(verrors, self.middleware, schema, data['home'])
 
         if 'home_mode' in data:
             try:


### PR DESCRIPTION
Missing "await" for this coroutine so it's never being scheduled to be executed as a task.

Original PR: https://github.com/truenas/middleware/pull/11293
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121924