### PR TITLE
NAS-122875 / 23.10 / [vm] Be more specific about which PCI device/controllers are "sensitive"

### DIFF
--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -7,8 +7,9 @@ from middlewared.service_exception import CallError
 
 RE_PCI_ADDR = re.compile(r'(?P<domain>.*):(?P<bus>.*):(?P<slot>.*)\.')
 SENSITIVE_PCI_DEVICE_TYPES = (
-    'Bridge',
-    'memory',
+    'PCI Bridge',
+    'ISA Bridge',
+    'RAM memory',
     'SMBus',
 )
 


### PR DESCRIPTION
(apologies if this isn't the right way to propose changes; I'm not familiar with the JIRA workflow and am external to iX systems)

I recently upgraded to TrueNAS 22.12.3.1 from 22.12.2.x and suddenly I was no longer able to pass an NVMe drive into one of my VMs as it's now considered "critical".

<img width="445" alt="image" src="https://github.com/truenas/middleware/assets/1163192/d594d0bd-59f8-42b1-ad36-1d15e00db967">

This is PCI device 0000:04:00.0.
```
$ lspci -nnD
...
0000:00:14.2 RAM memory [0500]: Intel Corporation Device [8086:7aa7] (rev 11)
...
0000:04:00.0 Non-Volatile memory controller [0108]: Phison Electronics Corporation PS5013 E13 NVMe Controller
...
```

I believe the catch-all for "memory" controller types was probably intended specifically for "RAM memory" PCI devices/controllers.

Fortunately, the existing code easily supports that with minimal changes (the regular expression already captures the full device/controller type). This PR simply specifies more specific sensitive device types to avoid accidentally catching those which aren't really sensitive at all.