### PR TITLE
fix netsnmpagent.py compatibility with py3.11

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -21,11 +21,11 @@ def get_kstat():
             for lineno, line in enumerate(f, start=1):
                 if lineno > 2 and (info := line.strip()):
                     name, _, data = info.split()
-                    kstat[f"kstat.zfs.misc.arcstats.{name}"] = Decimal(int(data))
+                    kstat[f"kstat.zfs.misc.arcstats.{name}"] = int(data)
     except Exception:
         return kstat
     else:
-        kstat["vfs.zfs.version.spa"] = Decimal(5000)
+        kstat["vfs.zfs.version.spa"] = 5000
 
     return kstat
 
@@ -462,13 +462,13 @@ if __name__ == "__main__":
             arc_efficiency = get_arc_efficiency(kstat)
 
             prefix = "kstat.zfs.misc.arcstats"
-            zfs_arc_size.update(kstat[f"{prefix}.size"] / 1024)
-            zfs_arc_meta.update(kstat[f"{prefix}.arc_meta_used"] / 1024)
-            zfs_arc_data.update(kstat[f"{prefix}.data_size"] / 1024)
-            zfs_arc_hits.update(kstat[f"{prefix}.hits"] % 2 ** 32)
-            zfs_arc_misses.update(kstat[f"{prefix}.misses"] % 2 ** 32)
-            zfs_arc_c.update(kstat[f"{prefix}.c"] / 1024)
-            zfs_arc_p.update(kstat[f"{prefix}.p"] / 1024)
+            zfs_arc_size.update(kstat[f"{prefix}.size"] // 1024)
+            zfs_arc_meta.update(kstat[f"{prefix}.arc_meta_used"] // 1024)
+            zfs_arc_data.update(kstat[f"{prefix}.data_size"] // 1024)
+            zfs_arc_hits.update(int(kstat[f"{prefix}.hits"] % 2 ** 32))
+            zfs_arc_misses.update(int(kstat[f"{prefix}.misses"] % 2 ** 32))
+            zfs_arc_c.update(kstat[f"{prefix}.c"] // 1024)
+            zfs_arc_p.update(kstat[f"{prefix}.p"] // 1024)
             zfs_arc_miss_percent.update(str(get_zfs_arc_miss_percent(kstat)).encode("ascii"))
             zfs_arc_cache_hit_ratio.update(str(arc_efficiency["cache_hit_ratio"]["per"][:-1]).encode("ascii"))
             zfs_arc_cache_miss_ratio.update(str(arc_efficiency["cache_miss_ratio"]["per"][:-1]).encode("ascii"))


### PR DESCRIPTION
This failed because of a series of problems. We upgraded to python3.11 which has more strict type checking. After upgrade, we saw this error:
```
May 23 11:23:57 truenas-b snmp-agent.py[2397583]: [Info] NET-SNMP version 5.9.3 AgentX subagent connected
May 23 11:23:57 truenas-b snmp-agent.py[2397583]: Traceback (most recent call last):
May 23 11:23:57 truenas-b snmp-agent.py[2397583]:   File "/usr/local/bin/snmp-agent.py", line 465, in <module>
May 23 11:23:57 truenas-b snmp-agent.py[2397583]:     zfs_arc_size.update(kstat[f"{prefix}.size"] // 1024)
May 23 11:23:57 truenas-b snmp-agent.py[2397583]:   File "/usr/lib/python3/dist-packages/netsnmpagent.py", line 511, in update
May 23 11:23:57 truenas-b snmp-agent.py[2397583]:     self._cvar.value = val
May 23 11:23:57 truenas-b snmp-agent.py[2397583]:     ^^^^^^^^^^^^^^^^
May 23 11:23:57 truenas-b snmp-agent.py[2397583]: TypeError: 'decimal.Decimal' object cannot be interpreted as an integer
```

I mistakenly peered into the `netsnmpagent.py` code and discovered that when you define snmp value types (i.e. `Unsigned32`, `DisplayString`, etc) it's actually using python's `ctypes` module to create a class representing that type (I think). I'm not 100% on that but my fix confirmed what I was able to glean from looking into the abyss.

It seems that cython api in python3.11 has more "strict" type checks so when we tried to assign the various ZFS snmp types to `Unsigned32`, we were dividing the values with a single forward-slash (i.e. `zfs-size = (blahA / blahB)`). This produces a floating point number which is not an integer which caused this crash.

To fix this problem, I use the double forward-slash `//` which maintains the left-operands type (in our use-case, it's always integer). Finally, I could not gather a straightforward reason on why we chose to use `Decimal` class. Maybe it was because we wanted high-precision floating point numbers but the point is that it's not possible since snmp value types are specified as Unsigned32.

Maybe we should convert these values to `DisplayString` and simply return a "floating point string" value since snmp clients will often cast the value to the necessary type as necessary. Idk, something to consider.