### PR TITLE
NAS-123741 / 24.04 / Fix disk service usage

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -285,8 +285,6 @@ class PoolDatasetService(Service):
                     f'{i + 1}) {ds!r}: {failed_datasets[ds]}' for i, ds in enumerate(failed_datasets)
                 )
 
-        services_to_restart = set()
-
         if unlocked:
             if options['toggle_attachments']:
                 job.set_progress(91, 'Handling attachments')
@@ -304,9 +302,6 @@ class PoolDatasetService(Service):
                 self.middleware.call_sync(
                     'pool.dataset.insert_or_update_encrypted_record', dataset_data(unlocked_dataset)
                 )
-
-            job.set_progress(93, 'Restarting services')
-            self.middleware.call_sync('pool.dataset.restart_services_after_unlock', id_, services_to_restart)
 
             job.set_progress(94, 'Running post-unlock tasks')
             self.middleware.call_hook_sync(

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -286,8 +286,6 @@ class PoolDatasetService(Service):
                 )
 
         services_to_restart = set()
-        if self.middleware.call_sync('system.ready'):
-            services_to_restart.add('disk')
 
         if unlocked:
             if options['toggle_attachments']:

--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -83,24 +83,3 @@ class PoolDatasetService(Service):
                 await self.middleware.call('vm.start', vm['id'])
             except Exception:
                 self.logger.error('Failed to start %r VM after %r unlock', vm['name'], dataset['name'], exc_info=True)
-
-    @private
-    async def restart_services_after_unlock(self, dataset_name, services_to_restart):
-        try:
-            to_restart = [[i] for i in set(services_to_restart)]
-            if not to_restart:
-                return
-
-            restart_job = await self.middleware.call('core.bulk', 'service.restart', to_restart)
-            statuses = await restart_job.wait()
-            for idx, srv_status in enumerate(statuses):
-                if srv_status['error']:
-                    self.logger.error(
-                        'Failed to restart %r service after %r unlock: %s',
-                        to_restart[idx], dataset_name, srv_status['error']
-                    )
-        except Exception:
-            self.logger.error(
-                'Failed to restart %r services after %r unlock', ', '.join(services_to_restart), dataset_name,
-                exc_info=True,
-            )


### PR DESCRIPTION
This PR adds changes to remove `pool.dataset.restart_services_after_unlock` method and disk service usages as disk service no longer exists and was removed when collectd was removed from our product.