### PR TITLE
NAS-122504 / 23.10 / Add raise_connect_error option to failover.call_remote

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -251,7 +251,8 @@ class ValidationErrors(ClientException):
 
 
 class CallTimeout(ClientException):
-    pass
+    def __init__(self):
+        super().__init__("Call timeout", errno.ETIMEDOUT)
 
 
 class Client:
@@ -486,7 +487,7 @@ class Client:
 
         try:
             if not c.returned.wait(timeout):
-                raise CallTimeout("Call timeout", errno.ETIMEDOUT)
+                raise CallTimeout()
 
             if c.errno:
                 if c.py_exception:

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -265,7 +265,7 @@ class DiskService(Service, ServiceChangeMixin):
             # entire database to the remote node after we're done. The (potential) speed
             # improvement this provides is substantial
             try:
-                self.middleware.call_sync('failover.datastore.send')
+                self.middleware.call_sync('failover.datastore.send', [], {'raise_connect_error': False})
             except Exception:
                 self.logger.warning('Unexpected failure syncing database to standby controller', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -426,7 +426,8 @@ class FailoverService(ConfigService):
         result = {'missing_local': list(), 'missing_remote': list()}
         if (ld := await self.get_disks_local()) is not None:
             try:
-                rd = await self.middleware.call('failover.call_remote', 'failover.get_disks_local')
+                rd = await self.middleware.call('failover.call_remote', 'failover.get_disks_local', [],
+                                                {'raise_connect_error': False})
             except Exception:
                 self.logger.error('Unhandled exception in get_disks_local on remote controller', exc_info=True)
             else:
@@ -1254,7 +1255,7 @@ async def service_remote(middleware, service, verb, options):
     try:
         await middleware.call('failover.call_remote', 'core.bulk', [
             f'service.{verb}', [[service, options]]
-        ])
+        ], {'raise_connect_error': False})
     except Exception:
         middleware.logger.warning('Failed to run %s(%s)', verb, service, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -737,17 +737,17 @@ class FailoverEventsService(Service):
 
         logger.info('Syncing encryption keys from MASTER node (if any)')
         try:
-            self.run_call('failover.call_remote', 'failover.sync_keys_to_remote_node')
+            self.run_call('failover.call_remote', 'failover.sync_keys_to_remote_node', [],
+                          {'raise_connect_error': False})
         except Exception:
             logger.warning('Unhandled exception syncing keys from MASTER node', exc_info=True)
 
         try:
-            self.run_call('failover.call_remote', 'interface.persist_link_addresses')
-        except Exception as e:
-            ignore = (errno.ECONNRESET, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-            if isinstance(e, CallError) and e.errno not in ignore:
-                logger.warning('Unhandled exception persisting network interface link addresses on MASTER node',
-                               exc_info=True)
+            self.run_call('failover.call_remote', 'interface.persist_link_addresses', [],
+                          {'raise_connect_error': False})
+        except Exception:
+            logger.warning('Unhandled exception persisting network interface link addresses on MASTER node',
+                           exc_info=True)
 
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -157,7 +157,8 @@ class PoolService(Service):
 
             if await self.middleware.call('failover.licensed'):
                 try:
-                    await self.middleware.call('failover.call_remote', 'disk.retaste')
+                    await self.middleware.call('failover.call_remote', 'disk.retaste', [],
+                                               {'raise_connect_error': False})
                 except Exception:
                     self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -464,7 +464,7 @@ class PoolService(CRUDService):
         await self.middleware.call('pool.format_disks', job, disks)
         if is_ha:
             try:
-                await self.middleware.call('failover.call_remote', 'disk.retaste')
+                await self.middleware.call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
             except Exception:
                 self.logger.warning('Failed to retaste disks on standby controller', exc_info=True)
 


### PR DESCRIPTION
Add `raise_connect_error` boolean option to `failover.call_remote`. If this is set to false, then it will not raise an exception of the remote call fails in a known way (i.e. standby node is rebooting/upgrading/heartbeat issue/etc). Defaults to true otherwise.