### PR TITLE
NAS-122096 / 22.12.3 / mark opnvpn{client/server} and rsync as deprecated

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/openvpn_client.py
+++ b/src/middlewared/middlewared/plugins/service_/services/openvpn_client.py
@@ -3,7 +3,6 @@ from .base import SimpleService
 
 class OpenVPNClientService(SimpleService):
     name = "openvpn_client"
-
+    deprecated = True
     etc = ["openvpn_client"]
-
     systemd_unit = "openvpn-client@client"

--- a/src/middlewared/middlewared/plugins/service_/services/openvpn_server.py
+++ b/src/middlewared/middlewared/plugins/service_/services/openvpn_server.py
@@ -3,7 +3,6 @@ from .base import SimpleService
 
 class OpenVPNServerService(SimpleService):
     name = "openvpn_server"
-
+    deprecated = True
     etc = ["ssl", "openvpn_server"]
-
     systemd_unit = "openvpn-server@server"

--- a/src/middlewared/middlewared/plugins/service_/services/rsync.py
+++ b/src/middlewared/middlewared/plugins/service_/services/rsync.py
@@ -3,7 +3,6 @@ from .base import SimpleService
 
 class RsyncService(SimpleService):
     name = "rsync"
-
+    deprecated = True
     etc = ["rsync"]
-
     systemd_unit = "rsync"


### PR DESCRIPTION
This marks the openvpn server, openvpn client and rsync host services as deprecated.