### PR TITLE
NAS-120267 / 23.10 / Remove geli related attributes from database

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-04-27_06-20_remove_geli_keys.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-04-27_06-20_remove_geli_keys.py
@@ -1,0 +1,25 @@
+"""
+Remove geli related keys
+
+Revision ID: d2a26c29efca
+Revises: 55836e7dac39
+Create Date: 2023-04-27 06:20:01.757983+00:00
+
+"""
+from alembic import op
+
+
+revision = 'd2a26c29efca'
+down_revision = '55836e7dac39'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('storage_volume', schema=None) as batch_op:
+        batch_op.drop_column('vol_encrypt')
+        batch_op.drop_column('vol_encryptkey')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-04-27_06-20_remove_geli_keys.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-04-27_06-20_remove_geli_keys.py
@@ -20,6 +20,8 @@ def upgrade():
         batch_op.drop_column('vol_encrypt')
         batch_op.drop_column('vol_encryptkey')
 
+    op.drop_table('storage_encrypteddisk')
+
 
 def downgrade():
     pass

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-06-04_00-20_remove_geli_keys.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-06-04_00-20_remove_geli_keys.py
@@ -2,15 +2,15 @@
 Remove geli related keys
 
 Revision ID: d2a26c29efca
-Revises: 55836e7dac39
-Create Date: 2023-04-27 06:20:01.757983+00:00
+Revises: 1519ee5b6e29
+Create Date: 2023-06-04 00:20:01.757983+00:00
 
 """
 from alembic import op
 
 
 revision = 'd2a26c29efca'
-down_revision = '55836e7dac39'
+down_revision = '1519ee5b6e29'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/alert/source/volume_status.py
+++ b/src/middlewared/middlewared/alert/source/volume_status.py
@@ -17,9 +17,6 @@ class VolumeStatusAlertSource(AlertSource):
 
         alerts = []
         for pool in await self.middleware.call("pool.query"):
-            if not pool["is_decrypted"]:
-                continue
-
             if not pool["healthy"] or pool["warning"]:
                 if await self.middleware.call("system.is_enterprise"):
                     try:

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -31,8 +31,6 @@ class BootService(Service):
         'pool_entry', 'get_state',
         ('rm', {'name': 'id'}),
         ('rm', {'name': 'guid'}),
-        ('rm', {'name': 'encrypt'}),
-        ('rm', {'name': 'encryptkey'})
     ))
     async def get_state(self):
         """

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1184,15 +1184,6 @@ async def hook_pool_export(middleware, pool=None, *args, **kwargs):
     await middleware.call('failover.remove_encryption_keys', {'pools': [pool]})
 
 
-async def hook_pool_post_import(middleware, pool):
-    if pool and pool['encrypt'] == 2 and pool['passphrase']:
-        await middleware.call(
-            'failover.update_encryption_keys', {
-                'pools': [{'name': pool['name'], 'passphrase': pool['passphrase']}]
-            }
-        )
-
-
 async def hook_pool_dataset_unlock(middleware, datasets):
     datasets = [
         {'name': ds['name'], 'passphrase': ds['encryption_key']}
@@ -1307,7 +1298,6 @@ async def setup(middleware):
     middleware.register_hook('pool.post_create_or_update', hook_setup_ha, sync=True)
     middleware.register_hook('pool.post_export', hook_pool_export, sync=True)
     middleware.register_hook('pool.post_import', hook_setup_ha, sync=True)
-    middleware.register_hook('pool.post_import', hook_pool_post_import, sync=True)
     middleware.register_hook('dataset.post_create', hook_pool_dataset_post_create, sync=True)
     middleware.register_hook('dataset.post_delete', hook_pool_dataset_post_delete_lock, sync=True)
     middleware.register_hook('dataset.post_lock', hook_pool_dataset_post_delete_lock, sync=True)

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -26,9 +26,6 @@ class PoolService(Service):
         """
         pool = await self.middleware.call('pool.get_instance', oid)
         verrors = ValidationErrors()
-        if not pool['is_decrypted']:
-            verrors.add('oid', 'Pool must be unlocked for this action.')
-            verrors.check()
         topology = pool['topology']
         topology_type = vdev = None
         for i in topology:

--- a/src/middlewared/middlewared/plugins/pool_/attach_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/attach_disk.py
@@ -17,9 +17,6 @@ class PoolService(Service):
     @job(lock=lambda args: f'pool_attach_{args[0]}')
     async def attach(self, job, oid, options):
         """
-        For TrueNAS Core/Enterprise platform, if the `oid` pool is passphrase GELI encrypted, `passphrase`
-        must be specified for this operation to succeed.
-
         `target_vdev` is the GUID of the vdev where the disk needs to be attached. In case of STRIPED vdev, this
         is the STRIPED disk GUID which will be converted to mirror. If `target_vdev` is mirror, it will be converted
         into a n-way mirror.

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -445,9 +445,8 @@ class PoolDatasetService(CRUDService):
         `sparse` and `volblocksize` are only used for type=VOLUME.
 
         `encryption` when enabled will create an ZFS encrypted root dataset for `name` pool.
-        There are 2 cases where ZFS encryption is not allowed for a dataset:
-        1) Pool in question is GELI encrypted.
-        2) If the parent dataset is encrypted with a passphrase and `name` is being created
+        There is 1 case where ZFS encryption is not allowed for a dataset:
+        1) If the parent dataset is encrypted with a passphrase and `name` is being created
            with a key for encrypting the dataset.
 
         `encryption_options` specifies configuration for encryption of dataset for `name` pool.
@@ -608,13 +607,6 @@ class PoolDatasetService(CRUDService):
         if data['encryption']:
             if inherit_encryption_properties:
                 verrors.add('pool_dataset_create.inherit_encryption', 'Must be disabled when encryption is enabled.')
-            if (
-                    await self.middleware.call('pool.query', [['name', '=', data['name'].split('/')[0]]], {'get': True})
-            )['encrypt']:
-                verrors.add(
-                    'pool_dataset_create.encryption',
-                    'Encrypted datasets cannot be created on a GELI encrypted pool.'
-                )
 
             if not data['encryption_options']['passphrase']:
                 # We want to ensure that we don't have any parent for this dataset which is encrypted with PASSPHRASE

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -15,18 +15,6 @@ class PoolService(Service):
 
     @private
     def cleanup_after_export(self, poolinfo, opts):
-        if poolinfo['encrypt'] > 0:
-            try:
-                # this is CORE GELI encryption which doesn't exist on SCALE
-                # so it means someone upgraded from CORE to SCALE and their
-                # db has an entry with a GELI based encrypted pool in it so
-                # we'll remove the GELI key files associated with the zpool
-                os.remove(poolinfo['encryptkey'])
-            except Exception:
-                # not fatal, and doesn't really matter since SCALE can't
-                # use this zpool anyways
-                pass
-
         try:
             if all((opts['destroy'], opts['cascade'])) and (contents := os.listdir(poolinfo['path'])):
                 if len(contents) == 1 and contents[0] == 'ix-applications':

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -183,9 +183,7 @@ class PoolService(Service):
         # update db
         pool_id = await self.middleware.call('datastore.insert', 'storage.volume', {
             'vol_name': pool_name,
-            'vol_encrypt': 0,  # TODO: remove (geli not supported)
             'vol_guid': guid,
-            'vol_encryptkey': '',  # TODO: remove (geli not supported)
         })
         await self.middleware.call('pool.scrub.create', {'pool': pool_id})
 

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -242,10 +242,7 @@ class PoolService(Service):
 
         job.set_progress(0, 'Beginning pools import')
 
-        pools = self.middleware.call_sync('pool.query', [
-            ('encrypt', '<', 2),
-            ('status', '=', 'OFFLINE')
-        ])
+        pools = self.middleware.call_sync('pool.query', [('status', '=', 'OFFLINE')])
         for i, pool in enumerate(pools):
             # Importing pools is currently 80% of the job because we may still need
             # to set ACL mode for windows

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -65,7 +65,6 @@ class PoolService(Service):
         'pool_import',
         Str('guid', required=True),
         Str('name'),
-        Str('passphrase', private=True),
         Bool('enable_attachments'),
     ))
     @returns(Bool('successful_import'))
@@ -75,8 +74,6 @@ class PoolService(Service):
         Import a pool found with `pool.import_find`.
 
         If a `name` is specified the pool will be imported using that new name.
-
-        `passphrase` DEPRECATED. GELI not supported on SCALE.
 
         If `enable_attachments` is set to true, attachments that were disabled during pool export will be
         re-enabled.
@@ -201,7 +198,7 @@ class PoolService(Service):
             await self.middleware.call('keyvalue.delete', key)
 
         self.middleware.create_task(self.middleware.call('service.restart', 'collectd'))
-        await self.middleware.call_hook('pool.post_import', {'passphrase': data.get('passphrase'), **pool})
+        await self.middleware.call_hook('pool.post_import', pool)
         await self.middleware.call('pool.dataset.sync_db_keys', pool['name'])
         self.middleware.create_task(self.middleware.call('disk.swaps_configure'))
         self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)

--- a/src/middlewared/middlewared/plugins/pool_/info.py
+++ b/src/middlewared/middlewared/plugins/pool_/info.py
@@ -90,7 +90,7 @@ class PoolService(Service):
         """
         disks = []
         for pool in await self.middleware.call('pool.query', [] if not oid else [('id', '=', oid)]):
-            if pool['is_decrypted'] and pool['status'] != 'OFFLINE':
+            if pool['status'] != 'OFFLINE':
                 disks.extend(await self.middleware.call('zfs.pool.get_disks', pool['name']))
         return disks
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -21,7 +21,6 @@ class PoolModel(sa.Model):
     vol_name = sa.Column(sa.String(120), unique=True)
     vol_guid = sa.Column(sa.String(50))
     vol_encrypt = sa.Column(sa.Integer(), default=0)
-    vol_encryptkey = sa.Column(sa.String(50))
 
 
 class EncryptedDiskModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -40,10 +40,6 @@ class PoolService(CRUDService):
         Int('id', required=True),
         Str('name', required=True),
         Str('guid', required=True),
-        Int('encrypt', required=True),
-        Str('encryptkey', required=True),
-        Str('encryptkey_path', null=True, required=True),
-        Bool('is_decrypted', required=True),
         Str('status', required=True),
         Str('path', required=True),
         Dict(
@@ -156,8 +152,6 @@ class PoolService(CRUDService):
                 'source': 'DEFAULT',
                 'value': 'off'
             },
-            'encryptkey_path': None,
-            'is_decrypted': True,
         }
 
         if info := await self.middleware.call('zfs.pool.query', [('name', '=', pool_name)]):

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -22,15 +22,6 @@ class PoolModel(sa.Model):
     vol_guid = sa.Column(sa.String(50))
 
 
-class EncryptedDiskModel(sa.Model):
-    __tablename__ = 'storage_encrypteddisk'
-
-    id = sa.Column(sa.Integer(), primary_key=True)
-    encrypted_volume_id = sa.Column(sa.ForeignKey('storage_volume.id', ondelete='CASCADE'))
-    encrypted_disk_id = sa.Column(sa.ForeignKey('storage_disk.disk_identifier', ondelete='SET NULL'), nullable=True)
-    encrypted_provider = sa.Column(sa.String(120), unique=True)
-
-
 class PoolService(CRUDService):
 
     ENTRY = Dict(

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -174,11 +174,6 @@ class PoolService(CRUDService):
 
     @private
     def pool_extend(self, pool, context):
-
-        """
-        If pool is encrypted we need to check if the pool is imported
-        or if all geli providers exist.
-        """
         if context['extra'].get('is_upgraded'):
             pool['is_upgraded'] = self.middleware.call_sync('pool.is_upgraded_by_name', pool['name'])
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -20,7 +20,6 @@ class PoolModel(sa.Model):
     id = sa.Column(sa.Integer(), primary_key=True)
     vol_name = sa.Column(sa.String(120), unique=True)
     vol_guid = sa.Column(sa.String(50))
-    vol_encrypt = sa.Column(sa.Integer(), default=0)
 
 
 class EncryptedDiskModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -358,7 +358,6 @@ class UsageService(Service):
             pool_list.append({
                 'capacity': pd['used']['parsed'] + pd['available']['parsed'],
                 'disks': disks,
-                'encryption': bool(p['encrypt']),
                 'l2arc': bool(p['topology']['cache']),
                 'type': _type.lower(),
                 'usedbydataset': pd['usedbydataset']['parsed'],

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -790,9 +790,6 @@ class ZettareplService(Service):
         if pools[pool]["status"] == "OFFLINE":
             return f"Pool {pool} is offline"
 
-        if not pools[pool]["is_decrypted"]:
-            return f"Pool {pool} is locked"
-
     @asynccontextmanager
     async def _handle_ssh_exceptions(self):
         try:


### PR DESCRIPTION
This PR introduces changes to cover usages of encryption fields which we had in pool table.
We still have some leftover references of geli in failover plugin which will be handled in a separate ticket.