### PR TITLE
NAS-121907 / 22.12.3 / Remove immutable flag after mounting unlocked dataset too (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2575,6 +2575,10 @@ class PoolDatasetService(CRUDService):
                     failed[name]['error'] = f'Failed to mount dataset: {e}'
                 else:
                     unlocked.append(name)
+                    try:
+                        self.middleware.call_sync('filesystem.set_immutable', False, mount_path)
+                    except Exception:
+                        pass
 
         for failed_ds in failed:
             failed_datasets = {}


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b2faaf0fa1b32e0425dc035da8badca86437b050

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bd3e8959529925dfc35128773806fa7b0bacb0b1

(might be erroneously set previously)

Original PR: https://github.com/truenas/middleware/pull/11360
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121907