### PR TITLE
NAS-122774 / 23.10 / Use netdata for retrieving cpu temperatures

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -1,31 +1,90 @@
 from bases.FrameworkServices.SimpleService import SimpleService
+from collections import defaultdict
 from copy import deepcopy
+from third_party import lm_sensors as sensors
 
-from middlewared.utils.cpu import cpu_info, cpu_temperatures
+from middlewared.utils.cpu import amd_cpu_temperatures, generic_cpu_temperatures
 
 
-CHARTS = {
-    'temperatures': {
-        'options': ['cpu_temp', 'CPU Temperatures', 'Celsius', 'temperatures', 'cpu.temperatures', 'line'],
-        'lines': []
-    },
-}
+CPU_TEMPERATURE_FEAT_TYPE = 2
+
+
 ORDER = [
     'temperatures',
 ]
+
+# This is a prototype of chart definition which is used to dynamically create self.definitions
+CHARTS = {
+    'temperatures': {
+        'options': [None, 'Temperature', 'Celsius', 'temperature', 'sensors.temperature', 'line'],
+        'lines': []
+    }
+}
+
+
+def cpu_temperatures(cpu_metrics):
+    if amd_metrics := cpu_metrics.get('k10temp-pci-00c3'):
+        return amd_cpu_temperatures(amd_metrics)
+    return generic_cpu_temperatures(cpu_metrics)
 
 
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
-        self.order = ORDER
+        self.order = deepcopy(ORDER)
         self.definitions = deepcopy(CHARTS)
-        self.update_every = 1
+
+    def get_data(self):
+        seen, data, cpu_data = dict(), dict(), defaultdict(dict)
+        try:
+            for chip in sensors.ChipIterator():
+                chip_name = sensors.chip_snprintf_name(chip)
+                seen[chip_name] = defaultdict(list)
+                if not any(chip_name.startswith(cpu_chip) for cpu_chip in ('k10temp-pci-00c3', 'coretemp-isa')):
+                    continue
+
+                cpu_d = {}
+                for feat in sensors.FeatureIterator(chip):
+                    if feat.type != CPU_TEMPERATURE_FEAT_TYPE:
+                        continue
+
+                    feat_name = str(feat.name.decode())
+                    feat_label = sensors.get_label(chip, feat)
+                    sub_feat = next(sensors.SubFeatureIterator(chip, feat))  # current value
+
+                    if not sub_feat:
+                        continue
+
+                    try:
+                        v = sensors.get_value(chip, sub_feat.number)
+                    except sensors.SensorsError:
+                        continue
+
+                    if v is None:
+                        continue
+
+                    cpu_d[f'{chip_name}_{feat_name}'] = {'name': feat_label, 'value': v}
+
+                cpu_data[chip_name] = cpu_d
+        except sensors.SensorsError as error:
+            self.error(error)
+            return None
+
+        data = {}
+        for core, temp in cpu_temperatures(cpu_data).items():
+            data[str(core)] = temp
+
+        return data or None
 
     def check(self):
-        for i in range(cpu_info()['core_count']):
-            self.definitions['temperatures']['lines'].append([str(i)])
-        return True
+        try:
+            sensors.init()
+        except sensors.SensorsError as error:
+            self.error(error)
+            return False
 
-    def _get_data(self):
-        return cpu_temperatures() or {str(i): 0 for i in range(cpu_info()['core_count'])}
+        data = self.get_data()
+        for i in data:
+            self.definitions['temperatures']['lines'].append([str(i)])
+
+        return bool(data)

--- a/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
+++ b/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
@@ -1,28 +1,12 @@
-import threading
-import time
-
 from middlewared.service import private, Service
-from middlewared.utils.cpu import cpu_temperatures
 
 
 class ReportingService(Service):
-    CACHE = None
-    CACHE_LOCK = threading.Lock()
-    CACHE_TIME = None
-    LOGGED_ERROR = False
 
     @private
-    def cpu_temperatures(self):
-        with self.CACHE_LOCK:
-            if self.CACHE_TIME is None or time.monotonic() - self.CACHE_TIME >= 60:
-                try:
-                    self.CACHE = cpu_temperatures()
-                except Exception:
-                    self.CACHE = {}
-                    if not self.LOGGED_ERROR:
-                        self.middleware.logger.error("Error gathering CPU temperatures", exc_info=True)
-                        self.LOGGED_ERROR = True
-
-                self.CACHE_TIME = time.monotonic()
-
-            return self.CACHE
+    async def cpu_temperatures(self):
+        netdata_metrics = await self.middleware.call('netdata.get_all_metrics')
+        data = {}
+        for core, cpu_temp in netdata_metrics['cputemp.temperatures']['dimensions'].items():
+            data[core] = cpu_temp['value']
+        return data

--- a/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_amd.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_amd.py
@@ -3,36 +3,40 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from middlewared.utils.cpu import _amd_cpu_temperatures
+from middlewared.utils.cpu import amd_cpu_temperatures
 
 
 @pytest.mark.parametrize("model,core_count,reading,result", [
     # k10temp has no temperature offset constant for this CPU, Tdie will be equal to Tctl, it's better to use Tccd1
     ("AMD Ryzen 5 3600 6-Core Processor", 6, {
-        "Adapter": "PCI adapter",
-        "Tctl": {
-            "temp1_input": 48.625
+        "k10temp-pci-00c3_temp1": {
+            "name": "Tctl",
+            "value": 48.625
         },
-        "Tdie": {
-            "temp2_input": 48.625
+        "k10temp-pci-00c3_temp3": {
+            "name": "Tdie",
+            "value": 48.625
         },
-        "Tccd1": {
-            "temp3_input": 54.750
-        }
+        "k10temp-pci-00c3_temp4": {
+            "name": "Tccd1",
+            "value": 54.750
+        },
     }, dict(enumerate([54.750] * 6))),
     # k10temp has temperature offset constant for this CPU so we should use Tdie
     # https://jira.ixsystems.com/browse/NAS-110515
     ("AMD Ryzen Threadripper 1950X 16-Core Processor", 16, {
-        "Adapter": "PCI adapter",
-        "Tctl": {
-            "temp1_input": 67.0
+        "k10temp-pci-00c3_temp1": {
+            "name": "Tctl",
+            "value": 67.0
         },
-        "Tdie": {
-            "temp2_input": 40.0
+        "k10temp-pci-00c3_temp3": {
+            "name": "Tdie",
+            "value": 40.0
         },
-        "Tccd1": {
-            "temp3_input": 65.5
-        }
+        "k10temp-pci-00c3_temp4": {
+            "name": "Tccd1",
+            "value": 65.5
+        },
     }, dict(enumerate([40] * 16))),
 ])
 def test_amd_cpu_temperatures(model, core_count, reading, result):
@@ -41,4 +45,4 @@ def test_amd_cpu_temperatures(model, core_count, reading, result):
             return_value={"cpu_model": model, "physical_core_count": core_count}
         )
     ):
-        assert _amd_cpu_temperatures(reading) == result
+        assert amd_cpu_temperatures(reading) == result

--- a/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_generic.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_cpu_util_generic.py
@@ -3,41 +3,39 @@ from unittest.mock import Mock
 
 import pytest
 
-from middlewared.utils.cpu import _generic_cpu_temperatures
+from middlewared.utils.cpu import generic_cpu_temperatures
 
 
 @pytest.mark.parametrize("reading,result", [
     (
         {
             "coretemp-isa-0001": {
-                "Core 1": {
-                    "temp3_crit_alarm": 0.0,
-                    "temp3_max": 82.0,
-                    "temp3_crit": 92.0,
-                    "temp3_input": 54.0
+                "coretemp-isa-0001_temp1": {
+                    "name": "Package id 1",
+                    "value": 45
                 },
-                "Core 0": {
-                    "temp2_crit": 92.0,
-                    "temp2_max": 82.0,
-                    "temp2_input": 55.0,
-                    "temp2_crit_alarm": 0.0
+                "coretemp-isa-0001_temp2": {
+                    "name": "Core 0",
+                    "value": 55.0
                 },
-            },
+                "coretemp-isa-0001_temp3": {
+                    "name": "Core 1",
+                    "value": 54.0
+                }},
             "coretemp-isa-0000": {
-                "Core 0": {
-                    "temp2_crit": 92.0,
-                    "temp2_max": 82.0,
-                    "temp2_input": 48.0,
-                    "temp2_crit_alarm": 0.0
+                "coretemp-isa-0000_temp1": {
+                    "name": "Package id 0",
+                    "value": 36
                 },
-                "Core 1": {
-                    "temp3_crit_alarm": 0.0,
-                    "temp3_max": 82.0,
-                    "temp3_crit": 92.0,
-                    "temp3_input": 49.0
+                "coretemp-isa-0000_temp2": {
+                    "name": "Core 0",
+                    "value": 48.0
                 },
-            },
-        },
+                "coretemp-isa-0000_temp3": {
+                    "name": "Core 1",
+                    "value": 49.0
+                }
+            }},
         {
             0: 48.0,
             1: 49.0,
@@ -47,4 +45,4 @@ from middlewared.utils.cpu import _generic_cpu_temperatures
     )
 ])
 def test_generic_cpu_temperatures(reading, result):
-    assert _generic_cpu_temperatures(reading) == result
+    assert generic_cpu_temperatures(reading) == result


### PR DESCRIPTION
## Context

Netdata cpu temperature plugin has been updated to consume the library/logic netdata uses to retrieve cpu temperatures.

Reasoning for using our own implementation of cpu temperatures is for 2 reasons:
1. Only retrieve metrics we are interested in as otherwise sensors retrieve lots of other metrics which will consume space unnecessarily
2. `sensors` netdata plugin retrieves temperatures under different charts which makes it harder to normalize/properly retrieve when trying to get historical cpu temperature statistics.