### PR TITLE
NAS-123255 / 22.12.4 / Revert "Do not send events for transient jobs" (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -96,9 +96,7 @@ class JobsQueue(object):
 
         self.deque.add(job)
         self.queue.append(job)
-
-        if not job.options["transient"]:
-            self.middleware.send_event('core.get_jobs', 'ADDED', id=job.id, fields=job.__encode__())
+        self.middleware.send_event('core.get_jobs', 'ADDED', id=job.id, fields=job.__encode__())
 
         # A job has been added to the queue, let the queue scheduler run
         self.queue_event.set()
@@ -448,10 +446,9 @@ class Job:
 
             queue.release_lock(self)
             self._finished.set()
+            self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
             if self.options['transient']:
                 queue.remove(self.id)
-            else:
-                self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
 
     async def __run_body(self):
         """

--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -97,7 +97,8 @@ class JobsQueue(object):
         self.deque.add(job)
         self.queue.append(job)
 
-        job.send_event('ADDED', job.__encode__())
+        if not job.options["transient"]:
+            self.middleware.send_event('core.get_jobs', 'ADDED', id=job.id, fields=job.__encode__())
 
         # A job has been added to the queue, let the queue scheduler run
         self.queue_event.set()
@@ -322,7 +323,7 @@ class Job:
         """
         if self.description != description:
             self.description = description
-            self.send_event('CHANGED', self.__encode__())
+            self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
 
     def set_progress(self, percent=None, description=None, extra=None):
         """
@@ -360,7 +361,7 @@ class Job:
                 logger.warning('Failed to run on progress callback', exc_info=True)
 
         if changed:
-            self.send_event('CHANGED', encoded)
+            self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=encoded)
 
         for wrapped in self.wrapped:
             wrapped.set_progress(**self.progress)
@@ -421,7 +422,7 @@ class Job:
                 raise asyncio.CancelledError()
             else:
                 self.set_state('RUNNING')
-                self.send_event('CHANGED', self.__encode__())
+                self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
 
             self.future = asyncio.ensure_future(self.__run_body())
             try:
@@ -447,9 +448,10 @@ class Job:
 
             queue.release_lock(self)
             self._finished.set()
-            self.send_event('CHANGED', self.__encode__())
             if self.options['transient']:
                 queue.remove(self.id)
+            else:
+                self.middleware.send_event('core.get_jobs', 'CHANGED', id=self.id, fields=self.__encode__())
 
     async def __run_body(self):
         """
@@ -630,10 +632,6 @@ class Job:
 
     async def logs_fd_write(self, data):
         await self.middleware.run_in_thread(self.logs_fd.write, data)
-
-    def send_event(self, name, fields):
-        if not self.options['transient']:
-            self.middleware.send_event('core.get_jobs', name, id=self.id, fields=fields)
 
 
 class JobProgressBuffer:


### PR DESCRIPTION
This reverts commit https://github.com/truenas/middleware/commit/66442f016bfb62c6e57db2d35566b1cb6e3620f4.

This allows a deadlock to occur when using our websocket client and calling a method with the job=True argument. Since no events are emitted for the job, the websocket client will wait indefinitely but since no events are emitted it will never complete.

A subsequent change was made in https://github.com/truenas/middleware/pull/10714 which exposes the transient flag in core.get_jobs which is what the webUI team should use to filter jobs from the task UI.

Original PR: https://github.com/truenas/middleware/pull/11746
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123255