### PR TITLE
NAS-121945 / 22.12.3 / Add validation to force encryption with LDAP SMB (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -210,7 +210,7 @@ class LDAPClient(Service):
             pyldap.set_option(pyldap.OPT_NETWORK_TIMEOUT, data['options']['dns_timeout'])
 
             self._setup_ssl(data)
-            if data['security']['ssl'] == SSL.USESTARTTLS.name:
+            if SSL(data['security']['ssl']) == SSL.USESTARTTLS:
                 try:
                     self._handle.start_tls_s()
 
@@ -782,6 +782,10 @@ class LDAPService(TDBWrapConfigService):
         if data['has_samba_schema'] and not ldap_has_samba_schema:
             verrors.add('ldap_update.has_samba_schema',
                         'Remote LDAP server does not have Samba schema extensions.')
+
+        if data['has_samba_schema'] and SSL(data['ssl']) == SSL.NOSSL:
+            verrors.add('ldap_update.has_samba_schema',
+                        'Encryption is required in order to use legacy Samba schema.')
 
     @private
     async def autodetect_ldap_settings(self, data):


### PR DESCRIPTION
pdbldap requires encrypted LDAP transport since it is accessing sensitive user information via the LDAP schema. This also fixes a typo in SSL configuration validition.

Original PR: https://github.com/truenas/middleware/pull/11299
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121945