### PR TITLE
NAS-122211 / 23.10 / Improve display devices defaults

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1822,6 +1822,7 @@ class InterfaceService(CRUDService):
         ignore_nics = self.middleware.call_sync('interface.internal_interfaces')
         if choices['loopback']:
             ignore_nics.remove('lo')
+            static_ips['127.0.0.1'] = '127.0.0.1'
 
         ignore_nics = tuple(ignore_nics)
         for iface in filter(lambda x: not x.orig_name.startswith(ignore_nics), list(netif.list_interfaces().values())):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -23,9 +23,9 @@ class DISPLAY(Device):
         Str('resolution', enum=RESOLUTION_ENUM, default='1024x768'),
         Int('port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
         Int('web_port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
-        Str('bind', default='0.0.0.0'),
+        Str('bind', default='127.0.0.1'),
         Bool('wait', default=False),
-        Str('password', default=None, null=True, private=True),
+        Str('password', private=True, required=True, null=False, empty=False),
         Bool('web', default=True),
         Str('type', default='SPICE', enum=['SPICE', 'VNC']),
     )

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -109,7 +109,7 @@ class VMDeviceService(CRUDService):
         """
         return {
             d['address']: d['address'] for d in await self.middleware.call(
-                'interface.ip_in_use', {'static': True, 'any': True}
+                'interface.ip_in_use', {'static': True, 'any': True, 'loopback': True}
             )
         }
 


### PR DESCRIPTION
## Context

`DISPLAY` devices defaults have been to not ask user to specify `password` as a hard requirement.
However that is not appropriate because if VNC server socket is not protected by password it just means that any malicious actor can just scan ports and then gain access to a VMs console which in most cases is also connected to the user's local network.
Now specifying `password` is a hard requirement for any one looking to create more `DISPLAY` devices or edit the ones they have already. Also by default we are going to bind the VNC/spice server to `localhost` instead of wildcard ip i.e `0.0.0.0` improving the defaults further so only if anyone really wants to expose their VNC server socket they can do so explicitly.