### PR TITLE
NAS-123890 / 23.10 / Fix event name when creating/updating dataset (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -718,7 +718,7 @@ class PoolDatasetService(CRUDService):
             })
             await acl_job.wait(raise_error=True)
 
-        self.middleware.send_event('pool.query', 'ADDED', id=data['id'], fields=created_ds)
+        self.middleware.send_event('pool.dataset.query', 'ADDED', id=data['id'], fields=created_ds)
         return created_ds
 
     @accepts(Str('id', required=True), Patch(
@@ -866,7 +866,7 @@ class PoolDatasetService(CRUDService):
             await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id)
 
         updated_ds = await self.get_instance(id)
-        self.middleware.send_event('pool.query', 'CHANGED', id=id, fields=updated_ds)
+        self.middleware.send_event('pool.dataset.query', 'CHANGED', id=id, fields=updated_ds)
         return updated_ds
 
     @accepts(Str('id'), Dict(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 485036e26075af5796b75ee56914b7f53990a065

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4717cbc4560a0a1e47acff5faf4bbff327f7a55a



Original PR: https://github.com/truenas/middleware/pull/12031
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123890