### PR TITLE
NAS-123570 / 23.10 / Extending a file-based iSCSI target has no effect (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -119,6 +119,31 @@ class ISCSIGlobalService(Service):
                 self.logger.warning('Failed to resync lun size for %r', extent[0]['name'], exc_info=True)
 
     @private
+    def resync_lun_size_for_file(self, path):
+        if not self.middleware.call_sync('service.started', 'iscsitarget'):
+            return
+
+        extent = self.middleware.call_sync('iscsi.extent.query',
+                                           [['enabled', '=', True], ['type', '=', 'FILE'], ['path', '=', path]])
+        if not extent:
+            return
+
+        try:
+            extent_name = extent[0]["name"].replace('.', '_')
+            with open(f'/sys/kernel/scst_tgt/devices/{extent_name}/resync_size', 'w') as f:
+                f.write('1')
+        except Exception as e:
+            if isinstance(e, OSError) and e.errno == 124:
+                # 124 == Wrong medium type
+                # This is raised when all the iscsi targets are removed causing /etc/scst.conf to
+                # be written with a "blank" config. Once this occurs, any time a new iscsi target
+                # is added and the size gets changed, it will raise this error. In my testing,
+                # SCST sees the zvol size change and so does the initiator so it's safe to ignore.
+                pass
+            else:
+                self.logger.warning('Failed to resync lun size for %r', extent[0]['name'], exc_info=True)
+
+    @private
     async def terminate_luns_for_pool(self, pool_name):
         if not await self.middleware.call('service.started', 'iscsitarget'):
             return

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -252,21 +252,21 @@ def zvol_dataset(zvol, volsize=MB_512):
         assert results.status_code == 200, results.text
 
 
-def file_extent_resize(ident, filesize):
+def file_extent_resize(ident, filesize, expected_status_code=200):
     payload = {
         'filesize': filesize,
     }
     results = PUT(f"/iscsi/extent/id/{ident}/", payload)
-    assert results.status_code == 200, results.text
+    assert results.status_code == expected_status_code, results.text
 
 
-def zvol_resize(zvol, volsize):
+def zvol_resize(zvol, volsize, expected_status_code=200):
     payload = {
         'volsize': volsize,
     }
     zvol_url = zvol.replace('/', '%2F')
     result = PUT(f'/pool/dataset/id/{zvol_url}/', payload)
-    assert result.status_code == 200, result.text
+    assert result.status_code == expected_status_code, result.text
 
 
 @contextlib.contextmanager
@@ -2343,6 +2343,9 @@ def test_25_resize_target_zvol(request):
                 zvol_resize(zvol, MB_512)
                 expect_check_condition(s, sense_ascq_dict[0x2A09])  # "CAPACITY DATA HAS CHANGED"
                 assert MB_512 == _read_capacity16(s)
+                # Try to shrink the ZVOL again.  Expect an error (422)
+                zvol_resize(zvol, MB_256, 422)
+                assert MB_512 == _read_capacity16(s)
 
 
 def test_26_resize_target_file(request):
@@ -2371,6 +2374,9 @@ def test_26_resize_target_file(request):
                 SSH_TEST(f"echo 1 > /sys/kernel/scst_tgt/targets/iscsi/{iqn}/aen_disabled", user, password, ip)
                 file_extent_resize(extent_id, MB_512)
                 expect_check_condition(s, sense_ascq_dict[0x2A09])  # "CAPACITY DATA HAS CHANGED"
+                assert MB_512 == _read_capacity16(s)
+                # Try to shrink the file again.  Expect an error (422)
+                file_extent_resize(extent_id, MB_256, 422)
                 assert MB_512 == _read_capacity16(s)
 
 

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -252,6 +252,14 @@ def zvol_dataset(zvol, volsize=MB_512):
         assert results.status_code == 200, results.text
 
 
+def file_extent_resize(ident, filesize):
+    payload = {
+        'filesize': filesize,
+    }
+    results = PUT(f"/iscsi/extent/id/{ident}/", payload)
+    assert results.status_code == 200, results.text
+
+
 def zvol_resize(zvol, volsize):
     payload = {
         'volsize': volsize,
@@ -2333,6 +2341,35 @@ def test_25_resize_target_zvol(request):
                 # which means we will get a CHECK CONDITION on the next resize
                 SSH_TEST(f"echo 1 > /sys/kernel/scst_tgt/targets/iscsi/{iqn}/aen_disabled", user, password, ip)
                 zvol_resize(zvol, MB_512)
+                expect_check_condition(s, sense_ascq_dict[0x2A09])  # "CAPACITY DATA HAS CHANGED"
+                assert MB_512 == _read_capacity16(s)
+
+
+def test_26_resize_target_file(request):
+    """
+    Verify that an iSCSI client is notified when the size of a file-based
+    iSCSI extent is modified.
+    """
+    depends(request, ["iscsi_cmd_00"], scope="session")
+
+    with initiator_portal() as config:
+        with configured_target_to_file_extent(config,
+                                              target_name,
+                                              pool_name,
+                                              dataset_name,
+                                              file_name,
+                                              filesize=MB_100) as config:
+            iqn = f'{basename}:{target_name}'
+            with iscsi_scsi_connection(ip, iqn) as s:
+                extent_id = config['extent']['id']
+                TUR(s)
+                s.blocksize = 512
+                assert MB_100 == _read_capacity16(s)
+                file_extent_resize(extent_id, MB_256)
+                assert MB_256 == _read_capacity16(s)
+                # Turn AEN off so that we will get a CHECK CONDITION on the next resize
+                SSH_TEST(f"echo 1 > /sys/kernel/scst_tgt/targets/iscsi/{iqn}/aen_disabled", user, password, ip)
+                file_extent_resize(extent_id, MB_512)
                 expect_check_condition(s, sense_ascq_dict[0x2A09])  # "CAPACITY DATA HAS CHANGED"
                 assert MB_512 == _read_capacity16(s)
 


### PR DESCRIPTION
Allow the size of a file-based extent for an iSCSI target to be increased.

This includes adding `resync_lun_size_for_file` (similar to `resync_lun_size_for_zvol`) to notify SCST and any connected clients about the change.

---
Currently the API ignores attempts to reduce the size of the extent (although the size will be saved in the database).  I would like to tweak the API to also allow reducing the size of the file, however ...

For ZVOL based targets, the webui code currently traps attempting to reduce the size of a target.  It presents the error message:
> Shrinking a ZVOL is not allowed in the User Interface. This can lead to data loss.

@undsoft do you think the webui should add a similar block to prevent reducing the size of a file extent?  (If so, I can then tweak this PR to allow any size change.)  If not, should I throw a `ValidationError` if the user attempts to reduce the size?

Original PR: https://github.com/truenas/middleware/pull/11868
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123570