### PR TITLE
NAS-122363 / 23.10 / Fix vm display validation errors

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -124,7 +124,7 @@ class DISPLAY(Device):
 
             self.middleware.call_sync('vm.device.validate_display_devices', verrors, vm_instance)
 
-        self.validate_port_attrs(device, verrors)
+        verrors = self.validate_port_attrs(device, verrors)
 
         if device['attributes']['bind'] not in self.middleware.call_sync('vm.device.bind_choices'):
             verrors.add('attributes.bind', 'Requested bind address is not valid')


### PR DESCRIPTION
## Problem

The problem lies in the logic of the `validate_port_attrs` function. This function accepts a validation error as an optional parameter and should initializes a new validation error object if the parameter is not provided. The main problem arises there because validation error class has string method overridden which returns empty string if no validation error is added in verrors. So the `or` keyword used in this logic considers it `null` and initializes new object. As a result `validation_port_attr` function always initializes object if there are no validation errors already defined and in the main function `verrors` object being referenced does not contain the validation errors required.

## Solution

Use the `verrors` object returned by the port validation error function.