### PR TITLE
NAS-123326 / 24.04 / Improve retrieving historical stats performance

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
@@ -35,6 +35,6 @@ class Netdata(ClientMixin):
     async def get_chart_metrics(cls, chart, query_params=None):
         """Get metrics for `chart`"""
         return await cls.api_call(
-            f'data?chart={chart}{get_query_parameters(query_params)}',
+            f'data?chart={chart}&options=null2zero{get_query_parameters(query_params)}',
             version='v1',
         )


### PR DESCRIPTION
## Problem
The process of fetching data for `reporting.netdata_graph` is taking a significant amount of time, approximately around 1 minute and 10 seconds, particularly on systems with a large number of resources like disks. This duration exceeds our API timeout, which is set at 60 seconds.

## Solution
To address this performance issue, several optimizations have been implemented. Primarily, improvements were made to the aggregation function, which was consuming extra time. Additionally, the method of requesting data was changed from sequential to parallel retrieval. These enhancements collectively resulted in a performance boost of around 40-45%. As a result, the data retrieval process for `reporting.netdata_graph` now takes only 39 seconds, well within the API timeout on a system which has the most resources we support.