### PR TITLE
NAS-122495 / 22.12.4 / download update file once on HA systems (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -698,14 +698,10 @@ class FailoverService(ConfigService):
 
             self.middleware.call_sync('keyvalue.set', 'HA_UPGRADE', True)
 
-            if not options['resume']:
-                self.middleware.call_sync('failover.call_remote', 'update.destroy_upload_location')
-                remote_path = self.middleware.call_sync('failover.call_remote', 'update.create_upload_location')
-            else:
-                remote_path = self.middleware.call_sync('failover.call_remote', 'update.get_upload_location')
+            remote_path = self.middleware.call_sync('failover.call_remote', 'update.get_update_location')
 
-            if not options['resume'] and updatefile:
-                # means update file was provided to us so send it to the standby
+            if not options['resume']:
+                # Replicate uploaded or downloaded update it to the standby
                 job.set_progress(None, 'Sending files to Standby Controller')
                 token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
                 for f in os.listdir(local_path):


### PR DESCRIPTION
On an HA system, download the update file once (on the active controller) and then send that file to the other controller via the heartbeat interface. This prevents the standby from downloading the same files off the network.

Original PR: https://github.com/truenas/middleware/pull/11533
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122495