### PR TITLE
NAS-123066 / 23.10 / fix drive identify on mapped enclosures

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -438,6 +438,7 @@ class EnclosureService(Service):
         mapped = [
             {
                 "id": "mapped_enclosure_0",
+                "bsg": original_enclosure["bsg"],
                 "name": "Drive Bays",
                 "model": controller_enclosures[0]["model"],
                 "controller": True,


### PR DESCRIPTION
The r10 and r40 platforms head-unit have their drive slots mapped to a human readable way (i.e. physically cabled slot 5 is actually physical slot 1, etc). This means we need to ensure that `enclosure.set_slot_status` (the method used to identify a drive in the webUI) takes into account when we're on a system whose head-unit has been "mapped".

To simplify this greatly, I added a top-level `bsg` key to enclosure.query output since that's what is needed to instantiate an `EnclosureDevice` object which allows us to toggle the drive light.

Improvements and fixes employed in this PR:
- add top-level "bsg" key to `enclosure.query` output
- fix the for loop that was doing `set_control`. It was actually failing regardless of these changes because of a logic bug
- add more validation before we actually get to the point of lighting up the drive
- add a dedicated method that returns the "original" drive slot which allows mapped enclosures to light up drives accordingly