### PR TITLE
NAS-122211 / 22.12.4 / Improve display devices defaults (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1786,15 +1786,16 @@ class InterfaceService(CRUDService):
 
         """
         list_of_ip = []
+        static_ips = {}
         ignore_nics = self.middleware.call_sync('interface.internal_interfaces')
         ignore_nics.extend(self.middleware.call_sync(
             'failover.internal_interfaces'
         ))
         if choices['loopback']:
             ignore_nics.remove('lo')
+            static_ips['127.0.0.1'] = '127.0.0.1'
 
         ignore_nics = tuple(ignore_nics)
-        static_ips = {}
         if choices['static']:
             licensed = self.middleware.call_sync('failover.licensed')
             for i in self.middleware.call_sync('interface.query'):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -23,9 +23,9 @@ class DISPLAY(Device):
         Str('resolution', enum=RESOLUTION_ENUM, default='1024x768'),
         Int('port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
         Int('web_port', default=None, null=True, validators=[Range(min=5900, max=65535)]),
-        Str('bind', default='0.0.0.0'),
+        Str('bind', default='127.0.0.1'),
         Bool('wait', default=False),
-        Str('password', default=None, null=True, private=True),
+        Str('password', private=True, required=True, null=False, empty=False),
         Bool('web', default=True),
         Str('type', default='SPICE', enum=['SPICE', 'VNC']),
     )

--- a/src/middlewared/middlewared/plugins/vm/vm_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_devices.py
@@ -109,7 +109,7 @@ class VMDeviceService(CRUDService):
         """
         return {
             d['address']: d['address'] for d in await self.middleware.call(
-                'interface.ip_in_use', {'static': True, 'any': True}
+                'interface.ip_in_use', {'static': True, 'any': True, 'loopback': True}
             )
         }
 


### PR DESCRIPTION
## Context

`DISPLAY` devices defaults have been to not ask user to specify `password` as a hard requirement.
However that is not appropriate because if VNC server socket is not protected by password it just means that any malicious actor can just scan ports and then gain access to a VMs console which in most cases is also connected to the user's local network.
Now specifying `password` is a hard requirement for any one looking to create more `DISPLAY` devices or edit the ones they have already. Also by default we are going to bind the VNC/spice server to `localhost` instead of wildcard ip i.e `0.0.0.0` improving the defaults further so only if anyone really wants to expose their VNC server socket they can do so explicitly.

Original PR: https://github.com/truenas/middleware/pull/11429
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122211