### PR TITLE
NAS-123754 / 24.04 / Plumb mkdir operations through filesystem.mkdir

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -453,7 +453,7 @@ class UserService(CRUDService):
         if create:
             target = os.path.join(path, username)
             try:
-                os.mkdir(target, mode=int(mode, 8))
+                self.middleware.call_sync('filesystem.mkdir', path, {'mode': mode})
             except FileExistsError:
                 if not os.path.isdir(target):
                     raise CallError(
@@ -1405,7 +1405,7 @@ class UserService(CRUDService):
             return
 
         if not os.path.isdir(sshpath):
-            os.mkdir(sshpath, mode=0o700)
+            self.middleware.call_sync('filesystem.mkdir', sshpath, {'mode': '700'})
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')
 

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -16,7 +16,7 @@ from middlewared.event import EventSource
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 from middlewared.plugins.cluster_linux.utils import CTDBConfig, FuseConfig
 from middlewared.plugins.filesystem_ import chflags, dosmode, stat_x
-from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str
+from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str, UnixPerm
 from middlewared.service import private, CallError, filterable_returns, filterable, Service, job
 from middlewared.utils import filter_list
 from middlewared.utils.osc import getmntinfo
@@ -129,14 +129,22 @@ class FilesystemService(Service):
         mntinfo = getmntinfo()
         return filter_list(list(mntinfo.values()), filters, options)
 
-    @accepts(Str('path'), roles=['FILESYSTEM_DATA_WRITE'])
+    @accepts(
+        Str('path'),
+        Dict(
+            'options',
+            UnixPerm('mode', default='755'),
+        ),
+        roles=['FILESYSTEM_DATA_WRITE']
+    )
     @returns(Ref('path_entry'))
-    def mkdir(self, path):
+    def mkdir(self, path, options):
         """
         Create a directory at the specified path.
         """
         path = self.resolve_cluster_path(path)
         is_clustered = path.startswith("/cluster")
+        mode = int(options['mode'], 8)
 
         p = pathlib.Path(path)
         if not p.is_absolute():
@@ -149,9 +157,13 @@ class FilesystemService(Service):
         if not is_clustered and not realpath.startswith('/mnt/'):
             raise CallError(f'{path}: path not permitted', errno.EPERM)
 
-        os.mkdir(path)
+        os.mkdir(path, mode=mode)
         stat = p.stat()
-        data = {
+        if statlib.S_IMODE(stat.st_mode) != mode:
+            # This may happen if requested mode is greater than umask
+            os.chmod(path, mode)
+
+        return {
             'name': p.parts[-1],
             'path': path,
             'realpath': realpath,
@@ -161,9 +173,9 @@ class FilesystemService(Service):
             'acl': False if self.acl_is_trivial(path) else True,
             'uid': stat.st_uid,
             'gid': stat.st_gid,
+            'is_mountpoint': False,
+            'is_ctldir': False,
         }
-
-        return data
 
     @private
     def statx_entry_impl(self, entry, options=None):

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -4,6 +4,7 @@
 # License: BSD
 
 import pytest
+import stat
 import sys
 import os
 apifolder = os.getcwd()
@@ -380,3 +381,11 @@ def file_and_directory():
 def test_type_filter(file_and_directory, query, result):
     listdir = call("filesystem.listdir", f"/mnt/{file_and_directory}", query)
     assert {item["name"] for item in listdir} == result, listdir
+
+
+def test_mkdir_mode():
+    with dataset("test_mkdir_mode") as ds:
+        testdir = os.path.join("/mnt", ds, "testdir")
+        call("filesystem.mkdir", testdir, {'mode': '777'})
+        st = call("filesystem.stat", testdir)
+        assert stat.S_IMODE(st["mode"]) == 0o777


### PR DESCRIPTION
These specific calls to os.mkdir can be replaced by filesystem.mkdir API calls. This is to help standardize local filesystem access. Currently the filesystem.mkdir API lacks ability to specify mode when creating a file, but in this case it was deemed redundant since the mkdir operation is subsequently followed by a filesystem.setperm call.