### PR TITLE
NAS-122319 / 22.12.3 / Fix booting back to FreeBSD (by themylogin) (by bugclerk)

### DIFF
--- a/debian/debian/ix-update.service
+++ b/debian/debian/ix-update.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 
 Before=middlewared.service
 
+ConditionEnvironment=!_BOOT_TRUENAS_CORE
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/src/freenas/usr/bin/ix-boot-core.py
+++ b/src/freenas/usr/bin/ix-boot-core.py
@@ -20,5 +20,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     subprocess.run(["zpool", "set", f"bootfs={name}", boot_pool], check=True)
+    subprocess.run(["mount", "-t", "zfs", f"{boot_pool}/grub", "/boot/grub"])
     subprocess.run(["update-grub"], check=True)
     subprocess.run(["reboot"], check=True)


### PR DESCRIPTION
    /boot/grub was not mounted at the time this script was started which prevented
    the GRUB config from being updated and resulted in booting back to CORE not
    possible.
    
    Additionally, let's stop running update script when we just need to boot back
    to FreeBSD as this consumes too much time.


Original PR: https://github.com/truenas/middleware/pull/11447
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122319

Original PR: https://github.com/truenas/middleware/pull/11448
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122319