### PR TITLE
NAS-123132 / 23.10 / Add validation for gluster volume creation

### DIFF
--- a/cluster-tests/init_gluster.py
+++ b/cluster-tests/init_gluster.py
@@ -24,11 +24,16 @@ def create_cluster():
         'brick_path': BRICK_PATH,
     }
 
+    # TODO: once we have more VMs available for cluster this
+    # should be switched to a more reasonable brick configuration
     payload = {
         'msg': 'method',
         'method': 'cluster.management.cluster_create',
         'params': [{
-            'volume_configuration': {'name': CLUSTER_INFO['GLUSTER_VOLUME']},
+            'volume_configuration': {
+                'name': CLUSTER_INFO['GLUSTER_VOLUME'],
+                'brick_layout': {'distribute_bricks': 3}
+            },
             'local_node_configuration': local_node,
             'peers': peers_config,
         }]

--- a/src/middlewared/middlewared/plugins/gluster_linux/rebalance.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/rebalance.py
@@ -6,7 +6,7 @@ from middlewared.service import Service, CallError, accepts, job
 from middlewared.schema import Dict, Str, Bool
 from middlewared.utils import filter_list
 from middlewared.validators import UUID
-from time import sleep
+from asyncio import sleep
 
 LOCK = 'rebalance_lock'
 
@@ -67,7 +67,7 @@ class GlusterRebalanceService(Service):
             return initial_status
 
         while remaining:
-            sleep(10)
+            await sleep(10)
             remaining = check_status(await self.status({'name': data['volume_name']}))
             percent_nodes_remaining = len(remaining) / len(initial_status['nodes'])
             remaining_names = [x['node_name'] for x in remaining]


### PR DESCRIPTION
Add some basic validation of payloads delivered related to brick and volume type, and expand cluster tests to validate that volumes are created properly.

Testing for validation and normalization of gluster config, and creating different volume configurations is achieved by using multiple bricks on the same server. This is a rough analogue to supported cluster configurations and something we can address later as the testing infrastructure for automation improves.