### PR TITLE
NAS-122754 / 23.10 / fix crash in ipmi.lan.update

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -116,7 +116,7 @@ class IPMILanService(CRUDService):
         rc = 0
         options = {'stdout': DEVNULL, 'stderr': DEVNULL}
         if data.get('dhcp'):
-            rc |= run(get_cmd(id, ['dhcp']), **options).returncode
+            rc |= run(get_cmd(['dhcp']), **options).returncode
         else:
             rc |= run(get_cmd(['ipsrc', 'static']), **options).returncode
             rc |= run(get_cmd(['ipaddr', data['ipaddress']]), **options).returncode


### PR DESCRIPTION
The inner function `get_cmd` takes a list of commands. When DHCP is passed in, it's passing more than 1 command which causes an error. Fix it by removing the `id` argument.