### PR TITLE
NAS-122689 / 22.12.3.2 / Allow sysdataset move if AD faulted (by anodos325) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -222,7 +222,7 @@ class SystemDatasetService(ConfigService):
         verrors = ValidationErrors()
         if new['pool'] != config['pool']:
             system_ready = await self.middleware.call('system.ready')
-            ad_enabled = (await self.middleware.call('activedirectory.get_state')) in ['HEALTHY', 'FAULTED']
+            ad_enabled = (await self.middleware.call('activedirectory.get_state')) == 'HEALTHY'
             if system_ready and ad_enabled:
                 verrors.add(
                     'sysdataset_update.pool',


### PR DESCRIPTION
This has knock-on effects regarding failover when AD is broken. We should ensure that it's always possible to get system dataset set up, and in principle if AD join is already broken things can't really get worse by moving around the system dataset.

Original PR: https://github.com/truenas/middleware/pull/11598
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122689

Original PR: https://github.com/truenas/middleware/pull/11601
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122689