### PR TITLE
NAS-122089 / 23.10 / Optimize and fix retrieval of SID info for AD user

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/cache.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/cache.py
@@ -117,8 +117,8 @@ class ActiveDirectoryService(Service):
                 'sshpubkey': None,
                 'local': False,
                 'id_type_both': u['domain_info']['idmap_backend'] in id_type_both_backends,
-                'nt_name': None,
-                'sid': None,
+                'nt_name': user_data.pw_name,
+                'sid': u['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
 
@@ -138,8 +138,8 @@ class ActiveDirectoryService(Service):
                 'users': [],
                 'local': False,
                 'id_type_both': g['domain_info']['idmap_backend'] in id_type_both_backends,
-                'nt_name': None,
-                'sid': None,
+                'nt_name': group_data.gr_name,
+                'sid': g['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)
 

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -301,7 +301,11 @@ class DSCache(Service):
             Str('who'),
             Int('id'),
         ),
-        Dict('options', Bool('synthesize', default=False))
+        Dict(
+            'options',
+            Bool('synthesize', default=False),
+            Bool('smb', default=False)
+        )
     )
     async def retrieve(self, ds, data, options):
         who_str = data.get('who')
@@ -313,6 +317,7 @@ class DSCache(Service):
         tdb_name = f'{ds.lower()}_{data["idtype"].lower()}'
         prefix = "NAME" if who_str else "ID"
         tdb_key = f'{prefix}_{who_str if who_str else who_id}'
+        name_key = "username" if data['idtype'] == 'USER' else 'group'
 
         try:
             entry = await self.middleware.call("tdb.fetch", {"name": tdb_name, "key": tdb_key})
@@ -328,20 +333,28 @@ class DSCache(Service):
             try:
                 if data['idtype'] == 'USER':
                     pwdobj = await self.middleware.call('dscache.get_uncached_user',
-                                                        who_str, who_id)
+                                                        who_str, who_id, False, True)
                     entry = await self.middleware.call('idmap.synthetic_user',
                                                        ds.lower(), pwdobj)
+                    entry['sid'] = pwdobj['sid_info']['sid']
                 else:
                     grpobj = await self.middleware.call('dscache.get_uncached_group',
-                                                        who_str, who_id)
+                                                        who_str, who_id, True)
                     entry = await self.middleware.call('idmap.synthetic_group',
                                                        ds.lower(), grpobj)
+                    entry['sid'] = grpobj['sid_info']['sid']
+
                 await self.insert(ds, data['idtype'], entry)
+                entry['nt_name'] = entry[name_key]
             except KeyError:
                 entry = None
 
         elif not entry:
             raise KeyError(who_str if who_str else who_id)
+
+        if not options['smb']:
+            entry['sid'] = None
+            entry['nt_name'] = None
 
         return entry
 
@@ -418,7 +431,7 @@ class DSCache(Service):
 
         return user_obj
 
-    def get_uncached_group(self, groupname=None, gid=None):
+    def get_uncached_group(self, groupname=None, gid=None, sid_info=False):
         """
         Returns dictionary containing grp_struct data for
         the specified group or gid. Will raise an exception
@@ -431,11 +444,32 @@ class DSCache(Service):
             g = grp.getgrgid(gid)
         else:
             return {}
-        return {
+
+        grp_obj = {
             'gr_name': g.gr_name,
             'gr_gid': g.gr_gid,
             'gr_mem': g.gr_mem
         }
+
+        if sid_info:
+            try:
+                sid = self.middleware.call_sync('idmap.unixid_to_sid', {
+                    'id_type': 'GROUP',
+                    'id': grp_obj['gr_gid'],
+                })
+            except Exception:
+                self.logger.error('Failed to retrieve SID for uid: %d', grp.gr_gid, exc_info=True)
+                sid = None
+
+            if sid:
+                grp_obj['sid_info'] = {
+                    'sid': sid,
+                    'domain_information': self.parse_domain_info(sid)
+                }
+            else:
+                grp_obj['sid_info'] = None
+
+        return grp_obj
 
     @accepts(
         Str('objtype', enum=['USERS', 'GROUPS'], default='USERS'),
@@ -452,6 +486,7 @@ class DSCache(Service):
         ds_state = await self.middleware.call('directoryservices.get_state')
         enabled_ds = None
         extra = options.get("extra", {})
+        get_smb = 'SMB' in extra.get('additional_information', [])
 
         is_name_check = bool(filters and len(filters) == 1 and filters[0][0] in ['username', 'name'])
         is_id_check = bool(filters and len(filters) == 1 and filters[0][0] in ['uid', 'gid'])
@@ -474,7 +509,7 @@ class DSCache(Service):
             entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
                 'who': filters[0][2],
-            }, {'synthesize': True})
+            }, {'synthesize': True, 'smb': get_smb})
             return [entry] if entry else []
 
         if is_id_check and filters[0][1] == '=':
@@ -489,17 +524,10 @@ class DSCache(Service):
             return [entry] if entry else []
 
         entries = await self.entries(enabled_ds.upper(), objtype[:-1])
-        if 'SMB' in extra.get('additional_information', []):
+        if not get_smb:
             for entry in entries:
-                sid = await self.middleware.call('idmap.unixid_to_sid', {
-                    'id_type': objtype[:-1],
-                    'id': entry[f'{objtype[0].lower()}id'],
-                })
-                name_key = "username" if objtype == 'USERS' else 'group'
-                entry.update({
-                    'nt_name': entry[name_key],
-                    'sid': sid,
-                })
+                entry['sid'] = None
+                entry['nt_name'] = None
 
         entries_by_id = sorted(entries, key=lambda i: i['id'])
         res.extend(filter_list(entries_by_id, filters, options))


### PR DESCRIPTION
Store SID information when generating our AD user and group cache. In cases where user, uid, group, or gid are explicitly specified in query request, we directly query NSS on cache miss. In this case we need to also retrieve SID information and insert into new cache entry that is generated.