### PR TITLE
NAS-122231 / 23.10 / Revert "Fix KeyError in API tests (#11404)

### DIFF
--- a/src/freenas/usr/local/bin/truenas-set-authentication-method.py
+++ b/src/freenas/usr/local/bin/truenas-set-authentication-method.py
@@ -55,6 +55,10 @@ if __name__ == "__main__":
         c.execute("SELECT last_insert_rowid()")
         user_id = dict(c.fetchone())["last_insert_rowid()"]
 
+        c.execute("""
+        INSERT INTO account_twofactor_user_auth (secret, user_id) VALUES (?, ?)
+        """, (None, user_id))
+
         c.execute("SELECT id FROM account_bsdgroups WHERE bsdgrp_group = 'builtin_administrators'")
         builtin_administrators_group_id = dict(c.fetchone())["id"]
 

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-05-31_19-37_normalize_2fa_records.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-05-31_19-37_normalize_2fa_records.py
@@ -1,0 +1,35 @@
+"""
+Normalize 2FA AD records
+
+Revision ID: 1519ee5b6e29
+Revises: a63a2c20632a
+Create Date: 2023-05-31 19:37:17.935672+00:00
+"""
+from alembic import op
+
+
+revision = '1519ee5b6e29'
+down_revision = 'a63a2c20632a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    # We will now get all existing records from 2fa table and then if some user does not has his record in 2fa table
+    # we will add it to the 2fa table
+    existing_records = [
+        user_id['user_id'] for user_id in map(
+            dict, conn.execute('SELECT user_id FROM account_twofactor_user_auth').fetchall()
+        )
+    ]
+    for row in map(dict, conn.execute('SELECT id FROM account_bsdusers').fetchall()):
+        if row['id'] in existing_records:
+            continue
+
+        secret = None
+        conn.execute('INSERT INTO account_twofactor_user_auth (secret,user_id) VALUES (?,?)', (secret, row['id']))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -210,7 +210,7 @@ class UserService(CRUDService):
         user['sshpubkey'] = await self.middleware.run_in_thread(self._read_authorized_keys, user['home'])
 
         user['immutable'] = user['builtin'] or (user['username'] == 'admin' and user['home'] == '/home/admin')
-        user['twofactor_auth_configured'] = bool(ctx['user_2fa_mapping'].get(user['id']))
+        user['twofactor_auth_configured'] = bool(ctx['user_2fa_mapping'][user['id']])
 
         return user
 


### PR DESCRIPTION
This PR adds changes to make sure whenever an admin user is created, we also add a record of that user to our 2fa table as all local users have a 1-1 relation with the 2fa table and this was a case which we had missed where a user was being added but the relevant 2fa record was not being added.