### PR TITLE
NAS-123607 / 23.10 / Fix kubernetes passthrough test (by sonicaj)

### DIFF
--- a/tests/api2/test_25_kubernetes_passthrough_test.py
+++ b/tests/api2/test_25_kubernetes_passthrough_test.py
@@ -19,13 +19,14 @@ APP_NAME = 'syncthing'
 
 @pytest.mark.dependency(name='default_kubernetes_cluster')
 def test_01_default_kubernetes_cluster(request):
-    config = call('kubernetes.update', {'passthrough_mode': False, 'pool': pool_name}, job=True)
+    depends(request, ['setup_kubernetes'], scope='session')
+    config = call('kubernetes.config')
     assert config['passthrough_mode'] is False
 
 
 @pytest.mark.dependency(name='install_chart_release')
 def test_02_install_chart_release(request):
-    depends(request, ['setup_kubernetes', 'default_kubernetes_cluster'], scope='session')
+    depends(request, ['default_kubernetes_cluster'])
     payload = {'catalog': 'TRUENAS', 'item': 'syncthing', 'release_name': APP_NAME, 'train': 'charts'}
     call('chart.release.create', payload, job=True)
     assert call('chart.release.get_instance', APP_NAME)['name'] == APP_NAME

--- a/tests/api2/test_25_kubernetes_passthrough_test.py
+++ b/tests/api2/test_25_kubernetes_passthrough_test.py
@@ -25,7 +25,7 @@ def test_01_default_kubernetes_cluster(request):
 
 @pytest.mark.dependency(name='install_chart_release')
 def test_02_install_chart_release(request):
-    depends(request, ['default_kubernetes_cluster'])
+    depends(request, ['setup_kubernetes', 'default_kubernetes_cluster'], scope='session')
     payload = {'catalog': 'TRUENAS', 'item': 'syncthing', 'release_name': APP_NAME, 'train': 'charts'}
     call('chart.release.create', payload, job=True)
     assert call('chart.release.get_instance', APP_NAME)['name'] == APP_NAME


### PR DESCRIPTION
This PR adds changes to make sure we run the kubernetes passthrough test right after we have setup the cluster. Why this needs to be done is that after initial k8s tests are executed, we make network changes which are done in the testing framework which can result in temporary network failure in which if the cluster was downloading some images, that won't happen and cluster would not have initialized itself properly for the passthrough tests.

Original PR: https://github.com/truenas/middleware/pull/11986
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123607