### PR TITLE
NAS-123452 / 23.10 / Get rid of `NOTICE: s3: s3 provider "" not known - please set correctly` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -81,6 +81,7 @@ class S3RcloneRemote(BaseRcloneRemote):
             server_side_encryption=task["attributes"].get("encryption") or "",
             skip_region=undefined,
             signatures_v2=undefined,
+            provider="Other",
         )
 
         if not task["credentials"]["attributes"].get("skip_region", False):


### PR DESCRIPTION
There will be no behavioral change https://github.com/rclone/rclone/blob/34195fd3e87c51bbd1ed6ced9e5cf19f57ce7030/backend/s3/s3.go#L3051

Original PR: https://github.com/truenas/middleware/pull/11839
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123452