### PR TITLE
NAS-122958 / 22.12.4 / Separately check home_mode for immutable user (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -679,7 +679,10 @@ class UserService(CRUDService):
 
         # Do not allow attributes to be changed for builtin user
         if user['immutable']:
-            for i in ('group', 'home', 'home_mode', 'uid', 'username', 'smb'):
+            if 'home_mode' in data:
+                verrors.add('user_update.home_mode', 'This attribute cannot be changed')
+
+            for i in ('group', 'home', 'uid', 'username', 'smb'):
                 if i in data and data[i] != user[i]:
                     verrors.add(f'user_update.{i}', 'This attribute cannot be changed')
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -820,3 +820,20 @@ def test_59_create_user_ro_dataset(request):
         user_info['home'] = ds['mountpoint']
         results = POST("/user/", user_info)
         assert results.status_code == 422, results.text
+
+
+@pytest.mark.parametrize('payload', [
+    {'group': 1},
+    {'home': '/mnt/tank/foo', 'home_create': True},
+    {'uid': 777777},
+    {'smb': True},
+    {'username': 'glusterd_bad'},
+])
+def test_60_immutable_user_validation(payload, request):
+    # Glusterd happens to be an immutable 
+    user_req = GET('/user?username=glusterd')
+    assert user_req.status_code == 200, results.text
+    userid = user_req.json()[0]['id']
+
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 422, results.text

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -831,7 +831,7 @@ def test_59_create_user_ro_dataset(request):
 ])
 def test_60_immutable_user_validation(payload, request):
     # Glusterd happens to be an immutable 
-    user_req = GET('/user?username=glusterd')
+    user_req = GET('/user?username=gluster')
     assert user_req.status_code == 200, results.text
     userid = user_req.json()[0]['id']
 


### PR DESCRIPTION
This fixes KeyError when user submits payload that includes home_mode for immutable user.

Original PR: https://github.com/truenas/middleware/pull/11652
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122958