### PR TITLE
NAS-123392 / 23.10 / Simplify SMB share ACL handling (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_service.py
@@ -42,7 +42,6 @@ class ShareSchema(RegistrySchema):
                     data_aux.pop(k)
 
         data_out['auxsmbconf'] = '\n'.join([f'{k}={v}' if v is not None else k for k, v in data_aux.items()])
-        data_out['enabled'] = True
         data_out['locked'] = False
 
         return
@@ -147,6 +146,12 @@ class ShareSchema(RegistrySchema):
                     "[%s] contains invalid auxiliary parameter: [%s]",
                     data_in['auxsmbconf'], param
                 )
+
+        # There are two situations in which a share may be unavailable:
+        # 1) it's encypted and locked
+        # 2) it's specifically flagged as disabled
+        if data_in.get('locked'):
+            data_out['available'] = {'parsed': False}
 
         self._normalize_config(data_out)
         return
@@ -471,6 +476,7 @@ class ShareSchema(RegistrySchema):
         RegObj("vuid", "tn:vuid", ''),
         RegObj("comment", "comment", ""),
         RegObj("guestok", "guest ok", False),
+        RegObj("enabled", "available", True),
         RegObj("hostsallow", "hosts allow", []),
         RegObj("hostsdeny", "hosts deny", []),
         RegObj("abe", "access based share enum", False),

--- a/src/middlewared/middlewared/plugins/tdb/base.py
+++ b/src/middlewared/middlewared/plugins/tdb/base.py
@@ -155,7 +155,7 @@ class TDBService(Service, TDBMixin, SchemaMixin):
             elif state['data_type'] == 'STRING':
                 entry = tdb_data
             elif state['data_type'] == 'BYTES':
-                entry = b64encode(tdb_data)
+                entry = b64encode(tdb_data).decode()
 
             state['output'].append({"key": tdb_key, "val": entry})
             return True

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -75,6 +75,9 @@ class TDBWrap(object):
         ok = True
         for i in self.hdl.keys():
             tdb_key = i.decode()
+            if self.options['data_type'] == 'BYTES':
+                tdb_key = tdb_key[:-1]
+
             tdb_val = self.get(tdb_key)
             ok = fn(tdb_key, tdb_val, private_data)
             if not ok:

--- a/tests/api2/test_430_smb_sharesec.py
+++ b/tests/api2/test_430_smb_sharesec.py
@@ -7,6 +7,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from assets.REST.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.utils import client
 from functions import PUT, POST, GET, DELETE, SSH_TEST
 from functions import make_ws_request, wait_on_job
 from auto_config import pool_name, user, password, ip, dev_test
@@ -125,9 +126,8 @@ def test_25_verify_share_info_tdb_is_deleted(request):
 
 def test_27_restore_sharesec_with_flush_share_info(request):
     depends(request, ["sharesec_acl_set"], scope="session")
-    cmd = 'midclt call smb.sharesec._flush_share_info'
-    results = SSH_TEST(cmd, user, password, ip)
-    assert results['result'] is True, results['output']
+    with client() as c:
+        c.call('smb.sharesec._flush_share_info')
 
     results = POST("/sharing/smb/getacl", {'share_name': share_info['name']})
     assert results.status_code == 200, results.text


### PR DESCRIPTION
Store base64-encoded copy of share ACL blob per-share rather than converting to string via sharesec. This allows restoring ACL without having to use the sharesec utility. Also add plumbing for enabling / disabling SMB shares via the smb.conf parameter `available` this allows clustered shares to be enabled / disabled.

These are both preparation steps for finalizing share ACL support on clustered TrueNAS.

Original PR: https://github.com/truenas/middleware/pull/11785
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123392