### PR TITLE
NAS-121954 / 23.10 / Skip read of authorized keys where possible

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -191,6 +191,9 @@ class UserService(CRUDService):
 
     @private
     def _read_authorized_keys(self, homedir):
+        if not homedir:
+            return None
+
         keysfile = f'{homedir}/.ssh/authorized_keys'
         rv = None
         with suppress(FileNotFoundError):


### PR DESCRIPTION
If user does not have have a homedir we should not try to read its authorized_keys file (which would be a read of /.ssh/authorized_keys).