### PR TITLE
NAS-119331 / 22.12.4 / On bridge update, do not put its member down if it already was a member of the bridge before update. (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -50,6 +50,7 @@ class InterfaceService(Service):
                 self.logger.info('Bringing up member interface %r in %r', member_iface.name, name)
                 member_iface.up()
 
+        for member in db_members:
             parent_interfaces.append(member)
 
         if iface.stp != bridge['stp']:


### PR DESCRIPTION
This bug was introduced by 97ff05a74845dacbd2974ef8c03a846e060986aa

Original PR: https://github.com/truenas/middleware/pull/11657
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119331