### PR TITLE
NAS-123033 / 23.10 / Ignore interfaces created by tailscale

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
@@ -9,7 +9,7 @@ __all__ = ["bitmask_to_set", "INTERNAL_INTERFACES", "run"]
 
 INTERNAL_INTERFACES = [
     "wg", "lo", "tun", "tap", "docker", "veth", "kube-bridge", "kube-dummy-if", "vnet",
-    "macvtap", "ix",
+    "macvtap", "ix", "tailscale",
 ]
 
 


### PR DESCRIPTION
This commit adds changes to ignore any interfaces created by tailscale app when running in host network mode as they are not managed by middleware and will result in all sorts of different issues.