### PR TITLE
NAS-123017 / 24.04 / supersede nameservers in dhclient.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/dhclient.conf.mako
+++ b/src/middlewared/middlewared/etc_files/dhclient.conf.mako
@@ -5,6 +5,9 @@
     if gc['hostname'] and gc['domain']:
         use_fqdn = True
         hostname = f"{gc['hostname']}.{gc['domain']}"
+
+    nameservers = ', '.join([gc[f'nameserver{i}'] for i in range(1, 4) if gc[f'nameserver{i}']]) or None
+    use_ns = nameservers is not None
 %>
 option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
 % if use_fqdn:
@@ -14,10 +17,11 @@ send host-name "${hostname}";
 % endif
 % if gc['ipv4gateway']:
 supersede routers ${gc['ipv4gateway']};
-request subnet-mask, broadcast-address, time-offset,
-% else:
-request subnet-mask, broadcast-address, time-offset, routers,
 % endif
+% if use_ns:
+supersede domain-name-servers ${nameservers};
+% endif
+request subnet-mask, broadcast-address, time-offset, routers,
         domain-name, domain-name-servers, domain-search, host-name,
         dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
         netbios-name-servers, netbios-scope, interface-mtu,


### PR DESCRIPTION
Similar to what we do with the ipv4 gateway, we need to supersede the name servers provided by DHCP if we already have the name servers set in the database (user has manually configured them).