### PR TITLE
NAS-123069 / 23.10 / Prevent logged in iSCSI targets being included in get_disks

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/retaste.py
+++ b/src/middlewared/middlewared/plugins/disk_/retaste.py
@@ -5,10 +5,11 @@ import os
 
 from pyudev import Context
 
-from middlewared.service import Service, accepts, job
-from middlewared.schema import List, Str
+from middlewared.plugins.device_.device_info import (RE_NVME_PRIV,
+                                                     is_iscsi_device)
 from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
-from middlewared.plugins.device_.device_info import RE_NVME_PRIV
+from middlewared.schema import List, Str
+from middlewared.service import Service, accepts, job
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ def retaste_disks_impl(disks: set = None):
         disks = set()
         for disk in Context().list_devices(subsystem='block', DEVTYPE='disk'):
             if disk.sys_name.startswith(DISKS_TO_IGNORE) or RE_NVME_PRIV.match(disk.sys_name):
+                continue
+            if is_iscsi_device(disk):
                 continue
             disks.add(f'/dev/{disk.sys_name}')
 


### PR DESCRIPTION
### Problem
`get_disks` was returning logged in iSCSI targets.  The primary example was on the Standby controller of a HA system with ALUA enabled and at least one iSCSI target defined.  This was causing `hactl` on both nodes to emit "_The quantity of disks do not match between the nodes._" in error.

```
# hactl
Node status: Standby
This node serial: A1-89655
Other node serial: A1-89654
Failover status: The quantity of disks do not match between the nodes.
```

Some further investigation:
```
>>> from middlewared.client import Client
>>> Client().call('failover.mismatch_disks')
{'missing_local': [], 'missing_remote': ['']}
>>> Client().call('failover.get_disks_local')
['V1K9RJ5G', 'V1K9RHVG', 'V1K9RHRG', 'V1K9WPUG', '']
>>> Client().call('device.get_disks', False, True)
{'nvme0n1': '21322M809021', 'sda': 'V1K9RJ5G', 'sdb': 'V1K9RHVG', 'sdc': 'V1K9RHRG', 'sdd': 'V1K9WPUG', 'sde': ''}
```
So _sde_ is incorrect.

```
>>> import pyudev
>>> ctx = pyudev.Context()
>>> for dev in ctx.list_devices(subsystem='block', DEVTYPE='disk'):
...     print(dev)
...
Device('/sys/devices/pci0000:00/0000:00:1d.0/0000:04:00.0/nvme/nvme0/nvme0n1')
Device('/sys/devices/pci0000:16/0000:16:00.0/0000:17:00.0/host0/port-0:0/expander-0:0/port-0:0:0/end_device-0:0:0/target0:0:0/0:0:0:0/block/sda')
Device('/sys/devices/pci0000:16/0000:16:00.0/0000:17:00.0/host0/port-0:0/expander-0:0/port-0:0:1/end_device-0:0:1/target0:0:1/0:0:1:0/block/sdb')
Device('/sys/devices/pci0000:16/0000:16:00.0/0000:17:00.0/host0/port-0:0/expander-0:0/port-0:0:2/end_device-0:0:2/target0:0:2/0:0:2:0/block/sdc')
Device('/sys/devices/pci0000:16/0000:16:00.0/0000:17:00.0/host0/port-0:0/expander-0:0/port-0:0:3/end_device-0:0:3/target0:0:3/0:0:3:0/block/sdd')
Device('/sys/devices/platform/host13/session1/target13:0:0/13:0:0:0/block/sde')
Device('/sys/devices/virtual/block/loop0')
Device('/sys/devices/virtual/block/loop1')
Device('/sys/devices/virtual/block/loop2')
Device('/sys/devices/virtual/block/loop3')
Device('/sys/devices/virtual/block/loop4')
Device('/sys/devices/virtual/block/loop5')
Device('/sys/devices/virtual/block/loop6')
Device('/sys/devices/virtual/block/loop7')
```

This is despite the disk being hidden (and not otherwise surfacing)
```
# cat /sys/devices/platform/host13/session1/target13:0:0/13:0:0:0/block/sde/hidden
1
# cat /proc/partitions
major minor  #blocks  name

 259        0  244198584 nvme0n1
 259        1       1024 nvme0n1p1
 259        2     524288 nvme0n1p2
 259        3  243671207 nvme0n1p3
   8       16 3907018584 sdb
   8       17 3907018540 sdb1
   8       48 3907018584 sdd
   8       49 3907018540 sdd1
   8       32 3907018584 sdc
   8       33 3907018540 sdc1
   8        0 3907018584 sda
   8        1 3907018540 sda1
# ls /dev/sd*
/dev/sda  /dev/sda1  /dev/sdb  /dev/sdb1  /dev/sdc  /dev/sdc1  /dev/sdd  /dev/sdd1
```

### Solution
Filter out devices with a `dev_path` that matches iSCSI targets.

Do **not** check the value of the _hidden_ file, as we don't want to include **_any_** logged in iSCSI targets, whether HA peer ones or not!