### PR TITLE
NAS-122862 / 23.10 / Specify checkpoint for generating 2fa ssh configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -266,7 +266,7 @@ class EtcService(Service):
             "entries": [
                 {'type': 'mako', 'path': 'local/ssh/sshd_config', 'checkpoint': 'interface_sync'},
                 {'type': 'mako', 'path': 'pam.d/sshd', 'local_path': 'pam.d/sshd_linux'},
-                {'type': 'mako', 'path': 'local/users.oath', 'mode': 0o0600},
+                {'type': 'mako', 'path': 'local/users.oath', 'mode': 0o0600, 'checkpoint': 'pool_import'},
                 {'type': 'py', 'path': 'local/ssh/config'},
             ]
         },


### PR DESCRIPTION
This commit adds changes to specify pool import checkpoint for generating 2fa ssh configuration because after AD support being added, system dataset must be there for us to find out users which are configured for 2fa as we query AD bits as well which lie in the system dataset.