### PR TITLE
NAS-122782 / 23.10 / Remove hard-coded ctdb_shared_vol for glusterfs

### DIFF
--- a/cluster-tests/config.py
+++ b/cluster-tests/config.py
@@ -43,7 +43,7 @@ CLUSTER_LDAP = {
 }
 
 TIMEOUTS = {
-    'FUSE_OP_TIMEOUT': environ.get('FUSE_OP_TIMEOUT', 60),,
+    'FUSE_OP_TIMEOUT': environ.get('FUSE_OP_TIMEOUT', 60),
     'FAILOVER_WAIT_TIMEOUT': environ.get('FAILOVER_WAIT_TIMEOUT', 10),
     'MONITOR_TIMEOUT': environ.get('MONITOR_TIMEOUT', 20),
     'CTDB_IP_TIMEOUT': environ.get('CTDB_IP_TIMEOUT', 60),

--- a/cluster-tests/config.py
+++ b/cluster-tests/config.py
@@ -43,11 +43,11 @@ CLUSTER_LDAP = {
 }
 
 TIMEOUTS = {
-    'FUSE_OP_TIMEOUT': environ.get('FUSE_OP_TIMEOUT', 10),
+    'FUSE_OP_TIMEOUT': environ.get('FUSE_OP_TIMEOUT', 60),,
     'FAILOVER_WAIT_TIMEOUT': environ.get('FAILOVER_WAIT_TIMEOUT', 10),
     'MONITOR_TIMEOUT': environ.get('MONITOR_TIMEOUT', 20),
-    'CTDB_IP_TIMEOUT': environ.get('CTDB_IP_TIMEOUT', 20),
-    'VOLUME_TIMEOUT': environ.get('VOLUME_TIMEOUT', 120),
+    'CTDB_IP_TIMEOUT': environ.get('CTDB_IP_TIMEOUT', 60),
+    'VOLUME_TIMEOUT': environ.get('VOLUME_TIMEOUT', 600),
 }
 
 CLEANUP_TEST_DIR = 'tests/cleanup'

--- a/cluster-tests/init_gluster.py
+++ b/cluster-tests/init_gluster.py
@@ -136,7 +136,7 @@ def create_volume():
 
 
 def wait_on_ctdb():
-    assert ctdb_healthy(timeout=30), 'CTDB Not healthy after 30 seconds'
+    assert ctdb_healthy(timeout=300), 'CTDB Not healthy after 300 seconds'
 
 
 def add_public_ips_to_ctdb():

--- a/cluster-tests/utils.py
+++ b/cluster-tests/utils.py
@@ -50,7 +50,10 @@ def wait_on_job(_id, ip, timeout):
 
     url = f'http://{ip}/api/v2.0/core/get_jobs/?id={_id}'
     while timeout > 0:
-        job = make_request('get', url).json()[0]
+        res = make_request('get', url)
+        assert res.status_code == 200, job.text
+
+        job = res.json()[0]
         state = job['state']
         if state in ('RUNNING', 'WAITING'):
             time.sleep(1)

--- a/src/middlewared/middlewared/alert/source/ctdb.py
+++ b/src/middlewared/middlewared/alert/source/ctdb.py
@@ -39,6 +39,16 @@ class ClusteredClockAlertClass(AlertClass):
     text = "%(errmsg)s"
 
 
+class ClusteredConfigRedundancyAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.CLUSTERING
+    level = AlertLevel.WARNING
+    title = "Clustered configuration volume lacks adequate redundancy"
+    text = "%(errmsg)s"
+
+    async def delete(self, alerts, query):
+        return []
+
+
 class ClusteredClockOffsetAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(hours=1))
     run_on_backup_node = False

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -2,13 +2,10 @@ import ctdb
 import json
 import os
 
+from middlewared.plugins.cluster_linux.utils import CTDBConfig
 from middlewared.schema import Bool, Dict, Int, IPAddr, List, returns, Str
 from middlewared.service import CallError, Service, accepts, private, filterable
 from middlewared.utils import run, filter_list
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
-
-
-CTDB_VOL = CTDBConfig.CTDB_VOL_NAME.value
 
 
 class CtdbGeneralService(Service):
@@ -219,10 +216,15 @@ class CtdbGeneralService(Service):
         #           return bool(open('/file/on/disk', 'r').read())
         # or something...
         try:
+            with open(CTDBConfig.CTDB_VOL_INFO_FILE.value, 'r') as f:
+                ctdb_vol_config = json.loads(f.read())
+        except Exception:
+            return False
+        try:
             # gluster volume root has inode of 1.
             # if gluster isn't mounted it will be different
             # if volume is unhealthy this will fail
-            if os.stat(f'/cluster/{CTDB_VOL}').st_ino != 1:
+            if os.stat(f'/cluster/{ctdb_vol_config["volume_name"]}').st_ino != 1:
                 return False
         except Exception:
             return False

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -139,6 +139,7 @@ class ClusterJob(Service):
             'is_job': is_job,
             'status': CLStatus.ACTIVE.name
         }
+        ctdb_config = await self.middleware.call('ctdb.shared.volume.config')
         await self.wait_for_method(job, method, 10)
         for node in (await self.middleware.call('ctdb.general.status'))['nodemap']['nodes']:
             if node['this_node'] or node['pnn'] == -1:
@@ -150,7 +151,7 @@ class ClusterJob(Service):
 
         data = {
             "event": "CLJOBS_PROCESS",
-            "name": CTDBConfig.CTDB_VOL_NAME.value,
+            "name": ctdb_config["volume_name"],
             "forward": True
         }
         await self.middleware.call('gluster.localevents.send', data)

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -1,6 +1,5 @@
 from middlewared.service import Service, private, job, periodic
 from middlewared.service_exception import CallError
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
 
 import time
 import errno

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -1,17 +1,23 @@
 import errno
 import json
+import os
 from pathlib import Path
 from glustercli.cli import volume
+from pyglfs import GLFSError
+from time import sleep
+from uuid import uuid4
 
 from middlewared.service import Service, CallError, job
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
+from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
+from middlewared.plugins.gluster_linux.utils import get_glusterd_uuid
 
 
 MOUNT_UMOUNT_LOCK = CTDBConfig.MOUNT_UMOUNT_LOCK.value
 CRE_OR_DEL_LOCK = CTDBConfig.CRE_OR_DEL_LOCK.value
-CTDB_VOL_NAME = CTDBConfig.CTDB_VOL_NAME.value
-CTDB_LOCAL_MOUNT = CTDBConfig.CTDB_LOCAL_MOUNT.value
+LEGACY_CTDB_VOL_NAME = CTDBConfig.LEGACY_CTDB_VOL_NAME.value
 CTDB_VOL_INFO_FILE = CTDBConfig.CTDB_VOL_INFO_FILE.value
+CTDB_STATE_DIR = CTDBConfig.CTDB_STATE_DIR.value
+MIGRATION_WAIT_TIME = 300
 
 
 class CtdbSharedVolumeService(Service):
@@ -20,24 +26,113 @@ class CtdbSharedVolumeService(Service):
         namespace = 'ctdb.shared.volume'
         private = True
 
+    def __get_vol_and_path(self):
+        """
+        Internal method that determines the gluster volume, path, and
+        glfs UUID of the directory holding our clustered state directory.
+        """
+        vol_names = self.middleware.call_sync('gluster.volume.list')
+        if LEGACY_CTDB_VOL_NAME in vol_names:
+            self.logger.error(
+                'Legacy ctdb_shared_vol is present in gluster volume list. '
+                'If this log entry is generated post-deployment, it indicates '
+                'that an unsupported upgrade from legacy cluster configuration '
+                'was performed.'
+            )
+            try:
+                uuid = self.middleware.call_sync('gluster.filesystem.lookup', {
+                    'volume_name': LEGACY_CTDB_VOL_NAME,
+                    'path': '.DEPRECATED'
+                })['uuid']
+            except GLFSError as e:
+                if e.errno != errno.ENOENT:
+                    raise CallError(
+                        'Failed to lookup DEPRECATED sentinel for legacy CTDB '
+                        f'shared volume: {e.errmsg}', e.errno
+                    )
+
+                # root of glusterfs volume always has uuid of 1
+                return {
+                    'volume': LEGACY_CTDB_VOL_NAME,
+                    'system_dir': '/',
+                    'uuid': '00000000-0000-0000-0000-000000000001'
+                }
+
+        for vol in vol_names:
+            if vol == LEGACY_CTDB_VOL_NAME:
+                continue
+
+            try:
+                uuid = self.middleware.call_sync('gluster.filesystem.lookup', {
+                    'volume_name': vol,
+                    'path': CTDB_STATE_DIR
+                })['uuid']
+            except GLFSError as e:
+                if e.errno != errno.ENOENT:
+                    raise CallError(
+                        'Failed to lookup truenas cluster state dir on '
+                        f'volume [{vol}]: {e.errmsg}', e.errno
+                    )
+
+                continue
+
+            return {
+                'volume': vol,
+                'system_dir': CTDB_STATE_DIR,
+                'uuid': uuid
+            }
+
+        if vol_names:
+            """
+            This code path will be followed when we create our first gluster volume.
+            It ensures that we have a valid clustered system directory available.
+            """
+            try:
+                uuid = self.middleware.call_sync('gluster.filesystem.mkdir', {
+                    'volume_name': vol_names[0],
+                    'path': CTDB_STATE_DIR,
+                    'options': {'mode': 0o700},
+                })['uuid']
+            except Exception:
+                self.logger.error('Failed to create clustered system directory', exc_info=True)
+                pass
+            else:
+                return {
+                    'volume': vol_names[0],
+                    'system_dir': CTDB_STATE_DIR,
+                    'uuid': uuid
+                }
+
+        raise CallError("No clustered state directory configured", errno.ENOENT)
+
     def generate_info(self):
-        volume = CTDB_VOL_NAME
-        volume_mp = Path(CTDBConfig.LOCAL_MOUNT_BASE.value, volume)
-        metadata_dir = '/'
-        glfs_uuid = self.middleware.call_sync('gluster.filesystem.lookup', {
-            'volume_name': CTDB_VOL_NAME,
-            'path': metadata_dir
-        })['uuid']
+        """
+        This method writes a local configuration file that contains
+        configuration information about the clustered system directory.
+        It is used within middleware and also ctdb event scripts and the
+        ctdb recovery lock helper to determine the correct volume and
+        path to use.
+        """
+        conf = self.__get_vol_and_path()
+
+        volume = conf['volume']
+        volume_mp = Path(FuseConfig.FUSE_PATH_BASE.value, volume)
+        system_dir = conf['system_dir']
         data = {
             'volume_name': volume,
             'volume_mountpoint': str(volume_mp),
-            'path': metadata_dir,
-            'mountpoint': str(Path(f'{volume_mp}/{metadata_dir}')),
-            'uuid': glfs_uuid
+            'path': system_dir,
+            'mountpoint': str(Path(f'{volume_mp}/{system_dir}')),
+            'uuid': conf['uuid']
         }
-        with open(CTDB_VOL_INFO_FILE, "w") as f:
-            f.write(json.dumps(data))
 
+        tmp_name = f'{CTDB_VOL_INFO_FILE}_{uuid4().hex}.tmp'
+        with open(tmp_name, "w") as f:
+            f.write(json.dumps(data))
+            f.flush()
+            os.fsync(f.fileno())
+
+        os.rename(tmp_name, CTDB_VOL_INFO_FILE)
         return data
 
     def config(self):
@@ -47,32 +142,276 @@ class CtdbSharedVolumeService(Service):
         except (FileNotFoundError, json.JSONDecodeError):
             return self.generate_info()
 
-    def update(self, data):
-        raise CallError('Updates to ctdb shared volume configuration are not supported', errno.EOPNOTSUPP)
+    @job(lock="ctdb_system_volume_update")
+    def update(self, job, data):
+        """
+        update is performed under lock to serialize update ops
+        and grant more visibility via jobs queue. ctdb service start
+        will wait for any pending update jobs to complete before actually
+        starting the service.
+        """
+        volume = data['name']
+        uuid = data['uuid']
+        info = self.middleware.call_sync('gluster.volume.exists_and_started', volume)
+        if not info['exists']:
+            raise CallError(
+                f'{volume}: volume does not exist', errno.ENOENT
+            )
 
-    async def validate(self):
-        filters = [('id', '=', CTDB_VOL_NAME)]
+        if not info['started']:
+            self.middleware.call_sync('gluster.volume.start', {'name': volume})
+
+        if self.middleware.call_sync('service.started', 'ctdb'):
+            raise CallError(
+                'Updates to TrueNAS clustered metadata volume are not '
+                'permitted when the ctdb service is started'
+            )
+
+        node_uuid = get_glusterd_uuid()
+        try:
+            self.middleware.call_sync('gluster.filesystem.unlink', {
+                'volume_name': volume,
+                'parent_uuid': uuid,
+                'path': f'.{node_uuid}_UPDATE_IN_PROGRESS'
+            })
+        except Exception:
+            self.logger.warning('Failed to unlink in-progress sentinel', exc_info=True)
+
+        return self.generate_info()
+
+    def __move_ctdb_vol(self, data):
+        # do not call this method directly
+        try:
+            current = self.config()
+        except CallError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+            self.logger.debug("Failed to detect metadata dir.", exc_info=True)
+            current = {'volume_name': None}
+
+        # If we're not moving the location, just make sure our vol file
+        # is present
+        if current['volume_name'] == data['name']:
+            try:
+                hdl = self.middleware.call_sync('gluster.filesystem.lookup', {
+                    'volume_name': current['volume_name'],
+                    'path': current['path']
+                })
+            except GLFSError as e:
+                if e.errno != errno.ENOENT:
+                    raise CallError(
+                        'Failed to lookup truenas cluster state dir '
+                        f'[{current["path"]}] on volume '
+                        f'[{current["volume_name"]}]: {e.errmsg}', e.errno
+                    )
+
+                hdl = self.middleware.call_sync('gluster.filesystem.mkdir', {
+                    'volume_name': current['volume_name'],
+                    'path': current['path'],
+                    'options': {'mode': 0o700}
+                })
+
+            return hdl['uuid']
+
+        elif current['volume_name'] is None:
+            hdl = self.middleware.call_sync('gluster.filesystem.mkdir', {
+                'volume_name': data['name'],
+                'path': CTDB_STATE_DIR,
+                'options': {'mode': 0o700}
+            })
+            return hdl['uuid']
+
+        src_uuid = self.middleware.call_sync('gluster.filesystem.lookup', {
+            'volume_name': current['volume_name'],
+            'path': current['path']
+        })['uuid']
+
+        try:
+            dst_uuid = self.middleware.call_sync('gluster.filesystem.lookup', {
+                'volume_name': data['name'],
+                'path': CTDB_STATE_DIR
+            })['uuid']
+        except GLFSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+            dst_uuid = self.middleware.call_sync('gluster.filesystem.mkdir', {
+                'volume_name': data['name'],
+                'path': CTDB_STATE_DIR,
+                'options': {'mode': 0o700}
+            })['uuid']
+
+        move_job = self.middleware.call_sync('gluster.filesystem.copy_tree', {
+            'src_volume_name': current['volume_name'],
+            'src_uuid': src_uuid,
+            'dst_volume_name': data['name'],
+            'dst_uuid': dst_uuid,
+            'force': True,
+        })
+        move_job.wait_sync(raise_error=True)
+
+        rmtree_job = self.middleware.call_sync('gluster.filesystem.rmtree', {
+            'volume_name': current['volume_name'],
+            'path': current['path']
+        })
+        rmtree_job.wait_sync()
+
+        # If we've moved away from existing ctdb_shared_vol
+        # then set sentinel file indicating it must be skipped.
+        if current['volume_name'] == LEGACY_CTDB_VOL_NAME:
+            self.middleware.call_sync('gluster.filesystem.create_file', {
+                'volume_name': current['volume_name'],
+                'path': '.DEPRECATED',
+                'options': {'mode': 0o700}
+            })
+
+        return dst_uuid
+
+    @job(lock=CRE_OR_DEL_LOCK)
+    def migrate(self, job, data):
+        """
+        WARNING: this method will cause production outage for the entire cluster
+        and _must_ only be performed during a maintenance window.
+
+        Within this method we maintain sentinel files indicating that an update
+        is in progress. The clustercache plugin may _not_ be used as the cluster
+        will be in a degraded state while we move the system files.
+        """
+
+        job.set_progress(0, f'Begining migration of cluster system config to {data["name"]} volume')
+        if not self.middleware.call_sync('ctdb.general.healthy'):
+            raise CallError(
+                'CTDB volume configuration may only be initiated with healthy cluster'
+            )
+
+        cur_info = self.config()
+        job.set_progress(10, f'Begining migration of cluster system config from {cur_info["volume_name"]} to {data["name"]}')
+        contents = self.middleware.call_sync('gluster.filesystem.contents', {
+            'volume_name': cur_info['volume_name'],
+            'uuid': cur_info['uuid'],
+        })
+
+        for file in contents:
+            if file.endswith('_UPDATE_IN_PROGRESS'):
+                peer_uuid = file.strip('_UPDATE_IN_PROGRESS')
+                raise CallError(
+                    f'{peer_uuid[1:]}: Gluster peer currently in process '
+                    'of updating system volume path', errno.EBUSY
+                )
+
+        job.set_progress(25, 'Stopping CTDB service on all nodes')
+
+        # We must stop ctdbd fist (will fault cluster)
+        self.middleware.call_sync('gluster.localevents.send', {
+            'event': 'CTDB_STOP',
+            'name': data['name'],
+            'forward': True
+        })
+
+        # By this point ctdbd is stopped on all nodes
+        #
+        # The following moves our nodes file and every other
+        # ctdb / cluster-config related file to the new volume
+        # then removes the originals
+        job.set_progress(50, 'Moving system files')
+        dst_uuid = self.__move_ctdb_vol(data)
+
+        # Set the sentinel files that will be removed as each node
+        # processes the SYSTEM_VOL_CHANGE event. Presence of sentinel
+        # means that the cluster node has not finished processing.
+        job.set_progress(60, 'Setting update sentinels')
+        for peer in self.middleware.call_sync('gluster.peer.query'):
+            try:
+                self.middleware.call_sync('gluster.filesystem.create_file', {
+                    'volume_name': data['name'],
+                    'parent_uuid': dst_uuid,
+                    'path': f'.{peer["uuid"]}_UPDATE_IN_PROGRESS'
+                })
+            except Exception:
+                # We're already pretty heavily commited at this point
+                # and so we'll just hope for the best that things shake out
+                # okay.
+                self.logger.warning(
+                    'Failed to generate sentinel for node %s',
+                    peer['hostname'], exc_info=True
+                )
+
+        # The event kicks off backgrounded change
+        job.set_progress(75, 'Sending command to remote nodes to update config')
+        self.middleware.call_sync('gluster.localevents.send', {
+            'event': 'SYSTEM_VOL_CHANGE',
+            'name': data['name'],
+            'uuid': dst_uuid,
+            'forward': True
+        })
+
+        # The cluster update is a backgrounded job, and may take a small
+        # amount of time to complete.
+        remaining = MIGRATION_WAIT_TIME
+        while remaining > 0:
+            contents = self.middleware.call_sync('gluster.filesystem.contents', {
+                'volume_name': data['name'],
+                'uuid': dst_uuid,
+            })
+            wait_for_nodes = []
+            for file_name in contents:
+                if not file_name.endswith('_UPDATE_IN_PROGRESS'):
+                    continue
+
+                peer_uuid = file_name.strip('_UPDATE_IN_PROGRESS')
+                wait_for_nodes.append(peer_uuid[1:])
+
+            if not wait_for_nodes:
+                break
+
+            job.set_progress(80, f'Waiting for peers [{", ".join(wait_for_nodes)}] to finish update.')
+            sleep(10)
+            remaining -= 10
+
+        # This validates our nodes file and starts ctdb
+        job.set_progress(90, 'Finalizing setup')
+        self.middleware.call_sync('ctdb.shared.volume.create')
+
+        # It may take up to a few minutes for ctdb to become healthy again
+        remaining = MIGRATION_WAIT_TIME
+        while remaining > 0:
+            status = self.middleware.call_sync('ctdb.general.status')
+            if status['all_healthy']:
+                break
+
+            job.set_progress(95, 'Waiting for CTDB to become healthy.')
+            sleep(10)
+            remaining -= 10
+
+        if remaining == 0:
+            # This may not necessarily be fatal. Adminstrative action may be required
+            # to unban a node.
+            self.logger.error("Timed out waiting for CTDB to become healthy post-move")
+
+    async def validate(self, ctdb_vol_name):
+        filters = [('id', '=', ctdb_vol_name)]
         ctdb = await self.middleware.call('gluster.volume.query', filters)
         if not ctdb:
             # it's expected that ctdb shared volume exists when
             # calling this method
-            raise CallError(f'{CTDB_VOL_NAME} does not exist', errno.ENOENT)
+            raise CallError(f'{ctdb_vol_name} does not exist', errno.ENOENT)
 
-        for i in ctdb:
-            err_msg = f'A volume named "{CTDB_VOL_NAME}" already exists '
-            if i['type'] != 'REPLICATE':
-                err_msg += (
-                    'but is not a "REPLICATE" type volume. '
-                    'Please delete or rename this volume and try again.'
-                )
-                raise CallError(err_msg)
-            elif i['replica'] < 3 or i['num_bricks'] < 3:
-                err_msg += (
-                    'but is configured in a way that '
-                    'could cause data corruption. Please delete '
-                    'or rename this volume and try again.'
-                )
-                raise CallError(err_msg)
+        # This should generate alert rather than exception
+        if ctdb[0]['type'] == 'DISTRIBUTE':
+            msg = (
+                f'{ctdb_vol_name}: volume hosting cluster system files is '
+                'configured as DISTRIBUTE type. Lack of redundancy for this volume '
+                'means that failure of single node will result in total production '
+                'outage.'
+            )
+            await self.middleware.call(
+                'alert.oneshot_create',
+                'ClusteredConfigRedundancy',
+                {'errmsg': msg}
+            )
+        else:
+            await self.middleware.call('alert.oneshot_delete', 'ClusteredConfigRedundancy', None)
 
     @job(lock=CRE_OR_DEL_LOCK)
     async def create(self, job):
@@ -80,57 +419,29 @@ class CtdbSharedVolumeService(Service):
         Create and mount the shared volume to be used
         by ctdb daemon.
         """
-        # check if ctdb shared volume already exists and started
-        info = await self.middleware.call('gluster.volume.exists_and_started', CTDB_VOL_NAME)
-        if not info['exists']:
-            # get the peers in the TSP
-            peers = await self.middleware.call('gluster.peer.query')
-            if not peers:
-                raise CallError('No peers detected')
-
-            # shared storage volume requires 3 nodes, minimally, to
-            # prevent the dreaded split-brain
-            con_peers = [i['hostname'] for i in peers if i['connected'] == 'Connected']
-            if len(con_peers) < 3:
-                raise CallError(
-                    '3 peers must be present and connected before the ctdb '
-                    'shared volume can be created.'
-                )
-
-            # get the system dataset location
-            ctdb_sysds_path = (await self.middleware.call('systemdataset.config'))['path']
-            if not ctdb_sysds_path:
-                raise CallError("System dataset is not properly mounted")
-
-            ctdb_sysds_path = str(Path(ctdb_sysds_path).joinpath(CTDB_VOL_NAME))
-
-            bricks = []
-            for i in con_peers:
-                bricks.append(i + ':' + ctdb_sysds_path)
-
-            options = {'args': (CTDB_VOL_NAME, bricks,)}
-            options['kwargs'] = {'replica': len(con_peers), 'force': True}
-            await self.middleware.call('gluster.method.run', volume.create, options)
+        config = await self.middleware.call('ctdb.shared.volume.config')
+        vol = config['volume_name']
+        info = await self.middleware.call('gluster.volume.exists_and_started', vol)
 
         # make sure the shared volume is configured properly to prevent
         # possibility of split-brain/data corruption with ctdb service
-        await self.middleware.call('ctdb.shared.volume.validate')
+        await self.middleware.call('ctdb.shared.volume.validate', vol)
 
         if not info['started']:
             # start it if we get here
-            await self.middleware.call('gluster.volume.start', {'name': CTDB_VOL_NAME})
+            await self.middleware.call('gluster.volume.start', {'name': vol})
 
         # try to mount it locally and send a request
         # to all the other peers in the TSP to also
         # FUSE mount it
-        data = {'event': 'VOLUME_START', 'name': CTDB_VOL_NAME, 'forward': True}
+        data = {'event': 'VOLUME_START', 'name': vol, 'forward': True}
         await self.middleware.call('gluster.localevents.send', data)
 
         # we need to wait on the local FUSE mount job since
         # ctdb daemon config is dependent on it being mounted
         fuse_mount_job = await self.middleware.call('core.get_jobs', [
             ('method', '=', 'gluster.fuse.mount'),
-            ('arguments.0.name', '=', 'ctdb_shared_vol'),
+            ('arguments.0.name', '=', vol),
             ('state', '=', 'RUNNING')
         ])
         if fuse_mount_job:
@@ -175,10 +486,10 @@ class CtdbSharedVolumeService(Service):
 
         # this sends an event telling all peers in the TSP (including this system)
         # to start the ctdb service
-        data = {'event': 'CTDB_START', 'name': CTDB_VOL_NAME, 'forward': True}
+        data = {'event': 'CTDB_START', 'name': vol, 'forward': True}
         await self.middleware.call('gluster.localevents.send', data)
 
-        return await self.middleware.call('gluster.volume.query', [('name', '=', CTDB_VOL_NAME)])
+        return await self.middleware.call('gluster.volume.query', [('name', '=', vol)])
 
     @job(lock=CRE_OR_DEL_LOCK)
     async def teardown(self, job, force=False):
@@ -194,12 +505,13 @@ class CtdbSharedVolumeService(Service):
 
         NOTE: THERE IS NO COMING BACK FROM THIS.
         """
+        config = await self.middleware.call('ctdb.shared.volume.config')
         if not force:
             for vol in await self.middleware.call('gluster.volume.query'):
-                if vol['name'] != CTDB_VOL_NAME:
+                if vol['name'] != config['volume_name']:
                     # If someone calls this method, we expect that all other gluster volumes
                     # have been destroyed
-                    raise CallError(f'{vol["name"]!r} must be removed before deleting {CTDB_VOL_NAME!r}')
+                    raise CallError(f'{vol["name"]!r} must be removed before deleting {config["volume_name"]!r}')
         else:
             # we have to stop gluster service because it spawns a bunch of child processes
             # for the ctdb shared volume. This also stops ctdb, smb and unmounts all the
@@ -223,17 +535,17 @@ class CtdbSharedVolumeService(Service):
         Delete and unmount the shared volume used by ctdb daemon.
         """
         # nothing to delete if it doesn't exist
-        info = await self.middleware.call('gluster.volume.exists_and_started', CTDB_VOL_NAME)
+        info = await self.middleware.call('gluster.volume.exists_and_started', LEGACY_CTDB_VOL_NAME)
         if not info['exists']:
             return
 
         # stop the gluster volume
         if info['started']:
-            options = {'args': (CTDB_VOL_NAME,), 'kwargs': {'force': True}}
-            job.set_progress(33, f'Stopping gluster volume {CTDB_VOL_NAME!r}')
+            options = {'args': (LEGACY_CTDB_VOL_NAME,), 'kwargs': {'force': True}}
+            job.set_progress(33, f'Stopping gluster volume {LEGACY_CTDB_VOL_NAME!r}')
             await self.middleware.call('gluster.method.run', volume.stop, options)
 
         # finally, we delete it
-        job.set_progress(66, f'Deleting gluster volume {CTDB_VOL_NAME!r}')
-        await self.middleware.call('gluster.method.run', volume.delete, {'args': (CTDB_VOL_NAME,)})
-        job.set_progress(100, f'Successfully deleted {CTDB_VOL_NAME!r}')
+        job.set_progress(66, f'Deleting gluster volume {LEGACY_CTDB_VOL_NAME!r}')
+        await self.middleware.call('gluster.method.run', volume.delete, {'args': (LEGACY_CTDB_VOL_NAME,)})
+        job.set_progress(100, f'Successfully deleted {LEGACY_CTDB_VOL_NAME!r}')

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -13,7 +13,6 @@ from middlewared.schema import Bool, returns
 from middlewared.service import (Service, ValidationErrors, accepts, job,
                                  private)
 from middlewared.service_exception import CallError
-from middlewared.utils import MIDDLEWARE_RUN_DIR
 from middlewared.utils.path import CLUSTER_PATH_PREFIX
 
 
@@ -162,7 +161,7 @@ class ClusterUtils(Service):
 
         files.extend(GlusterConfig.FILES_TO_REMOVE.value.copy())
 
-        interest = (f'.system/{CTDBConfig.CTDB_VOL_NAME.value}', '.system/glusterd')
+        interest = (f'.system/{CTDBConfig.LEGACY_CTDB_VOL_NAME.value}', '.system/glusterd')
         mount_info = self.middleware.call_sync('filesystem.mount_info')
         for i in filter(lambda x: x['mount_source'].endswith(interest), mount_info):
             dirs.append(i['mountpoint'])
@@ -244,10 +243,9 @@ class CTDBConfig(enum.Enum):
     GENERAL_FILE = 'ctdb.conf'
 
     # local gluster fuse client mount related config
-    LOCAL_MOUNT_BASE = FuseConfig.FUSE_PATH_BASE.value
-    CTDB_VOL_NAME = 'ctdb_shared_vol'
-    CTDB_VOL_INFO_FILE = f'{MIDDLEWARE_RUN_DIR}/ctdb_vol_info'
-    CTDB_LOCAL_MOUNT = os.path.join(LOCAL_MOUNT_BASE, CTDB_VOL_NAME)
+    LEGACY_CTDB_VOL_NAME = 'ctdb_shared_vol'
+    CTDB_VOL_INFO_FILE = '/data/ctdb_vol_info'
+    CTDB_STATE_DIR = '.clustered_system'
 
     CLUSTERED_SERVICES = '.clustered_services'
 
@@ -268,6 +266,7 @@ class CTDBConfig(enum.Enum):
         ETC_REC_FILE,
         ETC_PRI_IP_FILE,
         ETC_PUB_IP_FILE,
+        CTDB_VOL_INFO_FILE,
     ]
 
     # used in the ctdb.shared.volume.teardown method

--- a/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
@@ -3,6 +3,7 @@ import os
 import stat
 
 from base64 import b64encode, b64decode
+from pyglfs import GLFSError
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Ref
 from middlewared.service import Service, CallError, job, private
 from middlewared.schema import Path
@@ -578,7 +579,7 @@ class GlusterFilesystemService(Service):
             if entry.file_type == 'DIRECTORY':
                 try:
                     dst_hdl_lst.append(dst.mkdir(entry.name, mode=new_mode))
-                except pyglfs.GLFSError as e:
+                except GLFSError as e:
                     if e.errno != errno.EEXIST:
                         raise
                     existing_hdl = dst.lookup(entry.name)
@@ -589,7 +590,7 @@ class GlusterFilesystemService(Service):
             elif entry.file_type == 'FILE':
                 try:
                     hdl = dst.create(entry.name, os.O_RDWR, mode=new_mode)
-                except pyglfs.GLFSError as e:
+                except GLFSError as e:
                     if e.errno != errno.EEXIST or not data['force']:
                         raise
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/filesystem.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import stat
 
 from base64 import b64encode, b64decode
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Ref
@@ -540,3 +541,62 @@ class GlusterFilesystemService(Service):
 
             if attrs:
                 entry.handle.setattrs(**attrs)
+
+    @accepts(Dict(
+        'glfs-copy',
+        Str('src_volume_name', required=True),
+        Str('src_uuid', required=True, validators=[UUID()]),
+        Str('dst_volume_name', required=True),
+        Str('dst_uuid', required=True, validators=[UUID()]),
+        Ref('gluster-volume-options'),
+        Bool('force', default=False)
+    ))
+    @job()
+    def copy_tree(self, job, data):
+        src_vol = glfs.init_volume_mount(data['src_volume_name'], data['gluster-volume-options'])
+        dst_vol = glfs.init_volume_mount(data['dst_volume_name'], data['gluster-volume-options'])
+
+        src_hdl = self.get_object_handle(src_vol, data['src_uuid'])
+        dst_hdl = self.get_object_handle(dst_vol, data['dst_uuid'])
+
+        dst_hdl_lst = [dst_hdl]
+
+        if src_hdl.file_type['parsed'] != 'DIRECTORY':
+            raise CallError('Source of copy is not a directory')
+
+        if dst_hdl.file_type['parsed'] != 'DIRECTORY':
+            raise CallError('Destination of copy is not a directory')
+
+        for idx, entry in enumerate(src_hdl.fts_open()):
+            # fts entry depth starts at zero
+            while entry.depth < len(dst_hdl_lst) - 1:
+                dst_hdl_lst.pop()
+
+            new_mode = stat.S_IMODE(entry.handle.cached_stat.st_mode)
+            dst = dst_hdl_lst[-1]
+
+            if entry.file_type == 'DIRECTORY':
+                try:
+                    dst_hdl_lst.append(dst.mkdir(entry.name, mode=new_mode))
+                except pyglfs.GLFSError as e:
+                    if e.errno != errno.EEXIST:
+                        raise
+                    existing_hdl = dst.lookup(entry.name)
+                    dst_hdl_lst.append(existing_hdl)
+                    if new_mode != stat.S_IMODE(existing_hdl.cached_stat.st_mode):
+                        existing_hdl.open(os.O_DIRECTORY).fchmod(new_mode)
+
+            elif entry.file_type == 'FILE':
+                try:
+                    hdl = dst.create(entry.name, os.O_RDWR, mode=new_mode)
+                except pyglfs.GLFSError as e:
+                    if e.errno != errno.EEXIST or not data['force']:
+                        raise
+
+                    existing_hdl = dst.lookup(entry.name)
+                    fd = existing_hdl.open(os.O_RDWR)
+                    fd.ftruncate(0)
+                else:
+                    fd = hdl.open(os.O_RDWR)
+
+                fd.pwrite(entry.handle.contents(), 0)

--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -22,6 +22,7 @@ class AllowedEvents(enum.Enum):
     CTDB_STOP = 'CTDB_STOP'
     SMB_STOP = 'SMB_STOP'
     CLJOBS_PROCESS = 'CLJOBS_PROCESS'
+    SYSTEM_VOL_CHANGE = 'SYSTEM_VOL_CHANGE'
 
 
 class GlusterLocalEventsService(Service):
@@ -57,6 +58,7 @@ class GlusterLocalEventsService(Service):
         Str('event', required=True),
         Str('name', required=True),
         Bool('forward', default=True),
+        additional_attrs=True,
     ))
     @private
     async def send(self, data):
@@ -79,7 +81,8 @@ class GlusterLocalEventsService(Service):
             if status is not None:
                 # something failed
                 raise CallError(
-                    f'Failed to send event: {data["event"]} with status code of: {status} with reason: {reason}'
+                    f'Failed to send event: {data["event"]} with status code of: {status} '
+                    f'with reason: {reason}'
                 )
 
     @accepts()

--- a/src/middlewared/middlewared/plugins/gluster_linux/peer.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/peer.py
@@ -1,3 +1,4 @@
+import errno
 import subprocess
 import xml.etree.ElementTree as ET
 from glustercli.cli import peer
@@ -5,11 +6,9 @@ from glustercli.cli import peer
 from middlewared.utils import filter_list
 from middlewared.schema import accepts, Bool, Dict, List, Ref, returns, Str
 from middlewared.service import private, job, filterable, CallError, CRUDService, ValidationErrors
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
 from .utils import GlusterConfig
 
 
-CTDB_VOL = CTDBConfig.CTDB_VOL_NAME.value
 GLUSTER_JOB_LOCK = GlusterConfig.CLI_LOCK.value
 MAX_PEERS = GlusterConfig.MAX_PEERS.value
 
@@ -75,7 +74,15 @@ class GlusterPeerService(CRUDService):
         # this time since it requires expanding the ctdb_shared_vol. This is an
         # involved process and will require proper design/implementation.
         verrors = ValidationErrors()
-        if (await self.middleware.call('gluster.volume.exists_and_started', CTDB_VOL))['exists']:
+        try:
+            vol = (await self.middleware.call('ctdb.shared.volume.config'))['volume_name']
+        except CallError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+            vol = None
+
+        if vol and (await self.middleware.call('gluster.volume.exists_and_started', vol))['exists']:
             verbiage = 'Adding to' if schema == 'gluster.peer.create' else 'Removing from'
             verrors.add(schema, f'{verbiage} an existing trusted storage pool is not allowed at this time.')
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -73,10 +73,16 @@ def set_gluster_workdir_dataset(dataset_name):
         f.write(dataset_name)
 
 
+def get_glusterd_uuid():
+    with open(f'{GlusterConfig.WORKDIR.value}/glusterd.info', 'r') as f:
+        current_uuid = f.readline()
+
+    return current_uuid
+
+
 def check_glusterd_info():
     try:
-        with open(f'{GlusterConfig.WORKDIR.value}/glusterd.info', 'r') as f:
-            current_uuid = f.readline()
+        current_uuid = get_glusterd_uuid()
     except FileNotFoundError:
         if not os.path.exists(GlusterConfig.UUID_BACKUP.value):
             # Glusterd is most likely starting for the first time.

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -2,13 +2,14 @@ from glustercli.cli import volume, quota
 
 from middlewared.utils import filter_list
 from middlewared.service import CRUDService, accepts, job, filterable, private, ValidationErrors
+from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Str, Int, Bool, List, Ref, returns
 from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 from .utils import GlusterConfig, set_gluster_workdir_dataset, get_gluster_workdir_dataset, format_bricks
 
 
 GLUSTER_JOB_LOCK = GlusterConfig.CLI_LOCK.value
-CTDB_VOL_NAME = CTDBConfig.CTDB_VOL_NAME.value
+LEGACY_CTDB_VOL_NAME = CTDBConfig.LEGACY_CTDB_VOL_NAME.value
 FUSE_BASE = FuseConfig.FUSE_PATH_BASE.value
 
 
@@ -70,7 +71,7 @@ class GlusterVolumeService(CRUDService):
         verrors = ValidationErrors()
         create_request = schema_name == 'glustervolume_create'
 
-        if data['name'] == CTDB_VOL_NAME and create_request:
+        if data['name'] == LEGACY_CTDB_VOL_NAME and create_request:
             verrors.add(
                 f'{schema_name}.{data["name"]}',
                 f'"{data["name"]}" is a reserved name. Choose a different volume name.'
@@ -134,11 +135,6 @@ class GlusterVolumeService(CRUDService):
         # events for which we act upon (i.e. FUSE mounting)
         await self.middleware.call('service.start', 'glustereventsd')
 
-        # before we create the gluster volume, we need to ensure
-        # the ctdb shared volume is setup
-        ctdb_job = await self.middleware.call('ctdb.shared.volume.create')
-        await ctdb_job.wait(raise_error=True)
-
         name = data.pop('name')
         bricks = await format_bricks(data.pop('bricks'))
         options = {'args': (name, bricks,), 'kwargs': data}
@@ -146,6 +142,21 @@ class GlusterVolumeService(CRUDService):
         await self.middleware.call('gluster.method.run', volume.create, options)
         await self.middleware.call('gluster.volume.start', {'name': name})
         await self.middleware.call('gluster.volume.store_workdir')
+
+        # we need to wait on the local FUSE mount job since
+        # ctdb daemon config is dependent on it being mounted
+        fuse_mount_job = await self.middleware.call('core.get_jobs', [
+            ('method', '=', 'gluster.fuse.mount'),
+            ('arguments.0.name', '=', name),
+            ('state', '=', 'RUNNING')
+        ])
+        if fuse_mount_job:
+            wait_id = await self.middleware.call('core.job_wait', fuse_mount_job[0]['id'])
+            await wait_id.wait()
+
+        ctdb_job = await self.middleware.call('ctdb.shared.volume.create')
+        await ctdb_job.wait(raise_error=True)
+
         return await self.middleware.call('gluster.volume.query', [('id', '=', name)])
 
     @accepts(Dict(
@@ -211,7 +222,7 @@ class GlusterVolumeService(CRUDService):
     @accepts(Str('id'))
     @returns()
     @job(lock=GLUSTER_JOB_LOCK)
-    async def do_delete(self, job, id):
+    async def do_delete(self, job, volume_id):
         """
         Delete a gluster volume.
 
@@ -219,20 +230,48 @@ class GlusterVolumeService(CRUDService):
                 to be deleted
         """
 
-        args = {'args': ((await self.get_instance(id))['name'],)}
+        args = {'args': ((await self.get_instance(volume_id))['name'],)}
+        try:
+            meta_config = await self.middleware.call('ctdb.shared.volume.config')
+        except Exception:
+            self.logger.debug("Failed to retrieve metadata volume", exc_info=True)
+            meta_config = {'volume_name': None}
 
-        if id == CTDB_VOL_NAME:
+        if volume_id == CTDBConfig.LEGACY_CTDB_VOL_NAME.value:
+            await (await self.middleware.call('ctdb.shared.volume.delete')).wait(raise_error=True)
+            return
+
+        if volume_id == meta_config['volume_name']:
             # if the ctdb shared volume is being deleted then call
             # the ctdb shared volume specific API since it handles
             # other items
-            await (await self.middleware.call('ctdb.shared.volume.delete')).wait(raise_error=True)
-        else:
-            # need to unmount the FUSE mountpoint (if it exists) and
-            # send the request to do the same to all other peers in
-            # the TSP before we delete the volume
-            data = {'event': 'VOLUME_STOP', 'name': id, 'forward': True}
-            await self.middleware.call('gluster.localevents.send', data)
-            await self.middleware.call('gluster.method.run', volume.delete, args)
+            """
+            if not force:
+                raise CallError(
+                    f'{id}: gluster volume currently hosts mission-critical cluster '
+                    'and `force` was not specified. Forcing volume deletion will attempt to '
+                    'migrate to another gluster volume if available. If another gluster '
+                    'volume is not available then forcible deletion will break the cluster '
+                    'in a way that is not recoverable without manual intervention.'
+                )
+            """
+
+            volumes = await self.middleware.call('gluster.volume.list')
+            try:
+                volumes.remove(volume_id)
+            except ValueError:
+                pass
+
+            if volumes:
+                migrate_job = await self.middleware.call('ctdb.shared.volume.migrate', {'name': volumes[0]})
+                await migrate_job.wait(raise_error=True)
+
+        # need to unmount the FUSE mountpoint (if it exists) and
+        # send the request to do the same to all other peers in
+        # the TSP before we delete the volume
+        data = {'event': 'VOLUME_STOP', 'name': volume_id, 'forward': True}
+        await self.middleware.call('gluster.localevents.send', data)
+        await self.middleware.call('gluster.method.run', volume.delete, args)
 
     @accepts(Dict(
         'volume_info',

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -2,7 +2,6 @@ from glustercli.cli import volume, quota
 
 from middlewared.utils import filter_list
 from middlewared.service import CRUDService, accepts, job, filterable, private, ValidationErrors
-from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Str, Int, Bool, List, Ref, returns
 from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 from .utils import GlusterConfig, set_gluster_workdir_dataset, get_gluster_workdir_dataset, format_bricks
@@ -242,20 +241,6 @@ class GlusterVolumeService(CRUDService):
             return
 
         if volume_id == meta_config['volume_name']:
-            # if the ctdb shared volume is being deleted then call
-            # the ctdb shared volume specific API since it handles
-            # other items
-            """
-            if not force:
-                raise CallError(
-                    f'{id}: gluster volume currently hosts mission-critical cluster '
-                    'and `force` was not specified. Forcing volume deletion will attempt to '
-                    'migrate to another gluster volume if available. If another gluster '
-                    'volume is not available then forcible deletion will break the cluster '
-                    'in a way that is not recoverable without manual intervention.'
-                )
-            """
-
             volumes = await self.middleware.call('gluster.volume.list')
             try:
                 volumes.remove(volume_id)

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -546,9 +546,10 @@ class SystemDatasetService(ConfigService):
         init_job = self.middleware.call_sync('gluster.eventsd.init')
         init_job.wait_sync()
         if init_job.error:
+            config = self.middleware.call_sync('ctdb.shared.volume.config')
             self.logger.error(
                 'Failed to initialize %s directory with error: %s',
-                CTDBConfig.CTDB_VOL_NAME.value,
+                config['volume_name'],
                 init_job.error
             )
 
@@ -601,7 +602,7 @@ class SystemDatasetService(ConfigService):
                 'cores', 'samba4',
                 f'rrd-{uuid}', f'configs-{uuid}',
                 'webui', 'services',
-                'glusterd', CTDBConfig.CTDB_VOL_NAME.value,
+                'glusterd', CTDBConfig.LEGACY_CTDB_VOL_NAME.value,
                 f'netdata-{uuid}',
             ]
         ]

--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -293,7 +293,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
                 continue
 
             with entry['lock']:
-                if entry['handle_internal'].validate_handle():
+                if entry['handle_internal'] and entry['handle_internal'].validate_handle():
                     entry['handle_internal'].close()
 
     @private

--- a/src/middlewared/middlewared/webhooks/cluster_events.py
+++ b/src/middlewared/middlewared/webhooks/cluster_events.py
@@ -28,6 +28,8 @@ class ClusterEventsApplication(object):
                 method = ('service.stop', 'cifs')
             elif event == 'CLJOBS_PROCESS':
                 method = 'clusterjob.process_queue'
+            elif event == 'SYSTEM_VOL_CHANGE':
+                method = 'ctdb.shared.volume.update'
 
             if method is not None:
                 if event.startswith('VOLUME'):
@@ -36,6 +38,8 @@ class ClusterEventsApplication(object):
                     await self.middleware.call(method[0], method[1])
                 elif event == 'CLJOBS_PROCESS':
                     await self.middleware.call(method)
+                elif event == 'SYSTEM_VOL_CHANGE':
+                    await self.middleware.call(method, {'name': name, 'uuid': data['uuid']})
 
                 if data.pop('forward', False):
                     # means the request originated from localhost


### PR DESCRIPTION
Ctdb and clustered middleware configuration relies on a small numbers of configuration files that are stored within a gluster volume. Originally, we used a hard-coded dedicated volume. This PR makes the location for these files configuable and provides a framework to shift volume location. This is a significantly disruptive operation cluster-wide and should only be performed in a maintenance window.