### PR TITLE
NAS-122264 / 23.10 / Duplicate LUN ID for an iSCSI Target

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -22,14 +22,13 @@ sys.path.append(apifolder)
 
 from auto_config import dev_test, ha, hostname, isns_ip, pool_name
 from functions import DELETE, GET, POST, PUT
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.utils import call
 from protocols import (initiator_name_supported, iscsi_scsi_connection,
                        isns_connection)
 
 from assets.REST.pool import dataset
 from assets.REST.snapshot import snapshot, snapshot_rollback
-from middlewared.test.integration.utils import call
-from middlewared.service_exception import ValidationErrors
-
 
 if ha and "virtual_ip" in os.environ:
     ip = os.environ["virtual_ip"]

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -1175,7 +1175,7 @@ def test_14_target_lun_extent_modify(request, extent_type):
     Perform some tests of the iscsi.targetextent.update API, including
     trying tp provide invalid
     """
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
 
     name1 = f'{target_name}1'
     name2 = f'{target_name}2'
@@ -1328,7 +1328,7 @@ def test_15_test_isns(request):
     """
     # Will use a more unique target name than usual, just in case several test
     # runs are hitting the same iSNS server at the same time.
-    depends(request, ["pool_04", "iscsi_cmd_00"], scope="session")
+    depends(request, ["iscsi_cmd_00"], scope="session")
     _host = socket.gethostname()
     _rand = ''.join(random.choices(string.digits + string.ascii_lowercase, k=12))
     _name_base = f'isnstest:{_host}:{_rand}'


### PR DESCRIPTION
Enhance `validate` routine for _iscsi.targetextent_:

- Now throw an error on LUN clash whether the LUNID or target has changed.
- Also throw an error if the extent is currently used in any target.

Add `test_14_target_lun_extent_modify` for _iscsi.targetextent_ operations

- Refactor `initiator_portal` out of `configured_target_to_file_extent` and `configured_target_to_zvol_extent` to facilitate their reuse (and the reuse of `configured_target`).  This is useful here, but will also be useful in future tests.

Renumber tests