### PR TITLE
Fix openvpn server logs ownership

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
@@ -1,0 +1,29 @@
+import errno
+import os
+
+from middlewared.service import CallError
+
+
+LOGS_FOLDER = '/var/log/openvpn'
+
+
+def fix_perms(middleware):
+    if nobody_user := middleware.call_sync('user.query', [('username', '=', 'nobody')]):
+        nobody_uid = nobody_user[0]['uid']
+        nobody_gid = nobody_user[0]['group']['bsdgrp_gid']
+    else:
+        raise CallError('Unable to locate "nobody" user', errno=errno.ENOENT)
+
+    os.makedirs(LOGS_FOLDER, exist_ok=True)
+    for path in (
+        LOGS_FOLDER, *map(lambda file: os.path.join(LOGS_FOLDER, file), ('openvpn.log', 'openvpn-status.log'))
+    ):
+        if not os.path.exists(path):
+            with open(path, 'w'):
+                pass
+        if os.stat(path).st_uid != nobody_uid or os.stat(path).st_gid != nobody_gid:
+            os.chown(path, uid=nobody_uid, gid=nobody_gid)
+
+
+def render(service, middleware):
+    fix_perms(middleware)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -303,7 +303,8 @@ class EtcService(Service):
             {
                 'type': 'mako', 'local_path': 'local/openvpn/server/openvpn_server.conf',
                 'path': 'local/openvpn/server/server.conf'
-            }
+            },
+            {'type': 'py', 'path': 'local/openvpn/server/perms'},
         ],
         'openvpn_client': [
             {


### PR DESCRIPTION
This PR fixes the ownership of openvpn server based log files which happened to be `root/root`. A user reported issues with his OpenVPN server not accepting clients because of these permission issues which when he manually fixed resulted in successful connection.

The user in question had some extra parameters specified as well but i think it is generally speaking good practice to do this.