### PR TITLE
NAS-122549 / 23.10 / fix typo in ipmi.sel.clear

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/sel.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/sel.py
@@ -79,6 +79,6 @@ class IpmiSelService(Service):
     @job(lock=SEL_LOCK, lock_queue_size=1)
     def clear(self, job):
         if self.middleware.call_sync('ipmi.is_loaded'):
-            cp = run(['ipmi-sel', '--clear'], check_output=True)
+            cp = run(['ipmi-sel', '--clear'], capture_output=True)
             if cp.returncode:
                 raise CallError(cp.stderr.decode().strip() or f'Unexpected failure with returncode: {cp.returncode!r}')


### PR DESCRIPTION
This fixes a typo in ipmi.sel.clear. Without the fix, it's impossible to clear the ipmi system event log.