### PR TITLE
NAS-123623 / 23.10 / acme: Fix instantiation of _CloudflareClient (by evan-a-a)

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
@@ -57,10 +57,9 @@ class CloudFlareAuthenticator(Authenticator):
 
     def get_cloudflare_object(self):
         if self.api_token:
-            params = (None, self.api_token)
+            return _CloudflareClient(api_token=self.api_token)
         else:
-            params = (self.cloudflare_email, self.api_key)
-        return _CloudflareClient(*params)
+            return _CloudflareClient(email=self.cloudflare_email, api_key=self.api_key)
 
     def _cleanup(self, domain, validation_name, validation_content):
         self.get_cloudflare_object().del_txt_record(domain, validation_name, validation_content)


### PR DESCRIPTION
`_CloudflareClient`'s constructor changed with https://github.com/certbot/certbot/commit/a845ab844622a5419de166a3a35bb4dca33d8060, which has been incorporated in the most recent version of the `certbot-dns-cloudflare` package. Update middleware's use of this class to prevent the error `neither email/key or token defined.` during DNS challenge creation.

Original PR: https://github.com/truenas/middleware/pull/11898
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123623