### PR TITLE
NAS-122974 / 23.10 / Shift automation workloads to dedicated AD OU

### DIFF
--- a/tests/api2/test_012_directory_service_ssh.py
+++ b/tests/api2/test_012_directory_service_ssh.py
@@ -12,7 +12,7 @@ from assets.REST.directory_services import active_directory, ldap, override_name
 from middlewared.test.integration.utils import call
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)
@@ -39,6 +39,7 @@ def do_ad_connection(request):
             ADUSERNAME,
             ADPASSWORD,
             netbiosname=hostname,
+            createcomputer=AD_COMPUTER_OU,
         ) as ad:
             yield (request, ad)
 

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -24,7 +24,7 @@ else:
     from auto_config import hostname
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
     AD_USER = fr"AD02\{ADUSERNAME.lower()}"
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
@@ -226,6 +226,7 @@ def test_07_enable_leave_activedirectory(request):
     global domain_users_id
     with active_directory(AD_DOMAIN, ADUSERNAME, ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
         dns_timeout=15
     ) as ad:
         # Verify that we're not leaking passwords into middleware log
@@ -310,6 +311,7 @@ def test_08_activedirectory_smb_ops(request):
     depends(request, ["ad_works"], scope="session")
     with active_directory(AD_DOMAIN, ADUSERNAME, ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
         dns_timeout=15
     ) as ad:
         with dataset(
@@ -442,6 +444,7 @@ def test_10_account_privilege_authentication(request):
 
     with active_directory(AD_DOMAIN, ADUSERNAME, ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
         dns_timeout=15
     ):
         call("system.general.update", {"ds_auth": True})

--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -23,7 +23,7 @@ from protocols import nfs_share
 from pytest_dependency import depends
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)
@@ -151,6 +151,7 @@ def do_ad_connection(request):
         ADUSERNAME,
         ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
     ) as ad:
         yield (request, ad)
 

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -18,7 +18,7 @@ from pytest_dependency import depends
 from time import sleep
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
     from config import (
         LDAPBASEDN,
         LDAPBINDDN,
@@ -59,6 +59,7 @@ def do_ad_connection(request):
         ADUSERNAME,
         ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
     ) as ad:
         yield (request, ad)
 

--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -17,7 +17,7 @@ from pytest_dependency import depends
 from middlewared.test.integration.utils import call
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)
@@ -81,6 +81,7 @@ def do_ad_connection(request):
         ADUSERNAME,
         ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
     ) as ad:
         yield (request, ad)
 

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -13,7 +13,7 @@ from auto_config import ip, hostname, password, user
 from pytest_dependency import depends
 
 try:
-    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)
@@ -32,6 +32,7 @@ def do_ad_connection(request):
         ADUSERNAME,
         ADPASSWORD,
         netbiosname=hostname,
+        createcomputer=AD_COMPUTER_OU,
     ) as ad:
         yield (request, ad)
 


### PR DESCRIPTION
Only install new computer objects in a dedicated OU in our AD domain during CI runs. This helps us to keep track of what was added via CI and what has been manually added (as well as simplifying permissions management).