### PR TITLE
NAS-121259 / 22.12.3 / add F1 product detection (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme.py
@@ -166,11 +166,17 @@ class EnclosureService(Service):
         return self.fake_nvme_enclosure(*self.map_r50_or_r50b_impl(info, acpihandles))
 
     @private
-    def map_r30(self):
-        _id = 'r30_nvme_enclosure'
-        name = 'R30 NVMe Enclosure'
-        model = 'R30'
-        count = 16  # r30 has 16 nvme drive bays in head-unit (all nvme flash system)
+    def map_r30_or_f1(self, prod):
+        if prod == 'R30':
+            _id = 'r30_nvme_enclosure'
+            name = 'R30 NVMe Enclosure'
+            model = 'R30'
+            count = 16  # r30 has 16 nvme drive bays in head-unit (all nvme flash system)
+        else:
+            _id = 'f1_nvme_enclosure'
+            name = 'F1 NVMe Enclosure'
+            model = 'F1'
+            count = 24  # F1 has 24 nvme drive bays in head-unit (all nvme flash system)
 
         ctx = Context()
         nvmes = {}
@@ -188,15 +194,25 @@ class EnclosureService(Service):
                 except (IndexError, AttributeError):
                     continue
 
-        # the keys in this dictionary are the 16 physical pcie slot ids
+        # the keys in this dictionary are the physical pcie slot ids
         # and the values are the slots that the webUI uses to map them
         # to their physical locations in a human manageable way
-        webui_map = {
-            '27': 1, '26': 7, '25': 2, '24': 8,
-            '37': 3, '36': 9, '35': 4, '34': 10,
-            '45': 5, '47': 11, '40': 6, '41': 12,
-            '38': 14, '39': 16, '43': 13, '44': 15,
-        }
+        if prod == 'R30':
+            webui_map = {
+                '27': 1, '26': 7, '25': 2, '24': 8,
+                '37': 3, '36': 9, '35': 4, '34': 10,
+                '45': 5, '47': 11, '40': 6, '41': 12,
+                '38': 14, '39': 16, '43': 13, '44': 15,
+            }
+        else:
+            # F1 vendor is nice to us and nvme phys slots start at 1
+            # and increment in a human readable way already
+            webui_map = {
+                '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6,
+                '7': 7, '8': 8, '9': 9, '10': 10, '11': 11, '12': 12,
+                '13': 13, '14': 14, '15': 15, '16': 16, '17': 17, '18': 18,
+                '19': 19, '20': 20, '21': 21, '22': 22, '23': 23, '24': 24,
+            }
 
         mapped = {}
         for i in Path('/sys/bus/pci/slots').iterdir():
@@ -209,7 +225,7 @@ class EnclosureService(Service):
     @private
     def valid_hardware(self, prod):
         prefix = 'TRUENAS-'
-        models = ['R30', 'R50', 'R50B', 'R50BM', 'M50', 'M60']
+        models = ['R30', 'R50', 'R50B', 'R50BM', 'M50', 'M60', 'F1']
         if prod != 'TRUENAS-' and any((j in prod for j in [f'{prefix}{i}' for i in models])):
             return prod.split('-')[1]
 
@@ -219,11 +235,11 @@ class EnclosureService(Service):
         if not prod:
             return []
 
-        if prod == 'R50' or prod == 'R50B':
+        if prod in ('R50', 'R50B'):
             return self.map_r50_or_r50b(prod)
-        elif prod == 'R30':
-            # all nvme system which we need to handle separately
-            return self.map_r30()
+        elif prod in ('R30', 'F1'):
+            # all nvme systems which we need to handle separately
+            return self.map_r30_or_f1(prod)
         else:
             # M50/60 and R50BM use same plx nvme bridge
             return self.map_plx_nvme(prod)

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -162,6 +162,7 @@ class FailoverService(ConfigService):
         Returns the hardware type for an HA system.
           ECHOSTREAM
           ECHOWARP
+          F1
           PUMA
           BHYVE
           MANUAL

--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -19,7 +19,8 @@ class EnclosureDetectionService(Service):
     @cache
     def detect(self):
         HARDWARE = NODE = 'MANUAL'
-        if self.middleware.call_sync('system.dmidecode_info')['system-product-name'] == 'BHYVE':
+        product = self.middleware.call_sync('system.dmidecode_info')['system-product-name']
+        if product == 'BHYVE':
             # bhyve host configures a scsi_generic device that when sent an inquiry will
             # respond with a string that we use to determine the position of the node
             ctx = Context()
@@ -34,6 +35,14 @@ class EnclosureDetectionService(Service):
                         NODE = 'B'
                         HARDWARE = 'BHYVE'
                         break
+
+            return HARDWARE, NODE
+        elif 'TRUENAS-F1' in product:
+            HARDWARE = 'F1'
+            rv = subprocess.run(['ipmi-raw', '0', '3c', '0e'], stdout=subprocess.PIPE)
+            if rv.stdout:
+                # Viking info via VSS2249RQ Management Over IPMI document Section 5.5 page 15
+                NODE = 'A' if rv.stdout.decode().strip()[-1] == '0' else 'B'
 
             return HARDWARE, NODE
 

--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -32,7 +32,7 @@ class InternalInterfaceService(Service):
                     if ZSERIES_PCI_ID and ZSERIES_PCI_SUBSYS_ID in data:
                         return [i.split('/')[4].strip()]
 
-        if hardware in ('PUMA', 'ECHOWARP'):
+        if hardware in ('PUMA', 'ECHOWARP', 'F1'):
             return ['ntb0']
 
         return []

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -34,6 +34,7 @@ PLATFORM_PREFIXES = (
     'TRUENAS-Z',  # z-series
     'TRUENAS-X',  # x-series
     'TRUENAS-M',  # m-series AND current mini platforms
+    'TRUENAS-F1',  # f1-series
     'TRUENAS-R',  # freenas certified replacement
     'FREENAS-MINI',  # minis tagged with legacy information
 )


### PR DESCRIPTION
This adds logic to properly detect the F1 HA product type. NOTE: this does not add the drive bay identification logic (that will come in another PR)

Original PR: https://github.com/truenas/middleware/pull/11313
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121259