### PR TITLE
Remove deprecated proftpd settings in CORE.

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/proftpd.conf
+++ b/src/middlewared/middlewared/etc_files/local/proftpd.conf
@@ -17,7 +17,6 @@ User nobody
 Group nogroup
 Umask ${ftp['filemask']} ${ftp['dirmask']}
 SyslogFacility ftp
-MultilineRFC2228 off
 DisplayLogin /var/run/proftpd/proftpd.motd
 DeferWelcome off
 TimeoutIdle ${ftp['timeout']}
@@ -130,7 +129,6 @@ UseReverseDNS ${'on' if ftp['reversedns'] else 'off'}
                     ('common_name_required', 'CommonNameRequired'),
                     ('enable_diags', 'EnableDiags'),
                     ('export_cert_data', 'ExportCertData'),
-                    ('no_cert_request', 'NoCertRequest'),
                     ('no_empty_fragments', 'NoEmptyFragments'),
                     ('no_session_reuse_required', 'NoSessionReuseRequired'),
                     ('stdenvvars', 'StdEnvVars'),

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -205,6 +205,9 @@ class FTPService(SystemServiceService):
         if new["masqaddress"]:
             await resolve_hostname(self.middleware, verrors, "ftp_update.masqaddress", new["masqaddress"])
 
+        if new["tls_opt_no_cert_request"]:
+            verrors.add("ftp_update.tls_opt_no_cert_request", "Setting is deprecated and cannot be set")
+
         if verrors:
             raise verrors
 


### PR DESCRIPTION
etc_files/local/proftpd.conf: 
    Remove MultilineRFC2228 and no_cert_request settings from the proftpd.conf mako file.
plugins/ftp.py: 
    Add validation check to block user setting no_cert_request.
tests/api2/test_200_ftp.py: 
    Add simple checks to confirm MultilineRFC2228 not preset and we block setting no_cert_request

No DB or API changes were made.