### PR TITLE
NAS-122178 / 13.0 / Don't toggle attachments after importing pool during failover

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -616,7 +616,8 @@ class FailoverService(ConfigService):
         unlock_job = await self.middleware.call(
             'pool.dataset.unlock', pool_name, {
                 'recursive': True,
-                'datasets': [{'name': name, 'passphrase': passphrase} for name, passphrase in zfs_keys.items()]
+                'datasets': [{'name': name, 'passphrase': passphrase} for name, passphrase in zfs_keys.items()],
+                'toggle_attachments': False,
             }
         )
         return await job.wrap(unlock_job)


### PR DESCRIPTION
## Problem

On a failover event we are importing pools using `zpool import` command bypassing middleware which suits us in a variety of ways.
However after importing pool we run `pool.dataset.unlock` essentially to unlock any datasets whose keys we might have in the database..during unlock we have a flag to toggle attachments which is enabled by default. What this did in the current case is that after each pool import it toggled all related services which caused variety of different issues.

## Solution

We should not be toggling attachments after each pool import while unlocking that pool's datasets as we have relevant logic in place which dictates the service restarts after pools have imported..this change already exists in `stable/bluefin` but has not been backported to CORE (3a7ae0d904e4ffe090c33cc061776125400aabc5).