### PR TITLE
NAS-123327 / 23.10 / fix ValueError crash in ipmi.sensors.query_impl (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/sensors.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/sensors.py
@@ -32,12 +32,11 @@ class IpmiSensorsService(Service):
 
     @private
     def query_impl(self):
-        rv = []
+        rv, reread = [], None
         if not self.middleware.call_sync('ipmi.is_loaded'):
-            return rv
+            return rv, reread
 
         mseries = self.middleware.call_sync('failover.hardware') == 'ECHOWARP'
-        reread = None
         for line in filter(lambda x: x, get_sensors_data()):
             if (values := line.split(',')) and len(values) == 13:
                 sensor = {


### PR DESCRIPTION
The caller of `query_impl` is expecting it to return a tuple of size 2 but if there is no IPMI device, it was returning a single object which was causing the caller to crash with `ValueError`

```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/ipmi_/sensors.py", line 73, in query
    sensors, reread = self.query_impl()
    ^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 0)

Original PR: https://github.com/truenas/middleware/pull/11758
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123327