### PR TITLE
NAS-122467 / 23.10 / fix > 1k skipped ci tests

### DIFF
--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -40,7 +40,7 @@ def test_001_check_sysdataset_exists_on_boot_pool(ws_client):
     assert bp_basename == sysds['basename']
 
 
-@pytest.mark.dependency(name='PERM_ZPOOL_CREATED')
+@pytest.mark.dependency(name=pool_name)
 def test_002_create_permanent_zpool(request, ws_client):
     """
     This creates the "permanent" zpool which is used by every other
@@ -79,7 +79,7 @@ def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(request, ws_
     2. make sure the system dataset doesn't migrate to the 2nd zpool that we create
         since it should only be migrating to the 1st zpool that is created
     """
-    depends(request, ['PERM_ZPOOL_CREATED'])
+    depends(request, [pool_name])
     unused_disks = ws_client.call('disk.get_unused')
     assert len(unused_disks) >= 1
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -320,7 +320,7 @@ def test_30_creating_home_dataset(request):
     we verify that ACL is being stripped properly from
     the newly-created home directory.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB",

--- a/tests/api2/test_023_kubernetes.py
+++ b/tests/api2/test_023_kubernetes.py
@@ -22,7 +22,7 @@ if not ha:
 
     @pytest.mark.dependency(name='setup_kubernetes')
     def test_02_setup_kubernetes(request):
-        depends(request, ["pool_04"], scope="session")
+        depends(request, [pool_name], scope="session")
         global payload
         gateway = GET("/network/general/summary/").json()['default_routes'][0]
         payload = {

--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -483,7 +483,7 @@ if not ha:
 
     @pytest.mark.dependency(name='hostpath-dataset')
     def test_36_create_datasets_hostpath(request):
-        depends(request, ['pool_04'], scope='session')
+        depends(request, [pool_name], scope='session')
         result = POST('/pool/dataset/', {'name': f'{pool_name}/tc-hostpath'})
         assert result.status_code == 200, result.text
 

--- a/tests/api2/test_050_alert.py
+++ b/tests/api2/test_050_alert.py
@@ -37,7 +37,7 @@ def test_03_get_alert_list_policies():
 
 @pytest.mark.dependency(name='degrade_pool')
 def test_04_degrading_a_pool_to_create_an_alert(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     global gptid
     get_pool = GET(f"/pool/?name={pool_name}").json()[0]
     id_path = '/dev/disk/by-partuuid/'

--- a/tests/api2/test_130_cloudsync.py
+++ b/tests/api2/test_130_cloudsync.py
@@ -39,13 +39,13 @@ def task():
 
 
 def test_01_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST("/pool/dataset/", {"name": dataset})
     assert result.status_code == 200, result.text
 
 
 def test_02_create_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST("/cloudsync/credentials/", {
         "name": "Test",
         "provider": "S3",
@@ -59,7 +59,7 @@ def test_02_create_cloud_credentials(request, credentials):
 
 
 def test_03_update_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(f"/cloudsync/credentials/id/{credentials['id']}/", {
         "name": "Test",
         "provider": "S3",
@@ -72,7 +72,7 @@ def test_03_update_cloud_credentials(request, credentials):
 
 
 def test_04_create_cloud_sync(request, credentials, task):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST("/cloudsync/", {
         "description": "Test",
         "direction": "PULL",
@@ -97,7 +97,7 @@ def test_04_create_cloud_sync(request, credentials, task):
 
 
 def test_05_update_cloud_sync(request, credentials, task):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(f"/cloudsync/id/{task['id']}/", {
         "description": "Test",
         "direction": "PULL",
@@ -121,7 +121,7 @@ def test_05_update_cloud_sync(request, credentials, task):
 
 
 def test_06_run_cloud_sync(request, task):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     result = POST(f"/cloudsync/id/{task['id']}/sync/")
     assert result.status_code == 200, result.text
     for i in range(120):
@@ -144,7 +144,7 @@ def test_06_run_cloud_sync(request, task):
 
 
 def test_07_restore_cloud_sync(request, task):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(f"/cloudsync/id/{task['id']}/restore/", {
         "transfer_mode": "COPY",
         "path": dataset_path,
@@ -156,25 +156,25 @@ def test_07_restore_cloud_sync(request, task):
 
 
 def test_96_delete_cloud_credentials_error(request, credentials):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f"/cloudsync/credentials/id/{credentials['id']}/")
     assert result.status_code == 422
     assert "This credential is used by cloud sync task" in result.json()["message"]
 
 
 def test_97_delete_cloud_sync(request, task):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f"/cloudsync/id/{task['id']}/")
     assert result.status_code == 200, result.text
 
 
 def test_98_delete_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f"/cloudsync/credentials/id/{credentials['id']}/")
     assert result.status_code == 200, result.text
 
 
 def test_99_destroy_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f"/pool/dataset/id/{urllib.parse.quote(dataset, '')}/")
     assert result.status_code == 200, result.text

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -69,7 +69,7 @@ def test_03_get_filesystem_stat_(path):
 
 
 def test_04_test_filesystem_statfs_fstype(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     # test zfs fstype first
     parent_path = f'/mnt/{pool_name}'
     results = POST('/filesystem/statfs/', parent_path)
@@ -108,7 +108,7 @@ def test_04_test_filesystem_statfs_fstype(request):
 
 
 def test_05_set_immutable_flag_on_path(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     t_path = os.path.join('/mnt', pool_name, 'random_directory_immutable')
     t_child_path = os.path.join(t_path, 'child')
 
@@ -149,7 +149,7 @@ def test_07_test_filesystem_stat_filetype(request):
     There is an additional check to make sure that paths
     in the ZFS CTL directory (.zfs) are properly flagged.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     ds_name = 'stat_test'
     snap_name = f'{ds_name}_snap1'
     path = f'/mnt/{pool_name}/{ds_name}'
@@ -208,7 +208,7 @@ def test_08_test_fiilesystem_statfs_flags(request):
     This test verifies that changing ZFS properties via
     middleware causes mountinfo changes visible via statfs.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     ds_name = 'statfs_test'
     target = f'{pool_name}/{ds_name}'
     target_url = target.replace('/', '%2F')

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -707,7 +707,7 @@ def test_001_validate_default_configuration(request, ftp_init_db_dflt):
     with migration code.
     NB1: This expects FTP to be in the default configuration
     '''
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     ftp_set_config(DB_DFLT)
 
     with ftp_server():
@@ -765,7 +765,7 @@ def test_010_ftp_service_start(request):
     Confirm we can start the FTP service with the default config
     Confirm the proftpd.conf file was generated
     '''
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     # Start FTP service
     with ftp_server():
         # Get current
@@ -787,7 +787,7 @@ def test_015_ftp_configuration(request):
     '''
     Confirm config changes get reflected in proftpd.conf
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
 
     with ftp_server():
         changes = {
@@ -806,7 +806,7 @@ def test_017_ftp_port(request):
     '''
     Confirm config changes get reflected in proftpd.conf
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
 
     with ftp_server():
         payload = {
@@ -849,7 +849,7 @@ def test_020_login_attempts(request, NumFailedTries, expect_to_pass):
     1) Test good password before running out of tries
     2) Test good password after running out of tries
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     login_setup = {
         "onlylocal": True,
         "loginattempt": 3,
@@ -882,7 +882,7 @@ def test_030_root_login(request, setting):
     Test the WebUI "Allow Root Login" setting.
     In our DB the setting is "rootlogin" and "RootLogin" in proftpd.conf.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     # Enable root login for the anonymous config
     ftp_setup = {
         "rootlogin": setting,
@@ -913,7 +913,7 @@ def test_031_anon_login(request, setting, ftpConfig):
     Test the WebUI "Allow Anonymous Login" setting.
     In our DB the setting is "onlyanonymous" and an "Anonymous" section in proftpd.conf.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     if setting is True:
         # Fixup anonpath
         ftpConfig['anonpath'] = f"/mnt/{pool_name}/{ftpConfig['anonpath']}"
@@ -937,7 +937,7 @@ def test_031_anon_login(request, setting, ftpConfig):
     ("BadUser", False)
 ])
 def test_032_local_login(request, localuser, expect_to_pass):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     with ftp_user_ds_and_srvr_conn('ftplocalDS', 'FTPlocaluser', {"onlylocal": True}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -948,7 +948,7 @@ def test_032_local_login(request, localuser, expect_to_pass):
 
 
 def test_040_reverse_dns(request):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     ftp_conf = {"onlylocal": True, "reversedns": True}
     with ftp_user_ds_and_srvr_conn('ftplocalDS', 'FTPlocaluser', ftp_conf) as ftpdata:
         ftpObj = ftpdata.ftp
@@ -966,7 +966,7 @@ def test_045_masquerade_address(request, masq_type, expect_to_pass):
         Public IP address or hostname. Set if FTP clients cannot connect through a NAT device.
     We test masqaddress with: hostname, IP address and an invalid fqdn.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     payload = {'msg': 'method', 'method': 'network.configuration.config', 'params': []}
     res = make_ws_request(ip, payload)
     assert res.get('error') is None, res
@@ -1013,7 +1013,7 @@ def test_050_passive_ports(request, testing, ftpConfig, expect_to_pass):
         | Should no open ports be found within the configured range, the server will default
         | to a random kernel-assigned port, and a message logged.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     if testing == 'config':
         try:
             with ftp_configure(ftpConfig):
@@ -1046,7 +1046,7 @@ def test_055_no_activity_timeout(request):
         | The TimeoutIdle directive configures the maximum number of seconds that proftpd will
         ! allow clients to stay connected without receiving any data on either the control or data connection
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     with ftp_anon_ds_and_srvr_conn('anonftpDS', {'timeout': 3}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -1068,7 +1068,7 @@ def test_056_no_xfer_timeout(request):
         | is allowed to spend connected, after authentication, without issuing a data transfer command
         | which results in a data connection (i.e. sending/receiving a file, or requesting a directory listing)
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     with ftp_anon_ds_and_srvr_conn('anonftpDS', {'timeout_notransfer': 3}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -1093,7 +1093,7 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
     ulConf = testwho + 'userbw'
     dlConf = testwho + 'userdlbw'
 
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     ftp_anon_bw_limit = {
         ulConf: ulRate,  # upload limit
         dlConf: dlRate   # download limit
@@ -1141,7 +1141,7 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
     ("007", "0660", "002", "0775"),
 ])
 def test_065_umask(request, fmask, f_expect, dmask, d_expect):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
     localfile = "/tmp/localfile"
     fname = "filemask" + fmask
     dname = "dirmask" + dmask
@@ -1181,7 +1181,7 @@ def test_065_umask(request, fmask, f_expect, dmask, d_expect):
     ({'resume': True}, True)
 ])
 def test_070_resume_xfer(request, ftpConf, expect_to_pass):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, [pool_name, "init_dflt_config"], scope="session")
 
     def upload_partial(ftp, src, tgt, NumKiB=128):
         with open(src, 'rb') as file:
@@ -1318,7 +1318,7 @@ class TestAnonUser(UserTests):
     """
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, [pool_name, "init_dflt_config"], scope="session")
 
         with ftp_anon_ds_and_srvr_conn('anonftpDS') as anonftp:
             # Make the directory owned by the anonymous ftp user
@@ -1344,7 +1344,7 @@ class TestLocalUser(UserTests):
 
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, [pool_name, "init_dflt_config"], scope="session")
 
         local_setup = {
             "onlylocal": True,
@@ -1371,7 +1371,7 @@ class TestFTPSUser(UserTests):
 
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, [pool_name, "init_dflt_config"], scope="session")
 
         # We include tls_opt_no_session_reuse_required because python
         # ftplib has a long running issue with support for it.

--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -94,7 +94,7 @@ def test_03_Add_iSCSI_target(request):
 
 @pytest.mark.dependency(name="iscsi_04")
 def test_04_Add_a_iSCSI_file_extent(request):
-    depends(request, ["pool_04", "iscsi_03"], scope="session")
+    depends(request, [pool_name, "iscsi_03"], scope="session")
     global extent_id
     payload = {
         'type': 'FILE',
@@ -295,7 +295,7 @@ def test_27_Delete_iSCSI_file_extent(request):
 
 @pytest.mark.dependency(name="iscsi_28")
 def test_28_creating_zvol_for_the_iscsi_share(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global results, payload
     payload = {
         'name': zvol,

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -527,7 +527,7 @@ def test_01_inquiry(request):
     This tests the Vendor and Product information in an INQUIRY response
     are 'TrueNAS' and 'iSCSI Disk' respectively.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with initiator():
         with portal() as portal_config:
             portal_id = portal_config['id']
@@ -548,7 +548,7 @@ def test_02_read_capacity16(request):
 
     It performs this test with a couple of sizes for both file & zvol based targets.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with initiator():
         with portal() as portal_config:
             portal_id = portal_config['id']
@@ -662,7 +662,7 @@ def test_03_readwrite16_file_extent(request):
     This tests WRITE SAME (16), READ (16) and WRITE (16) operations with
     a file extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name):
         iqn = f'{basename}:{target_name}'
         target_test_readwrite16(ip, iqn)
@@ -673,7 +673,7 @@ def test_04_readwrite16_zvol_extent(request):
     This tests WRITE SAME (16), READ (16) and WRITE (16) operations with
     a zvol extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         target_test_readwrite16(ip, iqn)
@@ -684,7 +684,7 @@ def test_05_chap(request):
     """
     This tests that CHAP auth operates as expected.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     user = "user1"
     secret = 'sec1' + ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=10))
     with initiator():
@@ -724,7 +724,7 @@ def test_06_mutual_chap(request):
     """
     This tests that Mutual CHAP auth operates as expected.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     user = "user1"
     secret = 'sec1' + ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=10))
     peer_user = "user2"
@@ -777,7 +777,7 @@ def test_07_report_luns(request):
     """
     This tests REPORT LUNS and accessing multiple LUNs on a target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with initiator():
         with portal() as portal_config:
@@ -972,7 +972,7 @@ def test_08_snapshot_zvol_extent(request):
     """
     This tests snapshots with a zvol extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_zvol_extent(target_name, zvol) as iscsi_config:
         target_test_snapshot_single_login(ip, iqn, iscsi_config['dataset']['id'])
@@ -984,7 +984,7 @@ def test_09_snapshot_file_extent(request):
     """
     This tests snapshots with a file extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name) as iscsi_config:
         target_test_snapshot_single_login(ip, iqn, iscsi_config['dataset']['id'])
@@ -999,7 +999,7 @@ def test_10_target_alias(request):
     At the moment SCST does not use the alias usefully (e.g. TargetAlias in
     LOGIN response).  When this is rectified this test should be extended.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
 
     data = {}
     for t in ["A", "B"]:
@@ -1042,7 +1042,7 @@ def test_11_modify_portal(request):
     """
     Test that we can modify a target portal.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with portal() as portal_config:
         assert portal_config['comment'] == 'Default portal', portal_config
         # First just change the comment
@@ -1060,7 +1060,7 @@ def test_12_pblocksize_setting(request):
     This tests whether toggling pblocksize has the desired result on READ CAPACITY 16, i.e.
     whether setting it results in LOGICAL BLOCKS PER PHYSICAL BLOCK EXPONENT being zero.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name) as iscsi_config:
         extent_config = iscsi_config['extent']
@@ -1134,7 +1134,7 @@ def test_13_test_target_name(request, extent_type):
     """
     Test the user-supplied target name.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
 
     name64 = generate_name(64)
     with configured_target(name64, extent_type):
@@ -1246,7 +1246,7 @@ class TestFixtureInitiatorName:
         """
         Deliberately send SCST some invalid initiator names and ensure it behaves OK.
         """
-        depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+        depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
 
         if expected:
             with iscsi_scsi_connection(ip, TestFixtureInitiatorName.iqn, initiator_name=initiator_name) as s:
@@ -1340,7 +1340,7 @@ def _pr_reservation(s, pr_type, scope=LU_SCOPE, other_connections=[], **kwargs):
 @skip_persistent_reservations
 @pytest.mark.dependency(name="iscsi_basic_persistent_reservation")
 def test_16_basic_persistent_reservation(request):
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         with iscsi_scsi_connection(ip, iqn) as s:
@@ -1496,7 +1496,7 @@ def _check_persistent_reservations(s1, s2):
 @skip_persistent_reservations
 @skip_multi_initiator
 def test_17_persistent_reservation_two_initiators(request):
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, [pool_name, "iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         with iscsi_scsi_connection(ip, iqn) as s1:
@@ -1839,7 +1839,7 @@ def test_18_alua_config(request):
 @skip_multi_initiator
 @skip_ha_tests
 def test_19_alua_basic_persistent_reservation(request):
-    # Don't need to specify "pool_04", "iscsi_cmd_00" here
+    # Don't need to specify pool_name, "iscsi_cmd_00" here
     depends(request, ["iscsi_alua_config", "iscsi_basic_persistent_reservation"], scope="session")
     # Turn on ALUA
     with alua_enabled():

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -126,7 +126,7 @@ def test_09_account_privilege_authentication(request):
 
 @pytest.mark.dependency(name="ldap_dataset")
 def test_09_creating_ldap_dataset_for_smb(request):
-    depends(request, ["pool_04", "setup_ldap"], scope="session")
+    depends(request, [pool_name, "setup_ldap"], scope="session")
     results = POST("/pool/dataset/", {"name": dataset, "share_type": "SMB"})
     assert results.status_code == 200, results.text
 

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -264,14 +264,14 @@ def test_01_creating_the_nfs_server():
 
 
 def test_02_creating_dataset_nfs(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {"name": dataset}
     results = POST("/pool/dataset/", payload)
     assert results.status_code == 200, results.text
 
 
 def test_03_changing_dataset_permissions_of_nfs_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         "acl": [],
         "mode": "777",
@@ -285,13 +285,13 @@ def test_03_changing_dataset_permissions_of_nfs_dataset(request):
 
 
 def test_04_verify_the_job_id_is_successfull(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     job_status = wait_on_job(job_id, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_05_creating_a_nfs_share_on_nfs_PATH(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global nfsid
     paylaod = {"comment": "My Test Share",
                "path": NFS_PATH,
@@ -302,19 +302,19 @@ def test_05_creating_a_nfs_share_on_nfs_PATH(request):
 
 
 def test_06_starting_nfs_service_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = PUT("/service/id/nfs/", {"enable": True})
     assert results.status_code == 200, results.text
 
 
 def test_07_checking_to_see_if_nfs_service_is_enabled_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["enable"] is True, results.text
 
 
 def test_08_starting_nfs_service(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {"service": "nfs"}
     results = POST("/service/start/", payload)
     assert results.status_code == 200, results.text
@@ -325,14 +325,14 @@ def test_08_starting_nfs_service(request):
 
 
 def test_09_checking_to_see_if_nfs_service_is_running(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results.text
 
 
 @pytest.mark.parametrize('vers', [3, 4])
 def test_10_perform_basic_nfs_ops(request, vers):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     with SSH_NFS(ip, NFS_PATH, vers=vers, user=user, password=password, ip=ip) as n:
         n.create('testfile')
         n.mkdir('testdir')
@@ -348,7 +348,7 @@ def test_10_perform_basic_nfs_ops(request, vers):
 
 
 def test_11_perform_server_side_copy(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip) as n:
         n.server_side_copy('ssc1', 'ssc2')
 
@@ -360,7 +360,7 @@ def test_19_updating_the_nfs_service(request):
     Latter goal is achieved by reading the nfs config file
     and verifying that the value here was set correctly.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     results = PUT("/nfs/", {"servers": "50"})
     assert results.status_code == 200, results.text
 
@@ -374,7 +374,7 @@ def test_19_updating_the_nfs_service(request):
 
 
 def test_20_update_nfs_share(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     nfsid = GET('/sharing/nfs?comment=My Test Share').json()[0]['id']
     payload = {"security": []}
     results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
@@ -382,7 +382,7 @@ def test_20_update_nfs_share(request):
 
 
 def test_21_checking_to_see_if_nfs_service_is_enabled(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results.text
 
@@ -396,7 +396,7 @@ def test_31_check_nfs_share_network(request):
         192.168.0.0/24(sec=sys,rw,subtree_check)\
         192.168.1.0/24(sec=sys,rw,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     networks_to_test = ["192.168.0.0/24", "192.168.1.0/24"]
 
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'networks': networks_to_test})
@@ -457,7 +457,7 @@ def test_32_check_nfs_share_hosts(request, hostlist, ExpectedToPass):
     - Dashes are allowed, but a level cannot start or end with a dash, '-'
     - Only the left most level may contain special characters: '*','?' and '[]'
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hostlist})
     if ExpectedToPass:
         assert results.status_code == 200, results.text
@@ -491,7 +491,7 @@ def test_33_check_nfs_share_ro(request):
     Verify that toggling `ro` will cause appropriate change in
     exports file. We also verify with write tests on a local mount.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
 
     # Make sure we end up in the original state with 'rw'
     try:
@@ -549,7 +549,7 @@ def test_34_check_nfs_share_maproot(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,anonuid=65534,anongid=65534,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     payload = {
         'maproot_user': 'nobody',
         'maproot_group': 'nogroup'
@@ -620,7 +620,7 @@ def test_35_check_nfs_share_mapall(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,all_squash,anonuid=65534,anongid=65534,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     payload = {
         'mapall_user': 'nobody',
         'mapall_group': 'nogroup'
@@ -663,7 +663,7 @@ def test_36_check_nfsdir_subtree_behavior(request):
     "/mnt/dozer/NFSV4/foobar"\
         *(sec=sys,rw,subtree_check)
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     tmp_path = f'{NFS_PATH}/sub1'
     results = POST('/filesystem/mkdir', tmp_path)
     assert results.status_code == 200, results.text
@@ -757,7 +757,7 @@ class Test37WithFixture:
         "/mnt/dozer/NFS/foo"\
             fred(rw)
         """
-        depends(request, ["pool_04", "ssh_password"], scope="session")
+        depends(request, [pool_name, "ssh_password"], scope="session")
 
         vol = dataset_and_dirs
         dirpath = f'{vol}/{dirname}'
@@ -782,7 +782,7 @@ def test_38_check_nfs_allow_nonroot_behavior(request):
     """
 
     # Verify that NFS server configuration is as expected
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/nfs")
     assert results.status_code == 200, results.text
     assert results.json()['allow_nonroot'] is False, results.text
@@ -819,7 +819,7 @@ def test_39_check_nfs_service_protocols_parameter(request):
     database) will be updated regardless, the server config file will not
     be updated.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results
 
@@ -899,7 +899,7 @@ def test_40_check_nfs_service_udp_parameter(request):
     This test verifies that toggling the `udp` option generates expected changes
     in nfs kernel server config.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     with nfs_config():
         get_payload = {'msg': 'method', 'method': 'nfs.config', 'params': []}
         set_payload = {'msg': 'method', 'method': 'nfs.update', 'params': []}
@@ -940,7 +940,7 @@ def test_41_check_nfs_service_ports(request):
     This test verifies that the custom ports we specified in
     earlier NFS tests are set in the relevant files.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
 
     results = GET("/nfs")
     assert results.status_code == 200, results.text
@@ -961,7 +961,7 @@ def test_42_check_nfs_client_status(request):
     of counts over NFSv3 protcol (specifically with regard to decrementing
     sessions) we only verify that count is non-zero for NFSv3.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
 
     with SSH_NFS(ip, NFS_PATH, vers=3, user=user, password=password, ip=ip):
         results = GET('/nfs/get_nfs3_clients/', payload={
@@ -990,7 +990,7 @@ def test_43_check_nfsv4_acl_support(request):
        ACL through the filesystem API.
     3) Repeate same process for each of the supported flags.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     acl_nfs_path = f'/mnt/{pool_name}/test_nfs4_acl'
     test_perms = {
         "READ_DATA": True,
@@ -1074,7 +1074,7 @@ def test_44_check_nfs_xattr_support(request):
     Mount path via NFS 4.2, create a file and dir,
     and write + read xattr on each.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     xattr_nfs_path = f'/mnt/{pool_name}/test_nfs4_xattr'
     with nfs_dataset("test_nfs4_xattr"):
         with nfs_share(xattr_nfs_path):
@@ -1094,7 +1094,7 @@ def test_45_check_setting_runtime_debug(request):
     """
     This validates that the private NFS debugging API works correctly.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     disabled = {"NFS": ["NONE"], "NFSD": ["NONE"], "NLM": ["NONE"], "RPC": ["NONE"]}
     enabled = {"NFS": ["PROC", "XDR", "CLIENT", "MOUNT", "XATTR_CACHE"],
                "NFSD": ["ALL"],
@@ -1127,7 +1127,7 @@ def test_45_check_setting_runtime_debug(request):
 
 
 def test_50_stoping_nfs_service(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     # Restore original settings before we stop
     restore_nfs_config()
     payload = {"service": "nfs"}
@@ -1137,7 +1137,7 @@ def test_50_stoping_nfs_service(request):
 
 
 def test_51_checking_to_see_if_nfs_service_is_stop(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "STOPPED", results.text
 
@@ -1179,18 +1179,18 @@ def test_53_set_bind_ip():
 
 
 def test_54_disable_nfs_service_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = PUT("/service/id/nfs/", {"enable": False})
     assert results.status_code == 200, results.text
 
 
 def test_55_checking_nfs_disable_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]['enable'] is False, results.text
 
 
 def test_56_destroying_smb_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text

--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -17,14 +17,14 @@ dataset_url = test1_dataset.replace("/", "%2F")
 
 
 def test_01_verify_default_acltype_from_pool_dataset_with_api(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET(f'/pool/dataset/id/{pool_name}/')
     assert results.status_code == 200, results.text
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
 def test_02_verify_default_acltype_from_pool_dataset_with_zfs_get(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     cmd = f"zfs get acltype {pool_name}"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -32,7 +32,7 @@ def test_02_verify_default_acltype_from_pool_dataset_with_zfs_get(request):
 
 
 def test_03_create_test1_dataset_to_verify_inherit_parent_acltype(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': test1_dataset
@@ -42,14 +42,14 @@ def test_03_create_test1_dataset_to_verify_inherit_parent_acltype(request):
 
 
 def test_04_verify_test1_dataset_inherited_parent_acltype_with_api(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = GET(f'/pool/dataset/id/{dataset_url}/')
     assert results.status_code == 200, results.text
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
 def test_05_verify_test1_dataset_inherited_parent_acltype_with_zfs_get(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     cmd = f"zfs get acltype {test1_dataset}"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -57,7 +57,7 @@ def test_05_verify_test1_dataset_inherited_parent_acltype_with_zfs_get(request):
 
 
 def test_06_change_acltype_to_nfsv4(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(
         f'/pool/dataset/id/{dataset_url}/', {
             'acltype': 'NFSV4',
@@ -84,7 +84,7 @@ def test_06_change_acltype_to_nfsv4(request):
 
 
 def test_07_reset_acltype_to_posix(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(
         f'/pool/dataset/id/{dataset_url}/', {
             'acltype': 'POSIX',
@@ -112,6 +112,6 @@ def test_07_reset_acltype_to_posix(request):
 
 
 def test_08_delete_test1_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = DELETE(f'/pool/dataset/id/{test1_dataset.replace("/", "%2F")}/')
     assert results.status_code == 200, results.text

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -39,12 +39,12 @@ default_acl = [
 
 
 def test_01_check_dataset_endpoint(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     assert isinstance(GET('/pool/dataset/').json(), list)
 
 
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': dataset,
@@ -55,14 +55,14 @@ def test_02_create_dataset(request):
 
 
 def test_03_query_dataset_by_name(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     dataset = GET(f'/pool/dataset/?id={dataset_url}')
 
     assert isinstance(dataset.json()[0], dict)
 
 
 def test_04_update_dataset_description(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(
         f'/pool/dataset/id/{dataset_url}/', {
             'comments': 'testing dataset'
@@ -73,7 +73,7 @@ def test_04_update_dataset_description(request):
 
 
 def test_05_set_permissions_for_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global JOB_ID
     result = POST(
         f'/pool/dataset/id/{dataset_url}/permission/', {
@@ -89,13 +89,13 @@ def test_05_set_permissions_for_dataset(request):
 
 
 def test_06_verify_job_id_is_successfull(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     job_status = wait_on_job(JOB_ID, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_07_promoting_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     # TODO: ONCE WE HAVE MANUAL SNAPSHOT FUNCTIONAITY IN MIDDLEWARED,
     # THIS TEST CAN BE COMPLETED THEN
     pass
@@ -107,7 +107,7 @@ def test_07_promoting_dataset(request):
 
 @pytest.mark.dependency(name="pool_dataset_08")
 def test_08_set_acl_for_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global JOB_ID
     result = POST(
         f'/pool/dataset/id/{dataset_url}/permission/', {
@@ -123,13 +123,13 @@ def test_08_set_acl_for_dataset(request):
 
 @pytest.mark.dependency(name="acl_pool_perm_09")
 def test_09_verify_job_id_is_successfull(request):
-    depends(request, ["pool_04", "pool_dataset_08"], scope="session")
+    depends(request, [pool_name, "pool_dataset_08"], scope="session")
     job_status = wait_on_job(JOB_ID, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_10_get_filesystem_getacl(request):
-    depends(request, ["pool_04", "acl_pool_perm_09"], scope="session")
+    depends(request, [pool_name, "acl_pool_perm_09"], scope="session")
     global results
     payload = {
         'path': f'/mnt/{dataset}',
@@ -141,20 +141,20 @@ def test_10_get_filesystem_getacl(request):
 
 @pytest.mark.parametrize('key', ['tag', 'type', 'perms', 'flags'])
 def test_11_verify_filesystem_getacl(request, key):
-    depends(request, ["pool_04", "acl_pool_perm_09"], scope="session")
+    depends(request, [pool_name, "acl_pool_perm_09"], scope="session")
     assert results.json()['acl'][0][key] == default_acl[0][key], results.text
     assert results.json()['acl'][1][key] == default_acl[1][key], results.text
 
 
 def test_12_filesystem_acl_is_present(request):
-    depends(request, ["pool_04", "acl_pool_perm_09"], scope="session")
+    depends(request, [pool_name, "acl_pool_perm_09"], scope="session")
     results = POST('/filesystem/stat/', f'/mnt/{dataset}')
     assert results.status_code == 200, results.text
     assert results.json()['acl'] is True, results.text
 
 
 def test_13_strip_acl_from_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global JOB_ID
     result = POST(
         f'/pool/dataset/id/{dataset_url}/permission/', {
@@ -171,7 +171,7 @@ def test_13_strip_acl_from_dataset(request):
 
 
 def test_14_setting_various_quotas(request):
-    depends(request, ['pool_04', 'shareuser'], scope='session')
+    depends(request, [pool_name, 'shareuser'], scope='session')
     user = group = 'shareuser'
     user_gid = GET('/group/?group=shareuser').json()[0]['gid']
     user_uid = GET('/user/?username=shareuser').json()[0]['uid']
@@ -230,13 +230,13 @@ def test_14_setting_various_quotas(request):
 
 
 def test_16_verify_job_id_is_successfull(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     job_status = wait_on_job(JOB_ID, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_17_filesystem_acl_is_removed(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     results = POST('/filesystem/stat/', f'/mnt/{dataset}')
     assert results.status_code == 200, results.text
     assert results.json()['acl'] is False, results.text
@@ -244,7 +244,7 @@ def test_17_filesystem_acl_is_removed(request):
 
 
 def test_18_delete_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(
         f'/pool/dataset/id/{dataset_url}/'
     )
@@ -252,13 +252,13 @@ def test_18_delete_dataset(request):
 
 
 def test_19_verify_the_id_dataset_does_not_exist(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = GET(f'/pool/dataset/id/{dataset_url}/')
     assert result.status_code == 404, result.text
 
 
 def test_20_creating_zvol(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global results, payload
     payload = {
         'name': zvol,
@@ -272,7 +272,7 @@ def test_20_creating_zvol(request):
 
 @pytest.mark.parametrize('key', ['name', 'type', 'volsize', 'volblocksize'])
 def test_21_verify_output(request, key):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     if key == 'volsize':
         assert results.json()[key]['parsed'] == payload[key], results.text
     elif key == 'volblocksize':
@@ -282,7 +282,7 @@ def test_21_verify_output(request, key):
 
 
 def test_22_query_zvol_by_id(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global results
     results = GET(f'/pool/dataset/id/{zvol_url}')
     assert isinstance(results.json(), dict)
@@ -290,7 +290,7 @@ def test_22_query_zvol_by_id(request):
 
 @pytest.mark.parametrize('key', ['name', 'type', 'volsize', 'volblocksize'])
 def test_23_verify_the_query_zvol_output(request, key):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     if key == 'volsize':
         assert results.json()[key]['parsed'] == payload[key], results.text
     elif key == 'volblocksize':
@@ -300,7 +300,7 @@ def test_23_verify_the_query_zvol_output(request, key):
 
 
 def test_24_update_zvol(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global payload, results
     payload = {
         'volsize': 163840,
@@ -312,12 +312,12 @@ def test_24_update_zvol(request):
 
 @pytest.mark.parametrize('key', ['volsize'])
 def test_25_verify_update_zvol_output(request, key):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     assert results.json()[key]['parsed'] == payload[key], results.text
 
 
 def test_26_query_zvol_changes_by_id(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global results
     results = GET(f'/pool/dataset/id/{zvol_url}')
     assert isinstance(results.json(), dict), results
@@ -325,25 +325,25 @@ def test_26_query_zvol_changes_by_id(request):
 
 @pytest.mark.parametrize('key', ['comments', 'volsize'])
 def test_27_verify_the_query_change_zvol_output(request, key):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     assert results.json()[key]['parsed'] == payload[key], results.text
 
 
 def test_28_delete_zvol(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f'/pool/dataset/id/{zvol_url}/')
     assert result.status_code == 200, result.text
 
 
 def test_29_verify_the_id_zvol_does_not_exist(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = GET(f'/pool/dataset/id/{zvol_url}/')
     assert result.status_code == 404, result.text
 
 
 @pytest.mark.parametrize("create_dst", [True, False])
 def test_30_delete_dataset_with_receive_resume_token(request, create_dst):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     result = POST('/pool/dataset/', {'name': f'{pool_name}/src'})
     assert result.status_code == 200, result.text
 
@@ -377,7 +377,7 @@ def test_31_path_to_dataset(request):
     a path to a dataset name. Return is expected to be None if the
     path points to the boot pool.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
 
     get_payload = {'msg': 'method', 'method': 'zfs.dataset.path_to_dataset', 'params': []}
     get_payload['params'] = [f'/mnt/{pool_name}']
@@ -393,7 +393,7 @@ def test_31_path_to_dataset(request):
 
 
 def test_32_test_apps_preset(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     with create_dataset(pool_name, 'APPS_TEST', options={'share_type': 'APPS'}) as ds:
         assert ds['acltype']['value'] == 'NFSV4'
         assert ds['atime']['value'] == 'OFF'

--- a/tests/api2/test_341_pool_dataset_encryption.py
+++ b/tests/api2/test_341_pool_dataset_encryption.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, PUT, wait_on_job, SSH_TEST
-from auto_config import ha, ip, password, user, dev_test
+from auto_config import pool_name, ha, ip, password, user, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skip for development testing')
 
@@ -28,7 +28,7 @@ child_dataset_url = child_dataset.replace('/', '%2F')
 
 @pytest.mark.dependency(name="CREATED_POOL")
 def test_create_a_normal_pool(request):
-    depends(request, ['pool_04'], scope='session')
+    depends(request, [pool_name], scope='session')
     global pool_id, pool_disks
     # Get one disk for encryption testing
     pool_disks = [POST('/disk/get_unused/', controller_a=ha).json()[0]['name']]

--- a/tests/api2/test_344_acl_templates.py
+++ b/tests/api2/test_344_acl_templates.py
@@ -22,7 +22,7 @@ def test_01_create_test_datasets(request, acltype):
     This test shouldn't fail unless pool.dataset endpoint is
     thoroughly broken.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': f'{pool_name}/acltemplate_{acltype.lower()}',

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -173,7 +173,7 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_DATASET,
@@ -1164,7 +1164,7 @@ def test_29_deleting_homedir_user(request):
 
 
 def test_30_delete_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(
         f'/pool/dataset/id/{dataset_url}/'
     )

--- a/tests/api2/test_347_posix_mode.py
+++ b/tests/api2/test_347_posix_mode.py
@@ -52,7 +52,7 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': MODE_DATASET

--- a/tests/api2/test_348_posix_acl.py
+++ b/tests/api2/test_348_posix_acl.py
@@ -78,7 +78,7 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_DATASET,
@@ -533,7 +533,7 @@ def test_20_delete_child_dataset(request):
 
 
 def test_30_delete_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(
         f'/pool/dataset/id/{DATASET_URL}/'
     )

--- a/tests/api2/test_350_pool_dataset_quota_alert.py
+++ b/tests/api2/test_350_pool_dataset_quota_alert.py
@@ -10,8 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST
-from auto_config import ip, pool_name, user, password
-from auto_config import dev_test
+from auto_config import dev_test, ip, pool_name, user, password
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -56,7 +55,7 @@ G = 1024 * 1024 * 1024
     ),
 ])
 def test_dataset_quota_alert(request, datasets, expected_alerts):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     assert "" in datasets
 
     try:

--- a/tests/api2/test_360_pool_scrub.py
+++ b/tests/api2/test_360_pool_scrub.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_01_create_scrub_for_same_pool(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global pool_id
     pool_id = GET(f"/pool/?name={pool_name}").json()[0]["id"]
     result = POST("/pool/scrub/", {
@@ -35,7 +35,7 @@ def test_01_create_scrub_for_same_pool(request):
 
 
 def test_02_get_pool_name_scrub_id(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     global scrub_id
     result = GET(f"/pool/scrub/?pool_name={pool_name}")
     assert result.status_code == 200, result.text
@@ -43,7 +43,7 @@ def test_02_get_pool_name_scrub_id(request):
 
 
 def test_03_update_scrub(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = PUT(f"/pool/scrub/id/{scrub_id}/", {
         "pool": pool_id,
         "threshold": 2,
@@ -61,13 +61,13 @@ def test_03_update_scrub(request):
 
 
 def test_04_delete_scrub(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = DELETE(f"/pool/scrub/id/{scrub_id}/")
     assert result.status_code == 200, result.text
 
 
 def test_05_create_scrub(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     result = POST("/pool/scrub/", {
         "pool": pool_id,
         "threshold": 1,

--- a/tests/api2/test_370_replication.py
+++ b/tests/api2/test_370_replication.py
@@ -9,7 +9,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, DELETE
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -37,7 +37,7 @@ def periodic_snapshot_tasks():
 
 
 def test_00_bootstrap(request, credentials, periodic_snapshot_tasks):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     for plugin in ["replication", "pool/snapshottask"]:
         for i in GET(f"/{plugin}/").json():
             assert DELETE(f"/{plugin}/id/{i['id']}").status_code == 200
@@ -222,7 +222,7 @@ def test_00_bootstrap(request, credentials, periodic_snapshot_tasks):
      "periodic_snapshot_tasks.1"),
 ])
 def test_create_replication(request, credentials, periodic_snapshot_tasks, req, error):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     if "ssh_credentials" in req:
         req["ssh_credentials"] = credentials["id"]
 

--- a/tests/api2/test_377_reporting.py
+++ b/tests/api2/test_377_reporting.py
@@ -35,7 +35,7 @@ def test_cputemp():
 
 
 def test_reporting_still_working_after_the_system_dataset_changes(request, reporing_data):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     pool_disk = [POST('/disk/get_unused/').json()[0]['name']]
     payload = {

--- a/tests/api2/test_380_rsync.py
+++ b/tests/api2/test_380_rsync.py
@@ -8,7 +8,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, GET, RC_TEST, DELETE, POST, SSH_TEST
-from auto_config import ip, user, dev_test
+from auto_config import pool_name, ip, user, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -26,7 +26,7 @@ def test_03_create_root_ssh_key(request):
 
 
 def test_04_Creating_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         'user': 'root',
         'mode': 'SSH',
@@ -43,35 +43,35 @@ def test_04_Creating_rsync_task(request, rsynctask_dict):
 
 
 def test_10_Disable_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     id = rsynctask_dict['id']
     results = PUT(f'/rsynctask/id/{id}/', {'enabled': False})
     assert results.status_code == 200, results.text
 
 
 def test_11_Check_that_API_reports_the_rsync_task_as_disabled(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     id = rsynctask_dict['id']
     results = GET(f'/rsynctask?id={id}')
     assert results.json()[0]['enabled'] is False
 
 
 def test_12_Delete_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     id = rsynctask_dict['id']
     results = DELETE(f'/rsynctask/id/{id}/')
     assert results.status_code == 200, results.text
 
 
 def test_13_Check_that_the_API_reports_rsync_task_as_deleted(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     id = rsynctask_dict['id']
     results = GET(f'/rsynctask?id={id}')
     assert results.json() == [], results.text
 
 
 def test_14_remove_root_ssh_key(request):
-    depends(request, ["pool_04", "ssh_key"], scope="session")
+    depends(request, [pool_name, "ssh_key"], scope="session")
     cmd = 'rm /root/.ssh/id_rsa*'
     results = SSH_TEST(cmd, user, None, ip)
     assert results['result'] is True, results['output']

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -62,7 +62,7 @@ def test_001_setting_auxilary_parameters_for_mount_smbfs(request):
 
 @pytest.mark.dependency(name="create_dataset")
 def test_002_creating_smb_dataset(request):
-    depends(request, ["pool_04", "smb_001"], scope="session")
+    depends(request, [pool_name, "smb_001"], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB",

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -102,7 +102,7 @@ SMB_PWD = "smb1234"
 
 @pytest.mark.dependency(name="SMB_DATASET_CREATED")
 def test_001_creating_smb_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB"

--- a/tests/api2/test_426_smb_vss.py
+++ b/tests/api2/test_426_smb_vss.py
@@ -114,7 +114,7 @@ def check_previous_version_contents(path, contents, offset):
 @pytest.mark.parametrize('ds', [dataset, dataset_nested])
 @pytest.mark.dependency(name="VSS_DATASET_CREATED")
 def test_001_creating_smb_dataset(request, ds):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         "name": ds,
         "share_type": "SMB"

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -163,7 +163,7 @@ def test_003_test_perms(request):
     correct NT ACL bit gets toggled when viewed through SMB
     protocol.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED", pool_name], scope="session")
 
     ds = 'nfs4acl_perms_smb'
     path = f'/mnt/{pool_name}/{ds}'
@@ -196,7 +196,7 @@ def test_004_test_flags(request):
     correct NT ACL bit gets toggled when viewed through SMB
     protocol.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED", pool_name], scope="session")
 
     ds = 'nfs4acl_flags_smb'
     path = f'/mnt/{pool_name}/{ds}'
@@ -228,7 +228,7 @@ def test_005_test_map_modify(request):
     grants an access mask equaivalent to MODIFY or FULL depending on whether it's
     the file owner or group / other.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED", pool_name], scope="session")
 
     ds = 'nfs4acl_map_modify'
     path = f'/mnt/{pool_name}/{ds}'
@@ -244,7 +244,7 @@ def test_005_test_map_modify(request):
 
 
 def test_006_test_preserve_dynamic_id_mapping(request):
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED", pool_name], scope="session")
     def _find_owner_rights(acl):
         for entry in acl:
             if 'owner rights' in entry['who']:
@@ -291,7 +291,7 @@ def test_006_test_preserve_dynamic_id_mapping(request):
 
 
 def test_007_test_disable_autoinherit(request):
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED", pool_name], scope="session")
     ds = 'nfs4acl_disable_inherit'
     path = f'/mnt/{pool_name}/{ds}'
     with create_dataset(f'{pool_name}/{ds}', {'share_type': 'SMB'}):

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -56,7 +56,7 @@ SAMPLE_AUX = [
 
 @pytest.mark.dependency(name="SMB_DATASET_CREATED")
 def test_001_creating_smb_DATASET(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     payload = {
         "name": DATASET,
         "share_type": "SMB"

--- a/tests/api2/test_438_snapshots.py
+++ b/tests/api2/test_438_snapshots.py
@@ -231,7 +231,7 @@ def test_01_snapshot_query_filter_dataset_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-name", ['name'])
 
 def test_02_snapshot_query_filter_dataset_props_createtxg(request):
@@ -240,7 +240,7 @@ def test_02_snapshot_query_filter_dataset_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_03_snapshot_query_filter_dataset_props_name_createtxg(request):
@@ -249,7 +249,7 @@ def test_03_snapshot_query_filter_dataset_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -259,7 +259,7 @@ def test_04_snapshot_query_filter_dataset_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])
@@ -363,7 +363,7 @@ def test_05_snapshot_query_filter_snapshot_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-name", ['name'])
 
 def test_06_snapshot_query_filter_snapshot_props_createtxg(request):
@@ -372,7 +372,7 @@ def test_06_snapshot_query_filter_snapshot_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_07_snapshot_query_filter_snapshot_props_name_createtxg(request):
@@ -381,7 +381,7 @@ def test_07_snapshot_query_filter_snapshot_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -391,7 +391,7 @@ def test_08_snapshot_query_filter_snapshot_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])
@@ -492,7 +492,7 @@ def test_09_snapshot_query_filter_pool_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-name", ['name'])
 
 def test_10_snapshot_query_filter_pool_props_createtxg(request):
@@ -501,7 +501,7 @@ def test_10_snapshot_query_filter_pool_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_11_snapshot_query_filter_pool_props_name_createtxg(request):
@@ -510,7 +510,7 @@ def test_11_snapshot_query_filter_pool_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -520,7 +520,7 @@ def test_12_snapshot_query_filter_pool_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])

--- a/tests/api2/test_439_snapshottask_retention.py
+++ b/tests/api2/test_439_snapshottask_retention.py
@@ -13,14 +13,14 @@ from middlewared.test.integration.utils import assert_creates_job, call
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, PUT, wait_on_job
-from auto_config import dev_test
+from auto_config import dev_test, pool_name
 from pytest_dependency import depends
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
 def test_change_retention(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     tz = pytz.timezone(call("system.info")["timezone"])
 
@@ -98,7 +98,7 @@ def test_change_retention(request):
 
 
 def test_delete_retention(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     tz = pytz.timezone(call("system.info")["timezone"])
 

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -31,7 +31,7 @@ def data():
 
 
 def test_01_vm_disk_choices(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1024000}) as ds:
         results = GET('/vm/device/disk_choices')
         assert isinstance(results.json(), dict), results.json()
@@ -99,7 +99,7 @@ if support_virtualization:
 
     @pytest.mark.dependency(name='DISK_CDROM_DATASET')
     def test_10_create_dataset_for_disk_and_cdrom(request):
-        depends(request, ["pool_04"], scope="session")
+        depends(request, [pool_name], scope="session")
         results = POST("/pool/dataset/", payload={"name": DISK_DATASET})
         assert results.status_code == 200, results.text
 

--- a/tests/api2/test_900_docs.py
+++ b/tests/api2/test_900_docs.py
@@ -9,13 +9,13 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import SSH_TEST
-from auto_config import ip, user, password, dev_test
+from auto_config import pool_name, ip, user, password, dev_test
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_core_get_methods(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+    depends(request, [pool_name, "ssh_password"], scope="session")
     results = SSH_TEST("midclt call core.get_methods", user, password, ip)
     assert results['result'] is True, results

--- a/tests/api2/test_999_pool_dataset_unlock.py
+++ b/tests/api2/test_999_pool_dataset_unlock.py
@@ -120,7 +120,7 @@ def smb_connection(**kwargs):
 @pytest.mark.dependency(name="create_dataset")
 @pytest.mark.parametrize("toggle_attachments", [True, False])
 def test_pool_dataset_unlock_smb(request, toggle_attachments):
-    depends(request, ["pool_04", "smb_001", "ssh_password"], scope="session")
+    depends(request, [pool_name, "smb_001", "ssh_password"], scope="session")
     # Prepare test SMB share
     with dataset("normal") as normal:
         with smb_share("normal", f"/mnt/{normal}"):

--- a/tests/api2/test_alert_classes.py
+++ b/tests/api2/test_alert_classes.py
@@ -6,7 +6,7 @@ from pytest_dependency import depends
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import call
 
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
@@ -39,7 +39,7 @@ def test__nonexisting_alert_class():
 
 
 def test__disable_proactive_support_for_valid_alert_class(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     call("alertclasses.update", {
         "classes": {
             "ZpoolCapacityNotice": {
@@ -50,7 +50,7 @@ def test__disable_proactive_support_for_valid_alert_class(request):
 
 
 def test__disable_proactive_support_for_invalid_alert_class(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with pytest.raises(ValidationErrors) as ve:
         call("alertclasses.update", {
             "classes": {

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -6,6 +6,7 @@ from pytest_dependency import depends
 
 sys.path.append(os.getcwd())
 
+from auto_config import pool_name
 from middlewared.test.integration.assets.nfs import nfs_share
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, client
@@ -16,7 +17,7 @@ CHILD_DATASET = f'{PARENT_DATASET}/child_dataset'
 
 
 def test_attachment_with_child_path(request):
-    depends(request, ['pool_04'], scope='session')
+    depends(request, [pool_name], scope='session')
     with dataset(PARENT_DATASET) as parent_dataset:
         parent_path = f'/mnt/{parent_dataset}'
         assert call('pool.dataset.attachments_with_path', parent_path) == []

--- a/tests/api2/test_cloud_sync.py
+++ b/tests/api2/test_cloud_sync.py
@@ -13,14 +13,14 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test, ha
+from auto_config import dev_test, ha, pool_name
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_include(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with local_ftp_task({
         "include": ["/office/**", "/work/**"],
     }) as task:
@@ -38,7 +38,7 @@ def test_include(request):
 
 
 def test_exclude_recycle_bin(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with local_ftp_task({
         "exclude": ["$RECYCLE.BIN/"],
     }) as task:
@@ -56,7 +56,7 @@ def test_exclude_recycle_bin(request):
 @pytest.mark.parametrize("defaultroot", [True, False])
 @pytest.mark.parametrize("has_leading_slash", [True, False])
 def test_ftp_subfolder(request, anonymous, defaultroot, has_leading_slash):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         config = {"defaultroot": defaultroot}
         with (anonymous_ftp_server if anonymous else ftp_server_with_user_account)(config) as ftp:
@@ -100,7 +100,7 @@ def test_ftp_subfolder(request, anonymous, defaultroot, has_leading_slash):
 
 @pytest.mark.parametrize("has_zvol_sibling", [True, False])
 def test_snapshot(request, has_zvol_sibling):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test") as ds:
         ssh(f"mkdir -p /mnt/{ds}/dir1/dir2")
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/dir1/dir2/blob bs=1M count=1")
@@ -133,7 +133,7 @@ def test_snapshot(request, has_zvol_sibling):
 
 
 def test_sync_onetime(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         with local_ftp_credential() as c:
             call("cloudsync.sync_onetime", {
@@ -148,7 +148,7 @@ def test_sync_onetime(request):
 
 
 def test_abort(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test") as ds:
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/blob bs=1M count=1")
 
@@ -180,7 +180,7 @@ def test_abort(request):
 @pytest.mark.flaky(reruns=5, reruns_delay=5)
 @pytest.mark.parametrize("create_empty_src_dirs", [True, False])
 def test_create_empty_src_dirs(request, create_empty_src_dirs):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         ssh(f"mkdir /mnt/{local_dataset}/empty-dir")
         ssh(f"mkdir /mnt/{local_dataset}/non-empty-dir")

--- a/tests/api2/test_cloud_sync_config.py
+++ b/tests/api2/test_cloud_sync_config.py
@@ -11,14 +11,14 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test
+from auto_config import dev_test, pool_name
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_rclone_config_writer_bool(request):
-    #depends(request, ["pool_04"], scope="session")
+    #depends(request, [pool_name], scope="session")
     with dataset("test") as ds:
         with credential({
             "name": "Google Cloud Storage",

--- a/tests/api2/test_cloud_sync_custom_s3.py
+++ b/tests/api2/test_cloud_sync_custom_s3.py
@@ -11,7 +11,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason=reason)
     )
 ])
 def test_custom_s3(request, credential_attributes, result):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test") as ds:
         with credential({
             "name": "S3",

--- a/tests/api2/test_cloudsync_storj.py
+++ b/tests/api2/test_cloudsync_storj.py
@@ -11,7 +11,7 @@ from middlewared.test.integration.assets.pool import dataset
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 
 try:
     from config import (
@@ -73,7 +73,7 @@ def test_storj_list_directory(storj_credential):
 
 
 def test_storj_sync(request, storj_credential):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     with dataset("test") as ds:
         with task({

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -2,6 +2,8 @@ import contextlib
 
 import pytest
 from pytest_dependency import depends
+
+from auto_config import pool_name
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.assets.pool import dataset
 
@@ -44,7 +46,7 @@ def lock_dataset(dataset_name):
 
 
 def test_service_restart_on_unlock_dataset(request):
-    depends(request, ['pool_04'], scope='session')
+    depends(request, [pool_name], scope='session')
     service_name = 'smb'
     registered_name = 'cifs'
     with dataset('testsvcunlock', data={

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -9,7 +9,7 @@ from pytest_dependency import depends
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.assets.pool import dataset
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -25,7 +25,7 @@ def iscsi_extent(data):
 
 
 def test__iscsi_extent__disk_choices(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,
@@ -54,7 +54,7 @@ def test__iscsi_extent__disk_choices(request):
 
 
 def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,
@@ -73,7 +73,7 @@ def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
 
 
 def test__iscsi_extent__locked(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,

--- a/tests/api2/test_kubernetes_passthrough_test.py
+++ b/tests/api2/test_kubernetes_passthrough_test.py
@@ -19,7 +19,7 @@ APP_NAME = 'syncthing'
 
 @pytest.mark.dependency(name='default_kubernetes_cluster')
 def test_01_default_kubernetes_cluster(request):
-    depends(request, ['pool_04'], scope='session')
+    depends(request, [pool_name], scope='session')
     config = call('kubernetes.update', {'passthrough_mode': False, 'pool': pool_name}, job=True)
     assert config['passthrough_mode'] is False
 

--- a/tests/api2/test_pool_dataset_set_quota.py
+++ b/tests/api2/test_pool_dataset_set_quota.py
@@ -7,7 +7,7 @@ from middlewared.test.integration.assets.pool import dataset
 import os
 import sys
 sys.path.append(os.getcwd())
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
     (["GROUPOBJ", "groupobj quota on gid"]),
 ])
 def test_errors(request, id, quota_type, error):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("test") as ds:
         with pytest.raises(ValidationErrors) as ve:
             call("pool.dataset.set_quota", ds, [{"quota_type": quota_type, "id": id, "quota_value": 5242880}])

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.assets.pool import dataset, pool
 import os
 import sys
 sys.path.append(os.getcwd())
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
@@ -43,7 +43,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
     ),
 ])
 def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with contextlib.ExitStack() as stack:
         for name, data in datasets:
             stack.enter_context(dataset(name, data))

--- a/tests/api2/test_pool_export.py
+++ b/tests/api2/test_pool_export.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_systemdataset_migrate_error(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     """
     On HA this test will fail with the error below if failover is enable:
     [ENOTSUP] Disable failover before exporting last pool on system.

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -10,7 +10,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 reason = 'Skipping for test development testing'
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason=reason)
@@ -56,7 +56,7 @@ def test_query_attachment_delegate(ssh_credentials, data, path, include):
 
 @pytest.mark.parametrize("exclude_mountpoint_property", [True, False])
 def test_run_onetime__exclude_mountpoint_property(request, exclude_mountpoint_property):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("src") as src:
         with dataset("src/legacy") as src_legacy:
             ssh(f"zfs set mountpoint=legacy {src_legacy}")

--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_dependency import depends
 from middlewared.test.integration.utils import call, pool
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
@@ -31,5 +31,5 @@ def localhost_ssh_connection():
 
 @pytest.mark.parametrize("transport", ["SSH", "SSH+NETCAT"])
 def test_list_datasets_ssh(request, localhost_ssh_connection, transport):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     assert pool in call("replication.list_datasets", transport, localhost_ssh_connection)

--- a/tests/api2/test_snapshot_count_alert.py
+++ b/tests/api2/test_snapshot_count_alert.py
@@ -2,14 +2,14 @@ import pytest
 from pytest_dependency import depends
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, mock
-from auto_config import dev_test
+from auto_config import dev_test, pool_name
 from time import sleep
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
 def test_snapshot_total_count_alert(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("snapshot_count") as ds:
         base = call("zfs.snapshot.query", [], {"count": True})
         with mock("pool.snapshottask.max_total_count", return_value=base + 10):
@@ -30,7 +30,7 @@ def test_snapshot_total_count_alert(request):
 
 
 def test_snapshot_count_alert(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with dataset("snapshot_count") as ds:
         with mock("pool.snapshottask.max_count", return_value=10):
             for i in range(10):

--- a/tests/api2/test_system_dataset.py
+++ b/tests/api2/test_system_dataset.py
@@ -4,7 +4,7 @@ from pytest_dependency import depends
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, mock, pool, ssh
 
-from auto_config import dev_test
+from auto_config import pool_name, dev_test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
@@ -27,7 +27,7 @@ def write_to_log(string):
 
 
 def test_system_dataset_migrate(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     config = call("systemdataset.config")
     assert config["pool"] == pool
@@ -48,7 +48,7 @@ def test_system_dataset_migrate(request):
 
 @pytest.mark.parametrize("lock", [False, True])
 def test_migrate_to_a_pool_with_passphrase_encrypted_root_dataset(request, lock):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     config = call("systemdataset.config")
     assert config["pool"] == pool
@@ -68,7 +68,7 @@ def test_migrate_to_a_pool_with_passphrase_encrypted_root_dataset(request, lock)
 
 
 def test_lock_passphrase_encrypted_pool_with_system_dataset(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
 
     with another_pool({"encryption": True, "encryption_options": {"passphrase": "passphrase"}}):
         call("systemdataset.update", {"pool": "test"}, job=True)

--- a/tests/api2/test_zpool_capacity_alert.py
+++ b/tests/api2/test_zpool_capacity_alert.py
@@ -3,12 +3,12 @@ from pytest_dependency import depends
 from middlewared.service_exception import CallError
 from middlewared.test.integration.utils import call, mock, pool
 
-from auto_config import dev_test
+from auto_config import dev_test, pool_name
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
 def test__does_not_emit_alert(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,
@@ -23,7 +23,7 @@ def test__does_not_emit_alert(request):
 
 
 def test__emits_alert(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,
@@ -42,7 +42,7 @@ def test__emits_alert(request):
 
 
 def test__does_not_flap_alert(request):
-    depends(request, ["pool_04"], scope="session")
+    depends(request, [pool_name], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,


### PR DESCRIPTION
I sped up the full CI run by over 2hrs! But I did it in an unexpected way :(. The "pool_04" string has been hard-coded _everywhere_ in our test modules so change all the references of this string to "pool_name" which is set in "auto_config" module. This will fix the > 1k tests that are being skipped.