### PR TITLE
NAS-122844 / 23.10 / better iommu enabled detection

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -13,7 +13,6 @@ from .utils import get_virsh_command_args
 
 
 RE_DEVICE_PATH = re.compile(r'pci_(\w+)_(\w+)_(\w+)_(\w+)')
-RE_IOMMU_ENABLED = re.compile(r'QEMU.*if IOMMU is enabled.*:\s*PASS.*')
 
 
 class VMDeviceService(Service):
@@ -24,12 +23,8 @@ class VMDeviceService(Service):
     @accepts()
     @returns(Bool())
     async def iommu_enabled(self):
-        """
-        Returns "true" if iommu is enabled, "false" otherwise
-        """
-        cp = await run(['virt-host-validate'], check=False)
-        # We still check for stdout because if some check in it fails, the command will have a non zero exit code
-        return bool(RE_IOMMU_ENABLED.findall((cp.stdout or b'').decode()))
+        """Returns "true" if iommu is enabled, "false" otherwise"""
+        return await self.middleware.run_in_thread(os.path.exists, '/sys/kernel/iommu_groups')
 
     @private
     def retrieve_node_information(self, xml):


### PR DESCRIPTION
The presence of the directory "iommu_groups" in /sys/kernel is enough to determine if IOMMU is enabled. Check that instead of sub processing in the main event loop and then parsing stdout.