### PR TITLE
NAS-123246 / 23.10 / fix TypeError crash in failover.mismatch_disks

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -435,8 +435,9 @@ class FailoverService(ConfigService):
             except Exception:
                 self.logger.error('Unhandled exception in get_disks_local on remote controller', exc_info=True)
             else:
-                result['missing_local'] = sorted(set(rd) - set(ld))
-                result['missing_remote'] = sorted(set(ld) - set(rd))
+                if rd is not None:
+                    result['missing_local'] = sorted(set(rd) - set(ld))
+                    result['missing_remote'] = sorted(set(ld) - set(rd))
 
         return result
 


### PR DESCRIPTION
`raise_connect_error: false` hides known exceptions when trying to connect to the other node. This means `rd` is None so when we try to `set(rd)` it raises a `TypeError`. Ensure `rd` is not None before casting it to a `set`