### PR TITLE
NAS-121959 / 22.12.3 / Properly make sure app migrations dir is copied over (by Qubad786)

### DIFF
--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -20,7 +20,10 @@ def get_assets(name):
     )
     result = []
     for root, dirs, files in os.walk(os.path.join(base_path, name)):
-        result.append(f'{os.path.relpath(root, base_path)}/*')
+        result.extend([f'{os.path.relpath(root, base_path)}/*'] + [
+            os.path.join(os.path.relpath(root, base_path), file)
+            for file in filter(lambda f: f == '.gitkeep', files)
+        ])
     return result
 
 


### PR DESCRIPTION
## Problem

Currently there are no app migrations written and the app migrations folder contains `.gitkeep` file which is not being retrieved by `get_assets` function. This results in the folder being missing which causes other regressions including failure of various integration tests.

## Solution

If we have a file named `.gitkeep`, let's gather it when we gather our assets which should be installed in the system.

Original PR: https://github.com/truenas/middleware/pull/11304
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121959