### PR TITLE
NAS-122594 / 23.10 / deepcopy `@cache`d function return value in case caller modifies it

### DIFF
--- a/src/middlewared/middlewared/utils/functools.py
+++ b/src/middlewared/middlewared/utils/functools.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import functools
 
 from middlewared.utils.lang import undefined
@@ -15,7 +16,7 @@ def cache(func):
             if value == undefined:
                 value = await func(self)
 
-            return value
+            return copy.deepcopy(value)
     else:
         @functools.wraps(func)
         def wrapped(self):
@@ -24,6 +25,6 @@ def cache(func):
             if value == undefined:
                 value = func(self)
 
-            return value
+            return copy.deepcopy(value)
 
     return wrapped


### PR DESCRIPTION
If the function that is being cached returns a mutable python object, then the caller of said function can alter the object. This will cause all other subsequent callers to receive the altered response.