### PR TITLE
NAS-121442 / 24.04 / Gather kubernetes statistics for UI

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
@@ -1,0 +1,86 @@
+import asyncio
+
+from aiohttp.client_exceptions import ClientConnectorError
+from collections import defaultdict
+from enum import Enum
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from middlewared.plugins.kubernetes_linux.k8s.core_api import Node
+from middlewared.plugins.kubernetes_linux.k8s.exceptions import ApiException
+
+
+class StatsTypes(Enum):
+    NETWORK = 'net'
+    CPU = 'cpu'
+    MEMORY = 'mem'
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.update_every = 1
+        self.k3s_prefix = 'k3s_stat'
+
+    def check(self):
+        return True
+
+    def get_chart_name(self, pod_name, stat_type):
+        return f'{pod_name}.{stat_type}'
+
+    def get_chart_options_base(self, chart_name):
+        return [chart_name, 'k3s_pod_stats', 'Pods Resource usage']
+
+    def add_cpu_chart(self, pod_name, state_type=StatsTypes.CPU.value):
+        chart_name = self.get_chart_name(pod_name, state_type)
+        self.charts.add_chart(
+            self.get_chart_options_base(chart_name) + [
+                'Nano Cores', 'k3s_status', 'Pods cpu usage', 'k3s stats', 'line'
+            ]
+        )
+        self.charts[chart_name].add_dimension([self.get_chart_name(pod_name, state_type)])
+
+    def add_net_chart(self, pod_name, state_type=StatsTypes.NETWORK.value):
+        chart_name = self.get_chart_name(pod_name, state_type)
+        self.charts.add_chart(
+            self.get_chart_options_base(chart_name) + [
+                'bytes', 'k3s_status', 'Pods network usage', 'k3s stats', 'line'
+            ]
+        )
+        self.charts[chart_name].add_dimension([f'{self.get_chart_name(pod_name, state_type)}.incoming'])
+        self.charts[chart_name].add_dimension([f'{self.get_chart_name(pod_name, state_type)}.outgoing'])
+
+    def add_mem_chart(self, pod_name, state_type=StatsTypes.MEMORY.value):
+        chart_name = self.get_chart_name(pod_name, state_type)
+        self.charts.add_chart(
+            self.get_chart_options_base(chart_name) + [
+                'bytes', 'k3s_status', 'Pods memory usage', 'k3s stats', 'line'
+            ]
+        )
+        self.charts[chart_name].add_dimension([self.get_chart_name(pod_name, state_type)])
+
+    def gather_pod_stat(self, pod_stats, data):
+        pod_name = pod_stats['podRef']['name']
+        data[self.get_chart_name(pod_name, StatsTypes.CPU.value)] = int(pod_stats['cpu']['usageNanoCores'])
+        data[self.get_chart_name(pod_name, StatsTypes.MEMORY.value)] = int(pod_stats['memory']['rssBytes'])
+        for interface in pod_stats['network']['interfaces']:
+            data[f'{self.get_chart_name(pod_name, StatsTypes.NETWORK.value)}.incoming'] += int(interface['rxBytes'])
+            data[f'{self.get_chart_name(pod_name, StatsTypes.NETWORK.value)}.outgoing'] += int(interface['txBytes'])
+
+    def prepare_pods_charts(self, pod_stats):
+        self.charts.charts.clear()
+        for pod_stat in pod_stats:
+            self.add_cpu_chart(pod_stat)
+            self.add_mem_chart(pod_stat)
+            self.add_net_chart(pod_stat)
+
+    def _get_data(self):
+        try:
+            pods_stats = asyncio.run(Node.get_stats())['pods']
+        except (ClientConnectorError, ApiException):
+            return {}
+        data = defaultdict(int)
+        self.prepare_pods_charts([pod['podRef']['name'] for pod in pods_stats])
+        for pod_stat in pods_stats:
+            self.gather_pod_stat(pod_stat, data)
+        return data

--- a/src/middlewared/middlewared/etc_files/netdata/python_conf.py
+++ b/src/middlewared/middlewared/etc_files/netdata/python_conf.py
@@ -8,4 +8,5 @@ def render(service, middleware):
         default_run: no
         cputemp: yes
         smart_log: yes
+        k3s_stats: yes
         '''))

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -53,6 +53,7 @@ def render(service, middleware):
             'kubelet-arg': kubelet_args,
             'protect-kernel-defaults': True,
             'disable': [features_mapping[feature] for feature in features_mapping if not config[feature]],
+            'write-kubeconfig-mode': 644,
         }))
 
     with open('/etc/containerd.json', 'w') as f:

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -136,6 +136,7 @@ class ChartReleaseService(CRUDService):
         extra = copy.deepcopy(options.get('extra', {}))
         retrieve_schema = extra.get('include_chart_schema')
         retrieve_stats = extra.get('stats', False)
+        netdata_metrics = await self.middleware.call('netdata.get_all_metrics') if retrieve_stats else None
         get_resources = extra.get('retrieve_resources')
         get_locked_paths = extra.get('retrieve_locked_paths')
         locked_datasets = await self.middleware.call('zfs.dataset.locked_datasets') if get_locked_paths else []
@@ -219,7 +220,7 @@ class ChartReleaseService(CRUDService):
 
             if retrieve_stats:
                 release_data['stats'] = await self.middleware.call(
-                    'chart.release.stats_internal', resources[Resources.POD.value][name]
+                    'chart.release.stats_internal', resources[Resources.POD.value][name], netdata_metrics,
                 )
 
             container_images_normalized = {

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -135,6 +135,7 @@ class ChartReleaseService(CRUDService):
         options = options or {}
         extra = copy.deepcopy(options.get('extra', {}))
         retrieve_schema = extra.get('include_chart_schema')
+        retrieve_stats = extra.get('stats', False)
         get_resources = extra.get('retrieve_resources')
         get_locked_paths = extra.get('retrieve_locked_paths')
         locked_datasets = await self.middleware.call('zfs.dataset.locked_datasets') if get_locked_paths else []
@@ -215,6 +216,11 @@ class ChartReleaseService(CRUDService):
                 'used_ports': ports_used[name],
                 'pod_status': pods_status,
             })
+
+            if retrieve_stats:
+                release_data['stats'] = await self.middleware.call(
+                    'chart.release.stats_internal', resources[Resources.POD.value][name]
+                )
 
             container_images_normalized = {
                 normalize_image_tag(i_name): {

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -1,15 +1,52 @@
 import asyncio
 import collections
 
-from middlewared.schema import Dict, List, Str, returns
+from middlewared.event import EventSource
+from middlewared.schema import Dict, Float, Int, List, Str, returns
 from middlewared.service import accepts, private, Service
 from middlewared.utils.itertools import infinite_multiplier_generator
+from middlewared.validators import Range
 
 from .utils import get_chart_release_from_namespace, get_namespace, is_ix_namespace
 
 
 EVENT_LOCKS = collections.defaultdict(asyncio.Lock)
 LOCKS = collections.defaultdict(asyncio.Lock)
+
+
+class ChartReleaseStatsEventSource(EventSource):
+    """
+    Retrieve real time statistics for chart releases
+    """
+    ACCEPTS = Dict(
+        Int('interval', default=2, validators=[Range(min=2)]),
+    )
+    RETURNS = List(
+        items=[Dict(
+            'chart_release_stats',
+            Str('id'),
+            Dict(
+                'stats',
+                Int('memory', description='Memory usage of app in MB'),
+                Float('cpu', description='Percentage of total core utilization'),
+                Dict(
+                    'network',
+                    Int('incoming', description='All Incoming network traffic in bytes'),
+                    Int('outgoing', description='All Outgoing network traffic in bytes'),
+                )
+            )
+        )]
+    )
+
+    async def run(self):
+        interval = self.arg['interval']
+
+        while not self._cancel.is_set():
+            self.send_event('ADDED', fields=await self.middleware.call(
+                'chart.release.query', [], {'extra': {'stats': True}, 'select': ['id', 'stats']},
+            ))
+
+            await asyncio.sleep(interval)
 
 
 class ChartReleaseService(Service):
@@ -137,5 +174,6 @@ async def chart_release_event(middleware, event_type, args):
 async def setup(middleware):
     middleware.event_subscribe('kubernetes.events', chart_release_event)
     middleware.event_register('chart.release.events', 'Application deployment events')
+    middleware.register_event_source('chart.release.statistics', ChartReleaseStatsEventSource)
     if await middleware.call('kubernetes.validate_k8s_setup', False):
         middleware.create_task(middleware.call('chart.release.refresh_events_state'))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -19,7 +19,7 @@ class ChartReleaseStatsEventSource(EventSource):
     Retrieve real time statistics for chart releases
     """
     ACCEPTS = Dict(
-        Int('interval', default=2, validators=[Range(min=2)]),
+        Int('interval', default=2, validators=[Range(min_=2)]),
     )
     RETURNS = List(
         items=[Dict(

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -2,6 +2,7 @@ import collections
 import errno
 import os
 
+from middlewared.plugins.reporting.stats_utils import get_kubernetes_pods_stats
 from middlewared.schema import Bool, Dict, Int, List, Ref, Str, returns
 from middlewared.service import accepts, CallError, job, private, Service
 from middlewared.validators import Range
@@ -303,3 +304,17 @@ class ChartReleaseService(Service):
             apps[app_name] = await self.middleware.call('chart.release.host_path_volumes', app_resources[app_name])
 
         return apps
+
+    @private
+    async def stats(self, release_name):
+        chart_release = await self.middleware.call('chart.release.get_instance', release_name, {
+            'extra': {'retrieve_resources': True, 'stats': False}
+        })
+        return await self.stats_internal(chart_release['resources']['pods'])
+
+    @private
+    async def stats_internal(self, pods, netdata_metrics=None):
+        return get_kubernetes_pods_stats(
+            [p['metadata']['name'] for p in pods],
+            netdata_metrics or await self.middleware.call('netdata.get_all_metrics')
+        )

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/resources.py
@@ -316,5 +316,5 @@ class ChartReleaseService(Service):
     async def stats_internal(self, pods, netdata_metrics=None):
         return get_kubernetes_pods_stats(
             [p['metadata']['name'] for p in pods],
-            netdata_metrics or await self.middleware.call('netdata.get_all_metrics')
+            netdata_metrics or await self.middleware.call('netdata.get_chart_metrics', 'k3s_stats.k3s_stats')
         )

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -98,6 +98,17 @@ def normalize_image_tag(tag: str) -> str:
             return complete_tag
 
 
+def default_stats_values() -> dict:
+    return {
+        'cpu': 0,
+        'memory': 0,
+        'network': {
+            'incoming': 0,
+            'outgoing': 0,
+        }
+    }
+
+
 def is_ix_namespace(namespace):
     return namespace.startswith(CHART_NAMESPACE_PREFIX)
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/core_api.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/core_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import os.path
 
 from dateutil.parser import parse as datetime_parse
 
@@ -59,6 +60,12 @@ class Node(CoreAPI):
             taints.pop(index)
 
         await cls.update(node_object['metadata']['name'], {'spec': {'taints': taints}})
+
+    @classmethod
+    async def get_stats(cls):
+        return await cls.call(
+            os.path.join(cls.uri(object_name=NODE_NAME), 'proxy/stats/summary'), mode=RequestMode.GET.value
+        )
 
 
 class Service(CoreAPI):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/stats.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/stats.py
@@ -1,0 +1,18 @@
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+from .k8s import Node
+
+
+class KubernetesStatsService(CRUDService):
+
+    class Config:
+        namespace = 'k8s.stats'
+        private = True
+
+    @filterable
+    async def summary(self, filters, options):
+        """
+        Retrieve summary of kubernetes cluster.
+        """
+        return filter_list((await Node.get_stats())['pods'], filters, options)

--- a/src/middlewared/middlewared/plugins/reporting/stats_utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/stats_utils.py
@@ -1,0 +1,24 @@
+from middlewared.utils.cpu import cpu_info
+
+from .realtime_reporting.utils import normalize_value, safely_retrieve_dimension
+
+
+def get_kubernetes_pods_stats(pod_names: list, netdata_metrics: dict) -> dict:
+    stats = {'memory': 0, 'cpu': 0, 'network': {'incoming': 0, 'outgoing': 0}}
+    for pod_name in pod_names:
+        stats['cpu'] += int(safely_retrieve_dimension(
+            netdata_metrics, f'k3s_stats.{pod_name}.cpu', f'{pod_name}.cpu', default=0
+        ))
+        stats['memory'] += normalize_value(int(safely_retrieve_dimension(
+            netdata_metrics, f'k3s_stats.{pod_name}.mem', f'{pod_name}.mem', default=0
+        )), divisor=1024 * 1024)  # Convert bytes to megabytes.
+        stats['network']['incoming'] += safely_retrieve_dimension(
+            netdata_metrics, f'k3s_stats.{pod_name}.net', f'{pod_name}.net.incoming', default=0
+        )
+        stats['network']['outgoing'] += safely_retrieve_dimension(
+            netdata_metrics, f'k3s_stats.{pod_name}.net', f'{pod_name}.net.outgoing', default=0
+        )
+
+    # Convert CPU usage from nanocores to percentage of total available CPU power across all cores.
+    stats['cpu'] = ((stats['cpu'] / 1000000000) / cpu_info()['core_count']) * 100
+    return stats

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -1,3 +1,6 @@
+K8S_PODS_COUNT = 20  # A default value has been assumed for now
+
+
 def calculate_disk_space_for_netdata(metrics: int, days: int) -> int:
     # Constants
     sec_per_day = 86400
@@ -114,4 +117,9 @@ def get_metrics_approximation(disk_count: int, core_count: int, interface_count:
 
         # smartd_logs
         'smart_log.temperature_celsius': disk_count,
+
+        # k8s pods stats
+        'k8s_cpu': K8S_PODS_COUNT,
+        'k8s_mem': K8S_PODS_COUNT,
+        'k8s_net': K8S_PODS_COUNT * 2,
     }


### PR DESCRIPTION
## Context
At present, k3s statistics are obtained during runtime using the k3s node summary API. However, this approach introduces notable sluggishness into the process, particularly due to the extensive number of API calls needed to access and update data in real-time. To tackle this performance bottleneck, a novel solution has been implemented in the form of a netdata python.d plugin. This plugin systematically collects data at set intervals, enabling us to efficiently retrieve data through streamlined queries. Consequently, this transition in data collection effectively distributes the computational load, significantly alleviating the previous strain on the middleware. It's important to note that netdata does not offer alternative methods that can be seamlessly integrated into the middleware for accessing API statistics. To leverage netdata's kubectl API functionality, either netdata needs to be executed within a Kubernetes environment or the entire Go plugin has to be installed, both of which are impractical. Thus, the introduction of the python.d plugin serves as a pragmatic solution to this issue.

## References
https://learn.netdata.cloud/docs/miscellaneous/kubernetes-monitoring-with-netdata-overview-and-visualizations

https://learn.netdata.cloud/docs/data-collection/kubernetes/kubelet