### PR TITLE
NAS-122871 / 23.10 / fix failing iscsi test

### DIFF
--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -25,15 +25,12 @@ def iscsi_extent(data):
 
 
 def test__iscsi_extent__disk_choices(request):
-    with dataset("test zvol", {
-        "type": "VOLUME",
-        "volsize": 1048576,
-    }) as ds:
+    with dataset("test zvol", {"type": "VOLUME", "volsize": 1048576}) as ds:
         # Make snapshots available for devices
         call("zfs.dataset.update", ds, {"properties": {"snapdev": {"parsed": "visible"}}})
         call("zfs.snapshot.create", {"dataset": ds, "name": "snap-1"})
         assert call("iscsi.extent.disk_choices") == {
-            f'zvol/{ds.replace(" ", "+")}': f'{ds} (1000 KiB)',
+            f'zvol/{ds.replace(" ", "+")}': f'{ds} (1 MiB)',
             f'zvol/{ds.replace(" ", "+")}@snap-1': f'{ds}@snap-1 [ro]',
         }
 


### PR DESCRIPTION
We changed the volume size to 1 Mebibyte in bytes but forgot to update the parenthesized value that gets displayed by iscsi (1000 KiB instead of 1 MiB)