### PR TITLE
NAS-122333 / 22.12.4 / Fix ID parsing in idmap bulk sid conversion (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -971,7 +971,7 @@ class IdmapDomainService(TDBWrapCRUDService):
             raise CallError(str(e), WBCErr[e.error_code], e.error_code)
 
         mapped = {sid: {
-            'type': entry.sid_type['parsed'][4:],
+            'type': IDType.parse_wbc_id_type(entry.id_type),
             'id': entry.id,
             'name': f'{entry.domain}{client.ctx.separator.decode()}{entry.name}',
         } for sid, entry in results['mapped'].items()}

--- a/src/middlewared/middlewared/plugins/idmap_/utils.py
+++ b/src/middlewared/middlewared/plugins/idmap_/utils.py
@@ -47,6 +47,18 @@ class IDType(enum.Enum):
 
         return val
 
+    def parse_wbc_id_type(type_in):
+        if type_in == wbclient.ID_TYPE_UID:
+            return IDType.USER.value
+
+        if type_in == wbclient.ID_TYPE_GID:
+            return IDType.GROUP.value
+
+        if type_in == wbclient.ID_TYPE_BOTH:
+            return IDType.BOTH.value
+
+        raise ValueError(f'{type_in}: invalid winbind ID type')
+
 
 class WBClient:
     def __init__(self, **kwargs):


### PR DESCRIPTION
We should be parsing the returned winbindd ID type and not SID type. Generally SID type string will match up until handling more obscure edge cases like dynamically allocated IDs via passdb.

Original PR: https://github.com/truenas/middleware/pull/11460
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122333