### PR TITLE
NAS-123363 / 23.10 / Fix disk temperature identifier bug (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -221,10 +221,10 @@ class DiskTempPlugin(GraphBase):
         all_charts = await self.all_charts()
         for disk in (await self.middleware.run_in_thread(get_disks_for_temperature_reading)).values():
             identifier = disk.id if disk.id.startswith('nvme') else disk.serial
-            if f'smart_log_smart.disktemp.{identifier}' not in all_charts:
-                continue
-
-            self.disk_mapping[disk.id] = identifier
+            for k in (identifier, identifier.replace('-', '_')):
+                if f'smart_log_smart.disktemp.{k}' in all_charts:
+                    self.disk_mapping[disk.id] = k
+                    break
 
     async def get_identifiers(self) -> typing.Optional[list]:
         return list(self.disk_mapping.keys())


### PR DESCRIPTION
## Problem

In a system we noted that some disks had their serials in the format `WD-WXB2XXXXS97` whereas the csv file created by smartd had been named `WD_WXB2XXXXS97` which ended up in us not retrieving details for the disk.

## Solution

Account for this change in the logic we have which determines which disks data has been collected by netdata.

Original PR: https://github.com/truenas/middleware/pull/11814
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123363