### PR TITLE
NAS-123375 / 23.10 / fix KeyError crash in enclosure.query (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -438,7 +438,7 @@ class EnclosureService(Service):
         mapped = [
             {
                 "id": "mapped_enclosure_0",
-                "bsg": original_enclosure["bsg"],
+                "bsg": controller_enclosures[0]["bsg"],
                 "name": "Drive Bays",
                 "model": controller_enclosures[0]["model"],
                 "controller": True,


### PR DESCRIPTION
This is crashing with a KeyError because I'm not referencing the correct dictionary. This means any platform that has a mapped head-unit will crash here
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure_/map.py", line 384, in map_enclosures
    return await self._map_enclosures(enclosures, version_mapping.slots)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure_/map.py", line 441, in _map_enclosures
    "bsg": original_enclosure["bsg"],
           ~~~~~~~~~~~~~~~~~~^^^^^^^
KeyError: 'bsg'

Original PR: https://github.com/truenas/middleware/pull/11792
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123375