### PR TITLE
fix slot information in disk.get_unused

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -71,7 +71,8 @@ class DiskService(Service):
 
             # add enclosure information
             i['enclosure'] = {}
-            if (enc_info := i.pop('enclosure_slot', None) is not None):
+            enc_info = i.pop('enclosure_slot', None)
+            if enc_info is not None:
                 i['enclosure'] = {'number': enc_info // 1000, 'slot': enc_info % 1000}
 
             # query partitions for the disk(s) if requested


### PR DESCRIPTION
The joys of misplacing a parenthesis which leads to non-intuitive behavior that results in it failing in a silent way....

The walrus operator (`:=`) has very peculiar interactions when you use them in an `if` branch. Without my changes, because I put a parenthesis around the entire operation, `enc_info` returned either True or False. To make matters worse, the modulus (%) and the floor division (//) actually worked just fine since False/True is silently cast to their respective integer value.... why this happens.....I'm not sure but it's not fun :) 
```
>>> True // 1000
0
>>> True % 1000
1

This fixes the above by explicitly creating a new variable without using the walrus operator. This fixes enclosure slot information in `disk.get_unused`