### PR TITLE
NAS-122390 / 22.12.3 / Log integration tests start/end (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/test/log.py
+++ b/src/middlewared/middlewared/plugins/test/log.py
@@ -1,0 +1,12 @@
+from middlewared.service import Service
+
+
+class TestService(Service):
+    class Config:
+        private = True
+
+    def notify_test_start(self, name):
+        self.middleware.logger.debug("Starting integration test %s", name)
+
+    def notify_test_end(self, name):
+        self.middleware.logger.debug("Ending integration test %s", name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import contextlib
+import os
+
+import pytest
+
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(autouse=True, scope="function")
+def log_test_name_to_middlewared_log(request):
+    client_kwargs_list = [dict(host_ip=os.environ.get('controller1_ip', None))]
+    if 'controller2_ip' in os.environ:
+        client_kwargs_list.append(dict(host_ip=os.environ['controller2_ip']))
+
+    for client_kwargs in client_kwargs_list:
+        # Beware that this is executed after session/package/module/class fixtures are applied so the logs will still
+        # not be exactly precise.
+        with contextlib.suppress(Exception):
+            call("test.notify_test_start", request.node.name, client_kwargs=client_kwargs)
+
+    yield
+
+    for client_kwargs in client_kwargs_list:
+        # That's why we also notify test ends. What happens between a test end and the next test start is caused by
+        # session/package/module/class fixtures setup code.
+        with contextlib.suppress(Exception):
+            call("test.notify_test_end", request.node.name, client_kwargs=client_kwargs)


### PR DESCRIPTION
We want to log test starts/ends to the middleware log so, when a message is logged, we have a better idea on which test caused it

Original PR: https://github.com/truenas/middleware/pull/11479
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122390