### PR TITLE
NAS-122512 / 22.12.4 / Only send the necessary update file to the standby controller (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -22,6 +22,7 @@ from middlewared.utils.contextlib import asyncnullcontext
 from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE, ZPOOL_CACHE_FILE_OVERWRITE
 from middlewared.plugins.failover_.configure import HA_LICENSE_CACHE_KEY
 from middlewared.plugins.update_.install import STARTING_INSTALLER
+from middlewared.plugins.update_.utils import DOWNLOAD_UPDATE_FILE
 
 ENCRYPTION_CACHE_LOCK = asyncio.Lock()
 
@@ -704,13 +705,16 @@ class FailoverService(ConfigService):
                 # Replicate uploaded or downloaded update it to the standby
                 job.set_progress(None, 'Sending files to Standby Controller')
                 token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
-                for f in os.listdir(local_path):
-                    self.middleware.call_sync(
-                        'failover.send_file',
-                        token,
-                        os.path.join(local_path, f),
-                        os.path.join(remote_path, f)
-                    )
+                if updatefile:
+                    f = updatefile_name
+                else:
+                    f = DOWNLOAD_UPDATE_FILE
+                self.middleware.call_sync(
+                    'failover.send_file',
+                    token,
+                    os.path.join(local_path, f),
+                    os.path.join(remote_path, f)
+                )
 
             local_version = self.middleware.call_sync('system.version')
             remote_version = self.middleware.call_sync('failover.call_remote', 'system.version')

--- a/src/middlewared/middlewared/plugins/update_/download.py
+++ b/src/middlewared/middlewared/plugins/update_/download.py
@@ -12,7 +12,7 @@ from middlewared.service import CallError, private, Service
 from middlewared.utils import osc
 from middlewared.utils.size import format_size
 
-from .utils import scale_update_server
+from .utils import DOWNLOAD_UPDATE_FILE, scale_update_server
 
 
 class UpdateService(Service):
@@ -22,7 +22,7 @@ class UpdateService(Service):
 
         train_check = self.middleware.call_sync("update.check_train", train)
         if train_check["status"] == "AVAILABLE":
-            dst = os.path.join(location, "update.sqsh")
+            dst = os.path.join(location, DOWNLOAD_UPDATE_FILE)
             if os.path.exists(dst):
                 job.set_progress(0, "Verifying existing update")
                 if osc.IS_FREEBSD:

--- a/src/middlewared/middlewared/plugins/update_/pending_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/pending_linux.py
@@ -5,7 +5,7 @@ import subprocess
 
 from middlewared.service import private, Service
 
-from .utils import SCALE_MANIFEST_FILE
+from .utils import SCALE_MANIFEST_FILE, DOWNLOAD_UPDATE_FILE
 from .utils_linux import mount_update
 
 run_kw = dict(check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8", errors="ignore")
@@ -14,14 +14,14 @@ run_kw = dict(check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encodi
 class UpdateService(Service):
     @private
     def get_pending_in_path(self, path):
-        if not os.path.exists(os.path.join(path, "update.sqsh")):
+        if not os.path.exists(os.path.join(path, DOWNLOAD_UPDATE_FILE)):
             return []
 
         with open(SCALE_MANIFEST_FILE) as f:
             old_manifest = json.load(f)
 
         try:
-            with mount_update(os.path.join(path, "update.sqsh")) as mounted:
+            with mount_update(os.path.join(path, DOWNLOAD_UPDATE_FILE)) as mounted:
                 with open(os.path.join(mounted, "manifest.json")) as f:
                     new_manifest = json.load(f)
         except Exception:

--- a/src/middlewared/middlewared/plugins/update_/utils.py
+++ b/src/middlewared/middlewared/plugins/update_/utils.py
@@ -6,6 +6,8 @@ import re
 DEFAULT_SCALE_UPDATE_SERVER = "https://update.ixsystems.com/scale"
 SCALE_MANIFEST_FILE = "/data/manifest.json"
 
+DOWNLOAD_UPDATE_FILE = "update.sqsh"
+
 UPLOAD_LOCATION = "/var/tmp/firmware"
 
 SEP = re.compile(r"[-.]")


### PR DESCRIPTION
Before these changes, this failed with the following error:
```
....
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1425, in call_sync
    return methodobj(*prepared_call.args)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/remote.py", line 269, in send_file
    self.CLIENT.send_file(token, src, dst)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/remote.py", line 180, in send_file
    raise CallError(
middlewared.service_exception.CallError: [EFAULT] Failed to send /var/db/system/update/updatefile.sqsh to Standby Controller: [Errno 28] No space left on device.
```

This is because we were sending the downloaded update file and the manual update file to the remote path which is tmpfs. The remote path is on tmpfs on HA systems and so it ran out of space. This changes it to only send the necessary file to remote side.

Original PR: https://github.com/truenas/middleware/pull/11540
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122512