### PR TITLE
NAS-122136 / 22.12.3 / remove "not installed" as a bad element status (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -21,8 +21,7 @@ class EnclosureStatusAlertSource(AlertSource):
     products = ("SCALE_ENTERPRISE",)
     failover_related = True
     run_on_backup_node = False
-    bad = ('critical', 'noncritical', 'unknown', 'unrecoverable', 'not installed')
-
+    bad = ('critical', 'noncritical', 'unknown', 'unrecoverable')
     bad_elements = []
 
     async def should_report(self, enclosure, element):


### PR DESCRIPTION
"Not Installed" or any variation thereof for an element in an enclosure doesn't warrant us alerting the end-user. This change was made in CORE but not backported here.

Original PR: https://github.com/truenas/middleware/pull/11389
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122136