### PR TITLE
NAS-122242 / 23.10 / fix typos in nvdimm firmware alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
+++ b/src/middlewared/middlewared/plugins/hardware/m_series_nvdimm.py
@@ -69,8 +69,8 @@ class MseriesNvdimmService(Service):
                 'qualified_firmware': ['2.4'],
                 'recommended_firmware': '2.4',
             },
-            '0xc180_0x4e88_0x33_0xc180_0x4331_0x01': {
-                'vendor': '0xc180', 'device': '0x4e88', 'rev_id': '0x33',
+            '0xce01_0x4e38_0x33_0xc180_0x4331_0x01': {
+                'vendor': '0xce01', 'device': '0x4e38', 'rev_id': '0x33',
                 'subvendor': '0xc180', 'subdevice': '0x4331', 'subrev_id': '0x01',
                 'part_num': 'AGIGA8811-016ACA',
                 'size': '16GB', 'clock_speed': '2933MHz',


### PR DESCRIPTION
2 problems (typos) being fixed.
- first typo is 0xc180 which should be 0xce01. this was a typo in the internal documentation
- second typo is 0x4e88 which should be 0x4e38. this was a typo introduced during development process

With both typos fixed, no more false nvdimm alerts are raised on m-series platforms with relevant nvdimm modules installed.

Original PR: https://github.com/truenas/middleware/pull/11424
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122242