### PR TITLE
NAS-123170 / 23.10 / Add endpoint to validate pool name

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -702,5 +702,12 @@ class PoolService(CRUDService):
         """
         verrors = ValidationErrors()
         if not validate_pool_name(pool_name):
-            verrors.add('pool_name', 'Invalid pool name', errno.EINVAL)
+            verrors.add(
+                'pool_name',
+                'Invalid pool name (please refer to https://openzfs.github.io/openzfs-docs/'
+                'man/8/zpool-create.8.html#DESCRIPTION for valid rules for pool name)',
+                errno.EINVAL
+            )
         verrors.check()
+
+        return True


### PR DESCRIPTION
This commit adds a separate endpoint to validate pool name so UI can consume it at the start of pool creation wizard and error out before user proceeds to next step in the wizard.