### PR TITLE
NAS-122859 / 23.10 / Improve schema handling for private items

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -379,12 +379,14 @@ def test__schema_dict_error_handler():
     assert ei.value.errors[0].attribute == 'create.repository'
 
 
-@pytest.mark.parametrize('items,value', [
-    ([List('b', items=[List('c', private=True)])], [[['a']]]),
-    ([Dict('b', Str('c', private=True))], [{'c': 'secret'}])
+@pytest.mark.parametrize('items,value,expected', [
+    ([List('b', items=[List('c', private=True)])], [[['a']]], [['********']]),
+    ([Dict('b', Str('c', private=True))], [{'c': 'secret'}], [{'c': '********'}]),
+    ([Dict('b', Str('c', private=True)), Dict('d', Str('e'))], [{'c': 'secret'}], [{'c': '********'}]),
+    ([Dict('b', Str('c')), Dict('d', Str('c', private=True))], [{'c': 'secret'}], ['********']),
 ])
-def test__schema_list_private_items(items, value):
-    assert List('a', items=items).dump(value) == '********'
+def test__schema_list_private_items(items, value, expected):
+    assert List('a', items=items).dump(value) == expected
 
 
 def test__schema_list_empty():


### PR DESCRIPTION
OROperator lacked has_private() method which broke dumping values in some edge cases.

Allow dumping of Lists where single item schema is set for the list and the schema contains private entries. If we don't do this then our job log is relatively useless.