### PR TITLE
NAS-122326 / 23.10 / Implement basic FreeIPA tests

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -819,7 +819,6 @@ class LDAPService(TDBWrapConfigService):
 
             default_naming_context = rootdse[0]['data']['defaultnamingcontext'][0]
             aux_params = [
-                'map group member uniqueMember',
                 f'base passwd cn=users,cn=accounts,{default_naming_context}',
                 f'base group cn=groups,cn=accounts,{default_naming_context}',
             ]

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+import os
+from pytest_dependency import depends
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import (
+    GET,
+    POST,
+)
+from assets.REST.directory_services import ldap
+from auto_config import dev_test
+# comment pytestmark for development testing with --dev-test
+pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
+
+try:
+    from config import (
+        FREEIPA_IP,
+        FREEIPA_BASEDN,
+        FREEIPA_BINDDN,
+        FREEIPA_BINDPW,
+        FREEIPA_HOSTNAME,
+    )
+except ImportError:
+    Reason = 'FREEIPA* variable are not setup in config.py'
+    pytestmark = pytest.mark.skipif(True, reason=Reason)
+
+
+@pytest.fixture(scope="module")
+def do_freeipa_connection(request):
+    with ldap(
+        FREEIPA_BASEDN,
+        FREEIPA_BINDDN,
+        FREEIPA_BINDPW,
+        FREEIPA_HOSTNAME,
+        validate_certificates=False,
+    ) as ldap_conn:
+        yield (request, ldap_conn)
+
+
+@pytest.mark.dependency(name="setup_freeipa")
+def test_01_setup_and_enabling_freeipa(do_freeipa_connection):
+    results = GET("/ldap/get_state/")
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), str), results.text
+    assert results.json() == "HEALTHY", results.text
+
+
+def test_02_verify_ldap_enable_is_true(request):
+    depends(request, ["setup_freeipa"], scope="session")
+    results = GET("/ldap/")
+    assert results.json()["enable"] is True, results.text
+
+
+@pytest.mark.dependency(name="FREEIPA_NSS_WORKING")
+def test_03_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
+    """
+    get_user_obj is a wrapper around the pwd module.
+    """
+    depends(request, ["setup_freeipa"], scope="session")
+    payload = {
+        "username": "ixauto_restricted",
+        "get_groups": True
+    }
+    results = POST("/user/get_user_obj/", payload)
+    assert results.status_code == 200, results.text
+    pwd_obj = results.json()
+    assert pwd_obj['pw_uid'] == 925000003
+    assert pwd_obj['pw_gid'] == 925000003
+    assert len(pwd_obj['grouplist']) > 1


### PR DESCRIPTION
This first group of tests just validates that we can bind to a FreeIPA LDAP server and configure NSS properly.