### PR TITLE
NAS-122093 / 22.12.3 / Add schema validation for Windows SIDs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -1,5 +1,5 @@
 from middlewared.plugins.sysdataset import SYSDATASET_PATH
-from middlewared.schema import Bool, Dict, List, Str, Int
+from middlewared.schema import Bool, Dict, List, SID, Str, Int
 from middlewared.service import (accepts, filterable, private, periodic, CRUDService)
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils import run, filter_list
@@ -361,7 +361,7 @@ class ShareSec(CRUDService):
             items=[
                 Dict(
                     'aclentry',
-                    Str('ae_who_sid', default=None),
+                    SID('ae_who_sid', default=None),
                     Dict(
                         'ae_who_name',
                         Str('domain', default=''),
@@ -410,7 +410,7 @@ class ShareSec(CRUDService):
                 items=[
                     Dict(
                         'aclentry',
-                        Str('ae_who_sid', default=None),
+                        SID('ae_who_sid', default=None),
                         Dict(
                             'ae_who_name',
                             Str('domain', default=''),

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -13,6 +13,7 @@ import ipaddress
 import os
 import pprint
 from urllib.parse import urlparse
+import wbclient
 
 from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.settings import conf
@@ -310,6 +311,37 @@ class Password(Str):
     def __init__(self, *args, **kwargs):
         self.private = True
         super().__init__(*args, **kwargs)
+
+
+class SID(Str):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def clean(self, value):
+        value = super().clean(value)
+
+        if value is None:
+            return value
+
+        value = value.strip()
+        return value.upper()
+
+    def validate(self, value):
+        if value is None:
+            return value
+
+        verrors = ValidationErrors()
+
+        if not wbclient.sid_is_valid(value):
+            verrors.add(
+                self.name,
+                'SID is malformed. See MS-DTYP Section 2.4 for SID type specifications. '
+                'Typically SIDs refer to existing objects on the local or remote server '
+                'and so an appropriate value should be queried prior to submitting to API '
+                'endpoints.'
+            )
+
+        verrors.check()
 
 
 class Dataset(Path):


### PR DESCRIPTION
There are a few API endpoints where we may ingest SIDs (even if internally), and so it's helpful to have schema validation option for them. This uses a freshly-minted py_wbclient method to perform validation (will not block).

Original PR: https://github.com/truenas/middleware/pull/11373
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122093