### PR TITLE
NAS-122658 / 22.12.4 / Fix Slack HTML escaping for alerts (by jburianek)

### DIFF
--- a/src/middlewared/middlewared/alert/service/slack.py
+++ b/src/middlewared/middlewared/alert/service/slack.py
@@ -23,7 +23,7 @@ class SlackAlertService(ThreadedAlertService):
             self.attributes["url"],
             headers={"Content-type": "application/json"},
             data=json.dumps({
-                "text": html.escape(html2text.html2text(self._format_alerts(alerts, gone_alerts, new_alerts))),
+                "text": html.escape(html2text.html2text(self._format_alerts(alerts, gone_alerts, new_alerts)), quote=False),
             }),
             timeout=INTERNET_TIMEOUT,
         )


### PR DESCRIPTION
This fixes this formatting bug in alerts sent to Slack:
<img width="815" alt="Screen Shot 2023-06-27 at 12 11 42 AM" src="https://github.com/truenas/middleware/assets/6167384/6e417629-f15e-4230-a08c-255c37c3e3de">

The issue is that Slack only wants `&`, `<`, and `>` escaped, we shouldn't escape `"` nor `'`: https://api.slack.com/reference/surfaces/formatting#escaping

Original PR: https://github.com/truenas/middleware/pull/11580
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122658