### PR TITLE
NAS-122271 / 22.12.4 / prevent AttributeError crash (caused by webUI)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/chassis.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/chassis.py
@@ -11,6 +11,12 @@ class IpmiChassisService(Service):
         cli_namespace = 'service.ipmi.chassis'
 
     @accepts()
+    def query(self):
+        # This is a shim for the webUI for 22.12.3+
+        # and has been removed/refactored in Cobia
+        return self.info()
+
+    @accepts()
     @returns(Dict('chassis_info', additional_attrs=True))
     def info(self):
         """Return looks like:


### PR DESCRIPTION
I've refactored and improved the ipmi plugin over many commits here recently. Unfortunately, it seems I backported a commit from the master branch that has caused the webUI to reference an endpoint that was removed/refactored in master. This takes the least path of resistance to prevent massive change in middleware and change in webUI.