### PR TITLE
Fix NFS 'at boot' state

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -40,6 +40,7 @@ systemctl disable winbind
 systemctl disable wsdd
 systemctl disable walinuxagent
 systemctl disable openipmi
+systemctl disable nfs-server
 
 # nvidia-persistenced is not respecting vendor preset file so we disable it explicitly
 systemctl disable nvidia-persistenced


### PR DESCRIPTION
Despite a 'preset' value of 'disabled, the NFS package install
results in running the NFS server at boot.   We add an explicit
disable for the service as a work around.