### PR TITLE
NAS-122659 / 22.12.4 / Properly catch exception with invalid helm secret (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/secrets_management.py
@@ -41,7 +41,7 @@ class ChartReleaseService(Service):
             data = release_secret.pop('data')
             try:
                 release = json.loads(gzip.decompress(b64decode(b64decode(data['release']))).decode())
-            except binascii.Error:
+            except (binascii.Error, gzip.BadGzipFile):
                 # We ignore this keeping in line with helm behaviour where the secret malformed is ignored by helm
                 if release_secret['metadata']['name'] not in self.LOGGED_SECRET:
                     self.logger.error('Failed to parse %r secret', release_secret['metadata']['name'])


### PR DESCRIPTION
We have seen cases earlier with users where helm had malformed secrets which resulted in us not being able to parse those secrets. Currently we have seen a user where another exception was being raised and this commit handles that exception so we properly handle this. This change makes sure that other apps which don't have a malformed secret are not affected by this inconsistency on helm side.

Original PR: https://github.com/truenas/middleware/pull/11660
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122659