### PR TITLE
NAS-121743 / 22.12.3 / NAS-121743 (by bmeagherix)

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -989,6 +989,46 @@ def test_13_test_target_name(request, extent_type):
     assert "Value greater than 64 not allowed" in str(ve), ve
 
 
+class TestFixtureInitiatorName:
+    """Fixture for test_15_invalid_initiator_name"""
+
+    iqn = f'{basename}:{target_name}'
+
+    @pytest.fixture(scope='class')
+    def create_target(self):
+        with configured_target(target_name, "FILE"):
+            yield
+
+    params = [
+        (None, True),
+        ("iqn.1991-05.com.microsoft:fake-host", True),
+        ("iqn.1991-05.com.microsoft:fake-/-host", False),
+        ("iqn.1991-05.com.microsoft:fake-#-host", False),
+        ("iqn.1991-05.com.microsoft:fake-%s-host", False),
+        ("iqn.1991-05.com.microsoft:unicode-\u6d4b\u8bd5-ok", True),		# 测试
+        ("iqn.1991-05.com.microsoft:unicode-\u30c6\u30b9\u30c8-ok", True),	# テスト
+        ("iqn.1991-05.com.microsoft:unicode-\u180E-bad", False),		# Mongolian vowel separator
+        ("iqn.1991-05.com.microsoft:unicode-\u2009-bad", False),		# Thin Space
+        ("iqn.1991-05.com.microsoft:unicode-\uFEFF-bad", False),		# Zero width no-break space
+    ]
+
+    @pytest.mark.parametrize("initiator_name, expected", params)
+    def test_14_invalid_initiator_name(self, request, create_target, initiator_name, expected):
+        """
+        Deliberately send SCST some invalid initiator names and ensure it behaves OK.
+        """
+        depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+
+        if expected:
+            with iscsi_scsi_connection(ip, TestFixtureInitiatorName.iqn, initiator_name=initiator_name) as s:
+                _verify_inquiry(s)
+        else:
+            with pytest.raises(RuntimeError) as ve:
+                with iscsi_scsi_connection(ip, TestFixtureInitiatorName.iqn, initiator_name=initiator_name) as s:
+                    assert False, "Should not have been able to connect with invalid initiator name."
+                assert 'Unable to connect to' in str(ve), ve
+
+
 def test_99_teardown(request):
     # Disable iSCSI service
     depends(request, ["iscsi_cmd_00"])

--- a/tests/protocols/iscsi_proto.py
+++ b/tests/protocols/iscsi_proto.py
@@ -1,9 +1,20 @@
-import contextlib                                                                                                                                               
-import pyscsi
-from pyscsi.utils import init_device
-from pyscsi.pyscsi.scsi import SCSI
+import contextlib
+import inspect
 
-def iscsi_scsi_connect(host, iqn, lun=0, user=None, secret=None, target_user=None, target_secret=None):
+from pyscsi.pyscsi.scsi import SCSI
+from pyscsi.utils import init_device
+
+
+def initiator_name_supported():
+    """
+    Returns whether a non-None initiator name may be supplied.
+
+    This can have an impact on what kinds of tests can be run.
+    """
+    return 'initiator_name' in inspect.signature(init_device).parameters
+
+
+def iscsi_scsi_connect(host, iqn, lun=0, user=None, secret=None, target_user=None, target_secret=None, initiator_name=None):
     """
     Connect to the specified target, returning a SCSI object from python-scsi.
 
@@ -17,24 +28,32 @@ def iscsi_scsi_connect(host, iqn, lun=0, user=None, secret=None, target_user=Non
     pprint.pprint(s.inquiry().result)
     s.device.close()
     """
+    hil = f"{host}/{iqn}/{lun}"
     if user is None and secret is None:
-        device = init_device("iscsi://{}/{}/{}".format(host, iqn, lun))
+        device_str = f"iscsi://{hil}"
     elif user and secret:
         if target_user is None and target_secret is None:
             # CHAP
-            device = init_device("iscsi://{}%{}@{}/{}/{}".format(user, secret, host, iqn, lun))
+            device_str = f"iscsi://{user}%{secret}@{hil}"
         elif target_user and target_secret:
             # Mutual CHAP
-            device = init_device("iscsi://{}%{}@{}/{}/{}?target_user={}&target_password={}".format(user, secret, host, iqn, lun, target_user, target_secret))
+            device_str = f"iscsi://{user}%{secret}@{hil}?target_user={target_user}&target_password={target_secret}"
         else:
             raise ValueError("If either of target_user and target_secret is set, then both should be set.")
     else:
         raise ValueError("If either of user and secret is set, then both should be set.")
+    if initiator_name:
+        if not initiator_name_supported():
+            raise ValueError("Initiator name supplied, but not supported.")
+        device = init_device(device_str, initiator_name=initiator_name)
+    else:
+        device = init_device(device_str)
     s = SCSI(device)
     return s
 
+
 @contextlib.contextmanager
-def iscsi_scsi_connection(host, iqn, lun=0, user=None, secret=None, target_user=None, target_secret=None):
+def iscsi_scsi_connection(host, iqn, lun=0, user=None, secret=None, target_user=None, target_secret=None, initiator_name=None):
     """
     Factory function to connect to the specified target, returning a SCSI
     object from python-scsi.
@@ -49,10 +68,9 @@ def iscsi_scsi_connection(host, iqn, lun=0, user=None, secret=None, target_user=
         inqdata = s.inquiry().result
     """
 
-    s = iscsi_scsi_connect(host, iqn, lun, user, secret, target_user, target_secret)
+    s = iscsi_scsi_connect(host, iqn, lun, user, secret, target_user, target_secret, initiator_name)
 
     try:
         yield s
     finally:
         s.device.close()
-


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ae57d7688873c052e9867a80ace1c039a6850c01
    git cherry-pick -x 61463a6b0736bd1df0a1cc15353f0c6912318903
    git cherry-pick -x 16a85ecde8e2e4a8fcf3841aae65178896b532e4

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4bad047b6d5e0de080403428c4c8172131c1d030

Now that SCST has been updated to check initiator name upon LOGIN, add a unit test.

Original PR: https://github.com/truenas/middleware/pull/11314
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121743