### PR TITLE
NAS-123741 / 23.10 / Fix disk service usage (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -286,8 +286,6 @@ class PoolDatasetService(Service):
                 )
 
         services_to_restart = set()
-        if self.middleware.call_sync('system.ready'):
-            services_to_restart.add('disk')
 
         if unlocked:
             if options['toggle_attachments']:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -285,8 +285,6 @@ class PoolDatasetService(Service):
                     f'{i + 1}) {ds!r}: {failed_datasets[ds]}' for i, ds in enumerate(failed_datasets)
                 )
 
-        services_to_restart = set()
-
         if unlocked:
             if options['toggle_attachments']:
                 job.set_progress(91, 'Handling attachments')
@@ -304,9 +302,6 @@ class PoolDatasetService(Service):
                 self.middleware.call_sync(
                     'pool.dataset.insert_or_update_encrypted_record', dataset_data(unlocked_dataset)
                 )
-
-            job.set_progress(93, 'Restarting services')
-            self.middleware.call_sync('pool.dataset.restart_services_after_unlock', id, services_to_restart)
 
             job.set_progress(94, 'Running post-unlock tasks')
             self.middleware.call_hook_sync(

--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -83,24 +83,3 @@ class PoolDatasetService(Service):
                 await self.middleware.call('vm.start', vm['id'])
             except Exception:
                 self.logger.error('Failed to start %r VM after %r unlock', vm['name'], dataset['name'], exc_info=True)
-
-    @private
-    async def restart_services_after_unlock(self, dataset_name, services_to_restart):
-        try:
-            to_restart = [[i] for i in set(services_to_restart)]
-            if not to_restart:
-                return
-
-            restart_job = await self.middleware.call('core.bulk', 'service.restart', to_restart)
-            statuses = await restart_job.wait()
-            for idx, srv_status in enumerate(statuses):
-                if srv_status['error']:
-                    self.logger.error(
-                        'Failed to restart %r service after %r unlock: %s',
-                        to_restart[idx], dataset_name, srv_status['error']
-                    )
-        except Exception:
-            self.logger.error(
-                'Failed to restart %r services after %r unlock', ', '.join(services_to_restart), dataset_name,
-                exc_info=True,
-            )


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x d424dd905aa29a4431ea940aa158a2d25127354b
    git cherry-pick -x f5ad14e26f4790b0e27fd3a39399821780f83f1f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 17d639b6442ad6b67f7d80eaf7590c30853ff3e0

This PR adds changes to remove `pool.dataset.restart_services_after_unlock` method and disk service usages as disk service no longer exists and was removed when collectd was removed from our product.

Original PR: https://github.com/truenas/middleware/pull/11957
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123741