### PR TITLE
NAS-123086 / 23.10 / Add option to rebalance volume when adding nodes

### DIFF
--- a/cluster-tests/tests/gluster/test_volume.py
+++ b/cluster-tests/tests/gluster/test_volume.py
@@ -167,7 +167,7 @@ def test_10_expand_cluster(request):
         'remote_credential': {
             'username': CLUSTER_INFO['APIUSER'],
             'password': CLUSTER_INFO['APIPASS']
-        }
+        },
     }]
 
     payload = {
@@ -175,6 +175,7 @@ def test_10_expand_cluster(request):
         'method': 'cluster.management.add_nodes',
         'params': [{
             'new_cluster_nodes': peers_config,
+            'options': {'rebalance_volume': True}
         }]
     }
     res = make_ws_request(CLUSTER_INFO['NODE_A_IP'], payload)


### PR DESCRIPTION
This commit adds a method that creates a job API consumers can use to track the progress of a gluster rebalance task to completion. Wrap around it if user specifies to rebalance after adding cluster nodes.