### PR TITLE
NAS-121981 / 23.10 / Add similarity score for retrieving similar apps

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -93,14 +93,25 @@ class AppService(Service):
         app = filter_list(
             available_apps, [['name', '=', app_name], ['catalog', '=', catalog], ['train', '=', train]], {'get': True}
         )
-        similar_apps = []
+        similar_apps = {}
+
+        # Calculate the number of common categories/tags between app and other apps
+        app_categories = set(app['categories'])
+        app_tags = set(app['tags'])
+        app_similarity = {}
+
         for to_check_app in available_apps:
             if all(to_check_app[k] == app[k] for k in ('name', 'catalog', 'train')):
                 continue
 
-            for key in ('categories', 'tags'):
-                if set(app[key]).intersection(to_check_app[key]):
-                    similar_apps.append(to_check_app)
-                    break
+            common_categories = set(to_check_app['categories']).intersection(app_categories)
+            common_tags = set(to_check_app['tags']).intersection(app_tags)
+            similarity_score = len(common_categories) + len(common_tags)
+            if similarity_score:
+                app_similarity[to_check_app['name']] = similarity_score
+                similar_apps[to_check_app['name']] = to_check_app
 
-        return similar_apps
+        # Sort apps based on the similarity score in descending order
+        sorted_apps = sorted(app_similarity.keys(), key=lambda x: app_similarity[x], reverse=True)
+
+        return [similar_apps[app] for app in sorted_apps]


### PR DESCRIPTION
## Context

We were retrieving similar apps based on common tags/categories, however this did not prioritise apps which were more "similar".
An improvement to the existing logic has been added where a similarity score has been added and we sort the similar apps based on the similarity score generated so apps which are more similar are prioritised first when retrieving similar apps.