### PR TITLE
NAS-122841 / 23.10 / Use 16K as default for volume block size

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -324,8 +324,12 @@ class PoolDatasetService(CRUDService):
                     verrors.add(f'{schema}.recordsize', f'{rs!r} is an invalid recordsize.')
 
         elif data['type'] == 'VOLUME':
-            if mode == 'CREATE' and 'volsize' not in data:
-                verrors.add(f'{schema}.volsize', 'This field is required for VOLUME')
+            if mode == 'CREATE':
+                if 'volsize' not in data:
+                    verrors.add(f'{schema}.volsize', 'This field is required for VOLUME')
+                if 'volblocksize' not in data:
+                    # with openzfs 2.2, zfs sets 16k as default https://github.com/openzfs/zfs/pull/12406
+                    data['volblocksize'] = '16K'
 
             for i in (
                 'aclmode', 'acltype', 'atime', 'casesensitivity', 'quota', 'refquota', 'recordsize',

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -31,7 +31,7 @@ def data():
 
 
 def test_01_vm_disk_choices(request):
-    with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1032192}) as ds:
+    with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1048576}) as ds:
         results = GET('/vm/device/disk_choices')
         assert isinstance(results.json(), dict), results.json()
         assert results.json().get(f'/dev/zvol/{ds.replace(" ", "+")}') == f'{ds}'

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -31,7 +31,7 @@ def data():
 
 
 def test_01_vm_disk_choices(request):
-    with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1024000}) as ds:
+    with dataset('test zvol', {'type': 'VOLUME', 'volsize': 1032192}) as ds:
         results = GET('/vm/device/disk_choices')
         assert isinstance(results.json(), dict), results.json()
         assert results.json().get(f'/dev/zvol/{ds.replace(" ", "+")}') == f'{ds}'

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -27,7 +27,7 @@ def iscsi_extent(data):
 def test__iscsi_extent__disk_choices(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1032192,
+        "volsize": 1048576,
     }) as ds:
         # Make snapshots available for devices
         call("zfs.dataset.update", ds, {"properties": {"snapdev": {"parsed": "visible"}}})
@@ -55,7 +55,7 @@ def test__iscsi_extent__disk_choices(request):
 def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1032192,
+        "volsize": 1048576,
     }) as ds:
         with pytest.raises(ValidationErrors) as e:
             with iscsi_extent({
@@ -73,7 +73,7 @@ def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
 def test__iscsi_extent__locked(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1032192,
+        "volsize": 1048576,
         "inherit_encryption": False,
         "encryption": True,
         "encryption_options": {"passphrase": "testtest"},

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -27,7 +27,7 @@ def iscsi_extent(data):
 def test__iscsi_extent__disk_choices(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1024000,
+        "volsize": 1032192,
     }) as ds:
         # Make snapshots available for devices
         call("zfs.dataset.update", ds, {"properties": {"snapdev": {"parsed": "visible"}}})
@@ -55,7 +55,7 @@ def test__iscsi_extent__disk_choices(request):
 def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1024000,
+        "volsize": 1032192,
     }) as ds:
         with pytest.raises(ValidationErrors) as e:
             with iscsi_extent({
@@ -73,7 +73,7 @@ def test__iscsi_extent__create_with_invalid_disk_with_whitespace(request):
 def test__iscsi_extent__locked(request):
     with dataset("test zvol", {
         "type": "VOLUME",
-        "volsize": 1024000,
+        "volsize": 1032192,
         "inherit_encryption": False,
         "encryption": True,
         "encryption_options": {"passphrase": "testtest"},

--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -18,7 +18,7 @@ def encryption_props():
 @pytest.mark.parametrize("zvol", [True, False])
 def test_restart_vm_on_dataset_unlock(zvol):
     if zvol:
-        data = {"type": "VOLUME", "volsize": 1032192}
+        data = {"type": "VOLUME", "volsize": 1048576}
     else:
         data = {}
 

--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -18,7 +18,7 @@ def encryption_props():
 @pytest.mark.parametrize("zvol", [True, False])
 def test_restart_vm_on_dataset_unlock(zvol):
     if zvol:
-        data = {"type": "VOLUME", "volsize": 1024000}
+        data = {"type": "VOLUME", "volsize": 1032192}
     else:
         data = {}
 


### PR DESCRIPTION
This PR adds changes to use 16K as default for volume block size based on changes introduced in https://github.com/openzfs/zfs/pull/12406.