### PR TITLE
NAS-123292 / 13.1 / Fix cron task for scrubbing a pool containing whitespace in its name

### DIFF
--- a/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
+++ b/src/middlewared/middlewared/etc_files/cron.d/middlewared.mako
@@ -1,5 +1,6 @@
 <%
     import random
+    import shlex
 
     system_advanced = middleware.call_sync("system.advanced.config")
     resilver = middleware.call_sync("pool.resilver.config")
@@ -39,7 +40,7 @@ ${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"
     % endfor
 
     % for job in middleware.call_sync("pool.scrub.query", [["enabled", "=", True]]):
-${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call pool.scrub.run {job['pool_name']} {job['threshold']}"))}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call pool.scrub.run {shlex.quote(job['pool_name'])} {job['threshold']}"))}
     % endfor
 
     % if resilver["enabled"]:


### PR DESCRIPTION
(cherry picked from commit e4ce3c2901670ac950a214fa1f0cac6e01503ae0)