### PR TITLE
NAS-123529 / 24.04 / Add nvme2.py (map_nvme() functionality) to enclosure plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -66,6 +66,13 @@ class Enclosure2Service(Service):
             not enclosure['model'].startswith('R20'),
         ))
 
+    def map_nvme(self):
+        """This method serves as an endpoint to easily be able to test
+        the nvme mapping logic specifically without having to call enclosure2.query
+        which includes the head-unit and all attached JBODs.
+        """
+        return map_nvme(self.middleware.call_sync('system.dmidecode_info')['system-product-name'])
+
     @filterable
     def query(self, filters, options):
         enclosures = []

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -1,0 +1,203 @@
+import pathlib
+import re
+
+from pyudev import Context, Devices, DeviceNotFoundAtPathError
+
+RE_SLOT = re.compile(r'^0-([0-9]+)$')
+
+
+def fake_nvme_enclosure(model, num_of_nvme_slots, mapped):
+    """This function takes the nvme devices that been mapped
+    to their respective slots and then creates a "fake" enclosure
+    device that matches (similarly) to what our real enclosure
+    mapping code does (map_enclosures()). It's _VERY_ important
+    that the keys in the `fake_enclosure` dictionary exist because
+    our generic enclosure mapping logic expects certain top-level
+    keys.
+
+    Furthermore, we generate DMI (SMBIOS) information for this
+    "fake" enclosure because our enclosure mapping logic has to have
+    a guaranteed unique key for each enclosure so it can properly
+    map the disks accordingly
+    """
+    dmi = f'{model.lower()}_nvme_enclosure'
+    fake_enclosure = {
+        'id': dmi,
+        'dmi': dmi,
+        'sg': None,
+        'bsg': None,
+        'name': f'{model} NVMe Enclosure',
+        'controller': True,
+        'status': ['OK'],
+        'elements': {'Array Device Slot': {}}
+    }
+    for slot in range(1, num_of_nvme_slots + 1):
+        device = mapped.get(slot, None)
+        if device is not None:
+            status = 'OK'
+            value_raw = '0x1000000'
+        else:
+            status = 'Not Installed'
+            value_raw = '0x0500000'
+
+        fake_enclosure['elements']['Array Device Slot'][slot] = {
+            'descriptor': f'Disk #{slot}',
+            'status': status,
+            'value': None,
+            'value_raw': value_raw,
+            'dev': device,
+            'original': {
+                'enclosure_id': dmi,
+                'enclosure_sg': None,
+                'enclosure_bsg': None,
+                'descriptor': f'slot{slot}',
+                'slot': slot,
+            }
+        }
+
+    return [fake_enclosure]
+
+
+def map_plx_nvme(model, ctx):
+    num_of_nvme_slots = 4  # nvme plx bridge used on m50/60 and r50bm have 4 nvme drive bays
+    addresses_to_slots = {
+        (slot / 'address').read_text().strip(): slot.name
+        for slot in pathlib.Path('/sys/bus/pci/slots').iterdir()
+    }
+    mapped = dict()
+    for i in filter(lambda x: x.attributes.get('path') == b'\\_SB_.PC03.BR3A', ctx.list_devices(subsystem='acpi')):
+        try:
+            physical_node = Devices.from_path(ctx, f'{i.sys_path}/physical_node')
+        except DeviceNotFoundAtPathError:
+            # happens when there are no rear-nvme drives plugged in
+            pass
+        else:
+            for child in physical_node.children:
+                if child.properties.get('SUBSYSTEM') != 'block':
+                    continue
+
+                try:
+                    controller_sys_name = child.parent.parent.sys_name
+                except AttributeError:
+                    continue
+
+                if (slot := addresses_to_slots.get(controller_sys_name.split('.')[0])) is None:
+                    continue
+
+                if not (m := re.match(RE_SLOT, slot)):
+                    continue
+
+                slot = int(m.group(1))
+                if model == 'R50BM':
+                    # When adding this code and testing on internal R50BM, the starting slot
+                    # number for the rear nvme drive bays starts at 2 and goes to 5. This means
+                    # we're always off by 1. The easiest solution is to just check for this
+                    # specific platform and subtract 1 from the slot number to keep everything
+                    # in check.
+                    # To make things event more complicated, we found (by testing on internal hardware)
+                    # that slot 2 on OS is actually slot 3 and vice versa. This means we need to swap
+                    # those 2 numbers with each other to keep the webUI lined up with reality.
+                    slot -= 1
+                    if slot == 2:
+                        slot = 3
+                    elif slot == 3:
+                        slot = 2
+
+                mapped[slot] = child.sys_name
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_r50_or_r50b(model, ctx):
+    num_of_nvme_slots = 3 if model == 'R50' else 2  # r50 has 3 rear nvme slots, r50b has 2
+    if model == 'R50':
+        acpihandles = {b'\\_SB_.PC00.RP01.PXSX': 3, b'\\_SB_.PC01.BR1A.OCL0': 1, b'\\_SB_.PC01.BR1B.OCL1': 2}
+    else:
+        acpihandles = {b'\\_SB_.PC03.BR3A': 2, b'\\_SB_.PC00.RP01.PXSX': 1}
+
+    mapped = dict()
+    for i in filter(lambda x: x.attributes.get('path') in acpihandles, ctx.list_devices(subsystem='acpi')):
+        acpi_handle = i.attributes.get('path')
+        try:
+            phys_node = Devices.from_path(ctx, f'{i.sys_path}/physical_node')
+        except DeviceNotFoundAtPathError:
+            break
+
+        slot = acpihandles[acpi_handle]
+        for nvme in filter(lambda x: x.sys_name.startswith('nvme') and x.subsystem == 'block', phys_node.children):
+            mapped[slot] = nvme.sys_name
+            break
+        else:
+            mapped[slot] = None
+
+        if len(mapped) == num_of_nvme_slots:
+            # there can be (and often is) TONS of acpi devices on
+            # any given system so once we've mapped the total # of
+            # nvme drives, we break out early as to be as efficient
+            # as possible
+            break
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_r30_or_fseries(model, ctx):
+    num_of_nvme_slots = 16 if model == 'R30' else 24  # r30 has 16 nvme slots, fseries has 24 (all nvme flash)
+    nvmes = {}
+    for i in ctx.list_devices(subsystem='nvme'):
+        try:
+            namespace_dev = Devices.from_path(ctx, f'{i.sys_path}/{i.sys_name}n1')
+        except DeviceNotFoundAtPathError:
+            # no namespace for the device
+            continue
+        else:
+            try:
+                # i.parent.sys_name looks like 0000:80:40.0
+                # namespace_dev.sys_name looks like nvme1n1
+                nvmes[i.parent.sys_name[:-2]] = namespace_dev.sys_name
+            except (IndexError, AttributeError):
+                continue
+
+    # the keys in this dictionary are the physical pcie slot ids
+    # and the values are the slots that the webUI uses to map them
+    # to their physical locations in a human manageable way
+    if model == 'R30':
+        webui_map = {
+            '27': 1, '26': 7, '25': 2, '24': 8,
+            '37': 3, '36': 9, '35': 4, '34': 10,
+            '45': 5, '47': 11, '40': 6, '41': 12,
+            '38': 14, '39': 16, '43': 13, '44': 15,
+        }
+    else:
+        # f-series vendor is nice to us and nvme phys slots start at 1
+        # and increment in a human readable way already
+        webui_map = {
+            '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6,
+            '7': 7, '8': 8, '9': 9, '10': 10, '11': 11, '12': 12,
+            '13': 13, '14': 14, '15': 15, '16': 16, '17': 17, '18': 18,
+            '19': 19, '20': 20, '21': 21, '22': 22, '23': 23, '24': 24,
+        }
+
+    mapped = {}
+    for i in pathlib.Path('/sys/bus/pci/slots').iterdir():
+        addr = (i / 'address').read_text().strip()
+        if (nvme := nvmes.get(addr, None)) and (mapped_slot := webui_map.get(i.name, None)):
+            mapped[mapped_slot] = nvme
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_nvme(dmi):
+    # mapping nvme drives only pertains to these models
+    models = ('R30', 'R50', 'R50B', 'R50BM', 'M50', 'M60', 'F60', 'F100', 'F130')
+    if not (model := dmi.removeprefix('TRUENAS-').removesuffix('-HA')) or (model not in models):
+        return []
+
+    ctx = Context()
+    if model in ('R50', 'R50B'):
+        return map_r50_or_r50b(model, ctx)
+    elif model in ('R30', 'F60', 'F100', 'F130'):
+        # all nvme systems which we need to handle separately
+        return map_r30_or_fseries(model, ctx)
+    else:
+        # M50, M60 and R50BM use same plx nvme bridge
+        return map_plx_nvme(model, ctx)

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -106,10 +106,15 @@ def get_slot_info(model):
             our enclosures is quite complex and this was the best mix
             of performance/maintability.
     """
-    if model in ('R40', 'R50', 'R50B', 'R50BM'):
-        # these rseries devices share same enclosure and mapping
+    if model in ('R50', 'R50B', 'R50BM'):
+        # these platforms share same enclosure and mapping
         # but it's important to always map the eDrawer4048S1
         # enclosure device to drives 1 - 24
+
+        # FIXME: R40 does not have a predictable guaranteed unique
+        # identifier so we'll map the 1st 24 drives to the
+        # enclosure with the smaller logical id and the last
+        # 24 drives to the larger logical id
         return {
             'any_version': True,
             'mapping_info': {'versions': {
@@ -167,6 +172,23 @@ def get_slot_info(model):
                             23: {'orig_slot': 23, 'mapped_slot': 47},
                             24: {'orig_slot': 24, 'mapped_slot': 48},
                         }
+                    },
+                    'id': {
+                        'r50_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                            3: {'orig_slot': 3, 'mapped_slot': 51},
+                        },
+                        'r50b_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                        },
+                        'r50bm_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                            3: {'orig_slot': 3, 'mapped_slot': 51},
+                            4: {'orig_slot': 4, 'mapped_slot': 52},
+                        },
                     }
                 }
             }}
@@ -414,8 +436,11 @@ MAPPINGS = {
     'TRUENAS-R20B': get_slot_info('R20B'),
     'TRUENAS-R40': get_slot_info('R40'),
     'TRUENAS-R50': get_slot_info('R50'),
+    'r50_nvme_enclosure': get_slot_info('R50'),
     'TRUENAS-R50B': get_slot_info('R50B'),
+    'r50b_nvme_enclosure': get_slot_info('R50B'),
     'TRUENAS-R50BM': get_slot_info('R50BM'),
+    'r50bm_nvme_enclosure': get_slot_info('R50BM'),
     'TRUENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
     'FREENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
     'TRUENAS-MINI-3.0-E+': get_slot_info('MINI-3.0-E+'),

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -176,16 +176,16 @@ def get_slot_info(model):
                     'id': {
                         'r50_nvme_enclosure': {
                             1: {'orig_slot': 1, 'mapped_slot': 49},
-                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
                             3: {'orig_slot': 3, 'mapped_slot': 51},
                         },
                         'r50b_nvme_enclosure': {
                             1: {'orig_slot': 1, 'mapped_slot': 49},
-                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
                         },
                         'r50bm_nvme_enclosure': {
                             1: {'orig_slot': 1, 'mapped_slot': 49},
-                            2: {'orig_slot': 1, 'mapped_slot': 50},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
                             3: {'orig_slot': 3, 'mapped_slot': 51},
                             4: {'orig_slot': 4, 'mapped_slot': 52},
                         },

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
@@ -4,67 +4,6 @@ from middlewared.plugins.enclosure_ import slot_mappings
 
 
 @pytest.mark.parametrize('data', [
-    ('R40', {
-        'any_version': True,
-        'mapping_info': {'versions': {
-            'DEFAULT': {
-                'product': {
-                    'eDrawer4048S1': {
-                        1: {'orig_slot': 1, 'mapped_slot': 1},
-                        2: {'orig_slot': 2, 'mapped_slot': 2},
-                        3: {'orig_slot': 3, 'mapped_slot': 3},
-                        4: {'orig_slot': 4, 'mapped_slot': 4},
-                        5: {'orig_slot': 5, 'mapped_slot': 5},
-                        6: {'orig_slot': 6, 'mapped_slot': 6},
-                        7: {'orig_slot': 7, 'mapped_slot': 7},
-                        8: {'orig_slot': 8, 'mapped_slot': 8},
-                        9: {'orig_slot': 9, 'mapped_slot': 9},
-                        10: {'orig_slot': 10, 'mapped_slot': 10},
-                        11: {'orig_slot': 11, 'mapped_slot': 11},
-                        12: {'orig_slot': 12, 'mapped_slot': 12},
-                        13: {'orig_slot': 13, 'mapped_slot': 13},
-                        14: {'orig_slot': 14, 'mapped_slot': 14},
-                        15: {'orig_slot': 15, 'mapped_slot': 15},
-                        16: {'orig_slot': 16, 'mapped_slot': 16},
-                        17: {'orig_slot': 17, 'mapped_slot': 17},
-                        18: {'orig_slot': 18, 'mapped_slot': 18},
-                        19: {'orig_slot': 19, 'mapped_slot': 19},
-                        20: {'orig_slot': 20, 'mapped_slot': 20},
-                        21: {'orig_slot': 21, 'mapped_slot': 21},
-                        22: {'orig_slot': 22, 'mapped_slot': 22},
-                        23: {'orig_slot': 23, 'mapped_slot': 23},
-                        24: {'orig_slot': 24, 'mapped_slot': 24},
-                    },
-                    'eDrawer4048S2': {
-                        1: {'orig_slot': 1, 'mapped_slot': 25},
-                        2: {'orig_slot': 2, 'mapped_slot': 26},
-                        3: {'orig_slot': 3, 'mapped_slot': 27},
-                        4: {'orig_slot': 4, 'mapped_slot': 28},
-                        5: {'orig_slot': 5, 'mapped_slot': 29},
-                        6: {'orig_slot': 6, 'mapped_slot': 30},
-                        7: {'orig_slot': 7, 'mapped_slot': 31},
-                        8: {'orig_slot': 8, 'mapped_slot': 32},
-                        9: {'orig_slot': 9, 'mapped_slot': 33},
-                        10: {'orig_slot': 10, 'mapped_slot': 34},
-                        11: {'orig_slot': 11, 'mapped_slot': 35},
-                        12: {'orig_slot': 12, 'mapped_slot': 36},
-                        13: {'orig_slot': 13, 'mapped_slot': 37},
-                        14: {'orig_slot': 14, 'mapped_slot': 38},
-                        15: {'orig_slot': 15, 'mapped_slot': 39},
-                        16: {'orig_slot': 16, 'mapped_slot': 40},
-                        17: {'orig_slot': 17, 'mapped_slot': 41},
-                        18: {'orig_slot': 18, 'mapped_slot': 42},
-                        19: {'orig_slot': 19, 'mapped_slot': 43},
-                        20: {'orig_slot': 20, 'mapped_slot': 44},
-                        21: {'orig_slot': 21, 'mapped_slot': 45},
-                        22: {'orig_slot': 22, 'mapped_slot': 46},
-                        23: {'orig_slot': 23, 'mapped_slot': 47},
-                        24: {'orig_slot': 24, 'mapped_slot': 48},
-                    }
-                }
-            }
-        }}
-    }),
     ('R50', {
         'any_version': True,
         'mapping_info': {'versions': {
@@ -121,6 +60,23 @@ from middlewared.plugins.enclosure_ import slot_mappings
                         22: {'orig_slot': 22, 'mapped_slot': 46},
                         23: {'orig_slot': 23, 'mapped_slot': 47},
                         24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
                     }
                 }
             }
@@ -183,6 +139,23 @@ from middlewared.plugins.enclosure_ import slot_mappings
                         23: {'orig_slot': 23, 'mapped_slot': 47},
                         24: {'orig_slot': 24, 'mapped_slot': 48},
                     }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
+                    }
                 }
             }
         }}
@@ -243,6 +216,23 @@ from middlewared.plugins.enclosure_ import slot_mappings
                         22: {'orig_slot': 22, 'mapped_slot': 46},
                         23: {'orig_slot': 23, 'mapped_slot': 47},
                         24: {'orig_slot': 24, 'mapped_slot': 48},
+                    }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
                     }
                 }
             }

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
@@ -65,16 +65,16 @@ from middlewared.plugins.enclosure_ import slot_mappings
                 'id': {
                     'r50_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                     },
                     'r50b_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                     },
                     'r50bm_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                         4: {'orig_slot': 4, 'mapped_slot': 52},
                     }
@@ -143,16 +143,16 @@ from middlewared.plugins.enclosure_ import slot_mappings
                 'id': {
                     'r50_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                     },
                     'r50b_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                     },
                     'r50bm_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                         4: {'orig_slot': 4, 'mapped_slot': 52},
                     }
@@ -221,16 +221,16 @@ from middlewared.plugins.enclosure_ import slot_mappings
                 'id': {
                     'r50_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                     },
                     'r50b_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                     },
                     'r50bm_nvme_enclosure': {
                         1: {'orig_slot': 1, 'mapped_slot': 49},
-                        2: {'orig_slot': 1, 'mapped_slot': 50},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
                         3: {'orig_slot': 3, 'mapped_slot': 51},
                         4: {'orig_slot': 4, 'mapped_slot': 52},
                     }


### PR DESCRIPTION
This adds the missing functionality that is responsible for mapping nvme drives on certain platforms that we sell. More specifically, it maps the M50, M60, F60, F100, F130, R50, R50B, and R50BM platforms. Again, this code is essentially copied and pasted from how we're currently mapping nvme drives on SCALE (`enclosure_/nvme.py`) but has been changed to work with the new enclosure rewrite.