### PR TITLE
NAS-123116 / 23.10 / Reduce log spam for clustered services file

### DIFF
--- a/src/middlewared/middlewared/scripts/ctdb_events.py
+++ b/src/middlewared/middlewared/scripts/ctdb_events.py
@@ -92,7 +92,9 @@ class CtdbEvent:
             except (FileNotFoundError, json.decoder.JSONDecodeError):
                 self.node_status = {}
 
-        except FileNotFoundError:
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            # The clustered services file is empty or missing.
+            # load the default values
             self.cl_services = deepcopy(CTDB_SERVICE_DEFAULTS)
 
         except OSError as e:


### PR DESCRIPTION
There are some situations in which the clustered services file may exist, but is empty. This should be treated in the same way in the ctdb event script as the case where the file simply doesn't exist (load our defaults).