### PR TITLE
NAS-123763 / 23.10 / fix edge-case crash in AddressMixin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
@@ -1,9 +1,10 @@
 import ipaddress
+import time
 
 from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkDumpInterrupted
 
 from middlewared.plugins.interface.netif_linux.utils import run
-
 from .ipv6 import ipv6_netmask_to_prefixlen
 from .types import AddressFamily, InterfaceAddress, LinkAddress
 
@@ -68,4 +69,16 @@ class AddressMixin:
 
     @property
     def addresses(self):
-        return self._get_addresses()
+        retries = 5
+        while True:
+            try:
+                return self._get_addresses()
+            except NetlinkDumpInterrupted:
+                # low-grade hardware can produce this which
+                # isn't necessarily fatal and the request
+                # should be retried
+                retries -= 1
+                if retries == 0:
+                    raise
+
+                time.sleep(0.2)


### PR DESCRIPTION
This same fix was already applied in our routing plugin but also needs to be applied here. This is considered an edge-case crash because we've only seen it twice in the wild. Checking upstream source implies that we should retry on this error since it's not considered fatal.

Original PR: https://github.com/truenas/middleware/pull/11974
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123763