### PR TITLE
NAS-123267 / 22.12.4 / Use the correct namespace id for disk resize (by ixhamza)

### DIFF
--- a/src/freenas/usr/local/sbin/disk_resize
+++ b/src/freenas/usr/local/sbin/disk_resize
@@ -167,7 +167,7 @@ sas|scsi)
 nvme)
 	# Get controller and current namespace ID.
 	ctrlr=/dev/${dev%n*}
-	nsid=${dev##nvme*n}
+	nsid=`nvme get-ns-id /dev/${dev} | awk -F 'namespace-id:' '{ print $2 }'`
 
 	# Identify controller properties.
 	idctrl=`nvme id-ctrl ${ctrlr}`


### PR DESCRIPTION
In nvmeXnY, 'Y' does not represent the namespace ID, but rather the namespace instance. Reading the correct namespace ID allows us to resize nvmeXn2 disks, which happens in the case of HA where fenced does not release a disk, making it reappear as nvmeXn2.

Tested by Jeff Ervin on f60-141.dc1.ixsystems.net.

Original PR: https://github.com/truenas/middleware/pull/11784
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123267