### PR TITLE
NAS-123822 / 23.10 / Fix syslog-ng config generation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -127,8 +127,8 @@ def generate_syslog_conf(middleware):
         syslog_conf = RE_DESTINATION.sub(fr"{generate_svc_filters()}\n\1", f.read())
 
     for line in (
-        "filter f_daemon { facility(daemon) and not filter(f_debug); };",
-        "filter f_syslog3 { not facility(auth, authpriv, mail) and not filter(f_debug); };",
+        "filter f_daemon { facility(daemon) and not filter(f_dbg); };",
+        "filter f_syslog3 { not facility(auth, authpriv, mail) and not filter(f_dbg); };",
         "filter f_messages { level(info,notice,warn) and"
     ):
         syslog_conf = syslog_conf.replace(


### PR DESCRIPTION
The default syslog-ng config file changed and our replacement logic stopped working for f_syslog3 and f_daemon.

Original PR: https://github.com/truenas/middleware/pull/11994
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123822