### PR TITLE
NAS-122714 / 23.10 / Limit app names to 40 characters

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -12,7 +12,7 @@ from middlewared.plugins.container_runtime_interface.utils import normalize_refe
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import CallError, CRUDService, filterable, job, private
 from middlewared.utils import filter_list
-from middlewared.validators import Match
+from middlewared.validators import Match, Range
 
 from .utils import (
     add_context_to_configuration, CHART_NAMESPACE_PREFIX, CONTEXT_KEY_NAME, get_action_context,
@@ -373,7 +373,7 @@ class ChartReleaseService(CRUDService):
                         e.g abc123, abc, abcd-1232
                         '''
                     )
-                )]
+                ), Range(min=1, max=40)]
             ),
             Str('train', default='charts'),
             Str('version', default='latest'),


### PR DESCRIPTION
## Problem

We are not validating maximum characters allowed in an app's name which results in errors being thrown from helm side.

## Solution

Properly validate the length of chart release name.