### PR TITLE
NAS-123286 / 23.10 / add ES60G2 enclosure detection

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -530,6 +530,8 @@ class Enclosure(object):
             self.model = "ES102S"
         elif self.encname.startswith("CELESTIC R0904"):
             self.model = "ES60"
+        elif self.encname.startswith("HGST H4060-J 3010"):
+            self.model = "ES60G2"
         elif ES24_REGEX.match(self.encname):
             self.model = "ES24"
         elif ES24F_REGEX.match(self.encname):

--- a/src/middlewared/middlewared/utils/license.py
+++ b/src/middlewared/middlewared/utils/license.py
@@ -8,4 +8,6 @@ LICENSE_ADDHW_MAPPING = {
     7: "ES24F",
     8: "ES60S",
     9: "ES102",
+    10: "ES102S",
+    11: "ES60G2",
 }


### PR DESCRIPTION
This adds ES60G2 enclosure detection while also adding it to utils/license.py. While I'm here, add ES102S to utils/license.py since it seems it was forgotten.