### PR TITLE
NAS-123353 / 24.04 / Remove redundant draid validation

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool.py
@@ -188,9 +188,5 @@ class ZFSPoolService(CRUDService):
                 f'topology.{topology_type}.type',
                 str(e),
             )
-        if vdev['draid_data_disks'] and (len(vdev['disks']) - nparity) % vdev['draid_data_disks'] != 0:
-            verrors.add(
-                f'topology.{topology_type}.type',
-                f'Total disks must be a multiple of "{vdev["draid_data_disks"]!r}" disks plus specified "{nparity!r}"'
-            )
+
         return verrors


### PR DESCRIPTION
## Problem

To create groups in draid, the total number of disks available for data must be divisible by `draid_data_disks`. For example, if there are 12 disks available for data, then `draid_data_disks` must be a number that is divisible by 12, such as 2, 3, or 4. These numbers can be evenly divided into 6, 4, and 3 groups, respectively.

However, this validation is already handled in py_libzfs when creating groups. The provided code snippet demonstrates how the left-hand side of the code ensures this validation. It attempts to find a multiple of available disks that will be grouped together. For example, if there are 12 disks with 3 `draid_data_disks` and 3 parity disks, it will iterate as follows: 1 * 6 % 12 = 6, and then in the second iteration, 2 * 6 % 12 = 0. This process finds a multiple for `(draid_data_disks + draid_parity)`.

In contrast, we are attempting to achieve the same result but in reverse order by finding a divisible number. However, this step is not necessary because py_libzfs already handles the validation during group creation.

```
    ngroups = 1
    while (ngroups * (draid_data_disks + draid_parity)) % (children - draid_spare_disks) != 0:
        ngroups += 1
```

With the validation already being present in py-libzfs this is a no-op and also while at it is faulty because it does not account for the groups.
