### PR TITLE
NAS-123332 / 23.10 / fix crash in alert.license_status (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -63,11 +63,11 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         model = self.middleware.call_sync('truenas.get_chassis_hardware').removeprefix('TRUENAS-').split('-')[0]
         if model == 'UNKNOWN':
             alerts.append(Alert(LicenseAlertClass, 'TrueNAS is running on unsupported hardware.'))
-        elif any(
+        elif any((
             # f-series has 2 license models F60 and F60-NR (NR is single-node only)
             (local_license['model'][0] == 'F' and model != local_license['model'].split('-')[0]),
             (model != local_license['model'])
-        ):
+        )):
             alerts.append(Alert(
                 LicenseAlertClass,
                 (


### PR DESCRIPTION
Missing parenthesis which is causing this to crash with a TypeError because the builtin any() is receiving 2 arguments instead of 1.

Original PR: https://github.com/truenas/middleware/pull/11764
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123332