### PR TITLE
NAS-123146 / 23.10 / Fix CTDB root dir migration

### DIFF
--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -258,7 +258,7 @@ class GlusterVolumeService(CRUDService):
                 pass
 
             if volumes:
-                migrate_job = await self.middleware.call('ctdb.shared.volume.migrate', {'name': volumes[0]})
+                migrate_job = await self.middleware.call('ctdb.root_dir.migrate', {'name': volumes[0]})
                 await migrate_job.wait(raise_error=True)
 
         # need to unmount the FUSE mountpoint (if it exists) and


### PR DESCRIPTION
As we deprecated the ctdb shared volume, the migrate method was moved from ctdb.shared.volume namespace to ctdb.root_dir namespace.