### PR TITLE
NAS-122970 / 24.04 / Add default value for available gpus

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -166,7 +166,11 @@ class KubernetesGPUService(Service):
         found_gpus = await self.get_system_gpus() if (
             await self.middleware.call('kubernetes.config')
         )['configure_gpus'] else set()
-        available_gpus = {}
+        available_gpus = {
+            'amd.com/gpu': '0',
+            'gpu.intel.com/i915': '0',
+            'nvidia.com/gpu': '0',
+        }
         for k, v in filter(
             lambda i: (i[0].endswith('/gpu') or i[0].startswith('gpu.intel')) and i[1] != '0',
             node_config['status']['allocatable'].items()


### PR DESCRIPTION
This commit adds changes to reflect default value for available gpus because in case if a user allocated a gpu to an app and then later removed the gpu, UI does not present him with a way of resetting that configuration because middleware reports empty dict for available gpus. The aim is to at least account for the keys with defaults so user can easily unset it - it is still currently possible to unset but via API.