### PR TITLE
NAS-123535 / 24.04 / Gracefully handle client os error

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -28,7 +28,7 @@ class ClientMixin:
                     yield resp
         except (asyncio.TimeoutError, aiohttp.ClientResponseError) as e:
             raise ApiException(f'Failed {resource!r} call: {e!r}')
-        except aiohttp.client_exceptions.ClientConnectorError as e:
+        except (aiohttp.client_exceptions.ClientConnectorError, aiohttp.client_exceptions.ClientOSError) as e:
             raise ClientConnectError(f'Failed to connect to {uri!r}: {e!r}')
 
     @classmethod


### PR DESCRIPTION
## Problem

When netdata is not running - `ClientOSError` can be raised as well by the aiohttp client so we should be handling that gracefully.

## Solution

Catch `ClientOSError` appropriately and raise it in a proper manner so it can be handled in middleware gracefully.