### PR TITLE
Validation of a negative number cause to 'Not an integer' error 

### DIFF
--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -614,6 +614,8 @@ class Int(EnumMixin, Attribute):
             return value
         if not isinstance(value, int) or isinstance(value, bool):
             if isinstance(value, str) and value.lstrip('-').isdigit():
+                if value.lstrip('-') != value:
+                    return int('-' + value.lstrip('-'))
                 return int(value)
             raise Error(self.name, 'Not an integer')
         return value

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -613,7 +613,7 @@ class Int(EnumMixin, Attribute):
         if value is None:
             return value
         if not isinstance(value, int) or isinstance(value, bool):
-            if isinstance(value, str) and value.isdigit():
+            if isinstance(value, str) and value.lstrip('-').isdigit():
                 return int(value)
             raise Error(self.name, 'Not an integer')
         return value


### PR DESCRIPTION
### TL;DR
The validation of a negative number cause to `Not an integer` error instead of accepting it as a normal integer.

### Why that's important
I have wanted to add Telegram notifications from TrueNAS to my notifications group. I have taken the bot token and the chat  id of my notifications group and I have inserted them into the Alert Services in TrueNAS settings and I have got the following error: `[EINVAL] alert_service_test.attributes.chat_ids: Item#0 is not valid per list types: [chat_id] Not an integer`.
I started to think and check for the functions on the error trace, and after I saw the check function of Int, I understood that the function that checks if a string is an integer returns an error if the number is negative!
Why probably nobody has seen this error before? Because Telegram chat ids are positive numbers for personal chat and negative numbers for group chat.


#### Full Error Trace:
```python
 Error: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 181, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1255, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1284, in nf
    return await func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/schema.py", line 1152, in nf
    res = await f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/alert.py", line 1068, in test
    await self._validate(data, "alert_service_test")
  File "/usr/lib/python3/dist-packages/middlewared/plugins/alert.py", line 962, in _validate
    raise verrors
middlewared.service_exception.ValidationErrors: [EINVAL] alert_service_test.attributes.chat_ids: Item#0 is not valid per list types: [chat_id] Not an integer

```