### PR TITLE
NAS-120951 / 23.10 / add hardware.memory.error_info endpoint

### DIFF
--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -1,20 +1,11 @@
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 
 
-class MemoryErrorsNoInfoAlertClass(AlertClass):
+class MemoryErrorsAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
     level = AlertLevel.WARNING
     title = 'Uncorrected Memory Errors Detected'
-    text = '%(count)d total uncorrected errors detected for memory controller "%(mc)s".'
-    products = ('SCALE_ENTERPRISE',)
-    proactive_support = True
-
-
-class MemoryErrorsInfoAlertClass(AlertClass):
-    category = AlertCategory.HARDWARE
-    level = AlertLevel.WARNING
-    title = 'Uncorrected Memory Errors Detected'
-    text = '%(count)d total uncorrected errors detected for memory controller "%(mc)s" on "%(dimm)s".'
+    text = '%(count)d total uncorrected errors detected for %(loc)s.'
     products = ('SCALE_ENTERPRISE',)
     proactive_support = True
 
@@ -24,12 +15,13 @@ class MemoryErrorsAlertSource(AlertSource):
     async def check(self):
         alerts = []
         for mem_ctrl, info in (await self.middleware.call('hardware.memory.error_info')).items():
+            location = f'memory controller {mem_ctrl}'
             if (val := info['uncorrected_errors_with_no_dimm_info']) is not None and val > 0:
                 # this means that there were uncorrected errors where no additional information
                 # is available. These errors occur when the system detects an uncorrectable memory
                 # error, but specific details about the error are not provided or accessible.
                 # Because of this fact, we'll just report the error count without the DIMM information.
-                alerts.append(Alert(MemoryErrorsNoInfoAlertClass, {'mc': mem_ctrl, 'count': val}))
+                alerts.append(Alert(MemoryErrorsAlertClass, {'count': val, 'loc': location}))
             elif (val := info['uncorrected_errors']) is not None and val > 0:
                 # this means that there were uncorrected errors where the dimm information was able
                 # to be obtained.
@@ -37,7 +29,7 @@ class MemoryErrorsAlertSource(AlertSource):
                     if (val2 := info[dimm_key]['uncorrected_errors']) is not None and val2 > 0:
                         # the specific dimm
                         alerts.append(Alert(
-                            MemoryErrorsInfoAlertClass, {'mc': mem_ctrl, 'count': val2, 'dimm': dimm_key}
+                            MemoryErrorsAlertClass, {'count': val2, 'loc': location + f' on dimm {dimm_key}'}
                         ))
 
         return alerts

--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -1,0 +1,43 @@
+from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
+
+
+class MemoryErrorsNoInfoAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
+    title = 'Uncorrected Memory Errors Detected'
+    text = '%(count)d total uncorrected errors detected for memory controller "%(mc)s".'
+    products = ('SCALE_ENTERPRISE',)
+    proactive_support = True
+
+
+class MemoryErrorsInfoAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
+    title = 'Uncorrected Memory Errors Detected'
+    text = '%(count)d total uncorrected errors detected for memory controller "%(mc)s" on "%(dimm)s".'
+    products = ('SCALE_ENTERPRISE',)
+    proactive_support = True
+
+
+class MemoryErrorsAlertSource(AlertSource):
+
+    async def check(self):
+        alerts = []
+        for mem_ctrl, info in (await self.middleware.call('hardware.memory.error_info')).items():
+            if (val := info['uncorrected_errors_with_no_dimm_info']) is not None and val > 0:
+                # this means that there were uncorrected errors where no additional information
+                # is available. These errors occur when the system detects an uncorrectable memory
+                # error, but specific details about the error are not provided or accessible.
+                # Because of this fact, we'll just report the error count without the DIMM information.
+                alerts.append(Alert(MemoryErrorsNoInfoAlertClass, {'mc': mem_ctrl, 'count': val}))
+            elif (val := info['uncorrected_errors']) is not None and val > 0:
+                # this means that there were uncorrected errors where the dimm information was able
+                # to be obtained.
+                for dimm_key in filter(lambda x: x.startswith(('dimm', 'rank')), info):
+                    if (val2 := info[dimm_key]['uncorrected_errors']) is not None and val2 > 0:
+                        # the specific dimm
+                        alerts.append(Alert(
+                            MemoryErrorsInfoAlertClass, {'mc': mem_ctrl, 'count': val2, 'dimm': dimm_key}
+                        ))
+
+        return alerts

--- a/src/middlewared/middlewared/plugins/hardware/mem_info.py
+++ b/src/middlewared/middlewared/plugins/hardware/mem_info.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from middlewared.service import Service
+from middlewared.schema import accepts, returns, List, Dict
+
+
+class HardwareMemoryService(Service):
+
+    class Config:
+        namespace = 'hardware.memory'
+        cli_namespace = 'system.hardware.memory'
+
+    @accepts()
+    @returns(List('mem_ctrls', items=[Dict('mem_ctrl', additional_attrs=True)]))
+    def error_info(self):
+        results = {}
+        mc_path = Path('/sys/devices/system/edac/mc')
+        if not mc_path.exists():
+            return results
+
+        dimm_or_rank = 'dimm'
+        mc_idx = 0
+        for mc in filter(lambda x: x.is_dir() and x.name.startswith('mc'), mc_path.iterdir()):
+            mc_info = {mc.name: {}}
+            if mc_idx == 0 and not (mc / f'{dimm_or_rank}{mc_idx}').exists():
+                # AMD systems use "rank" as top-level dir while Intel uses dimm
+                dimm_or_rank = 'rank'
+
+            # top-level memory controller information
+            for key, _file in (
+                ('corrected_errors', 'ce_count'),
+                ('uncorrected_errors', 'ue_count'),
+                ('corrected_errors_with_no_dimm_info', 'ce_noinfo_count'),
+                ('uncorrected_errors_with_no_dimm_info', 'ue_noinfo_count'),
+            ):
+                try:
+                    value = int((mc / _file).read_text().strip())
+                except (FileNotFoundError, ValueError):
+                    value = None
+
+                mc_info[mc.name].update({key: value})
+
+            # specific dimm module memory information
+            for dimm in filter(lambda x: x.is_dir() and x.name.startswith(dimm_or_rank), mc.iterdir()):
+                # looks like /sys/devices/edac/mc0/dimm(or rank){0/1/2}
+                mc_info[mc.name][dimm.name] = {}
+                for key, _file in (
+                    ('corrected_errors', 'dimm_ce_count'),
+                    ('uncorrected_errors', 'dimm_ue_count'),
+                ):
+                    try:
+                        value = int((dimm / _file).read_text().strip())
+                    except (FileNotFoundError, ValueError):
+                        value = None
+
+                    mc_info[mc.name][dimm.name].update({key: value})
+
+            mc_idx += 1
+            results.update(mc_info)
+
+        return results

--- a/src/middlewared/middlewared/plugins/hardware/mem_info.py
+++ b/src/middlewared/middlewared/plugins/hardware/mem_info.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from middlewared.service import Service
-from middlewared.schema import accepts, returns, List, Dict
+from middlewared.schema import accepts, returns, Dict
 
 
 class HardwareMemoryService(Service):
@@ -11,7 +11,7 @@ class HardwareMemoryService(Service):
         cli_namespace = 'system.hardware.memory'
 
     @accepts()
-    @returns(List('mem_ctrls', items=[Dict('mem_ctrl', additional_attrs=True)]))
+    @returns(Dict('mem_ctrl', additional_attrs=True))
     def error_info(self):
         results = {}
         mc_path = Path('/sys/devices/system/edac/mc')


### PR DESCRIPTION
We currently have a mechanism to report on APEI or MCA events on CORE for our enterprise users. This brings us to mostly feature parity with CORE by getting the relevant information from sysfs.