### PR TITLE
NAS-123309 / 23.10-BETA.1 / Safely retrieve data if netdata is not running (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/__init__.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/__init__.py
@@ -1,3 +1,4 @@
 from .connector import Netdata # noqa
+from .exceptions import ApiException, ClientConnectError # noqa
 from .graph_base import GraphBase, GRAPH_PLUGINS # noqa
 from .graphs import * # noqa

--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -3,7 +3,7 @@ import aiohttp.client_exceptions
 import asyncio
 import contextlib
 
-from .exceptions import ApiException
+from .exceptions import ApiException, ClientConnectError
 from .utils import NETDATA_URI, NETDATA_REQUEST_TIMEOUT
 
 
@@ -27,6 +27,8 @@ class ClientMixin:
                     yield resp
         except (asyncio.TimeoutError, aiohttp.ClientResponseError) as e:
             raise ApiException(f'Failed {resource!r} call: {e!r}')
+        except aiohttp.client_exceptions.ClientConnectorError as e:
+            raise ClientConnectError(f'Failed to connect to {uri!r}: {e!r}')
 
     @classmethod
     async def api_call(cls, resource: str, timeout: int = NETDATA_REQUEST_TIMEOUT, version: str = 'v1') -> dict:

--- a/src/middlewared/middlewared/plugins/reporting/netdata/exceptions.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/exceptions.py
@@ -3,3 +3,7 @@ from middlewared.service import CallError
 
 class ApiException(CallError):
     pass
+
+
+class ClientConnectError(CallError):
+    pass


### PR DESCRIPTION
## Problem

When system dataset is being migrated and a query is made by consumer to retrieve reporting metrics, that fails as netdata is not running during the migration of system dataset resulting in a traceback.

## Solution

We should not allow the calls to fail when system dataset is being migrated but still nevertheless log the error in case there is an actual bug which is worth investigating.

Original PR: https://github.com/truenas/middleware/pull/11783
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123309