### PR TITLE
NAS-123223 / 23.10 / Make Cluster Jobs payload private

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -124,7 +124,9 @@ class ClusterJob(Service):
         entry['status'] = status
         new_timeout = timeout_abs - now
 
-        await self.middleware.call('clustercache.put', key, entry, int(new_timeout), {'flag': 'REPLACE'})
+        await self.middleware.call(
+            'clustercache.put', key, entry, int(new_timeout), {'flag': 'REPLACE', 'private': True}
+        )
 
     @private
     @job(lock="cluster_job_send")
@@ -146,7 +148,7 @@ class ClusterJob(Service):
 
             job.set_progress(50, f'Setting job status indicator for node {node["address"]!r}')
             key = f'CLJOB_{method}_{node["pnn"]}'
-            await self.middleware.call('clustercache.put', key, payload, timeout)
+            await self.middleware.call('clustercache.put', key, payload, timeout, {'private': True})
 
         data = {
             "event": "CLJOBS_PROCESS",


### PR DESCRIPTION
This adds some protection for job contents being passed over the wire via ctdb.
There is already strict requirement that inter-node communication be on dedicated
network, but encrypting job payloads and results is trivial to implement.