### PR TITLE
NAS-123000 / 22.12.4 / SATA: Wait for udev events to settle before setting max sector count (by ixhamza)

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+udevd_timeout=10
 dev=$1
 osize=$2
 
@@ -120,6 +121,11 @@ ata|sata)
 
 	if [ -z "${size}" ]; then
 		size=${maxsect}
+	fi
+	echo "Waiting up to ${udevd_timeout} seconds for udevd events to settle"
+	udevadm settle -t ${udevd_timeout}
+	if [ $? -ne 0 ]; then
+		echo "Resize may fail. Udevd events failed to settle within ${udevd_timeout} seconds."
 	fi
 	echo "Setting Max Sectors to ${size}"
 	hdparm --yes-i-know-what-i-am-doing -N p${size} /dev/${dev}	# NB: the p is for persistence


### PR DESCRIPTION
When a process opens a device for a write operation and then closes it, udevd synthesizes a change event, which results in several ATA commands. The ATA_CMD_SET_MAX_EXT command requires ATA_CMD_READ_NATIVE_MAX_EXT to be executed exactly as the previous command. sginfo operations open the device with O_RDWR. Setting sense data before setting max sectors causes udevd to inject an ATA command between ATA_CMD_READ_NATIVE_MAX_EXT and ATA_CMD_SET_MAX_EXT, leading to the eventual failure of ATA_CMD_SET_MAX_EXT. To fix this issue, we should wait for the udev event queue to drain before setting max sectors.

Validated on both Bluefin and Cobia by Jeff Ervine.

Original PR: https://github.com/truenas/middleware/pull/11755
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123000