### PR TITLE
NAS-123609 / 23.10-RC.1 / Send pool.dataset.query events whenever create/update methods on dataset service are called (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -718,6 +718,7 @@ class PoolDatasetService(CRUDService):
             })
             await acl_job.wait(raise_error=True)
 
+        self.middleware.send_event('pool.query', 'ADDED', id=data['id'], fields=created_ds)
         return created_ds
 
     @accepts(Str('id', required=True), Patch(
@@ -864,7 +865,9 @@ class PoolDatasetService(CRUDService):
             # and if it is, resync it so the connected initiators can see the new size of the zvol
             await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id)
 
-        return await self.get_instance(id)
+        updated_ds = await self.get_instance(id)
+        self.middleware.send_event('pool.query', 'CHANGED', id=id, fields=updated_ds)
+        return updated_ds
 
     @accepts(Str('id'), Dict(
         'dataset_delete',


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 385a24c8ecfedc69d95bf3a33d5667830d21981d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4860d63da6f32595785d9637079ed40fbd59915f

This PR adds changes to only set create/update events of zfs datasets whenever changes are made via our API instead of relying on ZFS events because when for example replicating, numerous zfs create/set events are raised which result in us trying to engage the process pool to get all the data related to the dataset which can become expensive and results in blocking tasks in the process pool.

Original PR: https://github.com/truenas/middleware/pull/12027
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123609