### PR TITLE
NAS-123960 / 24.04 / Add ability to convert mountinfo to tree

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
@@ -1,3 +1,4 @@
+import pytest
 from middlewared.utils.osc.linux.mount import __parse_to_dev, __parse_to_mnt_id, __create_tree
 
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
@@ -165,3 +165,14 @@ def test__mountinfo_tree():
     root = root['children'][0]
     assert root['mount_source'] == 'dozer/administrative_share/backups_dataset/userdata/DOMAIN_GOAT/bob'
     assert len(root['children']) == 0, str(root)
+
+
+def test__mountinfo_tree_miss():
+    data = {}
+    for line in fake_mntinfo.splitlines():
+        __parse_to_mnt_id(line, data)
+
+    with pytest.raises(KeyError) as e:
+        root = __create_tree(data, 8675309)
+
+    assert 'device not in mountinfo' in str(e), str(e)

--- a/src/middlewared/middlewared/utils/osc/linux/mount.py
+++ b/src/middlewared/middlewared/utils/osc/linux/mount.py
@@ -62,6 +62,9 @@ def __create_tree(info, dev_id):
         else:
             parent['children'].append(entry)
 
+    if dev_id and not mount_id:
+        raise KeyError(f'{dev_id}: device not in mountinfo')
+
     return info[mount_id or root_id]
 
 
@@ -89,11 +92,9 @@ def getmntinfo(dev_id=None):
     User can optionally specify dev_t for faster lookup of single
     device.
     """
-    out = {}
-
-    __iter_mountinfo(dev_id, __parse_to_dev, out)
-
-    return out
+    info = {}
+    __iter_mountinfo(dev_id, __parse_to_dev, info)
+    return info
 
 
 def getmnttree(dev_id=None):

--- a/src/middlewared/middlewared/utils/osc/linux/mount.py
+++ b/src/middlewared/middlewared/utils/osc/linux/mount.py
@@ -4,16 +4,17 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["getmntinfo"]
+__all__ = ["getmntinfo", "getmnttree"]
 
 
-def __parse_mntent(line, out_dict):
+def __mntent_dict(line):
     mnt_id, parent_id, maj_min, root, mp, opts, extra = line.split(" ", 6)
     fstype, mnt_src, super_opts = extra.split(' - ')[1].split()
 
     major, minor = maj_min.split(':')
     devid = os.makedev(int(major), int(minor))
-    out_dict.update({devid: {
+
+    return {
         'mount_id': int(mnt_id),
         'parent_id': int(parent_id),
         'device_id': {
@@ -27,7 +28,59 @@ def __parse_mntent(line, out_dict):
         'fs_type': fstype,
         'mount_source': mnt_src.replace('\\040', ' '),
         'super_opts': super_opts.upper().split(','),
-    }})
+    }
+
+
+def __parse_to_dev(line, out_dict):
+    entry = __mntent_dict(line)
+    out_dict.update({entry['device_id']['dev_t']: entry})
+
+
+def __parse_to_mnt_id(line, out_dict):
+    entry = __mntent_dict(line)
+    out_dict.update({entry['mount_id']: entry})
+
+
+def __create_tree(info, dev_id):
+    root_id = None
+    mount_id = None
+
+    for entry in info.values():
+        if not entry.get('children'):
+            entry['children'] = []
+
+        if entry['parent_id'] == 1:
+            root_id = entry['mount_id']
+            continue
+
+        if entry['device_id']['dev_t'] == dev_id:
+            mount_id = entry['mount_id']
+
+        parent = info[entry['parent_id']]
+        if not parent.get('children'):
+            parent['children'] = [entry]
+        else:
+            parent['children'].append(entry)
+
+    return info[mount_id or root_id]
+
+
+def __iter_mountinfo(dev_id=None, callback=None, private_data=None):
+    if dev_id:
+        maj_min = f'{os.major(dev_id)}:{os.minor(dev_id)}'
+    else:
+        maj_min = None
+
+    with open('/proc/self/mountinfo') as f:
+        for line in f:
+            if maj_min:
+                if line.find(maj_min) == -1:
+                    continue
+
+                callback(line, private_data)
+                break
+
+            callback(line, private_data)
 
 
 def getmntinfo(dev_id=None):
@@ -36,21 +89,18 @@ def getmntinfo(dev_id=None):
     User can optionally specify dev_t for faster lookup of single
     device.
     """
-    if dev_id:
-        maj_min = f'{os.major(dev_id)}:{os.minor(dev_id)}'
-    else:
-        maj_min = None
-
     out = {}
-    with open('/proc/self/mountinfo') as f:
-        for line in f:
-            if maj_min:
-                if line.find(maj_min) == -1:
-                    continue
 
-                __parse_mntent(line, out)
-                break
-
-            __parse_mntent(line, out)
+    __iter_mountinfo(dev_id, __parse_to_dev, out)
 
     return out
+
+
+def getmnttree(dev_id=None):
+    """
+    Generate a mount info tree of either the root filesystem
+    or a given filesystem specified by dev_t.
+    """
+    info = {}
+    __iter_mountinfo(None, __parse_to_mnt_id, info)
+    return __create_tree(info, dev_id)


### PR DESCRIPTION
This provides validated method of generating tree for checking whether unexpected filesystems or ZFS dataset parameters are mounted under a given path. Example of how one would do this would be:

getmnttree(os.lstat('/mnt/dozer/SHARE').st_dev)