### PR TITLE
NAS-123068 / 23.10 / improve and fix service_remote and call_remote

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1268,19 +1268,12 @@ async def service_remote(middleware, service, verb, options):
 
     This is the middleware side of what legacy UI did on service changes.
     """
-    if not options['ha_propagate']:
+    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter')
+    if not options['ha_propagate'] or service in ignore or service == 'nginx' and verb == 'stop':
         return
-    # Skip if service is blacklisted or we are not MASTER
-    if service in (
-        'system',
-        'webshell',
-        'smartd',
-        'nfs',
-    ) or await middleware.call('failover.status') != 'MASTER':
+    elif await middleware.call('failover.status') != 'MASTER':
         return
-    # Nginx should never be stopped on standby node
-    if service == 'nginx' and verb == 'stop':
-        return
+
     try:
         await middleware.call('failover.call_remote', 'core.bulk', [
             f'service.{verb}', [[service, options]]

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -272,7 +272,7 @@ class FailoverService(Service):
             ignore = (errno.ETIMEDOUT, CallError.ENOMETHOD, errno.ECONNREFUSED, errno.ECONNABORTED, errno.EHOSTDOWN)
             if e.errno in ignore:
                 if raise_connect_error:
-                    raise CallError(str(e), errno.EFAULT)
+                    raise CallError(str(e), e.errno)
                 else:
                     self.logger.trace('Failed to call %r on remote node', method, exc_info=True)
             else:


### PR DESCRIPTION
A few problems:
- we're restarting Kubernetes and kuberouter services on the standby which shouldn't ever be done
- we're looking for 'webshell' service which no longer exists
- we're overwriting errno value in failover.call_remote if it's an error we expect and `raise_connect_error` is true (the default)