### PR TITLE
NAS-122456 / 22.12.3.1 / Properly mark a PCI device as critical (by Qubad786) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -98,7 +98,7 @@ class VMDeviceService(Service):
                 'vendor': 'Not Available',
             },
             'controller_type': controller_type,
-            'critical': (k.lower() in controller_type.lower() for k in SENSITIVE_PCI_DEVICE_TYPES),
+            'critical': any(k.lower() in controller_type.lower() for k in SENSITIVE_PCI_DEVICE_TYPES),
             'iommu_group': {},
             'available': False,
             'drivers': [],

--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -12,7 +12,7 @@ from .utils import get_virsh_command_args, SENSITIVE_PCI_DEVICE_TYPES
 
 RE_DEVICE_PATH = re.compile(r'pci_(\w+)_(\w+)_(\w+)_(\w+)')
 RE_IOMMU_ENABLED = re.compile(r'QEMU.*if IOMMU is enabled.*:\s*PASS.*')
-RE_PCI_CONTROLLER_TYPE = re.compile(r'^[\w:.]+\s+([\w\s]+)\s+\[')
+RE_PCI_CONTROLLER_TYPE = re.compile(r'^[\w:.]+\s+([\w\s-]+)\s+\[')
 RE_PCI_NAME = re.compile(r'^([\w:.]+)\s+')
 
 
@@ -98,7 +98,9 @@ class VMDeviceService(Service):
                 'vendor': 'Not Available',
             },
             'controller_type': controller_type,
-            'critical': any(k.lower() in controller_type.lower() for k in SENSITIVE_PCI_DEVICE_TYPES),
+            'critical': any(
+                not controller_type or k.lower() in controller_type.lower() for k in SENSITIVE_PCI_DEVICE_TYPES
+            ),
             'iommu_group': {},
             'available': False,
             'drivers': [],


### PR DESCRIPTION
## Problem

If a PCI device has any controller type which we deem as sensitive to system's functionality, we mark the PCI device as critical but  we are not properly marking it as critical right now.

## Solution

Properly mark a PCI device as critical as we were missing `any` keyword to do that.

Original PR: https://github.com/truenas/middleware/pull/11501
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122456

Original PR: https://github.com/truenas/middleware/pull/11514
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122456