### PR TITLE
NAS-123479 / 24.04 / port CORE enclosure plugin to SCALE (stage 1)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/element_types.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/element_types.py
@@ -28,8 +28,8 @@ def current(value_raw):
     values = {
         'Identify on': (value_raw >> 16) & 0x80,
         'Fail on': (value_raw >> 16) & 0x40,
-        'Warn Over': (value_raw >> 16) & 0x8,
-        'Crit Over': (value_raw >> 16) & 0x2,
+        'Warn over': (value_raw >> 16) & 0x8,
+        'Crit over': (value_raw >> 16) & 0x2,
     }
     return ', '.join([f'{(value_raw & 0xffff) / 100}A'] + [k for k, v in values.items() if v])
 
@@ -38,7 +38,7 @@ def enclosure(value_raw):
     values = {
         'Identify on': (value_raw >> 16) & 0x80,
         'Fail on': (value_raw >> 8) & 0x02,
-        'Warn On': (value_raw >> 8) & 0x01,
+        'Warn on': (value_raw >> 8) & 0x01,
     }
     result = [k for k, v in values.items() if v]
     if (pctime := (value_raw >> 10) & 0x3f):
@@ -65,13 +65,10 @@ def cooling(value_raw):
 
 
 def temp(value_raw):
-    temp = None
     if (temp := (value_raw & 0xff00) >> 8):
         # 8 bits represents -19C to +235C
         # value of 0 would imply -20C
-        temp = f'{temp -20}C'
-
-    return temp
+        return f'{temp -20}C'
 
 
 def psu(value_raw):
@@ -125,17 +122,17 @@ def sas_conn(value_raw):
         0x2f: 'SAS virtual connector [max 1 phy]',
         0x3f: 'Vendor specific internal connector',
     }
-    values.update({i: 'unknown external connector type: {hex(i)}' for i in range(0x8, 0xf)})
-    values.update({i: 'unknown internal wide connector type: {hex(i)}' for i in range(0x14, 0x20)})
-    values.update({i: 'unknown internal connector to end device type: {hex(i)}' for i in range(0x28, 0x2f)})
-    values.update({i: 'reserved for internal connector type: {hex(i)}' for i in range(0x30, 0x3f)})
-    values.update({i: 'reserved connector type: {hex(i)}' for i in range(0x40, 0x70)})
-    values.update({i: 'vendor specific connector type: {hex(i)}' for i in range(0x70, 0x80)})
+    values.update({i: f'unknown external connector type: {hex(i)}' for i in range(0x8, 0xf)})
+    values.update({i: f'unknown internal wide connector type: {hex(i)}' for i in range(0x14, 0x20)})
+    values.update({i: f'unknown internal connector to end device type: {hex(i)}' for i in range(0x28, 0x2f)})
+    values.update({i: f'reserved for internal connector type: {hex(i)}' for i in range(0x30, 0x3f)})
+    values.update({i: f'reserved connector type: {hex(i)}' for i in range(0x40, 0x70)})
+    values.update({i: f'vendor specific connector type: {hex(i)}' for i in range(0x70, 0x80)})
 
-    return ', '.join(
-        [values.get(conn_type, f'unexpected connector type: {hex(conn_type)}')] +
-        ['Fail On'] if value_raw & 0x40 else []
-    )
+    formatted = [values.get(conn_type, f'unexpected connector type: {hex(conn_type)}')]
+    if value_raw & 0x40:
+        formatted.append('Fail on')
+    return ', '.join(formatted)
 
 
 def sas_exp(value_raw):

--- a/src/middlewared/middlewared/plugins/enclosure_/element_types.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/element_types.py
@@ -1,0 +1,196 @@
+def alarm(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'RQST mute': value_raw & 0x80,
+        'Muted': value_raw & 0x40,
+        'Remind': value_raw & 0x10,
+        'INFO': value_raw & 0x08,
+        'NON-CRIT': value_raw & 0x04,
+        'CRIT': value_raw & 0x02,
+        'UNRECOV': value_raw & 0x01,
+    }
+    if (result := [k for k, v in values.items() if v]):
+        return ', '.join(result)
+
+
+def comm(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Disabled': value_raw & 0x01,
+    }
+    if (result := [k for k, v in values.items() if v]):
+        return ', '.join(result)
+
+
+def current(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Warn Over': (value_raw >> 16) & 0x8,
+        'Crit Over': (value_raw >> 16) & 0x2,
+    }
+    return ', '.join([f'{(value_raw & 0xffff) / 100}A'] + [k for k, v in values.items() if v])
+
+
+def enclosure(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 8) & 0x02,
+        'Warn On': (value_raw >> 8) & 0x01,
+    }
+    result = [k for k, v in values.items() if v]
+    if (pctime := (value_raw >> 10) & 0x3f):
+        potime = (value_raw >> 2) & 0x3f
+        result.append(f'Power cycle {pctime}min, power off for {potime}min')
+
+    return ', '.join(result) or None
+
+
+def volt(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Warn over': (value_raw >> 16) & 0x8,
+        'Warn under': (value_raw >> 16) & 0x4,
+        'Crit over': (value_raw >> 16) & 0x2,
+        'Crit under': (value_raw >> 16) & 0x1,
+    }
+    return ', '.join([f'{((value_raw & 0xffff) / 100)}V'] + [k for k, v in values.items() if v])
+
+
+def cooling(value_raw):
+    return f'{(((value_raw & 0x7ff00) >> 8) * 10)} RPM'
+
+
+def temp(value_raw):
+    temp = None
+    if (temp := (value_raw & 0xff00) >> 8):
+        # 8 bits represents -19C to +235C
+        # value of 0 would imply -20C
+        temp = f'{temp -20}C'
+
+    return temp
+
+
+def psu(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': value_raw & 0x40,
+        'DC overvoltage': (value_raw >> 8) & 0x8,
+        'DC undervoltage': (value_raw >> 8) & 0x4,
+        'DC overcurrent': (value_raw >> 8) & 0x2,
+        'Overtemp fail': value_raw & 0x8,
+        'Overtemp warn': value_raw & 0x4,
+        'AC fail': value_raw & 0x2,
+        'DC fail': value_raw & 0x1,
+        'Off': value_raw & 0x10,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+def array_dev(value_raw):
+    values = {
+        'Identify on': (value_raw >> 8) & 0x2,
+        'Fault on': value_raw & 0x20,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+def sas_conn(value_raw):
+    conn_type = (value_raw >> 16) & 0x7f
+    values = {
+        0x0: 'No information',
+        0x1: 'SAS 4x receptacle (SFF-8470) [max 4 phys]',
+        0x2: 'Mini SAS 4x receptacle (SFF-8088) [max 4 phys]',
+        0x3: 'QSFP+ receptacle (SFF-8436) [max 4 phys]',
+        0x4: 'Mini SAS 4x active receptacle (SFF-8088) [max 4 phys]',
+        0x5: 'Mini SAS HD 4x receptacle (SFF-8644) [max 4 phys]',
+        0x6: 'Mini SAS HD 8x receptacle (SFF-8644) [max 8 phys]',
+        0x7: 'Mini SAS HD 16x receptacle (SFF-8644) [max 16 phys]',
+        0xf: 'Vendor specific external connector',
+        0x10: 'SAS 4i plug (SFF-8484) [max 4 phys]',
+        0x11: 'Mini SAS 4i receptacle (SFF-8087) [max 4 phys]',
+        0x12: 'Mini SAS HD 4i receptacle (SFF-8643) [max 4 phys]',
+        0x13: 'Mini SAS HD 8i receptacle (SFF-8643) [max 8 phys]',
+        0x20: 'SAS Drive backplane receptacle (SFF-8482) [max 2 phys]',
+        0x21: 'SATA host plug [max 1 phy]',
+        0x22: 'SAS Drive plug (SFF-8482) [max 2 phys]',
+        0x23: 'SATA device plug [max 1 phy]',
+        0x24: 'Micro SAS receptacle [max 2 phys]',
+        0x25: 'Micro SATA device plug [max 1 phy]',
+        0x26: 'Micro SAS plug (SFF-8486) [max 2 phys]',
+        0x27: 'Micro SAS/SATA plug (SFF-8486) [max 2 phys]',
+        0x2f: 'SAS virtual connector [max 1 phy]',
+        0x3f: 'Vendor specific internal connector',
+    }
+    values.update({i: 'unknown external connector type: {hex(i)}' for i in range(0x8, 0xf)})
+    values.update({i: 'unknown internal wide connector type: {hex(i)}' for i in range(0x14, 0x20)})
+    values.update({i: 'unknown internal connector to end device type: {hex(i)}' for i in range(0x28, 0x2f)})
+    values.update({i: 'reserved for internal connector type: {hex(i)}' for i in range(0x30, 0x3f)})
+    values.update({i: 'reserved connector type: {hex(i)}' for i in range(0x40, 0x70)})
+    values.update({i: 'vendor specific connector type: {hex(i)}' for i in range(0x70, 0x80)})
+
+    return ', '.join(
+        [values.get(conn_type, f'unexpected connector type: {hex(conn_type)}')] +
+        ['Fail On'] if value_raw & 0x40 else []
+    )
+
+
+def sas_exp(value_raw):
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+ELEMENT_DESC = {
+    0: 'Unsupported',
+    1: 'OK',
+    2: 'Critical',
+    3: 'Noncritical',
+    4: 'Unrecoverable',
+    5: 'Not installed',
+    6: 'Unknown',
+    7: 'Not available',
+    8: 'No access allowed',
+    9: 'reserved [9]',
+    10: 'reserved [10]',
+    11: 'reserved [11]',
+    12: 'reserved [12]',
+    13: 'reserved [13]',
+    14: 'reserved [14]',
+    15: 'reserved [15]',
+    17: 'OK, Swapped',
+    21: 'Not Installed, Swapped',
+}
+ELEMENT_TYPES = {
+    0: ('Unspecified', lambda *args: None),
+    1: ('Device Slot', lambda *args: None),
+    2: ('Power Supply', psu),
+    3: ('Cooling', cooling),
+    4: ('Temperature Sensors', temp),
+    5: ('Door Lock', lambda *args: None),
+    6: ('Audible Alarm', alarm),
+    7: ('Enclosure Services Controller Electronics', lambda *args: None),
+    8: ('SCC Controller Electronics', lambda *args: None),
+    9: ('Nonvolatile Cache', lambda *args: None),
+    10: ('Invalid Operation Reason', lambda *args: None),
+    11: ('Uninterruptible Power Supply', lambda *args: None),
+    12: ('Display', lambda *args: None),
+    13: ('Key Pad Entry', lambda *args: None),
+    14: ('Enclosure', enclosure),
+    15: ('SCSI Port/Transciever', lambda *args: None),
+    16: ('Language', lambda *args: None),
+    17: ('Communication Port', comm),
+    18: ('Voltage Sensor', volt),
+    19: ('Current Sensor', current),
+    20: ('SCSI Target Port', lambda *args: None),
+    21: ('SCSI Initiator Port', lambda *args: None),
+    22: ('Simple Subenclosure', lambda *args: None),
+    23: ('Array Device Slot', array_dev),
+    24: ('SAS Expander', sas_exp),
+    25: ('SAS Connector', sas_conn),
+}

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -1,0 +1,59 @@
+import pathlib
+
+from pyudev import Context
+
+from libsg3.ses import EnclosureDevice
+from middlewared.service import Service, filterable
+from middlewared.utils import filter_list
+from .enclosure_class import Enclosure
+from .map2 import map_enclosures
+
+
+class Enclosure2Service(Service):
+
+    class Config:
+        cli_namespace = 'storage.enclosure2'
+        private = True
+
+    def get_ses_enclosures(self):
+        output = list()
+        dmi = self.middleware.call_sync('system.dmidecode_info')['system-product-name']
+        for i in Context().list_devices(subsystem='enclosure'):
+            bsg = f'/dev/bsg/{i.sys_name}'
+            try:
+                enc_status = EnclosureDevice(bsg).status()
+            except OSError:
+                self.logger.error('Error querying enclosure status for %r', bsg)
+                continue
+
+            sg = next(pathlib.Path(f'/sys/class/enclosure/{i.sys_name}/device/scsi_generic').iterdir())
+            output.append(Enclosure(bsg, f'/dev/{sg.name}', dmi, enc_status).asdict())
+
+        return output
+
+    def to_ignore(self, enclosure):
+        return all((
+            enclosure['product'] == 'SGPIOEnclosure',
+            '-MINI-' not in enclosure['model'],
+            not enclosure['model'].startswith('R20'),
+        ))
+
+    @filterable
+    def query(self, filters, options):
+        enclosures = []
+        if self.middleware.call_sync('truenas.get_chassis_hardware') == 'TRUENAS-UNKNOWN':
+            # this feature is only available on hardware that ix sells
+            return enclosures
+
+        labels = {
+            label["encid"]: label["label"]
+            for label in self.middleware.call_sync("datastore.query", "truenas.enclosurelabel")
+        }
+        for i in filter(lambda x: not self.to_ignore(x), self.get_ses_enclosures()):
+            i['label'] = labels.get(i['id']) or i['name']
+            enclosures.append(i)
+
+        # TODO: fix nvme mapping
+        # enclosures.extend(self.middleware.call_sync("enclosure.map_nvme"))
+        enclosures = map_enclosures(enclosures)
+        return filter_list(enclosures, filters, options)

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -1,0 +1,141 @@
+import logging
+import pathlib
+
+from middlewared.utils.scsi_generic import inquiry
+from .identification import get_enclosure_model_and_controller
+from .element_types import ELEMENT_TYPES, ELEMENT_DESC
+
+
+logger = logging.getLogger(__name__)
+
+
+class Enclosure:
+    def __init__(self, bsg, sg, dmi, enc_stat):
+        self.bsg, self.sg, self.pci, self.dmi = bsg, sg, bsg.removeprefix('/dev/bsg/'), dmi
+        self.encid, self.status = enc_stat['id'], list(enc_stat['status'])
+        self.vendor, self.product, self.revision, self.encname = self._get_vendor_product_revision_and_encname()
+        self.model, self.controller = self._get_model_and_controller()
+        self.elements = self._parse_elements(enc_stat['elements'])
+
+    def asdict(self):
+        return {
+            'name': self.encname,
+            'model': self.model,
+            'controller': self.controller,
+            'dmi': self.dmi,
+            'status': self.status,
+            'id': self.encid,
+            'vendor': self.vendor,
+            'product': self.product,
+            'revision': self.revision,
+            'bsg': self.bsg,
+            'sg': self.sg,
+            'pci': self.pci,
+            'elements': self.elements
+        }
+
+    def _get_vendor_product_revision_and_encname(self):
+        inq = inquiry(self.sg)
+        data = [inq['vendor'], inq['product'], inq['revision']]
+        data.append(' '.join(data))
+        return data
+
+    def _get_model_and_controller(self):
+        key = f'{self.vendor}_{self.product}'
+        return get_enclosure_model_and_controller(key, self.dmi)
+
+    def _map_disks_to_enclosure_slots(self):
+        """
+        The sysfs directory structure is dynamic based on the enclosure that
+        is attached.
+        Here are some examples of what we've seen on internal hardware:
+            /sys/class/enclosure/19:0:6:0/SLOT_001/
+            /sys/class/enclosure/13:0:0:0/Drive Slot #0_0000000000000000/
+            /sys/class/enclosure/13:0:0:0/Disk #00/
+            /sys/class/enclosure/13:0:0:0/Slot 00/
+            /sys/class/enclosure/13:0:0:0/slot00/
+
+        The safe assumption that we can make on whether or not the directory
+        represents a drive slot is looking for the file named "slot" underneath
+        each directory. (i.e. /sys/class/enclosure/13:0:0:0/Disk #00/slot)
+
+        If this file doesn't exist, it means 1 thing
+            1. this isn't a drive slot directory
+
+        Once we've determined that there is a file named "slot", we can read the
+        contents of that file to get the slot number associated to the disk device.
+        The "slot" file is always an integer so we don't need to convert to hexadecimal.
+        """
+        mapping = dict()
+        for i in filter(lambda x: x.is_dir(), pathlib.Path(f'/sys/class/enclosure/{self.pci}').iterdir()):
+            try:
+                slot = int((i / 'slot').read_text().strip())
+            except (FileNotFoundError, ValueError):
+                # not a slot directory
+                continue
+            else:
+                try:
+                    dev = next((i / 'device/block').iterdir(), None)
+                    mapping[slot] = dev.name if dev is not None else ''
+                except FileNotFoundError:
+                    # no disk in this slot
+                    mapping[slot] = ''
+        try:
+            # we have a single enclosure (at time of writing this) that enumerates
+            # sysfs drive slots starting at number 1 while every other JBOD
+            # (and head-units) enumerate syfs drive slots starting at number 0
+            min_slot = min(mapping)
+        except ValueError:
+            min_slot = 0
+
+        return min_slot, mapping
+
+    def _elements_to_ignore(self, element):
+        return element['descriptor'] in ('<empty>', 'ArrayDevices', 'Drive Slots')
+
+    def _parse_elements(self, elements):
+        final = {}
+        min_slot, disk_map = self._map_disks_to_enclosure_slots()
+        for slot, element in filter(lambda x: not self._elements_to_ignore(x[1]), elements.items()):
+            try:
+                element_type = ELEMENT_TYPES[element['type']]
+            except KeyError:
+                # means the element type that's being
+                # reported to us is unknown so log it
+                # and continue on
+                logger.warning('Unknown element type: %r for %r', element['type'], self.devname)
+                continue
+
+            try:
+                element_status = ELEMENT_DESC[element['status'][0]]
+            except KeyError:
+                # means the elements status reported by the enclosure
+                # is not mapped so just report unknown
+                element_status = 'UNKNOWN'
+
+            if element_type[0] not in final:
+                # first time seeing this element type so add it
+                final[element_type[0]] = {}
+
+            # convert list of integers representing the elements
+            # raw status to an integer so it can be converted
+            # appropriately based on the element type
+            value_raw = 0
+            for val in element['status']:
+                value_raw = (value_raw << 8) + val
+
+            parsed = {slot: {
+                'descriptor': element['descriptor'].strip(),
+                'status': element_status,
+                'value': element_type[1](value_raw),
+                'value_raw': value_raw,
+            }}
+            if element_type[0] == 'Array Device Slot':
+                parsed[slot]['dev'] = None
+                orig_slot = slot - 1 if min_slot == 0 else slot
+                if (disk_dev := disk_map.get(orig_slot, False)):
+                    parsed[slot]['dev'] = disk_dev
+
+            final[element_type[0]].update(parsed)
+
+        return final

--- a/src/middlewared/middlewared/plugins/enclosure_/identification.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/identification.py
@@ -1,7 +1,7 @@
 def r20_variants_or_mini(pr, pnr, dmi):
     if dmi in ['TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B']:
         return pr, True
-    elif dmi in ['TRUENAS-MINI', 'FREENAS-MINI']:
+    elif dmi.startswith(('TRUENAS-MINI', 'FREENAS-MINI')):
         # minis do not have the TRUENAS- prefix removed
         return pnr, True
     else:

--- a/src/middlewared/middlewared/plugins/enclosure_/identification.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/identification.py
@@ -1,0 +1,57 @@
+def r20_variants_or_mini(pr, pnr, dmi):
+    if dmi in ['TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B']:
+        return pr, True
+    elif dmi in ['TRUENAS-MINI', 'FREENAS-MINI']:
+        # minis do not have the TRUENAS- prefix removed
+        return pnr, True
+    else:
+        return '', False
+
+
+def get_enclosure_model_and_controller(key, dmi):
+    pr, pnr = dmi.replace('TRUENAS-', ''), dmi
+    try:
+        return {
+            # M series
+            'ECStream_4024Sp': ('M Series', True),
+            'ECStream_4024Ss': ('M Series', True),
+            'iX_4024Sp': ('M Series', True),
+            'iX_4024Ss': ('M Series', True),
+            # X series
+            'CELESTIC_P3215-O': ('X Series', True),
+            'CELESTIC_P3217-B': ('X Series', True),
+            # R series (just uses dmi info for model)
+            'ECStream_FS1': (pr, True),
+            'ECStream_FS2': (pr, True),
+            'ECStream_DSS212Sp': (pr, True),
+            'ECStream_DSS212Ss': (pr, True),
+            'iX_FS1': (pr, True),
+            'iX_FS2': (pr, True),
+            'iX_DSS212Sp': (pr, True),
+            'iX_DSS212Ss': (pr, True),
+            # R20
+            'iX_TrueNAS R20p': (pr, True),
+            'iX_TrueNAS 2012Sp': (pr, True),
+            'iX_TrueNAS SMC SC826-P': (pr, True),
+            # R20 variants
+            'AHCI_SGPIOEnclosure': r20_variants_or_mini(pr, pnr, dmi),
+            # R50
+            'iX_eDrawer4048S1': (pr, True),
+            'iX_eDrawer4048S2': (pr, True),
+            # JBODS
+            'ECStream_3U16RJ-AC.r3': ('E16', False),
+            'Storage_1729': ('E24', False),
+            'QUANTA _JB9 SIM': ('E60', False),
+            'CELESTIC_X2012': ('ES12', False),
+            'ECStream_4024J': ('ES24', False),
+            'iX_4024J': ('ES24', False),
+            'ECStream_2024Jp': ('ES24F', False),
+            'ECStream_2024Js': ('ES24F', False),
+            'iX_2024Jp': ('ES24F', False),
+            'iX_2024Js': ('ES24F', False),
+            'CELESTIC_R0904': ('ES60', False),
+            'HGST_H4102-J': ('ES102', False),
+            'VikingES_NDS-41022-BB': ('ES102S', False),
+        }[key]
+    except KeyError:
+        return '', False

--- a/src/middlewared/middlewared/plugins/enclosure_/map2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map2.py
@@ -49,7 +49,7 @@ def map_enclosures(enclosures):
                     'original': {
                         'enclosure_id': enclosure['id'],
                         'enclosure_sg': enclosure['sg'],
-                        'encllsure_bsg': enclosure['bsg'],
+                        'enclosure_bsg': enclosure['bsg'],
                         'descriptor': orig_info['descriptor'],
                         'slot': orig_slot
                     }

--- a/src/middlewared/middlewared/plugins/enclosure_/map2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map2.py
@@ -1,0 +1,59 @@
+from .slot_mappings import MAPPINGS
+
+
+def map_enclosures(enclosures):
+    mapped = [{'id': 'mapped_enclosure_0', 'elements': {'Array Device Slot': {}}}]
+    jbods = []
+    for enclosure in enclosures:
+        if not enclosure['controller']:
+            jbods.append(enclosure)
+            continue
+
+        try:
+            mapped_dict = MAPPINGS[enclosure['dmi']]['mapping_info']
+        except KeyError:
+            # X, M, F series don't need to be mapped so this is expected
+            return enclosures
+
+        vers_key = 'DEFAULT'
+        if not MAPPINGS[enclosure['dmi']]['any_version']:
+            # platforms can have different "versions" which
+            # means that they can be ever so slightly cabled
+            # differently which leads to us having to map the
+            # drives based on how they're cabled
+            # (hence the "version")
+            for key, vers in mapped_dict['versions'].items():
+                if enclosure['revision'] == key:
+                    vers_key = vers
+                    break
+
+        for key, _dsm in MAPPINGS[enclosure['dmi']]['mapping_info']['versions'][vers_key].items():
+            # now that we know what product "version" we're on, we need to be
+            # sure and pull the drive mappings based on the enclosures unique
+            # (non-changing) id. The non-changing id that uniquely identifies
+            # the enclosure is different between each platform
+            if (disk_slots_mapping := _dsm.get(enclosure[key])) is not None:
+                break
+        else:
+            raise LookupError(f'Enclosure {enclosure["name"]!r} not found in mapping')
+
+        for orig_slot, orig_info in enclosure['elements']['Array Device Slot'].items():
+            mapped_slot = disk_slots_mapping[orig_slot]['mapped_slot']
+            mapped[0]['elements']['Array Device Slot'].update({
+                mapped_slot: {
+                    'descriptor': f'Disk #{mapped_slot}',
+                    'status': orig_info['status'],
+                    'value': orig_info['value'],
+                    'value_raw': orig_info['value_raw'],
+                    'dev': orig_info['dev'],
+                    'original': {
+                        'enclosure_id': enclosure['id'],
+                        'enclosure_sg': enclosure['sg'],
+                        'encllsure_bsg': enclosure['bsg'],
+                        'descriptor': orig_info['descriptor'],
+                        'slot': orig_slot
+                    }
+                }
+            })
+
+    return mapped + jbods

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -1,0 +1,309 @@
+def get_slot_info(model):
+    if model in ('R40', 'R50', 'R50B', 'R50BM'):
+        # these rseries devices share same enclosure and mapping
+        # but it's important to always map the eDrawer4048S1
+        # enclosure device to drives 1 - 24
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'product': {
+                        'eDrawer4048S1': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                            5: {'orig_slot': 5, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6},
+                            7: {'orig_slot': 7, 'mapped_slot': 7},
+                            8: {'orig_slot': 8, 'mapped_slot': 8},
+                            9: {'orig_slot': 9, 'mapped_slot': 9},
+                            10: {'orig_slot': 10, 'mapped_slot': 10},
+                            11: {'orig_slot': 11, 'mapped_slot': 11},
+                            12: {'orig_slot': 12, 'mapped_slot': 12},
+                            13: {'orig_slot': 13, 'mapped_slot': 13},
+                            14: {'orig_slot': 14, 'mapped_slot': 14},
+                            15: {'orig_slot': 15, 'mapped_slot': 15},
+                            16: {'orig_slot': 16, 'mapped_slot': 16},
+                            17: {'orig_slot': 17, 'mapped_slot': 17},
+                            18: {'orig_slot': 18, 'mapped_slot': 18},
+                            19: {'orig_slot': 19, 'mapped_slot': 19},
+                            20: {'orig_slot': 20, 'mapped_slot': 20},
+                            21: {'orig_slot': 21, 'mapped_slot': 21},
+                            22: {'orig_slot': 22, 'mapped_slot': 22},
+                            23: {'orig_slot': 23, 'mapped_slot': 23},
+                            24: {'orig_slot': 24, 'mapped_slot': 24},
+                        },
+                        'eDrawer4048S2': {
+                            1: {'orig_slot': 1, 'mapped_slot': 25},
+                            2: {'orig_slot': 2, 'mapped_slot': 26},
+                            3: {'orig_slot': 3, 'mapped_slot': 27},
+                            4: {'orig_slot': 4, 'mapped_slot': 28},
+                            5: {'orig_slot': 5, 'mapped_slot': 29},
+                            6: {'orig_slot': 6, 'mapped_slot': 30},
+                            7: {'orig_slot': 7, 'mapped_slot': 31},
+                            8: {'orig_slot': 8, 'mapped_slot': 32},
+                            9: {'orig_slot': 9, 'mapped_slot': 33},
+                            10: {'orig_slot': 10, 'mapped_slot': 34},
+                            11: {'orig_slot': 11, 'mapped_slot': 35},
+                            12: {'orig_slot': 12, 'mapped_slot': 36},
+                            13: {'orig_slot': 13, 'mapped_slot': 37},
+                            14: {'orig_slot': 14, 'mapped_slot': 38},
+                            15: {'orig_slot': 15, 'mapped_slot': 39},
+                            16: {'orig_slot': 16, 'mapped_slot': 40},
+                            17: {'orig_slot': 17, 'mapped_slot': 41},
+                            18: {'orig_slot': 18, 'mapped_slot': 42},
+                            19: {'orig_slot': 19, 'mapped_slot': 43},
+                            20: {'orig_slot': 20, 'mapped_slot': 44},
+                            21: {'orig_slot': 21, 'mapped_slot': 45},
+                            22: {'orig_slot': 22, 'mapped_slot': 46},
+                            23: {'orig_slot': 23, 'mapped_slot': 47},
+                            24: {'orig_slot': 24, 'mapped_slot': 48},
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'R10':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            5: {'orig_slot': 5, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            13: {'orig_slot': 13, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6},
+                            10: {'orig_slot': 10, 'mapped_slot': 7},
+                            14: {'orig_slot': 14, 'mapped_slot': 8},
+                            3: {'orig_slot': 3, 'mapped_slot': 9},
+                            7: {'orig_slot': 7, 'mapped_slot': 10},
+                            11: {'orig_slot': 11, 'mapped_slot': 11},
+                            15: {'orig_slot': 15, 'mapped_slot': 12},
+                            4: {'orig_slot': 4, 'mapped_slot': 13},
+                            8: {'orig_slot': 8, 'mapped_slot': 14},
+                            12: {'orig_slot': 12, 'mapped_slot': 15},
+                            16: {'orig_slot': 16, 'mapped_slot': 16}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model in ('R20', 'R20B'):
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            3: {'orig_slot': 3, 'mapped_slot': 1},
+                            6: {'orig_slot': 6, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            12: {'orig_slot': 12, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            8: {'orig_slot': 8, 'mapped_slot': 7},
+                            11: {'orig_slot': 11, 'mapped_slot': 8},
+                            1: {'orig_slot': 1, 'mapped_slot': 9},
+                            4: {'orig_slot': 4, 'mapped_slot': 10},
+                            7: {'orig_slot': 7, 'mapped_slot': 11},
+                            10: {'orig_slot': 10, 'mapped_slot': 12}
+                        }
+                    },
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 13},
+                            2: {'orig_slot': 2, 'mapped_slot': 14}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'R20A':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            3: {'orig_slot': 3, 'mapped_slot': 1},
+                            6: {'orig_slot': 6, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            12: {'orig_slot': 12, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            8: {'orig_slot': 8, 'mapped_slot': 7},
+                            11: {'orig_slot': 11, 'mapped_slot': 8},
+                            1: {'orig_slot': 1, 'mapped_slot': 9},
+                            4: {'orig_slot': 4, 'mapped_slot': 10},
+                            7: {'orig_slot': 7, 'mapped_slot': 11},
+                            10: {'orig_slot': 10, 'mapped_slot': 12}
+                        }
+                    },
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 13},
+                            2: {'orig_slot': 2, 'mapped_slot': 14}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-3.0-E':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                            5: {'orig_slot': 5, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-3.0-E+':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                        },
+                        '3000000000000002': {
+                            1: {'orig_slot': 1, 'mapped_slot': 5},
+                            2: {'orig_slot': 2, 'mapped_slot': 6}
+
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-3.0-X':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                # TODO: 1.0 "version" has same mapping?? (CORE is the same)
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                        },
+                        '3000000000000002': {
+                            1: {'orig_slot': 1, 'mapped_slot': 5},
+                            2: {'orig_slot': 2, 'mapped_slot': 6},
+                            4: {'orig_slot': 4, 'mapped_slot': 7}
+
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-3.0-X+':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                            5: {'orig_slot': 5, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6},
+                            7: {'orig_slot': 7, 'mapped_slot': 7}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-3.0-XL+':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000002': {
+                            6: {'orig_slot': 6, 'mapped_slot': 1},
+                        },
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 2},
+                            2: {'orig_slot': 2, 'mapped_slot': 3},
+                            3: {'orig_slot': 3, 'mapped_slot': 4},
+                            4: {'orig_slot': 4, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            6: {'orig_slot': 6, 'mapped_slot': 7},
+                            7: {'orig_slot': 6, 'mapped_slot': 8},
+                            8: {'orig_slot': 6, 'mapped_slot': 9}
+                        }
+                    }
+                }
+            }}
+        }
+    elif model == 'MINI-R':
+        return {
+            'any_version': True,
+            'mapping_info': {'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 2},
+                            2: {'orig_slot': 2, 'mapped_slot': 3},
+                            3: {'orig_slot': 3, 'mapped_slot': 4},
+                            4: {'orig_slot': 4, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            6: {'orig_slot': 6, 'mapped_slot': 7},
+                            7: {'orig_slot': 6, 'mapped_slot': 8}
+                        },
+                        '3000000000000002': {
+                            4: {'orig_slot': 4, 'mapped_slot': 9},
+                            5: {'orig_slot': 5, 'mapped_slot': 10},
+                            6: {'orig_slot': 6, 'mapped_slot': 11},
+                            7: {'orig_slot': 7, 'mapped_slot': 12}
+                        }
+                    }
+                }
+            }}
+        }
+    else:
+        return {}
+
+
+MAPPINGS = {
+    'TRUENAS-R10': get_slot_info('R10'),
+    'TRUENAS-R20': get_slot_info('R20'),
+    'TRUENAS-R20A': get_slot_info('R20A'),
+    'TRUENAS-R20B': get_slot_info('R20B'),
+    'TRUENAS-R40': get_slot_info('R40'),
+    'TRUENAS-R50': get_slot_info('R50'),
+    'TRUENAS-R50B': get_slot_info('R50B'),
+    'TRUENAS-R50BM': get_slot_info('R50BM'),
+    'TRUENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
+    'FREENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
+    'TRUENAS-MINI-3.0-E+': get_slot_info('MINI-3.0-E+'),
+    'FREENAS-MINI-3.0-E+': get_slot_info('MINI-3.0-E+'),
+    'TRUENAS-MINI-3.0-X': get_slot_info('MINI-3.0-X'),
+    'FREENAS-MINI-3.0-X': get_slot_info('MINI-3.0-X'),
+    'TRUENAS-MINI-3.0-X+': get_slot_info('MINI-3.0-X+'),
+    'FREENAS-MINI-3.0-X+': get_slot_info('MINI-3.0-X+'),
+    'TRUENAS-MINI-3.0-XL+': get_slot_info('MINI-3.0-XL+'),
+    'FREENAS-MINI-3.0-XL+': get_slot_info('MINI-3.0-XL+'),
+    'TRUENAS-MINI-R': get_slot_info('MINI-R'),
+    'FREENAS-MINI-R': get_slot_info('MINI-R')
+}

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
@@ -1,0 +1,322 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import element_types
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100000, 'Identify on'),
+    (0x080000, 'Fail on'),
+    (0x000080, 'RQST mute'),
+    (0x000040, 'Muted'),
+    (0x000010, 'Remind'),
+    (0x000008, 'INFO'),
+    (0x000004, 'NON-CRIT'),
+    (0x000002, 'CRIT'),
+    (0x000001, 'UNRECOV'),
+    # No flag
+    (0x000000, None),
+    # All flags
+    (0x1800FF, 'Identify on, Fail on, RQST mute, Muted, Remind, INFO, NON-CRIT, CRIT, UNRECOV')
+])
+def test_alarm(data):
+    value_raw, expected_result = data
+    assert element_types.alarm(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100000, 'Identify on'),
+    (0x080000, 'Fail on'),
+    (0x000001, 'Disabled'),
+    # Test with no flags set
+    (0x000000, None),
+    # Test combinations
+    (0x180000, 'Identify on, Fail on'),
+    (0x100001, 'Identify on, Disabled'),
+    (0x080001, 'Fail on, Disabled'),
+    # Test with all flags set
+    (0x180001, 'Identify on, Fail on, Disabled')
+])
+def test_comm(data):
+    value_raw, expected_result = data
+    assert element_types.comm(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100010, '6.56A, Identify on'),
+    (0x080020, '8.0A, Fail on'),
+    (0x000830, '12.96A, Warn Over'),
+    (0x000240, '5.76A, Crit Over'),
+    # No flag
+    (0x000000, '0.0A'),
+    # Test with all flags set
+    (0x1C0A10, '4.16A, Identify on, Fail on, Warn Over, Crit Over')
+])
+def test_current(data):
+    value_raw, expected_result = data
+    assert element_types.current(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100000, 'Identify on'),
+    (0x000200, 'Fail on'),
+    (0x000100, 'Warn On'),
+    # Test power cycle and power off time flags
+    (0x000840, 'Power cycle 1min, power off for 16min'),
+    # Test with no flags set
+    (0x000000, None),
+    # Test combinations
+    (0x100200, 'Identify on, Fail on'),
+    (0x100100, 'Identify on, Warn On'),
+    (0x000300, 'Fail on, Warn On'),
+    # Test with all flags set and power cycle time
+    (0x100F4C, 'Identify on, Fail on, Warn On, Power cycle 15min, power off for 19min'),
+])
+def test_enclosure(data):
+    value_raw, expected_result = data
+    assert element_types.enclosure(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100010, '6.56V, Identify on'),
+    (0x080020, '8.0V, Fail on'),
+    (0x000830, '12.96V, Warn over'),
+    (0x000440, '17.44V, Warn under'),
+    (0x000240, '5.76V, Crit over'),
+    (0x000141, '3.21V, Crit under'),
+    # Test with no flags set
+    (0x000080, '1.28V'),
+    # Test combinations
+    (0x180010, '6.56V, Identify on, Fail on'),
+    (0x1C0A10, '4.16V, Identify on, Fail on, Warn over, Warn under'),
+    # Test with all flags set
+    (0x1F0F1F, '7.83V, Identify on, Fail on, Warn over, Warn under, Crit over, Crit under'),
+])
+def test_volt(data):
+    value_raw, expected_result = data
+    assert element_types.volt(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x000000, '0 RPM'),
+    (0x001000, '160 RPM'),
+    (0x010000, '10240 RPM'),
+    (0x7ff00, '524280 RPM'),
+    # Ensure mask works correctly
+    (0xFFFF00, '524280 RPM'),
+    # Test with bits set outside the mask
+    (0xABCDEF, '686080 RPM')
+])
+def test_cooling(data):
+    value_raw, expected_result = data
+    assert element_types.cooling(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x0000, None),
+    # Check for minimum temperature
+    (0x0100, '-19C'),
+    # Check for an arbitrary temperature
+    (0x8000, '108C'),
+    # Check for maximum temperature
+    (0xFF00, '235C'),
+    # Check that extra bits do not affect the result
+    (0xFFFF, '235C')
+])
+def test_temp(data):
+    value_raw, expected_result = data
+    assert element_types.temp(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x100000, 'Identify on'),
+    (0x40, 'Fail on'),
+    (0x800, 'DC overvoltage'),
+    (0x400, 'DC undervoltage'),
+    (0x200, 'DC overcurrent'),
+    (0x8, 'Overtemp fail'),
+    (0x4, 'Overtemp warn'),
+    (0x2, 'AC fail'),
+    (0x1, 'DC fail'),
+    (0x10, 'Off'),
+    # Test with no flags set
+    (0x000000, None),
+    # Test some combinations
+    (0x100400, 'Identify on, DC undervoltage'),
+    (0x40C, 'Fail on, DC overcurrent, Overtemp warn'),
+    # Test with all flags set
+    (
+        0x10045F, '''Identify on, Fail on, DC overvoltage,
+        DC undervoltage, DC overcurrent, Overtemp fail,
+        Overtemp warn, AC fail, DC fail, Off'''
+    )
+])
+def test_psu(data):
+    value_raw, expected_result = data
+    assert element_types.psu(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x200, 'Identify on'),
+    (0x20, 'Fault on'),
+    # Test with no flags set
+    (0x0, None),
+    # Test combinations
+    (0x220, 'Identify on, Fault on')
+])
+def test_array_dev(data):
+    value_raw, expected_result = data
+    assert element_types.array_dev(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x000000, 'No information'),
+    (0x010000, 'SAS 4x receptacle (SFF-8470) [max 4 phys]'),
+    (0x020000, 'Mini SAS 4x receptacle (SFF-8088) [max 4 phys]'),
+    (0x030000, 'QSFP+ receptacle (SFF-8436) [max 4 phys]'),
+    (0x040000, 'Mini SAS 4x active receptacle (SFF-8088) [max 4 phys]'),
+    (0x050000, 'Mini SAS HD 4x receptacle (SFF-8644) [max 4 phys]'),
+    (0x060000, 'Mini SAS HD 8x receptacle (SFF-8644) [max 8 phys]'),
+    (0x070000, 'Mini SAS HD 16x receptacle (SFF-8644) [max 16 phys]'),
+    (0x080000, 'unknown external connector type: 0x8'),
+    (0x090000, 'unknown external connector type: 0x9'),
+    (0x0a0000, 'unknown external connector type: 0xa'),
+    (0x0b0000, 'unknown external connector type: 0xb'),
+    (0x0c0000, 'unknown external connector type: 0xc'),
+    (0x0d0000, 'unknown external connector type: 0xd'),
+    (0x0e0000, 'unknown external connector type: 0xe'),
+    (0x0f0000, 'Vendor specific external connector'),
+    (0x100000, 'SAS 4i plug (SFF-8484) [max 4 phys]'),
+    (0x110000, 'Mini SAS 4i receptacle (SFF-8087) [max 4 phys]'),
+    (0x120000, 'Mini SAS HD 4i receptacle (SFF-8643) [max 4 phys]'),
+    (0x130000, 'Mini SAS HD 8i receptacle (SFF-8643) [max 8 phys]'),
+    (0x140000, 'unknown internal wide connector type: 0x14'),
+    (0x150000, 'unknown internal wide connector type: 0x15'),
+    (0x160000, 'unknown internal wide connector type: 0x16'),
+    (0x170000, 'unknown internal wide connector type: 0x17'),
+    (0x180000, 'unknown internal wide connector type: 0x18'),
+    (0x190000, 'unknown internal wide connector type: 0x19'),
+    (0x200000, 'SAS Drive backplane receptacle (SFF-8482) [max 2 phys]'),
+    (0x210000, 'SATA host plug [max 1 phy]'),
+    (0x220000, 'SAS Drive plug (SFF-8482) [max 2 phys]'),
+    (0x230000, 'SATA device plug [max 1 phy]'),
+    (0x240000, 'Micro SAS receptacle [max 2 phys]'),
+    (0x250000, 'Micro SATA device plug [max 1 phy]'),
+    (0x260000, 'Micro SAS plug (SFF-8486) [max 2 phys]'),
+    (0x270000, 'Micro SAS/SATA plug (SFF-8486) [max 2 phys]'),
+    (0x280000, 'unknown internal connector to end device type: 0x28'),
+    (0x290000, 'unknown internal connector to end device type: 0x29'),
+    (0x2a0000, 'unknown internal connector to end device type: 0x2a'),
+    (0x2b0000, 'unknown internal connector to end device type: 0x2b'),
+    (0x2c0000, 'unknown internal connector to end device type: 0x2c'),
+    (0x2d0000, 'unknown internal connector to end device type: 0x2d'),
+    (0x2e0000, 'unknown internal connector to end device type: 0x2e'),
+    (0x2f0000, 'SAS virtual connector [max 1 phy]'),
+    (0x300000, 'reserved for internal connector type: 0x30'),
+    (0x310000, 'reserved for internal connector type: 0x31'),
+    (0x320000, 'reserved for internal connector type: 0x32'),
+    (0x330000, 'reserved for internal connector type: 0x33'),
+    (0x340000, 'reserved for internal connector type: 0x34'),
+    (0x350000, 'reserved for internal connector type: 0x35'),
+    (0x360000, 'reserved for internal connector type: 0x36'),
+    (0x370000, 'reserved for internal connector type: 0x37'),
+    (0x380000, 'reserved for internal connector type: 0x38'),
+    (0x390000, 'reserved for internal connector type: 0x39'),
+    (0x3a0000, 'reserved for internal connector type: 0x3a'),
+    (0x3b0000, 'reserved for internal connector type: 0x3b'),
+    (0x3c0000, 'reserved for internal connector type: 0x3c'),
+    (0x3d0000, 'reserved for internal connector type: 0x3d'),
+    (0x3e0000, 'reserved for internal connector type: 0x3e'),
+    (0x3f0000, 'Vendor specific internal connector'),
+    (0x400000, 'reserved connector type: 0x40'),
+    (0x410000, 'reserved connector type: 0x41'),
+    (0x420000, 'reserved connector type: 0x42'),
+    (0x430000, 'reserved connector type: 0x43'),
+    (0x440000, 'reserved connector type: 0x44'),
+    (0x450000, 'reserved connector type: 0x45'),
+    (0x460000, 'reserved connector type: 0x46'),
+    (0x470000, 'reserved connector type: 0x47'),
+    (0x480000, 'reserved connector type: 0x48'),
+    (0x490000, 'reserved connector type: 0x49'),
+    (0x4a0000, 'reserved connector type: 0x4a'),
+    (0x4b0000, 'reserved connector type: 0x4b'),
+    (0x4c0000, 'reserved connector type: 0x4c'),
+    (0x4d0000, 'reserved connector type: 0x4d'),
+    (0x4e0000, 'reserved connector type: 0x4e'),
+    (0x4f0000, 'reserved connector type: 0x4f'),
+    (0x500000, 'reserved connector type: 0x50'),
+    (0x510000, 'reserved connector type: 0x51'),
+    (0x520000, 'reserved connector type: 0x52'),
+    (0x530000, 'reserved connector type: 0x53'),
+    (0x540000, 'reserved connector type: 0x54'),
+    (0x550000, 'reserved connector type: 0x55'),
+    (0x560000, 'reserved connector type: 0x56'),
+    (0x570000, 'reserved connector type: 0x57'),
+    (0x580000, 'reserved connector type: 0x58'),
+    (0x590000, 'reserved connector type: 0x59'),
+    (0x5a0000, 'reserved connector type: 0x5a'),
+    (0x5b0000, 'reserved connector type: 0x5b'),
+    (0x5c0000, 'reserved connector type: 0x5c'),
+    (0x5d0000, 'reserved connector type: 0x5d'),
+    (0x5e0000, 'reserved connector type: 0x5e'),
+    (0x5f0000, 'reserved connector type: 0x5f'),
+    (0x600000, 'reserved connector type: 0x60'),
+    (0x610000, 'reserved connector type: 0x61'),
+    (0x620000, 'reserved connector type: 0x62'),
+    (0x630000, 'reserved connector type: 0x63'),
+    (0x640000, 'reserved connector type: 0x64'),
+    (0x650000, 'reserved connector type: 0x65'),
+    (0x660000, 'reserved connector type: 0x66'),
+    (0x670000, 'reserved connector type: 0x67'),
+    (0x680000, 'reserved connector type: 0x68'),
+    (0x690000, 'reserved connector type: 0x69'),
+    (0x6a0000, 'reserved connector type: 0x6a'),
+    (0x6b0000, 'reserved connector type: 0x6b'),
+    (0x6c0000, 'reserved connector type: 0x6c'),
+    (0x6d0000, 'reserved connector type: 0x6d'),
+    (0x6e0000, 'reserved connector type: 0x6e'),
+    (0x6f0000, 'reserved connector type: 0x6f'),
+    (0x700000, 'vendor specific connector type: 0x70'),
+    (0x710000, 'vendor specific connector type: 0x71'),
+    (0x720000, 'vendor specific connector type: 0x72'),
+    (0x730000, 'vendor specific connector type: 0x73'),
+    (0x740000, 'vendor specific connector type: 0x74'),
+    (0x750000, 'vendor specific connector type: 0x75'),
+    (0x760000, 'vendor specific connector type: 0x76'),
+    (0x770000, 'vendor specific connector type: 0x77'),
+    (0x780000, 'vendor specific connector type: 0x78'),
+    (0x790000, 'vendor specific connector type: 0x79'),
+    (0x7a0000, 'vendor specific connector type: 0x7a'),
+    (0x7b0000, 'vendor specific connector type: 0x7b'),
+    (0x7c0000, 'vendor specific connector type: 0x7c'),
+    (0x7d0000, 'vendor specific connector type: 0x7d'),
+    (0x7e0000, 'vendor specific connector type: 0x7e'),
+    (0x7f0000, 'vendor specific connector type: 0x7f'),
+    # Test out of bounds connector type
+    (0x800000, 'unexpected connector type: 0x80'),
+    # Test connector type with fail on
+    (0x220040, 'SAS Drive plug (SFF-8482) [max 2 phys], Fail On'),
+    # Test out of bounds connector type with fail on
+    (0x800040, 'unexpected connector type: 0x80, Fail On')
+])
+def test_sas_conn(data):
+    value_raw, expected_result = data
+    assert element_types.sas_conn(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x0000, None),
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
+    (0xC00000, 'Identify on, Fail on')
+])
+def test_sas_exp(data):
+    value_raw, expected_result = data
+    assert element_types.sas_exp(value_raw) == expected_result

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
@@ -4,9 +4,8 @@ from middlewared.plugins.enclosure_ import element_types
 
 
 @pytest.mark.parametrize('data', [
-    # Test each individual flag
-    (0x100000, 'Identify on'),
-    (0x080000, 'Fail on'),
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
     (0x000080, 'RQST mute'),
     (0x000040, 'Muted'),
     (0x000010, 'Remind'),
@@ -14,10 +13,8 @@ from middlewared.plugins.enclosure_ import element_types
     (0x000004, 'NON-CRIT'),
     (0x000002, 'CRIT'),
     (0x000001, 'UNRECOV'),
-    # No flag
     (0x000000, None),
-    # All flags
-    (0x1800FF, 'Identify on, Fail on, RQST mute, Muted, Remind, INFO, NON-CRIT, CRIT, UNRECOV')
+    (0xf000ff, 'Identify on, Fail on, RQST mute, Muted, Remind, INFO, NON-CRIT, CRIT, UNRECOV')
 ])
 def test_alarm(data):
     value_raw, expected_result = data
@@ -25,18 +22,11 @@ def test_alarm(data):
 
 
 @pytest.mark.parametrize('data', [
-    # Test each individual flag
-    (0x100000, 'Identify on'),
-    (0x080000, 'Fail on'),
-    (0x000001, 'Disabled'),
-    # Test with no flags set
     (0x000000, None),
-    # Test combinations
-    (0x180000, 'Identify on, Fail on'),
-    (0x100001, 'Identify on, Disabled'),
-    (0x080001, 'Fail on, Disabled'),
-    # Test with all flags set
-    (0x180001, 'Identify on, Fail on, Disabled')
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
+    (0x000001, 'Disabled'),
+    (0xc00001, 'Identify on, Fail on, Disabled'),
 ])
 def test_comm(data):
     value_raw, expected_result = data
@@ -44,15 +34,23 @@ def test_comm(data):
 
 
 @pytest.mark.parametrize('data', [
-    # Test each individual flag
-    (0x100010, '6.56A, Identify on'),
-    (0x080020, '8.0A, Fail on'),
-    (0x000830, '12.96A, Warn Over'),
-    (0x000240, '5.76A, Crit Over'),
-    # No flag
     (0x000000, '0.0A'),
-    # Test with all flags set
-    (0x1C0A10, '4.16A, Identify on, Fail on, Warn Over, Crit Over')
+    (0x800000, '0.0A, Identify on'),
+    (0x400000, '0.0A, Fail on'),
+    (0x070000, '0.0A, Crit over'),
+    (0x080000, '0.0A, Warn over'),
+    # 2.5A
+    (0x0000fa, '2.5A'),
+    (0x08010a, '2.66A, Warn over'),
+    (0x070110, '2.72A, Crit over'),
+    # 5.0A
+    (0x0001f4, '5.0A'),
+    (0x080210, '5.28A, Warn over'),
+    (0x070220, '5.44A, Crit over'),
+    # 12.0A
+    (0x0004b0, '12.0A'),
+    (0x0804d0, '12.32A, Warn over'),
+    (0x0704f0, '12.64A, Crit over'),
 ])
 def test_current(data):
     value_raw, expected_result = data
@@ -60,20 +58,18 @@ def test_current(data):
 
 
 @pytest.mark.parametrize('data', [
-    # Test each individual flag
-    (0x100000, 'Identify on'),
+    (0x800000, 'Identify on'),
+    (0x000100, 'Warn on'),
     (0x000200, 'Fail on'),
-    (0x000100, 'Warn On'),
-    # Test power cycle and power off time flags
-    (0x000840, 'Power cycle 1min, power off for 16min'),
-    # Test with no flags set
-    (0x000000, None),
-    # Test combinations
-    (0x100200, 'Identify on, Fail on'),
-    (0x100100, 'Identify on, Warn On'),
-    (0x000300, 'Fail on, Warn On'),
-    # Test with all flags set and power cycle time
-    (0x100F4C, 'Identify on, Fail on, Warn On, Power cycle 15min, power off for 19min'),
+    (0x000300, 'Fail on, Warn on'),
+    (0x800100, 'Identify on, Warn on'),
+    (0x800200, 'Identify on, Fail on'),
+    (0x800300, 'Identify on, Fail on, Warn on'),
+    (0x000400, 'Power cycle 1min, power off for 0min'),
+    (0x000500, 'Warn on, Power cycle 1min, power off for 0min'),
+    (0x000600, 'Fail on, Power cycle 1min, power off for 0min'),
+    (0x800400, 'Identify on, Power cycle 1min, power off for 0min'),
+    (0x0004f0, 'Power cycle 1min, power off for 60min'),
 ])
 def test_enclosure(data):
     value_raw, expected_result = data
@@ -81,20 +77,27 @@ def test_enclosure(data):
 
 
 @pytest.mark.parametrize('data', [
-    # Test each individual flag
-    (0x100010, '6.56V, Identify on'),
-    (0x080020, '8.0V, Fail on'),
-    (0x000830, '12.96V, Warn over'),
-    (0x000440, '17.44V, Warn under'),
-    (0x000240, '5.76V, Crit over'),
-    (0x000141, '3.21V, Crit under'),
-    # Test with no flags set
-    (0x000080, '1.28V'),
-    # Test combinations
-    (0x180010, '6.56V, Identify on, Fail on'),
-    (0x1C0A10, '4.16V, Identify on, Fail on, Warn over, Warn under'),
-    # Test with all flags set
-    (0x1F0F1F, '7.83V, Identify on, Fail on, Warn over, Warn under, Crit over, Crit under'),
+    (0x100000, '0.0V'),
+    (0x110000, '0.0V, Crit under'),
+    (0x410000, '0.0V, Fail on, Crit under'),
+    (0x810000, '0.0V, Identify on, Crit under'),
+    (0xf10000, '0.0V, Identify on, Fail on, Crit under'),
+    (0x220000, '0.0V, Crit over'),
+    (0x520000, '0.0V, Fail on, Crit over'),
+    (0x820000, '0.0V, Identify on, Crit over'),
+    (0xf20000, '0.0V, Identify on, Fail on, Crit over'),
+    # 2.5V
+    (0x0100f0, '2.4V, Crit under'),
+    (0x0000fa, '2.5V'),
+    (0x020110, '2.72V, Crit over'),
+    # 5.0V
+    (0x0101e4, '4.84V, Crit under'),
+    (0x0001f4, '5.0V'),
+    (0x020210, '5.28V, Crit over'),
+    # 12.0V
+    (0x0104a0, '11.84V, Crit under'),
+    (0x0004b0, '12.0V'),
+    (0x0204d0, '12.32V, Crit over'),
 ])
 def test_volt(data):
     value_raw, expected_result = data
@@ -104,12 +107,10 @@ def test_volt(data):
 @pytest.mark.parametrize('data', [
     (0x000000, '0 RPM'),
     (0x001000, '160 RPM'),
-    (0x010000, '10240 RPM'),
-    (0x7ff00, '524280 RPM'),
+    (0x010000, '2560 RPM'),
+    (0x6f0000, '17920 RPM'),
     # Ensure mask works correctly
-    (0xFFFF00, '524280 RPM'),
-    # Test with bits set outside the mask
-    (0xABCDEF, '686080 RPM')
+    (0xFFFF00, '20470 RPM'),
 ])
 def test_cooling(data):
     value_raw, expected_result = data
@@ -134,7 +135,7 @@ def test_temp(data):
 
 @pytest.mark.parametrize('data', [
     # Test each individual flag
-    (0x100000, 'Identify on'),
+    (0x800000, 'Identify on'),
     (0x40, 'Fail on'),
     (0x800, 'DC overvoltage'),
     (0x400, 'DC undervoltage'),
@@ -147,14 +148,8 @@ def test_temp(data):
     # Test with no flags set
     (0x000000, None),
     # Test some combinations
-    (0x100400, 'Identify on, DC undervoltage'),
-    (0x40C, 'Fail on, DC overcurrent, Overtemp warn'),
-    # Test with all flags set
-    (
-        0x10045F, '''Identify on, Fail on, DC overvoltage,
-        DC undervoltage, DC overcurrent, Overtemp fail,
-        Overtemp warn, AC fail, DC fail, Off'''
-    )
+    (0x800400, 'Identify on, DC undervoltage'),
+    (0x40C, 'DC undervoltage, Overtemp fail, Overtemp warn'),
 ])
 def test_psu(data):
     value_raw, expected_result = data
@@ -300,11 +295,11 @@ def test_array_dev(data):
     (0x7e0000, 'vendor specific connector type: 0x7e'),
     (0x7f0000, 'vendor specific connector type: 0x7f'),
     # Test out of bounds connector type
-    (0x800000, 'unexpected connector type: 0x80'),
+    (0x800000, 'No information'),
     # Test connector type with fail on
-    (0x220040, 'SAS Drive plug (SFF-8482) [max 2 phys], Fail On'),
+    (0x220040, 'SAS Drive plug (SFF-8482) [max 2 phys], Fail on'),
     # Test out of bounds connector type with fail on
-    (0x800040, 'unexpected connector type: 0x80, Fail On')
+    (0x800040, 'No information, Fail on')
 ])
 def test_sas_conn(data):
     value_raw, expected_result = data

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
@@ -1,0 +1,55 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import identification
+
+
+@pytest.mark.parametrize('data', [
+    # M series
+    ('ECStream_4024Sp', 'TRUENAS-M40', ('M Series', True)),
+    ('ECStream_4024Ss', 'TRUENAS-M40', ('M Series', True)),
+    ('iX_4024Sp', 'TRUENAS-M40', ('M Series', True)),
+    ('iX_4024Ss', 'TRUENAS-M40', ('M Series', True)),
+    # X series
+    ('CELESTIC_P3215-O', 'TRUENAS-X20', ('X Series', True)),
+    ('CELESTIC_P3217-B', 'TRUENAS-X20', ('X Series', True)),
+    # R series (just uses dmi info for model)
+    ('ECStream_FS1', 'TRUENAS-R10', ('R10', True)),
+    ('ECStream_FS2', 'TRUENAS-R20', ('R20', True)),
+    ('ECStream_DSS212Sp', 'TRUENAS-R50', ('R50', True)),
+    ('ECStream_DSS212Ss', 'TRUENAS-R40', ('R40', True)),
+    ('iX_FS1', 'TRUENAS-R10', ('R10', True)),
+    ('iX_FS2', 'TRUENAS-R10', ('R10', True)),
+    ('iX_DSS212Sp', 'TRUENAS-R10', ('R10', True)),
+    ('iX_DSS212Ss', 'TRUENAS-R10', ('R10', True)),
+    # R20
+    ('iX_TrueNAS R20p', 'TRUENAS-R20', ('R20', True)),
+    ('iX_TrueNAS 2012Sp', 'TRUENAS-R20', ('R20', True)),
+    ('iX_TrueNAS SMC SC826-P', 'TRUENAS-R20', ('R20', True)),
+    # R20 variants (and minis)
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20', ('R20', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20A', ('R20A', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20B', ('R20B', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-MINI-R', ('TRUENAS-MINI-R', True)),
+    ('AHCI_SGPIOEnclosure', 'FREENAS-MINI-X', ('FREENAS-MINI-X', True)),
+    ('AHCI_SGPIOEnclosure', 'OOPS', ('', False)),
+    # R50
+    ('iX_eDrawer4048S1', 'TRUENAS-R50', ('R50', True)),
+    ('iX_eDrawer4048S2', 'TRUENAS-R50', ('R50', True)),
+    # JBODS
+    ('ECStream_3U16RJ-AC.r3', 'TRUENAS-F60', ('E16', False)),
+    ('Storage_1729', 'TRUENAS-F60', ('E24', False)),
+    ('QUANTA _JB9 SIM', 'TRUENAS-F60', ('E60', False)),
+    ('CELESTIC_X2012', 'TRUENAS-F60', ('ES12', False)),
+    ('ECStream_4024J', 'TRUENAS-F60', ('ES24', False)),
+    ('iX_4024J', 'TRUENAS-F60', ('ES24', False)),
+    ('ECStream_2024Jp', 'TRUENAS-F60', ('ES24F', False)),
+    ('ECStream_2024Js', 'TRUENAS-F60', ('ES24F', False)),
+    ('iX_2024Jp', 'TRUENAS-F60', ('ES24F', False)),
+    ('iX_2024Js', 'TRUENAS-F60', ('ES24F', False)),
+    ('CELESTIC_R0904', 'TRUENAS-F60', ('ES60', False)),
+    ('HGST_H4102-J', 'TRUENAS-F60', ('ES102', False)),
+    ('VikingES_NDS-41022-BB', 'TRUENAS-F60', ('ES102S', False))
+])
+def test_get_enclosure_model_and_controller(data):
+    key, dmi, expected_result = data
+    assert identification.get_enclosure_model_and_controller(key, dmi) == expected_result

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
@@ -1,0 +1,492 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import slot_mappings
+
+
+@pytest.mark.parametrize('data', [
+    ('R40', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7},
+                        8: {'orig_slot': 8, 'mapped_slot': 8},
+                        9: {'orig_slot': 9, 'mapped_slot': 9},
+                        10: {'orig_slot': 10, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        12: {'orig_slot': 12, 'mapped_slot': 12},
+                        13: {'orig_slot': 13, 'mapped_slot': 13},
+                        14: {'orig_slot': 14, 'mapped_slot': 14},
+                        15: {'orig_slot': 15, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16},
+                        17: {'orig_slot': 17, 'mapped_slot': 17},
+                        18: {'orig_slot': 18, 'mapped_slot': 18},
+                        19: {'orig_slot': 19, 'mapped_slot': 19},
+                        20: {'orig_slot': 20, 'mapped_slot': 20},
+                        21: {'orig_slot': 21, 'mapped_slot': 21},
+                        22: {'orig_slot': 22, 'mapped_slot': 22},
+                        23: {'orig_slot': 23, 'mapped_slot': 23},
+                        24: {'orig_slot': 24, 'mapped_slot': 24},
+                    },
+                    'eDrawer4048S2': {
+                        1: {'orig_slot': 1, 'mapped_slot': 25},
+                        2: {'orig_slot': 2, 'mapped_slot': 26},
+                        3: {'orig_slot': 3, 'mapped_slot': 27},
+                        4: {'orig_slot': 4, 'mapped_slot': 28},
+                        5: {'orig_slot': 5, 'mapped_slot': 29},
+                        6: {'orig_slot': 6, 'mapped_slot': 30},
+                        7: {'orig_slot': 7, 'mapped_slot': 31},
+                        8: {'orig_slot': 8, 'mapped_slot': 32},
+                        9: {'orig_slot': 9, 'mapped_slot': 33},
+                        10: {'orig_slot': 10, 'mapped_slot': 34},
+                        11: {'orig_slot': 11, 'mapped_slot': 35},
+                        12: {'orig_slot': 12, 'mapped_slot': 36},
+                        13: {'orig_slot': 13, 'mapped_slot': 37},
+                        14: {'orig_slot': 14, 'mapped_slot': 38},
+                        15: {'orig_slot': 15, 'mapped_slot': 39},
+                        16: {'orig_slot': 16, 'mapped_slot': 40},
+                        17: {'orig_slot': 17, 'mapped_slot': 41},
+                        18: {'orig_slot': 18, 'mapped_slot': 42},
+                        19: {'orig_slot': 19, 'mapped_slot': 43},
+                        20: {'orig_slot': 20, 'mapped_slot': 44},
+                        21: {'orig_slot': 21, 'mapped_slot': 45},
+                        22: {'orig_slot': 22, 'mapped_slot': 46},
+                        23: {'orig_slot': 23, 'mapped_slot': 47},
+                        24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                }
+            }
+        }}
+    }),
+    ('R50', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7},
+                        8: {'orig_slot': 8, 'mapped_slot': 8},
+                        9: {'orig_slot': 9, 'mapped_slot': 9},
+                        10: {'orig_slot': 10, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        12: {'orig_slot': 12, 'mapped_slot': 12},
+                        13: {'orig_slot': 13, 'mapped_slot': 13},
+                        14: {'orig_slot': 14, 'mapped_slot': 14},
+                        15: {'orig_slot': 15, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16},
+                        17: {'orig_slot': 17, 'mapped_slot': 17},
+                        18: {'orig_slot': 18, 'mapped_slot': 18},
+                        19: {'orig_slot': 19, 'mapped_slot': 19},
+                        20: {'orig_slot': 20, 'mapped_slot': 20},
+                        21: {'orig_slot': 21, 'mapped_slot': 21},
+                        22: {'orig_slot': 22, 'mapped_slot': 22},
+                        23: {'orig_slot': 23, 'mapped_slot': 23},
+                        24: {'orig_slot': 24, 'mapped_slot': 24},
+                    },
+                    'eDrawer4048S2': {
+                        1: {'orig_slot': 1, 'mapped_slot': 25},
+                        2: {'orig_slot': 2, 'mapped_slot': 26},
+                        3: {'orig_slot': 3, 'mapped_slot': 27},
+                        4: {'orig_slot': 4, 'mapped_slot': 28},
+                        5: {'orig_slot': 5, 'mapped_slot': 29},
+                        6: {'orig_slot': 6, 'mapped_slot': 30},
+                        7: {'orig_slot': 7, 'mapped_slot': 31},
+                        8: {'orig_slot': 8, 'mapped_slot': 32},
+                        9: {'orig_slot': 9, 'mapped_slot': 33},
+                        10: {'orig_slot': 10, 'mapped_slot': 34},
+                        11: {'orig_slot': 11, 'mapped_slot': 35},
+                        12: {'orig_slot': 12, 'mapped_slot': 36},
+                        13: {'orig_slot': 13, 'mapped_slot': 37},
+                        14: {'orig_slot': 14, 'mapped_slot': 38},
+                        15: {'orig_slot': 15, 'mapped_slot': 39},
+                        16: {'orig_slot': 16, 'mapped_slot': 40},
+                        17: {'orig_slot': 17, 'mapped_slot': 41},
+                        18: {'orig_slot': 18, 'mapped_slot': 42},
+                        19: {'orig_slot': 19, 'mapped_slot': 43},
+                        20: {'orig_slot': 20, 'mapped_slot': 44},
+                        21: {'orig_slot': 21, 'mapped_slot': 45},
+                        22: {'orig_slot': 22, 'mapped_slot': 46},
+                        23: {'orig_slot': 23, 'mapped_slot': 47},
+                        24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                }
+            }
+        }}
+    }),
+    ('R50B', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7},
+                        8: {'orig_slot': 8, 'mapped_slot': 8},
+                        9: {'orig_slot': 9, 'mapped_slot': 9},
+                        10: {'orig_slot': 10, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        12: {'orig_slot': 12, 'mapped_slot': 12},
+                        13: {'orig_slot': 13, 'mapped_slot': 13},
+                        14: {'orig_slot': 14, 'mapped_slot': 14},
+                        15: {'orig_slot': 15, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16},
+                        17: {'orig_slot': 17, 'mapped_slot': 17},
+                        18: {'orig_slot': 18, 'mapped_slot': 18},
+                        19: {'orig_slot': 19, 'mapped_slot': 19},
+                        20: {'orig_slot': 20, 'mapped_slot': 20},
+                        21: {'orig_slot': 21, 'mapped_slot': 21},
+                        22: {'orig_slot': 22, 'mapped_slot': 22},
+                        23: {'orig_slot': 23, 'mapped_slot': 23},
+                        24: {'orig_slot': 24, 'mapped_slot': 24},
+                    },
+                    'eDrawer4048S2': {
+                        1: {'orig_slot': 1, 'mapped_slot': 25},
+                        2: {'orig_slot': 2, 'mapped_slot': 26},
+                        3: {'orig_slot': 3, 'mapped_slot': 27},
+                        4: {'orig_slot': 4, 'mapped_slot': 28},
+                        5: {'orig_slot': 5, 'mapped_slot': 29},
+                        6: {'orig_slot': 6, 'mapped_slot': 30},
+                        7: {'orig_slot': 7, 'mapped_slot': 31},
+                        8: {'orig_slot': 8, 'mapped_slot': 32},
+                        9: {'orig_slot': 9, 'mapped_slot': 33},
+                        10: {'orig_slot': 10, 'mapped_slot': 34},
+                        11: {'orig_slot': 11, 'mapped_slot': 35},
+                        12: {'orig_slot': 12, 'mapped_slot': 36},
+                        13: {'orig_slot': 13, 'mapped_slot': 37},
+                        14: {'orig_slot': 14, 'mapped_slot': 38},
+                        15: {'orig_slot': 15, 'mapped_slot': 39},
+                        16: {'orig_slot': 16, 'mapped_slot': 40},
+                        17: {'orig_slot': 17, 'mapped_slot': 41},
+                        18: {'orig_slot': 18, 'mapped_slot': 42},
+                        19: {'orig_slot': 19, 'mapped_slot': 43},
+                        20: {'orig_slot': 20, 'mapped_slot': 44},
+                        21: {'orig_slot': 21, 'mapped_slot': 45},
+                        22: {'orig_slot': 22, 'mapped_slot': 46},
+                        23: {'orig_slot': 23, 'mapped_slot': 47},
+                        24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                }
+            }
+        }}
+    }),
+    ('R50BM', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7},
+                        8: {'orig_slot': 8, 'mapped_slot': 8},
+                        9: {'orig_slot': 9, 'mapped_slot': 9},
+                        10: {'orig_slot': 10, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        12: {'orig_slot': 12, 'mapped_slot': 12},
+                        13: {'orig_slot': 13, 'mapped_slot': 13},
+                        14: {'orig_slot': 14, 'mapped_slot': 14},
+                        15: {'orig_slot': 15, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16},
+                        17: {'orig_slot': 17, 'mapped_slot': 17},
+                        18: {'orig_slot': 18, 'mapped_slot': 18},
+                        19: {'orig_slot': 19, 'mapped_slot': 19},
+                        20: {'orig_slot': 20, 'mapped_slot': 20},
+                        21: {'orig_slot': 21, 'mapped_slot': 21},
+                        22: {'orig_slot': 22, 'mapped_slot': 22},
+                        23: {'orig_slot': 23, 'mapped_slot': 23},
+                        24: {'orig_slot': 24, 'mapped_slot': 24},
+                    },
+                    'eDrawer4048S2': {
+                        1: {'orig_slot': 1, 'mapped_slot': 25},
+                        2: {'orig_slot': 2, 'mapped_slot': 26},
+                        3: {'orig_slot': 3, 'mapped_slot': 27},
+                        4: {'orig_slot': 4, 'mapped_slot': 28},
+                        5: {'orig_slot': 5, 'mapped_slot': 29},
+                        6: {'orig_slot': 6, 'mapped_slot': 30},
+                        7: {'orig_slot': 7, 'mapped_slot': 31},
+                        8: {'orig_slot': 8, 'mapped_slot': 32},
+                        9: {'orig_slot': 9, 'mapped_slot': 33},
+                        10: {'orig_slot': 10, 'mapped_slot': 34},
+                        11: {'orig_slot': 11, 'mapped_slot': 35},
+                        12: {'orig_slot': 12, 'mapped_slot': 36},
+                        13: {'orig_slot': 13, 'mapped_slot': 37},
+                        14: {'orig_slot': 14, 'mapped_slot': 38},
+                        15: {'orig_slot': 15, 'mapped_slot': 39},
+                        16: {'orig_slot': 16, 'mapped_slot': 40},
+                        17: {'orig_slot': 17, 'mapped_slot': 41},
+                        18: {'orig_slot': 18, 'mapped_slot': 42},
+                        19: {'orig_slot': 19, 'mapped_slot': 43},
+                        20: {'orig_slot': 20, 'mapped_slot': 44},
+                        21: {'orig_slot': 21, 'mapped_slot': 45},
+                        22: {'orig_slot': 22, 'mapped_slot': 46},
+                        23: {'orig_slot': 23, 'mapped_slot': 47},
+                        24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                }
+            }
+        }}
+    }),
+    ('R10', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R10': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        5: {'orig_slot': 5, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        13: {'orig_slot': 13, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        10: {'orig_slot': 10, 'mapped_slot': 7},
+                        14: {'orig_slot': 14, 'mapped_slot': 8},
+                        3: {'orig_slot': 3, 'mapped_slot': 9},
+                        7: {'orig_slot': 7, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        15: {'orig_slot': 15, 'mapped_slot': 12},
+                        4: {'orig_slot': 4, 'mapped_slot': 13},
+                        8: {'orig_slot': 8, 'mapped_slot': 14},
+                        12: {'orig_slot': 12, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16}
+                    }
+                }
+            }
+        }}
+    }),
+    ('R20', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }}
+    }),
+    ('R20B', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20B': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }}
+    }),
+    ('R20A', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20A': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-3.0-E', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6}
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-3.0-E+', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                    },
+                    '3000000000000002': {
+                        1: {'orig_slot': 1, 'mapped_slot': 5},
+                        2: {'orig_slot': 2, 'mapped_slot': 6}
+
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-3.0-X', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            # TODO: 1.0 "version" has same mapping?? (CORE is the same)
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                    },
+                    '3000000000000002': {
+                        1: {'orig_slot': 1, 'mapped_slot': 5},
+                        2: {'orig_slot': 2, 'mapped_slot': 6},
+                        4: {'orig_slot': 4, 'mapped_slot': 7}
+
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-3.0-X+', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7}
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-3.0-XL+', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000002': {
+                        6: {'orig_slot': 6, 'mapped_slot': 1},
+                    },
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 2},
+                        2: {'orig_slot': 2, 'mapped_slot': 3},
+                        3: {'orig_slot': 3, 'mapped_slot': 4},
+                        4: {'orig_slot': 4, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        6: {'orig_slot': 6, 'mapped_slot': 7},
+                        7: {'orig_slot': 6, 'mapped_slot': 8},
+                        8: {'orig_slot': 6, 'mapped_slot': 9}
+                    }
+                }
+            }
+        }}
+    }),
+    ('MINI-R', {
+        'any_version': True,
+        'mapping_info': {'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 2},
+                        2: {'orig_slot': 2, 'mapped_slot': 3},
+                        3: {'orig_slot': 3, 'mapped_slot': 4},
+                        4: {'orig_slot': 4, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        6: {'orig_slot': 6, 'mapped_slot': 7},
+                        7: {'orig_slot': 6, 'mapped_slot': 8}
+                    },
+                    '3000000000000002': {
+                        4: {'orig_slot': 4, 'mapped_slot': 9},
+                        5: {'orig_slot': 5, 'mapped_slot': 10},
+                        6: {'orig_slot': 6, 'mapped_slot': 11},
+                        7: {'orig_slot': 7, 'mapped_slot': 12}
+                    }
+                }
+            }
+        }}
+    }),
+    ('BAD-MODEL', {})
+])
+def test_slot_mappings(data):
+    model, expected_result = data
+    assert slot_mappings.get_slot_info(model) == expected_result

--- a/src/middlewared/middlewared/utils/scsi_generic.py
+++ b/src/middlewared/middlewared/utils/scsi_generic.py
@@ -1,0 +1,114 @@
+import ctypes
+import fcntl
+import os
+
+# SG_IO ioctl command constant
+SG_IO = 0x2285
+
+# SCSI sense buffer size constant
+SG_MAX_SENSE = 32
+
+# Other necessary constants
+SG_DXFER_FROM_DEV = -3
+SG_DXFER_NONE = 0
+SG_FLAG_DIRECT_IO = 1
+SG_INFO_OK = 0
+
+# SCSI Enclosure Services command
+SES_RECEIVE_DIAGNOSTIC = 0x1C
+SES_ENCLOSURE_STATUS_PAGE_CODE = 0x02
+INQUIRY = 0x12
+
+
+class sg_io_hdr_v3(ctypes.Structure):
+    _fields_ = [
+        ("interface_id", ctypes.c_int),
+        ("dxfer_direction", ctypes.c_int),
+        ("cmd_len", ctypes.c_ubyte),
+        ("mx_sb_len", ctypes.c_ubyte),
+        ("iovec_count", ctypes.c_ushort),
+        ("dxfer_len", ctypes.c_uint),
+        ("dxferp", ctypes.c_void_p),
+        ("cmdp", ctypes.c_void_p),
+        ("sbp", ctypes.c_void_p),
+        ("timeout", ctypes.c_uint),
+        ("flags", ctypes.c_uint),
+        ("pack_id", ctypes.c_int),
+        ("usr_ptr", ctypes.c_void_p),
+        ("status", ctypes.c_ubyte),
+        ("masked_status", ctypes.c_ubyte),
+        ("msg_status", ctypes.c_ubyte),
+        ("sb_len_wr", ctypes.c_ubyte),
+        ("host_status", ctypes.c_ushort),
+        ("driver_status", ctypes.c_ushort),
+        ("resid", ctypes.c_int),
+        ("duration", ctypes.c_uint),
+        ("info", ctypes.c_uint),
+    ]
+
+
+def get_sgio_hdr_structure(cdb, dxfer_len, timeout=60000):
+    # Create a buffer for the sense data
+    sense_buffer = (ctypes.c_ubyte * SG_MAX_SENSE)()
+    results_buffer = (ctypes.c_ubyte * dxfer_len)()
+
+    hdr = sg_io_hdr_v3()
+    hdr.interface_id = ord('S')
+    hdr.cmd_len = len(cdb)
+    hdr.cmdp = ctypes.cast(cdb, ctypes.c_void_p)
+    hdr.dxfer_direction = SG_DXFER_FROM_DEV
+    hdr.dxfer_len = dxfer_len
+    hdr.dxferp = ctypes.cast(results_buffer, ctypes.c_void_p)
+    hdr.sbp = ctypes.cast(sense_buffer, ctypes.c_void_p)
+    hdr.mx_sb_len = len(sense_buffer)
+    hdr.timeout = timeout
+
+    return hdr, results_buffer, sense_buffer
+
+
+def do_io(device, hdr):
+    fd = os.open(device, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        # Make the ioctl call
+        if fcntl.ioctl(fd, SG_IO, hdr) != 0:
+            raise OSError("SG_IO ioctl failed")
+        elif (hdr.info & SG_INFO_OK) != 0:
+            raise OSError("SG_IO ioctl indicated failure")
+    finally:
+        # Close the device
+        os.close(fd)
+
+
+def inquiry(device):
+    dxfer_len = 0x38
+    cdb = (ctypes.c_ubyte * 6)(INQUIRY, 0x00, 0x00, 0x00, dxfer_len, 0x00)
+    hdr, results_buffer, sense_buffer = get_sgio_hdr_structure(cdb, dxfer_len)
+    do_io(device, hdr)
+
+    # Table 148 in SPC-5
+    t10_vendor_start, t10_vendor_end, t10_final = 8, (15 + 1), ''
+    product_ident_start, product_ident_end, product_ident_final = t10_vendor_end, (31 + 1), ''
+    product_rev_start, product_rev_end, product_rev_final = product_ident_end, (35 + 1), ''
+    serial_start, serial_end, serial_final = product_rev_end, (55 + 1), ''
+
+    for char in results_buffer[t10_vendor_start:t10_vendor_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        t10_final += _ascii
+
+    for char in results_buffer[product_ident_start:product_ident_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        product_ident_final += _ascii
+
+    for char in results_buffer[product_rev_start:product_rev_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        product_rev_final += _ascii
+
+    for char in results_buffer[serial_start:serial_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        serial_final += _ascii
+
+    return {'vendor': t10_final, 'product': product_ident_final, 'revision': product_rev_final, 'serial': serial_final}


### PR DESCRIPTION
### Introduction
Before the reviewer(s) go(es) into a panic because of the ~2k lines of changes, it's important to note a few things.
1. this is NOT being used by the front-end and isn't even being called by back-end. This is incomplete right now (still need to handle mapping nvme drives on our enclosures, and drive identification) but is fully functional otherwise
2. the `element_types.py`, `enclosure_class.py` and `identification.py` files are essentially copy and pasted directly from CORE with a few minor tweaks.
3. 869 lines of changes are from unit tests (yayyy, unit tests are better than no tests 😄 )
4. MOST of this logic is essentially what we do on CORE so I'm not diverging significantly
5. I've added a pure python (ctypes) script (`scsi_generic.py`) for sending inquiry commands to the enclosure devices (will work with SAS drives too) to more efficiently return the vendor, product, revision (and serial if we wanted) data from said device.

### Description
The changes employed here were made because of learning of some fundamental design flaws with how our current enclosure operates. Frankly, our existing logic is working by pure luck. "Failing successfully" essentially. Our old logic references "num" as an item in the namedtuple which, historically, was an attribute added in CORE because on freeBSD the enclosure devices are enumerated as devices starting at `/dev/ses0` and incrementing by 1. The `0` is what we referenced as the `num` in said namedtuple. Barring myself from writing a novel to explain on how that is actually flawed logic as well, I'll cut to the point. SCALE (linux) doesn't have such a notion but even more so enclosure device attributes will change (and often do) depending on what else is plugged into the system. We have to have some form of unchanging uniquely identifying property of the enclosure to ensure we can properly find said enclosure and map the drive slots accordingly. I've managed to do this in the `slot_mapping.py` file. The "unchanging" unique identifiers for our enclosure devices are what our drive mapping logic is hinged upon. This varies between platforms, obviously, but it solves the overarching problem with how we've designed our enclosure plugin currently.

### Unit Tests
I've added unit tests because our current enclosure logic isn't tested in any fashion. While unit tests don't guarantee success, they provide other developers an idea of what particular functions do and how data should be formatted. Some tests are better than no tests 😄 

### Maintainability
Code maintainability has, hopefully, been improved as well. While this is highly subjective, the current code was unnecessarily complex and fragile. With the changes employed here, I can write developer documentation on how to add a new platform and what all changes are required for this to happen. While this could have been done with the existing logic, the rewrite has allowed me to have a clear picture of exactly what needs to change.

### Performance
Finally performance has been lacking in this particular area because of the complexity of our old logic. I have tested the changes on the largest system we sell (~1.2k HDDs with 12x ES102 shelves) and it is 133% faster (2.5 seconds to 0.5 seconds for `enclosure.query` to complete)

### To-do
1. fix the `map_nvme` logic
2. add drive identification to `enclosure2.py` (and test by physical going into DC and visually inspecting drive leds)
3. add docstrings to _EVERYTHING_ where necessary
4. add developer documentation for adding a new enclosure
5. add moarrrr tests