### PR TITLE
NAS-123446 / 23.10 / Fix new port assignment bug (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -136,6 +136,9 @@ class DISPLAY(Device):
         )
         new_ports = list((self.middleware.call_sync('vm.port_wizard')).values())
         dev_attrs = device['attributes']
+        for port in filter(lambda p: p in new_ports, (dev_attrs.get('port'), dev_attrs.get('web_port'))):
+            new_ports.remove(port)
+
         for key in ('port', 'web_port'):
             if device['attributes'].get(key):
                 if dev_attrs[key] in display_devices_ports:


### PR DESCRIPTION
## Problem

When assigning a port number to `web_port`, we are not taking into account the display port number that will be utilized by SPICE. Consequently, there are instances where the `web_port` and display ports end up being the same. This issue disrupts the entire virtual machine display configuration.

## Solution

If user has already specified a port we should remove that from the new ports we are getting from our port wizard so that if one of the attrs has been specified already and it matches to what the port wizard provided us, we remove it from there and make sure we don't end up using it.

Original PR: https://github.com/truenas/middleware/pull/11825
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123446