### PR TITLE
NAS-123764 / 23.10 / Fix owner for authorized keys file (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1397,12 +1397,9 @@ class UserService(CRUDService):
         }).wait_sync(raise_error=True)
 
         with open(keysfile, 'w') as f:
-            f.write(pubkey)
-            f.write('\n')
-        self.middleware.call_sync('filesystem.setperm', {
-            'path': keysfile,
-            'mode': str(600)
-        }).wait_sync(raise_error=True)
+            os.fchmod(f.fileno(), 0o600)
+            os.fchown(f.fileno(), user['uid'], gid)
+            f.write(f'{pubkey}\n')
 
 
 class GroupModel(sa.Model):


### PR DESCRIPTION
The authorized keys file needs to be chowned to the newly-created user. Since this function is now synchronous and parent dir is guaranteed to be ACL-free, we can just use fchmod and fchown on it.

Original PR: https://github.com/truenas/middleware/pull/11973
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123764