### PR TITLE
NAS-122511 / 22.12.3.1 / Better progress report for failover upgrade (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -724,21 +724,24 @@ class FailoverService(ConfigService):
             remote_version = self.middleware.call_sync('failover.call_remote', 'system.version')
 
             local_started_installer = False
-            update_remote_descr = update_local_descr = 'Starting upgrade'
+            local_progress = remote_progress = 0
+            local_descr = remote_descr = 'Starting upgrade'
 
             def callback(j, controller):
-                nonlocal local_started_installer, update_local_descr, update_remote_descr
+                nonlocal local_started_installer, local_progress, remote_progress, local_descr, remote_descr
                 if controller == 'LOCAL' and j['progress']['description'] == STARTING_INSTALLER:
                     local_started_installer = True
-                if j['state'] != 'RUNNING':
+                if j['state'] not in ['RUNNING', 'SUCCESS']:
                     return
                 if controller == 'LOCAL':
-                    update_local_descr = f'{int(j["progress"]["percent"])}%: {j["progress"]["description"]}'
+                    local_progress = j["progress"]["percent"]
+                    local_descr = f'{int(j["progress"]["percent"])}%: {j["progress"]["description"]}'
                 else:
-                    update_remote_descr = f'{int(j["progress"]["percent"])}%: {j["progress"]["description"]}'
+                    remote_progress = j["progress"]["percent"]
+                    remote_descr = f'{int(j["progress"]["percent"])}%: {j["progress"]["description"]}'
                 job.set_progress(
-                    None,
-                    f'Active Controller: {update_local_descr}\n' + f'Standby Controller: {update_remote_descr}'
+                    min(local_progress, remote_progress),
+                    f'Active Controller: {local_descr}\n' + f'Standby Controller: {remote_descr}'
                 )
 
             if updatefile:


### PR DESCRIPTION
This improves the progress reporting when upgrading an HA system. Instead of showing 0% for the entire process, it'll update accordingly.

Original PR: https://github.com/truenas/middleware/pull/11541
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122511