### PR TITLE
NAS-123611 / 24.04 / add enclosure2.set_slot_status

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -3,11 +3,15 @@ import pathlib
 from pyudev import Context
 
 from libsg3.ses import EnclosureDevice
+from middlewared.schema import accepts, Dict, Str, Int
 from middlewared.service import Service, filterable
+from middlewared.service_exception import MatchNotFound, ValidationError
 from middlewared.utils import filter_list
 from .enclosure_class import Enclosure
 from .map2 import map_enclosures
 from .nvme2 import map_nvme
+from .r30_drive_identify import set_slot_status as r30_set_slot_status
+from .fseries_drive_identify import set_slot_status as fseries_set_slot_status
 
 
 class Enclosure2Service(Service):
@@ -72,6 +76,70 @@ class Enclosure2Service(Service):
         which includes the head-unit and all attached JBODs.
         """
         return map_nvme(self.middleware.call_sync('system.dmidecode_info')['system-product-name'])
+
+    def get_original_disk_slot(self, slot, enc_info):
+        """Get the original slot based on the `slot` passed to us via the end-user.
+        NOTE: Most drives original slot will match their "mapped" slot because there
+        is no need to map them. We always include an "original" slot key for all
+        enclosures as to keep this for loop as simple as possible and it also allows
+        more flexbiility when we do get an enclosure that maps drives differently.
+        (i.e. the ES102S is a prime example of this (enumerates drives at 1 instead of 0))
+        """
+        sgdev = origslot = None
+        for encslot, devinfo in filter(lambda x: x[0] == slot, enc_info['elements']['Array Device Slot'].items()):
+            sgdev = devinfo['original']['enclosure_sg']
+            origslot = devinfo['original']['slot']
+
+        return sgdev, origslot
+
+    @accepts(Dict(
+        Str('enclosure_id', required=True),
+        Int('slot', required=True),
+        Str('status', required=True, enum=['CLEAR', 'IDENT', 'FAULT'])
+    ))
+    def set_slot_status(self, data):
+        """Set enclosure bay number `slot` to `status` for `enclosure_id`.
+
+        `enclosure_id` str: represents the enclosure logical identifier of the enclosure
+        `slot` int: the enclosure drive bay number to send the status command
+        `status` str: the status for which to send to the command
+        """
+        try:
+            enc_info = self.middleware.call_sync(
+                'enclosure2.query', [['id', '=', data['enclosure_id']]], {'get': True}
+            )
+        except MatchNotFound:
+            raise ValidationError('enclosure2.set_slot_status', f'Enclosure with id: {data["enclosure_id"]} not found')
+
+        if enc_info['id'].endswith('_nvme_enclosure'):
+            if enc_info['id'].startswith('r30'):
+                # an all nvme flash system so drive identification is handled
+                # in a completely different way than sata/scsi
+                return r30_set_slot_status(data['slot'], data['status'])
+            elif enc_info['id'].startswith(('f60', 'f100', 'f130')):
+                return fseries_set_slot_status(data['slot'], data['status'])
+            else:
+                # mseries, and some rseries have mapped nvme enclosures but they
+                # don't support drive LED identification
+                return
+
+        sgdev, origslot = self.get_original_disk_slot(data['slot'], enc_info)
+        if sgdev is None:
+            raise ValidationError('enclosure2.set_slot_status', 'Unable to find scsi generic device for enclosure')
+        elif origslot is None:
+            raise ValidationError('enclosure2.set_slot_status', f'Slot {data["slot"]!r} not found in enclosure')
+
+        if data['status'] == 'CLEAR':
+            actions = ('clear=ident', 'clear=fault')
+        else:
+            actions = (f'set={data["status"].lower()}')
+
+        encdev = Enclosure(sgdev)
+        try:
+            for action in actions:
+                encdev.set_control(str(origslot), action)
+        except OSError:
+            self.logger.warning('Failed to {data["status"]} slot {data["slot"]!r} on enclosure {enc_info["id"]}')
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -84,10 +84,10 @@ class Enclosure:
             else:
                 try:
                     dev = next((i / 'device/block').iterdir(), None)
-                    mapping[slot] = dev.name if dev is not None else ''
+                    mapping[slot] = dev.name if dev is not None else None
                 except FileNotFoundError:
                     # no disk in this slot
-                    mapping[slot] = ''
+                    mapping[slot] = None
         try:
             # we have a single enclosure (at time of writing this) that enumerates
             # sysfs drive slots starting at number 1 while every other JBOD
@@ -151,15 +151,17 @@ class Enclosure:
                 'value_raw': value_raw,
             }}
             if element_type[0] == 'Array Device Slot':
-                parsed[slot]['dev'] = None
                 # see docstring in `self._map_disks_to_enclosure_slots` for
-                # why we have to get the min_slot (i.e. at time of writing
-                # this the ES102S JBOD enumerates drives starting at 1 instead
-                # of 0 (which is literally how every other single enclosure we
-                # use enumerates them)) We should always start drive slots at 1.
+                # why we have to get the min_slot
                 orig_slot = slot - 1 if min_slot == 0 else slot
-                if (disk_dev := disk_map.get(orig_slot, False)):
-                    parsed[slot]['dev'] = disk_dev
+                parsed[slot]['dev'] = disk_map.get(orig_slot, None)
+                parsed[slot]['original'] = {
+                    'enclosure_id': self.encid,
+                    'enclosure_sg': self.sg,
+                    'enclosure_bsg': self.bsg,
+                    'descriptor': f'slot{orig_slot}',
+                    'slot': orig_slot,
+                }
 
             final[element_type[0]].update(parsed)
 

--- a/src/middlewared/middlewared/plugins/enclosure_/identification.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/identification.py
@@ -6,13 +6,13 @@ def r20_variants_or_mini(model, dmi):
     NOTE: this information is burned in by the production team
     into the motherboard (SMBIOS) before we ship the system
     """
-    if dmi in ['TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B']:
-        return model
+    if dmi in ('TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B'):
+        return model, True
     elif dmi.startswith(('TRUENAS-MINI', 'FREENAS-MINI')):
         # minis do not have the TRUENAS- prefix removed
-        return dmi
+        return dmi, True
     else:
-        return ''
+        return '', False
 
 
 def get_enclosure_model_and_controller(key, dmi):
@@ -35,12 +35,12 @@ def get_enclosure_model_and_controller(key, dmi):
         case 'iX_FS1' | 'iX_FS2' | 'iX_DSS212Sp' | 'iX_DSS212Ss':
             # more R series
             return model, True
-        case 'iX_TrueNAS R20p' | 'iX_TrueNAS 20212Sp' | 'iX_TrueNAS SMC SC826-P':
+        case 'iX_TrueNAS R20p' | 'iX_TrueNAS 2012Sp' | 'iX_TrueNAS SMC SC826-P':
             # R20
             return model, True
         case 'AHCI_SGPIOEnclosure':
             # R20 variants or MINIs
-            return r20_variants_or_mini(model, dmi), True
+            return r20_variants_or_mini(model, dmi)
         case 'iX_eDrawer4048S1' | 'iX_eDrawer4048S2':
             # R50
             return model, True
@@ -56,7 +56,7 @@ def get_enclosure_model_and_controller(key, dmi):
             return 'ES12', False
         case 'ECStream_4024J' | 'iX_4024J':
             return 'ES24', False
-        case 'ECStream_2024Jp' | 'ECStream_2024Js':
+        case 'ECStream_2024Jp' | 'ECStream_2024Js' | 'iX_2024Jp' | 'iX_2024Js':
             return 'ES24F', False
         case 'CELESTIC_R0904':
             return 'ES60', False

--- a/src/middlewared/middlewared/plugins/enclosure_/identification.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/identification.py
@@ -1,4 +1,4 @@
-def r20_variants_or_mini(pr, pnr, dmi):
+def r20_variants_or_mini(model, dmi):
     """If this is an r20 variant then we return the model
     with the TRUENAS- suffix stripped. Otherwise, if this is
     a MINI then we just return the entire string.
@@ -7,12 +7,12 @@ def r20_variants_or_mini(pr, pnr, dmi):
     into the motherboard (SMBIOS) before we ship the system
     """
     if dmi in ['TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B']:
-        return pr, True
+        return model
     elif dmi.startswith(('TRUENAS-MINI', 'FREENAS-MINI')):
         # minis do not have the TRUENAS- prefix removed
-        return pnr, True
+        return dmi
     else:
-        return '', False
+        return ''
 
 
 def get_enclosure_model_and_controller(key, dmi):
@@ -20,54 +20,51 @@ def get_enclosure_model_and_controller(key, dmi):
     the 'key' is the concatenated string of t10 vendor and product
     info returned by a standard INQUIRY command to the enclosure
     device.
-
-    NOTE: If the key doesn't exist in this dictionary then we're
-    not going to properly map the enclosure.
     """
-    pr, pnr = dmi.replace('TRUENAS-', ''), dmi
-    try:
-        return {
+    model = dmi.removeprefix('TRUENAS-').removesuffix('-HA')
+    match key:
+        case 'ECStream_4024Sp' | 'ECStream_4024Ss' | 'iX_4024Sp' | 'iX_4024Ss':
             # M series
-            'ECStream_4024Sp': ('M Series', True),
-            'ECStream_4024Ss': ('M Series', True),
-            'iX_4024Sp': ('M Series', True),
-            'iX_4024Ss': ('M Series', True),
+            return model, True
+        case 'CELESTIC_P3215-O' | 'CELESTIC_P3217-B':
             # X series
-            'CELESTIC_P3215-O': ('X Series', True),
-            'CELESTIC_P3217-B': ('X Series', True),
-            # R series (just uses dmi info for model)
-            'ECStream_FS1': (pr, True),
-            'ECStream_FS2': (pr, True),
-            'ECStream_DSS212Sp': (pr, True),
-            'ECStream_DSS212Ss': (pr, True),
-            'iX_FS1': (pr, True),
-            'iX_FS2': (pr, True),
-            'iX_DSS212Sp': (pr, True),
-            'iX_DSS212Ss': (pr, True),
+            return model, True
+        case 'ECStream_FS1' | 'ECStream_FS2' | 'ECStream_DSS212Sp' | 'ECStream_DSS212Ss':
+            # R series
+            return model, True
+        case 'iX_FS1' | 'iX_FS2' | 'iX_DSS212Sp' | 'iX_DSS212Ss':
+            # more R series
+            return model, True
+        case 'iX_TrueNAS R20p' | 'iX_TrueNAS 20212Sp' | 'iX_TrueNAS SMC SC826-P':
             # R20
-            'iX_TrueNAS R20p': (pr, True),
-            'iX_TrueNAS 2012Sp': (pr, True),
-            'iX_TrueNAS SMC SC826-P': (pr, True),
-            # R20 variants
-            'AHCI_SGPIOEnclosure': r20_variants_or_mini(pr, pnr, dmi),
+            return model, True
+        case 'AHCI_SGPIOEnclosure':
+            # R20 variants or MINIs
+            return r20_variants_or_mini(model, dmi), True
+        case 'iX_eDrawer4048S1' | 'iX_eDrawer4048S2':
             # R50
-            'iX_eDrawer4048S1': (pr, True),
-            'iX_eDrawer4048S2': (pr, True),
-            # JBODS
-            'ECStream_3U16RJ-AC.r3': ('E16', False),
-            'Storage_1729': ('E24', False),
-            'QUANTA _JB9 SIM': ('E60', False),
-            'CELESTIC_X2012': ('ES12', False),
-            'ECStream_4024J': ('ES24', False),
-            'iX_4024J': ('ES24', False),
-            'ECStream_2024Jp': ('ES24F', False),
-            'ECStream_2024Js': ('ES24F', False),
-            'iX_2024Jp': ('ES24F', False),
-            'iX_2024Js': ('ES24F', False),
-            'CELESTIC_R0904': ('ES60', False),
-            'HGST_H4060-J': ('ES60G2', False),
-            'HGST_H4102-J': ('ES102', False),
-            'VikingES_NDS-41022-BB': ('ES102S', False),
-        }[key]
-    except KeyError:
-        return '', False
+            return model, True
+
+        # JBODS
+        case 'ECStream_3U16RJ-AC.r3':
+            return 'E16', False
+        case 'Storage_1729':
+            return 'E24', False
+        case 'QUANTA _JB9 SIM':
+            return 'E60', False
+        case 'CELESTIC_X2012':
+            return 'ES12', False
+        case 'ECStream_4024J' | 'iX_4024J':
+            return 'ES24', False
+        case 'ECStream_2024Jp' | 'ECStream_2024Js':
+            return 'ES24F', False
+        case 'CELESTIC_R0904':
+            return 'ES60', False
+        case 'HGST_H4060-J':
+            return 'ES60G2', False
+        case 'HGST_H4102-J':
+            return 'ES102', False
+        case 'VikingES_NDS-41022-BB':
+            return 'ES102S', False
+        case _:
+            return '', False

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -400,31 +400,32 @@ def get_mapping_info(dmi, enclosures=None):
     are not physically present where all the other disks
     are. We still need to map them to slots on the enclosure.
     """
+    mapping = {
+        'TRUENAS-R10': 'R10',
+        'TRUENAS-R20': 'R20',
+        'TRUENAS-R20A': 'R20A',
+        'TRUENAS-R20B': 'R20B',
+        'TRUENAS-R40': 'R40',
+        'TRUENAS-R50': 'R50',
+        'r50_nvme_enclosure': 'R50',
+        'TRUENAS-R50B': 'R50B',
+        'r50b_nvme_enclosure': 'R50B',
+        'TRUENAS-R50BM': 'R50BM',
+        'r50bm_nvme_enclosure': 'R50BM',
+        'TRUENAS-MINI-3.0-E': 'MINI-3.0-E',
+        'FREENAS-MINI-3.0-E': 'MINI-3.0-E',
+        'TRUENAS-MINI-3.0-E+': 'MINI-3.0-E+',
+        'FREENAS-MINI-3.0-E+': 'MINI-3.0-E+',
+        'TRUENAS-MINI-3.0-X': 'MINI-3.0-X',
+        'FREENAS-MINI-3.0-X': 'MINI-3.0-X',
+        'TRUENAS-MINI-3.0-X+': 'MINI-3.0-X+',
+        'FREENAS-MINI-3.0-X+': 'MINI-3.0-X+',
+        'TRUENAS-MINI-3.0-XL+': 'MINI-3.0-XL+',
+        'FREENAS-MINI-3.0-XL+': 'MINI-3.0-XL+',
+        'TRUENAS-MINI-R': 'MINI-R',
+        'FREENAS-MINI-R': 'MINI-R'
+    }
     try:
-        return {
-            'TRUENAS-R10': get_slot_info('R10'),
-            'TRUENAS-R20': get_slot_info('R20'),
-            'TRUENAS-R20A': get_slot_info('R20A'),
-            'TRUENAS-R20B': get_slot_info('R20B'),
-            'TRUENAS-R40': get_slot_info('R40', enclosures),
-            'TRUENAS-R50': get_slot_info('R50'),
-            'r50_nvme_enclosure': get_slot_info('R50'),
-            'TRUENAS-R50B': get_slot_info('R50B'),
-            'r50b_nvme_enclosure': get_slot_info('R50B'),
-            'TRUENAS-R50BM': get_slot_info('R50BM'),
-            'r50bm_nvme_enclosure': get_slot_info('R50BM'),
-            'TRUENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
-            'FREENAS-MINI-3.0-E': get_slot_info('MINI-3.0-E'),
-            'TRUENAS-MINI-3.0-E+': get_slot_info('MINI-3.0-E+'),
-            'FREENAS-MINI-3.0-E+': get_slot_info('MINI-3.0-E+'),
-            'TRUENAS-MINI-3.0-X': get_slot_info('MINI-3.0-X'),
-            'FREENAS-MINI-3.0-X': get_slot_info('MINI-3.0-X'),
-            'TRUENAS-MINI-3.0-X+': get_slot_info('MINI-3.0-X+'),
-            'FREENAS-MINI-3.0-X+': get_slot_info('MINI-3.0-X+'),
-            'TRUENAS-MINI-3.0-XL+': get_slot_info('MINI-3.0-XL+'),
-            'FREENAS-MINI-3.0-XL+': get_slot_info('MINI-3.0-XL+'),
-            'TRUENAS-MINI-R': get_slot_info('MINI-R'),
-            'FREENAS-MINI-R': get_slot_info('MINI-R')
-        }[dmi]
+        get_slot_info(mapping[dmi], enclosures)
     except KeyError:
         pass

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
@@ -5,13 +5,13 @@ from middlewared.plugins.enclosure_ import identification
 
 @pytest.mark.parametrize('data', [
     # M series
-    ('ECStream_4024Sp', 'TRUENAS-M40', ('M Series', True)),
-    ('ECStream_4024Ss', 'TRUENAS-M40', ('M Series', True)),
-    ('iX_4024Sp', 'TRUENAS-M40', ('M Series', True)),
-    ('iX_4024Ss', 'TRUENAS-M40', ('M Series', True)),
+    ('ECStream_4024Sp', 'TRUENAS-M40', ('M40', True)),
+    ('ECStream_4024Ss', 'TRUENAS-M40', ('M40', True)),
+    ('iX_4024Sp', 'TRUENAS-M40', ('M40', True)),
+    ('iX_4024Ss', 'TRUENAS-M40', ('M40', True)),
     # X series
-    ('CELESTIC_P3215-O', 'TRUENAS-X20', ('X Series', True)),
-    ('CELESTIC_P3217-B', 'TRUENAS-X20', ('X Series', True)),
+    ('CELESTIC_P3215-O', 'TRUENAS-X20', ('X20', True)),
+    ('CELESTIC_P3217-B', 'TRUENAS-X20', ('X20', True)),
     # R series (just uses dmi info for model)
     ('ECStream_FS1', 'TRUENAS-R10', ('R10', True)),
     ('ECStream_FS2', 'TRUENAS-R20', ('R20', True)),


### PR DESCRIPTION
This adds `enclosure2.set_slot_status` to the new enclosure plugin. This code isn't called anywhere but has been tested on real hardware to ensure it doesn't crash. This also fixes a crash in `slot_mappings.py` that was occurring on m-series systems for the rear nvme enclosure mapping code.