### PR TITLE
NAS-123825 / 24.04 / call query_imported_fast_impl in disabled_reasons

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -1,6 +1,7 @@
 from middlewared.schema import accepts, returns, List, Str
 from middlewared.service import Service, pass_app, no_auth_required, private
 from middlewared.plugins.interface.netif import netif
+from middlewared.utils.zfs import query_imported_fast_impl
 
 
 class FailoverDisabledReasonsService(Service):
@@ -97,7 +98,7 @@ class FailoverDisabledReasonsService(Service):
             reasons.add('NO_VIP')
         elif master:
             fenced_running = self.middleware.call_sync('failover.fenced.run_info')['running']
-            num_of_zpools_imported = len(self.middleware.call_sync('zfs.pool.query_imported_fast'))
+            num_of_zpools_imported = len(query_imported_fast_impl())
             if num_of_zpools_imported > 1:
                 # boot pool is returned by default which is why we check > 1
                 if not fenced_running:


### PR DESCRIPTION
This method is in a hot-path on our HA systems. It's vitally important to be as efficient and as quick as possible here. By calling `query_imported_fast_impl`, it removes a call to our process pool which is an efficiency and speed boost.