### PR TITLE
NAS-121867 / 23.10 / Fix CRUD service events/hooks not working with job based methods

### DIFF
--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -183,7 +183,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
     @pass_app(rest=True)
     async def delete(self, app, id, *args):
         return await self.middleware._call(
-            f'{self._config.namespace}.delete', self, self._get_crud_wrapper_func(
+            f'{self._config.namespace}.delete', self, await self._get_crud_wrapper_func(
                 self.do_delete, 'delete', 'REMOVED', id,
             ), [id] + list(args), app=app,
         )

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -177,14 +177,11 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
 
     @pass_app(rest=True)
     async def update(self, app, id, data):
-        rv = await self.middleware._call(
-            f'{self._config.namespace}.update', self, self.do_update, [id, data], app=app,
+        return await self.middleware._call(
+            f'{self._config.namespace}.update', self, await self._get_crud_wrapper_func(
+                self.do_update, 'update', 'CHANGED', id,
+            ), [id, data], app=app,
         )
-        await self.middleware.call_hook(f'{self._config.namespace}.post_update', rv)
-        if self._config.event_send:
-            if isinstance(rv, dict) and 'id' in rv:
-                self.middleware.send_event(f'{self._config.namespace}.query', 'CHANGED', id=rv['id'], fields=rv)
-        return rv
 
     @pass_app(rest=True)
     async def delete(self, app, id, *args):

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -7,7 +7,7 @@ import requests
 from middlewared.client import Client
 from middlewared.client.utils import undefined
 
-__all__ = ["client", "host", "password", "session", "url", "websocket_url"]
+__all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url"]
 
 
 @contextlib.contextmanager
@@ -15,10 +15,7 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
     if auth is undefined:
         auth = ("root", password())
 
-    if host_ip is None:
-        host_ip = host()
-
-    with Client(f"ws://{host_ip}/websocket", py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+    with Client(host_websocket_uri(host_ip), py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
         if auth is not None:
             logged_in = c.call("auth.login", *auth)
             if auth_required:
@@ -31,6 +28,10 @@ def host():
         return os.environ["NODE_A_IP"]
     else:
         return os.environ["MIDDLEWARE_TEST_IP"]
+
+
+def host_websocket_uri(host_ip=None):
+    return f"ws://{host_ip or host()}/websocket"
 
 
 def password():

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -39,7 +39,7 @@ def gather_events(event_endpoint: str, context_args: dict = None):
         'timeout': 60,
         **(context_args or {})
     }
-    thread = threading.Thread(target=event_thread, args=(event_endpoint, context))
+    thread = threading.Thread(target=event_thread, args=(event_endpoint, context), daemon=True)
     thread.start()
     if not context['start_event'].wait(timeout=30):
         raise Exception('Timed out waiting for event thread to start')
@@ -53,7 +53,6 @@ def gather_events(event_endpoint: str, context_args: dict = None):
 
 
 def assert_result(context: dict, event_endpoint: str, oid: typing.Union[int, str], event_type: str) -> None:
-    assert context['result'] is not None
     assert context['result'] == {
         'msg': event_type,
         'collection': event_endpoint,

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -85,3 +85,19 @@ def test_event_create_on_job_method():
                 }, context['result']
             finally:
                 call('certificate.delete', cert['id'], job=True)
+
+
+def test_event_update_on_non_job_method():
+    with root_certificate_authority('root_ca_update_event_test') as root_ca:
+        with gather_events('certificateauthority.query') as context:
+            assert root_ca['CA_type_internal'] is True, root_ca
+            assert context['result'] is None, context
+
+            call('certificateauthority.update', root_ca['id'], {})
+
+            assert context['result'] is not None, context
+            assert context['result'] == {
+                'msg': 'changed',
+                'collection': 'certificateauthority.query',
+                'id': root_ca['id'],
+            }, context['result']

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -96,3 +96,17 @@ def test_event_update_on_non_job_method():
             call('certificateauthority.update', root_ca['id'], {})
 
             assert_result(context, 'certificateauthority.query', root_ca['id'], 'changed')
+
+
+def test_event_update_on_job_method():
+    tunable = call('tunable.create', {
+        'type': 'SYSCTL',
+        'var': 'kernel.watchdog',
+        'value': '1',
+    }, job=True)
+    try:
+        with gather_events('tunable.query') as context:
+            call('tunable.update', tunable['id'], {'value': '0'}, job=True)
+            assert_result(context, 'tunable.query', tunable['id'], 'changed')
+    finally:
+        call('tunable.delete', tunable['id'], job=True)

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -26,7 +26,8 @@ def event_thread(event_endpoint: str, context: dict):
             event.set()
 
         c.subscribe(event_endpoint, cb, subscribe_payload)
-        event.wait(timeout=context['timeout'])
+        if not event.wait(timeout=context['timeout']):
+            raise Exception('Timed out waiting for CRUD event to be generated')
 
 
 @contextlib.contextmanager
@@ -40,7 +41,9 @@ def gather_events(event_endpoint: str, context_args: dict = None):
     }
     thread = threading.Thread(target=event_thread, args=(event_endpoint, context))
     thread.start()
-    context['start_event'].wait(timeout=30)
+    if not context['start_event'].wait(timeout=30):
+        raise Exception('Timed out waiting for event thread to start')
+
     try:
         yield context
     finally:

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -1,28 +1,14 @@
 import contextlib
-import functools
-import os
-import sys
 import threading
 import typing
 
-from middlewared.client import Client
 from middlewared.test.integration.assets.crypto import get_cert_params, root_certificate_authority
 from middlewared.test.integration.utils import call
-from middlewared.test.integration.utils.client import host_websocket_uri, password
-
-
-sys.path.append(os.getcwd())
-
-
-@functools.cache
-def auth():
-    return 'root', password()
+from middlewared.test.integration.utils.client import client
 
 
 def event_thread(event_endpoint: str, context: dict):
-    with Client(host_websocket_uri(), py_exceptions=False) as c:
-        assert c.call('auth.login', *auth()) is True
-
+    with client(py_exceptions=False) as c:
         context['start_event'].set()
         subscribe_payload = c.event_payload()
         event = subscribe_payload['event']
@@ -64,12 +50,12 @@ def gather_events(event_endpoint: str, context_args: dict = None):
 
 
 def assert_result(context: dict, event_endpoint: str, oid: typing.Union[int, str], event_type: str) -> None:
-    assert context['result'] is not None, context
+    assert context['result'] is not None
     assert context['result'] == {
         'msg': event_type,
         'collection': event_endpoint,
         'id': oid,
-    }, context['result']
+    }
 
 
 def test_event_create_on_non_job_method():

--- a/tests/api2/test_crud_events.py
+++ b/tests/api2/test_crud_events.py
@@ -1,0 +1,45 @@
+import functools
+import os
+import sys
+
+from middlewared.client import Client
+from middlewared.test.integration.utils.client import host_websocket_uri, password
+
+
+sys.path.append(os.getcwd())
+
+
+@functools.cache
+def auth():
+    return 'root', password()
+
+
+def event_thread(event_endpoint: str):
+    with Client(host_websocket_uri(), py_exceptions=False) as c:
+        c.call('auth.login', *auth())
+
+        event_msg = None
+        subscribe_payload = c.event_payload()
+        event = subscribe_payload['event']
+
+        def cb(mtype, **message):
+            nonlocal event_msg
+            if len(message) != 3 or not all(
+                k in message for k in ('id', 'msg', 'collection')
+            ) or message['collection'] != event_endpoint or message['msg'] not in (
+                'added', 'changed', 'removed'
+            ):
+                return
+
+            event_msg = message
+            event.set()
+
+        c.subscribe(event_endpoint, cb, subscribe_payload)
+
+        if not event.wait():
+            return event_msg
+
+        if subscribe_payload['error']:
+            return event_msg
+
+        return event_msg


### PR DESCRIPTION
This PR fixes create/update/delete post execution events/hooks when any of those methods are jobs as we were not waiting for the job to actually finish before trying to fire events and it has never worked for job based methods. Now with the current changes we properly wait for the actual method to complete execution and then we fire events/hooks regardless of the actual method being a job or not.