### PR TITLE
NAS-122338 / 23.10 / Retrieve unused ports to be added to questions

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -211,6 +211,7 @@ class CatalogService(Service):
             'certificates': await self.middleware.call('chart.release.certificate_choices'),
             'certificate_authorities': await self.middleware.call('chart.release.certificate_authority_choices'),
             'system.general.config': await self.middleware.call('system.general.config'),
+            'unused_ports': await self.middleware.call('port.get_unused_ports'),
         }
 
     @private

--- a/src/middlewared/middlewared/plugins/ports/ports.py
+++ b/src/middlewared/middlewared/plugins/ports/ports.py
@@ -35,6 +35,16 @@ class PortService(Service):
             raise ValueError(f'{delegate.namespace!r} delegate is already registered with Port Service')
         self.DELEGATES[delegate.namespace] = delegate
 
+    async def get_all_used_ports(self):
+        used_ports = await self.get_in_use()
+        return [
+            port_entry[1] for entry in used_ports for port_entry in entry['ports']
+        ]
+
+    async def get_unused_ports(self, lower_port_limit=1025):
+        used_ports = set(await self.get_all_used_ports())
+        return [i for i in range(lower_port_limit, 65535) if i not in used_ports]
+
     async def get_in_use(self):
         ports = []
         for delegate in self.DELEGATES.values():

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -21,10 +21,7 @@ class VMService(Service):
 
         Returns a dict with two keys `port` and `web`.
         """
-        used_ports = await self.middleware.call('port.get_in_use')
-        all_ports = [
-            port_entry[1] for entry in used_ports for port_entry in entry['ports']
-        ]
+        all_ports = await self.middleware.call('port.get_all_used_ports')
 
         def get_next_port():
             for i in filter(lambda i: i not in all_ports, range(5900, 65535)):


### PR DESCRIPTION
## Context

A `ref` is being added so questions in an app which consume ports and allow it to be user configurable have a way to show unused ports which can actually be used by the app.