### PR TITLE
NAS-123227 / 23.10 / use EINVAL for default errno for ValidationError

### DIFF
--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -29,7 +29,7 @@ class ValidationError(CallException):
     attribute of a middleware method is invalid/not allowed.
     """
 
-    def __init__(self, attribute, errmsg, errno=errno.EFAULT):
+    def __init__(self, attribute, errmsg, errno=errno.EINVAL):
         self.attribute = attribute
         self.errmsg = errmsg
         self.errno = errno


### PR DESCRIPTION
There is minor descripancy between ValidationError and ValidationErrors regarding default errno that is set. It makes sense to use EINVAL in both cases since they're related to validation failures.