### PR TITLE
Restore depends

### DIFF
--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -8,6 +8,7 @@ from time import sleep
 import pytest
 from pysnmp.hlapi import (CommunityData, ContextData, ObjectIdentity,
                           ObjectType, SnmpEngine, UdpTransportTarget, getCmd)
+from pytest_dependency import depends
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)


### PR DESCRIPTION
Restore the import of depends, removed during backport for NAS-122482.