### PR TITLE
NAS-123229 / 23.10 / Safely retrieve cpu temp stats

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
+++ b/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
@@ -7,6 +7,6 @@ class ReportingService(Service):
     async def cpu_temperatures(self):
         netdata_metrics = await self.middleware.call('netdata.get_all_metrics')
         data = {}
-        for core, cpu_temp in netdata_metrics['cputemp.temperatures']['dimensions'].items():
+        for core, cpu_temp in netdata_metrics.get('cputemp.temperatures', {'dimensions': {}})['dimensions'].items():
             data[core] = cpu_temp['value']
         return data


### PR DESCRIPTION
## Problem

A VM will not have cpu temperature stats being retrieved so currently retrieving cpu temperature stats will fail and will result in a traceback.

## Solution

Safely retrieve cpu temperature statistics.