### PR TITLE
NAS-123451 / 23.10 / Add clustered sysdataset validation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -55,6 +55,13 @@ class ClusterPeerConnection:
         if self.conn:
             self.conn.close()
 
+    def __validate_sysdataset(self, schema_name, verrors):
+        if self.call_fn('systemdataset.is_boot_pool'):
+            verrors.add(
+                f'{schema_name}.hostname',
+                'System dataset may not reside on boot pool when configuring clustering.'
+            )
+
     def __validate_ntp(self, schema_name, ntp_peers, verrors):
         active = filter_list(ntp_peers, [['active', '=', True]])
         if not active:
@@ -200,6 +207,7 @@ class ClusterPeerConnection:
         self.__validate_brick_path(schema_name, verrors)
         self.__validate_dns(schema_name, hosts_to_check, verrors)
         self.__validate_private_address(schema_name, verrors)
+        self.__validate_sysdataset(schema_name, verrors)
 
 
 class ClusterManagement(Service):


### PR DESCRIPTION
We shouldn't allow cluster to be set up if system dataset is on the boot device, and users should be prevented from moving the system dataset on a clustered server.

Original PR: https://github.com/truenas/middleware/pull/11811
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123451