### PR TITLE
NAS-122365 / 23.10 / Add state management for kubernetes

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/attachments.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/attachments.py
@@ -3,6 +3,8 @@ import os
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.common.ports import ServicePortDelegate
 
+from .utils import Status
+
 
 class KubernetesFSAttachmentDelegate(FSAttachmentDelegate):
     name = 'kubernetes'
@@ -47,7 +49,8 @@ class KubernetesFSAttachmentDelegate(FSAttachmentDelegate):
             return
         try:
             await self.middleware.call('service.start', 'kubernetes')
-        except Exception:
+        except Exception as e:
+            await self.middleware.call('kubernetes.set_status', Status.FAILED.value, str(e))
             self.middleware.logger.error('Failed to start kubernetes')
 
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -286,7 +286,7 @@ class KubernetesService(Service):
             self.middleware.call_sync('kubernetes.status_change_internal')
         except Exception as e:
             self.middleware.call_sync('alert.oneshot_create', 'ApplicationsConfigurationFailed', {'error': str(e)})
-            await self.set_status(Status.FAILED.value)
+            self.middleware.call_sync('kubernetes.set_status', Status.FAILED.value)
             raise
         else:
             with open(config_path, 'w') as f:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -46,7 +46,7 @@ class KubernetesService(Service):
             await self.post_start_internal()
             await self.add_iptables_rules()
         except Exception as e:
-            await self.set_status(Status.FAILED.value)
+            await self.set_status(Status.FAILED.value, str(e))
             await self.middleware.call('alert.oneshot_create', 'ApplicationsStartFailed', {'error': str(e)})
             raise
         else:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -409,7 +409,7 @@ class KubernetesService(Service):
     async def set_status(self, new_status):
         assert new_status in Status.__members__
         self.STATUS = Status(new_status)
-        # TODO: Let's perhaps send an event here ?
+        self.middleware.send_event('kubernetes.state', 'CHANGED', fields={'status': new_status})
 
     @accepts()
     @returns(Str())
@@ -452,6 +452,7 @@ async def _event_system_shutdown(middleware, event_type, args):
 
 
 async def setup(middleware):
+    middleware.event_register('kubernetes.state', 'Kubernetes state events')
     middleware.event_subscribe('system.ready', _event_system_ready)
     middleware.event_subscribe('system.shutdown', _event_system_shutdown)
     await middleware.call('kubernetes.initialize_k8s_status')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -406,9 +406,12 @@ class KubernetesService(Service):
         await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
     @private
-    async def set_status(self, new_status):
+    async def set_status(self, new_status, extra=None):
         assert new_status in Status.__members__
-        self.STATUS = APPS_STATUS(Status(new_status), STATUS_DESCRIPTIONS[new_status])
+        self.STATUS = APPS_STATUS(
+            Status(new_status),
+            f'{STATUS_DESCRIPTIONS[new_status]}:\n{extra}' if extra else '',
+        )
         self.middleware.send_event('kubernetes.state', 'CHANGED', fields=await self.get_status_dict())
 
     @private

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Dict
 
+from middlewared.schema import accepts, returns, Str
 from middlewared.service import CallError, private, Service
 from middlewared.utils import run
 
@@ -409,6 +410,14 @@ class KubernetesService(Service):
         assert new_status in Status.__members__
         self.STATUS = Status(new_status)
         # TODO: Let's perhaps send an event here ?
+
+    @accepts()
+    @returns(Str())
+    async def status(self):
+        """
+        Returns the status of the Kubernetes service.
+        """
+        return self.STATUS.value
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -285,6 +285,7 @@ class KubernetesService(Service):
             self.middleware.call_sync('kubernetes.status_change_internal')
         except Exception as e:
             self.middleware.call_sync('alert.oneshot_create', 'ApplicationsConfigurationFailed', {'error': str(e)})
+            await self.set_status(Status.FAILED.value)
             raise
         else:
             with open(config_path, 'w') as f:
@@ -295,6 +296,7 @@ class KubernetesService(Service):
 
     @private
     async def status_change_internal(self):
+        await self.set_status(Status.INITIALIZING.value)
         await self.validate_k8s_fs_setup()
         await self.middleware.call('k8s.migration.run')
         await self.middleware.call('service.start', 'kubernetes')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -3,12 +3,12 @@ import errno
 import json
 import os
 import shutil
+import typing
 import uuid
 
 from datetime import datetime
-from typing import Dict
 
-from middlewared.schema import accepts, returns, Str
+from middlewared.schema import accepts, Dict, returns, Str
 from middlewared.service import CallError, private, Service
 from middlewared.utils import run
 
@@ -312,7 +312,7 @@ class KubernetesService(Service):
         await self.middleware.call('catalog.sync_all')
 
     @private
-    def get_dataset_update_props(self, props: Dict) -> Dict:
+    def get_dataset_update_props(self, props: typing.Dict) -> typing.Dict:
         return {
             attr: value
             for attr, value in props.items()
@@ -369,7 +369,7 @@ class KubernetesService(Service):
         ]
 
     @private
-    def kubernetes_dataset_custom_props(self, ds: str) -> Dict:
+    def kubernetes_dataset_custom_props(self, ds: str) -> typing.Dict:
         props = {
             'ix-applications': {
                 'encryption': 'off'
@@ -424,7 +424,10 @@ class KubernetesService(Service):
         return {'status': self.STATUS.status.value, 'description': self.STATUS.description}
 
     @accepts()
-    @returns(Str())
+    @returns(Dict(
+        Str('status', enum=[e.value for e in Status]),
+        Str('description'),
+    ))
     async def status(self):
         """
         Returns the status of the Kubernetes service.

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -12,12 +12,15 @@ from middlewared.service import CallError, private, Service
 from middlewared.utils import run
 
 from .k8s.config import reinitialize_config
+from .utils import Status
 
 
 START_LOCK = asyncio.Lock()
 
 
 class KubernetesService(Service):
+
+    STATUS = Status.UNCONFIGURED
 
     @private
     async def post_start(self):
@@ -394,6 +397,12 @@ class KubernetesService(Service):
             raise
 
         await self.middleware.call('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
+
+    @private
+    async def set_status(self, new_status):
+        assert new_status in Status.__members__
+        self.STATUS = Status(new_status)
+        # TODO: Let's perhaps send an event here ?
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -10,7 +10,7 @@ from middlewared.schema import Bool, Dict, Int, IPAddr, Patch, returns, Str
 from middlewared.service import accepts, CallError, job, private, ConfigService, ValidationErrors
 
 from .k8s import ApiException, Node
-from .utils import applications_ds_name
+from .utils import applications_ds_name, Status
 
 
 class KubernetesModel(sa.Model):
@@ -486,6 +486,7 @@ class KubernetesService(ConfigService):
                     # host catalog repos temporarily. Otherwise, we should call this after k8s datasets have
                     # been initialised
                     await self.middleware.call('catalog.sync_all')
+                    await self.middleware.call('kubernetes.set_status', Status.UNCONFIGURED.value)
 
         return await self.config()
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -18,6 +18,7 @@ UPDATE_BACKUP_PREFIX = 'system-update-'
 class Status(enum.Enum):
     RUNNING = 'running'
     INITIALIZING = 'initializing'
+    STOPPING = 'stopping'
     STOPPED = 'stopped'
     UNCONFIGURED = 'unconfigured'
     FAILED = 'failed'

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -25,5 +25,16 @@ class Status(enum.Enum):
     FAILED = 'FAILED'
 
 
+STATUS_DESCRIPTIONS = {
+    Status.PENDING: 'Application(s) state is to be determined yet',
+    Status.RUNNING: 'Application(s) are currently running',
+    Status.INITIALIZING: 'Application(s) are being initialized',
+    Status.STOPPING: 'Application(s) are being stopped',
+    Status.STOPPED: 'Application(s) have been stopped',
+    Status.UNCONFIGURED: 'Application(s) are not configured',
+    Status.FAILED: 'Application(s) have failed to start',
+}
+
+
 def applications_ds_name(pool):
     return os.path.join(pool, 'ix-applications')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -1,7 +1,10 @@
 import enum
 import os
 
+from collections import namedtuple
 
+
+APPS_STATUS = namedtuple('Status', ['status', 'description'])
 BACKUP_NAME_PREFIX = 'ix-applications-backup-'
 KUBECONFIG_FILE = '/etc/rancher/k3s/k3s.yaml'
 KUBERNETES_WORKER_NODE_PASSWORD = 'e3d26cefbdf2f81eff5181e68a02372f'

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -16,13 +16,13 @@ UPDATE_BACKUP_PREFIX = 'system-update-'
 
 
 class Status(enum.Enum):
-    PENDING = 'pending'
-    RUNNING = 'running'
-    INITIALIZING = 'initializing'
-    STOPPING = 'stopping'
-    STOPPED = 'stopped'
-    UNCONFIGURED = 'unconfigured'
-    FAILED = 'failed'
+    PENDING = 'PENDING'
+    RUNNING = 'RUNNING'
+    INITIALIZING = 'INITIALIZING'
+    STOPPING = 'STOPPING'
+    STOPPED = 'STOPPED'
+    UNCONFIGURED = 'UNCONFIGURED'
+    FAILED = 'FAILED'
 
 
 def applications_ds_name(pool):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -1,3 +1,4 @@
+import enum
 import os
 
 
@@ -12,6 +13,14 @@ NODE_NAME = 'ix-truenas'
 NVIDIA_RUNTIME_CLASS_NAME = 'nvidia'
 OPENEBS_ZFS_GROUP_NAME = 'zfs.openebs.io'
 UPDATE_BACKUP_PREFIX = 'system-update-'
+
+
+class Status(enum.Enum):
+    RUNNING = 'running'
+    INITIALIZING = 'initializing'
+    STOPPED = 'stopped'
+    UNCONFIGURED = 'unconfigured'
+    FAILED = 'failed'
 
 
 def applications_ds_name(pool):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -16,6 +16,7 @@ UPDATE_BACKUP_PREFIX = 'system-update-'
 
 
 class Status(enum.Enum):
+    PENDING = 'pending'
     RUNNING = 'running'
     INITIALIZING = 'initializing'
     STOPPING = 'stopping'


### PR DESCRIPTION
This PR adds state management for kubernetes so we stay up to date on what the current state of kubernetes cluster is. Motivation behind this change is users accessing apps page when the cluster is initializing which can potentially result in giving invalid results as the cluster might be starting or is yet to be started if system is not ready yet.