### PR TITLE
NAS-123247 / 23.10 / account for new NR license model for f-series

### DIFF
--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -63,7 +63,11 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         model = self.middleware.call_sync('truenas.get_chassis_hardware').removeprefix('TRUENAS-').split('-')[0]
         if model == 'UNKNOWN':
             alerts.append(Alert(LicenseAlertClass, 'TrueNAS is running on unsupported hardware.'))
-        elif model != local_license['model']:
+        elif any(
+            # f-series has 2 license models F60 and F60-NR (NR is single-node only)
+            (local_license['model'][0] == 'F' and model != local_license['model'].split('-')[0]),
+            (model != local_license['model'])
+        ):
             alerts.append(Alert(
                 LicenseAlertClass,
                 (


### PR DESCRIPTION
The new f-series platform has a new licensed variant that ends with `-NR`. We need to account for this in the license alert so we don't raise false positive alerts to the end-user.