### PR TITLE
NAS-122382 / 23.10 / fix system/__init__:setup function

### DIFF
--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -1,34 +1,38 @@
-# -*- coding=utf-8 -*-
 import os
+import subprocess
 import uuid
 
-from middlewared.utils import BOOTREADY, run
+from middlewared.utils import BOOTREADY
 
 from .utils import FIRST_INSTALL_SENTINEL, lifecycle_conf
 
 
-async def firstboot(middleware):
-    if os.path.exists(FIRST_INSTALL_SENTINEL):
+def firstboot(middleware):
+    if os.path.exists(BOOTREADY):
+        lifecycle_conf.SYSTEM_READY = True
+    elif os.path.exists(FIRST_INSTALL_SENTINEL):
         lifecycle_conf.SYSTEM_FIRST_BOOT = True
         # Delete sentinel file before making clone as we
         # we do not want the clone to have the file in it.
         os.unlink(FIRST_INSTALL_SENTINEL)
 
-        if await middleware.call('system.is_enterprise'):
-            config = await middleware.call('datastore.config', 'system.advanced')
-            await middleware.call('datastore.update', 'system.advanced', config['id'], {'adv_autotune': True})
+        if middleware.call_sync('system.is_enterprise'):
+            config = middleware.call_sync('datastore.config', 'system.advanced')
+            middleware.call_sync('datastore.update', 'system.advanced', config['id'], {'adv_autotune': True})
 
         # Creating pristine boot environment from the "default"
         initial_install_be = 'Initial-Install'
         middleware.logger.info('Creating %r boot environment...', initial_install_be)
-        activated_be = await middleware.call('bootenv.query', [['activated', '=', True]], {'get': True})
+        activated_be = middleware.call_sync('bootenv.query', [['activated', '=', True]], {'get': True})
         try:
-            await middleware.call('bootenv.create', {'name': initial_install_be, 'source': activated_be['realname']})
+            middleware.call_sync('bootenv.create', {'name': initial_install_be, 'source': activated_be['realname']})
         except Exception:
             middleware.logger.error('Failed to create initial boot environment', exc_info=True)
         else:
-            boot_pool = await middleware.call('boot.pool_name')
-            cp = await run('zfs', 'set', 'zectl:keep=True', os.path.join(boot_pool, 'ROOT/Initial-Install'))
+            boot_pool = middleware.call_sync('boot.pool_name')
+            cp = subprocess.run(
+                ['zfs', 'set', 'zectl:keep=True', os.path.join(boot_pool, 'ROOT/Initial-Install')], capture_output=True
+            )
             if cp.returncode != 0:
                 middleware.logger.error(
                     'Failed to set keep attribute for Initial-Install boot environment: %s', cp.stderr.decode()
@@ -37,25 +41,14 @@ async def firstboot(middleware):
 
 async def setup(middleware):
     lifecycle_conf.SYSTEM_BOOT_ID = str(uuid.uuid4())
-
     middleware.event_register('system.ready', 'Finished boot process')
     middleware.event_register('system.reboot', 'Started reboot process')
     middleware.event_register('system.shutdown', 'Started shutdown process')
 
-    if os.path.exists(BOOTREADY):
-        lifecycle_conf.SYSTEM_READY = True
-    else:
-        await firstboot(middleware)
+    await middleware.run_in_thread(firstboot, middleware)
 
     settings = await middleware.call('system.general.config')
+    middleware.logger.debug('Setting timezone to %r', settings['timezone'])
     await middleware.call('core.environ_update', {'TZ': settings['timezone']})
-
-    middleware.logger.debug(f'Timezone set to {settings["timezone"]}')
-
     await middleware.call('system.general.set_language')
-
-    CRASH_DIR = '/data/crash'
-    os.makedirs(CRASH_DIR, exist_ok=True)
-    os.chmod(CRASH_DIR, 0o775)
-
     await middleware.call('sysctl.set_zvol_volmode', 2)


### PR DESCRIPTION
Working on an unrelated issue, I saw that this file had some problems.

Changes that I've made:
- remove blocking I/O be called in main event loop by making firstboot() function a non-coroutine and running it in a native thread (since it's being called by a coroutine)
- remove `/data/crash/` since that's a remnant from CORE which isn't used on SCALE
- remove unnecessary newlines
- fix a logging statement to use "%" operator to match what we're doing everywhere else