### PR TITLE
NAS-123488 / 23.10 / Fix bug in interface stats (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
@@ -35,4 +35,4 @@ def get_interface_stats(netdata_metrics: dict, interfaces: typing.List[str]) -> 
                 'sent_bytes_rate': 0,
             })
 
-        return data
+    return data


### PR DESCRIPTION
## Problem

The ifstat function is currently returning data on the first iteration, which prevents it from processing other interfaces.

## Solution

Make sure all interfaces are processed when getting realtime interface stats.

Original PR: https://github.com/truenas/middleware/pull/11848
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123488