### PR TITLE
NAS-122818 / 22.12.4 / Fix gluster.volume.optset endpoint (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -324,7 +324,7 @@ class GlusterVolumeService(CRUDService):
             --value-- is the value to be given to the option
         """
 
-        options = {'args': (data['name'],), 'kwargs': data['opts']}
+        options = {'args': (data['name'], data['opts'])}
         return await self.middleware.call('gluster.method.run', volume.optset, options)
 
     @accepts(Dict(


### PR DESCRIPTION
Glustercli expects the dict to be presented as arg rather than breaking into kwargs.

Original PR: https://github.com/truenas/middleware/pull/11625
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122818