### PR TITLE
NAS-122818 / 23.10 / Fix gluster.volume.optset endpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -324,7 +324,7 @@ class GlusterVolumeService(CRUDService):
             --value-- is the value to be given to the option
         """
 
-        options = {'args': (data['name'],), 'kwargs': data['opts']}
+        options = {'args': (data['name'], data['opts'])}
         return await self.middleware.call('gluster.method.run', volume.optset, options)
 
     @accepts(Dict(


### PR DESCRIPTION
Glustercli expects the dict to be presented as arg rather than breaking into kwargs.