### PR TITLE
fix netdata on failover event

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1268,7 +1268,7 @@ async def service_remote(middleware, service, verb, options):
 
     This is the middleware side of what legacy UI did on service changes.
     """
-    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter')
+    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter', 'netdata')
     if not options['ha_propagate'] or service in ignore or service == 'nginx' and verb == 'stop':
         return
     elif await middleware.call('failover.status') != 'MASTER':

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -565,6 +565,9 @@ class FailoverEventsService(Service):
         logger.info('Restarting remaining services')
         self.run_call('failover.events.restart_services', {'critical': False, 'timeout': 60})
 
+        logger.info('Restarting reporting metrics')
+        self.run_call('service.restart', 'netdata')
+
         self.run_call('failover.events.start_apps_vms')
         self.run_call('truecommand.start_truecommand_service')
         self.run_call('zettarepl.update_tasks')
@@ -714,8 +717,8 @@ class FailoverEventsService(Service):
         logger.info('Regenerating cron')
         self.run_call('etc.generate', 'cron')
 
-        logger.info('Stopping rrdcached')
-        self.run_call('service.stop', 'rrdcached', self.HA_PROPAGATE)
+        logger.info('Stopping reporting metrics')
+        self.run_call('service.stop', 'netdata', self.HA_PROPAGATE)
 
         self.run_call('truecommand.stop_truecommand_service')
 


### PR DESCRIPTION
This does 3 things:
- ensure netdata isn't running on the standby controller
- be sure we don't start the netdata service on the standby node
- remove a call to stop rrdcached since we no longer depend on that