### PR TITLE
NAS-122548 / 23.10 / Fix KeyError in ACL validation

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -55,7 +55,7 @@ class ACLTemplateService(CRUDService):
             )
 
         for idx, ace in enumerate(data['acl']):
-            if ace['id'] is None:
+            if ace.get('id') is None:
                 verrors.add(f'{schema}.{idx}.id', 'null id is not permitted.')
 
     @accepts(Dict(


### PR DESCRIPTION
In some circumstances webui sends an invalid ACE that is missing the `id` key entirely. We need to properly handle this variety of malformed payload.