### PR TITLE
NAS-122322 / 23.10 / Improve sharesec validation

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -36,6 +36,7 @@ class ShareSec(CRUDService):
     class Config:
         namespace = 'smb.sharesec'
         cli_namespace = 'sharing.smb.sharesec'
+        private = True
 
     tdb_options = {
         'backend': 'CUSTOM',
@@ -196,6 +197,16 @@ class ShareSec(CRUDService):
         If the `option` `resolve_sids` is set to `False` then the returned ACL will not
         contain names.
         """
+        if share_name.upper() == 'HOMES':
+            share_filter = [['home', '=', True]]
+        else:
+            share_filter = [['name', 'C=', share_name]]
+
+        try:
+            await self.middleware.call('sharing.smb.query', share_filter, {'get': True})
+        except MatchNotFound:
+            raise CallError(f'{share_name}: share does not exist')
+
         sharesec = await self._sharesec(action='--view', share=share_name)
         share_sd = f'[{share_name.upper()}]\n{sharesec}'
         return await self.parse_share_sd(share_sd, options)
@@ -246,6 +257,16 @@ class ShareSec(CRUDService):
 
         `ae_type` can be ALLOWED or DENIED.
         """
+        if data['share_name'].upper() == 'HOMES':
+            share_filter = [['home', '=', True]]
+        else:
+            share_filter = [['name', 'C=', data['share_name']]]
+
+        try:
+            config_share = await self.middleware.call('sharing.smb.query', share_filter, {'get': True})
+        except MatchNotFound:
+            raise CallError(f'{data["share_name"]}: share does not exist')
+
         ae_list = []
         for entry in data['share_acl']:
             ae_list.append(await self._ae_to_string(entry))
@@ -254,7 +275,6 @@ class ShareSec(CRUDService):
         if not db_commit:
             return
 
-        config_share = await self.middleware.call('sharing.smb.query', [('name', '=', data['share_name'])], {'get': True})
         await self.middleware.call('datastore.update', 'sharing.cifs_share', config_share['id'],
                                    {'cifs_share_acl': ' '.join(ae_list)})
 


### PR DESCRIPTION
Shift lookup of share name in smb.sharesec endpoint to earlier in setacl function so that we fail with MatchNotFound if the share doesn't exist. This PR also fixes handling for HOMES shares.