### PR TITLE
NAS-123692 / 23.10 / Add additional draid vdev stats when querying pool data (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -1,6 +1,5 @@
 import errno
 import os
-import re
 
 import middlewared.sqlalchemy as sa
 
@@ -14,11 +13,9 @@ from middlewared.service_exception import InstanceNotFound
 from middlewared.utils.size import format_size
 from middlewared.validators import Range
 
-from .utils import ZFS_CHECKSUM_CHOICES, ZFS_ENCRYPTION_ALGORITHM_CHOICES, ZPOOL_CACHE_FILE
-
-
-RE_DATA = re.compile(r':\d*d')
-RE_SPARE = re.compile(r':\d*s')
+from .utils import (
+    ZFS_CHECKSUM_CHOICES, ZFS_ENCRYPTION_ALGORITHM_CHOICES, ZPOOL_CACHE_FILE, RE_DRAID_DATA_DISKS, RE_DRAID_SPARE_DISKS
+)
 
 
 class PoolModel(sa.Model):
@@ -315,8 +312,8 @@ class PoolService(CRUDService):
                         # normalize it so that it reflects the parity as well i.e DRAID1, DRAID2, etc.
                         # sample value of name here is: draid1:1d:2c:0s-0
                         entry['type'] = f'{i["type"]}{i["name"][len("draid"):len("draid") + 1]}'
-                        entry['draid_spare_disks'] = int(RE_SPARE.findall(i['name'])[0][1:-1])
-                        entry['draid_data_disks'] = int(RE_DATA.findall(i['name'])[0][1:-1])
+                        entry['draid_spare_disks'] = int(RE_DRAID_SPARE_DISKS.findall(i['name'])[0][1:-1])
+                        entry['draid_data_disks'] = int(RE_DRAID_DATA_DISKS.findall(i['name'])[0][1:-1])
                     rv.append(entry)
             return rv
 

--- a/src/middlewared/middlewared/plugins/pool_/topology.py
+++ b/src/middlewared/middlewared/plugins/pool_/topology.py
@@ -1,6 +1,7 @@
 from collections import deque
 
 from middlewared.service import private, Service
+from .utils import RE_DRAID_SPARE_DISKS, RE_DRAID_DATA_DISKS, RE_DRAID_NAME
 
 
 class PoolService(Service):
@@ -52,6 +53,12 @@ class PoolService(Service):
             for key in x:
                 if key == 'type' and isinstance(x[key], str):
                     x[key] = x[key].upper()
+                elif key == 'name' and RE_DRAID_NAME.match(x[key]) and isinstance(x.get('stats'), dict):
+                    x['stats'].update({
+                        'draid_spare_disks': int(RE_DRAID_SPARE_DISKS.findall(x['name'])[0][1:-1]),
+                        'draid_data_disks': int(RE_DRAID_DATA_DISKS.findall(x['name'])[0][1:-1]),
+                        'draid_parity': int(x['name'][len('draid'):len('draid') + 1]),
+                    })
                 else:
                     x[key] = self.transform_topology(x[key], dict(options, geom_scan=False))
         elif isinstance(x, list):

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -2,6 +2,7 @@ import enum
 import itertools
 import json
 import os
+import re
 
 from pathlib import Path
 
@@ -10,6 +11,9 @@ from middlewared.utils.size import MB
 
 
 DATASET_DATABASE_MODEL_NAME = 'storage.encrypteddataset'
+RE_DRAID_DATA_DISKS = re.compile(r':\d*d')
+RE_DRAID_SPARE_DISKS = re.compile(r':\d*s')
+RE_DRAID_NAME = re.compile(r'draid\d:\d+d:\d+c:\d+s-\d+')
 ZFS_CHECKSUM_CHOICES = ['ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN', 'EDONR']
 ZFS_COMPRESSION_ALGORITHM_CHOICES = [
     'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-FAST', 'ZLE', 'LZJB',


### PR DESCRIPTION
## Context

It was requested by UI that middleware should report draid vdev statistics like parity/spares/data disks etc when querying for pool information.

Original PR: https://github.com/truenas/middleware/pull/11934
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123692