### PR TITLE
NAS-123403 / 24.04 / Expanding iSCSI ZVol with a period in name doesn't notify connected client

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -102,7 +102,10 @@ class ISCSIGlobalService(Service):
             return
 
         try:
-            with open(f'/sys/kernel/scst_tgt/devices/{extent[0]["name"]}/resync_size', 'w') as f:
+            # CORE ctl device names are incompatible with SCALE SCST
+            # so (similarly to scst.mako.conf) replace period with underscore
+            extent_name = extent[0]["name"].replace('.', '_')
+            with open(f'/sys/kernel/scst_tgt/devices/{extent_name}/resync_size', 'w') as f:
                 f.write('1')
         except Exception as e:
             if isinstance(e, OSError) and e.errno == 124:

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -860,7 +860,7 @@ class PoolDatasetService(CRUDService):
             raise verrors
 
         if data['type'] == 'VOLUME' and 'volsize' in data and data['volsize'] > dataset[0]['volsize']['parsed']:
-            # means the zvol size has increased so we need to check if this zvol is shared via SCST (iscs)
+            # means the zvol size has increased so we need to check if this zvol is shared via SCST (iscsi)
             # and if it is, resync it so the connected initiators can see the new size of the zvol
             await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id)
 


### PR DESCRIPTION
Certain iSCSI configurations were permitted in CORE that are not valid in SCALE.  One of these was **already** being [handled](https://github.com/truenas/middleware/blob/master/src/middlewared/middlewared/etc_files/scst.conf.mako#L114) in _scst.conf.mako_

This PR makes a similar change is required in `resync_lun_size_for_zvol`.

Furthermore, a unit test is added: _test_25_resize_target_zvol_
