### PR TITLE
Fix bluefin tests for official catalog

### DIFF
--- a/tests/api2/test_022_catalog.py
+++ b/tests/api2/test_022_catalog.py
@@ -43,38 +43,38 @@ if not ha:
         assert isinstance(results.json(), list), results.text
 
     def test_02_search_for_official_catalog_with_the_label():
-        results = GET('/catalog/?label=OFFICIAL')
+        results = GET('/catalog/?label=TRUENAS')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), list), results.text
-        assert results.json()[0]['id'] == 'OFFICIAL', results.text
+        assert results.json()[0]['id'] == 'TRUENAS', results.text
 
     def test_03_get_official_catalog_with_id():
-        results = GET('/catalog/id/OFFICIAL/')
+        results = GET('/catalog/id/TRUENAS/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
-        assert results.json()['label'] == 'OFFICIAL', results.text
+        assert results.json()['label'] == 'TRUENAS', results.text
 
     def test_04_verify_official_catalog_repository_with_id():
-        results = GET('/catalog/id/OFFICIAL/')
+        results = GET('/catalog/id/TRUENAS/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
         assert results.json()['repository'] == official_repository, results.text
 
     def test_05_verify_official_catalog_repository_with_id():
-        results = GET('/catalog/id/OFFICIAL/')
+        results = GET('/catalog/id/TRUENAS/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
         assert results.json()['repository'] == official_repository, results.text
 
     def test_06_validate_official_catalog():
-        results = POST('/catalog/validate/', 'OFFICIAL')
+        results = POST('/catalog/validate/', 'TRUENAS')
         assert results.status_code == 200, results.text
         job_id = results.json()
         job_status = wait_on_job(job_id, 300)
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
     def test_07_sync_official_catalog():
-        results = POST('/catalog/sync/', 'OFFICIAL')
+        results = POST('/catalog/sync/', 'TRUENAS')
         assert results.status_code == 200, results.text
         job_id = results.json()
         job_status = wait_on_job(job_id, 300)
@@ -85,7 +85,7 @@ if not ha:
     @pytest.mark.parametrize('chart', official_charts)
     def test_08_get_official_catalog_item(chart):
         payload = {
-            'label': 'OFFICIAL',
+            'label': 'TRUENAS',
             'options': {
                 'cache': True
             }

--- a/tests/api2/test_025_chart_release.py
+++ b/tests/api2/test_025_chart_release.py
@@ -51,7 +51,7 @@ if not ha:
         payload = {
             "item_name": "ipfs",
             "item_version_details": {
-                "catalog": "OFFICIAL",
+                "catalog": "TRUENAS",
                 "train": 'community'
             }
         }
@@ -66,7 +66,7 @@ if not ha:
         depends(request, ['setup_kubernetes', 'ipfs_version'], scope='session')
         global release_id
         payload = {
-            'catalog': 'OFFICIAL',
+            'catalog': 'TRUENAS',
             'item': 'ipfs',
             'release_name': 'ipfs',
             'train': 'community',
@@ -84,7 +84,7 @@ if not ha:
         results = GET(f'/chart/release/id/{release_id}/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
-        assert results.json()['catalog'] == 'OFFICIAL', results.text
+        assert results.json()['catalog'] == 'TRUENAS', results.text
 
     def test_08_get_ipfs_chart_release_catalog_train(request):
         depends(request, ['release_ipfs'])


### PR DESCRIPTION
## Problem

Official catalog was renamed to `TRUENAS` but there were some integration tests which still referenced `OFFICIAL` catalog in bluefin which caused test failures as no catalog with that name exists anymore.

## Solution

Update all references of `OFFICIAL` to `TRUENAS` to cover up the renaming change.