### PR TITLE
NAS-123613 / 23.10 / fix UnboundLocalError crash in ipmi_/lan.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -57,11 +57,13 @@ class IPMILanService(CRUDService):
                 # TODO: fix this in dragonfish (dependent on webUI changes to be made see NAS-123225)
                 # raise CallError(f'Failed to get details from channel {channel}: {stderr}')
                 self.logger.error('Failed to get details from channel %r with error %r', channel, stderr)
-            elif not (stdout := cp.stdout.decode()):
+
+            stdout = cp.stdout.decode().split('\n')
+            if not stdout:
                 continue
 
             data = {'channel': channel, 'id': channel}
-            for i in filter(lambda x: x.startswith('\t') and not x.startswith('\t#'), stdout.split('\n')):
+            for i in filter(lambda x: x.startswith('\t') and not x.startswith('\t#'), stdout):
                 try:
                     name, value = i.strip().split()
                     name, value = name.lower(), value.lower()


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 181, in nf
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/ipmi_/lan.py", line 64, in query
    for i in filter(lambda x: x.startswith('\t') and not x.startswith('\t#'), stdout.split('\n')):
                                                                              ^^^^^^
UnboundLocalError: cannot access local variable 'stdout' where it is not associated with a value
```

Original PR: https://github.com/truenas/middleware/pull/11902
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123613