### PR TITLE
NAS-123676 / 24.04 / Disable all forms of passthrough on ha machines

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -18,6 +18,12 @@ class SystemAdvancedService(Service):
         if isolated_gpu_pci_ids:
             verrors = await self.validate_gpu_pci_ids(isolated_gpu_pci_ids, verrors, 'gpu_settings')
 
+        if await self.middleware.call('system.is_ha_capable') and isolated_gpu_pci_ids:
+            verrors.add(
+                'gpu_settings.isolated_gpu_pci_ids',
+                'HA capable systems do not support PCI passthrough'
+            )
+
         verrors.check()
 
         await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -99,6 +99,9 @@ class PCI(Device):
                 'and cannot be used for PCI passthrough'
             )
 
+        if self.middleware.call_sync('system.is_ha_capable'):
+            verrors.add('attribute.pptdev', 'HA capable systems do not support PCI passthrough')
+
         if not self.middleware.call_sync('vm.device.iommu_enabled'):
             verrors.add('attribute.pptdev', 'IOMMU support is required.')
 

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -100,6 +100,9 @@ class USB(Device):
                 'Either device or attributes.usb must be specified'
             )
 
+        if self.middleware.call_sync('system.is_ha_capable'):
+            verrors.add('attributes.usb', 'HA capable systems do not support USB passthrough.')
+
         if verrors:
             return
 

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -39,6 +39,14 @@ class VMService(Service, VMSupervisorMixin):
         if vm['bootloader'] not in await self.middleware.call('vm.bootloader_options'):
             raise CallError(f'"{vm["bootloader"]}" is not supported on this platform.')
 
+        if await self.middleware.call('system.is_ha_capable'):
+            for device in vm['devices']:
+                if device['dtype'] in ('PCI', 'USB'):
+                    raise CallError(
+                        'Please remove PCI/USB devices from VM before starting it in HA capable machines as '
+                        'they are not supported.'
+                    )
+
         # Perhaps we should have a default config option for VMs?
         await self.middleware.call('vm.init_guest_vmemory', vm, options['overcommit'])
 


### PR DESCRIPTION
## Problem

It is not guarenteed that in HA machines on both nodes the PCI structure and the devices attached are same which means on failover we could end up with a disastrous scenario of bricking the system by trying to critical PCI slots/devices.

## Solution

All forms of passthrough being disabled on HA machines addresses this problem.