### PR TITLE
NAS-123968 / 23.10-RC.1 / Fix usage plugin (by anodos325) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -394,7 +394,7 @@ class UsageService(Service):
                         'streams': s['streams'],
                     })
                 elif service == 'nfs':
-                    sharing_list.append({'type': service_upper, 'readonly': s['ro'], 'quiet': s['quiet']})
+                    sharing_list.append({'type': service_upper, 'readonly': s['ro']})
                 elif service == 'iscsi':
                     tar = await self.middleware.call('iscsi.target.query', [('id', '=', s['target'])], {'get': True})
                     ext = await self.middleware.call('iscsi.extent.query', [('id', '=', s['extent'])], {'get': True})


### PR DESCRIPTION
Quiet option for NFS exports was removed.

Original PR: https://github.com/truenas/middleware/pull/12051
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123968