### PR TITLE
NAS-122657 / 23.10 / Reset 2FA configuration for users when 2FA global configuration is changed

### DIFF
--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -79,7 +79,7 @@ class TwoFactorAuthService(ConfigService):
         config.update(data)
 
         if config == old_config:
-            return
+            return config
 
         if any(config[k] != old_config[k] for k in ['otp_digits', 'interval']):
             # Now we want to reset all the secrets for local/non-local users

--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -124,15 +124,19 @@ class TwoFactorAuthService(ConfigService):
             'datastore.query', 'account.twofactor_user_auth', [['secret', '!=', None]]
         ):
             username = None
+            ad_user = False
             if config['user']:
                 username = config['user']['bsdusr_username']
             elif user := mapping.get(config['user_sid']):
                 username = user['username']
+                ad_user = True
 
             if username:
                 users.append({
                     'username': username,
-                    'secret_hex': base64.b16encode(base64.b32decode(config['secret'])).decode()
+                    'secret_hex': base64.b16encode(base64.b32decode(config['secret'])).decode(),
+                    'row_id': config['id'],
+                    'ad_user': ad_user,
                 })
 
         return users


### PR DESCRIPTION
This PR adds changes to reset 2fa configured for users when 2fa global configuration changes because the secret generated for those users needs to be generated again.