### PR TITLE
NAS-123592 / 23.10 / Fix case when reporting identifier can be none (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/graphs.py
@@ -57,7 +57,7 @@ class ReportingService(Service):
         # TODO: Optimize this so when retrieving stats for multiple plugins we do not get all charts
         #  again and again
         await graph_plugin.build_context()
-        for identifier in (await graph_plugin.get_identifiers() or [None]):
+        for identifier in (await graph_plugin.get_identifiers() if graph_plugin.uses_identifiers else [None]):
             # TODO: Handle 404 gracefully which can happen if no metrics have been collected
             # so far for the identifier/chart in question
             results.append(await graph_plugin.export(query_params, identifier, aggregate=query['aggregate']))
@@ -149,10 +149,7 @@ class ReportingService(Service):
         rv = []
         for graph_plugin in self.__graphs.values():
             await graph_plugin.build_context()
-            idents = await graph_plugin.get_identifiers()
-            if idents is None:
-                idents = [None]
-            for ident in idents:
+            for ident in (await graph_plugin.get_identifiers() if graph_plugin.uses_identifiers else [None]):
                 rv.append(await graph_plugin.export(query_params, ident, aggregate=query['aggregate']))
         return rv
 

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -34,6 +34,7 @@ class GraphBase(metaclass=GraphMeta):
 
     aggregations = ('min', 'mean', 'max')
     title = None
+    uses_identifiers = True
     vertical_label = None
 
     AGG_MAP = {
@@ -70,11 +71,11 @@ class GraphBase(metaclass=GraphMeta):
             'name': self.name,
             'title': self.get_title(),
             'vertical_label': self.vertical_label,
-            'identifiers': await self.get_identifiers(),
+            'identifiers': await self.get_identifiers() if self.uses_identifiers else None,
         }
 
-    async def get_identifiers(self) -> typing.Optional[list]:
-        return None
+    async def get_identifiers(self) -> list:
+        return []
 
     def normalize_metrics(self, metrics) -> dict:
         metrics['legend'] = metrics.pop('labels')

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -8,6 +8,7 @@ from .graph_base import GraphBase
 class CPUPlugin(GraphBase):
 
     title = 'CPU Usage'
+    uses_identifiers = False
     vertical_label = '%CPU'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -22,6 +23,7 @@ class CPUPlugin(GraphBase):
 class CPUTempPlugin(GraphBase):
 
     title = 'CPU Temperature'
+    uses_identifiers = False
     vertical_label = 'Celsius'
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
@@ -97,6 +99,7 @@ class InterfacePlugin(GraphBase):
 class LoadPlugin(GraphBase):
 
     title = 'System Load Average'
+    uses_identifiers = False
     vertical_label = 'Processes'
 
     LOAD_MAPPING = {
@@ -117,6 +120,7 @@ class LoadPlugin(GraphBase):
 class MemoryPlugin(GraphBase):
 
     title = 'Physical memory utilization'
+    uses_identifiers = False
     vertical_label = 'Mebibytes'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -126,6 +130,7 @@ class MemoryPlugin(GraphBase):
 class SwapPlugin(GraphBase):
 
     title = 'Swap Utilization'
+    uses_identifiers = False
     vertical_label = 'Mebibytes'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -140,6 +145,7 @@ class SwapPlugin(GraphBase):
 class UptimePlugin(GraphBase):
 
     title = 'System Uptime'
+    uses_identifiers = False
     vertical_label = 'Seconds'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -152,6 +158,7 @@ class UptimePlugin(GraphBase):
 class ARCActualRatePlugin(GraphBase):
 
     title = 'ZFS Actual Cache Hits Rate'
+    uses_identifiers = False
     vertical_label = 'Events/s'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -161,6 +168,7 @@ class ARCActualRatePlugin(GraphBase):
 class ARCRatePlugin(GraphBase):
 
     title = 'ZFS ARC Hits Rate'
+    uses_identifiers = False
     vertical_label = 'Events/s'
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
@@ -170,6 +178,7 @@ class ARCRatePlugin(GraphBase):
 class ARCSizePlugin(GraphBase):
 
     title = 'ZFS ARC Size'
+    uses_identifiers = False
     vertical_label = 'Mebibytes'
 
     LABEL_MAPPING = {


### PR DESCRIPTION
## Problem

To put the problem in perspective - if a machine has no disks for which we can collect temperature, whenever `reporting.netdata_graph` will be called it will assume a `None` identifier as some plugins do not require an explicit identifier and keeping in line with old behavior we were doing the same.
However if a plugin which actually consumes identifiers and reports an empty list because there are no identifiers available in this case and the plugin will fail if that is done - we were doing exactly that which resulted in traceback.

## Solution

Make sure we take into account if the plugin actually needs/consumes identifiers and based on that we retrieve graphs appropriately.

Original PR: https://github.com/truenas/middleware/pull/11873
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123592