### PR TITLE
NAS-122177 / 23.10 / Avoid tdb lookup during cluster start

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -136,6 +136,7 @@ class EtcService(Service):
                 {'type': 'mako', 'path': 'pam.d/common-password'},
                 {'type': 'mako', 'path': 'pam.d/common-session-noninteractive'},
                 {'type': 'mako', 'path': 'pam.d/common-session'},
+                {'type': 'mako', 'path': 'security/pam_winbind.conf'},
             ]
         },
         'pam_middleware': [
@@ -257,7 +258,6 @@ class EtcService(Service):
         ],
         'smb': [
             {'type': 'mako', 'path': 'local/smb4.conf'},
-            {'type': 'mako', 'path': 'security/pam_winbind.conf', 'checkpoint': 'pool_import'},
         ],
         'ctdb': [
             {


### PR DESCRIPTION
We need to generate the smb.conf during ctdb startup, but setting up PAM at this point creates potential for CTDB_START cluster event to hang for an unreasonable time. There's not really a downside to configuring pam_winbind settings with other pam settings.