### PR TITLE
NAS-123029 / 23.10 / Fix nested subquestions on app upgrade

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -130,13 +130,19 @@ def get_schema(variable_details, update, existing=NOT_PROVIDED):
     return result
 
 
+def clean_subquestions_for_upgrade(variable, valid_attrs):
+    for sub in (variable['schema'].get('subquestions') or []):
+        valid_attrs[sub['variable']] = sub
+        if sub['schema'].get('subquestions'):
+            clean_subquestions_for_upgrade(sub, valid_attrs)
+
+
 def clean_value_of_attr_for_upgrade(orig_value, variable):
     value = deepcopy(orig_value)
     valid_attrs = {}
     for v in variable['schema']['attrs']:
         valid_attrs[v['variable']] = v
-        for sub in (v['schema'].get('subquestions') or []):
-            valid_attrs[sub['variable']] = sub
+        clean_subquestions_for_upgrade(v, valid_attrs)
 
     for k, v in orig_value.items():
         if k not in valid_attrs:


### PR DESCRIPTION
## Problem

The problem identified is that the `clean_value_of_attr_for_upgrade` function does not support nested sub-questions in variables which results in nested subquestions values getting cleaned/added to the values for the app in question.


## Solution

A recursive approach has been added to the function where this implementation enables support for nested sub-questions 
being cleaned and added to cleaned values for the app in question.