### PR TITLE
NAS-121697 / 23.10 / Start service if it stopped for lockable fs attachment delegates

### DIFF
--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -89,6 +89,14 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
             filters += [[self.locked_field, '=', options['locked']]]
         return filters
 
+    async def start_service(self):
+        if not (
+            service_obj := await self.middleware.call('service.query', [['service', '=', self.service]])
+        ) or not service_obj[0]['enable'] or service_obj[0]['state'] == 'RUNNING':
+            return
+
+        await self.middleware.call('service.start', self.service)
+
     async def query(self, path, enabled, options=None):
         results = []
         options = options or {}
@@ -149,6 +157,7 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
             return is_child
 
     async def start(self, attachments):
+        await self.start_service()
         for attachment in attachments:
             await self.remove_alert(attachment)
         if attachments:

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -1,0 +1,74 @@
+import contextlib
+
+import pytest
+from pytest_dependency import depends
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.assets.pool import dataset
+
+import os
+import sys
+sys.path.append(os.getcwd())
+
+
+PASSPHRASE = 'testing123'
+
+
+@contextlib.contextmanager
+def enable_auto_start(service_name):
+    service = call('service.query', [['service', '=', service_name]], {'get': True})
+    try:
+        yield call('service.update', service['id'], {'enable': True})
+    finally:
+        call('service.update', service['id'], {'enable': False})
+
+
+@contextlib.contextmanager
+def start_service(service_name):
+    try:
+        yield call('service.start', service_name)
+    finally:
+        call('service.stop', service_name)
+
+
+@contextlib.contextmanager
+def lock_dataset(dataset_name):
+    try:
+        yield call('pool.dataset.lock', dataset_name, {'force_umount': True}, job=True)
+    finally:
+        call(
+            'pool.dataset.unlock', dataset_name, {
+                'datasets': [{'passphrase': PASSPHRASE, 'name': dataset_name}]
+            },
+            job=True,
+        )
+
+
+def test_service_restart_on_unlock_dataset(request):
+    depends(request, ['pool_04'], scope='session')
+    service_name = 'smb'
+    registered_name = 'cifs'
+    with dataset('testsvcunlock', data={
+        'encryption': True,
+        'encryption_options': {
+            'algorithm': 'AES-256-GCM',
+            'pbkdf2iters': 350000,
+            'passphrase': PASSPHRASE,
+        },
+        'inherit_encryption': False
+    }) as ds:
+        path = f'/mnt/{ds}'
+        share = call(f'sharing.{service_name}.create', {'path': path, 'name': 'smb-dataset'})
+        assert share['locked'] is False
+
+        with start_service(registered_name) as service_started:
+            assert service_started is True
+
+            call('service.stop', registered_name)
+            assert call('service.started', registered_name) is False
+            with enable_auto_start(registered_name):
+                with lock_dataset(ds):
+                    assert call(f'sharing.{service_name}.get_instance', share['id'])['locked'] is True
+                    assert call('service.started', registered_name) is False
+
+                assert call(f'sharing.{service_name}.get_instance', share['id'])['locked'] is False
+                assert call('service.started', registered_name) is True


### PR DESCRIPTION
## Problem

Services are not restarted when datasets are unlocked if they were already stopped at the time of unlocking. In a change introduced in https://github.com/truenas/middleware/pull/7388, motivation was that we should always be restarting/reloading necessary services and that does not take into account the case where service was stopped at the time dataset was unlocked.

## Solution

After discussing with Caleb, we decided that the service if stopped should be started on dataset unlock if the service is meant to be started on boot. Changes have been made to Lockable FS attachment delegate so any attachments defined using this will be making use of this change.

## Notes:

For testing this change, i configured different shares and tried following cases to see that we are not regressing:
1. Exporting pool
2. Deleting dataset
3. Locking dataset
4. Importing pool
5. Unlocking dataset
