### PR TITLE
NAS-122819 / 22.12.4 / Do not allow remote fuse mounts of ctdb_shared_vol

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -111,6 +111,10 @@ class CtdbSharedVolumeService(Service):
             options = {'args': (CTDB_VOL_NAME, bricks,)}
             options['kwargs'] = {'replica': len(con_peers), 'force': True}
             await self.middleware.call('gluster.method.run', volume.create, options)
+            await self.middleware.call('gluster.volume.optset', {
+                'name': CTDB_VOL_NAME,
+                'opts': {'auth.allow': 'NONE'}
+            })
 
         # make sure the shared volume is configured properly to prevent
         # possibility of split-brain/data corruption with ctdb service


### PR DESCRIPTION
There isn't a legitimate reason to allow remote clients to mount this.