### PR TITLE
NAS-119483 / 23.10 / Remove host path validation logic from kubernetes

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
@@ -2,7 +2,7 @@
 Remove validate_host_path column from k8s column
 
 Revision ID: a1917e15f409
-Revises: 1cdfe58ae329
+Revises: 593f8ded154e
 Create Date: 2023-07-13 20:35:14.561629+00:00
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 
 revision = 'a1917e15f409'
-down_revision = '1cdfe58ae329'
+down_revision = '593f8ded154e'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
@@ -1,0 +1,26 @@
+"""
+Remove validate_host_path column from k8s column
+
+Revision ID: a1917e15f409
+Revises: 1cdfe58ae329
+Create Date: 2023-07-13 20:35:14.561629+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a1917e15f409'
+down_revision = '1cdfe58ae329'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_kubernetes', schema=None) as batch_op:
+        batch_op.drop_column('validate_host_path')
+
+
+def downgrade():
+    pass
+

--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-07-13_20-35_k8s_host_path_validation.py
@@ -23,4 +23,3 @@ def upgrade():
 
 def downgrade():
     pass
-

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -57,6 +57,5 @@ def render(service, middleware):
 
     with open('/etc/containerd.json', 'w') as f:
         f.write(json.dumps({
-            'verifyVolumes': config['validate_host_path'],
             'appsDataset': config['dataset'],
         }))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -12,15 +12,6 @@ class ChartReleaseService(Service):
         namespace = 'chart.release'
 
     @private
-    async def ix_mount_validation(self, path, path_type):
-        path_list = [p for p in path.split('/') if p.strip()]
-        if safe_to_ignore_path(path):
-            if path_list and len(path_list) < 3 and path_list[0] == 'mnt':
-                return f'Invalid path {path}. Mounting root dataset or path outside a pool is not allowed'
-        else:
-            return f'{path!r} {path_type!r} not allowed to be mounted'
-
-    @private
     async def validate_host_source_path(self, path):
         # Let's keep this endpoint in case we want to debug a path and this endpoint can do the
         # work for us in case a user comes to us and complains and we want to verify if the path

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -21,32 +21,6 @@ class ChartReleaseService(Service):
             return f'{path!r} {path_type!r} not allowed to be mounted'
 
     @private
-    async def attached_path_validation(self, path, path_type):
-        allowed_service_types = {
-            'Chart Releases',
-            'Rsync Task',
-            'Snapshot Task',
-            'Rsync Module',
-            'CloudSync Task',
-            'Replication',
-        }
-        in_use_attachments = []
-        for attachment_entry in filter(
-            lambda attachment: attachment['type'] not in allowed_service_types,
-            await self.middleware.call('pool.dataset.attachments_with_path', path, True)
-        ):
-            if attachment_entry['service'].lower() == 'kubernetes' and is_ix_volume_path(
-                path, (await self.middleware.call('kubernetes.config'))['dataset']
-            ):
-                continue
-
-            in_use_attachments.append(attachment_entry)
-
-        if in_use_attachments:
-            return f'Invalid mount {path!r} {path_type}. Following service(s) use this ' \
-                   f'path: {", ".join(attachment["type"] for attachment in in_use_attachments)}'
-
-    @private
     async def validate_host_source_path(self, path):
         # Let's keep this endpoint in case we want to debug a path and this endpoint can do the
         # work for us in case a user comes to us and complains and we want to verify if the path

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -3,8 +3,6 @@ import os
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.service import private, Service
 
-from .utils import is_ix_volume_path, safe_to_ignore_path
-
 
 class ChartReleaseService(Service):
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -48,6 +48,9 @@ class ChartReleaseService(Service):
 
     @private
     async def validate_host_source_path(self, path):
+        # Let's keep this endpoint in case we want to debug a path and this endpoint can do the
+        # work for us in case a user comes to us and complains and we want to verify if the path
+        # is problematic wrt usages and should or should not be used.
         paths = {
             'path': path,
         }

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -59,14 +59,9 @@ class ChartReleaseService(Service):
             paths[f'path (real path of {path})'] = real_path
 
         for path_type, path_to_test in paths.items():
-            if err := await self.ix_mount_validation(path_to_test, path_type):
-                return err
-
             if path_to_test.startswith('/mnt/'):
                 if await self.middleware.call('pool.dataset.path_in_locked_datasets', path_to_test):
                     return f'Path {path_to_test!r} {path_type} is locked'
-                if err := await self.attached_path_validation(path_to_test, path_type):
-                    return err
 
 
 class ChartReleaseFSAttachmentDelegate(FSAttachmentDelegate):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/host_path_attachments.py
@@ -11,9 +11,7 @@ class ChartReleaseService(Service):
 
     @private
     async def validate_host_source_path(self, path):
-        # Let's keep this endpoint in case we want to debug a path and this endpoint can do the
-        # work for us in case a user comes to us and complains and we want to verify if the path
-        # is problematic wrt usages and should or should not be used.
+        # We just validate now that the path is not in a locked dataset
         paths = {
             'path': path,
         }

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -70,30 +70,6 @@ def get_chart_release_from_namespace(namespace):
     return namespace.split(CHART_NAMESPACE_PREFIX, 1)[-1]
 
 
-def safe_to_ignore_path(path: str) -> bool:
-    # "/" and "/home/keys/" are added for openebs use only, regular containers can't mount "/" as we have validation
-    # already in place by docker elsewhere to prevent that from happening
-    if path == '/':
-        return True
-
-    for ignore_path in (
-        '/dev/',  # required by openebs
-        '/etc/group',  # required by netdata
-        '/etc/os-release',  # required by netdata
-        '/etc/passwd',  # required by netdata
-        '/home/keys/',  # required by openebs
-        '/mnt/',
-        '/proc/',  # required by netdata
-        '/sys/',  # required by netdata
-        '/usr/lib/os-release',  # required by netdata
-        '/var/lib/kubelet/',
-    ):
-        if path.startswith(ignore_path) or path == ignore_path.removesuffix('/'):
-            return True
-
-    return False
-
-
 def is_ix_volume_path(path: str, dataset: str) -> bool:
     release_path = os.path.join('/mnt', dataset, 'releases')
     if not path.startswith(release_path):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -120,7 +120,8 @@ class ChartReleaseService(Service):
 
     @private
     async def validate_host_path_field(self, value, verrors, schema_name):
-        pass
+        if err_str := await self.middleware.call('chart.release.validate_host_source_path', value):
+            verrors.add(schema_name, err_str)
 
     @private
     async def validate_port_available_on_node(self, verrors, value, question, schema_name, release_data):

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -95,9 +95,6 @@ class ChartReleaseService(Service):
                         var_attr, attr, f'{schema_name}.{index}', release_data,
                     )
 
-        if schema['type'] == 'hostpath':
-            await self.validate_host_path_field(value, verrors, schema_name)
-
         for validator_def in filter(lambda k: k in validation_mapping, schema.get('$ref', [])):
             await self.middleware.call(
                 f'chart.release.validate_{validation_mapping[validator_def]}',

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -119,14 +119,6 @@ class ChartReleaseService(Service):
         return verrors
 
     @private
-    async def validate_host_path_field(self, value, verrors, schema_name):
-        if not (await self.middleware.call('kubernetes.config'))['validate_host_path']:
-            return
-
-        if err_str := await self.middleware.call('chart.release.validate_host_source_path', value):
-            verrors.add(schema_name, err_str)
-
-    @private
     async def validate_port_available_on_node(self, verrors, value, question, schema_name, release_data):
         if release_data and value in [p['port'] for p in release_data['used_ports']]:
             # TODO: This still leaves a case where user has multiple ports in a single app and mixes

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -119,6 +119,10 @@ class ChartReleaseService(Service):
         return verrors
 
     @private
+    async def validate_host_path_field(self, value, verrors, schema_name):
+        pass
+
+    @private
     async def validate_port_available_on_node(self, verrors, value, question, schema_name, release_data):
         if release_data and value in [p['port'] for p in release_data['used_ports']]:
             # TODO: This still leaves a case where user has multiple ports in a single app and mixes

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -95,6 +95,9 @@ class ChartReleaseService(Service):
                         var_attr, attr, f'{schema_name}.{index}', release_data,
                     )
 
+        if schema['type'] == 'hostpath':
+            await self.validate_host_path_field(value, verrors, schema_name)
+
         for validator_def in filter(lambda k: k in validation_mapping, schema.get('$ref', [])):
             await self.middleware.call(
                 f'chart.release.validate_{validation_mapping[validator_def]}',

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -352,12 +352,6 @@ class KubernetesService(ConfigService):
                     'Specified value is not present on any network cidr in use by the system'
                 )
 
-        if not data['validate_host_path'] and await self.middleware.call('failover.hardware') != 'MANUAL':
-            verrors.add(
-                f'{schema}.validate_host_path',
-                'Host path validation cannot be switched off for SCALE ENTERPRISE users'
-            )
-
         force = data.pop('force', False)
         if data['pool'] and not verrors:
             await self.middleware.call('kubernetes.check_config_on_apps_dataset', data['pool'], verrors, force, schema)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -29,7 +29,6 @@ class KubernetesModel(sa.Model):
     cni_config = sa.Column(sa.JSON(type=dict), default={})
     configure_gpus = sa.Column(sa.Boolean(), default=True, nullable=False)
     servicelb = sa.Column(sa.Boolean(), default=True, nullable=False)
-    validate_host_path = sa.Column(sa.Boolean(), default=True)
     passthrough_mode = sa.Column(sa.Boolean(), default=False)
     metrics_server = sa.Column(sa.Boolean(), default=False, nullable=False)
 
@@ -46,7 +45,6 @@ class KubernetesService(ConfigService):
         Bool('servicelb', required=True),
         Bool('configure_gpus', required=True),
         Bool('metrics_server', required=True),
-        Bool('validate_host_path', required=True),
         Bool('passthrough_mode', required=True),
         Str('pool', required=True, null=True),
         IPAddr('cluster_cidr', required=True, cidr=True, empty=True),

--- a/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
@@ -45,6 +45,7 @@ async def test_create_schema_formation():
     chart_release_svc = ChartReleaseService(m)
 
     m['chart.release.validate_locked_host_path'] = chart_release_svc.validate_locked_host_path
+    m['chart.release.validate_host_source_path'] = chart_release_svc.validate_host_source_path
     m['kubernetes.config'] = lambda *args: {
         'id': 1,
         'pool': 'pool',

--- a/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_release_validation_schema.py
@@ -58,7 +58,6 @@ async def test_create_schema_formation():
         'node_ip': '192.168.0.10',
         'configure_gpus': True,
         'servicelb': True,
-        'validate_host_path': False,
         'passthrough_mode': False,
         'dataset': 'pool/ix-applications'
     }

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_kubernetes.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_kubernetes.py
@@ -30,7 +30,6 @@ async def test_kubernetes_configuration_for_licensed_and_unlicensed_systems(ha_c
         'configure_gpus': True,
         'passthrough_mode': False,
         'servicelb': True,
-        'validate_host_path': True,
     }
 
     m['interface.choices'] = lambda *args: []


### PR DESCRIPTION
Kris has requested that we remove host path validation logic from kubernetes. All of the logic in place wrt that has been removed and we just now always validate that the path in question does not belong to a locked dataset.

In a future ticket we would be however adding tracing in containerd so we keep track of which paths were mounted by apps and we can based on that make a decision if we want to debug a ticket further or not.