### PR TITLE
NAS-122318 / 22.12.4 / Properly handle negative integers in int schema (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -202,6 +202,8 @@ def test__schema_int_not_null():
 @pytest.mark.parametrize("value,expected", [
     (3, 3),
     ('3', 3),
+    ('-3', -3),
+    (-3, -3),
     (3.0, ValidationErrors),
     ('FOO', ValidationErrors),
     (False, ValidationErrors),

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import json
 import string
@@ -595,13 +596,13 @@ class Int(EnumMixin, Attribute):
 
     def clean(self, value):
         value = super(Int, self).clean(value)
-        if value is None:
+        if value is None or (not isinstance(value, bool) and isinstance(value, int)):
             return value
-        if not isinstance(value, int) or isinstance(value, bool):
-            if isinstance(value, str) and value.isdigit():
+        elif isinstance(value, str):
+            with contextlib.suppress(ValueError):
                 return int(value)
-            raise Error(self.name, 'Not an integer')
-        return value
+
+        raise Error(self.name, 'Not an integer')
 
     def to_json_schema(self, parent=None):
         return {


### PR DESCRIPTION
## Context

@topazbarziv raised a PR https://github.com/truenas/middleware/pull/11443 proposing a fix for properly handling negative integer values as they are not being handled by `Int` schema currently and instead it fails if such a value is supplied.

Co-authored-by: Topaz Barziv <mail@topazbarziv.com>

Original PR: https://github.com/truenas/middleware/pull/11445
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122318