### PR TITLE
NAS-122829 / 23.10 / Configure 2fa for user after enabling it globally in tests

### DIFF
--- a/tests/api2/test_twofactor_auth.py
+++ b/tests/api2/test_twofactor_auth.py
@@ -77,8 +77,8 @@ def test_user_2fa_secret_renewal():
         'password': TEST_PASSWORD_2,
         'full_name': TEST_USERNAME_2,
     }) as user_obj:
-        call('user.renew_2fa_secret', user_obj['username'])
         with enabled_twofactor_auth():
+            call('user.renew_2fa_secret', user_obj['username'])
             assert call(
                 'auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2,
                 get_2fa_totp_token(get_user_secret(user_obj['id'])['secret'])


### PR DESCRIPTION
This commit fixes an issue where in integration test we configured 2fa for user before enabling 2fa globally which resulted in configuration for user 2fa getting wiped as expected because we remove 2fa configuration for user when parameters like interval are changed for 2fa as secret needs to be regenerated at that point.