### PR TITLE
NAS-123516 / 24.04 / fix smb.sharesec.entries

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -70,13 +70,18 @@ class ShareSec(CRUDService):
         })
 
     @private
-    async def entries(self, share_name, filters, options):
+    @filterable
+    async def entries(self, filters, options):
         # TDB file contains INFO/version key that we don't want to return
-        entries = await self.middleware.call('tdb.entries', {
-            'name': LOCAL_SHARE_INFO_FILE,
-            'key': f'SECDESC/{share_name.lower()}',
-            'query-filters': [['key', '^', 'SECDESC/']]
-        })
+        try:
+            entries = await self.middleware.call('tdb.entries', {
+                'name': LOCAL_SHARE_INFO_FILE,
+                'query-filters': [['key', '^', 'SECDESC/']]
+            })
+        except FileNotFoundError:
+            # If samba has never started or user manually deleted file
+            # it may not exist yet.
+            entries = []
 
         return filter_list(entries, filters, options)
 


### PR DESCRIPTION
Fix arguments, use filterable decorator, and return empty list if the share_info.tdb file is missing.