### PR TITLE
NAS-122384 / 23.10 / handle known errors in failover.call_remote

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -486,7 +486,7 @@ class Client:
 
         try:
             if not c.returned.wait(timeout):
-                raise CallTimeout("Call timeout")
+                raise CallTimeout("Call timeout", errno.ETIMEDOUT)
 
             if c.errno:
                 if c.py_exception:

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -1,10 +1,8 @@
 import re
-import errno
 from datetime import datetime, timedelta
 
 from middlewared.schema import accepts, Bool, Dict, Str
 from middlewared.service import job, private, Service, ServiceChangeMixin
-from middlewared.service_exception import CallError
 
 RE_IDENT = re.compile(r'^\{(?P<type>.+?)\}(?P<value>.+)$')
 
@@ -268,12 +266,8 @@ class DiskService(Service, ServiceChangeMixin):
             # improvement this provides is substantial
             try:
                 self.middleware.call_sync('failover.datastore.send')
-            except Exception as e:
-                ignore = (errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-                if isinstance(e, CallError) and e.errno in ignore:
-                    pass
-                else:
-                    self.logger.warning('Unexpected failure syncing database to standby controller', exc_info=True)
+            except Exception:
+                self.logger.warning('Unexpected failure syncing database to standby controller', exc_info=True)
 
         job.set_progress(100, 'Syncing all disks complete')
         return 'OK'

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from middlewared.service import CallError, Service
+from middlewared.service import Service
 from middlewared.plugins.config import FREENAS_DATABASE
 from middlewared.plugins.datastore.connection import thread_pool
 from middlewared.utils.threading import start_daemon_thread, set_thread_name
@@ -113,12 +113,6 @@ def hook_datastore_execute_write(middleware, sql, params, options):
             },
         )
     except Exception as e:
-        if isinstance(e, CallError) and e.errno == CallError.ENOMETHOD:
-            # the other node is running an old version so it'll fail as expected
-            # just ignore this error since the other node will eventually be updated
-            # to the same version as the current node
-            return
-
         middleware.logger.warning('Error replicating SQL on the remote node: %r', e)
         middleware.call_sync('failover.datastore.set_failure')
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -267,12 +267,8 @@ class FailoverEventsService(Service):
                     wait_id = self.middleware.call_sync('core.job_wait', i['id'])
                     wait_id.wait_sync(raise_error=True)
                     logger.info('Failover job event with id "%d" finished', i['id'])
-                except Exception as e:
-                    ignore = (errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-                    if isinstance(e, CallError) and e.errno in ignore:
-                        pass
-                    else:
-                        logger.warning('Failover job event with id "%d" failed', i['id'], exc_info=True)
+                except Exception:
+                    logger.warning('Failover job event with id "%d" failed', i['id'], exc_info=True)
 
     def _event(self, ifname, event):
 
@@ -740,10 +736,8 @@ class FailoverEventsService(Service):
         logger.info('Syncing encryption keys from MASTER node (if any)')
         try:
             self.run_call('failover.call_remote', 'failover.sync_keys_to_remote_node')
-        except Exception as e:
-            ignore = (errno.ECONNRESET, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-            if isinstance(e, CallError) and e.errno not in ignore:
-                logger.warning('Unhandled exception syncing keys from MASTER node', exc_info=True)
+        except Exception:
+            logger.warning('Unhandled exception syncing keys from MASTER node', exc_info=True)
 
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -158,12 +158,8 @@ class PoolService(Service):
             if await self.middleware.call('failover.licensed'):
                 try:
                     await self.middleware.call('failover.call_remote', 'disk.retaste')
-                except Exception as e:
-                    ignore = (CallError.ENOMETHOD, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-                    if isinstance(e, CallError) and e.errno in ignore:
-                        pass
-                    else:
-                        self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
+                except Exception:
+                    self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
 
             job.set_progress(85, 'Syncing disk changes')
             djob = await self.middleware.call('disk.sync_all')

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -465,12 +465,8 @@ class PoolService(CRUDService):
         if is_ha:
             try:
                 await self.middleware.call('failover.call_remote', 'disk.retaste')
-            except Exception as e:
-                ignore = (CallError.ENOMETHOD, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-                if isinstance(e, CallError) and e.errno in ignore:
-                    pass
-                else:
-                    self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
+            except Exception:
+                self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
 
         options = {
             'feature@lz4_compress': 'enabled',


### PR DESCRIPTION
We had a ton of code duplication and specific error handling for when the remote request fails in known ways. This moves the logic to `failover.call_remote` (the lowest caller in the stack) and handles it there. I've added a logger.trace message there just in case we ever need to start middleware with TRACE debug level set to get the messages. I've also fixed a flake8 issue while I'm here.