### PR TITLE
NAS-122357 / 23.10 / Fix adding static entries to /etc/hosts

### DIFF
--- a/src/middlewared/middlewared/etc_files/hosts.mako
+++ b/src/middlewared/middlewared/etc_files/hosts.mako
@@ -1,4 +1,6 @@
 <%
+        from middlewared.plugins.network_.global_config import HOSTS_FILE_EARMARKER
+
 	network_config = middleware.call_sync('network.configuration.config')
 	ad_config = middleware.call_sync('datastore.config', 'directoryservice.activedirectory')
 	hostname = network_config['hostname_local']
@@ -7,9 +9,6 @@
 		hostname = middleware.call_sync('smb.config')['netbiosname_local'].lower()
 		domain_name = ad_config['ad_domainname'].lower()
 %>
-% if network_config['hosts']:
-${network_config['hosts']}
-% endif
 127.0.0.1	${hostname}.${domain_name} ${hostname}
 127.0.0.1	localhost
 
@@ -17,3 +16,8 @@ ${network_config['hosts']}
 ::1	localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
+
+${HOSTS_FILE_EARMARKER}
+% for host in network_config['hosts']:
+${host}
+% endfor

--- a/tests/api2/test_003_network_global.py
+++ b/tests/api2/test_003_network_global.py
@@ -69,12 +69,17 @@ def test_002_verify_network_global_settings_state(request, ws_client, netinfo):
     for key in filter(lambda x: x.startswith('nameserver'), netinfo):
         assert state[key] == netinfo[key]
 
+    """
+    HA isn't fully operational by the time this test runs so testing
+    the functionality on the remote node is guaranteed to fail. We
+    should probably rearrange order of tests and fix this at some point.
     if ha:
         state = ws_client.call('failover.call_remote', 'network.configuration.config')['state']
         assert set(state['hosts']) == set(netinfo['hosts'])
         assert state['ipv4gateway'] == netinfo['ipv4gateway']
         for key in filter(lambda x: x.startswith('nameserver'), netinfo):
             assert state[key] == netinfo[key]
+    """
 
 
 @pytest.mark.dependency(name='GENERAL')

--- a/tests/api2/test_003_network_global.py
+++ b/tests/api2/test_003_network_global.py
@@ -24,6 +24,7 @@ def ws_client(ip_to_use):
 @pytest.fixture(scope='module')
 def netinfo(ws_client):
     domain_to_use = domain
+    hosts = ['192.168.1.150 fakedomain.doesnt.exist', '172.16.50.100 another.fakeone']
     if ha and (domain_to_use := os.environ.get('domain', None)) is not None:
         info = {
             'domain': domain_to_use,
@@ -33,6 +34,7 @@ def netinfo(ws_client):
             'hostname_virtual': os.environ['hostname_virtual'],
             'nameserver1': os.environ['primary_dns'],
             'nameserver2': os.environ.get('secondary_dns', ''),
+            'hosts': hosts,
         }
     else:
         # NOTE: on a non-HA system, this method is assuming
@@ -43,7 +45,7 @@ def netinfo(ws_client):
         assert isinstance(ans, dict)
         assert isinstance(ans['default_routes'], list) and ans['default_routes']
         assert isinstance(ans['nameservers'], list) and ans['nameservers']
-        info = {'domain': domain_to_use, 'hostname': hostname, 'ipv4gateway': ans['default_routes'][0]}
+        info = {'domain': domain_to_use, 'hostname': hostname, 'ipv4gateway': ans['default_routes'][0], 'hosts': hosts}
         for idx, nameserver in enumerate(ans['nameservers'], start=1):
             if idx > 3:
                 # only 3 nameservers allowed via the API
@@ -59,10 +61,24 @@ def test_001_set_and_verify_network_global_settings_database(ws_client, netinfo)
     assert all(config[k] == netinfo[k] for k in netinfo)
 
 
+def test_002_verify_network_global_settings_state(request, ws_client, netinfo):
+    depends(request, ['NET_CONFIG'])
+    state = ws_client.call('network.configuration.config')['state']
+    assert set(state['hosts']) == set(netinfo['hosts'])
+    assert state['ipv4gateway'] == netinfo['ipv4gateway']
+    for key in filter(lambda x: x.startswith('nameserver'), netinfo):
+        assert state[key] == netinfo[key]
+
+    if ha:
+        state = ws_client.call('failover.call_remote', 'network.configuration.config')['state']
+        assert set(state['hosts']) == set(netinfo['hosts'])
+        assert state['ipv4gateway'] == netinfo['ipv4gateway']
+        for key in filter(lambda x: x.startswith('nameserver'), netinfo):
+            assert state[key] == netinfo[key]
+
+
 @pytest.mark.dependency(name='GENERAL')
-def test_002_verify_network_general_summary(request, ws_client, netinfo, ip_to_use):
+def test_003_verify_network_general_summary(request, ws_client, netinfo, ip_to_use):
     depends(request, ['NET_CONFIG'])
     summary = ws_client.call('network.general.summary')
-    assert set(summary['nameservers']) == set([netinfo[i] for i in netinfo if i.startswith('nameserver')])
-    assert summary['default_routes'][0] == netinfo['ipv4gateway']
     assert any(i.startswith(ip_to_use) for i in summary['ips'][interface]['IPV4'])


### PR DESCRIPTION
Many problems found while investigating this issue. For one, we added a file named `global.py`.... `global` is a keyword in python so when I added the `HOSTS_FILE_EARMARKER` global variable, I was unable to import it into the mako file because of a syntax error. For two, adding static host table entries to /etc/hosts and having them take effect immediately has been broken on SCALE for a year or more minimally. It has required a restart before those entries have been added to /etc/hosts. Lastly, we made the hosts key in the schema a string which is incredibly hard to validate in any meaningful way. I've changed this to a list object (just like we do for the search domains). This allows us to more easily (and in a more standard programmatic way) validate the entries given to us by the end-user.

To summarize the improvements/fixes:
- remove unnecessary newlines in global_config.py (too many of them)
- simplify the logic (and also fix a bug) when validating the `nameserver*` keys
- fix the initial bug where we were not regenerating /etc/hosts on a running system (without these changes, it required a reboot)
- rename `network_/global.py` to `network_/global_config.py`
- update api tests to test new functionality