### PR TITLE
NAS-122330 / 22.12.4 / fix system.general.timezone_choices and test (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system_general/timezone.py
+++ b/src/middlewared/middlewared/plugins/system_general/timezone.py
@@ -1,12 +1,11 @@
-import os
+from subprocess import run
 
 from middlewared.schema import accepts, Dict, returns
-from middlewared.service import private, Service
+from middlewared.service import Service
+from middlewared.utils.functools import cache
 
 
 class SystemGeneralService(Service):
-
-    TIMEZONE_CHOICES = None
 
     class Config:
         namespace = 'system.general'
@@ -14,26 +13,11 @@ class SystemGeneralService(Service):
 
     @accepts()
     @returns(Dict('system_timezone_choices', additional_attrs=True, title='System Timezone Choices'))
-    async def timezone_choices(self):
-        """
-        Returns time zone choices.
-        """
-        if not self.TIMEZONE_CHOICES:
-            self.TIMEZONE_CHOICES = await self.get_timezone_choices()
-
-        return self.TIMEZONE_CHOICES
-
-    @private
-    async def get_timezone_choices(self):
-        timezones = {}
-        basepath = '/usr/share/zoneinfo/'
-        for root, dirs, files in os.walk(basepath):
-            relpath = os.path.normpath(os.path.relpath(root, basepath))
-            for timezone in (files if 'right' not in relpath and 'posix' not in relpath else []):
-                if relpath != '.':
-                    zone_name = f'{relpath}/{timezone}'
-                else:
-                    zone_name = timezone
-                if 'Etc/GMT' not in zone_name:
-                    timezones[zone_name] = zone_name
-        return timezones
+    @cache
+    def timezone_choices(self):
+        """Returns available timezones"""
+        choices = dict()
+        for i in run(['timedatectl', 'list-timezones'], capture_output=True).stdout.decode().split('\n'):
+            if (choice := i.strip()):
+                choices[choice] = choice
+        return choices

--- a/tests/api2/test_490_system_general.py
+++ b/tests/api2/test_490_system_general.py
@@ -69,13 +69,3 @@ def test_08_Checking_timezone_using_ssh(request):
     results = SSH_TEST(f'diff /etc/localtime /usr/share/zoneinfo/{TIMEZONE}',
                        user, password, ip)
     assert results['result'] is True, results
-
-
-def test_09_timezone_choices():
-    timezones_dic = call('system.general.timezone_choices')
-    result = ssh('timedatectl list-timezones')
-    missing = []
-    for timezone in filter(bool, result.split('\n')):
-        if not timezones_dic.get(timezone):
-            missing.append(timezone)
-    assert missing == []


### PR DESCRIPTION
The test was failing which caused me to investigate and find a bunch of problems.

- performing blocking IO in the main event loop
- we are reading from a directory and that was producing a bunch of unexpected entries that differed from the command timedatectl list-timezones
- don't read from a directory, just run timedatectl list-timezones since it does exactly what we need
- cache the response of this method using @cache decorator instead of using a class attribute
- fix the test by removing it. We already call timezone_choices endpoint in this test so there is nothing else to do

Original PR: https://github.com/truenas/middleware/pull/11471
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122330