### PR TITLE
NAS-123576 / 23.10 / Fix cpu temp plugin for those machine which don't have sensors (by Qubad786)

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from copy import deepcopy
 from third_party import lm_sensors as sensors
 
-from middlewared.utils.cpu import amd_cpu_temperatures, generic_cpu_temperatures
+from middlewared.utils.cpu import amd_cpu_temperatures, generic_cpu_temperatures, cpu_info
 
 
 CPU_TEMPERATURE_FEAT_TYPE = 2
@@ -74,7 +74,7 @@ class Service(SimpleService):
         for core, temp in cpu_temperatures(cpu_data).items():
             data[str(core)] = temp
 
-        return data or None
+        return data or {str(i): 0 for i in range(cpu_info()['core_count'])}
 
     def check(self):
         try:


### PR DESCRIPTION
## Problem

The existing cputemp plugin encounters issues when dealing with hardware that lacks physical sensors. This deficiency leads to None type errors within the netdata python.d plugin.

## Solution

To address this problem, a solution has been devised wherein default sensor data is integrated. This data will be utilized as a substitute for None values, effectively resolving the problem.

Original PR: https://github.com/truenas/middleware/pull/11865
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123576