### PR TITLE
NAS-119369 / 13.1 / Properly account for the case when TC container might not be running (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alert/source/truecommand.py
+++ b/src/middlewared/middlewared/alert/source/truecommand.py
@@ -45,3 +45,18 @@ class TruecommandConnectionHealthAlertClass(AlertClass, OneShotAlertClass):
 
     async def delete(self, alerts, query):
         return []
+
+
+class TruecommandContainerHealthAlertClass(AlertClass, OneShotAlertClass):
+    deleted_automatically = False
+
+    category = AlertCategory.SYSTEM
+    level = AlertLevel.CRITICAL
+    title = 'TrueCommand Container Failed Scheduled Health Check'
+    text = 'TrueCommand container failed scheduled health check, please contact Truecommand support.'
+
+    async def create(self, args):
+        return Alert(TruecommandContainerHealthAlertClass, args)
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -44,10 +44,12 @@ class TruecommandService(Service, TruecommandAPIMixin):
                 )
                 if status['tc_state'] == 'running':
                     await self.middleware.call('truecommand.dismiss_alerts')
-                    await self.middleware.call('truecommand.start_truecommand_service')
                 else:
                     await self.middleware.call('truecommand.dismiss_alerts', True)
                     await self.middleware.call('alert.oneshot_create', 'TruecommandContainerHealth', None)
+
+                await self.middleware.call('truecommand.start_truecommand_service')
+
                 break
 
             elif status['state'] == PortalResponseState.UNKNOWN:

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -42,8 +42,12 @@ class TruecommandService(Service, TruecommandAPIMixin):
                 self.middleware.send_event(
                     'truecommand.config', 'CHANGED', fields=(await self.middleware.call('truecommand.config'))
                 )
-                await self.middleware.call('truecommand.dismiss_alerts')
-                await self.middleware.call('truecommand.start_truecommand_service')
+                if status['tc_state'] == 'running':
+                    await self.middleware.call('truecommand.dismiss_alerts')
+                    await self.middleware.call('truecommand.start_truecommand_service')
+                else:
+                    await self.middleware.call('truecommand.dismiss_alerts', True)
+                    await self.middleware.call('alert.oneshot_create', 'TruecommandContainerHealth', None)
                 break
 
             elif status['state'] == PortalResponseState.UNKNOWN:

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -42,7 +42,7 @@ class TruecommandService(Service, TruecommandAPIMixin):
                 self.middleware.send_event(
                     'truecommand.config', 'CHANGED', fields=(await self.middleware.call('truecommand.config'))
                 )
-                if status['tc_state'] == 'running':
+                if status.get('tc_state') == 'running':
                     await self.middleware.call('truecommand.dismiss_alerts')
                 else:
                     await self.middleware.call('truecommand.dismiss_alerts', True)

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -199,5 +199,5 @@ class TruecommandService(ConfigService):
         # we update TC service or the health is okay now with the service running or when service is not running
         for klass in [
             'TruecommandConnectionDisabled', 'TruecommandConnectionPending'
-        ] + (['TruecommandConnectionHealth'] if dismiss_health else []):
+        ] + (['TruecommandConnectionHealth', 'TruecommandContainerHealth'] if dismiss_health else []):
             await self.middleware.call('alert.oneshot_delete', klass, None)

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -193,11 +193,15 @@ class TruecommandService(ConfigService):
         self.middleware.send_event('truecommand.config', 'CHANGED', fields=(await self.config()))
 
     @private
-    async def dismiss_alerts(self, dismiss_health=False):
+    async def dismiss_alerts(self, dismiss_health=False, dismiss_health_only=False):
         # We do not dismiss health by default because it's possible that the key has not been revoked
         # and it's just that TC has not connected to TN in 30 minutes, so we only should dismiss it when
         # we update TC service or the health is okay now with the service running or when service is not running
-        for klass in [
-            'TruecommandConnectionDisabled', 'TruecommandConnectionPending'
-        ] + (['TruecommandConnectionHealth', 'TruecommandContainerHealth'] if dismiss_health else []):
+        health_alerts = {'TruecommandConnectionHealth', 'TruecommandContainerHealth'}
+        non_health_alerts = {'TruecommandConnectionDisabled', 'TruecommandConnectionPending'}
+        if dismiss_health_only:
+            to_dismiss_alerts = health_alerts
+        else:
+            to_dismiss_alerts = health_alerts | non_health_alerts if dismiss_health else non_health_alerts
+        for klass in to_dismiss_alerts:
             await self.middleware.call('alert.oneshot_delete', klass, None)

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -60,7 +60,7 @@ class TruecommandService(Service):
             # truecommand.config and is in WAITING state right now assuming that an event will be
             # raised when TC finally connects
             await self.middleware.call('truecommand.set_status', Status.CONNECTED.value)
-            await self.middleware.call('alert.oneshot_delete', 'TruecommandConnectionHealth', None)
+            await self.middleware.call('truecommand.dismiss_alerts', False, True)
 
     @private
     async def wireguard_connection_health(self):


### PR DESCRIPTION
This PR adds changes to raise an alert for the user in the case when wireguard service on truenas is running as desired but the the TC container is actually down.

Original PR: https://github.com/truenas/middleware/pull/11937
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119369