### PR TITLE
NAS-121517 / 23.10 / Rename official catalog to "Truenas" (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2023-04-27_08-00_official_catalog_rename.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2023-04-27_08-00_official_catalog_rename.py
@@ -1,0 +1,31 @@
+"""
+Change official catalog label
+
+Revision ID: 441144fa08e7
+Revises: 7035fa70c0c0
+Create Date: 2023-04-27 08:00:08.436590+00:00
+
+"""
+import json
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '441144fa08e7'
+down_revision = '7035fa70c0c0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    conn.execute("DELETE FROM services_catalog WHERE label = 'TRUENAS'")
+    conn.execute("UPDATE services_catalog SET label = ? WHERE label = ?", (
+        'TRUENAS', 'OFFICIAL'
+    ))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/22.12/2023-05-18_08-00_official_catalog_rename.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2023-05-18_08-00_official_catalog_rename.py
@@ -2,18 +2,16 @@
 Change official catalog label
 
 Revision ID: 441144fa08e7
-Revises: 7035fa70c0c0
-Create Date: 2023-04-27 08:00:08.436590+00:00
+Revises: 08539dfd0500
+Create Date: 2023-05-18 08:00:08.436590+00:00
 
 """
-import json
-
 from alembic import op
 
 
 # revision identifiers, used by Alembic.
 revision = '441144fa08e7'
-down_revision = '7035fa70c0c0'
+down_revision = '08539dfd0500'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-05-19_18-00_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-05-19_18-00_merge.py
@@ -1,0 +1,21 @@
+"""Merge
+
+Revision ID: a70b230c1675
+Revises: 58a555dd9612, 441144fa08e7
+Create Date: 2023-05-19 18:00:29.283266+00:00
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a70b230c1675'
+down_revision = ('58a555dd9612', '441144fa08e7')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -13,7 +13,7 @@ from middlewared.validators import Match
 from .utils import convert_repository_to_path, get_cache_key
 
 OFFICIAL_ENTERPRISE_TRAIN = 'enterprise'
-OFFICIAL_LABEL = 'OFFICIAL'
+OFFICIAL_LABEL = 'TRUENAS'
 TMP_IX_APPS_DIR = '/tmp/ix-applications'
 
 


### PR DESCRIPTION
This PR adds changes to rename the official catalog to be named as `Truenas` instead. This change affects apps which we are going to install or update and not the already existing ones. There is a separate PR for that change.

Original PR: https://github.com/truenas/middleware/pull/11348
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121517