### PR TITLE
NAS-123981 / 24.04 / dramatically improve alert/license_status.py

### DIFF
--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 import textwrap
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+from middlewared.alert.schedule import IntervalSchedule
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
@@ -33,6 +34,7 @@ class LicenseHasExpiredAlertClass(AlertClass):
 class LicenseStatusAlertSource(ThreadedAlertSource):
     products = ("SCALE_ENTERPRISE",)
     run_on_backup_node = False
+    schedule = IntervalSchedule(timedelta(hours=24))
 
     def check_sync(self):
         alerts = []
@@ -77,15 +79,7 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
             ))
 
         enc_nums = defaultdict(lambda: 0)
-        seen_ids = []
-        for enc in self.middleware.call_sync('enclosure.query'):
-            if enc['id'] in seen_ids:
-                continue
-            seen_ids.append(enc['id'])
-
-            if enc['controller']:
-                continue
-
+        for enc in filter(lambda x: not x['controller'], self.middleware.call_sync('enclosure2.query')):
             enc_nums[enc['model']] += 1
 
         if local_license['addhw']:
@@ -95,7 +89,6 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
                     continue
 
                 name = LICENSE_ADDHW_MAPPING[code]
-
                 if name == 'ES60':
                     continue
 
@@ -115,9 +108,6 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
                 LicenseAlertClass,
                 'Unlicensed Expansion shelf detected. This system is not licensed for additional expansion shelves.'
             ))
-
-        if self.middleware.call_sync("failover.status") == "BACKUP":
-            return alerts
 
         for days in [0, 14, 30, 90, 180]:
             if local_license['contract_end'] <= date.today() + timedelta(days=days):


### PR DESCRIPTION
On our M60 with 12x ES102 JBODs (with ~1.2k+ hard drives), I was noticing that `failover.get_ips` was taking > 46 seconds to return.

I gathered flame graphs of the running middleware process and noticed that `alert/license_status.py` line 81 (`enclosure.query`) was the spot where it was blocked. This doesn't surprise me because that's the old enclosure code that wasn't written in a way to be efficient. It's the exact opposite of efficient.

I changed to using `enclosure2.query` which is the new enclosure code that was written exclusively with speed/efficiency in mind and `failover.get_ips` now takes ~0.4 seconds to return.

The only logical conclusion that I can come up with is that our alert was calling such an inefficient method every 60 seconds that it was slowing down the entire main event loop to the point other methods were waiting on that to complete. Probably something to do with our general design of our schema that does too many deepcopy's.

Anyways, I've done 3 primary things here which dramatically improves the situation
1. run this alert every 24 hours, there is no reason to run every 60 seconds
2. use `enclosure2.query` which is where 99% of the improvements come from
3. remove a call to failover.status since `run_on_backup_node = False` is set as a class attribute for the alert already