### PR TITLE
NAS-123597 / 23.10 / Add an additional attribute in replication task (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -367,7 +367,7 @@ class PoolDatasetService(Service):
 
         for source_ds in task['source_datasets']:
             for ds_name, key in mapping[source_ds].items():
-                for dataset in dataset_mapping[ds_name] if include_encryption_root_children else [{'id': ds_name}]:
+                for dataset in (dataset_mapping[ds_name] if include_encryption_root_children else [{'id': ds_name}]):
                     result[dataset['id'].replace(source_ds, source_mapping[source_ds], 1)] = key
 
         return result
@@ -379,6 +379,8 @@ class PoolDatasetService(Service):
             'pool.dataset.query', [], {'extra': {'properties': ['encryptionroot']}}
         ):
             dataset_encryption_root_mapping[dataset['encryption_root']].append(dataset)
+
+        return dataset_encryption_root_mapping
 
     @accepts(
         Str('id'),

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -334,7 +334,7 @@ class PoolDatasetService(Service):
         if task['direction'] != 'PUSH':
             raise CallError('Only push replication tasks are supported.', errno.EINVAL)
 
-        if skip_syncing_db_keys:
+        if not skip_syncing_db_keys:
             await (await self.middleware.call(
                 'core.bulk', 'pool.dataset.sync_db_keys', [[source] for source in task['source_datasets']]
             )).wait()

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -98,7 +98,6 @@ class ReplicationService(CRUDService):
     @private
     async def extend_context(self, rows, extra):
         if extra.get("check_dataset_encryption_keys", False) and any(row["direction"] == "PUSH" for row in rows):
-            (await self.middleware.call("pool.dataset.sync_db_keys")).wait()
             dataset_mapping = await self.middleware.call("pool.dataset.dataset_encryption_root_mapping")
         else:
             dataset_mapping = {}

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -105,6 +105,7 @@ class ReplicationService(CRUDService):
         return {
             "state": await self.middleware.call("zettarepl.get_state"),
             "dataset_encryption_root_mapping": dataset_mapping,
+            "check_dataset_encryption_keys": extra.get("check_dataset_encryption_keys", False),
         }
 
     @private
@@ -135,13 +136,16 @@ class ReplicationService(CRUDService):
 
         data["job"] = data["state"].pop("job", None)
 
-        if context["dataset_encryption_root_mapping"] and data["direction"] == "PUSH":
-            data["has_encrypted_dataset_keys"] = bool(
-                await self.middleware.call(
-                    "pool.dataset.export_keys_for_replication_internal", data,
-                    context["dataset_encryption_root_mapping"], True,
+        if context["check_dataset_encryption_keys"]:
+            if context["dataset_encryption_root_mapping"] and data["direction"] == "PUSH":
+                data["has_encrypted_dataset_keys"] = bool(
+                    await self.middleware.call(
+                        "pool.dataset.export_keys_for_replication_internal", data,
+                        context["dataset_encryption_root_mapping"], True,
+                    )
                 )
-            )
+            else:
+                data["has_encrypted_dataset_keys"] = False
 
         return data
 

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -139,7 +139,7 @@ class ReplicationService(CRUDService):
         if context["dataset_encryption_root_mapping"] and data["direction"] == "PUSH":
             data["has_encrypted_dataset_keys"] = bool(
                 await self.middleware.call(
-                    "pool.dataset.export_keys_for_replication_internal", data["id"],
+                    "pool.dataset.export_keys_for_replication_internal", data,
                     context["dataset_encryption_root_mapping"], True,
                 )
             )


### PR DESCRIPTION
This PR adds an additional attribute in replication tasks which can be used to determine if the task has associated datasets which have encryption keys which can be downloaded by the user. This attribute can be consumed by UI to display a button next to replication tasks so that it is only displayed when there are actually datasets available which match the criteria.

While at it, performance for gathering keys which will be exported for a replication task has been improved as well with previous timing for me being on average 4 seconds for a task i have and now i am seeing 1.5 seconds.

For `replication.query` i see that when the extra flag is not specified the time for me is `0.09` seconds and with the flag it is 0.2 seconds where i have 3 replication tasks.

Original PR: https://github.com/truenas/middleware/pull/11874
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123597