### PR TITLE
NAS-123042 / 24.04 / Relax restrictions on NFS subdir sharing

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -285,8 +285,8 @@ class SharingNFSService(SharingService):
         Dir("path", required=True),
         List("aliases", items=[Str("path", validators=[Match(r"^/.*")])]),
         Str("comment", default=""),
-        List("networks", items=[IPAddr("network", network=True)]),
-        List("hosts", items=[Str("host", validators=[Match(r'^\S+$')])]),
+        List("networks", items=[IPAddr("network", network=True)], unique=True),
+        List("hosts", items=[Str("host", validators=[Match(r'^\S+$')])], unique=True),
         Bool("ro", default=False),
         Str("maproot_user", required=False, default=None, null=True),
         Str("maproot_group", required=False, default=None, null=True),
@@ -420,9 +420,7 @@ class SharingNFSService(SharingService):
         )
 
         # Confirm the share will not collide with an existing share
-        await self.middleware.run_in_thread(
-            self.validate_share_path, other_shares, data, schema_name, verrors
-        )
+        await self.validate_share_path(other_shares, data, schema_name, verrors)
 
         for k in ["maproot", "mapall"]:
             if not data[f"{k}_user"] and not data[f"{k}_group"]:
@@ -470,14 +468,6 @@ class SharingNFSService(SharingService):
                 "ERROR - '*', i.e. 'everybody', cannot be included with other entries on same share path"
             )
 
-        # Check for duplicates
-        dups = list(set([x for x in hosts if hosts.count(x) >= 2]))
-        if len(dups) > 0:
-            verrors.add(
-                f"{schema_name}.hosts",
-                f"ERROR - Duplicate host entries are not allowed: {', '.join(dups)}"
-            )
-
     @private
     def validate_share_networks_input(self, networks, dns_cache, schema_name, verrors):
         """
@@ -485,14 +475,6 @@ class SharingNFSService(SharingService):
         The input validator should enforce the CIDR format and a single address per entry.
         This validation is limited to detecting repeats and overlapping subnets.
         """
-        # Check for duplicates
-        if len(networks) != len(set(networks)):
-            dups = list(set([x for x in networks if networks.count(x) >= 2]))
-            verrors.add(
-                f"{schema_name}.networks",
-                f"ERROR - Duplicate network entries are not allowed: {', '.join(dups)}"
-            )
-        # Check for duplicates via hostname (which should be in dns_cache)
         dns_cache_values = list(dns_cache.values())
         for IPaddr in networks:
             IPinterface = ipaddress.ip_interface(IPaddr)
@@ -667,7 +649,7 @@ class SharingNFSService(SharingService):
             used_networks.add(network)
 
     @private
-    def validate_share_path(self, other_shares, data, schema_name, verrors):
+    async def validate_share_path(self, other_shares, data, schema_name, verrors):
         """
         A share path centric test. Checks new share path against existing.
         There are multiple ways to get duplicate entries for a given share path
@@ -681,15 +663,15 @@ class SharingNFSService(SharingService):
         This function checks for common conditions.
         """
         # We test other shares that are sharing the same path
-        tgt_path_stat = os.stat(data["path"])
-        tgt_dev = tgt_path_stat.st_dev
-        tgt_ino = tgt_path_stat.st_ino
+        tgt_path_stat = await self.middleware.call('filesystem.stat', data["path"])
+        tgt_dev = tgt_path_stat['dev']
+        tgt_ino = tgt_path_stat['inode']
 
         for share in other_shares:
             try:
-                share_stat = os.stat(share["path"])
-                share_dev = share_stat.st_dev
-                share_ino = share_stat.st_ino
+                share_stat = await self.middleware.call('filesystem.stat', share["path"])
+                share_dev = share_stat['dev']
+                share_ino = share_stat['inode']
             except Exception:
                 self.logger.warning("Failed to stat path for %r", share, exc_info=True)
                 continue

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -463,23 +463,12 @@ class SharingNFSService(SharingService):
     def validate_and_clean_share_hosts_intput(self, hosts, schema_name, verrors):
         """
         The host field can contain multiple 'host' entries that are space delimited
-        At this time the following are now allowed: ',' '/'
         The validation is limited to detecting repeated 'host' names
 
         This will return a list of hosts
         """
-        # We do not allow the hosts field to contain ',' or '/'
-        ILLEGAL_CHARS = re.compile(r'[\/]')
         new_host_list = []
         for host_str in hosts:
-            # Trap illegal characters
-            if res := ILLEGAL_CHARS.findall(host_str):
-                verrors.add(
-                    f"{schema_name}.hosts",
-                    f"Host field contains {res} and cannot include ',' or '/':  {host_str}"
-                )
-                continue
-
             # Trap space delimited hosts
             if ' ' in host_str:
                 new_host_list.extend(shlex.split(host_str))

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -3,7 +3,6 @@ import enum
 import ipaddress
 import itertools
 import os
-import re
 import shlex
 
 from middlewared.common.attachment import LockableFSAttachmentDelegate

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
@@ -1,101 +1,89 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from middlewared.plugins.nfs import SharingNFSService
 
 
 def test__sharing_nfs_service__validate_hosts_and_networks__host_is_32_network():
-    with patch("middlewared.plugins.nfs.os.stat", lambda dev: {
-        "/mnt/data/a": Mock(st_dev=1),
-        "/mnt/data/b": Mock(st_dev=1),
-    }[dev]):
-        middleware = Mock()
+    middleware = Mock()
 
-        verrors = Mock()
+    verrors = Mock()
 
-        SharingNFSService(middleware).validate_hosts_and_networks(
-            [
-                {
-                    "path": "/mnt/data/a",
-                    "hosts": ["192.168.0.1"],
-                    "networks": [],
-                },
-            ],
+    SharingNFSService(middleware).validate_hosts_and_networks(
+        [
             {
-                "path": "/mnt/data/b",
+                "path": "/mnt/data/a",
                 "hosts": ["192.168.0.1"],
                 "networks": [],
             },
-            "sharingnfs_update",
-            verrors,
-            {
-                "192.168.0.1": "192.168.0.1",
-            },
-        )
+        ],
+        {
+            "path": "/mnt/data/b",
+            "hosts": ["192.168.0.1"],
+            "networks": [],
+        },
+        "sharingnfs_update",
+        verrors,
+        {
+            "192.168.0.1": "192.168.0.1",
+        },
+    )
 
-        # NAS-123042: A passing condition
-        verrors.add.assert_not_called()
+    # NAS-123042: A passing condition
+    verrors.add.assert_not_called()
 
 
 def test__sharing_nfs_service__validate_hosts_and_networks__dataset_is_already_exported():
-    with patch("middlewared.plugins.nfs.os.stat", lambda dev: {
-        "/mnt/data/a": Mock(st_dev=1),
-        "/mnt/data/b": Mock(st_dev=1),
-    }[dev]):
-        middleware = Mock()
+    middleware = Mock()
 
-        verrors = Mock()
+    verrors = Mock()
 
-        SharingNFSService(middleware).validate_hosts_and_networks(
-            [
-                {
-                    "path": "/mnt/data/a",
-                    "hosts": [],
-                    "networks": ["192.168.0.0/24"],
-                },
-            ],
+    SharingNFSService(middleware).validate_hosts_and_networks(
+        [
             {
-                "path": "/mnt/data/b",
+                "path": "/mnt/data/a",
                 "hosts": [],
                 "networks": ["192.168.0.0/24"],
             },
-            "sharingnfs_update",
-            verrors,
-            {
-                "192.168.0.1": "192.168.0.1",
-            },
-        )
+        ],
+        {
+            "path": "/mnt/data/b",
+            "hosts": [],
+            "networks": ["192.168.0.0/24"],
+        },
+        "sharingnfs_update",
+        verrors,
+        {
+            "192.168.0.1": "192.168.0.1",
+        },
+    )
 
-        # NAS-123042: A passing condition
-        verrors.add.assert_not_called()
+    # NAS-123042: A passing condition
+    verrors.add.assert_not_called()
 
 
 def test__sharing_nfs_service__validate_hosts_and_networks__fs_is_already_exported_for_world():
-    with patch("middlewared.plugins.nfs.os.stat", lambda dev: {
-        "/mnt/data/a": Mock(st_dev=1),
-        "/mnt/data/b": Mock(st_dev=1),
-    }[dev]):
-        middleware = Mock()
+    middleware = Mock()
 
-        verrors = Mock()
+    verrors = Mock()
 
-        SharingNFSService(middleware).validate_hosts_and_networks(
-            [
-                {
-                    "path": "/mnt/data/a",
-                    "hosts": ["192.168.0.1"],
-                    "networks": [],
-                },
-            ],
+    SharingNFSService(middleware).validate_hosts_and_networks(
+        [
             {
-                "path": "/mnt/data/b",
-                "hosts": [],
+                "path": "/mnt/data/a",
+                "hosts": ["192.168.0.1"],
                 "networks": [],
             },
-            "sharingnfs_update",
-            verrors,
-            {
-                "192.168.0.1": "192.168.0.1",
-            },
-        )
-        # This is now a passing condition: NAS-120957
-        verrors.add.assert_not_called()
+        ],
+        {
+            "path": "/mnt/data/b",
+            "hosts": [],
+            "networks": [],
+        },
+        "sharingnfs_update",
+        verrors,
+        {
+            "192.168.0.1": "192.168.0.1",
+        },
+    )
+    # This is now a passing condition: NAS-120957
+    verrors.add.assert_not_called()

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_nfs.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 from middlewared.plugins.nfs import SharingNFSService
 
@@ -32,7 +32,8 @@ def test__sharing_nfs_service__validate_hosts_and_networks__host_is_32_network()
             },
         )
 
-        verrors.add.assert_called_once_with("sharingnfs_update.hosts", ANY)
+        # NAS-123042: A passing condition
+        verrors.add.assert_not_called()
 
 
 def test__sharing_nfs_service__validate_hosts_and_networks__dataset_is_already_exported():
@@ -64,7 +65,8 @@ def test__sharing_nfs_service__validate_hosts_and_networks__dataset_is_already_e
             },
         )
 
-        verrors.add.assert_called_once_with("sharingnfs_update.networks", ANY)
+        # NAS-123042: A passing condition
+        verrors.add.assert_not_called()
 
 
 def test__sharing_nfs_service__validate_hosts_and_networks__fs_is_already_exported_for_world():

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -16,6 +16,7 @@ sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from functions import make_ws_request
 from auto_config import pool_name, ha, hostname
+from auto_config import interface
 from auto_config import dev_test, password, user
 from protocols import SSH_NFS
 # comment pytestmark for development testing with --dev-test
@@ -296,6 +297,7 @@ def test_01_creating_the_nfs_server():
     # The service is not yet enabled, so we cannot yet confirm the settings
 
 
+@pytest.mark.dependency(name='NFS_DATASET_CREATED')
 def test_02_creating_dataset_nfs(request):
     payload = {"name": dataset}
     results = POST("/pool/dataset/", payload)
@@ -320,6 +322,7 @@ def test_04_verify_the_job_id_is_successfull(request):
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
+@pytest.mark.dependency(name='NFSID_SHARE_CREATED')
 def test_05_creating_a_nfs_share_on_nfs_PATH(request):
     global nfsid
     paylaod = {"comment": "My Test Share",
@@ -390,6 +393,7 @@ def test_19_updating_the_nfs_service(request):
 
 
 def test_20_update_nfs_share(request):
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     nfsid = GET('/sharing/nfs?comment=My Test Share').json()[0]['id']
     payload = {"security": []}
     results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
@@ -410,6 +414,7 @@ def test_31_check_nfs_share_network(request):
         192.168.0.0/24(sec=sys,rw,subtree_check)\
         192.168.1.0/24(sec=sys,rw,subtree_check)
     """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     networks_to_test = ["192.168.0.0/24", "192.168.1.0/24"]
 
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'networks': networks_to_test})
@@ -444,9 +449,15 @@ hostnames_to_test = [
       "asdfdm[0-9].example.com", "dmix?-*dev[0-9].ixsystems.com"], True),
     # Invalid hostnames
     (["-asdffail", "*.asdffail.com", "*.*.com", "bozofail.?.*"], False),
+    (["bogus/name"], False),
+    (["192.168.1.0/24"], False),
     # Mix of valid and invalid hostnames
     (["asdfdm[0-9].example.com", "-asdffail",
-      "devteam-*.ixsystems.com", "*.asdffail.com"], False)
+      "devteam-*.ixsystems.com", "*.asdffail.com"], False),
+    # Duplicate names (not allowed)
+    (["192.168.1.0", "192.168.1.0"], False),
+    # Invalid IP address
+    (["192.168.1.o"], False),
 ]
 
 
@@ -470,6 +481,7 @@ def test_32_check_nfs_share_hosts(request, hostlist, ExpectedToPass):
     - Dashes are allowed, but a level cannot start or end with a dash, '-'
     - Only the left most level may contain special characters: '*','?' and '[]'
     """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     results = PUT(f"/sharing/nfs/id/{nfsid}/", {'hosts': hostlist})
     if ExpectedToPass:
         assert results.status_code == 200, results.text
@@ -504,6 +516,7 @@ def test_33_check_nfs_share_ro(request):
     exports file. We also verify with write tests on a local mount.
     """
 
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     # Make sure we end up in the original state with 'rw'
     try:
         # Confirm 'rw' initial state and create a file and dir
@@ -560,6 +573,7 @@ def test_34_check_nfs_share_maproot(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,anonuid=65534,anongid=65534,subtree_check)
     """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     payload = {
         'maproot_user': 'nobody',
         'maproot_group': 'nogroup'
@@ -630,6 +644,7 @@ def test_35_check_nfs_share_mapall(request):
     "/mnt/dozer/NFSV4"\
         *(sec=sys,rw,all_squash,anonuid=65534,anongid=65534,subtree_check)
     """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     payload = {
         'mapall_user': 'nobody',
         'mapall_group': 'nogroup'
@@ -672,6 +687,7 @@ def test_36_check_nfsdir_subtree_behavior(request):
     "/mnt/dozer/NFSV4/foobar"\
         *(sec=sys,rw,subtree_check)
     """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     tmp_path = f'{NFS_PATH}/sub1'
     results = POST('/filesystem/mkdir', tmp_path)
     assert results.status_code == 200, results.text
@@ -693,6 +709,10 @@ class Test37WithFixture:
     in the parametrized test
     """
 
+    res = SSH_TEST(f"ip address show {interface} | grep inet6", user, password, ip)
+    ipv6_network = str(res['output'].split()[1])
+    ipv6_host = ipv6_network.split('/')[0]
+
     @pytest.fixture(scope='class')
     def dataset_and_dirs(self):
         """
@@ -710,7 +730,9 @@ class Test37WithFixture:
                 startIdList = [item.get('id') for item in contents]
 
                 # Create the dirs
-                dirs = ["dir1", "dir2", "dir3", "dir4", "dir5", "dir6"]
+                dirs = ["everybody_1", "everybody_2",
+                        "limited_1", "limited_2",
+                        "dir_1", "dir_2"]
                 subdirs = ["subdir1", "subdir2", "subdir3"]
                 try:
                     for dir in dirs:
@@ -738,37 +760,53 @@ class Test37WithFixture:
     # Parameters for test_37
     # Directory (dataset share VOL0), hostname, ExpectedToPass
     dirs_to_export = [
-        ("dir1", ["*"], True),  # Test NAS-120957
-        ("dir2", ["*"], True),  # Test NAS-120957, allow non-related paths to same hosts
-        ("dir3", ["*.example.com"], True),
-        ("dir3", ["*.example.com"], False),  # Already exported
-        ("dir1/subdir1", ["192.168.0.0"], True),
-        ("dir1/subdir2", ["127.0.0.1"], False),  # Already exported at share root, VOL0
-        ("dir4/subdir1", ["192.168.1.0"], True),
-        ("dir4", ["192.168.1.0"], False),  # Already shared by dir4/subdir1
-        ("dir4", ["*.ixsystems.com"], True),
-        ("dir4/subdir2", ["192.168.1.0", "*.ixsystems.com"], False)  # ixsystems already shared
+        ("everybody_1", True, ["*"], True),                   # 0: Test NAS-120957
+        ("everybody_2", True, ["*"], True),                   # 1: Test NAS-120957, allow non-related paths to same hosts
+        ("limited_1", True, ["127.0.0.1"], True),             # 2: Test NAS-123042, allow export of subdirs
+        ("limited_2", True, ["127.0.0.1"], True),             # 3: Test NAS-120957, NAS-123042
+        ("limited_2", True, ["*"], False),                    # 4: Test NAS-123042, export collision, same path, different entry
+        ("dir_1", True, ["*.example.com"], True),             # 5: Setup for test 6
+        ("dir_1", True, ["*.example.com"], False),            # 6: Already exported
+        ("dir_1", True, [ipv6_host], True),                   # 7: ipv6
+        ("dir_1/subdir1", True, ["192.168.0.0"], True),       # 8: Setup for test 9
+        ("dir_1/subdir1", True, ["192.168.0.0"], False),      # 9: Alread exported, non-wildcard
+        ("limited_2/subdir2", True, ["127.0.0.1"], True),     # 10: Test NAS-123042, allow export of subdirs
+        ("limited_1/subdir2", True, ["*"], True),             # 11: Test NAS-123042, everybody
+        ("dir_2/subdir2", False, ["192.168.1.0/24"], True),   # 12: Setup for test 13
+        ("dir_2/subdir2", False, ["192.168.1.0/32"], False),  # 13: Test NAS-123042 - export collision, overlaping networks
+        ("everybody_1/subdir1", True, ["*", "*.ixsystems.com"], False),        # 14: Test NAS-123042, export collision, same path and entry
+        ("limited_1/subdir3", True, ["192.168.1.0", "*.ixsystems.com"], True)  # 15: Test NAS-123042
     ]
 
-    @pytest.mark.parametrize("dirname,host,ExpectedToPass", dirs_to_export)
-    def test_37_check_nfsdir_subtree_share(self, request, dataset_and_dirs, dirname, host, ExpectedToPass):
+    @pytest.mark.parametrize("dirname,isHost,HostOrNet,ExpectedToPass", dirs_to_export)
+    def test_37_check_nfsdir_subtree_share(self, request, dataset_and_dirs, dirname, isHost, HostOrNet, ExpectedToPass):
         """
         Sharing subtrees to the same host can cause problems for
         NFSv3.  This check makes sure a share creation follows
         the rules.
             * First match is applied
-            * A new path that is related to an existing path cannot be shared to same 'host'
+            * A new path that is _the same_ as existing path cannot be shared to same 'host'
 
         For example, the following is not allowed:
         "/mnt/dozer/NFS"\
             fred(rw)
-        "/mnt/dozer/NFS/foo"\
-            fred(rw)
+        "/mnt/dozer/NFS"\
+            fred(ro)
+
+        Also not allowed are collisions that may result in unexpected share permissions.
+        For example, the following is not allowed:
+        "/mnt/dozer/NFS"\
+            *(rw)
+        "/mnt/dozer/NFS"\
+            marketing(ro)
         """
 
         vol = dataset_and_dirs
         dirpath = f'{vol}/{dirname}'
-        payload = {"path": dirpath, "hosts": host}
+        if isHost:
+            payload = {"path": dirpath, "hosts": HostOrNet}
+        else:
+            payload = {"path": dirpath, "networks": HostOrNet}
         results = POST("/sharing/nfs/", payload)
         if ExpectedToPass:
             assert results.status_code == 200, results.text
@@ -965,6 +1003,7 @@ def test_42_check_nfs_client_status(request):
     sessions) we only verify that count is non-zero for NFSv3.
     """
 
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     with SSH_NFS(ip, NFS_PATH, vers=3, user=user, password=password, ip=ip):
         results = GET('/nfs/get_nfs3_clients/', payload={
             'query-filters': [],

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -16,7 +16,6 @@ sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from functions import make_ws_request
 from auto_config import pool_name, ha, hostname
-# from auto_config import interface
 from auto_config import dev_test, password, user
 from protocols import SSH_NFS
 # comment pytestmark for development testing with --dev-test
@@ -459,8 +458,9 @@ hostnames_to_test = [
       "devteam-*.ixsystems.com", "*.asdffail.com"], False),
     # Duplicate names (not allowed)
     (["192.168.1.0", "192.168.1.0"], False),
-    # Invalid IP address, hostname with spaces
+    # Invalid IP address
     (["192.168.1.o"], False),
+    # Hostname with spaces
     (["bad host"], False)
 ]
 
@@ -746,6 +746,12 @@ class Test37WithFixture:
                         for subdir in subdirs:
                             results = SSH_TEST(f"mkdir -p {vol0}/{dir}/{subdir}", user, password, ip)
                             assert results['result'] is True
+                            # And symlinks
+                            results = SSH_TEST(
+                                f"ln -sf {vol0}/{dir}/{subdir} {vol0}/{dir}/symlink2{subdir}",
+                                user, password, ip
+                            )
+                            assert results['result'] is True
 
                     yield vol0
                 finally:
@@ -779,8 +785,9 @@ class Test37WithFixture:
         ("limited_1/subdir2", True, ["*"], True),             # 10: Test NAS-123042, everybody
         ("dir_2/subdir2", False, ["192.168.1.0/24"], True),   # 11: Setup for test 13
         ("dir_2/subdir2", False, ["192.168.1.0/32"], False),  # 12: Test NAS-123042 - export collision, overlaping networks
-        ("everybody_1/subdir1", True, ["*", "*.ixsystems.com"], False),        # 13: Test NAS-123042, export collision, same path and entry
-        ("limited_1/subdir3", True, ["192.168.1.0", "*.ixsystems.com"], True)  # 14: Test NAS-123042
+        ("everybody_1/subdir1", True, ["*", "*.ixsystems.com"], False),         # 13: Test NAS-123042, export collision, same path and entry
+        ("limited_1/subdir3", True, ["192.168.1.0", "*.ixsystems.com"], True),  # 14: Test NAS-123042
+        ("dir_1/symlink2subdir3", True, ["192.168.0.0"], False),                # 15: Block exporting symlinks
     ]
 
     @pytest.mark.parametrize("dirname,isHost,HostOrNet,ExpectedToPass", dirs_to_export)

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -16,7 +16,7 @@ sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from functions import make_ws_request
 from auto_config import pool_name, ha, hostname
-from auto_config import interface
+# from auto_config import interface
 from auto_config import dev_test, password, user
 from protocols import SSH_NFS
 # comment pytestmark for development testing with --dev-test
@@ -709,9 +709,10 @@ class Test37WithFixture:
     in the parametrized test
     """
 
-    res = SSH_TEST(f"ip address show {interface} | grep inet6", user, password, ip)
-    ipv6_network = str(res['output'].split()[1])
-    ipv6_host = ipv6_network.split('/')[0]
+    # TODO: Work up a valid IPv6 test
+    # res = SSH_TEST(f"ip address show {interface} | grep inet6", user, password, ip)
+    # ipv6_network = str(res['output'].split()[1])
+    # ipv6_host = ipv6_network.split('/')[0]
 
     @pytest.fixture(scope='class')
     def dataset_and_dirs(self):
@@ -767,15 +768,15 @@ class Test37WithFixture:
         ("limited_2", True, ["*"], False),                    # 4: Test NAS-123042, export collision, same path, different entry
         ("dir_1", True, ["*.example.com"], True),             # 5: Setup for test 6
         ("dir_1", True, ["*.example.com"], False),            # 6: Already exported
-        ("dir_1", True, [ipv6_host], True),                   # 7: ipv6
-        ("dir_1/subdir1", True, ["192.168.0.0"], True),       # 8: Setup for test 9
-        ("dir_1/subdir1", True, ["192.168.0.0"], False),      # 9: Alread exported, non-wildcard
-        ("limited_2/subdir2", True, ["127.0.0.1"], True),     # 10: Test NAS-123042, allow export of subdirs
-        ("limited_1/subdir2", True, ["*"], True),             # 11: Test NAS-123042, everybody
-        ("dir_2/subdir2", False, ["192.168.1.0/24"], True),   # 12: Setup for test 13
-        ("dir_2/subdir2", False, ["192.168.1.0/32"], False),  # 13: Test NAS-123042 - export collision, overlaping networks
-        ("everybody_1/subdir1", True, ["*", "*.ixsystems.com"], False),        # 14: Test NAS-123042, export collision, same path and entry
-        ("limited_1/subdir3", True, ["192.168.1.0", "*.ixsystems.com"], True)  # 15: Test NAS-123042
+        # ("dir_1", True, [ipv6_host], True),                   # -: ipv6
+        ("dir_1/subdir1", True, ["192.168.0.0"], True),       # 7: Setup for test 9
+        ("dir_1/subdir1", True, ["192.168.0.0"], False),      # 8: Alread exported, non-wildcard
+        ("limited_2/subdir2", True, ["127.0.0.1"], True),     # 9: Test NAS-123042, allow export of subdirs
+        ("limited_1/subdir2", True, ["*"], True),             # 10: Test NAS-123042, everybody
+        ("dir_2/subdir2", False, ["192.168.1.0/24"], True),   # 11: Setup for test 13
+        ("dir_2/subdir2", False, ["192.168.1.0/32"], False),  # 12: Test NAS-123042 - export collision, overlaping networks
+        ("everybody_1/subdir1", True, ["*", "*.ixsystems.com"], False),        # 13: Test NAS-123042, export collision, same path and entry
+        ("limited_1/subdir3", True, ["192.168.1.0", "*.ixsystems.com"], True)  # 14: Test NAS-123042
     ]
 
     @pytest.mark.parametrize("dirname,isHost,HostOrNet,ExpectedToPass", dirs_to_export)


### PR DESCRIPTION
What is restricted on sharing to the same path:
1) Repeated 'host' or 'network' names
2) Potential collisions with the use of wildcards (everyone) and
   overlaping of network subnets