### PR TITLE
NAS-123331 / 24.04 / optimize RealtimeEventSource

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -70,7 +70,9 @@ class RealtimeEventSource(EventSource):
                 'memory': get_memory_info(netdata_metrics),
                 'virtual_memory': psutil.virtual_memory()._asdict(),
                 'cpu': get_cpu_stats(netdata_metrics, cores),
-                'disks': get_disk_stats(netdata_metrics, list(self.middleware.call_sync('device.get_disks'))),
+                'disks': get_disk_stats(
+                    netdata_metrics, list(self.middleware.call_sync('device.get_disks', False, True))
+                ),
                 'interfaces': get_interface_stats(
                     netdata_metrics, [i['name'] for i in self.middleware.call_sync('interface.query')]
                 ),


### PR DESCRIPTION
Optimize our realtime event subscription by calling `device.get_disks, False, True` which will call the "quick" path. This will only retrieve drive names and their serials instead of all the verbose detail information. This can be 40-60% faster on systems with "large" (>= 100's) of disks.