### PR TITLE
more pci passthrough woes

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
@@ -50,7 +50,17 @@ class AddressMixin:
     def addresses(self):
         addresses = []
 
-        for family, family_addresses in netifaces.ifaddresses(self.name).items():
+        try:
+            iface = netifaces.ifaddresses(self.name)
+        except Exception:
+            # a ValueError will be raised when this function is given an interface
+            # that doesn't exist on the host OS. How might we get to this point for
+            # an interface that doesn't exist on the OS you might wonder? PCI passthrough
+            # is how. By the time this method is called the NIC existed on the host
+            # OS but was gobbled up by the VM which removes it from the host OS entirely.
+            return addresses
+
+        for family, family_addresses in iface.items():
             try:
                 af = AddressFamily(family)
             except ValueError:


### PR DESCRIPTION
We have a design problem where when we run our etc.generate plugin, we call `interface.query` in many different places. While this is running, we will start VMs. If any of those VMs are passing through an ethernet device, the other etc plugins will crash in random places because of a race condition.

- The NICs will show on the host OS before VMs start
- we query said NICs and various information
- VMs get started and the NICs that are passed through get ripped from the host OS
- another thread is trying to probe for information at the same time this VM starts and crashes because the NIC goes away

There is no easy way to associate a series of pci devices to ethernet devices that have been passed through to a VM. We also can't take the performance penalty of running vm.query and then trying to write some miserable logic to map said devices back to the ethernet interfaces every time we call interface.query.

Luckily, once the VM has started, the passed through NICs "go away" on the host OS and we don't have to worry about this. The path of least resistance for fixing this issue is to simply catch the exception that's raised in this scenario and continue on.