### PR TITLE
NAS-122102 / 22.12.4 / Prefer sids privileges (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1022,7 +1022,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if domain is None:
             domain = (await self.config())['domainname']
 
-        lookup = await self.cache_flush_retry([SMBCmd.NET.value, '--json', '-S', domain, 'ads', 'lookup'])
+        lookup = await self.cache_flush_retry([SMBCmd.NET.value, '--json', '-S', domain, '--realm', domain, 'ads', 'lookup'])
         if lookup.returncode != 0:
             raise CallError("Failed to look up Domain Controller information: "
                             f"{lookup.stderr.decode().strip()}")

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -964,6 +964,12 @@ class IdmapDomainService(TDBWrapCRUDService):
 
     @private
     def convert_sids(self, sidlist):
+        """
+        Internal bulk conversion method Windows-style SIDs to Unix IDs (uid or gid)
+        This ends up being a de-facto wrapper around wbcCtxSidsToUnixIds from
+        libwbclient (single winbindd request), and so it is the preferred
+        method of batch conversion.
+        """
         try:
             client = WBClient()
             results = client.sids_to_users_and_groups(sidlist)
@@ -980,6 +986,12 @@ class IdmapDomainService(TDBWrapCRUDService):
 
     @private
     def convert_unixids(self, id_list):
+        """
+        Internal bulk conversion method for Unix IDs (uid or gid) to Windows-style
+        SIDs. This ends up being a de-facto wrapper around wbcCtxUnixIdsToSids
+        from libwbclient (single winbindd request), and so it is the preferred
+        method of batch conversion.
+        """
         payload = []
         for entry in id_list:
             unixid = entry.get("id")


### PR DESCRIPTION
SIDS are more stable (can't change value based on user configuration)
and so should be preferred for mapping privileges for directory
services groups.

This PR adds a bulk conversion API for mapping unix ids to SIDs, which
is used for privilege evaluation.

Original PR: https://github.com/truenas/middleware/pull/11375
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122102