### PR TITLE
NAS-122292 / 22.12.3 / Don't try to copy symlinks in /var/log (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -289,6 +289,9 @@ def configure_syslog(middleware):
                 dst = os.path.join(log_path, item)
                 item = os.path.join("/var/log", item)
 
+                if os.path.islink(item):
+                    continue
+
                 if os.path.isdir(item):
                     # Pick up any new directories and sync them
                     if not os.path.isdir(dst):


### PR DESCRIPTION
Generally speaking, /var/log shouldn't have symlinks in it and so we can safely skip any that appear (for example symlink to systemd README file).

Original PR: https://github.com/truenas/middleware/pull/11446
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122292