### PR TITLE
NAS-123015 / 24.04 / Do not allow starting k8s if system is not licensed

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -384,6 +384,9 @@ class KubernetesService(Service):
     async def start_service(self):
         await self.set_status(Status.INITIALIZING.value)
         try:
+            if not await self.middleware.call('kubernetes.license_active'):
+                raise CallError('System is not licensed to use Applications')
+
             await self.before_start_check()
             await self.middleware.call('k8s.migration.scale_version_check')
             await self.middleware.call('k8s.migration.run')


### PR DESCRIPTION
This commit adds changes to make sure if license has been revoked on a HA system, we do not allow starting k8s for the system in question.