### PR TITLE
NAS-123572 / 13.0 / Update OTP test to try and disable 2FA (by sonicaj)

### DIFF
--- a/tests/api2/test_auth_otp.py
+++ b/tests/api2/test_auth_otp.py
@@ -15,6 +15,6 @@ def otp_enabled():
 
 def test_otp_http_basic_auth(otp_enabled):
     with session() as s:
-        r = s.get(f"{url()}/api/v2.0/system/info/")
+        r = s.put(f"{url()}/api/v2.0/auth/twofactor/", data=json.dumps({"enabled": False}))
         assert r.status_code == 401
         assert r.text == "HTTP Basic Auth is unavailable when OTP is enabled"


### PR DESCRIPTION
This commit adds changes to try and disable 2fa instead of querying system info as a customer had faced this scenario in previous versions and we want to be sure we are not allowing that to happen.

Original PR: https://github.com/truenas/middleware/pull/11860
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123572