### PR TITLE
NAS-121932 / 13.0 / fix 2 regressions in 13 HA code

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -149,7 +149,7 @@ class FailoverService(ConfigService):
         new = old.copy()
         new.update(data)
 
-        if master is not NOT_PROVIDED:
+        if master is NOT_PROVIDED:
             # The node making the call is the one we want to make MASTER by default
             new['master_node'] = await self.middleware.call('failover.node')
         else:

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -25,7 +25,7 @@ import enum
 
 from functools import partial
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import (
     job, no_auth_required, pass_app, private, throttle, CallError, ConfigService, ValidationErrors,
 )
@@ -143,8 +143,7 @@ class FailoverService(ConfigService):
                 This setting does NOT effect the `disabled` or `master` parameters.
         """
         master = data.pop('master', True)  # The node making the call is the one we want to make MASTER by default
-        old = await self.middleware.call('datastore.config', 'system.failover')
-        new = old.copy()
+        new = await self.middleware.call('datastore.config', 'system.failover')
         new.update(data)
 
         new['master_node'] = await self._master_node(master)

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -368,7 +368,7 @@ class FailoverService(ConfigService):
 
         crit_ints = [i for i in await self.middleware.call('interface.query') if i.get('failover_critical', False)]
         for i in crit_ints:
-            await self.middleware.call('failover.events.event', i['name'], 'forcetakeover')
+            await self.middleware.call('failover.event', i['name'], i['failover_vhid'], 'forcetakeover')
             return True
         else:
             # if there are no interfaces marked critical for failover and this method was

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -142,18 +142,12 @@ class FailoverService(ConfigService):
             **NOTE**
                 This setting does NOT effect the `disabled` or `master` parameters.
         """
-        master = data.pop('master', NOT_PROVIDED)
-
+        master = data.pop('master', True)  # The node making the call is the one we want to make MASTER by default
         old = await self.middleware.call('datastore.config', 'system.failover')
-
         new = old.copy()
         new.update(data)
 
-        if master is NOT_PROVIDED:
-            # The node making the call is the one we want to make MASTER by default
-            new['master_node'] = await self.middleware.call('failover.node')
-        else:
-            new['master_node'] = await self._master_node(master)
+        new['master_node'] = await self._master_node(master)
 
         verrors = ValidationErrors()
         if new['disabled'] is False:


### PR DESCRIPTION
1. failover.update has been broken for a long time. The truth logic is inversed (`if master is not NOT_PROVIDED` should be `if master is NOT_PROVIDED`). This took me entirely too long to notice but once I did, I realized this can be simplified and prevents the next developer from trying to understand obtuse logic.
2. Once I got the logic working in failover.update, I noticed another issue in failover.force_master and traced it to a cherry-pick from SCALE to CORE for `failover.events.event` but that does not exist on CORE, it is still just `failover.event`

This fixes the ability in the webUI to go to `System->Failover` and disable HA and mark the other truenas controller as the default controller (trigger a failover event in a round-about way).