### PR TITLE
NAS-123755 / 23.10 / Collect disk temperature stats at 30 min intervals (by Qubad786)

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/smart_log.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/smart_log.chart.py
@@ -258,6 +258,9 @@ class Service(SimpleService):
         self.disks = list()
         self.runs = 0
         self.do_force_rescan = False
+        # smartd daemon only queries drive temps every 30mins so the files won't be updated
+        # but once every 30ish minutes - we should change this if at any point we change smartd interval
+        self.update_every = 30 * 60
 
     def check(self):
         return self.scan() > 0

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -42,12 +42,12 @@ class NetdataService(Service):
             return {}
 
     def calculated_metrics_count(self):
-        return sum(get_metrics_approximation(
+        return get_metrics_approximation(
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
             self.middleware.call_sync('zfs.pool.query', [], {'count': True}),
-        ).values())
+        )
 
     def get_disk_space(self):
         return calculate_disk_space_for_netdata(

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -5,14 +5,14 @@ import typing
 from .netdata.graph_base import GraphBase
 
 
-def calculate_disk_space_for_netdata(metrics: int, days: int) -> int:
+def calculate_disk_space_for_netdata(metric_intervals: dict, days: int) -> int:
     # Constants
     sec_per_day = 86400
-    points_per_metric_per_day = sec_per_day * days
     bytes_per_point = 1
-
-    # Calculate required disk space in bytes
-    required_disk_space_bytes = metrics * points_per_metric_per_day * bytes_per_point
+    required_disk_space_bytes = 0
+    for collection_interval_seconds, metrics in metric_intervals.items():
+        points_per_metric_per_day = (sec_per_day / collection_interval_seconds) * days
+        required_disk_space_bytes += metrics * points_per_metric_per_day * bytes_per_point
 
     # Convert bytes to megabytes (1 MB = 1024 * 1024 bytes)
     required_disk_space_mb = required_disk_space_bytes / (1024 * 1024)
@@ -44,94 +44,98 @@ async def fetch_data_from_graph_plugin(
 
 
 def get_metrics_approximation(disk_count: int, core_count: int, interface_count: int, pool_count: int) -> dict:
+    data = {
+        1: {
+            'system.cpu': 10,
+            'cpu.cpu': 10 * core_count,
+            'cpu.cpu0_cpuidle': 4 * core_count,
+            'cpu.cpufreq': core_count,
+            'system.intr': 1,
+            'system.ctxt': 1,
+            'system.forks': 1,
+            'system.processes': 2,
+            'zfs_state_pool': pool_count * 6,
+            'system.clock_sync_state': 1,
+            'system.clock_status': 2,
+            'system.clock_sync_offset': 1,
+
+            # diskstats
+            'system.io': 2,
+            'disk': 2 * disk_count,
+            'disk_ext': disk_count,
+            'disk_ops': 2 * disk_count,
+            'disk_ext_ops': 2 * disk_count,
+            'disk_backlog': disk_count,
+            'disk_busy': disk_count,
+            'disk_util': disk_count,
+            'disk_iotime': 2 * disk_count,
+            'disk_ext_iotime': 2 * disk_count,
+            'disk_svctm': 1 * disk_count,
+            'disk_qops': 2 * disk_count,
+            'disk_mops': 2 * disk_count,
+            'disk_ext_mops': disk_count,
+            'disk_avgsz': 2 * disk_count,
+            'disk_ext_avgsz': disk_count,
+            'disk_await': 2 * disk_count,
+            'disk_ext_await': 2 * disk_count,
+
+            # meminfo
+            'system.ram': 4,
+            'mem.available': 1,
+            'system.swap': 2,
+            'mem.committed': 1,
+            'mem.writeback': 5,
+            'mem.kernel': 5,
+            'mem.slab': 2,
+            'mem.transparent_hugepages': 2,
+
+            # net
+            'system.net': 2,
+            'net': 2 * interface_count,
+            'net_speed': interface_count,
+            'net_duplex': 3 * interface_count,
+            'net_operstate': 7 * interface_count,
+            'net_mtu': interface_count,
+            'net_packets': 3 * interface_count,
+            'net_drops': 2 * interface_count,
+            'net_carrier': 2 * interface_count,
+
+            # uptime
+            'system.uptime': 1,
+
+            # loadavg
+            'system.load': 3,
+            'system.active_processes': 1,
+
+            # zfs arcstats
+            'zfs.arc_size': 4,
+            'zfs.reads': 5,
+            'zfs.hits': 2,
+            'zfs.hits_rate': 2,
+            'zfs.dhits': 2,
+            'zfs.dhits_rate': 2,
+            'zfs.phits': 2,
+            'zfs.phits_rate': 2,
+            'zfs.mhits': 2,
+            'zfs.mhits_rate': 2,
+            'zfs.list_hits': 4,
+            'zfs.arc_size_breakdown': 2,
+            'zfs.important_ops': 4,
+            'zfs.actual_hits': 2,
+            'zfs.actual_hits_rate': 2,
+            'zfs.demand_data_hits': 2,
+            'zfs.demand_data_hits_rate': 2,
+            'zfs.prefetch_data_hits': 2,
+            'zfs.prefetch_data_hits_rate': 2,
+            'zfs.hash_elements': 2,
+            'zfs.hash_chains': 2,
+
+            # cputemp
+            'cputemp.temperatures': core_count,
+        },
+        1800: {  # smartd_logs
+            'smart_log.temperature_celsius': disk_count}
+    }
     return {
-        'system.cpu': 10,
-        'cpu.cpu': 10 * core_count,
-        'cpu.cpu0_cpuidle': 4 * core_count,
-        'cpu.cpufreq': core_count,
-        'system.intr': 1,
-        'system.ctxt': 1,
-        'system.forks': 1,
-        'system.processes': 2,
-        'zfs_state_pool': pool_count * 6,
-        'system.clock_sync_state': 1,
-        'system.clock_status': 2,
-        'system.clock_sync_offset': 1,
-
-        # diskstats
-        'system.io': 2,
-        'disk': 2 * disk_count,
-        'disk_ext': disk_count,
-        'disk_ops': 2 * disk_count,
-        'disk_ext_ops': 2 * disk_count,
-        'disk_backlog': disk_count,
-        'disk_busy': disk_count,
-        'disk_util': disk_count,
-        'disk_iotime': 2 * disk_count,
-        'disk_ext_iotime': 2 * disk_count,
-        'disk_svctm': 1 * disk_count,
-        'disk_qops': 2 * disk_count,
-        'disk_mops': 2 * disk_count,
-        'disk_ext_mops': disk_count,
-        'disk_avgsz': 2 * disk_count,
-        'disk_ext_avgsz': disk_count,
-        'disk_await': 2 * disk_count,
-        'disk_ext_await': 2 * disk_count,
-
-        # meminfo
-        'system.ram': 4,
-        'mem.available': 1,
-        'system.swap': 2,
-        'mem.committed': 1,
-        'mem.writeback': 5,
-        'mem.kernel': 5,
-        'mem.slab': 2,
-        'mem.transparent_hugepages': 2,
-
-        # net
-        'system.net': 2,
-        'net': 2 * interface_count,
-        'net_speed': interface_count,
-        'net_duplex': 3 * interface_count,
-        'net_operstate': 7 * interface_count,
-        'net_mtu': interface_count,
-        'net_packets': 3 * interface_count,
-        'net_drops': 2 * interface_count,
-        'net_carrier': 2 * interface_count,
-
-        # uptime
-        'system.uptime': 1,
-
-        # loadavg
-        'system.load': 3,
-        'system.active_processes': 1,
-
-        # zfs arcstats
-        'zfs.arc_size': 4,
-        'zfs.reads': 5,
-        'zfs.hits': 2,
-        'zfs.hits_rate': 2,
-        'zfs.dhits': 2,
-        'zfs.dhits_rate': 2,
-        'zfs.phits': 2,
-        'zfs.phits_rate': 2,
-        'zfs.mhits': 2,
-        'zfs.mhits_rate': 2,
-        'zfs.list_hits': 4,
-        'zfs.arc_size_breakdown': 2,
-        'zfs.important_ops': 4,
-        'zfs.actual_hits': 2,
-        'zfs.actual_hits_rate': 2,
-        'zfs.demand_data_hits': 2,
-        'zfs.demand_data_hits_rate': 2,
-        'zfs.prefetch_data_hits': 2,
-        'zfs.prefetch_data_hits_rate': 2,
-        'zfs.hash_elements': 2,
-        'zfs.hash_chains': 2,
-
-        # cputemp
-        'cputemp.temperatures': core_count,
-
-        # smartd_logs
-        'smart_log.temperature_celsius': disk_count,
+        sec: sum(d.values()) for sec, d in data.items()
     }

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -1,0 +1,24 @@
+import pytest
+
+from middlewared.plugins.reporting.utils import get_metrics_approximation, calculate_disk_space_for_netdata
+
+
+@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,expected_output', [
+    (4, 2, 1, 2, {1: 354, 1800: 4}),
+    (1600, 32, 4, 4, {1: 44001, 1800: 1600}),
+    (10, 16, 2, 2, {1: 761, 1800: 10}),
+])
+def test_netdata_metrics_count_approximation(disk_count, core_count, interface_count, pool_count, expected_output):
+    assert get_metrics_approximation(disk_count, core_count, interface_count, pool_count) == expected_output
+
+
+@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,days,expected_output', [
+    (4, 2, 1, 2, 7, 204),
+    (1600, 32, 4, 4, 4, 14502),
+    (10, 16, 2, 2, 3, 188),
+    (1600, 32, 4, 4, 18, 65261),
+])
+def test_netdata_disk_space_approximation(disk_count, core_count, interface_count, pool_count, days, expected_output):
+    assert calculate_disk_space_for_netdata(get_metrics_approximation(
+        disk_count, core_count, interface_count, pool_count
+    ), days) == expected_output


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4d0f2b0894cea383f7fdf06280e0739192596c2f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3d6089534ae02e747892fcfd8c774160c732f0d4

## Problem

Currently, smartd collects data at a 30-minute interval. However, our current data collection process from smartd involves allocating disk space for a 1-second interval. This mismatch between the collection intervals and disk space allocation intervals is causing excessive disk space allocation and unnecessarily cpu is being consumed as well.

## Solution

To address this, we need to adjust our data collection process to match the 30-minute interval used by smartd for data collection.

Original PR: https://github.com/truenas/middleware/pull/11964
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123755