### PR TITLE
NAS-122042 / 22.12.3 / Close SMB share in a few more cases (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1186,6 +1186,7 @@ class SharingSMBService(SharingService):
             await self.middleware.call('sharing.smb.reg_addshare', new)
 
         elif not old_is_locked and new_is_locked:
+            await self.close_share(newname)
             await self.middleware.call('smb.sharesec.toggle_share', newname, False)
             try:
                 await self.middleware.call('sharing.smb.reg_delshare', oldname)
@@ -1195,6 +1196,9 @@ class SharingSMBService(SharingService):
                                     old['name'], exc_info=True)
 
         if new['enabled'] != old['enabled']:
+            if not new['enabled']:
+                await self.close_share(newname)
+
             await self.middleware.call('smb.sharesec.toggle_share', newname, new['enabled'])
             check_mdns = True
 


### PR DESCRIPTION
Forcibly shut down SMB sessions if share is being locked or disabled.

Original PR: https://github.com/truenas/middleware/pull/11350
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122042