### PR TITLE
NAS-123222 / 22.12.4 / mark ipmi.sel.elist/info as transient=true (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/sel.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/sel.py
@@ -33,7 +33,7 @@ class IpmiSelService(Service):
 
     @filterable
     @filterable_returns(Dict('ipmi_elist', additional_attrs=True))
-    @job(lock=SEL_LOCK, lock_queue_size=1)
+    @job(lock=SEL_LOCK, lock_queue_size=1, transient=True)
     def elist(self, job, filters, options):
         """Query IPMI System Event Log (SEL) extended list"""
         rv = []
@@ -58,7 +58,7 @@ class IpmiSelService(Service):
 
     @accepts()
     @returns(Dict('ipmi_sel_info', additional_attrs=True))
-    @job(lock=SEL_LOCK, lock_queue_size=1)
+    @job(lock=SEL_LOCK, lock_queue_size=1, transient=True)
     def info(self, job):
         """Query General information about the IPMI System Event Log"""
         rv = {}


### PR DESCRIPTION
These 2 endpoints are called every 5 minutes in an alert so these are filling up the task manager screen in UI. Mark them as transient so they don't show up there.

Original PR: https://github.com/truenas/middleware/pull/11728
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123222