### PR TITLE
NAS-123625 / 23.10 / Add changes to ensure UPS service works nicely in bookworm (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -17,6 +17,7 @@ class UPSService(SimpleService):
 
     async def start(self):
         if (await self.middleware.call("ups.config"))["mode"] == "MASTER":
+            await self._systemd_unit("nut-driver-enumerator", "start")
             await self._systemd_unit("nut-server", "start")
         await self._unit_action("Start")
 

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -7,7 +7,10 @@ class UPSService(SimpleService):
     systemd_unit = "nut-monitor"
 
     async def systemd_extra_units(self):
-        return ["nut-server"] if (await self.middleware.call("ups.config"))["mode"] == "MASTER" else []
+        if (await self.middleware.call("ups.config"))["mode"] == "MASTER":
+            return ["nut-driver-enumerator", "nut-server"]
+        else:
+            return []
 
     async def before_start(self):
         await self.middleware.call("ups.dismiss_alerts")
@@ -22,4 +25,5 @@ class UPSService(SimpleService):
 
     async def stop(self):
         await self._unit_action("Stop")
+        await self._systemd_unit("nut-driver-enumerator", "stop")
         await self._systemd_unit("nut-server", "stop")


### PR DESCRIPTION
This PR adds changes to account for `nut-driver-enumerator` service which needs to be accounted for as well when UPS is running in bookworm because without that the ups driver is not recognized which results in UPS not working.

Original PR: https://github.com/truenas/middleware/pull/11914
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123625