### PR TITLE
NAS-122548 / 22.12.4 / Fix KeyError in ACL validation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -55,7 +55,7 @@ class ACLTemplateService(CRUDService):
             )
 
         for idx, ace in enumerate(data['acl']):
-            if ace['id'] is None:
+            if ace.get('id') is None:
                 verrors.add(f'{schema}.{idx}.id', 'null id is not permitted.')
 
     @accepts(Dict(


### PR DESCRIPTION
In some circumstances webui sends an invalid ACE that is missing the `id` key entirely. We need to properly handle this variety of malformed payload.

Original PR: https://github.com/truenas/middleware/pull/11554
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122548