### PR TITLE
NAS-122320 / 23.10 / Properly handle unattributed Storj buckets

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/storjix.py
+++ b/src/middlewared/middlewared/rclone/remote/storjix.py
@@ -64,7 +64,7 @@ class StorjIxRcloneRemote(BaseRcloneRemote):
                 {
                     "name": bucket.find(f"{ns}Name").text,
                     "time": bucket.find(f"{ns}CreationDate").text,
-                    "enabled": "ix-storj-1" in bucket.find(f"{ns}Attribution").text,
+                    "enabled": "ix-storj-1" in (bucket.find(f"{ns}Attribution").text or ""),
                 }
                 for bucket in ET.parse(io.StringIO(r.text)).iter(f"{ns}Bucket")
             ]


### PR DESCRIPTION
In order to determine whether a Storj bucket was associated with iX Systems, the text contents of the bucket's `Attribution` tag in Storj's S3 XML response was checked to see whether it contained the iX-Storj user agent. However, a `TypeError` exception was raised if the bucket was unattributed because the content of the empty `Attribution` element was `None`. This issue has been fixed by gracefully handling the empty element.