### PR TITLE
NAS-122344 / 22.12.4 / Rely exclusively on kerberos tickets for AD ops (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -173,7 +173,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         foreign entries.
         kinit will fail if domain name is lower-case.
         """
-        for key in ['netbiosname', 'netbiosname_b', 'netbiosalias']:
+        for key in ['netbiosname', 'netbiosname_b', 'netbiosalias', 'bindpw']:
             if key in ad:
                 ad.pop(key)
 
@@ -549,6 +549,9 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'to match active directory value of %s', ret['domainname'], exc_info=True
                     )
 
+            if not await self.middleware.call('kerberos._klist_test'):
+                await self.middleware.call('kerberos.start')
+
             job = (await self.middleware.call('activedirectory.start')).id
 
         elif not new['enable'] and old['enable']:
@@ -710,7 +713,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
             if kt_id:
                 self.logger.debug('Successfully generated keytab for computer account. Clearing bind credentials')
                 ad = await self.direct_update({
-                    'bindpw': '',
                     'kerberos_principal': f'{ad["netbiosname"].upper()}$@{ad["domainname"]}'
                 })
 


### PR DESCRIPTION
For quite some time already we don't need the AD bindpw stored in our sqlite database. Pop it out of config dict before insertion in activedirectory.update (after we've performed kinit to get kerberos ticket as admin).

Original PR: https://github.com/truenas/middleware/pull/11464
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122344