### PR TITLE
NAS-123372 / 24.04 / Add a public endpoint to download dataset keys related to a replication task

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -310,7 +310,7 @@ class PoolDatasetService(Service):
 
     @accepts(Int('id'))
     @returns()
-    @job(lock='replication_task_dataset_export_keys', pipes=['output'])
+    @job(pipes=['output'])
     def export_keys_for_replication(self, job, task_id):
         """
         Export keys for `id` and its children which are stored in the system. The exported file is a JSON file

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -313,8 +313,8 @@ class PoolDatasetService(Service):
     @job(pipes=['output'])
     def export_keys_for_replication(self, job, task_id):
         """
-        Export keys for `id` and its children which are stored in the system. The exported file is a JSON file
-        which has a dictionary containing dataset names as keys and their keys as the value.
+        Export keys for replication task `id` for source dataset(s) which are stored in the system. The exported file
+        is a JSON file which has a dictionary containing dataset names as keys and their keys as the value.
 
         Please refer to websocket documentation for downloading the file.
         """

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -318,9 +318,8 @@ class PoolDatasetService(Service):
 
         Please refer to websocket documentation for downloading the file.
         """
-        datasets = self.middleware.call_sync('replication.query_encrypted_roots_keys', task_id)
-        with BytesIO(json.dumps(datasets).encode()) as f:
-            shutil.copyfileobj(f, job.pipes.output.w)
+        datasets = self.middleware.call_sync('pool.dataset.export_keys_for_replication_internal', task_id)
+        job.pipes.output.w.write(json.dumps(datasets).encode())
 
     @private
     async def export_keys_for_replication_internal(self, replication_task_id):

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -342,6 +342,11 @@ class PoolDatasetService(Service):
             source_ds = task['source_datasets'][0]
             for ds_name, key in mapping[source_ds].items():
                 normalized_result[ds_name.replace(source_ds, target_ds, 1)] = key
+        else:
+            for source_ds in task['source_datasets']:
+                source_ds_name = source_ds.rsplit('/', 1)[-1]
+                for ds_name, key in mapping[source_ds].items():
+                    normalized_result[ds_name.replace(source_ds, f'{target_ds}/{source_ds_name}', 1)] = key
 
         return normalized_result
 

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -540,12 +540,17 @@ class ZettareplService(Service):
             "eligible": len(parsed),
         }
 
-    async def target_unmatched_snapshots(self, direction, source_datasets, target_dataset, transport, ssh_credentials):
+    async def get_source_target_datasets_mapping(self, source_datasets, target_dataset):
         fake_replication_task = types.SimpleNamespace()
         fake_replication_task.source_datasets = source_datasets
         fake_replication_task.target_dataset = target_dataset
-        datasets = {source_dataset: get_target_dataset(fake_replication_task, source_dataset)
-                    for source_dataset in source_datasets}
+        return {
+            source_dataset: get_target_dataset(fake_replication_task, source_dataset)
+            for source_dataset in source_datasets
+        }
+
+    async def target_unmatched_snapshots(self, direction, source_datasets, target_dataset, transport, ssh_credentials):
+        datasets = await self.get_source_target_datasets_mapping(source_datasets, target_dataset)
 
         try:
             local_shell = LocalShell()

--- a/tests/api2/test_dataset_encryption_keys_in_replication.py
+++ b/tests/api2/test_dataset_encryption_keys_in_replication.py
@@ -38,9 +38,9 @@ def make_assertions(source_datasets, task_id, target_dataset, unlocked_datasets)
 
 
 def test_single_source_replication():
-    with dataset('source_test', encryption_props(), pool='tank') as src:
-        with dataset('parent_destination', encryption_props(), pool='tank') as parent_ds:
-            with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test', pool='tank') as dst:
+    with dataset('source_test', encryption_props()) as src:
+        with dataset('parent_destination', encryption_props()) as parent_ds:
+            with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test') as dst:
                 with replication_task({
                     **BASE_REPLICATION,
                     'name': 'encryption_replication_test',
@@ -53,10 +53,10 @@ def test_single_source_replication():
 
 
 def test_single_source_recursive_replication():
-    with dataset('source_test', encryption_props(), pool='tank') as src:
-        with dataset(f'{src.rsplit("/", 1)[-1]}/child_source_test', encryption_props(), pool='tank') as child_src:
-            with dataset('parent_destination', encryption_props(), pool='tank') as parent_ds:
-                with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test', pool='tank') as dst:
+    with dataset('source_test', encryption_props()) as src:
+        with dataset(f'{src.rsplit("/", 1)[-1]}/child_source_test', encryption_props()) as child_src:
+            with dataset('parent_destination', encryption_props()) as parent_ds:
+                with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test') as dst:
                     with replication_task({
                         **BASE_REPLICATION,
                         'name': 'encryption_replication_test',
@@ -70,10 +70,10 @@ def test_single_source_recursive_replication():
 
 
 def test_multiple_source_replication():
-    with dataset('source_test1', encryption_props(), pool='tank') as src1:
-        with dataset('source_test2', encryption_props(), pool='tank') as src2:
-            with dataset('parent_destination', encryption_props(), pool='tank') as parent_ds:
-                with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test', pool='tank') as dst:
+    with dataset('source_test1', encryption_props()) as src1:
+        with dataset('source_test2', encryption_props()) as src2:
+            with dataset('parent_destination', encryption_props()) as parent_ds:
+                with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test') as dst:
                     with replication_task({
                         **BASE_REPLICATION,
                         'name': 'encryption_replication_test',
@@ -88,12 +88,12 @@ def test_multiple_source_replication():
 
 
 def test_multiple_source_recursive_replication():
-    with dataset('source_test1', encryption_props(), pool='tank') as src1:
-        with dataset(f'{src1.rsplit("/", 1)[-1]}/child_source_test1', encryption_props(), pool='tank') as child_src1:
-            with dataset('source_test2', encryption_props(), pool='tank') as src2:
-                with dataset(f'{src2.rsplit("/", 1)[-1]}/child_source_test2', encryption_props(), pool='tank') as child_src2:
-                    with dataset('parent_destination', encryption_props(), pool='tank') as parent_ds:
-                        with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test', pool='tank') as dst:
+    with dataset('source_test1', encryption_props()) as src1:
+        with dataset(f'{src1.rsplit("/", 1)[-1]}/child_source_test1', encryption_props()) as child_src1:
+            with dataset('source_test2', encryption_props()) as src2:
+                with dataset(f'{src2.rsplit("/", 1)[-1]}/child_source_test2', encryption_props()) as child_src2:
+                    with dataset('parent_destination', encryption_props()) as parent_ds:
+                        with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test') as dst:
                             with replication_task({
                                 **BASE_REPLICATION,
                                 'name': 'encryption_replication_test',

--- a/tests/api2/test_dataset_encryption_keys_in_replication.py
+++ b/tests/api2/test_dataset_encryption_keys_in_replication.py
@@ -1,0 +1,39 @@
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.replication import replication_task
+from middlewared.test.integration.utils import call
+
+
+BASE_REPLICATION = {
+    'direction': 'PUSH',
+    'transport': 'LOCAL',
+    'source_datasets': [],
+    'target_dataset': None,
+    'recursive': False,
+    'auto': False,
+    'retention_policy': 'NONE',
+}
+
+
+def encryption_props():
+    return {
+        'encryption_options': {'generate_key': True},
+        'encryption': True,
+        'inherit_encryption': False
+    }
+
+
+def test_single_source_replication():
+    with dataset('source_test', encryption_props(), pool='tank') as src:
+        with dataset('parent_destination', encryption_props(), pool='tank') as parent_ds:
+            with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test', pool='tank') as dst:
+                with replication_task({
+                    **BASE_REPLICATION,
+                    'name': 'encryption_replication_test',
+                    'source_datasets': [src],
+                    'target_dataset': dst,
+                    'name_regex': '.+',
+                    'auto': False,
+                }) as task:
+
+                    call('zfs.snapshot.create', {'dataset': src, 'name': 'snap-1', 'recursive': True})
+                    call('replication.run', task['id'], job=True)

--- a/tests/api2/test_dataset_encryption_keys_in_replication.py
+++ b/tests/api2/test_dataset_encryption_keys_in_replication.py
@@ -34,6 +34,12 @@ def test_single_source_replication():
                     'name_regex': '.+',
                     'auto': False,
                 }) as task:
-
                     call('zfs.snapshot.create', {'dataset': src, 'name': 'snap-1', 'recursive': True})
                     call('replication.run', task['id'], job=True)
+                    keys = call('pool.dataset.export_keys_for_replication_internal', task['id'])
+                    unlocked_info = call(
+                        'pool.dataset.unlock', dst, {
+                            'datasets': [{'name': name, 'key': key} for name, key in keys.items()],
+                        }, job=True
+                    )
+                    assert unlocked_info['unlocked'] == [dst], unlocked_info


### PR DESCRIPTION
This PR adds changes to add a public end point to download encryption keys of datasets related to a replication task. This can then be used in the UI so that the downloaded file can be directly used by users in the target/destination system to unlock the encrypted datasets.