### PR TITLE
NAS-123632 / 23.10 / switch to `KubeletConfiguration` as flags are deprecated and add grace periods for node shutdown (by stavros-k)

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -12,6 +12,8 @@ KUBELET_CONFIG = {
     'apiVersion': 'kubelet.config.k8s.io/v1beta1',
     'kind': 'KubeletConfiguration',
     'maxPods': 250,
+    'shutdownGracePeriod': '15s',
+    'shutdownGracePeriodCriticalPods': '10s',
 }
 
 

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -8,13 +8,6 @@ import yaml
 
 FLAGS_PATH = '/etc/rancher/k3s/config.yaml'
 KUBELET_CONFIG_PATH = '/etc/rancher/k3s/kubelet_config.yaml'
-KUBELET_CONFIG = {
-    'apiVersion': 'kubelet.config.k8s.io/v1beta1',
-    'kind': 'KubeletConfiguration',
-    'maxPods': 250,
-    'shutdownGracePeriod': '15s',
-    'shutdownGracePeriodCriticalPods': '10s',
-}
 
 
 def render(service, middleware):
@@ -47,7 +40,13 @@ def render(service, middleware):
     features_mapping = {'servicelb': 'servicelb', 'metrics_server': 'metrics-server'}
 
     with open(KUBELET_CONFIG_PATH, 'w') as f:
-        f.write(yaml.dump(KUBELET_CONFIG))
+        f.write(yaml.dump({
+            'apiVersion': 'kubelet.config.k8s.io/v1beta1',
+            'kind': 'KubeletConfiguration',
+            'maxPods': 250,
+            'shutdownGracePeriod': '15s',
+            'shutdownGracePeriodCriticalPods': '10s',
+        }))
 
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({

--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -7,6 +7,12 @@ import yaml
 
 
 FLAGS_PATH = '/etc/rancher/k3s/config.yaml'
+KUBELET_CONFIG_PATH = '/etc/rancher/k3s/kubelet_config.yaml'
+KUBELET_CONFIG = {
+    'apiVersion': 'kubelet.config.k8s.io/v1beta1',
+    'kind': 'KubeletConfiguration',
+    'maxPods': 250,
+}
 
 
 def render(service, middleware):
@@ -32,11 +38,14 @@ def render(service, middleware):
         'feature-gates=MixedProtocolLBService=true',
     ]
     kubelet_args = [
-        'max-pods=250',
+        f'config={KUBELET_CONFIG_PATH}',
     ]
     os.makedirs('/etc/rancher/k3s', exist_ok=True)
 
     features_mapping = {'servicelb': 'servicelb', 'metrics_server': 'metrics-server'}
+
+    with open(KUBELET_CONFIG_PATH, 'w') as f:
+        f.write(yaml.dump(KUBELET_CONFIG))
 
     with open(FLAGS_PATH, 'w') as f:
         f.write(yaml.dump({


### PR DESCRIPTION
Reason for switching to `KubeletConfiguration` is that kubelet flags are [deprecated](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) (See on every flag description).

Also added a gracefulShutdown period for pods. So k8s can try to stop pods when a shutdown is detected.
While the feature gate `GracefulNodeShutdown` is [enabled by default](https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown) on v1.21 and later it needs some configuration to actually be enabled. 

---

Tested that config file is being picked up, by doing the following
1. make the changes on my system (but setting maxPods to `1`)
2. restart middlewared
3. unset pool
4. set pool
5. observe that only 1 pod could start
6. reset maxPods back to 250
7. Repeat 2-4
8. observe all pods start

Original PR: https://github.com/truenas/middleware/pull/11838
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123632