### PR TITLE
TE-629 / 13.0 / Fixed internal release build train test and added longer timeout for iscsi wait

### DIFF
--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -148,7 +148,7 @@ def test_09_Connecting_to_iSCSI_target(request):
 
 
 @bsd_host_cfg
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 @pytest.mark.dependency(name="iscsi_10")
 def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name(request):
     depends(request, ["iscsi_09"])
@@ -370,7 +370,7 @@ def test_34_connecting_to_the_zvol_iscsi_target(request):
 
 
 @bsd_host_cfg
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(30)
 @pytest.mark.dependency(name="iscsi_35")
 def test_35_waiting_for_iscsi_connection_before_grabbing_device_name(request):
     depends(request, ["iscsi_34"])

--- a/tests/api2/test_790_update.py
+++ b/tests/api2/test_790_update.py
@@ -186,7 +186,10 @@ if os.path.exists(f'{apifolder}/config.cfg') is True:
     version = configs['NAS_CONFIG']['version']
 
     def test_16_verify_TrueNAS_trains():
-        if 'INTERNAL' in version:
+        if 'INTERNAL' in version and any(line in version for line in ['-RELEASE', '-U']):
+            train = version.rsplit('-', maxsplit=3)[0] + '-STABLE'
+            current = version.rsplit('-', maxsplit=3)[0].lower() + '-internal'
+        elif 'INTERNAL' in version:
             train = version.rsplit('-', maxsplit=2)[0] + '-STABLE'
             current = version.rsplit('-', maxsplit=1)[0].lower()
         elif any(line in version for line in ['-RELEASE', '-U']):


### PR DESCRIPTION
All api test passed https://builds.ixsystems.com/job/Test%20development/job/TrueNAS%2013.0%20Internal%20API%20Tests%20from%20branch/50/