### PR TITLE
NAS-122679 / 23.10 / Add changes to integrate SMB/NFS CSI in kubernetes lifecycle

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -41,6 +41,8 @@ def get_action_context(release_name):
         'upgradeMetadata': {},
         'hasSMBCSI': True,
         'hasNFSCSI': True,
+        'smbProvisioner': 'smb.csi.k8s.io',
+        'nfsProvisioner': 'nfs.csi.k8s.io',
     })
 
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -39,6 +39,8 @@ def get_action_context(release_name):
         'isUpgrade': False,
         'storageClassName': get_storage_class_name(release_name),
         'upgradeMetadata': {},
+        'hasSMBCSI': True,
+        'hasNFSCSI': True,
     })
 
 


### PR DESCRIPTION
This PR adds changes to add some metadata to the app so it can make an informed decision on how to expose/consume SMB/NFS CSI for storage.