### PR TITLE
NAS-122813 / 23.10 / Add more protection for JWT usage in cluster event

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -4,12 +4,14 @@ import jwt
 import enum
 import asyncio
 import os
+import time
 
 from middlewared.service_exception import CallError
 from middlewared.schema import Dict, Str, Bool, returns
 from middlewared.service import (accepts, Service,
                                  private, ValidationErrors)
 from .utils import GlusterConfig
+from uuid import uuid4
 
 
 SECRETS_FILE = GlusterConfig.SECRETS_FILE.value
@@ -63,7 +65,7 @@ class GlusterLocalEventsService(Service):
     async def send(self, data):
         await self.middleware.call('gluster.localevents.validate', data)
         secret = await self.middleware.call('gluster.localevents.get_set_jwt_secret')
-        token = jwt.encode({'dummy': 'data'}, secret, algorithm='HS256')
+        token = jwt.encode({'ts': int(time.time()), 'msg_id': uuid4().hex}, secret, algorithm='HS256')
         headers = {'JWTOKEN': token, 'content-type': 'application/json'}
         async with aiohttp.ClientSession() as sess:
             status = reason = None

--- a/src/middlewared/middlewared/webhooks/cluster_events.py
+++ b/src/middlewared/middlewared/webhooks/cluster_events.py
@@ -1,16 +1,21 @@
 import aiohttp
 import asyncio
+import time
 
 from jwt import encode, decode
 from jwt.exceptions import DecodeError, InvalidSignatureError
+
+# Other cluster nodes should have time offset within a second of this node
+ALLOWED_SKEW = 10
 
 
 class ClusterEventsApplication(object):
 
     def __init__(self, middleware):
         self.middleware = middleware
+        self.received_messages = []
 
-    async def process_event(self, data):
+    async def process_event(self, msg_info, data):
         event = data.get('event', None)
         name = data.get('name', None)
         method = None
@@ -41,7 +46,7 @@ class ClusterEventsApplication(object):
                     # means the request originated from localhost
                     # so we need to forward it out to the other
                     # peers in the trusted storage pool
-                    await self.forward_event(data)
+                    await self.forward_event(msg_info, data)
 
     async def response(self, status_code=200, err=None):
         if status_code == 200:
@@ -63,7 +68,7 @@ class ClusterEventsApplication(object):
             session.post(url, headers=headers, json=json)
         ), timeout=timeout)
 
-    async def forward_event(self, data):
+    async def forward_event(self, msg_info, data):
         peer_urls = []
         localhost = {'localhost': False}
         for i in await self.middleware.call('gluster.peer.status', localhost):
@@ -77,7 +82,11 @@ class ClusterEventsApplication(object):
             secret = await self.middleware.call(
                 'gluster.localevents.get_set_jwt_secret'
             )
-            token = encode({'dummy': 'data'}, secret, algorithm='HS256')
+
+            # We are sending to peers that should never have seen this message
+            # before. Reset our timer for the message because local processing
+            # may have eaten up some of the time.
+            token = encode({'ts': int(time.time()), 'msg_id': msg_info['msg_id']}, secret, algorithm='HS256')
             headers = {
                 'JWTOKEN': token,
                 'content-type': 'application/json'
@@ -103,6 +112,18 @@ class ClusterEventsApplication(object):
                             timeout
                         )
 
+    async def check_received(self, msg_id):
+        current_ts = time.time()
+
+        for msg in self.received_messages.copy():
+            if abs(current_ts - msg['ts']) > 86400:
+                self.received_messages.remove(msg)
+                continue
+            if msg_id == msg['msg_id']:
+                return False
+
+        return True
+
     async def listener(self, request):
         # request is empty when the
         # "gluster-eventsapi webhook-test"
@@ -115,7 +136,7 @@ class ClusterEventsApplication(object):
         )
         token = request.headers.get('JWTOKEN', None)
         try:
-            decode(token, secret, algorithms='HS256')
+            decoded = decode(token, secret, algorithms='HS256')
         except (DecodeError, InvalidSignatureError):
             # signature failed due to bad secret (or no secret)
             # or decode failed because no token or invalid
@@ -125,5 +146,26 @@ class ClusterEventsApplication(object):
             # unhandled so play it safe
             return await self.response(status_code=500, err=f'{e}')
 
-        await self.process_event(await request.json())
+        if not (ts := decoded.get('ts')):
+            self.middleware.logger.debug('Received JWTOKEN lacks timestamp: %s', decoded)
+            return await self.response(status_code=401)
+        elif not (msg_id := decoded.get('msg_id')):
+            self.middleware.logger.debug('Received JWTOKEN lacks message id: %s', decoded)
+            return await self.response(status_code=401)
+
+        # Reject the payload in the following two cases:
+        # 1 - we have received something that is more than 10 seconds old. Clocks on
+        # all nodes must be synchronized via NTP.
+        # 2 - we have already seen this message ID before. Message ID is set by original
+        # sender of the local event.
+        if abs(time.time() - ts) > ALLOWED_SKEW:
+            self.middleware.logger.warning('Received expired message from cluster peer')
+            return await self.response(status_code=401)
+
+        if not await self.check_received(decoded['msg_id']):
+            self.middleware.logger.warning('Received duplicate message from cluster peer')
+            return await self.response(status_code=401)
+
+        self.received_messages.append(decoded)
+        await self.process_event(decoded, await request.json())
         return await self.response()


### PR DESCRIPTION
Initial implementation of JWT usage was to encode static dummy payload with pre-shared key. Presence of decodable header was used to authenticate the command / payload sent to the webhook. Since the encoded payload and secret were both static, the JWTOKEN used for all commands was identical.

This PR replaces the static dummy payload with a dict containing timestamp and uuid for message id. If clock slew from message we receive is more than 10 seconds or if the message id is reused, then we reject the event request.