### PR TITLE
NAS-123255 / 23.10 / Revert "Do not send events for transient jobs"

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -95,9 +95,7 @@ class JobsQueue(object):
 
         self.deque.add(job)
         self.queue.append(job)
-
-        if not job.options["transient"]:
-            self.middleware.send_event('core.get_jobs', 'ADDED', id=job.id, fields=job.__encode__())
+        self.middleware.send_event('core.get_jobs', 'ADDED', id=job.id, fields=job.__encode__())
 
         # A job has been added to the queue, let the queue scheduler run
         self.queue_event.set()
@@ -447,10 +445,9 @@ class Job:
 
             queue.release_lock(self)
             self._finished.set()
+            self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
             if self.options['transient']:
                 queue.remove(self.id)
-            else:
-                self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
 
     async def __run_body(self):
         """


### PR DESCRIPTION
This reverts commit https://github.com/truenas/middleware/commit/66442f016bfb62c6e57db2d35566b1cb6e3620f4.

This allows a deadlock to occur when using our websocket client and calling a method with the job=True argument. Since no events are emitted for the job, the websocket client will wait indefinitely but since no events are emitted it will never complete.

A subsequent change was made in https://github.com/truenas/middleware/pull/10714 which exposes the transient flag in core.get_jobs which is what the webUI team should use to filter jobs from the task UI.