### PR TITLE
NAS-121206 / 22.12.3 / Expand validation of user home directories (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -291,8 +291,25 @@ class UserService(CRUDService):
         )
 
     @private
+    def validate_homedir_mountinfo(self, verrors, schema, dev):
+        mntinfo = self.middleware.call_sync(
+            'filesystem.mount_info',
+            [['device_id.dev_t', '=', dev]],
+            {'get': True}
+        )
+
+        if 'RO' in mntinfo['mount_opts']:
+            verrors.add(f'{schema}.home', 'Path has the ZFS readonly property set.')
+            return False
+
+        if mntinfo['fs_type'] != 'zfs':
+            verrors.add(f'{schema}.home', 'Path is not on a ZFS filesystem')
+            return False
+
+        return True
+
+    @private
     def validate_homedir_path(self, verrors, schema, data, users):
-        needs_additional_validation = True
         p = Path(data['home'])
 
         if not p.is_absolute():
@@ -325,7 +342,21 @@ class UserService(CRUDService):
                     f'{data["home"]}: path specified to use as home directory does not exist.'
                 )
 
-            return False
+            if not p.parent.exists():
+                verrors.add(
+                    f'{schema}.home',
+                    f'{p.parent}: parent path of specified home directory does not exist.'
+                )
+
+            if not verrors:
+                self.validate_homedir_mountinfo(verrors, schema, p.parent.stat().st_dev)
+
+        elif self.validate_homedir_mountinfo(verrors, schema, p.stat().st_dev):
+            if self.middleware.call_sync('filesystem.is_immutable', data['home']):
+                verrors.add(
+                    f'{schema}.home',
+                    f'{data["home"]}: home directory path is immutable.'
+                )
 
         in_use = filter_list(users, [('home', '=', data['home'])])
         if in_use:
@@ -334,7 +365,6 @@ class UserService(CRUDService):
                 f'{data["home"]}: homedir already used by {in_use[0]["username"]}.',
                 errno.EEXIST
             )
-            needs_additional_validation = False
 
         if not data['home'].startswith('/mnt/'):
             verrors.add(
@@ -342,8 +372,12 @@ class UserService(CRUDService):
                 '"Home Directory" must begin with /mnt/ or set to '
                 f'{DEFAULT_HOME_PATH}.'
             )
-            needs_additional_validation = False
-        elif not any(
+
+        if verrors:
+            # if we're already going to error out, skip more expensive tests
+            return False
+
+        if not any(
             data['home'] == i['path'] or data['home'].startswith(i['path'] + '/')
             for i in self.middleware.call_sync('pool.query')
         ):
@@ -352,21 +386,18 @@ class UserService(CRUDService):
                 f'The path for the home directory "({data["home"]})" '
                 'must include a volume or dataset.'
             )
-            needs_additional_validation = False
         elif self.middleware.call_sync('pool.dataset.path_in_locked_datasets', data['home']):
             verrors.add(
                 f'{schema}.home',
                 'Path component for "Home Directory" is currently encrypted and locked'
             )
-            needs_additional_validation = False
         elif len(p.resolve().parents) == 2 and not data.get('home_create'):
             verrors.add(
                 f'{schema}.home',
                 f'The specified path is a ZFS pool mountpoint "({data["home"]})".'
             )
-            needs_additional_validation = False
 
-        return needs_additional_validation
+        return p.exists() and not verrors
 
     @private
     def setup_homedir(self, path, username, mode, uid, gid, create=False):

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -805,3 +805,18 @@ def test_58_create_new_user_existing_home_path(request):
             'home_create': True,
         })
         assert results.status_code == 422, results.text
+
+
+def test_59_create_user_ro_dataset(request):
+    user_info = {
+        'username': 't1',
+        "full_name": 'T1',
+        'group_create': True,
+        'password': 'test1234',
+        'home_mode': '770',
+        'home_create': True,
+    }
+    with tmp_dataset(pool_name, 'ro_user_ds', {'readonly': 'ON'}) as ds:
+        user_info['home'] = ds['mountpoint']
+        results = POST("/user/", user_info)
+        assert results.status_code == 422, results.text


### PR DESCRIPTION
We should catch following cases and turn them into informative validation errors:

* New home directory doesn't exist and parent directory is on RO dataset
* New home directory doesn't exist and parent directory is immutable
* New home directory exists and is on RO dataset or immutable

Since we're already having to get mount information, this commit adds an additional check for filesystem type in the returned mount info. If any validation errors have been added, then skip more expensive checks using libzfs.

Original PR: https://github.com/truenas/middleware/pull/10994
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121206