### PR TITLE
Allow question mark through backend validation

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -838,16 +838,7 @@ class UserService(CRUDService):
                         errno.EEXIST,
                     )
 
-        password = data.get('password')
-        if password and '?' in password:
-            # See bug #4098
-            verrors.add(
-                f'{schema}.password',
-                'An SMB issue prevents creating passwords containing a '
-                'question mark (?).',
-                errno.EINVAL
-            )
-        elif not pk and not password and not data.get('password_disabled'):
+        if not pk and not password and not data.get('password_disabled'):
             verrors.add(f'{schema}.password', 'Password is required')
         elif data.get('password_disabled') and password:
             verrors.add(

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -838,6 +838,7 @@ class UserService(CRUDService):
                         errno.EEXIST,
                     )
 
+        password = data.get('password')
         if not pk and not password and not data.get('password_disabled'):
             verrors.add(f'{schema}.password', 'Password is required')
         elif data.get('password_disabled') and password:


### PR DESCRIPTION
There is no technical reason to prevent using question mark in an SMB password. This was requested by customer.