### PR TITLE
NAS-122551 / 23.10 / Fix failover.call_remote TypeError crash

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -263,15 +263,15 @@ class FailoverService(Service):
             `raise_connect_error`: If false, will not raise an exception if a connection error to the other node
                 happens, or connection/call timeout happens, or method does not exist on the remote node.
         """
-        options = options or {}
         if options.pop('job_return'):
             options['job'] = 'RETURN'
+        raise_connect_error = options.pop('raise_connect_error')
         try:
             return self.CLIENT.call(method, *args, **options)
         except ClientException as e:
             ignore = (errno.ETIMEDOUT, CallError.ENOMETHOD, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
             if e.errno in ignore:
-                if options['raise_connect_error']:
+                if raise_connect_error:
                     raise CallError(str(e), errno.EFAULT)
                 else:
                     self.logger.trace('Failed to call %r on remote node', method, exc_info=True)


### PR DESCRIPTION
```
  File "/usr/local/lib/python3.11/dist-packages/middlewared/plugins/failover_/remote.py", line 270, in call_remote
    return self.CLIENT.call(method, *args, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/middlewared/plugins/failover_/remote.py", line 128, in call
    return self.client.call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Client.call() got an unexpected keyword argument 'raise_connect_error'