### PR TITLE
NAS-122143 / 23.10 / add DeprecatedServiceConfigurationAlert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/deprecated_config.py
+++ b/src/middlewared/middlewared/alert/source/deprecated_config.py
@@ -1,0 +1,25 @@
+import json
+
+from middlewared.alert.base import Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel
+
+URL = "https://www.truenas.com/docs/scale/scaledeprecatedfeatures/"
+
+
+class DeprecatedServiceConfigurationAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "Deprecated Service Configuration Detected"
+    text = (
+        "The following service configuration is deprecated %(config)s. "
+        "This functionality is scheduled for removal in a future version of SCALE. "
+        f"Before upgrading, please check {URL} for more information."
+    )
+
+    async def create(self, args):
+        return Alert(DeprecatedServiceConfigurationAlertClass, args, key=args['config'])
+
+    async def delete(self, alerts, query):
+        return list(filter(
+            lambda alert: json.loads(alert.key) != str(query),
+            alerts
+        ))

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1166,13 +1166,13 @@ class LDAPService(TDBWrapConfigService):
         if ldap['has_samba_schema']:
             await self.middleware.call(
                 'alert.oneshot_create',
-                'DeprecatedService',
-                {'service': LDAP_DEPRECATED}
+                'DeprecatedServiceConfiguration',
+                {'config': LDAP_DEPRECATED}
             )
             job.set_progress(70, 'Storing LDAP password for SMB configuration')
             await self.middleware.call('smb.store_ldap_admin_password')
         else:
-            await self.middleware.call('alert.oneshot_delete', 'DeprecatedService', LDAP_DEPRECATED)
+            await self.middleware.call('alert.oneshot_delete', 'DeprecatedServiceConfiguration', LDAP_DEPRECATED)
 
         await self.set_state(DSStatus['HEALTHY'])
         job.set_progress(80, 'Restarting dependent services')
@@ -1198,7 +1198,7 @@ class LDAPService(TDBWrapConfigService):
         job.set_progress(0, 'Preparing to stop LDAP directory service.')
         await self.direct_update({"enable": False})
 
-        await self.middleware.call('alert.oneshot_delete', 'DeprecatedService', LDAP_DEPRECATED)
+        await self.middleware.call('alert.oneshot_delete', 'DeprecatedServiceConfiguration', LDAP_DEPRECATED)
         await self.set_state(DSStatus['LEAVING'])
         job.set_progress(10, 'Rewriting configuration files.')
         await self.middleware.call('etc.generate', 'rc')


### PR DESCRIPTION
This isn't used in Bluefin (yet) but is needed in Cobia since we have parameters for certain services that are being deprecated. This separates deprecated services vs deprecated service configuration.

Original PR: https://github.com/truenas/middleware/pull/11395
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122143