### PR TITLE
NAS-122331 / 22.12.4 / Fix VM dataset unlock test in bluefin

### DIFF
--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -26,7 +26,7 @@ def test_restart_vm_on_dataset_unlock(zvol):
         call("pool.dataset.lock", ds, job=True)
 
         if zvol:
-            device = {"dtype": "DISK", "attributes": {"path": f"/dev/zvol/{ds}/child"}}
+            device = {"dtype": "DISK", "attributes": {"path": f"/dev/zvol/{ds}"}}
         else:
             device = {"dtype": "RAW", "attributes": {"path": f"/mnt/{ds}/child"}}
 


### PR DESCRIPTION
## Context

VM unlock test had not been updated to reflect a bug fix test done which assessed children of a dataset correctly. In case of a zvol there is no child involved and the test will fail so the parameters have been updated accordingly to reflect the correct logic.