### PR TITLE
NAS-123033 / 22.12.4 / Ignore interfaces created by tailscale (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
@@ -9,7 +9,7 @@ __all__ = ["bitmask_to_set", "INTERNAL_INTERFACES", "run"]
 
 INTERNAL_INTERFACES = [
     "wg", "lo", "tun", "tap", "docker", "veth", "kube-bridge", "kube-dummy-if", "vnet",
-    "openvpn", "macvtap", "ix",
+    "openvpn", "macvtap", "ix", "tailscale",
 ]
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 682765cc1189a33774dea333711c38538f8b8098

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 6e4b2f30ec59c1143915a20ddc5ded59a68e026f

This commit adds changes to ignore any interfaces created by tailscale app when running in host network mode as they are not managed by middleware and will result in all sorts of different issues.

Original PR: https://github.com/truenas/middleware/pull/11719
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123033