### PR TITLE
NAS-122934 / 23.10 / Fix NVMe drives resizing in Cobia

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -165,7 +165,7 @@ nvme)
 
 	# Identify controller properties.
 	idctrl=`nvme id-ctrl ${ctrlr}`
-	ctrls=`nvme list-ctrl ${ctrlr} | awk -F: '{ print $2 }' | xargs | tr ' ' ,`
+	ctrls=`nvme list-ctrl ${ctrlr} | awk -F: '/^\[\s*[0-9]+\]/ { print $2 }' | xargs | tr ' ' ,`
 
 	# Check Namespace Management is supported by the controller.
 	oacs=`echo "${idctrl}" | awk -F ' +: ' '$1 == "oacs" { print $2 }'`


### PR DESCRIPTION
In recent versions, the `nvme list-ctrl` command outputs additional information in the form of "num of ctrls present: 1" which causes the disk_resize script to behave unexpectedly. This commit addresses the issue by also matching the output format of [1-9].