### PR TITLE
NAS-123326 / 23.10 / Improve retrieving historical stats performance (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
@@ -35,6 +35,6 @@ class Netdata(ClientMixin):
     async def get_chart_metrics(cls, chart, query_params=None):
         """Get metrics for `chart`"""
         return await cls.api_call(
-            f'data?chart={chart}{get_query_parameters(query_params)}',
+            f'data?chart={chart}&options=null2zero{get_query_parameters(query_params)}',
             version='v1',
         )

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -1,3 +1,10 @@
+import asyncio
+import contextlib
+import typing
+
+from .netdata.graph_base import GraphBase
+
+
 def calculate_disk_space_for_netdata(metrics: int, days: int) -> int:
     # Constants
     sec_per_day = 86400
@@ -21,6 +28,19 @@ def convert_unit(unit: str, page: int) -> int:
         'MONTH': 60 * 24 * 30,
         'YEAR': 60 * 24 * 365,
     }[unit] * page
+
+
+async def fetch_data_from_graph_plugin(
+    graph_plugin: GraphBase, query_params: dict, identifier: typing.Optional[str], aggregate: bool,
+    semaphore: asyncio.Semaphore, graph_plugins: set,
+) -> typing.Optional[dict]:
+    if graph_plugin.name not in graph_plugins:
+        await graph_plugin.build_context()
+        graph_plugins.add(graph_plugin.name)
+
+    async with semaphore:
+        with contextlib.suppress(Exception):
+            return await graph_plugin.export(query_params, identifier, aggregate=aggregate)
 
 
 def get_metrics_approximation(disk_count: int, core_count: int, interface_count: int, pool_count: int) -> dict:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x eeaedd2cdcf9b83fdd694d6414d7fa1acec3ec10

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 58c406958c04ffd231367c14686fc06a911b0cbe

## Problem
The process of fetching data for `reporting.netdata_graph` is taking a significant amount of time, approximately around 1 minute and 10 seconds, particularly on systems with a large number of resources like disks. This duration exceeds our API timeout, which is set at 60 seconds.

## Solution
To address this performance issue, several optimizations have been implemented. Primarily, improvements were made to the aggregation function, which was consuming extra time. Additionally, the method of requesting data was changed from sequential to parallel retrieval. These enhancements collectively resulted in a performance boost of around 40-45%. As a result, the data retrieval process for `reporting.netdata_graph` now takes only 39 seconds, well within the API timeout on a system which has the most resources we support.

Original PR: https://github.com/truenas/middleware/pull/11943
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123326