### PR TITLE
NAS-122035 / 23.10 / Make virtio-ballooning auto deflation on

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
@@ -188,6 +188,9 @@ def devices_xml(vm_data, context):
         'children': [create_element('target', type='virtio', name='org.qemu.guest_agent.0')]
     }))
     devices.append(create_element('serial', type='pty'))
+    if vm_data['min_memory']:
+        # memballoon device needs to be added if memory ballooning is enabled
+        devices.append(create_element('memballoon', model='virtio', autodeflate='on'))
     return create_element('devices', attribute_dict={'children': devices})
 
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -11,9 +11,9 @@ GUEST_CHANEL = '<channel type="unix"><target type="virtio" name="org.qemu.guest_
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': []},
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [], 'min_memory': None},
      f'<devices>{GUEST_CHANEL}<serial type="pty" /></devices>'),
-    ({'ensure_display_device': True, 'trusted_platform_module': False, 'devices': []},
+    ({'ensure_display_device': True, 'trusted_platform_module': False, 'devices': [], 'min_memory': None},
      f'<devices><video />{GUEST_CHANEL}<serial type="pty" /></devices>'),
 ])
 def test_basic_devices_xml(vm_data, expected_xml):
@@ -21,7 +21,7 @@ def test_basic_devices_xml(vm_data, expected_xml):
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {'path': '/mnt/tank/disk.iso'},
         'dtype': 'CDROM',
     }]}, '<devices><disk type="file" device="cdrom"><driver name="qemu" type="raw" />'
@@ -39,7 +39,7 @@ def test_cdrom_xml(vm_data, expected_xml):
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'dtype': 'DISPLAY',
         'attributes': {
             'bind': '0.0.0.0',
@@ -67,7 +67,7 @@ def test_display_xml(vm_data, expected_xml):
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
@@ -79,7 +79,7 @@ def test_display_xml(vm_data, expected_xml):
          '<mac address="00:a0:99:7e:bb:8a" /></interface>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
@@ -91,7 +91,7 @@ def test_display_xml(vm_data, expected_xml):
          '<model type="virtio" /><mac address="00:a0:99:7e:bb:8a" /></interface>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
@@ -118,7 +118,7 @@ def test_nic_xml(vm_data, expected_xml):
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'path': '/dev/zvol/pool/boot_1',
             'type': 'AHCI',
@@ -142,7 +142,7 @@ def test_disk_xml(vm_data, expected_xml):
 
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'path': '/mnt/tank/somefile',
             'type': 'AHCI',
@@ -155,7 +155,7 @@ def test_disk_xml(vm_data, expected_xml):
          '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
-    ({'ensure_display_device': False, 'trusted_platform_module': False, 'devices': [{
+    ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
         'attributes': {
             'path': '/mnt/tank/somefile',
             'type': 'AHCI',


### PR DESCRIPTION
## Problem

The current issue is that Qemu can deflate (decrease) the memory allocation for a guest machine, but it does not have the capability to automatically inflate (increase) the memory allocation when the guest machine requires more memory. This problem leads to out-of-memory (OOM) errors when the guest machine needs more memory, even though the host machine has available memory. Ideally, the system should allocate free memory from the host to the guest machine and inflate the guest machine's memory allocation.

## Solution

To address this problem, it is necessary to enable automatic deflation of the guest machine's memory allocation. By default, this feature is not enabled. Some changes need to be made in the system configuration to enable automatic deflation.

Once the automatic deflation feature is enabled, the system will be able to dynamically adjust the memory allocation of the guest machine based on its needs. This will help prevent OOM errors and optimize the allocation of memory resources between the host and guest machines.