### PR TITLE
NAS-122808 / 22.12.4 / Restrict permissions on gluster jwt seed (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -3,6 +3,7 @@ import contextlib
 import jwt
 import enum
 import asyncio
+import os
 
 from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Str, Bool, returns
@@ -140,4 +141,5 @@ class GlusterLocalEventsService(Service):
 
         self.JWT_SECRET = data['secret']
         with open(SECRETS_FILE, 'w+') as f:
+            os.fchmod(f.fileno(), 0o600)
             f.write(data['secret'])


### PR DESCRIPTION
Impact of exposure of this is minimal in clustered situation, but this should be made readable only by root.

Original PR: https://github.com/truenas/middleware/pull/11620
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122808