### PR TITLE
NAS-122280 / 22.12.4 / prevent new webdav share creation

### DIFF
--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -5,7 +5,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.async_validators import validate_port
 from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.schema import accepts, returns, Bool, Dict, Int, Patch, Str, ValidationErrors
-from middlewared.service import SharingService, SystemServiceService, private
+from middlewared.service import SharingService, SystemServiceService, private, ValidationError
 
 
 WEBDAV_USER = 'webdav'
@@ -79,6 +79,11 @@ class WebDAVSharingService(SharingService):
         `perm` when enabled automatically recursively changes the ownership of this share to
         webdav ( user and group both ).
         """
+        err = (
+            'This feature is deprecated. '
+            'Please use the WebDAV application from the Apps catalog to create new WebDAV shares.'
+        )
+        raise ValidationError('webdav_share_create.new', err)
 
         await self.validate_data(data, 'webdav_share_create')
 


### PR DESCRIPTION
After internal discussion with QE and Exec team, it has been decided to prevent the creation of new webdav shares (using the webdav native host service) in 22.12.3. This is to further encourage the migration to the webDAV app since this service has been removed in Cobia (in favor of the webdav app).

This does not prevent the editing or deletion of existing webdav shares, simply prevents new ones from being created.