### PR TITLE
NAS-122367 / 23.10 / Fix middleware start failure

### DIFF
--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -53,7 +53,6 @@ async def setup(middleware):
     middleware.logger.debug(f'Timezone set to {settings["timezone"]}')
 
     await middleware.call('system.general.set_language')
-    await middleware.call('system.general.set_crash_reporting')
 
     CRASH_DIR = '/data/crash'
     os.makedirs(CRASH_DIR, exist_ok=True)


### PR DESCRIPTION
Crash reporting framework was removed and so we shouldn't set it on start.