### PR TITLE
Convert gluster events to job

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_accounts.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_accounts.py
@@ -123,11 +123,12 @@ class CtdbAccountsService(Service):
         # should be converted to a job or this method should be converted
         # to use the cluster jobs framework.
         config = await self.middleware.call('ctdb.root_dir.config')
-        await self.middleware.call('gluster.localevents.send', {
+        onnode = await self.middleware.call('gluster.localevents.send', {
             'event': 'CLUSTER_ACCOUNT',
             'name': config['volume_name'],
             'forward': True
         } | data)
+        await onnode.wait(raise_error=True)
 
 
 class ClusterUserService(CRUDService):

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_job.py
@@ -153,6 +153,8 @@ class ClusterJob(Service):
             "name": ctdb_config["volume_name"],
             "forward": True
         }
-        await self.middleware.call('gluster.localevents.send', data)
+        onnode = await self.middleware.call('gluster.localevents.send', data)
+        await onnode.wait(raise_error=True)
+
         await self.wait_for_method(job, method, 90)
         job.set_progress(100, 'Finished submitting cluster job')

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
@@ -505,9 +505,10 @@ class CtdbRootDirService(Service):
         # try to mount it locally and send a request
         # to all the other peers in the TSP to also
         # FUSE mount it
-        await self.middleware.call('gluster.localevents.send', {
+        onnode = await self.middleware.call('gluster.localevents.send', {
             'event': 'VOLUME_START', 'name': vol, 'forward': True
         })
+        await onnode.wait(raise_error=True)
 
         # we need to wait on the local FUSE mount job since
         # ctdb daemon config is dependent on it being mounted
@@ -568,7 +569,8 @@ class CtdbRootDirService(Service):
         # this sends an event telling all peers in the TSP (including this system)
         # to start the ctdb service
         data = {'event': 'CTDB_START', 'name': vol, 'forward': True}
-        await self.middleware.call('gluster.localevents.send', data)
+        onnode = await self.middleware.call('gluster.localevents.send', data)
+        await onnode.wait(raise_error=True)
 
         if ip_info:
             # If we changed the nodes files here, then issue command to all nodes

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -56,6 +56,8 @@ class GlusterConfig(enum.Enum):
         UUID_BACKUP
     ]
 
+    EVENT_TIMEOUT = 300
+
 
 async def format_bricks(bricks):
     # bricks shoud look like [{"peer_name": "blah", "peer_path": "/blah/blah"}, {...]

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -183,7 +183,7 @@ class GlusterVolumeService(CRUDService):
         # in the TSP to FUSE mount this volume locally
         data = {'event': 'VOLUME_START', 'name': name, 'forward': True}
         onnode = await self.middleware.call('gluster.localevents.send', data)
-        await onnode.wait()
+        await onnode.wait(raise_error=True)
 
         return result
 


### PR DESCRIPTION
Depending on situation we were hitting timeouts for cluster-wide
operations. This converts the method into a job and bumps up
timeouts.