### PR TITLE
NAS-123466 / 23.10 / Make sure containerd has initialized itself before declaring apps are ready (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
@@ -20,6 +20,7 @@ DOCKER_AUTH_SERVICE = 'registry.docker.io'
 DOCKER_MANIFEST_SCHEMA_V1 = 'application/vnd.docker.distribution.manifest.v1+json'
 DOCKER_MANIFEST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.v2+json'
 DOCKER_MANIFEST_LIST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.list.v2+json'
+CONTAINERD_SOCKET_PATH = '/run/k3s/containerd/containerd.sock'
 
 
 def parse_digest_from_schema(response):
@@ -152,7 +153,7 @@ class ContainerdClient:
         'container': Containers,
         'image': Images,
     }
-    CONTAINERD_SOCKET: str = 'unix:///run/k3s/containerd/containerd.sock'
+    CONTAINERD_SOCKET: str = f'unix://{CONTAINERD_SOCKET_PATH}'
 
     def __init__(self, client_type: str):
         self.channel: typing.Optional[typing.Type[Channel]] = None

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import yaml
 
-from middlewared.plugins.container_runtime_interface.client import ContainerdClient
+from middlewared.plugins.container_runtime_interface.client import CONTAINERD_SOCKET_PATH
 from middlewared.schema import Dict, List, Str
 from middlewared.service import accepts, ConfigService
 from middlewared.utils.socket import is_socket_available
@@ -20,7 +20,7 @@ class KubernetesNodeService(ConfigService):
     async def config(self):
         try:
             containerd_socket_available = await self.middleware.run_in_thread(
-                is_socket_available, ContainerdClient.CONTAINERD_SOCKET
+                is_socket_available, CONTAINERD_SOCKET_PATH
             )
             return {
                 'node_configured': True and containerd_socket_available,

--- a/src/middlewared/middlewared/utils/socket.py
+++ b/src/middlewared/middlewared/utils/socket.py
@@ -1,16 +1,13 @@
-import os
 import socket
 
 
 def is_socket_available(socket_path: str) -> bool:
     """Check if a Unix socket is available."""
-    if not os.path.exists(socket_path):
-        return False
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
         s.connect(socket_path)
         return True
-    except socket.error:
+    except (socket.error, FileNotFoundError):
         return False
     finally:
         s.close()

--- a/src/middlewared/middlewared/utils/socket.py
+++ b/src/middlewared/middlewared/utils/socket.py
@@ -1,0 +1,16 @@
+import os
+import socket
+
+
+def is_socket_available(socket_path: str) -> bool:
+    """Check if a Unix socket is available."""
+    if not os.path.exists(socket_path):
+        return False
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.connect(socket_path)
+        return True
+    except socket.error:
+        return False
+    finally:
+        s.close()


### PR DESCRIPTION
This PR adds changes which makes sure that containerd socket is available and has initialized itself appropriately as we are seeing in some cases that we mark the node as ready but that is not the case with containerd socket still not available for consumption.

Original PR: https://github.com/truenas/middleware/pull/11850
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123466