### PR TITLE
NAS-123289 / 13.0 / HTTP Basic Auth is unavailable when OTP is enabl… (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -447,6 +447,10 @@ class FileApplication(object):
         auth = request.headers.get('Authorization')
         if auth:
             if auth.startswith('Basic '):
+                twofactor_auth = await self.middleware.call('auth.twofactor.config')
+                if twofactor_auth['enabled']:
+                    return web.Response(status=401, body='HTTP Basic Auth is unavailable when OTP is enabled')
+
                 try:
                     auth = binascii.a2b_base64(auth[6:]).decode()
                     if ':' in auth:

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -22,6 +22,10 @@ async def authenticate(middleware, req):
         raise web.HTTPUnauthorized()
 
     if auth.startswith('Basic '):
+        twofactor_auth = await middleware.call('auth.twofactor.config')
+        if twofactor_auth['enabled']:
+            raise web.HTTPUnauthorized(text='HTTP Basic Auth is unavailable when OTP is enabled')
+
         try:
             username, password = base64.b64decode(auth[6:]).decode('utf8').split(':', 1)
         except UnicodeDecodeError:

--- a/tests/api2/test_auth_otp.py
+++ b/tests/api2/test_auth_otp.py
@@ -1,0 +1,29 @@
+import pytest
+
+from middlewared.test.integration.utils import call, session, ssh, url
+
+
+@pytest.fixture(scope="module")
+def otp_enabled():
+    call("auth.twofactor.update", {"enabled": True})
+
+    try:
+        yield
+    finally:
+        ssh("midclt call auth.twofactor.update '{\"enabled\": false}'")
+
+
+def test_otp_http_basic_auth(otp_enabled):
+    with session() as s:
+        r = s.get(f"{url()}/api/v2.0/system/info/")
+        assert r.status_code == 401
+        assert r.text == "HTTP Basic Auth is unavailable when OTP is enabled"
+
+
+def test_otp_http_basic_auth_upload(otp_enabled):
+    with session() as s:
+        r = s.get(f"{url()}/_upload/")
+        assert r.status_code == 401
+        assert r.text == "HTTP Basic Auth is unavailable when OTP is enabled"
+
+

--- a/tests/api2/test_auth_otp.py
+++ b/tests/api2/test_auth_otp.py
@@ -18,12 +18,3 @@ def test_otp_http_basic_auth(otp_enabled):
         r = s.get(f"{url()}/api/v2.0/system/info/")
         assert r.status_code == 401
         assert r.text == "HTTP Basic Auth is unavailable when OTP is enabled"
-
-
-def test_otp_http_basic_auth_upload(otp_enabled):
-    with session() as s:
-        r = s.get(f"{url()}/_upload/")
-        assert r.status_code == 401
-        assert r.text == "HTTP Basic Auth is unavailable when OTP is enabled"
-
-


### PR DESCRIPTION
…ed (#9742)

* HTTP Basic Auth is unavailable when OTP is enabled

* OTP integration tests

Original PR: https://github.com/truenas/middleware/pull/11818
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123289