### PR TITLE
NAS-123053 / 23.10 / Send event to TrueCommand when node becomes leader

### DIFF
--- a/src/freenas/usr/local/sbin/ctdb_glfs_lock
+++ b/src/freenas/usr/local/sbin/ctdb_glfs_lock
@@ -9,6 +9,7 @@ import pyglfs
 import signal
 import sys
 
+from middlewared.client import Client
 from time import sleep
 
 """
@@ -59,6 +60,15 @@ class GlusterConn:
             len=1
         )
         self.reclock_uuid = lock_file.uuid
+
+        # Attempt to send event that we became cluster leader to TrueCommand.
+        # Failure here should be non-fatal because we must avoid ping-ponging
+        # the recovery lock between nodes.
+        try:
+            with Client() as c:
+                c.call('ctdb.event.process', {'event': 'LEADER', 'status': 'SUCCESS'})
+        except Exception:
+            pass
 
     def liveness_check(self):
         """


### PR DESCRIPTION
The CTDB cluster leader is the node that currently holds the ctdb recovery lock. The node holding leader role becomes source of truth about status of other cluster nodes. This commit changes our recovery lock script so that a node will send an event to TrueCommand upon successfully taking the CTDB recovery lock. The payload to TC includes the pnn, gluster peer uuid, and private ip of the new leader.