### PR TITLE
NAS-121891 / 23.10 / Consume update warnings and allow resuming the update after warning

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -377,7 +377,7 @@ class Job:
                 raise CallError(self.error)
         return self.result
 
-    def wait_sync(self, raise_error=False):
+    def wait_sync(self, raise_error=False, timeout=None):
         """
         Synchronous method to wait for a job in another thread.
         """
@@ -388,7 +388,9 @@ class Job:
             event.set()
 
         fut.add_done_callback(done)
-        event.wait()
+        if not event.wait(timeout):
+            fut.cancel()
+            raise TimeoutError()
         if raise_error:
             if self.error:
                 if isinstance(self.exc_info[1], CallError):

--- a/src/middlewared/middlewared/plugins/update_/install_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/install_linux.py
@@ -13,21 +13,10 @@ logger = logging.getLogger(__name__)
 
 class UpdateService(Service):
     @private
-    def install_impl(self, job, location):
-        self._install(
-            os.path.join(location, "update.sqsh"),
-            lambda progress, description: job.set_progress((0.5 + 0.5 * progress) * 100, description),
-        )
+    def install(self, job, path, options):
+        def progress_callback(progress, description):
+            job.set_progress((0.5 + 0.5 * progress) * 100, description)
 
-    @private
-    def install_manual_impl(self, job, path, dest_extracted, options=None):
-        self._install(
-            path,
-            lambda progress, description: job.set_progress((0.5 + 0.5 * progress) * 100, description),
-            options,
-        )
-
-    def _install(self, path, progress_callback, options=None):
         progress_callback(0, "Reading update file")
         with mount_update(path) as mounted:
             with open(os.path.join(mounted, "manifest.json")) as f:

--- a/src/middlewared/middlewared/plugins/update_/upload_location_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/upload_location_linux.py
@@ -12,6 +12,10 @@ from .utils_linux import run_kw
 
 class UpdateService(Service):
     @private
+    def get_upload_location(self):
+        return UPLOAD_LOCATION
+
+    @private
     def create_upload_location(self):
         if not os.path.ismount(UPLOAD_LOCATION):
             subprocess.run(["mount", "-o", "size=2800M", "-t", "tmpfs", "none", UPLOAD_LOCATION], **run_kw)


### PR DESCRIPTION
Warning will be returned as `EAGAIN` `CallError`. The UI will check for this specific `errno`, present a yes/no dialog, and, if "yes" is selected, will call the same method but with `{"resume": true}` option (no file re-upload will be necessary, no repeated network requests will be performed).