### PR TITLE
NAS-122374 / 22.12.4 / Fix vm display ports logic (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
@@ -132,7 +132,7 @@ def devices_xml(vm_data, context):
     usb_controllers = {'nec-xhci': 0}
     virtual_device_no = Nid(1)
     devices = []
-    for device in filter(lambda d: d.is_available(), context['devices']):
+    for device in context['devices']:
         if isinstance(device, (DISK, CDROM, RAW)):
             if device.data['attributes'].get('type') == 'VIRTIO':
                 disk_no = virtual_device_no()

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -1,5 +1,4 @@
 import ipaddress
-import itertools
 
 from middlewared.schema import accepts, Dict, Int, List, Ref, returns, Str
 from middlewared.service import pass_app, private, Service
@@ -22,9 +21,10 @@ class VMService(Service):
 
         Returns a dict with two keys `port` and `web`.
         """
-        all_ports = list(itertools.chain(
-            *[entry['ports'] for entry in await self.middleware.call('port.get_in_use')]
-        ))
+        used_ports = await self.middleware.call('port.get_in_use')
+        all_ports = [
+            port_entry[1] for entry in used_ports for port_entry in entry['ports']
+        ]
 
         def get_next_port():
             for i in filter(lambda i: i not in all_ports, range(5900, 65535)):


### PR DESCRIPTION
## Problem

When no explicit port was specified for DISPLAY device we try to auto assign ports which are not being used by the system currently.
That logic was flawed and this resulted in subsequent DISPLAY device getting ports of the first DISPLAY device which is bound to fail.

## Solution

Logic which provided ports which were unused was fixed to make sure it properly took into account currently used ports in the system and for devices which might already have this issue some changes were made to not allow a VM to start if it's DISPLAY device port is being used by any other VM or a service.

**Note:** Should we add a migration which automatically updates existing DISPLAY devices which have port clashes? Problem with that might be that we might update some ports magically which user was not expecting and it results in his workflow being broken - at least temporarily

Original PR: https://github.com/truenas/middleware/pull/11481
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122374