### PR TITLE
NAS-122715 / 23.10 / Allow validating path is dir/file on host in apps

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -5,7 +5,7 @@ from itertools import chain
 from typing import Union
 
 from middlewared.service_exception import ValidationErrors
-from middlewared.schema import Bool, Cron, Dict, HostPath, Int, IPAddr, List, NOT_PROVIDED, Path, Str, URI
+from middlewared.schema import Bool, Cron, Dict, Dir, File, HostPath, Int, IPAddr, List, NOT_PROVIDED, Path, Str, URI
 from middlewared.validators import Match, Range, validate_schema
 
 
@@ -15,6 +15,8 @@ mapping = {
     'boolean': Bool,
     'path': Path,
     'hostpath': HostPath,
+    'hostpathdirectory': Dir,
+    'hostpathfile': File,
     'list': List,
     'dict': Dict,
     'ipaddr': IPAddr,


### PR DESCRIPTION
## Context

Expose `hostpathdirectory` and `hostpathfile` schemas to app developers so that they can consume it to validate if the host path being specified is a directory/file and have more validation in place to properly validate their app's values to conform to what's actually required by the app.