### PR TITLE
NAS-123782 / 23.10 / Update default recordsize for draid pool based datasets/zvols (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -578,6 +578,9 @@ class PoolService(CRUDService):
             **encryption_dict
         }
 
+        if any(topology['type'].startswith('DRAID') for topology in data['topology']['data']):
+            fsoptions['recordsize'] = '1M'
+
         dedup = data.get('deduplication')
         if dedup:
             fsoptions['dedup'] = dedup.lower()
@@ -745,3 +748,11 @@ class PoolService(CRUDService):
         verrors.check()
 
         return True
+
+    @private
+    async def is_draid_pool(self, pool_name):
+        if pool := await self.middleware.call('zfs.pool.query', [['name', '=', pool_name]]):
+            if any(group['type'] == 'draid' for group in pool[0]['groups']['data']):
+                return True
+
+        return False

--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -24,6 +24,18 @@ ZFS_ENCRYPTION_ALGORITHM_CHOICES = [
     'AES-128-CCM', 'AES-192-CCM', 'AES-256-CCM', 'AES-128-GCM', 'AES-192-GCM', 'AES-256-GCM'
 ]
 ZFS_MAX_DATASET_NAME_LEN = 200  # It's really 256, but we should leave some space for snapshot names
+ZFS_VOLUME_BLOCK_SIZE_CHOICES = {
+    '512': 512,
+    '512B': 512,
+    '1K': 1024,
+    '2K': 2048,
+    '4K': 4096,
+    '8K': 8192,
+    '16K': 16384,
+    '32K': 32768,
+    '64K': 65536,
+    '128K': 131072,
+}
 ZPOOL_CACHE_FILE = '/data/zfs/zpool.cache'
 ZPOOL_KILLCACHE = '/data/zfs/killcache'
 

--- a/tests/api2/test_draid_record_and_block_size.py
+++ b/tests/api2/test_draid_record_and_block_size.py
@@ -1,0 +1,177 @@
+import pytest
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call
+
+
+if len(call('disk.get_unused')) < 2:
+    pytest.skip('Insufficient number of disk to perform these test')
+
+
+@pytest.fixture(scope='module')
+def draid_pool():
+    unused_disks = call('disk.get_unused')
+    with another_pool({
+        'name': 'test_draid_pool',
+        'topology': {
+            'data': [{
+                'disks': [disk['name'] for disk in unused_disks[:2]],
+                'type': 'DRAID1',
+                'draid_data_disks': 1
+            }],
+        },
+        'allow_duplicate_serials': True,
+    }) as pool_name:
+        yield pool_name
+
+
+@pytest.fixture(scope='module')
+def mirror_pool():
+    unused_disks = call('disk.get_unused')
+    with another_pool({
+        'name': 'test_mirror_pool',
+        'topology': {
+            'data': [{
+                'disks': [disk['name'] for disk in unused_disks[:2]],
+                'type': 'MIRROR',
+            }],
+        },
+        'allow_duplicate_serials': True,
+    }) as pool_name:
+        yield pool_name
+
+
+@pytest.mark.parametrize(
+    'record_size', ['1M']
+)
+def test_draid_pool_default_record_size(draid_pool, record_size):
+    assert call('pool.dataset.get_instance', draid_pool['name'])['recordsize']['value'] == record_size
+
+
+@pytest.mark.parametrize(
+    'record_size', ['128K']
+)
+def test_non_draid_pool_default_record_size(mirror_pool, record_size):
+    assert call('pool.dataset.get_instance', mirror_pool['name'])['recordsize']['value'] == record_size
+
+
+@pytest.mark.parametrize(
+    'update_recordsize, validation_error', [
+        ('512K', False),
+        ('256K', False),
+        ('128K', False),
+        ('2M', False),
+        ('512', True),
+        ('4K', True),
+        ('64K', True),
+    ]
+)
+def test_draid_root_dataset_valid_recordsize(draid_pool, update_recordsize, validation_error):
+    if not validation_error:
+        assert call(
+            'pool.dataset.update', draid_pool['name'], {'recordsize': update_recordsize}
+        )['recordsize']['value'] == update_recordsize
+    else:
+        with pytest.raises(ValidationErrors) as ve:
+            call('pool.dataset.update', draid_pool['name'], {'recordsize': update_recordsize})
+
+        assert ve.value.errors[0].attribute == 'pool_dataset_update.recordsize'
+        assert ve.value.errors[0].errmsg == f"'{update_recordsize}' is an invalid recordsize."
+
+
+@pytest.mark.parametrize(
+    'update_recordsize', ['512K', '256K', '128K', '2M', '512', '4K', '64K']
+)
+def test_non_draid_root_dataset_valid_recordsize(mirror_pool, update_recordsize):
+    assert call(
+        'pool.dataset.update', mirror_pool['name'], {'recordsize': update_recordsize}
+    )['recordsize']['value'] == update_recordsize
+
+
+@pytest.mark.parametrize(
+    'recordsize, validation_error', [
+        ('512K', False),
+        ('256K', False),
+        ('128K', False),
+        ('2M', False),
+        ('512', True),
+        ('4K', True),
+        ('64K', True),
+    ]
+)
+def test_draid_dataset_valid_recordsize(draid_pool, recordsize, validation_error):
+    if not validation_error:
+        assert call(
+            'pool.dataset.create', {'name': f'{draid_pool["name"]}/test_dataset_{recordsize}', 'recordsize': recordsize}
+        )['recordsize']['value'] == recordsize
+    else:
+        with pytest.raises(ValidationErrors) as ve:
+            call('pool.dataset.create', {'name': f'{draid_pool["name"]}/test_dataset_{recordsize}',
+                                         'recordsize': recordsize})
+
+        assert ve.value.errors[0].attribute == 'pool_dataset_create.recordsize'
+        assert ve.value.errors[0].errmsg == f"'{recordsize}' is an invalid recordsize."
+
+
+@pytest.mark.parametrize(
+    'recordsize', ['512K', '256K', '128K', '2M', '512', '4K', '64K']
+)
+def test_non_draid_dataset_valid_recordsize(mirror_pool, recordsize):
+    assert call(
+        'pool.dataset.create', {'name': f'{mirror_pool["name"]}/test_dataset_{recordsize}', 'recordsize': recordsize}
+    )['recordsize']['value'] == recordsize
+
+
+@pytest.mark.parametrize(
+    'blocksize,validation_error', [
+        ('16K', True),
+        ('32K', False),
+    ]
+)
+def test_draid_zvol_valid_blocksize(draid_pool, blocksize, validation_error):
+    if not validation_error:
+        assert call(
+            'pool.dataset.create', {
+                'name': f'{draid_pool["name"]}/test_dataset_{blocksize}', 'volsize': 268468224,
+                'volblocksize': blocksize, 'type': 'VOLUME',
+            }
+        )['volblocksize']['value'] == blocksize
+    else:
+        with pytest.raises(ValidationErrors) as ve:
+            call(
+                'pool.dataset.create', {
+                    'name': f'{draid_pool["name"]}/test_dataset_{blocksize}', 'volsize': 268468224,
+                    'volblocksize': blocksize, 'type': 'VOLUME'
+                }
+            )
+
+        assert ve.value.errors[0].attribute == 'pool_dataset_create.volblocksize'
+        assert ve.value.errors[0].errmsg == 'Volume block size must be greater than or equal to 32K for dRAID pools'
+
+
+@pytest.mark.parametrize(
+    'blocksize', ['16K', '32K']
+)
+def test_non_draid_zvol_valid_blocksize(mirror_pool, blocksize):
+    assert call(
+        'pool.dataset.create', {
+            'name': f'{mirror_pool["name"]}/test_dataset_{blocksize}', 'volsize': 268468224,
+            'volblocksize': blocksize, 'type': 'VOLUME',
+        }
+    )['volblocksize']['value'] == blocksize
+
+
+@pytest.mark.parametrize(
+    'update_recordsize, default_record_size', [
+        ('512K', '1M'),
+    ]
+)
+def test_draid_dataset_default_recordsize(draid_pool, update_recordsize, default_record_size):
+    assert call(
+        'pool.dataset.update', draid_pool['name'], {'recordsize': update_recordsize}
+    )['recordsize']['value'] == update_recordsize
+
+    assert call(
+        'pool.dataset.create', {'name': f'{draid_pool["name"]}/test_dataset'}
+    )['recordsize']['value'] == default_record_size


### PR DESCRIPTION
## Context

A request was made to redefine default values and minimum values for recordsize/volblocksize attrs of a dataest/zvol for draid based pools.

Original PR: https://github.com/truenas/middleware/pull/12026
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123782