### PR TITLE
NAS-123700 / 23.10 / strip trailing newline/whitespace on sshpubkey (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -191,13 +191,9 @@ class UserService(CRUDService):
 
     @private
     def _read_authorized_keys(self, homedir):
-        keysfile = f'{homedir}/.ssh/authorized_keys'
-        rv = None
         with suppress(FileNotFoundError):
-            with open(keysfile, 'r') as f:
-                rv = f.read()
-
-        return rv
+            with open(f'{homedir}/.ssh/authorized_keys') as f:
+                return f.read().strip()
 
     @private
     async def user_extend(self, user, ctx):

--- a/tests/api2/test_account_ssh_key.py
+++ b/tests/api2/test_account_ssh_key.py
@@ -25,7 +25,7 @@ def test_account_create_update_ssh_key_in_existing_dir():
                 "sshpubkey": "new",
             }) as u:
                 u = call("user.get_instance", u["id"])
-                assert u["sshpubkey"] == "new\n"
+                assert u["sshpubkey"] == "new"
 
 
 def test_account_update_ssh_key_and_set_homedir():
@@ -44,7 +44,7 @@ def test_account_update_ssh_key_and_set_homedir():
             })
 
             u = call("user.get_instance", u["id"])
-            assert u["sshpubkey"] == "new\n"
+            assert u["sshpubkey"] == "new"
 
 
 def test_account_sets_ssh_key_on_user_create():


### PR DESCRIPTION
Strip trailing newlines/whitespace in `user.query` for the `sshpubkey` attribute.

Original PR: https://github.com/truenas/middleware/pull/11963
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123700