### PR TITLE
NAS-123057 / 22.12.4 / `failover.datastore.send` does not accept extra arguments (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -266,14 +266,7 @@ class DiskService(Service, ServiceChangeMixin):
             # so we're not sync'ing these db changes synchronously. Instead we're sync'ing the
             # entire database to the remote node after we're done. The (potential) speed
             # improvement this provides is substantial
-            try:
-                self.middleware.call_sync('failover.datastore.send')
-            except Exception as e:
-                ignore = (errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
-                if isinstance(e, CallError) and e.errno in ignore:
-                    pass
-                else:
-                    self.logger.warning('Unexpected failure syncing database to standby controller', exc_info=True)
+            self.middleware.call_sync('failover.datastore.force_send')
 
         job.set_progress(100, 'Syncing all disks complete')
         return 'OK'


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 95ece4afae40b76680a6d76bd2e157f6e4220a37

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 9cf10d3bcdc52dc8b2bd9dd092dc6c72116ae9a9



Original PR: https://github.com/truenas/middleware/pull/11687
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123057