### PR TITLE
NAS-121506 / 22.12.3 / Use subprocess for pulling large docker images

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -1,6 +1,10 @@
+import contextlib
+
 import docker
 import re
+
 from collections import defaultdict
+from subprocess import DEVNULL, PIPE, Popen
 from typing import Dict, Union
 
 from middlewared.service import CallError
@@ -83,3 +87,23 @@ def get_chart_releases_consuming_image(
 
 def get_docker_client() -> docker.DockerClient:
     return docker.from_env()
+
+
+@contextlib.contextmanager
+def docker_auth(auth: dict) -> None:
+    """
+    Authenticates docker client in a context manager with given credentials using subprocess and a
+    try/finally block to logout
+    """
+    cp = Popen(['docker', 'login', '-u', auth['username'], '-p', auth['password']], stderr=PIPE, stdout=DEVNULL)
+    stderr = cp.communicate()[1]
+    if cp.returncode != 0:
+        raise CallError(f'Failed to login to docker registry: {stderr.decode()}')
+
+    try:
+        yield
+    finally:
+        cp = Popen(['docker', 'logout'], stderr=PIPE, stdout=DEVNULL)
+        stderr = cp.communicate()[1]
+        if cp.returncode != 0:
+            raise CallError(f'Failed to logout from docker registry: {stderr.decode()}')

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -95,15 +95,17 @@ def docker_auth(auth: dict) -> None:
     Authenticates docker client in a context manager with given credentials using subprocess and a
     try/finally block to logout
     """
-    cp = Popen(['docker', 'login', '-u', auth['username'], '-p', auth['password']], stderr=PIPE, stdout=DEVNULL)
-    stderr = cp.communicate()[1]
-    if cp.returncode != 0:
-        raise CallError(f'Failed to login to docker registry: {stderr.decode()}')
+    if auth:
+        cp = Popen(['docker', 'login', '-u', auth['username'], '-p', auth['password']], stderr=PIPE, stdout=DEVNULL)
+        stderr = cp.communicate()[1]
+        if cp.returncode != 0:
+            raise CallError(f'Failed to login to docker registry: {stderr.decode()}')
 
     try:
         yield
     finally:
-        cp = Popen(['docker', 'logout'], stderr=PIPE, stdout=DEVNULL)
-        stderr = cp.communicate()[1]
-        if cp.returncode != 0:
-            raise CallError(f'Failed to logout from docker registry: {stderr.decode()}')
+        if auth:
+            cp = Popen(['docker', 'logout'], stderr=PIPE, stdout=DEVNULL)
+            stderr = cp.communicate()[1]
+            if cp.returncode != 0:
+                raise CallError(f'Failed to logout from docker registry: {stderr.decode()}')


### PR DESCRIPTION
This PR adds changes to use subprocess for pulling large docker images in bluefin as the python client which we were using breaks the connection when pulling large images and so does k3s.

This is not an issue in cobia, so for bluefin let's use subprocess instead.