### PR TITLE
NAS-123609 / 24.04 / Send pool.dataset.query events whenever create/update methods on dataset service are called

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -718,6 +718,7 @@ class PoolDatasetService(CRUDService):
             })
             await acl_job.wait(raise_error=True)
 
+        self.middleware.send_event('pool.query', 'ADDED', id=data['id'], fields=created_ds)
         return created_ds
 
     @accepts(Str('id', required=True), Patch(
@@ -864,7 +865,9 @@ class PoolDatasetService(CRUDService):
             # and if it is, resync it so the connected initiators can see the new size of the zvol
             await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id_)
 
-        return await self.get_instance(id_)
+        updated_ds = await self.get_instance(id_)
+        self.middleware.send_event('pool.query', 'CHANGED', id=id_, fields=updated_ds)
+        return updated_ds
 
     @accepts(Str('id'), Dict(
         'dataset_delete',


### PR DESCRIPTION
This PR adds changes to only set create/update events of zfs datasets whenever changes are made via our API instead of relying on ZFS events because when for example replicating, numerous zfs create/set events are raised which result in us trying to engage the process pool to get all the data related to the dataset which can become expensive and results in blocking tasks in the process pool.