### PR TITLE
NAS-121993 / 13.0 / Improve IPMI password validation (#9251)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -3,10 +3,10 @@ try:
 except ImportError:
     kld = None
 
-from middlewared.schema import Bool, Dict, Int, IPAddr, Str, accepts
+from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, Password, Str
 from middlewared.service import CallError, CRUDService, filterable, ValidationErrors
 from middlewared.utils import filter_list, run
-from middlewared.validators import Netmask
+from middlewared.validators import Netmask, PasswordComplexity, Range
 
 import errno
 import os
@@ -77,7 +77,10 @@ class IPMIService(CRUDService):
         IPAddr('ipaddress', v6=False),
         Str('netmask', validators=[Netmask(ipv6=False, prefix_length=False)]),
         IPAddr('gateway', v6=False),
-        Str('password', private=True),
+        Password('password', validators=[
+            PasswordComplexity(["ASCII_UPPER", "ASCII_LOWER", "DIGIT", "SPECIAL"], 3),
+            Range(8, 16)
+        ]),
         Bool('dhcp'),
         Int('vlan', null=True),
     ))
@@ -96,12 +99,6 @@ class IPMIService(CRUDService):
             raise CallError('The ipmi device could not be found')
 
         verrors = ValidationErrors()
-
-        if data.get('password') and len(data.get('password')) > 20:
-            verrors.add(
-                'ipmi_update.password',
-                'A maximum of 20 characters are allowed'
-            )
 
         if not data.get('dhcp'):
             for k in ['ipaddress', 'netmask', 'gateway']:

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -220,6 +220,12 @@ class Path(Str):
         return os.path.normpath(value.strip().strip("/").strip())
 
 
+class Password(Str):
+    def __init__(self, *args, **kwargs):
+        self.private = True
+        super().__init__(*args, **kwargs)
+
+
 class Dir(Str):
 
     def validate(self, value):

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -3,6 +3,7 @@ import ipaddress
 import re
 from urllib.parse import urlparse
 import uuid
+from string import digits, ascii_uppercase, ascii_lowercase, punctuation
 
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
@@ -206,6 +207,58 @@ class UUID:
             uuid.UUID(value, version=4)
         except ValueError as e:
             raise ValueError(f'Invalid UUID: {e}')
+
+
+class PasswordComplexity:
+    def __init__(self, required_types, required_cnt=None):
+        self.required_types = required_types
+        self.required_cnt = required_cnt
+
+    def __call__(self, value):
+        cnt = 0
+        reqs = []
+        errstr = ''
+
+        if value and self.required_types:
+            if 'ASCII_LOWER' in self.required_types:
+                reqs.append('lowercase character')
+                if not any(c in ascii_lowercase for c in value):
+                    if self.required_cnt is None:
+                        errstr += 'Must contain at least one lowercase character. '
+                else:
+                    cnt += 1
+
+            if 'ASCII_UPPER' in self.required_types:
+                reqs.append('uppercase character')
+                if not any(c in ascii_uppercase for c in value):
+                    if self.required_cnt is None:
+                        errstr += 'Must contain at least one uppercase character. '
+                else:
+                    cnt += 1
+
+            if 'DIGIT' in self.required_types:
+                reqs.append('digits 0-9')
+                if not any(c in digits for c in value):
+                    if self.required_cnt is None:
+                        errstr += 'Must contain at least one numeric digit (0-9). '
+                else:
+                    cnt += 1
+
+            if 'SPECIAL' in self.required_types:
+                reqs.append('special characters (!, $, #, %, etc.)')
+                if not any(c in punctuation for c in value):
+                    if self.required_cnt is None:
+                        errstr += 'Must contain at least one special character (!, $, #, %, etc.). '
+                else:
+                    cnt += 1
+
+        if self.required_cnt and self.required_cnt > cnt:
+            raise ValueError(
+                f'Must contain at least {self.required_cnt} of the following categories: {", ".join(reqs)}'
+            )
+
+        if errstr:
+            raise ValueError(errstr)
 
 
 def validate_attributes(schema, data, additional_attrs=False, attr_key="attributes"):


### PR DESCRIPTION
This addresses a couple of issues with IPMI password validation

1) The webui lists password complexity requirements that are
   not validated within middleware before sending payload
   through ipmitool.

2) Password length of 20 characters is enforced in middleware,
   but this value exceeds that supported by ipmi 1.5 (16 characters).

The first item is problematic because the error messages from ipmitool for passwords that lack sufficient complexity are less than helpful ("Request data field length limit exceeded").

The second item is also incredibly problematic because on some devices a password of more than 16 characters will be silently truncated to 16 characters.

This PR shifts validation to the middleware schema by introducing two changes:

a) Password() schema type. This currently only hardcodes 'private' key, but the guiding principal is that we can start shifting places where we are handling passwords to have a common schema so that it is simpler to identify and audit where middleware is handling passwords.

b) PasswordComplexity validator. This implements validation of the sort where you need two or three of certain character types in a password.