### PR TITLE
NAS-121359 / 22.12.3 / Fix openvpn server logs ownership (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
@@ -1,0 +1,29 @@
+import errno
+import os
+
+from middlewared.service import CallError
+
+
+LOGS_FOLDER = '/var/log/openvpn'
+
+
+def fix_perms(middleware):
+    if nobody_user := middleware.call_sync('user.query', [('username', '=', 'nobody')]):
+        nobody_uid = nobody_user[0]['uid']
+        nobody_gid = nobody_user[0]['group']['bsdgrp_gid']
+    else:
+        raise CallError('Unable to locate "nobody" user', errno=errno.ENOENT)
+
+    os.makedirs(LOGS_FOLDER, exist_ok=True)
+    for path in (
+        LOGS_FOLDER, *map(lambda file: os.path.join(LOGS_FOLDER, file), ('openvpn.log', 'openvpn-status.log'))
+    ):
+        if not os.path.exists(path):
+            with open(path, 'w'):
+                pass
+        if os.stat(path).st_uid != nobody_uid or os.stat(path).st_gid != nobody_gid:
+            os.chown(path, uid=nobody_uid, gid=nobody_gid)
+
+
+def render(service, middleware):
+    fix_perms(middleware)

--- a/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
@@ -15,11 +15,11 @@ def fix_perms(middleware):
 
     log_dir = Path('/var/log/openvpn')
     log_dir.mkdir(parents=True, exist_ok=True)
-    for path_attr in (
-        log_dir, *map(lambda file_name: log_dir / file_name, ('openvpn.log', 'openvpn-status.log'))
-    ):
-        path_attr.touch(exist_ok=True)
-        os.chown(path_attr.absolute().as_posix(), uid=nobody_uid, gid=nobody_gid)
+    os.chown(log_dir.absolute().as_posix(), uid=nobody_uid, gid=nobody_gid)
+    for file_name in ('openvpn.log', 'openvpn-status.log'):
+        file_attr = log_dir / file_name
+        file_attr.touch(exist_ok=True)
+        os.chown(file_attr.absolute().as_posix(), uid=nobody_uid, gid=nobody_gid)
 
 
 def render(service, middleware):

--- a/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
+++ b/src/middlewared/middlewared/etc_files/local/openvpn/server/perms.py
@@ -6,9 +6,6 @@ from pathlib import Path
 from middlewared.service import CallError
 
 
-LOGS_FOLDER = '/var/log/openvpn'
-
-
 def fix_perms(middleware):
     if nobody_user := middleware.call_sync('user.query', [('username', '=', 'nobody')]):
         nobody_uid = nobody_user[0]['uid']
@@ -16,7 +13,7 @@ def fix_perms(middleware):
     else:
         raise CallError('Unable to locate "nobody" user', errno=errno.ENOENT)
 
-    log_dir = Path(LOGS_FOLDER)
+    log_dir = Path('/var/log/openvpn')
     log_dir.mkdir(parents=True, exist_ok=True)
     for path_attr in (
         log_dir, *map(lambda file_name: log_dir / file_name, ('openvpn.log', 'openvpn-status.log'))

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -309,7 +309,8 @@ class EtcService(Service):
             {
                 'type': 'mako', 'local_path': 'local/openvpn/server/openvpn_server.conf',
                 'path': 'local/openvpn/server/server.conf'
-            }
+            },
+            {'type': 'py', 'path': 'local/openvpn/server/perms'},
         ],
         'openvpn_client': [
             {


### PR DESCRIPTION
This PR fixes the ownership of openvpn server based log files which happened to be `root/root`. A user reported issues with his OpenVPN server not accepting clients because of these permission issues which when he manually fixed resulted in successful connection.

The user in question had some extra parameters specified as well but i think it is generally speaking good practice to do this.

Original PR: https://github.com/truenas/middleware/pull/11321
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121359