### PR TITLE
NAS-122467 / 23.10 / Reduce pytest_dependency usage (pool_04 and ssh_password)

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -33,7 +33,8 @@ def test_001_is_system_ready(ws_client):
     # will be non-deterministic because middleware plugins
     # internally expect that the system is ready before
     # propertly responding to REST/WS requests.
-    assert ws_client.call('system.ready'), f'System is not ready. Currently: {ws_client.call("system.state")}'
+    if not ws_client.call('system.ready'):
+        pytest.exit(f'System is not ready. Currently: {ws_client.call("system.state")}. Aborting tests.')
 
 
 def test_002_firstboot_checks(ws_client):

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -92,7 +92,8 @@ def test_004_enable_and_start_ssh(ws_client):
 
 def test_005_ssh_using_root_password(ip_to_use):
     results = SSH_TEST('ls -la', user, password, ip_to_use)
-    assert results['result'] is True, results['output']
+    if not results['result']:
+        pytest.exit(f"SSH is not usable: {results['output']}. Aborting tests.")
 
 
 def test_006_setup_and_login_using_root_ssh_key(ip_to_use):

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -40,7 +40,6 @@ def test_001_check_sysdataset_exists_on_boot_pool(ws_client):
     assert bp_basename == sysds['basename']
 
 
-@pytest.mark.dependency(name='PERM_ZPOOL_CREATED')
 def test_002_create_permanent_zpool(request, ws_client):
     """
     This creates the "permanent" zpool which is used by every other
@@ -63,7 +62,7 @@ def test_002_create_permanent_zpool(request, ws_client):
             job=True
         )
     except Exception as e:
-        assert False, e
+        pytest.exit(f"Unable to create test pool: {e!r}. Aborting tests.")
     else:
         results = ws_client.call('systemdataset.config')
         assert results['pool'] == pool_name
@@ -71,7 +70,7 @@ def test_002_create_permanent_zpool(request, ws_client):
 
 
 @pytest.mark.dependency(name='POOL_FUNCTIONALITY1')
-def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(request, ws_client, pool_data):
+def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(ws_client, pool_data):
     """
     This tests a few items related to zpool creation logic:
     1. disk.get_unused should NOT show disks that are a part of a zpool that is
@@ -79,7 +78,6 @@ def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(request, ws_
     2. make sure the system dataset doesn't migrate to the 2nd zpool that we create
         since it should only be migrating to the 1st zpool that is created
     """
-    depends(request, ['PERM_ZPOOL_CREATED'])
     unused_disks = ws_client.call('disk.get_unused')
     assert len(unused_disks) >= 1
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -114,7 +114,7 @@ def test_02_creating_user_testuser(request):
 
 
 def test_03_verify_post_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["user_01", "ssh_password"], scope="session")
+    depends(request, ["user_01"], scope="session")
     cmd = """grep -R "test1234" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -229,7 +229,7 @@ def test_15_updating_user_testuser_info(request):
 
 
 def test_16_verify_put_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["user_02", "user_01", "ssh_password"], scope="session")
+    depends(request, ["user_02", "user_01"], scope="session")
     cmd = """grep -R "testing123" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -300,7 +300,6 @@ def test_27_creating_shareuser_to_test_sharing(request):
 
 
 def test_28_verify_post_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "testing" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -320,7 +319,6 @@ def test_30_creating_home_dataset(request):
     we verify that ACL is being stripped properly from
     the newly-created home directory.
     """
-    depends(request, ["pool_04"], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB",
@@ -378,7 +376,7 @@ def test_31_creating_user_with_homedir(request):
 
 
 def test_32_verify_post_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     cmd = """grep -R "test1234" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -421,7 +419,7 @@ def test_36_homedir_check_perm(to_test, request):
 
 
 def test_37_homedir_testfile_create(request):
-    depends(request, ["HOMEDIR_EXISTS", "ssh_password"], scope="session")
+    depends(request, ["HOMEDIR_EXISTS"], scope="session")
     testfile = f'/mnt/{dataset}/testuser2/testfile.txt'
 
     cmd = f'touch {testfile}; chown {next_uid} {testfile}'
@@ -513,7 +511,7 @@ def test_42_verify_locked_smb_user_is_disabled(request):
     This test verifies that the passdb user is disabled
     when "locked" is set to True.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     cmd = "midclt call smb.passdb_list true"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -591,7 +589,7 @@ def test_46_creating_non_smb_user(request):
 
 
 def test_47_verify_post_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["ssh_password", "NON_SMB_USER_CREATED"], scope="session")
+    depends(request, ["NON_SMB_USER_CREATED"], scope="session")
     cmd = """grep -R "testabcd" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -644,7 +642,7 @@ def test_50_convert_to_smb_user(request):
 
 
 def test_51_verify_put_user_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["ssh_password", "NON_SMB_USER_CREATED"], scope="session")
+    depends(request, ["NON_SMB_USER_CREATED"], scope="session")
     cmd = """grep -R "testabcd1234" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -673,7 +671,7 @@ def test_52_converted_smb_user_passb_entry_exists(request):
 
 
 def test_53_add_user_to_sudoers(request):
-    depends(request, ["ssh_password", "NON_SMB_USER_CREATED"], scope="session")
+    depends(request, ["NON_SMB_USER_CREATED"], scope="session")
     results = PUT(f"/user/id/{testuser_id}", {"sudo_commands": ["ALL"], "sudo_commands_nopasswd": []})
     assert results.status_code == 200, results.text
 
@@ -691,7 +689,7 @@ def test_53_add_user_to_sudoers(request):
 
 
 def test_54_disable_password_auth(request):
-    depends(request, ["ssh_password", "NON_SMB_USER_CREATED"], scope="session")
+    depends(request, ["NON_SMB_USER_CREATED"], scope="session")
     results = PUT(f"/user/id/{testuser_id}", {"password_disabled": True})
     assert results.status_code == 200, results.text
 

--- a/tests/api2/test_012_directory_service_ssh.py
+++ b/tests/api2/test_012_directory_service_ssh.py
@@ -51,7 +51,6 @@ def do_ldap_connection(request):
 
 
 def test_08_test_ssh_ad(do_ad_connection, request):
-    depends(request, ["ssh_password"], scope="session")
     userobj = call('user.get_user_obj', {'username': f'{ADUSERNAME}@{AD_DOMAIN}'})
     groupobj = call('group.get_group_obj', {'gid': userobj['pw_gid']})
     call('ssh.update', {"password_login_groups": [groupobj['gr_name']]})
@@ -61,7 +60,6 @@ def test_08_test_ssh_ad(do_ad_connection, request):
 
 
 def test_09_test_ssh_ldap(do_ldap_connection, request):
-    depends(request, ["ssh_password"], scope="session")
     userobj = call('user.get_user_obj', {'username': LDAPUSER})
     groupobj = call('group.get_group_obj', {'gid': userobj['pw_gid']})
     call('ssh.update', {"password_login_groups": [groupobj['gr_name']]})

--- a/tests/api2/test_023_kubernetes.py
+++ b/tests/api2/test_023_kubernetes.py
@@ -22,7 +22,6 @@ if not ha:
 
     @pytest.mark.dependency(name='setup_kubernetes')
     def test_02_setup_kubernetes(request):
-        depends(request, ["pool_04"], scope="session")
         global payload
         gateway = GET("/network/general/summary/").json()['default_routes'][0]
         payload = {

--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -483,7 +483,6 @@ if not ha:
 
     @pytest.mark.dependency(name='hostpath-dataset')
     def test_36_create_datasets_hostpath(request):
-        depends(request, ['pool_04'], scope='session')
         result = POST('/pool/dataset/', {'name': f'{pool_name}/tc-hostpath'})
         assert result.status_code == 200, result.text
 

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -107,7 +107,7 @@ def test_08_test_backend_options(request, backend):
     DS_TYPE_DEFAULT_DOMAIN have hard-coded ids and
     so we don't need to look them up.
     """
-    depends(request, ["GATHERED_BACKEND_OPTIONS", "ssh_password"], scope="session")
+    depends(request, ["GATHERED_BACKEND_OPTIONS"], scope="session")
     opts = BACKEND_OPTIONS[backend]['parameters'].copy()
     set_secret = False
 
@@ -345,7 +345,7 @@ def test_12_idmap_low_high_range_inversion_fail(request):
 
 @pytest.mark.dependency(name="CREATED_NEW_DOMAIN")
 def test_13_idmap_new_domain(request):
-    depends(request, ["AD_IS_HEALTHY", "ssh_password"], scope="session")
+    depends(request, ["AD_IS_HEALTHY"], scope="session")
     global dom_id
     cmd = 'midclt call idmap.get_next_idmap_range'
     results = SSH_TEST(cmd, user, password, ip)
@@ -369,7 +369,7 @@ def test_14_idmap_new_domain_duplicate_fail(request):
     It should not be possible to create a new domain that
     has a name conflict with an existing one.
     """
-    depends(request, ["AD_IS_HEALTHY", "ssh_password"], scope="session")
+    depends(request, ["AD_IS_HEALTHY"], scope="session")
     cmd = 'midclt call idmap.get_next_idmap_range'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -76,7 +76,7 @@ def test_07_check_for_ad_users(request):
     This test validates that we can query AD users using
     filter-option {"extra": {"search_dscache": True}}
     """
-    depends(request, ["INITIAL_CACHE_FILL", "ssh_password"], scope="session")
+    depends(request, ["INITIAL_CACHE_FILL"], scope="session")
     cmd = "wbinfo -u"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'], str(results['output'])
@@ -100,7 +100,7 @@ def test_08_check_for_ad_groups(request):
     This test validates that we can query AD groups using
     filter-option {"extra": {"search_dscache": True}}
     """
-    depends(request, ["INITIAL_CACHE_FILL", "ssh_password"], scope="session")
+    depends(request, ["INITIAL_CACHE_FILL"], scope="session")
     cmd = "wbinfo -g"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'], str(results['output'])
@@ -127,7 +127,7 @@ def test_09_check_directoryservices_cache_refresh(request):
     This currently happens once per 24 hours. Result of failure here will
     be lack of users/groups visible in webui.
     """
-    depends(request, ["AD_USERS_CACHED", "AD_GROUPS_CACHED", "ssh_password"], scope="session")
+    depends(request, ["AD_USERS_CACHED", "AD_GROUPS_CACHED"], scope="session")
     rebuild_ok = False
 
     """
@@ -180,7 +180,7 @@ def test_10_check_lazy_initialization_of_users_and_groups_by_name(request):
     to only hit the cache. Code paths are slightly different for lookups
     by id or by name and so they are tested separately.
     """
-    depends(request, ["REBUILD_AD_CACHE", "ssh_password"], scope="session")
+    depends(request, ["REBUILD_AD_CACHE"], scope="session")
     global ad_user_id
     global ad_domain_users_id
     domain_prefix = f'{WORKGROUP.upper()}{WINBIND_SEPARATOR}'
@@ -247,7 +247,7 @@ def test_11_check_lazy_initialization_of_users_and_groups_by_id(request):
     to only hit the cache. Code paths are slightly different for lookups
     by id or by name and so they are tested separately.
     """
-    depends(request, ["LAZY_INITIALIZATION_BY_NAME", "ssh_password"], scope="session")
+    depends(request, ["LAZY_INITIALIZATION_BY_NAME"], scope="session")
 
     cmd = 'rm -f /root/tdb/persistent/*'
     results = SSH_TEST(cmd, user, password, ip)

--- a/tests/api2/test_050_alert.py
+++ b/tests/api2/test_050_alert.py
@@ -37,7 +37,6 @@ def test_03_get_alert_list_policies():
 
 @pytest.mark.dependency(name='degrade_pool')
 def test_04_degrading_a_pool_to_create_an_alert(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     global gptid
     get_pool = GET(f"/pool/?name={pool_name}").json()[0]
     id_path = '/dev/disk/by-partuuid/'

--- a/tests/api2/test_080_auth.py
+++ b/tests/api2/test_080_auth.py
@@ -30,7 +30,6 @@ def test_01_check_valid_root_user_authentication():
 
 
 def test_02_verify_auth_does_not_leak_password_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{password}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])

--- a/tests/api2/test_130_cloudsync.py
+++ b/tests/api2/test_130_cloudsync.py
@@ -39,13 +39,11 @@ def task():
 
 
 def test_01_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST("/pool/dataset/", {"name": dataset})
     assert result.status_code == 200, result.text
 
 
 def test_02_create_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
     result = POST("/cloudsync/credentials/", {
         "name": "Test",
         "provider": "S3",
@@ -59,7 +57,6 @@ def test_02_create_cloud_credentials(request, credentials):
 
 
 def test_03_update_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
     result = PUT(f"/cloudsync/credentials/id/{credentials['id']}/", {
         "name": "Test",
         "provider": "S3",
@@ -72,7 +69,6 @@ def test_03_update_cloud_credentials(request, credentials):
 
 
 def test_04_create_cloud_sync(request, credentials, task):
-    depends(request, ["pool_04"], scope="session")
     result = POST("/cloudsync/", {
         "description": "Test",
         "direction": "PULL",
@@ -97,7 +93,6 @@ def test_04_create_cloud_sync(request, credentials, task):
 
 
 def test_05_update_cloud_sync(request, credentials, task):
-    depends(request, ["pool_04"], scope="session")
     result = PUT(f"/cloudsync/id/{task['id']}/", {
         "description": "Test",
         "direction": "PULL",
@@ -121,7 +116,6 @@ def test_05_update_cloud_sync(request, credentials, task):
 
 
 def test_06_run_cloud_sync(request, task):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     result = POST(f"/cloudsync/id/{task['id']}/sync/")
     assert result.status_code == 200, result.text
     for i in range(120):
@@ -144,7 +138,6 @@ def test_06_run_cloud_sync(request, task):
 
 
 def test_07_restore_cloud_sync(request, task):
-    depends(request, ["pool_04"], scope="session")
     result = POST(f"/cloudsync/id/{task['id']}/restore/", {
         "transfer_mode": "COPY",
         "path": dataset_path,
@@ -156,25 +149,21 @@ def test_07_restore_cloud_sync(request, task):
 
 
 def test_96_delete_cloud_credentials_error(request, credentials):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/cloudsync/credentials/id/{credentials['id']}/")
     assert result.status_code == 422
     assert "This credential is used by cloud sync task" in result.json()["message"]
 
 
 def test_97_delete_cloud_sync(request, task):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/cloudsync/id/{task['id']}/")
     assert result.status_code == 200, result.text
 
 
 def test_98_delete_cloud_credentials(request, credentials):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/cloudsync/credentials/id/{credentials['id']}/")
     assert result.status_code == 200, result.text
 
 
 def test_99_destroy_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/pool/dataset/id/{urllib.parse.quote(dataset, '')}/")
     assert result.status_code == 200, result.text

--- a/tests/api2/test_150_cronjob.py
+++ b/tests/api2/test_150_cronjob.py
@@ -57,7 +57,6 @@ def test_05_Checking_that_API_reports_the_cronjob_as_updated(cronjob_dict):
 
 
 def test_06_Deleting_test_file_created_by_cronjob(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'rm "{TESTFILE}"', user, password, ip)
     assert results['result'] is True, results['output']
 

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -69,7 +69,6 @@ def test_03_get_filesystem_stat_(path):
 
 
 def test_04_test_filesystem_statfs_fstype(request):
-    depends(request, ["pool_04"], scope="session")
     # test zfs fstype first
     parent_path = f'/mnt/{pool_name}'
     results = POST('/filesystem/statfs/', parent_path)
@@ -108,7 +107,6 @@ def test_04_test_filesystem_statfs_fstype(request):
 
 
 def test_05_set_immutable_flag_on_path(request):
-    depends(request, ["pool_04"], scope="session")
     t_path = os.path.join('/mnt', pool_name, 'random_directory_immutable')
     t_child_path = os.path.join(t_path, 'child')
 
@@ -149,7 +147,6 @@ def test_07_test_filesystem_stat_filetype(request):
     There is an additional check to make sure that paths
     in the ZFS CTL directory (.zfs) are properly flagged.
     """
-    depends(request, ["pool_04"], scope="session")
     ds_name = 'stat_test'
     snap_name = f'{ds_name}_snap1'
     path = f'/mnt/{pool_name}/{ds_name}'
@@ -208,7 +205,6 @@ def test_08_test_fiilesystem_statfs_flags(request):
     This test verifies that changing ZFS properties via
     middleware causes mountinfo changes visible via statfs.
     """
-    depends(request, ["pool_04"], scope="session")
     ds_name = 'statfs_test'
     target = f'{pool_name}/{ds_name}'
     target_url = target.replace('/', '%2F')

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -707,7 +707,6 @@ def test_001_validate_default_configuration(request, ftp_init_db_dflt):
     with migration code.
     NB1: This expects FTP to be in the default configuration
     '''
-    depends(request, ["pool_04"], scope="session")
     ftp_set_config(DB_DFLT)
 
     with ftp_server():
@@ -765,7 +764,6 @@ def test_010_ftp_service_start(request):
     Confirm we can start the FTP service with the default config
     Confirm the proftpd.conf file was generated
     '''
-    depends(request, ["pool_04"], scope="session")
     # Start FTP service
     with ftp_server():
         # Get current
@@ -787,7 +785,7 @@ def test_015_ftp_configuration(request):
     '''
     Confirm config changes get reflected in proftpd.conf
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
 
     with ftp_server():
         changes = {
@@ -806,7 +804,7 @@ def test_017_ftp_port(request):
     '''
     Confirm config changes get reflected in proftpd.conf
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
 
     with ftp_server():
         payload = {
@@ -849,7 +847,7 @@ def test_020_login_attempts(request, NumFailedTries, expect_to_pass):
     1) Test good password before running out of tries
     2) Test good password after running out of tries
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     login_setup = {
         "onlylocal": True,
         "loginattempt": 3,
@@ -882,7 +880,7 @@ def test_030_root_login(request, setting):
     Test the WebUI "Allow Root Login" setting.
     In our DB the setting is "rootlogin" and "RootLogin" in proftpd.conf.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     # Enable root login for the anonymous config
     ftp_setup = {
         "rootlogin": setting,
@@ -913,7 +911,7 @@ def test_031_anon_login(request, setting, ftpConfig):
     Test the WebUI "Allow Anonymous Login" setting.
     In our DB the setting is "onlyanonymous" and an "Anonymous" section in proftpd.conf.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     if setting is True:
         # Fixup anonpath
         ftpConfig['anonpath'] = f"/mnt/{pool_name}/{ftpConfig['anonpath']}"
@@ -937,7 +935,7 @@ def test_031_anon_login(request, setting, ftpConfig):
     ("BadUser", False)
 ])
 def test_032_local_login(request, localuser, expect_to_pass):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     with ftp_user_ds_and_srvr_conn('ftplocalDS', 'FTPlocaluser', {"onlylocal": True}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -948,7 +946,7 @@ def test_032_local_login(request, localuser, expect_to_pass):
 
 
 def test_040_reverse_dns(request):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     ftp_conf = {"onlylocal": True, "reversedns": True}
     with ftp_user_ds_and_srvr_conn('ftplocalDS', 'FTPlocaluser', ftp_conf) as ftpdata:
         ftpObj = ftpdata.ftp
@@ -966,7 +964,7 @@ def test_045_masquerade_address(request, masq_type, expect_to_pass):
         Public IP address or hostname. Set if FTP clients cannot connect through a NAT device.
     We test masqaddress with: hostname, IP address and an invalid fqdn.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     payload = {'msg': 'method', 'method': 'network.configuration.config', 'params': []}
     res = make_ws_request(ip, payload)
     assert res.get('error') is None, res
@@ -1013,7 +1011,7 @@ def test_050_passive_ports(request, testing, ftpConfig, expect_to_pass):
         | Should no open ports be found within the configured range, the server will default
         | to a random kernel-assigned port, and a message logged.
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     if testing == 'config':
         try:
             with ftp_configure(ftpConfig):
@@ -1046,7 +1044,7 @@ def test_055_no_activity_timeout(request):
         | The TimeoutIdle directive configures the maximum number of seconds that proftpd will
         ! allow clients to stay connected without receiving any data on either the control or data connection
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     with ftp_anon_ds_and_srvr_conn('anonftpDS', {'timeout': 3}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -1068,7 +1066,7 @@ def test_056_no_xfer_timeout(request):
         | is allowed to spend connected, after authentication, without issuing a data transfer command
         | which results in a data connection (i.e. sending/receiving a file, or requesting a directory listing)
     '''
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     with ftp_anon_ds_and_srvr_conn('anonftpDS', {'timeout_notransfer': 3}) as ftpdata:
         ftpObj = ftpdata.ftp
         try:
@@ -1093,7 +1091,7 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
     ulConf = testwho + 'userbw'
     dlConf = testwho + 'userdlbw'
 
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     ftp_anon_bw_limit = {
         ulConf: ulRate,  # upload limit
         dlConf: dlRate   # download limit
@@ -1141,7 +1139,7 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
     ("007", "0660", "002", "0775"),
 ])
 def test_065_umask(request, fmask, f_expect, dmask, d_expect):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
     localfile = "/tmp/localfile"
     fname = "filemask" + fmask
     dname = "dirmask" + dmask
@@ -1181,7 +1179,7 @@ def test_065_umask(request, fmask, f_expect, dmask, d_expect):
     ({'resume': True}, True)
 ])
 def test_070_resume_xfer(request, ftpConf, expect_to_pass):
-    depends(request, ["pool_04", "init_dflt_config"], scope="session")
+    depends(request, ["init_dflt_config"], scope="session")
 
     def upload_partial(ftp, src, tgt, NumKiB=128):
         with open(src, 'rb') as file:
@@ -1318,7 +1316,7 @@ class TestAnonUser(UserTests):
     """
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, ["init_dflt_config"], scope="session")
 
         with ftp_anon_ds_and_srvr_conn('anonftpDS') as anonftp:
             # Make the directory owned by the anonymous ftp user
@@ -1344,7 +1342,7 @@ class TestLocalUser(UserTests):
 
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, ["init_dflt_config"], scope="session")
 
         local_setup = {
             "onlylocal": True,
@@ -1371,7 +1369,7 @@ class TestFTPSUser(UserTests):
 
     @pytest.fixture(scope='class')
     def setup(self, request):
-        depends(request, ["pool_04", "init_dflt_config"], scope="session")
+        depends(request, ["init_dflt_config"], scope="session")
 
         # We include tls_opt_no_session_reuse_required because python
         # ftplib has a long running issue with support for it.

--- a/tests/api2/test_210_group.py
+++ b/tests/api2/test_210_group.py
@@ -258,7 +258,7 @@ def test_27_full_groupmap_check(request):
     """
     Full check of groupmap contents
     """
-    depends(request, ["SMB_GROUP_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SMB_GROUP_CREATED"], scope="session")
     cmd = "midclt call smb.groupmap_list"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'], str(results['output'])

--- a/tests/api2/test_240_initshutdownscript.py
+++ b/tests/api2/test_240_initshutdownscript.py
@@ -37,7 +37,6 @@ def test_01_Create_initshutdownscript_command(initshutdowncmd_dict):
 
 
 def test_02_Touch_initshutdownscript_script_file(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'touch "{TESTSCRIPT}"', user, password, ip)
     assert results['result'] is True, results['output']
 
@@ -82,7 +81,6 @@ def test_07_Check_that_API_reports_the_script_as_updated(initshutdownsc_dict):
 
 
 def test_08_Delete_script_file(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'rm "{TESTSCRIPT}"', user, password, ip)
     assert results['result'] is True, results['output']
 

--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -94,7 +94,7 @@ def test_03_Add_iSCSI_target(request):
 
 @pytest.mark.dependency(name="iscsi_04")
 def test_04_Add_a_iSCSI_file_extent(request):
-    depends(request, ["pool_04", "iscsi_03"], scope="session")
+    depends(request, ["iscsi_03"], scope="session")
     global extent_id
     payload = {
         'type': 'FILE',
@@ -295,7 +295,6 @@ def test_27_Delete_iSCSI_file_extent(request):
 
 @pytest.mark.dependency(name="iscsi_28")
 def test_28_creating_zvol_for_the_iscsi_share(request):
-    depends(request, ["pool_04"], scope="session")
     global results, payload
     payload = {
         'name': zvol,

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -527,7 +527,7 @@ def test_01_inquiry(request):
     This tests the Vendor and Product information in an INQUIRY response
     are 'TrueNAS' and 'iSCSI Disk' respectively.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with initiator():
         with portal() as portal_config:
             portal_id = portal_config['id']
@@ -548,7 +548,7 @@ def test_02_read_capacity16(request):
 
     It performs this test with a couple of sizes for both file & zvol based targets.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with initiator():
         with portal() as portal_config:
             portal_id = portal_config['id']
@@ -662,7 +662,7 @@ def test_03_readwrite16_file_extent(request):
     This tests WRITE SAME (16), READ (16) and WRITE (16) operations with
     a file extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name):
         iqn = f'{basename}:{target_name}'
         target_test_readwrite16(ip, iqn)
@@ -673,7 +673,7 @@ def test_04_readwrite16_zvol_extent(request):
     This tests WRITE SAME (16), READ (16) and WRITE (16) operations with
     a zvol extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         target_test_readwrite16(ip, iqn)
@@ -684,7 +684,7 @@ def test_05_chap(request):
     """
     This tests that CHAP auth operates as expected.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     user = "user1"
     secret = 'sec1' + ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=10))
     with initiator():
@@ -724,7 +724,7 @@ def test_06_mutual_chap(request):
     """
     This tests that Mutual CHAP auth operates as expected.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     user = "user1"
     secret = 'sec1' + ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=10))
     peer_user = "user2"
@@ -777,7 +777,7 @@ def test_07_report_luns(request):
     """
     This tests REPORT LUNS and accessing multiple LUNs on a target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with initiator():
         with portal() as portal_config:
@@ -972,7 +972,7 @@ def test_08_snapshot_zvol_extent(request):
     """
     This tests snapshots with a zvol extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_zvol_extent(target_name, zvol) as iscsi_config:
         target_test_snapshot_single_login(ip, iqn, iscsi_config['dataset']['id'])
@@ -984,7 +984,7 @@ def test_09_snapshot_file_extent(request):
     """
     This tests snapshots with a file extent based iSCSI target.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name) as iscsi_config:
         target_test_snapshot_single_login(ip, iqn, iscsi_config['dataset']['id'])
@@ -999,7 +999,7 @@ def test_10_target_alias(request):
     At the moment SCST does not use the alias usefully (e.g. TargetAlias in
     LOGIN response).  When this is rectified this test should be extended.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
 
     data = {}
     for t in ["A", "B"]:
@@ -1042,7 +1042,7 @@ def test_11_modify_portal(request):
     """
     Test that we can modify a target portal.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with portal() as portal_config:
         assert portal_config['comment'] == 'Default portal', portal_config
         # First just change the comment
@@ -1060,7 +1060,7 @@ def test_12_pblocksize_setting(request):
     This tests whether toggling pblocksize has the desired result on READ CAPACITY 16, i.e.
     whether setting it results in LOGICAL BLOCKS PER PHYSICAL BLOCK EXPONENT being zero.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     iqn = f'{basename}:{target_name}'
     with configured_target_to_file_extent(target_name, pool_name, dataset_name, file_name) as iscsi_config:
         extent_config = iscsi_config['extent']
@@ -1134,7 +1134,7 @@ def test_13_test_target_name(request, extent_type):
     """
     Test the user-supplied target name.
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
 
     name64 = generate_name(64)
     with configured_target(name64, extent_type):
@@ -1246,7 +1246,7 @@ class TestFixtureInitiatorName:
         """
         Deliberately send SCST some invalid initiator names and ensure it behaves OK.
         """
-        depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+        depends(request, ["iscsi_cmd_00"], scope="session")
 
         if expected:
             with iscsi_scsi_connection(ip, TestFixtureInitiatorName.iqn, initiator_name=initiator_name) as s:
@@ -1340,7 +1340,7 @@ def _pr_reservation(s, pr_type, scope=LU_SCOPE, other_connections=[], **kwargs):
 @skip_persistent_reservations
 @pytest.mark.dependency(name="iscsi_basic_persistent_reservation")
 def test_16_basic_persistent_reservation(request):
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         with iscsi_scsi_connection(ip, iqn) as s:
@@ -1496,7 +1496,7 @@ def _check_persistent_reservations(s1, s2):
 @skip_persistent_reservations
 @skip_multi_initiator
 def test_17_persistent_reservation_two_initiators(request):
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     with configured_target_to_zvol_extent(target_name, zvol):
         iqn = f'{basename}:{target_name}'
         with iscsi_scsi_connection(ip, iqn) as s1:
@@ -1839,7 +1839,7 @@ def test_18_alua_config(request):
 @skip_multi_initiator
 @skip_ha_tests
 def test_19_alua_basic_persistent_reservation(request):
-    # Don't need to specify "pool_04", "iscsi_cmd_00" here
+    # Don't need to specify "iscsi_cmd_00" here
     depends(request, ["iscsi_alua_config", "iscsi_basic_persistent_reservation"], scope="session")
     # Turn on ALUA
     with alua_enabled():

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -126,13 +126,13 @@ def test_09_account_privilege_authentication(request):
 
 @pytest.mark.dependency(name="ldap_dataset")
 def test_09_creating_ldap_dataset_for_smb(request):
-    depends(request, ["pool_04", "setup_ldap"], scope="session")
+    depends(request, ["setup_ldap"], scope="session")
     results = POST("/pool/dataset/", {"name": dataset, "share_type": "SMB"})
     assert results.status_code == 200, results.text
 
 
 def test_10_verify_that_the_ldap_user_is_listed_with_pdbedit(request):
-    depends(request, ["setup_ldap", "ssh_password"], scope="session")
+    depends(request, ["setup_ldap"], scope="session")
     results = SSH_TEST(f'pdbedit -L {LDAPUSER}', user, password, ip)
     assert results['result'] is True, str(results['output'])
     assert LDAPUSER in results['output'], str(results['output'])
@@ -272,7 +272,7 @@ def test_23_restarting_cifs_service_after_changing_has_samba_schema(request):
 
 
 def test_24_verify_that_the_ldap_user_is_not_listed_with_pdbedit(request):
-    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap", "ssh_password"], scope="session")
+    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap"], scope="session")
     results = SSH_TEST(f'pdbedit -L {LDAPUSER}', user, password, ip)
     assert results['result'] is False, results['output']
 
@@ -313,7 +313,7 @@ def test_28_verify_if_cifs_service_is_running(request):
 
 
 def test_29_verify_that_the_ldap_user_is_listed_with_pdbedit(request):
-    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap", "ssh_password"], scope="session")
+    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap"], scope="session")
     results = SSH_TEST(f'pdbedit -L {LDAPUSER}', user, password, ip)
     assert results['result'] is True, results['output']
 
@@ -361,7 +361,7 @@ def test_34_restarting_cifs_service_after_changing_has_samba_schema(request):
 
 
 def test_35_verify_that_the_ldap_user_is_not_listed_with_pdbedit(request):
-    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap", "ssh_password"], scope="session")
+    depends(request, ["setup_ldap", "ldap_dataset", "smb_share_ldap"], scope="session")
     results = SSH_TEST(f'pdbedit -L {LDAPUSER}', user, password, ip)
     assert results['result'] is False, results['output']
 

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -264,14 +264,12 @@ def test_01_creating_the_nfs_server():
 
 
 def test_02_creating_dataset_nfs(request):
-    depends(request, ["pool_04"], scope="session")
     payload = {"name": dataset}
     results = POST("/pool/dataset/", payload)
     assert results.status_code == 200, results.text
 
 
 def test_03_changing_dataset_permissions_of_nfs_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     payload = {
         "acl": [],
         "mode": "777",
@@ -285,13 +283,11 @@ def test_03_changing_dataset_permissions_of_nfs_dataset(request):
 
 
 def test_04_verify_the_job_id_is_successfull(request):
-    depends(request, ["pool_04"], scope="session")
     job_status = wait_on_job(job_id, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
 def test_05_creating_a_nfs_share_on_nfs_PATH(request):
-    depends(request, ["pool_04"], scope="session")
     global nfsid
     paylaod = {"comment": "My Test Share",
                "path": NFS_PATH,
@@ -302,19 +298,16 @@ def test_05_creating_a_nfs_share_on_nfs_PATH(request):
 
 
 def test_06_starting_nfs_service_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
     results = PUT("/service/id/nfs/", {"enable": True})
     assert results.status_code == 200, results.text
 
 
 def test_07_checking_to_see_if_nfs_service_is_enabled_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["enable"] is True, results.text
 
 
 def test_08_starting_nfs_service(request):
-    depends(request, ["pool_04"], scope="session")
     payload = {"service": "nfs"}
     results = POST("/service/start/", payload)
     assert results.status_code == 200, results.text
@@ -325,14 +318,12 @@ def test_08_starting_nfs_service(request):
 
 
 def test_09_checking_to_see_if_nfs_service_is_running(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results.text
 
 
 @pytest.mark.parametrize('vers', [3, 4])
 def test_10_perform_basic_nfs_ops(request, vers):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     with SSH_NFS(ip, NFS_PATH, vers=vers, user=user, password=password, ip=ip) as n:
         n.create('testfile')
         n.mkdir('testdir')
@@ -348,7 +339,6 @@ def test_10_perform_basic_nfs_ops(request, vers):
 
 
 def test_11_perform_server_side_copy(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip) as n:
         n.server_side_copy('ssc1', 'ssc2')
 
@@ -360,7 +350,6 @@ def test_19_updating_the_nfs_service(request):
     Latter goal is achieved by reading the nfs config file
     and verifying that the value here was set correctly.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     results = PUT("/nfs/", {"servers": "50"})
     assert results.status_code == 200, results.text
 
@@ -374,7 +363,6 @@ def test_19_updating_the_nfs_service(request):
 
 
 def test_20_update_nfs_share(request):
-    depends(request, ["pool_04"], scope="session")
     nfsid = GET('/sharing/nfs?comment=My Test Share').json()[0]['id']
     payload = {"security": []}
     results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
@@ -382,7 +370,6 @@ def test_20_update_nfs_share(request):
 
 
 def test_21_checking_to_see_if_nfs_service_is_enabled(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results.text
 
@@ -396,7 +383,6 @@ def test_31_check_nfs_share_network(request):
         192.168.0.0/24(sec=sys,rw,subtree_check)\
         192.168.1.0/24(sec=sys,rw,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     networks_to_test = ["192.168.0.0/24", "192.168.1.0/24"]
 
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'networks': networks_to_test})
@@ -457,7 +443,6 @@ def test_32_check_nfs_share_hosts(request, hostlist, ExpectedToPass):
     - Dashes are allowed, but a level cannot start or end with a dash, '-'
     - Only the left most level may contain special characters: '*','?' and '[]'
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hostlist})
     if ExpectedToPass:
         assert results.status_code == 200, results.text
@@ -491,7 +476,6 @@ def test_33_check_nfs_share_ro(request):
     Verify that toggling `ro` will cause appropriate change in
     exports file. We also verify with write tests on a local mount.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
 
     # Make sure we end up in the original state with 'rw'
     try:
@@ -549,7 +533,6 @@ def test_34_check_nfs_share_maproot(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,anonuid=65534,anongid=65534,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     payload = {
         'maproot_user': 'nobody',
         'maproot_group': 'nogroup'
@@ -620,7 +603,6 @@ def test_35_check_nfs_share_mapall(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,all_squash,anonuid=65534,anongid=65534,subtree_check)
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     payload = {
         'mapall_user': 'nobody',
         'mapall_group': 'nogroup'
@@ -663,7 +645,6 @@ def test_36_check_nfsdir_subtree_behavior(request):
     "/mnt/dozer/NFSV4/foobar"\
         *(sec=sys,rw,subtree_check)
     """
-    depends(request, ["pool_04"], scope="session")
     tmp_path = f'{NFS_PATH}/sub1'
     results = POST('/filesystem/mkdir', tmp_path)
     assert results.status_code == 200, results.text
@@ -757,7 +738,6 @@ class Test37WithFixture:
         "/mnt/dozer/NFS/foo"\
             fred(rw)
         """
-        depends(request, ["pool_04", "ssh_password"], scope="session")
 
         vol = dataset_and_dirs
         dirpath = f'{vol}/{dirname}'
@@ -782,7 +762,6 @@ def test_38_check_nfs_allow_nonroot_behavior(request):
     """
 
     # Verify that NFS server configuration is as expected
-    depends(request, ["pool_04"], scope="session")
     results = GET("/nfs")
     assert results.status_code == 200, results.text
     assert results.json()['allow_nonroot'] is False, results.text
@@ -819,7 +798,6 @@ def test_39_check_nfs_service_protocols_parameter(request):
     database) will be updated regardless, the server config file will not
     be updated.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "RUNNING", results
 
@@ -899,7 +877,6 @@ def test_40_check_nfs_service_udp_parameter(request):
     This test verifies that toggling the `udp` option generates expected changes
     in nfs kernel server config.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     with nfs_config():
         get_payload = {'msg': 'method', 'method': 'nfs.config', 'params': []}
         set_payload = {'msg': 'method', 'method': 'nfs.update', 'params': []}
@@ -940,7 +917,6 @@ def test_41_check_nfs_service_ports(request):
     This test verifies that the custom ports we specified in
     earlier NFS tests are set in the relevant files.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
 
     results = GET("/nfs")
     assert results.status_code == 200, results.text
@@ -961,7 +937,6 @@ def test_42_check_nfs_client_status(request):
     of counts over NFSv3 protcol (specifically with regard to decrementing
     sessions) we only verify that count is non-zero for NFSv3.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
 
     with SSH_NFS(ip, NFS_PATH, vers=3, user=user, password=password, ip=ip):
         results = GET('/nfs/get_nfs3_clients/', payload={
@@ -990,7 +965,6 @@ def test_43_check_nfsv4_acl_support(request):
        ACL through the filesystem API.
     3) Repeate same process for each of the supported flags.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     acl_nfs_path = f'/mnt/{pool_name}/test_nfs4_acl'
     test_perms = {
         "READ_DATA": True,
@@ -1074,7 +1048,6 @@ def test_44_check_nfs_xattr_support(request):
     Mount path via NFS 4.2, create a file and dir,
     and write + read xattr on each.
     """
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     xattr_nfs_path = f'/mnt/{pool_name}/test_nfs4_xattr'
     with nfs_dataset("test_nfs4_xattr"):
         with nfs_share(xattr_nfs_path):
@@ -1094,7 +1067,6 @@ def test_45_check_setting_runtime_debug(request):
     """
     This validates that the private NFS debugging API works correctly.
     """
-    depends(request, ["pool_04"], scope="session")
     disabled = {"NFS": ["NONE"], "NFSD": ["NONE"], "NLM": ["NONE"], "RPC": ["NONE"]}
     enabled = {"NFS": ["PROC", "XDR", "CLIENT", "MOUNT", "XATTR_CACHE"],
                "NFSD": ["ALL"],
@@ -1127,7 +1099,6 @@ def test_45_check_setting_runtime_debug(request):
 
 
 def test_50_stoping_nfs_service(request):
-    depends(request, ["pool_04"], scope="session")
     # Restore original settings before we stop
     restore_nfs_config()
     payload = {"service": "nfs"}
@@ -1137,7 +1108,6 @@ def test_50_stoping_nfs_service(request):
 
 
 def test_51_checking_to_see_if_nfs_service_is_stop(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "STOPPED", results.text
 
@@ -1179,18 +1149,15 @@ def test_53_set_bind_ip():
 
 
 def test_54_disable_nfs_service_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
     results = PUT("/service/id/nfs/", {"enable": False})
     assert results.status_code == 200, results.text
 
 
 def test_55_checking_nfs_disable_at_boot(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET("/service?service=nfs")
     assert results.json()[0]['enable'] is False, results.text
 
 
 def test_56_destroying_smb_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text

--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -17,14 +17,12 @@ dataset_url = test1_dataset.replace("/", "%2F")
 
 
 def test_01_verify_default_acltype_from_pool_dataset_with_api(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET(f'/pool/dataset/id/{pool_name}/')
     assert results.status_code == 200, results.text
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
 def test_02_verify_default_acltype_from_pool_dataset_with_zfs_get(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     cmd = f"zfs get acltype {pool_name}"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -32,7 +30,6 @@ def test_02_verify_default_acltype_from_pool_dataset_with_zfs_get(request):
 
 
 def test_03_create_test1_dataset_to_verify_inherit_parent_acltype(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': test1_dataset
@@ -42,14 +39,12 @@ def test_03_create_test1_dataset_to_verify_inherit_parent_acltype(request):
 
 
 def test_04_verify_test1_dataset_inherited_parent_acltype_with_api(request):
-    depends(request, ["pool_04"], scope="session")
     results = GET(f'/pool/dataset/id/{dataset_url}/')
     assert results.status_code == 200, results.text
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
 def test_05_verify_test1_dataset_inherited_parent_acltype_with_zfs_get(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     cmd = f"zfs get acltype {test1_dataset}"
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -57,7 +52,6 @@ def test_05_verify_test1_dataset_inherited_parent_acltype_with_zfs_get(request):
 
 
 def test_06_change_acltype_to_nfsv4(request):
-    depends(request, ["pool_04"], scope="session")
     result = PUT(
         f'/pool/dataset/id/{dataset_url}/', {
             'acltype': 'NFSV4',
@@ -84,7 +78,6 @@ def test_06_change_acltype_to_nfsv4(request):
 
 
 def test_07_reset_acltype_to_posix(request):
-    depends(request, ["pool_04"], scope="session")
     result = PUT(
         f'/pool/dataset/id/{dataset_url}/', {
             'acltype': 'POSIX',
@@ -112,6 +105,5 @@ def test_07_reset_acltype_to_posix(request):
 
 
 def test_08_delete_test1_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     results = DELETE(f'/pool/dataset/id/{test1_dataset.replace("/", "%2F")}/')
     assert results.status_code == 200, results.text

--- a/tests/api2/test_341_pool_dataset_encryption.py
+++ b/tests/api2/test_341_pool_dataset_encryption.py
@@ -28,7 +28,6 @@ child_dataset_url = child_dataset.replace('/', '%2F')
 
 @pytest.mark.dependency(name="CREATED_POOL")
 def test_create_a_normal_pool(request):
-    depends(request, ['pool_04'], scope='session')
     global pool_id, pool_disks
     # Get one disk for encryption testing
     pool_disks = [POST('/disk/get_unused/', controller_a=ha).json()[0]['name']]
@@ -69,7 +68,6 @@ def test_create_a_passphrase_encrypted_root_on_normal_pool(request):
 
 
 def test_verify_pool_dataset_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -183,7 +181,6 @@ def test_try_to_create_an_encrypted_dataset_with_inherit_encryption_true(request
 
 
 def test_verify_pool_encrypted_dataset_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -242,7 +239,6 @@ def test_create_an_encrypted_root_with_a_key(request):
 
 
 def test_verify_pool_encrypted_root_dataset_does_not_leak_encryption_key_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -288,7 +284,6 @@ def test_verify_that_the_dataset_changed_to_passphrase(request):
 
 
 def test_verify_pool_dataset_change_key_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -462,7 +457,6 @@ def test_create_a_passphrase_encrypted_pool(request):
 
 
 def test_verify_pool_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_pool_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -494,7 +488,6 @@ def test_create_a_passphrase_encrypted_root_on_passphrase_encrypted_pool(request
 
 
 def test_verify_pool_encrypted_root_dataset_change_key_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -516,7 +509,6 @@ def test_try_to_change_a_passphrase_encrypted_root_to_key_on_passphrase_encrypte
 
 
 def test_verify_pool_dataset_change_key_does_not_leak_passphrase_into_middleware_log_after_key_change(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -574,7 +566,6 @@ def test_try_to_create_an_encrypted_root_with_key_on_passphrase_encrypted_pool(r
 
 
 def test_verify_pool_key_encrypted_dataset_does_not_leak_encryption_key_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -620,7 +611,6 @@ def test_creating_a_key_encrypted_pool(request):
 
 
 def test_verify_pool_does_not_leak_encryption_key_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{pool_token_hex}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -650,7 +640,6 @@ def test_creating_a_key_encrypted_root_on_key_encrypted_pool(request):
 
 
 def test_verify_pool_dataset_does_not_leak_encryption_hex_key_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -672,7 +661,6 @@ def test_change_a_key_encrypted_root_to_passphrase_on_key_encrypted_pool(request
 
 
 def test_verify_pool_encrypted_root_key_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -750,7 +738,6 @@ def test_unlock_passphrase_key_encrypted_datasets(request):
 
 
 def test_verify_pool_dataset_unlock_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -834,7 +821,6 @@ def test_create_a_passphrase_encrypted_root_dataset_parrent(request):
 
 
 def test_verify_pool_passphrase_encrypted_root_dataset_parrent_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -855,7 +841,6 @@ def test_create_a_passphrase_encrypted_root_child_of_passphrase_parent(request):
 
 
 def test_verify_encrypted_root_child_of_passphrase_parent_dataset_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase2" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -951,7 +936,6 @@ def test_try_to_unlock_the_child_of_lock_parent_encrypted_root(request):
 
 
 def test_verify_child_of_lock_parent_encrypted_root_dataset_unlock_do_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase2" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -1004,7 +988,6 @@ def test_unlock_parent_dataset_with_child_recursively(request):
 
 
 def test_verify_pool_dataset_unlock_with_child_dataset_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -1091,7 +1074,6 @@ def test_creating_a_key_encrypted_dataset_on_key_encrypted_pool(request):
 
 
 def test_verify_pool_encrypted_dataset_on_key_encrypted_pool_does_not_leak_encryption_key_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])
@@ -1112,7 +1094,6 @@ def test_create_a_passphrase_encrypted_root_from_key_encrypted_root(request):
 
 
 def test_verify_ncrypted_root_from_key_encrypted_root_does_not_leak_passphrase_into_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])

--- a/tests/api2/test_344_acl_templates.py
+++ b/tests/api2/test_344_acl_templates.py
@@ -22,7 +22,6 @@ def test_01_create_test_datasets(request, acltype):
     This test shouldn't fail unless pool.dataset endpoint is
     thoroughly broken.
     """
-    depends(request, ["pool_04"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': f'{pool_name}/acltemplate_{acltype.lower()}',

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -173,7 +173,6 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_DATASET,
@@ -367,7 +366,7 @@ We first create a child dataset to verify that ACLs do not change unless
 
 
 def test_12_prepare_recursive_tests(request):
-    depends(request, ["HAS_NFS4_ACLS", "ssh_password"], scope="session")
+    depends(request, ["HAS_NFS4_ACLS"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_SUBDATASET,
@@ -585,7 +584,7 @@ def test_21_creating_shareuser_to_test_acls(request):
 
 @pytest.mark.dependency(name="HAS_TESTFILE")
 def test_22_prep_testfile(request):
-    depends(request, ["ACL_USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["ACL_USER_CREATED"], scope="session")
     cmd = f'touch /mnt/{ACLTEST_DATASET}/acltest.txt'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -622,7 +621,7 @@ def test_23_test_acl_function_deny(perm, request):
     acltest user, then attempt to perform an action that
     should result in failure.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
 
     if perm == "FULL_DELETE":
         to_deny = {"DELETE_CHILD": True, "DELETE": True}
@@ -720,7 +719,7 @@ def test_24_test_acl_function_allow(perm, request):
     acltest user, then attempt to perform an action that
     should result in success.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
 
     """
     Some extra permissions bits must be set for these tests
@@ -815,7 +814,7 @@ def test_25_test_acl_function_omit(perm, request):
     on presence of the particular permissions bit. Then we omit
     it. This should result in a failure.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09", "ssh_password"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
 
     """
     Some extra permissions bits must be set for these tests
@@ -900,7 +899,7 @@ def test_25_test_acl_function_allow_restrict(perm, request):
     they grant no more permissions than intended. Some bits cannot
     be tested in isolation effectively using built in utilities.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
 
     """
     Some extra permissions bits must be set for these tests
@@ -1010,7 +1009,7 @@ def test_26_file_execute_deny(request):
     Base permset with everyone@ FULL_CONTROL, but ace added on
     top explictly denying EXECUTE. Attempt to execute file should fail.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
     payload_acl = [
         {
             "tag": "USER",
@@ -1059,7 +1058,7 @@ def test_27_file_execute_allow(request):
     READ_ATTRIBUTES are also granted beecause we need to be able to
     stat and read our test script.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
     payload_acl = [
         {
             "tag": "USER",
@@ -1111,7 +1110,7 @@ def test_28_file_execute_omit(request):
     Grant user all permissions except EXECUTE. Attempt to execute
     file should fail.
     """
-    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "ssh_password", "acl_pool_perm_09"], scope="session")
+    depends(request, ["ACL_USER_CREATED", "HAS_TESTFILE", "acl_pool_perm_09"], scope="session")
     payload_acl = [
         {
             "tag": "USER",
@@ -1164,7 +1163,6 @@ def test_29_deleting_homedir_user(request):
 
 
 def test_30_delete_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(
         f'/pool/dataset/id/{dataset_url}/'
     )

--- a/tests/api2/test_347_posix_mode.py
+++ b/tests/api2/test_347_posix_mode.py
@@ -52,7 +52,6 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': MODE_DATASET
@@ -98,7 +97,7 @@ def test_04_verify_setting_mode_bits_nonrecursive(request, mode_bit):
 
 @pytest.mark.dependency(name="RECURSIVE_PREPARED")
 def test_05_prepare_recursive_tests(request):
-    depends(request, ["IS_TRIVIAL", "ssh_password"], scope="session")
+    depends(request, ["IS_TRIVIAL"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': MODE_SUBDATASET
@@ -361,7 +360,7 @@ def test_11_test_directory_owner_bits_function_allow(mode_bit, request):
     In case of directory, Execute must be set concurrently with write
     in order to verify correct write behavior.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
     if new_mode == stat.S_IWUSR:
         new_mode |= stat.S_IXUSR
@@ -392,7 +391,7 @@ def test_12_test_directory_group_bits_function_allow(mode_bit, request):
     In case of directory, Execute must be set concurrently with write
     in order to verify correct write behavior.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
     if new_mode == stat.S_IWGRP:
         new_mode |= stat.S_IXGRP
@@ -423,7 +422,7 @@ def test_13_test_directory_other_bits_function_allow(mode_bit, request):
     In case of directory, Execute must be set concurrently with write
     in order to verify correct write behavior.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
     if new_mode == stat.S_IWOTH:
         new_mode |= stat.S_IXOTH
@@ -448,7 +447,7 @@ def test_13_test_directory_other_bits_function_allow(mode_bit, request):
 
 
 def test_14_setup_file_test(request):
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     result = POST(
         '/filesystem/setperm/', {
             'path': f'/mnt/{MODE_DATASET}',
@@ -472,7 +471,7 @@ def test_15_test_file_owner_bits_function_allow(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
 
     result = POST(
@@ -499,7 +498,7 @@ def test_16_test_file_group_bits_function_allow(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
 
     result = POST(
@@ -526,7 +525,7 @@ def test_17_test_file_other_bits_function_allow(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = MODE[mode_bit]
 
     result = POST(
@@ -553,7 +552,7 @@ def test_18_test_file_owner_bits_xor(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
     new_mode = new_mode ^ MODE[mode_bit]
 
@@ -581,7 +580,7 @@ def test_19_test_file_group_bits_xor(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
     new_mode = new_mode ^ MODE[mode_bit]
 
@@ -609,7 +608,7 @@ def test_20_test_file_other_bits_xor(mode_bit, request):
     """
     Verify mode behavior correct when it's the only bit set.
     """
-    depends(request, ["USER_CREATED", "ssh_password"], scope="session")
+    depends(request, ["USER_CREATED"], scope="session")
     new_mode = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
     new_mode = new_mode ^ MODE[mode_bit]
 

--- a/tests/api2/test_348_posix_acl.py
+++ b/tests/api2/test_348_posix_acl.py
@@ -78,7 +78,6 @@ def test_01_check_dataset_endpoint():
 
 @pytest.mark.dependency(name="DATASET_CREATED")
 def test_02_create_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_DATASET,
@@ -355,7 +354,7 @@ We first create a child dataset to verify that ACLs do not change unless
 
 
 def test_12_prepare_recursive_tests(request):
-    depends(request, ["HAS_POSIX_ACLS", "ssh_password"], scope="session")
+    depends(request, ["HAS_POSIX_ACLS"], scope="session")
     result = POST(
         '/pool/dataset/', {
             'name': ACLTEST_SUBDATASET,
@@ -533,7 +532,6 @@ def test_20_delete_child_dataset(request):
 
 
 def test_30_delete_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(
         f'/pool/dataset/id/{DATASET_URL}/'
     )

--- a/tests/api2/test_350_pool_dataset_quota_alert.py
+++ b/tests/api2/test_350_pool_dataset_quota_alert.py
@@ -56,7 +56,6 @@ G = 1024 * 1024 * 1024
     ),
 ])
 def test_dataset_quota_alert(request, datasets, expected_alerts):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     assert "" in datasets
 
     try:

--- a/tests/api2/test_360_pool_scrub.py
+++ b/tests/api2/test_360_pool_scrub.py
@@ -13,7 +13,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_01_create_scrub_for_same_pool(request):
-    depends(request, ["pool_04"], scope="session")
     global pool_id
     pool_id = GET(f"/pool/?name={pool_name}").json()[0]["id"]
     result = POST("/pool/scrub/", {
@@ -35,7 +34,6 @@ def test_01_create_scrub_for_same_pool(request):
 
 
 def test_02_get_pool_name_scrub_id(request):
-    depends(request, ["pool_04"], scope="session")
     global scrub_id
     result = GET(f"/pool/scrub/?pool_name={pool_name}")
     assert result.status_code == 200, result.text
@@ -43,7 +41,6 @@ def test_02_get_pool_name_scrub_id(request):
 
 
 def test_03_update_scrub(request):
-    depends(request, ["pool_04"], scope="session")
     result = PUT(f"/pool/scrub/id/{scrub_id}/", {
         "pool": pool_id,
         "threshold": 2,
@@ -61,13 +58,11 @@ def test_03_update_scrub(request):
 
 
 def test_04_delete_scrub(request):
-    depends(request, ["pool_04"], scope="session")
     result = DELETE(f"/pool/scrub/id/{scrub_id}/")
     assert result.status_code == 200, result.text
 
 
 def test_05_create_scrub(request):
-    depends(request, ["pool_04"], scope="session")
     result = POST("/pool/scrub/", {
         "pool": pool_id,
         "threshold": 1,

--- a/tests/api2/test_370_replication.py
+++ b/tests/api2/test_370_replication.py
@@ -37,7 +37,6 @@ def periodic_snapshot_tasks():
 
 
 def test_00_bootstrap(request, credentials, periodic_snapshot_tasks):
-    depends(request, ["pool_04"], scope="session")
     for plugin in ["replication", "pool/snapshottask"]:
         for i in GET(f"/{plugin}/").json():
             assert DELETE(f"/{plugin}/id/{i['id']}").status_code == 200
@@ -222,7 +221,6 @@ def test_00_bootstrap(request, credentials, periodic_snapshot_tasks):
      "periodic_snapshot_tasks.1"),
 ])
 def test_create_replication(request, credentials, periodic_snapshot_tasks, req, error):
-    depends(request, ["pool_04"], scope="session")
     if "ssh_credentials" in req:
         req["ssh_credentials"] = credentials["id"]
 

--- a/tests/api2/test_377_reporting.py
+++ b/tests/api2/test_377_reporting.py
@@ -35,7 +35,6 @@ def test_cputemp():
 
 
 def test_reporting_still_working_after_the_system_dataset_changes(request, reporing_data):
-    depends(request, ["pool_04"], scope="session")
 
     pool_disk = [POST('/disk/get_unused/').json()[0]['name']]
     payload = {

--- a/tests/api2/test_380_rsync.py
+++ b/tests/api2/test_380_rsync.py
@@ -26,7 +26,6 @@ def test_03_create_root_ssh_key(request):
 
 
 def test_04_Creating_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
     payload = {
         'user': 'root',
         'mode': 'SSH',
@@ -43,35 +42,31 @@ def test_04_Creating_rsync_task(request, rsynctask_dict):
 
 
 def test_10_Disable_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
     id = rsynctask_dict['id']
     results = PUT(f'/rsynctask/id/{id}/', {'enabled': False})
     assert results.status_code == 200, results.text
 
 
 def test_11_Check_that_API_reports_the_rsync_task_as_disabled(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
     id = rsynctask_dict['id']
     results = GET(f'/rsynctask?id={id}')
     assert results.json()[0]['enabled'] is False
 
 
 def test_12_Delete_rsync_task(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
     id = rsynctask_dict['id']
     results = DELETE(f'/rsynctask/id/{id}/')
     assert results.status_code == 200, results.text
 
 
 def test_13_Check_that_the_API_reports_rsync_task_as_deleted(request, rsynctask_dict):
-    depends(request, ["pool_04"], scope="session")
     id = rsynctask_dict['id']
     results = GET(f'/rsynctask?id={id}')
     assert results.json() == [], results.text
 
 
 def test_14_remove_root_ssh_key(request):
-    depends(request, ["pool_04", "ssh_key"], scope="session")
+    depends(request, ["ssh_key"], scope="session")
     cmd = 'rm /root/.ssh/id_rsa*'
     results = SSH_TEST(cmd, user, None, ip)
     assert results['result'] is True, results['output']

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -62,7 +62,7 @@ def test_001_setting_auxilary_parameters_for_mount_smbfs(request):
 
 @pytest.mark.dependency(name="create_dataset")
 def test_002_creating_smb_dataset(request):
-    depends(request, ["pool_04", "smb_001"], scope="session")
+    depends(request, ["smb_001"], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB",
@@ -125,7 +125,7 @@ def test_010_checking_to_see_if_nfs_service_is_running(request):
 
 
 def test_011_verify_smbclient_127_0_0_1_connection(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = 'smbclient -NL //127.0.0.1'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -193,7 +193,6 @@ def test_019_change_sharing_smd_home_to_true_and_set_guestok_to_false(request):
 
 
 def test_020_verify_smbclient_127_0_0_1_nt_status_access_is_denied(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = 'smbclient -NL //127.0.0.1'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, results['output']
@@ -201,7 +200,7 @@ def test_020_verify_smbclient_127_0_0_1_nt_status_access_is_denied(request):
 
 
 def test_021_verify_smb_getparm_path_homes(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = 'midclt call smb.getparm path homes'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -275,7 +274,7 @@ def test_035_verify_that_timemachine_is_true(request):
 
 @pytest.mark.parametrize('vfs_object', ["fruit", "streams_xattr"])
 def test_036_verify_smb_getparm_vfs_objects_share(request, vfs_object):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = f'midclt call smb.getparm "vfs objects" {SMB_NAME}'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -283,7 +282,7 @@ def test_036_verify_smb_getparm_vfs_objects_share(request, vfs_object):
 
 
 def test_037_verify_smb_getparm_fruit_time_machine_is_yes(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = f'midclt call smb.getparm "fruit:time machine" {SMB_NAME}'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -325,7 +324,7 @@ def test_040_verify_that_recyclebin_is_true(request):
 
 @pytest.mark.parametrize('vfs_object', ["recycle"])
 def test_041_verify_smb_getparm_vfs_objects_share(request, vfs_object):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = f'midclt call smb.getparm "vfs objects" {SMB_NAME}'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -374,7 +373,7 @@ def test_042_recyclebin_functional_test(request):
 
 @windows_host_cred
 def test_047_create_a_dir_and_a_file_in_windows(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd1 = 'mkdir testdir'
     results = SSH_TEST(cmd1, WIN_USERNAME, WIN_PASSWORD, WIN_HOST)
     assert results['result'] is True, results['output']
@@ -393,7 +392,7 @@ def test_047_create_a_dir_and_a_file_in_windows(request):
 
 @windows_host_cred
 def test_048_mount_the_smb_share_robocopy_testdir_to_the_share_windows_mount(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     # sleep 61 second to make sure that
     sleep(61)
     script = '@echo on\n'
@@ -453,7 +452,7 @@ def test_050_verify_testfile_is_on_recycle_bin_in_the_active_directory_share(req
 
 @windows_host_cred
 def test_051_delete_the_test_dir_and_a_file_in_windows(request):
-    depends(request, ["service_cifs_running", "ssh_password"], scope="session")
+    depends(request, ["service_cifs_running"], scope="session")
     cmd = 'rmdir /S /Q testdir'
     results = SSH_TEST(cmd, WIN_USERNAME, WIN_PASSWORD, WIN_HOST)
     assert results['result'] is True, results['output']
@@ -508,7 +507,7 @@ def test_057_create_new_smb_group_for_sid_test(request):
     Create testgroup and verify that groupmap entry generated
     with new SID.
     """
-    depends(request, ["SID_CHANGED", "ssh_password"], scope="session")
+    depends(request, ["SID_CHANGED"], scope="session")
     global group_id
     payload = {
         "name": "testsidgroup",
@@ -540,7 +539,7 @@ def test_058_change_netbios_name_and_check_groupmap(request):
     Verify that changes to netbios name result in groupmap sid
     changes.
     """
-    depends(request, ["SID_CHANGED", "ssh_password"], scope="session")
+    depends(request, ["SID_CHANGED"], scope="session")
     payload = {
         "netbiosname": old_netbiosname,
     }

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -102,7 +102,6 @@ SMB_PWD = "smb1234"
 
 @pytest.mark.dependency(name="SMB_DATASET_CREATED")
 def test_001_creating_smb_dataset(request):
-    depends(request, ["pool_04"], scope="session")
     payload = {
         "name": dataset,
         "share_type": "SMB"
@@ -604,7 +603,7 @@ def test_151_set_xattr_via_ssh(request, xat):
     Iterate through AFP xattrs and set them on testfile
     via SSH.
     """
-    depends(request, ["AFP_ENABLED", "ssh_password"], scope="session")
+    depends(request, ["AFP_ENABLED"], scope="session")
     afptestfile = f'{smb_path}/afp_xattr_testfile'
     cmd = f'touch {afptestfile} && chown {SMB_USER} {afptestfile} && '
     cmd += f'echo -n \"{AFPXattr[xat]["text"]}\" | base64 -d | '
@@ -678,7 +677,7 @@ def test_155_ssh_read_afp_xattr(request, xat):
     Read xattr that was set via SMB protocol directly via
     SSH and verify that data is the same.
     """
-    depends(request, ["XATTR_CHECK_SMB_WRITE", "ssh_password"], scope="session")
+    depends(request, ["XATTR_CHECK_SMB_WRITE"], scope="session")
     # Netatalk-compatible xattr gets additional
     # metadata written to it, which makes comparison
     # of all bytes problematic.

--- a/tests/api2/test_426_smb_vss.py
+++ b/tests/api2/test_426_smb_vss.py
@@ -114,7 +114,6 @@ def check_previous_version_contents(path, contents, offset):
 @pytest.mark.parametrize('ds', [dataset, dataset_nested])
 @pytest.mark.dependency(name="VSS_DATASET_CREATED")
 def test_001_creating_smb_dataset(request, ds):
-    depends(request, ["pool_04"], scope="session")
     payload = {
         "name": ds,
         "share_type": "SMB"
@@ -166,7 +165,7 @@ def test_003_changing_dataset_owner(request):
 
 @pytest.mark.dependency(name="VSS_SHARE_CREATED")
 def test_004_creating_a_smb_share_path(request):
-    depends(request, ["VSS_DATASET_CREATED", "ssh_password"], scope="session")
+    depends(request, ["VSS_DATASET_CREATED"], scope="session")
     global payload, results, smb_id
     payload = {
         "comment": "SMB VSS Testing Share",

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -163,7 +163,7 @@ def test_003_test_perms(request):
     correct NT ACL bit gets toggled when viewed through SMB
     protocol.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED"], scope="session")
 
     ds = 'nfs4acl_perms_smb'
     path = f'/mnt/{pool_name}/{ds}'
@@ -196,7 +196,7 @@ def test_004_test_flags(request):
     correct NT ACL bit gets toggled when viewed through SMB
     protocol.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED"], scope="session")
 
     ds = 'nfs4acl_flags_smb'
     path = f'/mnt/{pool_name}/{ds}'
@@ -228,7 +228,7 @@ def test_005_test_map_modify(request):
     grants an access mask equaivalent to MODIFY or FULL depending on whether it's
     the file owner or group / other.
     """
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED"], scope="session")
 
     ds = 'nfs4acl_map_modify'
     path = f'/mnt/{pool_name}/{ds}'
@@ -244,7 +244,7 @@ def test_005_test_map_modify(request):
 
 
 def test_006_test_preserve_dynamic_id_mapping(request):
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED"], scope="session")
     def _find_owner_rights(acl):
         for entry in acl:
             if 'owner rights' in entry['who']:
@@ -291,7 +291,7 @@ def test_006_test_preserve_dynamic_id_mapping(request):
 
 
 def test_007_test_disable_autoinherit(request):
-    depends(request, ["SMB_SERVICE_STARTED", "pool_04"], scope="session")
+    depends(request, ["SMB_SERVICE_STARTED"], scope="session")
     ds = 'nfs4acl_disable_inherit'
     path = f'/mnt/{pool_name}/{ds}'
     with create_dataset(f'{pool_name}/{ds}', {'share_type': 'SMB'}):

--- a/tests/api2/test_430_smb_sharesec.py
+++ b/tests/api2/test_430_smb_sharesec.py
@@ -103,14 +103,14 @@ def test_07_set_smb_acl_by_unix_id(request):
 
 
 def test_24_delete_share_info_tdb(request):
-    depends(request, ["sharesec_acl_set", "ssh_password"], scope="session")
+    depends(request, ["sharesec_acl_set"], scope="session")
     cmd = 'rm /var/db/system/samba4/share_info.tdb'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
 
 
 def test_25_verify_share_info_tdb_is_deleted(request):
-    depends(request, ["sharesec_acl_set", "ssh_password"], scope="session")
+    depends(request, ["sharesec_acl_set"], scope="session")
     cmd = 'test -f /var/db/system/samba4/share_info.tdb'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, results['output']
@@ -124,7 +124,7 @@ def test_25_verify_share_info_tdb_is_deleted(request):
 
 
 def test_27_restore_sharesec_with_flush_share_info(request):
-    depends(request, ["sharesec_acl_set", "ssh_password"], scope="session")
+    depends(request, ["sharesec_acl_set"], scope="session")
     cmd = 'midclt call smb.sharesec._flush_share_info'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -138,7 +138,7 @@ def test_27_restore_sharesec_with_flush_share_info(request):
 
 
 def test_29_verify_share_info_tdb_is_created(request):
-    depends(request, ["sharesec_acl_set", "ssh_password"], scope="session")
+    depends(request, ["sharesec_acl_set"], scope="session")
     cmd = 'test -f /var/db/system/samba4/share_info.tdb'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -146,7 +146,7 @@ def test_29_verify_share_info_tdb_is_created(request):
 
 @pytest.mark.dependency(name="sharesec_rename")
 def test_30_rename_smb_share_and_verify_share_info_moved(request):
-    depends(request, ["sharesec_acl_set", "ssh_password"], scope="session")
+    depends(request, ["sharesec_acl_set"], scope="session")
     results = PUT(f"/sharing/smb/id/{share_info['id']}/",
                   {"name": "my_sharesec2"})
     assert results.status_code == 200, results.text
@@ -161,7 +161,7 @@ def test_30_rename_smb_share_and_verify_share_info_moved(request):
 
 
 def test_31_toggle_share_and_verify_acl_preserved(request):
-    depends(request, ["sharesec_rename", "ssh_password"], scope="session")
+    depends(request, ["sharesec_rename"], scope="session")
 
     results = PUT(f"/sharing/smb/id/{share_info['id']}/",
                   {"enabled": False})

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -56,7 +56,6 @@ SAMPLE_AUX = [
 
 @pytest.mark.dependency(name="SMB_DATASET_CREATED")
 def test_001_creating_smb_DATASET(request):
-    depends(request, ["pool_04"], scope="session")
     payload = {
         "name": DATASET,
         "share_type": "SMB"
@@ -117,7 +116,7 @@ def test_004_creating_a_smb_share_path(request, smb_share):
 
 
 def test_005_shares_in_registry(request):
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -140,7 +139,7 @@ def test_007_renamed_shares_in_registry(request):
     it will actually result in share being removed from
     registry and re-added with different name.
     """
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -164,7 +163,7 @@ def test_008_test_presets(request, preset):
     be reflected in returned auxsmbconf and so we'll need
     to directly reach out and run smb.getparm.
     """
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     global DETECTED_PRESETS
     if not DETECTED_PRESETS:
         results = GET("/sharing/smb/presets")
@@ -212,7 +211,7 @@ def test_009_reset_smb(request):
 
 
 def test_010_test_aux_param_on_update(request):
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     results = GET(
         '/sharing/smb', payload={
             'query-filters': [['id', '=', SHARE_DICT["REGISTRYTEST_0"]]],
@@ -283,7 +282,7 @@ def test_010_test_aux_param_on_update(request):
 
 
 def test_011_test_aux_param_on_create(request):
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     smb_share = "AUX_CREATE"
 
     target = f'{SMB_PATH}/{smb_share}'
@@ -369,7 +368,7 @@ def test_012_delete_shares(request, smb_share):
 
 
 def test_013_registry_is_empty(request):
-    depends(request, ["SHARES_CREATED", "ssh_password"], scope="session")
+    depends(request, ["SHARES_CREATED"], scope="session")
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -426,7 +425,7 @@ def test_016_verify_homeshare_in_registry(request):
     share was added to the configuration with the
     correct name.
     """
-    depends(request, ["HOME_SHARE_CREATED", "ssh_password"], scope="session")
+    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     has_homes_share = False
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
@@ -455,7 +454,7 @@ def test_018_verify_non_home_share_in_registry(request):
     definition being removed and replaced with a new share
     name.
     """
-    depends(request, ["HOME_SHARE_CREATED", "ssh_password"], scope="session")
+    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     has_homes_share = False
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
@@ -484,7 +483,7 @@ def test_020_verify_homeshare_in_registry(request):
     a "homes" share reverts us to having a proper
     share definition for this special behavior.
     """
-    depends(request, ["HOME_SHARE_CREATED", "ssh_password"], scope="session")
+    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     has_homes_share = False
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
@@ -506,7 +505,7 @@ def test_021_registry_has_single_entry(request):
     definition has switched several times. This test
     verifies that we're properly removing the old share.
     """
-    depends(request, ["HOME_SHARE_CREATED", "ssh_password"], scope="session")
+    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     cmd = 'midclt call sharing.smb.reg_listshares'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
@@ -523,7 +522,7 @@ def test_022_registry_rebuild_homes(request):
     method is called (among other places) when the CIFS
     service reloads.
     """
-    depends(request, ["HOME_SHARE_CREATED", "ssh_password"], scope="session")
+    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     cmd = 'net conf delshare HOMES'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']

--- a/tests/api2/test_438_snapshots.py
+++ b/tests/api2/test_438_snapshots.py
@@ -231,7 +231,6 @@ def test_01_snapshot_query_filter_dataset_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-name", ['name'])
 
 def test_02_snapshot_query_filter_dataset_props_createtxg(request):
@@ -240,7 +239,6 @@ def test_02_snapshot_query_filter_dataset_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_03_snapshot_query_filter_dataset_props_name_createtxg(request):
@@ -249,7 +247,6 @@ def test_03_snapshot_query_filter_dataset_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -259,7 +256,6 @@ def test_04_snapshot_query_filter_dataset_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_dataset("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])
@@ -363,7 +359,6 @@ def test_05_snapshot_query_filter_snapshot_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-name", ['name'])
 
 def test_06_snapshot_query_filter_snapshot_props_createtxg(request):
@@ -372,7 +367,6 @@ def test_06_snapshot_query_filter_snapshot_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_07_snapshot_query_filter_snapshot_props_name_createtxg(request):
@@ -381,7 +375,6 @@ def test_07_snapshot_query_filter_snapshot_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -391,7 +384,6 @@ def test_08_snapshot_query_filter_snapshot_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_snapshot("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])
@@ -492,7 +484,6 @@ def test_09_snapshot_query_filter_pool_props_name(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-name", ['name'])
 
 def test_10_snapshot_query_filter_pool_props_createtxg(request):
@@ -501,7 +492,6 @@ def test_10_snapshot_query_filter_pool_props_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['createtxg'])
 
 def test_11_snapshot_query_filter_pool_props_name_createtxg(request):
@@ -510,7 +500,6 @@ def test_11_snapshot_query_filter_pool_props_name_createtxg(request):
 
     The results should be simple (fast-path) without 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-name-createtxg", ['name', 'createtxg'])
     _test_simple_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg-name", ['createtxg', 'name'])
 
@@ -520,7 +509,6 @@ def test_12_snapshot_query_filter_pool_props_used(request):
 
     The results should be regular (NON fast-path) query that returns 'properties'.
     """
-    depends(request, ["pool_04"], scope="session")
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used'])
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used', 'name'])
     _test_full_snapshot_query_filter_pool("ds-snapshot-simple-query-createtxg", ['used', 'name', 'createtxg'])

--- a/tests/api2/test_439_snapshottask_retention.py
+++ b/tests/api2/test_439_snapshottask_retention.py
@@ -20,7 +20,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_change_retention(request):
-    depends(request, ["pool_04"], scope="session")
 
     tz = pytz.timezone(call("system.info")["timezone"])
 
@@ -98,7 +97,6 @@ def test_change_retention(request):
 
 
 def test_delete_retention(request):
-    depends(request, ["pool_04"], scope="session")
 
     tz = pytz.timezone(call("system.info")["timezone"])
 

--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -34,7 +34,6 @@ def test_02_Enable_SNMP_service_at_boot():
 
 
 def test_03_verify_snmp_do_not_leak_password_in_middleware_log(request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f"""grep -R "{PASSWORD}" /var/log/middlewared.log"""
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, str(results['output'])

--- a/tests/api2/test_450_staticroutes.py
+++ b/tests/api2/test_450_staticroutes.py
@@ -42,7 +42,6 @@ def test_02_check_staticroute_configured_using_api(sr_dict):
 
 
 def test_03_checking_staticroute_configured_using_ssh(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password, ip)
     assert results['result'] is True, results
     assert results['output'].strip().split()[1] == GATEWAY, results
@@ -62,6 +61,5 @@ def test_05_check_staticroute_unconfigured_using_api(sr_dict):
 
 
 def test_06_checking_staticroute_unconfigured_using_ssh(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password, ip)
     assert results['result'] is False, results

--- a/tests/api2/test_480_system_advanced.py
+++ b/tests/api2/test_480_system_advanced.py
@@ -54,7 +54,6 @@ def test_04_system_advanced_check_serial_port_using_api(sysadv_dict):
 
 
 def test_05_system_advanced_check_serial_port_using_ssh(sysadv_dict, request):
-    depends(request, ["ssh_password"], scope="session")
     cmd = f'systemctl | grep "{sysadv_dict["serial_choices"][0]}"'
     results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results
@@ -70,7 +69,6 @@ def test_06_system_advanced_disable_serial_port():
 
 
 def test_07_system_advanced_check_disabled_serial_port_using_ssh(sysadv_dict, request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'cat /boot/loader.conf.local | grep "{sysadv_dict["serial_choices"][0]}"', user, password, ip)
     assert results['result'] is False, results
 
@@ -93,7 +91,6 @@ def test_09_system_advanced_check_motd_using_api():
 
 
 def test_10_system_advanced_check_motd_using_ssh(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'cat /etc/motd | grep "{MOTD}"', user, password, ip)
     assert results['result'] is True, results
 

--- a/tests/api2/test_490_system_general.py
+++ b/tests/api2/test_490_system_general.py
@@ -65,7 +65,6 @@ def test_07_Checking_timezone_using_api():
 
 
 def test_08_Checking_timezone_using_ssh(request):
-    depends(request, ["ssh_password"], scope="session")
     results = SSH_TEST(f'diff /etc/localtime /usr/share/zoneinfo/{TIMEZONE}',
                        user, password, ip)
     assert results['result'] is True, results

--- a/tests/api2/test_500_system_ntpservers.py
+++ b/tests/api2/test_500_system_ntpservers.py
@@ -66,7 +66,6 @@ class TestBadNtpServer:
         assert data[0]['address'] == badNtpServer, data
 
     def test_03_Checking_ntpserver_configured_using_ssh(self, request):
-        depends(request, ["ssh_password"], scope="session")
         cmd = f'fgrep "{badNtpServer}" {CONFIG_FILE}'
         results = SSH_TEST(cmd, user, password, ip)
         assert results['result'] is True, results
@@ -90,7 +89,6 @@ class TestBadNtpServer:
             ntp_dict['servers'].pop(k)
 
     def test_06_Checking_ntpservers_num_configured_using_ssh(self, ntp_dict, request):
-        depends(request, ["ssh_password"], scope="session")
         results = SSH_TEST(f'grep -R ^server {CONFIG_FILE}', user, password, ip)
         assert results['result'] is True, results
         assert len(results['output'].strip().split('\n')) == \

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -31,7 +31,6 @@ def data():
 
 
 def test_01_vm_disk_choices(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1024000}) as ds:
         results = GET('/vm/device/disk_choices')
         assert isinstance(results.json(), dict), results.json()
@@ -99,7 +98,6 @@ if support_virtualization:
 
     @pytest.mark.dependency(name='DISK_CDROM_DATASET')
     def test_10_create_dataset_for_disk_and_cdrom(request):
-        depends(request, ["pool_04"], scope="session")
         results = POST("/pool/dataset/", payload={"name": DISK_DATASET})
         assert results.status_code == 200, results.text
 

--- a/tests/api2/test_550_vmware.py
+++ b/tests/api2/test_550_vmware.py
@@ -40,7 +40,6 @@ if vmw_credentials:
         assert isinstance(results.json(), list) is True, results.text
 
     def test_03_verify_vmware_get_datastore_do_not_leak_password(request):
-        depends(request, ["ssh_password"], scope="session")
         cmd = f"grep -R \"{os.environ['VMWARE_PASSWORD']}\" " \
             "/var/log/middlewared.log"
         results = SSH_TEST(cmd, user, password, ip)

--- a/tests/api2/test_790_update.py
+++ b/tests/api2/test_790_update.py
@@ -17,7 +17,6 @@ url = "https://raw.githubusercontent.com/iXsystems/ixbuild/master/prepnode/"
 
 if update:
     def test_00_get_update_conf_for_internals_and_nightly(request):
-        depends(request, ["ssh_password"], scope="session")
         version = GET("/system/info/").json()['version']
         update_conf = 'truenas-update.conf'
         fetch_cmd = f'fetch {url}{update_conf}'

--- a/tests/api2/test_900_docs.py
+++ b/tests/api2/test_900_docs.py
@@ -16,6 +16,5 @@ pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_core_get_methods(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
     results = SSH_TEST("midclt call core.get_methods", user, password, ip)
     assert results['result'] is True, results

--- a/tests/api2/test_999_pool_dataset_unlock.py
+++ b/tests/api2/test_999_pool_dataset_unlock.py
@@ -120,7 +120,7 @@ def smb_connection(**kwargs):
 @pytest.mark.dependency(name="create_dataset")
 @pytest.mark.parametrize("toggle_attachments", [True, False])
 def test_pool_dataset_unlock_smb(request, toggle_attachments):
-    depends(request, ["pool_04", "smb_001", "ssh_password"], scope="session")
+    depends(request, ["smb_001"], scope="session")
     # Prepare test SMB share
     with dataset("normal") as normal:
         with smb_share("normal", f"/mnt/{normal}"):

--- a/tests/api2/test_alert_classes.py
+++ b/tests/api2/test_alert_classes.py
@@ -39,7 +39,6 @@ def test__nonexisting_alert_class():
 
 
 def test__disable_proactive_support_for_valid_alert_class(request):
-    depends(request, ["pool_04"], scope="session")
     call("alertclasses.update", {
         "classes": {
             "ZpoolCapacityNotice": {
@@ -50,7 +49,6 @@ def test__disable_proactive_support_for_valid_alert_class(request):
 
 
 def test__disable_proactive_support_for_invalid_alert_class(request):
-    depends(request, ["pool_04"], scope="session")
     with pytest.raises(ValidationErrors) as ve:
         call("alertclasses.update", {
             "classes": {

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -34,7 +34,6 @@ def user():
 
 
 def test_root_api_key_websocket(request):
-    depends(request, ["ssh_password"], scope="session")
     """We should be able to call a method with root API key using Websocket."""
     with api_key([{"method": "*", "resource": "*"}]) as key:
         with user():
@@ -45,7 +44,6 @@ def test_root_api_key_websocket(request):
 
 
 def test_allowed_api_key_websocket(request):
-    depends(request, ["ssh_password"], scope="session")
     """We should be able to call a method with API key that allows that call using Websocket."""
     with api_key([{"method": "CALL", "resource": "system.info"}]) as key:
         with user():
@@ -56,7 +54,6 @@ def test_allowed_api_key_websocket(request):
 
 
 def test_denied_api_key_websocket(request):
-    depends(request, ["ssh_password"], scope="session")
     """We should not be able to call a method with API key that does not allow that call using Websocket."""
     with api_key([{"method": "CALL", "resource": "system.info_"}]) as key:
         with user():

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -16,7 +16,6 @@ CHILD_DATASET = f'{PARENT_DATASET}/child_dataset'
 
 
 def test_attachment_with_child_path(request):
-    depends(request, ['pool_04'], scope='session')
     with dataset(PARENT_DATASET) as parent_dataset:
         parent_path = f'/mnt/{parent_dataset}'
         assert call('pool.dataset.attachments_with_path', parent_path) == []

--- a/tests/api2/test_cloud_sync.py
+++ b/tests/api2/test_cloud_sync.py
@@ -20,7 +20,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_include(request):
-    depends(request, ["pool_04"], scope="session")
     with local_ftp_task({
         "include": ["/office/**", "/work/**"],
     }) as task:
@@ -38,7 +37,6 @@ def test_include(request):
 
 
 def test_exclude_recycle_bin(request):
-    depends(request, ["pool_04"], scope="session")
     with local_ftp_task({
         "exclude": ["$RECYCLE.BIN/"],
     }) as task:
@@ -56,7 +54,6 @@ def test_exclude_recycle_bin(request):
 @pytest.mark.parametrize("defaultroot", [True, False])
 @pytest.mark.parametrize("has_leading_slash", [True, False])
 def test_ftp_subfolder(request, anonymous, defaultroot, has_leading_slash):
-    depends(request, ["pool_04"], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         config = {"defaultroot": defaultroot}
         with (anonymous_ftp_server if anonymous else ftp_server_with_user_account)(config) as ftp:
@@ -100,7 +97,6 @@ def test_ftp_subfolder(request, anonymous, defaultroot, has_leading_slash):
 
 @pytest.mark.parametrize("has_zvol_sibling", [True, False])
 def test_snapshot(request, has_zvol_sibling):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test") as ds:
         ssh(f"mkdir -p /mnt/{ds}/dir1/dir2")
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/dir1/dir2/blob bs=1M count=1")
@@ -133,7 +129,6 @@ def test_snapshot(request, has_zvol_sibling):
 
 
 def test_sync_onetime(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         with local_ftp_credential() as c:
             call("cloudsync.sync_onetime", {
@@ -148,7 +143,6 @@ def test_sync_onetime(request):
 
 
 def test_abort(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test") as ds:
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/blob bs=1M count=1")
 
@@ -180,7 +174,6 @@ def test_abort(request):
 @pytest.mark.flaky(reruns=5, reruns_delay=5)
 @pytest.mark.parametrize("create_empty_src_dirs", [True, False])
 def test_create_empty_src_dirs(request, create_empty_src_dirs):
-    depends(request, ["pool_04"], scope="session")
     with dataset("cloudsync_local") as local_dataset:
         ssh(f"mkdir /mnt/{local_dataset}/empty-dir")
         ssh(f"mkdir /mnt/{local_dataset}/non-empty-dir")

--- a/tests/api2/test_cloud_sync_config.py
+++ b/tests/api2/test_cloud_sync_config.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(dev_test, reason=reason)
 
 
 def test_rclone_config_writer_bool(request):
-    #depends(request, ["pool_04"], scope="session")
+    #
     with dataset("test") as ds:
         with credential({
             "name": "Google Cloud Storage",

--- a/tests/api2/test_cloud_sync_custom_s3.py
+++ b/tests/api2/test_cloud_sync_custom_s3.py
@@ -30,7 +30,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason=reason)
     )
 ])
 def test_custom_s3(request, credential_attributes, result):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test") as ds:
         with credential({
             "name": "S3",

--- a/tests/api2/test_cloudsync_storj.py
+++ b/tests/api2/test_cloudsync_storj.py
@@ -73,7 +73,6 @@ def test_storj_list_directory(storj_credential):
 
 
 def test_storj_sync(request, storj_credential):
-    depends(request, ["pool_04"], scope="session")
 
     with dataset("test") as ds:
         with task({

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -44,7 +44,6 @@ def lock_dataset(dataset_name):
 
 
 def test_service_restart_on_unlock_dataset(request):
-    depends(request, ['pool_04'], scope='session')
     service_name = 'smb'
     registered_name = 'cifs'
     with dataset('testsvcunlock', data={

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -25,7 +25,6 @@ def iscsi_extent(data):
 
 
 def test__iscsi_extent__disk_choices(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,
@@ -54,7 +53,6 @@ def test__iscsi_extent__disk_choices(request):
 
 
 def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,
@@ -73,7 +71,6 @@ def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
 
 
 def test__iscsi_extent__locked(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test zvol", {
         "type": "VOLUME",
         "volsize": 1024000,

--- a/tests/api2/test_kubernetes_passthrough_test.py
+++ b/tests/api2/test_kubernetes_passthrough_test.py
@@ -19,7 +19,6 @@ APP_NAME = 'syncthing'
 
 @pytest.mark.dependency(name='default_kubernetes_cluster')
 def test_01_default_kubernetes_cluster(request):
-    depends(request, ['pool_04'], scope='session')
     config = call('kubernetes.update', {'passthrough_mode': False, 'pool': pool_name}, job=True)
     assert config['passthrough_mode'] is False
 

--- a/tests/api2/test_pool_dataset_set_quota.py
+++ b/tests/api2/test_pool_dataset_set_quota.py
@@ -19,7 +19,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
     (["GROUPOBJ", "groupobj quota on gid"]),
 ])
 def test_errors(request, id, quota_type, error):
-    depends(request, ["pool_04"], scope="session")
     with dataset("test") as ds:
         with pytest.raises(ValidationErrors) as ve:
             call("pool.dataset.set_quota", ds, [{"quota_type": quota_type, "id": id, "quota_value": 5242880}])

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -43,7 +43,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
     ),
 ])
 def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
-    depends(request, ["pool_04"], scope="session")
     with contextlib.ExitStack() as stack:
         for name, data in datasets:
             stack.enter_context(dataset(name, data))

--- a/tests/api2/test_pool_export.py
+++ b/tests/api2/test_pool_export.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_systemdataset_migrate_error(request):
-    depends(request, ["pool_04"], scope="session")
     """
     On HA this test will fail with the error below if failover is enable:
     [ENOTSUP] Disable failover before exporting last pool on system.

--- a/tests/api2/test_replication.py
+++ b/tests/api2/test_replication.py
@@ -56,7 +56,6 @@ def test_query_attachment_delegate(ssh_credentials, data, path, include):
 
 @pytest.mark.parametrize("exclude_mountpoint_property", [True, False])
 def test_run_onetime__exclude_mountpoint_property(request, exclude_mountpoint_property):
-    depends(request, ["pool_04"], scope="session")
     with dataset("src") as src:
         with dataset("src/legacy") as src_legacy:
             ssh(f"zfs set mountpoint=legacy {src_legacy}")

--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -31,5 +31,4 @@ def localhost_ssh_connection():
 
 @pytest.mark.parametrize("transport", ["SSH", "SSH+NETCAT"])
 def test_list_datasets_ssh(request, localhost_ssh_connection, transport):
-    depends(request, ["pool_04"], scope="session")
     assert pool in call("replication.list_datasets", transport, localhost_ssh_connection)

--- a/tests/api2/test_snapshot_count_alert.py
+++ b/tests/api2/test_snapshot_count_alert.py
@@ -9,7 +9,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test_snapshot_total_count_alert(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("snapshot_count") as ds:
         base = call("zfs.snapshot.query", [], {"count": True})
         with mock("pool.snapshottask.max_total_count", return_value=base + 10):
@@ -30,7 +29,6 @@ def test_snapshot_total_count_alert(request):
 
 
 def test_snapshot_count_alert(request):
-    depends(request, ["pool_04"], scope="session")
     with dataset("snapshot_count") as ds:
         with mock("pool.snapshottask.max_count", return_value=10):
             for i in range(10):

--- a/tests/api2/test_system_dataset.py
+++ b/tests/api2/test_system_dataset.py
@@ -27,7 +27,6 @@ def write_to_log(string):
 
 
 def test_system_dataset_migrate(request):
-    depends(request, ["pool_04"], scope="session")
 
     config = call("systemdataset.config")
     assert config["pool"] == pool
@@ -48,7 +47,6 @@ def test_system_dataset_migrate(request):
 
 @pytest.mark.parametrize("lock", [False, True])
 def test_migrate_to_a_pool_with_passphrase_encrypted_root_dataset(request, lock):
-    depends(request, ["pool_04"], scope="session")
 
     config = call("systemdataset.config")
     assert config["pool"] == pool
@@ -68,7 +66,6 @@ def test_migrate_to_a_pool_with_passphrase_encrypted_root_dataset(request, lock)
 
 
 def test_lock_passphrase_encrypted_pool_with_system_dataset(request):
-    depends(request, ["pool_04"], scope="session")
 
     with another_pool({"encryption": True, "encryption_options": {"passphrase": "passphrase"}}):
         call("systemdataset.update", {"pool": "test"}, job=True)

--- a/tests/api2/test_zpool_capacity_alert.py
+++ b/tests/api2/test_zpool_capacity_alert.py
@@ -8,7 +8,6 @@ pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development 
 
 
 def test__does_not_emit_alert(request):
-    depends(request, ["pool_04"], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,
@@ -23,7 +22,6 @@ def test__does_not_emit_alert(request):
 
 
 def test__emits_alert(request):
-    depends(request, ["pool_04"], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,
@@ -42,7 +40,6 @@ def test__emits_alert(request):
 
 
 def test__does_not_flap_alert(request):
-    depends(request, ["pool_04"], scope="session")
     with mock("zfs.pool.query", return_value=[
         {
             "name": pool,


### PR DESCRIPTION
I sped up the full CI run by over 2hrs! But I did it in an unexpected way :(. The "pool_04" string has been hard-coded everywhere in our test modules. Investigating this a bit further, we’ve decided to abort the entire CI session if we fail to create the zpool. This allows us to remove the pytest_dependency dance that we have to perform (which is inefficient and doesn’t scale). We’re doing the same for the “ssh_password” dependency as well.