### PR TITLE
NAS-122460 / 22.12.4 / Re-init global SMB parameters when DS stopped (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -802,6 +802,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
             cl_reload = await self.middleware.call('clusterjob.submit', 'activedirectory.cluster_reload', 'STOP')
             await cl_reload.wait()
 
+        await self.middleware.call('smb.initialize_globals')
         await self.middleware.call('service.start', 'cifs')
         await self.set_state(DSStatus['DISABLED'].name)
         job.set_progress(100, 'Active Directory stop completed.')

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1200,6 +1200,7 @@ class LDAPService(TDBWrapConfigService):
         job.set_progress(30, 'Reconfiguring SMB service.')
         await self.middleware.call('smb.synchronize_passdb')
         await self.middleware.call('smb.synchronize_group_mappings')
+        await self.middleware.call('smb.initialize_globals')
         await self._service_change('cifs', 'restart')
 
         job.set_progress(50, 'Clearing directory service cache.')


### PR DESCRIPTION
Ensure that winbind request timeout and passdb path are set back to defaults for standalone server when LDAP and AD are stopped.

Original PR: https://github.com/truenas/middleware/pull/11504
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122460