### PR TITLE
NAS-122157 / 23.10 / Fix ipaddr

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -675,6 +675,8 @@ def test__schema_ipaddr_cidr_allow_zone_index(value, expected):
     ('192.168.0.0/24', '192.168.0.0/24'),
     ('192.168.0.0/255.255.255.0', '192.168.0.0/24'),
     ('192.168.0.1', '192.168.0.1/32'),
+    ('192.168.0.999', ValidationErrors),
+    ('BOGUS.NAME', ValidationErrors),
 ])
 def test__schema_ipaddr_network(value, expected):
 
@@ -689,6 +691,22 @@ def test__schema_ipaddr_network(value, expected):
             ipaddrv(self, value)
     else:
         assert ipaddrv(self, value) == expected
+
+@pytest.mark.parametrize("value,expected", [
+    ('192.168.0.0/24', None),
+    ('192.168.0.0/255.255.255.0', None),
+    ('192.168.0.1', None),
+    ('192.168.0.999', ValidationErrors),
+    ('BOGUS.NAME', ValidationErrors),
+])
+def test__schema_ipaddr_validate(value, expected):
+    network = value.find('/') != -1
+    ipaddr = IPAddr(network = network)
+    if expected is ValidationErrors:
+        with pytest.raises(ValidationErrors):
+            ipaddr.validate(value)
+    else:
+        assert ipaddr.validate(value) == expected
 
 
 def test__schema_str_default():

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -692,6 +692,7 @@ def test__schema_ipaddr_network(value, expected):
     else:
         assert ipaddrv(self, value) == expected
 
+
 @pytest.mark.parametrize("value,expected", [
     ('192.168.0.0/24', None),
     ('192.168.0.0/255.255.255.0', None),
@@ -701,7 +702,7 @@ def test__schema_ipaddr_network(value, expected):
 ])
 def test__schema_ipaddr_validate(value, expected):
     network = value.find('/') != -1
-    ipaddr = IPAddr(network = network)
+    ipaddr = IPAddr(network=network)
     if expected is ValidationErrors:
         with pytest.raises(ValidationErrors):
             ipaddr.validate(value)

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -501,6 +501,21 @@ class IPAddr(Str):
         return value
 
 
+    def validate(self, value):
+        if value is None:
+            return value
+
+        verrors = ValidationErrors()
+
+        try:
+            self.clean(value)
+        except (Error, ValueError) as e:
+            verrors.add(self.name, str(e))
+
+        verrors.check()
+
+        return super().validate(value)
+
 class Time(Str):
 
     def clean(self, value):

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -500,7 +500,6 @@ class IPAddr(Str):
 
         return value
 
-
     def validate(self, value):
         if value is None:
             return value
@@ -515,6 +514,7 @@ class IPAddr(Str):
         verrors.check()
 
         return super().validate(value)
+
 
 class Time(Str):
 


### PR DESCRIPTION
There are a couple of places in middleware where we call `IPAddr().validate(ip)`.  This _used_ to raise an error if an invalid value was provided, but has not done so since Dec 2021.

Therefore, added some additional tests, along with a **tentative** fix for `IPAddr.validate` (mostly to solicit input).

