### PR TITLE
NAS-121919 / 22.12.4 / Enable cgroup controllers at boot (by sonicaj)

### DIFF
--- a/debian/debian/ix-cgroups.service
+++ b/debian/debian/ix-cgroups.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Enable required cgroups for TrueNAS
+DefaultDependencies=no
+# We want to do this after ix-zfs and before network is setup
+# systemd disables cpuset during boot phase and after much
+# fiddling, this combination of deps addresses our usecase
+# and keeps systemd happy at the end of the day
+Before=network-pre.target
+After=ix-zfs.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/setup_cgroups
+StandardOutput=null
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -10,6 +10,7 @@ override_dh_auto_install:
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-boot-core
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-cgroups
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-conf
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-etc
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-freebsd-to-scale-update

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -1,13 +1,7 @@
-import contextlib
 import os
-import re
-
-from middlewared.service import CallError
 
 
 BACKUP_NAME_PREFIX = 'ix-applications-backup-'
-CGROUP_ROOT_PATH = '/sys/fs/cgroup'
-CGROUP_AVAILABLE_CONTROLLERS_PATH = os.path.join(CGROUP_ROOT_PATH, 'cgroup.subtree_control')
 KUBECONFIG_FILE = '/etc/rancher/k3s/k3s.yaml'
 KUBERNETES_WORKER_NODE_PASSWORD = 'e3d26cefbdf2f81eff5181e68a02372f'
 KUBEROUTER_RULE_PRIORITY = 32764
@@ -16,30 +10,8 @@ KUBEROUTER_TABLE_NAME = 'kube-router'
 MIGRATION_NAMING_SCHEMA = 'ix-app-migrate-%Y-%m-%d_%H-%M'
 NODE_NAME = 'ix-truenas'
 OPENEBS_ZFS_GROUP_NAME = 'zfs.openebs.io'
-RE_CGROUP_CONTROLLERS = re.compile(r'(\w+)\s+')
 UPDATE_BACKUP_PREFIX = 'system-update-'
 
 
 def applications_ds_name(pool):
     return os.path.join(pool, 'ix-applications')
-
-
-def get_available_controllers_for_consumption() -> set:
-    try:
-        with open(CGROUP_AVAILABLE_CONTROLLERS_PATH, 'r') as f:
-            return set(RE_CGROUP_CONTROLLERS.findall(f.read()))
-    except FileNotFoundError:
-        raise CallError(
-            'Unable to determine cgroup controllers which are available for consumption as '
-            f'{CGROUP_AVAILABLE_CONTROLLERS_PATH!r} does not exist'
-        )
-
-
-def update_available_controllers_for_consumption(to_add_controllers: set) -> set:
-    # This will try to update available controllers for consumption and return the current state
-    # regardless of the update failing
-    with contextlib.suppress(FileNotFoundError, OSError):
-        with open(CGROUP_AVAILABLE_CONTROLLERS_PATH, 'w') as f:
-            f.write(f'{" ".join(map(lambda s: f"+{s}", to_add_controllers))}')
-
-    return get_available_controllers_for_consumption()

--- a/src/middlewared/middlewared/scripts/setup_cgroups.py
+++ b/src/middlewared/middlewared/scripts/setup_cgroups.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+import contextlib
+import os
+
+
+CGROUP_ROOT_PATH = '/sys/fs/cgroup'
+CGROUP_AVAILABLE_CONTROLLERS_PATH = os.path.join(CGROUP_ROOT_PATH, 'cgroup.subtree_control')
+
+
+def get_available_controllers_for_consumption() -> set:
+    try:
+        with open(CGROUP_AVAILABLE_CONTROLLERS_PATH, 'r') as f:
+            return set(f.read().split())
+    except FileNotFoundError:
+        raise Exception(
+            'Unable to determine cgroup controllers which are available for consumption as '
+            f'{CGROUP_AVAILABLE_CONTROLLERS_PATH!r} does not exist'
+        )
+
+
+def update_available_controllers_for_consumption(to_add_controllers: set) -> set:
+    # This will try to update available controllers for consumption and return the current state
+    # regardless of the update failing
+    with contextlib.suppress(FileNotFoundError, OSError):
+        with open(CGROUP_AVAILABLE_CONTROLLERS_PATH, 'w') as f:
+            f.write(f'{" ".join(map(lambda s: f"+{s}", to_add_controllers))}')
+
+    return get_available_controllers_for_consumption()
+
+
+def main():
+    # Logic copied over from kubernetes
+    # https://github.com/kubernetes/kubernetes/blob/08fbe92fa76d35048b4b4891b41fc6912e689cc7/
+    # pkg/kubelet/cm/cgroup_manager_linux.go#L238
+    supported_controllers = {'cpu', 'cpuset', 'memory', 'hugetlb', 'pids'}
+    system_supported_controllers_path = os.path.join(CGROUP_ROOT_PATH, 'cgroup.controllers')
+    try:
+        with open(system_supported_controllers_path, 'r') as f:
+            available_controllers = set(f.read().split())
+    except FileNotFoundError:
+        raise Exception(
+            'Unable to determine available cgroup controllers as '
+            f'{system_supported_controllers_path!r} does not exist'
+        )
+
+    # What we are doing here is that we get controllers which are supported and required by k8s to function
+    # then we check if they are available for consumption, if not we try to add them to subtree control
+    # and then do a final check to confirm they have been added as desired
+
+    needed_controllers = supported_controllers & available_controllers
+    available_controllers_for_consumption = get_available_controllers_for_consumption()
+    if missing_controllers := needed_controllers - available_controllers_for_consumption:
+        # If we have missing controllers, lets try adding them to subtree control
+        available_controllers_for_consumption = update_available_controllers_for_consumption(missing_controllers)
+
+    missing_controllers = needed_controllers - available_controllers_for_consumption
+    if missing_controllers:
+        raise Exception(
+            f'Missing {", ".join(missing_controllers)!r} cgroup controller(s) '
+            'which are required for apps to function'
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -68,6 +68,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'setup_cgroups = middlewared.scripts.setup_cgroups:main',
             'middlewared = middlewared.main:main',
             'midclt = middlewared.client.client:main',
             'midgdb = middlewared.scripts.gdb:main',


### PR DESCRIPTION
This PR adds changes to enable cgroup controllers at boot. Motivation behind the change is that OS team found if some process has `PF_NO_SETAFFINITY ` flag set, we are not able to add cpuset controller. This happens when SMB service is started and it has shares mounted which starts a process which has the flag which means that after that we can't enable the `cpuset` controller.

There are 2 approaches to solve the problem:
1. Enable cgroup controllers before everything else
2. Have a firewall in place which does not allow users to connect before the system is ready

After discussion with Andrew, we have done point 1 and Andrew will be syncing with services team to see if we should factor in other services as well for the firewall and those changes can still be added separately as they still bring value to the table.

Original PR: https://github.com/truenas/middleware/pull/11291
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121919