### PR TITLE
NAS-122038 / 23.10 / Migrate existing installed apps to TrueNAS catalog

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations/01_middleware_migrate_official_catalog.json
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations/01_middleware_migrate_official_catalog.json
@@ -1,5 +1,7 @@
-{
-  "action": "rename_catalog",
-  "old_catalog": "OFFICIAL",
-  "new_catalog": "TRUENAS"
-}
+[
+  {
+    "action": "rename_catalog",
+    "old_catalog": "OFFICIAL",
+    "new_catalog": "TRUENAS"
+  }
+]

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations/01_middleware_migrate_official_catalog.json
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/app_migrations/01_middleware_migrate_official_catalog.json
@@ -1,0 +1,5 @@
+{
+  "action": "rename_catalog",
+  "old_catalog": "OFFICIAL",
+  "new_catalog": "TRUENAS"
+}


### PR DESCRIPTION
This PR adds changes to account for the rename we are doing of `OFFICIAL` catalog to be named as `TRUENAS`.