### PR TITLE
NAS-122869 / 22.12.4 / Better REST error message (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -594,6 +594,21 @@ class Resource(object):
 
         return [filters, options] if filters or options else []
 
+    async def parse_rest_json_request(self, req, resp):
+        body, error = None, False
+        try:
+            body = await req.json()
+        except json.decoder.JSONDecodeError as e:
+            resp.set_status(400)
+            resp.headers['Content-type'] = 'application/json'
+            resp.text = json.dumps({
+                'message': f'json parse error: {e}',
+                'errno': errno.EINVAL,
+            }, indent=True)
+            error = True
+
+        return body, error
+
     async def do(self, http_method, req, resp, authenticated_credentials, **kwargs):
         assert http_method in ('delete', 'get', 'post', 'put')
 
@@ -662,11 +677,15 @@ class Resource(object):
                 else:
                     if await req.text():
                         has_request_body = True
-                        request_body = await req.json()
+                        request_body, error = await self.parse_rest_json_request(req, resp)
+                        if error:
+                            return resp
         else:
             if await req.text():
                 has_request_body = True
-                request_body = await req.json()
+                request_body, error = await self.parse_rest_json_request(req, resp)
+                if error:
+                    return resp
 
         download_pipe = None
         if method['downloadable']:


### PR DESCRIPTION
If a consumer of our REST API sends us json formatted data that is incorrect we crash here:
```
  File "/usr/lib/python3/dist-packages/middlewared/restful.py", line 524, in on_method
    return await do(method, req, resp, authenticated_credentials, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/middlewared/restful.py", line 669, in do
    request_body = await req.json()
  File "/usr/lib/python3/dist-packages/aiohttp/web_request.py", line 614, in json
    return loads(body)
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The consumer gets a 500 error without any real helpful information
```
'500 Internal Server Error\n\nServer got itself in trouble'
```

If we fail to decode json coming in on the rest interface, then handle that error a bit better and give a better error message and set the status to 400 (Bad Request) instead of 500 (Internal Server Error)

Original PR: https://github.com/truenas/middleware/pull/11645
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122869