### PR TITLE
NAS-123938 / 23.10 / fix login on HA taking >4mins

### DIFF
--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -79,7 +79,7 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
             ))
 
         enc_nums = defaultdict(lambda: 0)
-        for enc in filter(lambda x: not x['controller'], self.middleware.call_sync('enclosure.query')):
+        for enc in filter(lambda x: not x['controller'], self.middleware.call_sync('enclosure2.query')):
             enc_nums[enc['model']] += 1
 
         if local_license['addhw']:

--- a/src/middlewared/middlewared/plugins/enclosure_/element_types.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/element_types.py
@@ -1,0 +1,276 @@
+def alarm(value_raw):
+    """See SES-4 7.3.8 Audible Alarm element, Table 98 — Audible Alarm status element
+
+    Returns a comma-separated string for each alarm bit set or None otherwise
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'RQST mute': value_raw & 0x80,
+        'Muted': value_raw & 0x40,
+        'Remind': value_raw & 0x10,
+        'INFO': value_raw & 0x08,
+        'NON-CRIT': value_raw & 0x04,
+        'CRIT': value_raw & 0x02,
+        'UNRECOV': value_raw & 0x01,
+    }
+    if (result := [k for k, v in values.items() if v]):
+        return ', '.join(result)
+
+
+def comm(value_raw):
+    """See SES-4 7.3.19 Communication Port element, Table 140 — Communication Port status element
+
+    Returns a comma-separated string for each comm port bit set or None otherwise
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Disabled': value_raw & 0x01,
+    }
+    if (result := [k for k, v in values.items() if v]):
+        return ', '.join(result)
+
+
+def current(value_raw):
+    """See SES-4 7.3.21 Current Sensor element, Table 148 — Current Sensor status element
+
+    Returns a comma-separated string for each current sensor bit set or None otherwise
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Warn over': (value_raw >> 16) & 0x8,
+        'Crit over': (value_raw >> 16) & 0x2,
+    }
+    return ', '.join([f'{(value_raw & 0xffff) / 100}A'] + [k for k, v in values.items() if v])
+
+
+def enclosure(value_raw):
+    """See SES-4 7.3.16 Enclosure element, Table 130 — Enclosure status element
+
+    Returns a comma-separated string for each status bit set as well as the
+    time until power cycle and the requested time to be powered off. Otherwise
+    if no bits are set, it will return None
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 8) & 0x02,
+        'Warn on': (value_raw >> 8) & 0x01,
+        'RQST fail': value_raw & 0x02,
+        'RQST warn': value_raw & 0x01,
+    }
+    result = [k for k, v in values.items() if v]
+    if (pctime := (value_raw >> 10) & 0x3f):
+        pctime = f'Power cycle {pctime}min'
+        potime = (value_raw >> 2) & 0x3f
+        if potime == 0:
+            potime = ', power off until manually restored'
+        else:
+            potime = f', power off for {potime}min'
+
+        result.append(f'{pctime}{potime}')
+
+    return ', '.join(result) or None
+
+
+def volt(value_raw):
+    """See SES-4 7.3.20 Voltage Sensor element, Table 144 — Voltage Sensor status element
+
+    Returns a comma-separated string for each voltage sensor bit set as well as the
+    current voltage being reported. If no voltage sensor bit is set, will return
+    the calculated voltage. (In Volts)
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+        'Warn over': (value_raw >> 16) & 0x8,
+        'Warn under': (value_raw >> 16) & 0x4,
+        'Crit over': (value_raw >> 16) & 0x2,
+        'Crit under': (value_raw >> 16) & 0x1,
+    }
+    return ', '.join([f'{((value_raw & 0xffff) / 100)}V'] + [k for k, v in values.items() if v])
+
+
+def cooling(value_raw):
+    """See SES-4 7.3.5 Cooling element, Table 89 — Cooling status element
+
+    Returns the rotations per minute (RPM). NOTE: we only care about these
+    bits for our implementation
+    """
+    return f'{(((value_raw & 0x7ff00) >> 8) * 10)} RPM'
+
+
+def temp(value_raw):
+    """See SES-4 7.3.6 Temperature Sensor element, Table 94 — Temperature Sensor status element
+
+    Returns a string of the calculated temperature (in celsius) for the given element. If the
+    calculated temperature is 0, it would imply -20C so we return None
+    """
+    if (temp := (value_raw & 0xff00) >> 8):
+        # 8 bits represents -19C to +235C
+        # value of 0 would imply -20C
+        return f'{temp -20}C'
+
+
+def psu(value_raw):
+    """See SES-4 7.3.4 Power Supply element, Table 86 — Power Supply status element
+
+    Returns a comma-separated string for each psu element sensor bit set or None otherwise
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Do not remove': (value_raw >> 16) & 0x40,
+        'DC overvoltage': (value_raw >> 8) & 0x8,
+        'DC undervoltage': (value_raw >> 8) & 0x4,
+        'DC overcurrent': (value_raw >> 8) & 0x2,
+        'Hot swap': value_raw & 0x80,
+        'Fail on': value_raw & 0x40,
+        'RQST on': value_raw & 0x20,
+        'Off': value_raw & 0x10,
+        'Overtemp fail': value_raw & 0x8,
+        'Overtemp warn': value_raw & 0x4,
+        'AC fail': value_raw & 0x2,
+        'DC fail': value_raw & 0x1,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+def array_dev(value_raw):
+    """See SES-4 7.3.3 Array Device Slot element, Table 84 — Array Device Slot status element
+
+    Returns a comma-separated string for each array device element sensor set or None otherwise
+
+    NOTE: SES-4 spec informs us of _many_ other bits that can be set but we only care about
+    the IDENT and FAULT REQSTD bits for our implementation
+    """
+    values = {
+        'Identify on': (value_raw >> 8) & 0x2,
+        'Fault on': value_raw & 0x20,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+def sas_conn(value_raw):
+    """See SES-4 7.3.26 SAS Connector element, Table 158 — SAS Connector status element and
+    Table 159 — CONNECTOR TYPE field.
+
+    Returns a comma separated string specifying the connector type as well as returning
+    whether or not the FAIL bit is set
+    """
+    conn_type = (value_raw >> 16) & 0x7f
+    values = {
+        0x0: 'No information',
+        0x1: 'SAS 4x receptacle (SFF-8470) [max 4 phys]',
+        0x2: 'Mini SAS 4x receptacle (SFF-8088) [max 4 phys]',
+        0x3: 'QSFP+ receptacle (SFF-8436) [max 4 phys]',
+        0x4: 'Mini SAS 4x active receptacle (SFF-8088) [max 4 phys]',
+        0x5: 'Mini SAS HD 4x receptacle (SFF-8644) [max 4 phys]',
+        0x6: 'Mini SAS HD 8x receptacle (SFF-8644) [max 8 phys]',
+        0x7: 'Mini SAS HD 16x receptacle (SFF-8644) [max 16 phys]',
+        0xf: 'Vendor specific external connector',
+        0x10: 'SAS 4i plug (SFF-8484) [max 4 phys]',
+        0x11: 'Mini SAS 4i receptacle (SFF-8087) [max 4 phys]',
+        0x12: 'Mini SAS HD 4i receptacle (SFF-8643) [max 4 phys]',
+        0x13: 'Mini SAS HD 8i receptacle (SFF-8643) [max 8 phys]',
+        0x14: 'Mini SAS HD 16i receptacle (SFF-8643) [max 16 phys]',
+        0x15: 'SlimSAS 4i (SFF-8654) [max 4 phys]',
+        0x16: 'SlimSAS 8i (SFF-8654) [max 8 phys]',
+        0x17: 'SAS MiniLink 4i (SFF-8612) [max 4 phys]',
+        0x18: 'SAS MiniLink 8i (SFF-8612) [max 8 phys]',
+        0x19: 'unknown internal wide connector type: 0x19',
+        0x20: 'SAS Drive backplane receptacle (SFF-8482) [max 2 phys]',
+        0x21: 'SATA host plug [max 1 phy]',
+        0x22: 'SAS Drive plug (SFF-8482) [max 2 phys]',
+        0x23: 'SATA device plug [max 1 phy]',
+        0x24: 'Micro SAS receptacle [max 2 phys]',
+        0x25: 'Micro SATA device plug [max 1 phy]',
+        0x26: 'Micro SAS plug (SFF-8486) [max 2 phys]',
+        0x27: 'Micro SAS/SATA plug (SFF-8486) [max 2 phys]',
+        0x28: '12 Gbit/s SAS Drive backplane receptacle (SFF-8680) [max 2 phys]',
+        0x29: '12 Gbit/s SAS Drive Plug (SFF-8680) [max 2 phys]',
+        0x2a: 'Multifunction 12 Gbit/s 6x Unshielded receptacle connector receptacle (SFF-8639) [max 6 phys]',
+        0x2b: 'Multifunction 12 Gbit/s 6x Unshielded receptacle connector plug (SFF-8639) [max 6 phys]',
+        0x2c: 'SAS Multilink Drive backplane receptacle (SFF-8630) [max 4 phys]',
+        0x2d: 'SAS Multilink Drive backplane plug (SFF-8630) [max 4 phys]',
+        0x2e: 'unknown internal connector to end device type: 0x2e',
+        0x2f: 'SAS virtual connector [max 1 phy]',
+        0x3f: 'Vendor specific internal connector',
+        0x40: 'SAS High Density Drive backplane receptacle (SFF-8631) [max 8 phys]',
+        0x41: 'SAS High Density Drive backplane plug (SFF-8631) [max 8 phys]',
+    }
+    values.update({i: f'unknown external connector type: {hex(i)}' for i in range(0x8, 0xf)})
+    values.update({i: f'reserved for internal connector type: {hex(i)}' for i in range(0x30, 0x3f)})
+    values.update({i: f'reserved connector type: {hex(i)}' for i in range(0x42, 0x70)})
+    values.update({i: f'vendor specific connector type: {hex(i)}' for i in range(0x70, 0x80)})
+
+    formatted = [values.get(conn_type, f'unexpected connector type: {hex(conn_type)}')]
+    if value_raw & 0x40:
+        formatted.append('Fail on')
+    return ', '.join(formatted)
+
+
+def sas_exp(value_raw):
+    """See SES-4 7.3.25 SAS Expander element, Table 156 — SAS Expander status element
+
+    Returns a comma separated string for each bit set or None otherwise
+    """
+    values = {
+        'Identify on': (value_raw >> 16) & 0x80,
+        'Fail on': (value_raw >> 16) & 0x40,
+    }
+    return ', '.join([k for k, v in values.items() if v]) or None
+
+
+# See SES-4 7.2.3 Status element format, Table 74 — ELEMENT STATUS CODE field
+ELEMENT_DESC = {
+    0: 'Unsupported',
+    1: 'OK',
+    2: 'Critical',
+    3: 'Noncritical',
+    4: 'Unrecoverable',
+    5: 'Not installed',
+    6: 'Unknown',
+    7: 'Not available',
+    8: 'No access allowed',
+    9: 'reserved [9]',
+    10: 'reserved [10]',
+    11: 'reserved [11]',
+    12: 'reserved [12]',
+    13: 'reserved [13]',
+    14: 'reserved [14]',
+    15: 'reserved [15]',
+    # getencstat on CORE reports these last 2 statuses on the X-series enclosure
+    # so while it's not in the spec, we'll just maintain backwards compatible
+    # behavior
+    17: 'OK, Swapped',
+    21: 'Not Installed, Swapped',
+}
+ELEMENT_TYPES = {
+    0: ('Unspecified', lambda *args: None),
+    1: ('Device Slot', lambda *args: None),
+    2: ('Power Supply', psu),
+    3: ('Cooling', cooling),
+    4: ('Temperature Sensors', temp),
+    5: ('Door Lock', lambda *args: None),
+    6: ('Audible Alarm', alarm),
+    7: ('Enclosure Services Controller Electronics', lambda *args: None),
+    8: ('SCC Controller Electronics', lambda *args: None),
+    9: ('Nonvolatile Cache', lambda *args: None),
+    10: ('Invalid Operation Reason', lambda *args: None),
+    11: ('Uninterruptible Power Supply', lambda *args: None),
+    12: ('Display', lambda *args: None),
+    13: ('Key Pad Entry', lambda *args: None),
+    14: ('Enclosure', enclosure),
+    15: ('SCSI Port/Transciever', lambda *args: None),
+    16: ('Language', lambda *args: None),
+    17: ('Communication Port', comm),
+    18: ('Voltage Sensor', volt),
+    19: ('Current Sensor', current),
+    20: ('SCSI Target Port', lambda *args: None),
+    21: ('SCSI Initiator Port', lambda *args: None),
+    22: ('Simple Subenclosure', lambda *args: None),
+    23: ('Array Device Slot', array_dev),
+    24: ('SAS Expander', sas_exp),
+    25: ('SAS Connector', sas_conn),
+}

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -1,0 +1,167 @@
+import pathlib
+
+from pyudev import Context
+
+from libsg3.ses import EnclosureDevice
+from middlewared.schema import accepts, Dict, Str, Int
+from middlewared.service import Service, filterable
+from middlewared.service_exception import MatchNotFound, ValidationError
+from middlewared.utils import filter_list
+from .enclosure_class import Enclosure
+from .map2 import map_enclosures
+from .nvme2 import map_nvme
+from .r30_drive_identify import set_slot_status as r30_set_slot_status
+from .fseries_drive_identify import set_slot_status as fseries_set_slot_status
+
+
+class Enclosure2Service(Service):
+
+    class Config:
+        cli_namespace = 'storage.enclosure2'
+        private = True
+
+    def get_ses_enclosures(self, dmi=None):
+        """This generates the "raw" list of enclosures detected on the system. It
+        serves as the "entry" point to "enclosure2.query" and is foundational in
+        how all of the structuring of the final data object is returned.
+
+        We use pyudev to enumerate enclosure type devices using a socket to the
+        udev database. While we're at it, we also add some useful keys to the
+        object (/dev/bsg, /dev/sg, and dmi). Then we use SCSI commands (issued
+        directly to the enclosure) to generate an object of all elements and the
+        information associated to each element.
+
+        It's _VERY_ important to understand that the "dmi" key is the hingepoint for
+        identifying what platform we're on. This is SMBIOS data and is burned into
+        the motherboard before we ship to our customers. This is also how we map the
+        enclosure's array device slots (disk drives) to a human friendly format.
+
+        The `Enclosure` class is where all the magic happens wrt to taking in all the
+        raw data and formatting it into a structured object that will be consumed by
+        the webUI team as well as on the backend (alerts, drive identifiction, etc).
+        """
+        if dmi is None:
+            dmi = self.middleware.call_sync('system.dmidecode_info')['system-product-name']
+
+        output = list()
+        for i in Context().list_devices(subsystem='enclosure'):
+            bsg = f'/dev/bsg/{i.sys_name}'
+            try:
+                enc_status = EnclosureDevice(bsg).status()
+            except OSError:
+                self.logger.error('Error querying enclosure status for %r', bsg)
+                continue
+
+            sg = next(pathlib.Path(f'/sys/class/enclosure/{i.sys_name}/device/scsi_generic').iterdir())
+            output.append(Enclosure(bsg, f'/dev/{sg.name}', dmi, enc_status).asdict())
+
+        return output
+
+    def to_ignore(self, enclosure):
+        """On our MINI and R20 platforms, we actually use the Virtual AHCI
+        enclosure devices since those platforms don't have another enclosure
+        wired up interally for which the drives are attached. This function
+        checks to make sure that we skip the Virtual AHCI enclosures on all
+        platforms with the exception of MINIs and R20 variants.
+        """
+        return all((
+            enclosure['product'] == 'SGPIOEnclosure',
+            '-MINI-' not in enclosure['model'],
+            not enclosure['model'].startswith('R20'),
+        ))
+
+    def map_nvme(self):
+        """This method serves as an endpoint to easily be able to test
+        the nvme mapping logic specifically without having to call enclosure2.query
+        which includes the head-unit and all attached JBODs.
+        """
+        return map_nvme(self.middleware.call_sync('system.dmidecode_info')['system-product-name'])
+
+    def get_original_disk_slot(self, slot, enc_info):
+        """Get the original slot based on the `slot` passed to us via the end-user.
+        NOTE: Most drives original slot will match their "mapped" slot because there
+        is no need to map them. We always include an "original" slot key for all
+        enclosures as to keep this for loop as simple as possible and it also allows
+        more flexbiility when we do get an enclosure that maps drives differently.
+        (i.e. the ES102S is a prime example of this (enumerates drives at 1 instead of 0))
+        """
+        sgdev = origslot = None
+        for encslot, devinfo in filter(lambda x: x[0] == slot, enc_info['elements']['Array Device Slot'].items()):
+            sgdev = devinfo['original']['enclosure_sg']
+            origslot = devinfo['original']['slot']
+
+        return sgdev, origslot
+
+    @accepts(Dict(
+        Str('enclosure_id', required=True),
+        Int('slot', required=True),
+        Str('status', required=True, enum=['CLEAR', 'IDENT', 'FAULT'])
+    ))
+    def set_slot_status(self, data):
+        """Set enclosure bay number `slot` to `status` for `enclosure_id`.
+
+        `enclosure_id` str: represents the enclosure logical identifier of the enclosure
+        `slot` int: the enclosure drive bay number to send the status command
+        `status` str: the status for which to send to the command
+        """
+        try:
+            enc_info = self.middleware.call_sync(
+                'enclosure2.query', [['id', '=', data['enclosure_id']]], {'get': True}
+            )
+        except MatchNotFound:
+            raise ValidationError('enclosure2.set_slot_status', f'Enclosure with id: {data["enclosure_id"]} not found')
+
+        if enc_info['id'].endswith('_nvme_enclosure'):
+            if enc_info['id'].startswith('r30'):
+                # an all nvme flash system so drive identification is handled
+                # in a completely different way than sata/scsi
+                return r30_set_slot_status(data['slot'], data['status'])
+            elif enc_info['id'].startswith(('f60', 'f100', 'f130')):
+                return fseries_set_slot_status(data['slot'], data['status'])
+            else:
+                # mseries, and some rseries have mapped nvme enclosures but they
+                # don't support drive LED identification
+                return
+
+        sgdev, origslot = self.get_original_disk_slot(data['slot'], enc_info)
+        if sgdev is None:
+            raise ValidationError('enclosure2.set_slot_status', 'Unable to find scsi generic device for enclosure')
+        elif origslot is None:
+            raise ValidationError('enclosure2.set_slot_status', f'Slot {data["slot"]!r} not found in enclosure')
+
+        if data['status'] == 'CLEAR':
+            actions = ('clear=ident', 'clear=fault')
+        else:
+            actions = (f'set={data["status"].lower()}')
+
+        encdev = Enclosure(sgdev)
+        try:
+            for action in actions:
+                encdev.set_control(str(origslot), action)
+        except OSError:
+            self.logger.warning('Failed to {data["status"]} slot {data["slot"]!r} on enclosure {enc_info["id"]}')
+
+    @filterable
+    def query(self, filters, options):
+        enclosures = []
+        if self.middleware.call_sync('truenas.get_chassis_hardware') == 'TRUENAS-UNKNOWN':
+            # this feature is only available on hardware that ix sells
+            return enclosures
+
+        labels = {
+            label['encid']: label['label']
+            for label in self.middleware.call_sync('datastore.query', 'truenas.enclosurelabel')
+        }
+        dmi = self.middleware.call_sync('system.dmidecode_info')['system-product-name']
+        for i in filter(lambda x: not self.to_ignore(x), self.get_ses_enclosures()):
+            # this is a user-provided string to label the enclosures so we'll add it at as a
+            # top-level dictionary key "label", if the user hasn't provided a label then we'll
+            # fill in the info with whatever is in the "name" key. The "name" key is the
+            # t10 vendor, product and revision information combined as a single space separated
+            # string reported by the enclosure itself via a standard inquiry command
+            i['label'] = labels.get(i['id']) or i['name']
+            enclosures.append(i)
+
+        enclosures.extend(map_nvme(dmi))
+        enclosures = map_enclosures(enclosures)
+        return filter_list(enclosures, filters, options)

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -1,0 +1,168 @@
+import logging
+import pathlib
+
+from middlewared.utils.scsi_generic import inquiry
+from .identification import get_enclosure_model_and_controller
+from .element_types import ELEMENT_TYPES, ELEMENT_DESC
+
+
+logger = logging.getLogger(__name__)
+
+
+class Enclosure:
+    def __init__(self, bsg, sg, dmi, enc_stat):
+        self.bsg, self.sg, self.pci, self.dmi = bsg, sg, bsg.removeprefix('/dev/bsg/'), dmi
+        self.encid, self.status = enc_stat['id'], list(enc_stat['status'])
+        self.vendor, self.product, self.revision, self.encname = self._get_vendor_product_revision_and_encname()
+        self.model, self.controller = self._get_model_and_controller()
+        self.elements = self._parse_elements(enc_stat['elements'])
+
+    def asdict(self):
+        return {
+            'name': self.encname,  # vendor, product and revision joined by whitespace
+            'model': self.model,  # M60, F100, TRUENAS-MINI-R, etc
+            'controller': self.controller,  # if True, represents the "head-unit"
+            'dmi': self.dmi,  # comes from system.dmidecode_info[system-product-name]
+            'status': self.status,  # the overall status reported by the enclosure
+            'id': self.encid,
+            'vendor': self.vendor,  # t10 vendor from INQUIRY
+            'product': self.product,  # product from INQUIRY
+            'revision': self.revision,  # revision from INQUIRY
+            'bsg': self.bsg,  # the path for which this maps to a bsg device (/dev/bsg/0:0:0:0)
+            'sg': self.sg,  # the scsi generic device (/dev/sg0)
+            'pci': self.pci,  # the pci info (0:0:0:0)
+            'elements': self.elements  # dictionary with all element types and their relevant information
+        }
+
+    def _get_vendor_product_revision_and_encname(self):
+        """Sends a standard INQUIRY command to the enclosure device
+        so we can parse the vendor/prodcut/revision(and /serial if we ever wanted
+        to use that information) for the enclosure device. It's important
+        that we parse this information into their own top-level keys since we
+        base some of our drive mappings (potentially) on the "revision" (aka firmware)
+        for the enclosure
+        """
+        inq = inquiry(self.sg)
+        data = [inq['vendor'], inq['product'], inq['revision']]
+        data.append(' '.join(data))
+        return data
+
+    def _get_model_and_controller(self):
+        key = f'{self.vendor}_{self.product}'
+        return get_enclosure_model_and_controller(key, self.dmi)
+
+    def _map_disks_to_enclosure_slots(self):
+        """
+        The sysfs directory structure is dynamic based on the enclosure that
+        is attached.
+        Here are some examples of what we've seen on internal hardware:
+            /sys/class/enclosure/19:0:6:0/SLOT_001/
+            /sys/class/enclosure/13:0:0:0/Drive Slot #0_0000000000000000/
+            /sys/class/enclosure/13:0:0:0/Disk #00/
+            /sys/class/enclosure/13:0:0:0/Slot 00/
+            /sys/class/enclosure/13:0:0:0/slot00/
+            /sys/class/enclosure/13:0:0:0/slot00       / (yes those are spaces and really show up on a system)
+
+        The safe assumption that we can make on whether or not the directory
+        represents a drive slot is looking for the file named "slot" underneath
+        each directory. (i.e. /sys/class/enclosure/13:0:0:0/Disk #00/slot)
+
+        If this file doesn't exist, it means 1 thing
+            1. this isn't a drive slot directory
+
+        Once we've determined that there is a file named "slot", we can read the
+        contents of that file to get the slot number associated to the disk device.
+        The "slot" file is always an integer so we don't need to convert to hexadecimal.
+        """
+        mapping = dict()
+        for i in filter(lambda x: x.is_dir(), pathlib.Path(f'/sys/class/enclosure/{self.pci}').iterdir()):
+            try:
+                slot = int((i / 'slot').read_text().strip())
+            except (FileNotFoundError, ValueError):
+                # not a slot directory
+                continue
+            else:
+                try:
+                    dev = next((i / 'device/block').iterdir(), None)
+                    mapping[slot] = dev.name if dev is not None else None
+                except FileNotFoundError:
+                    # no disk in this slot
+                    mapping[slot] = None
+        try:
+            # we have a single enclosure (at time of writing this) that enumerates
+            # sysfs drive slots starting at number 1 while every other JBOD
+            # (and head-units) enumerate syfs drive slots starting at number 0
+            min_slot = min(mapping)
+        except ValueError:
+            min_slot = 0
+
+        return min_slot, mapping
+
+    def _elements_to_ignore(self, element):
+        """We ignore these elements as they typically serve as a beginning
+        element for a specific group type. (i.e. ArrayDevices is the element
+        that preceeds all the actual array device elements with the disk
+        information). We ignore these types so we don't fill the data object
+        with a bunch of useless objects that eventually get sifted through
+        anyways. These are also ignored because we run a periodic alert
+        that checks enclosure element statuses and we've seen these elements
+        report "issues" when they're not used anyways.
+        """
+        return any((
+            element['descriptor'] in ('<empty>', 'ArrayDevices', 'Drive Slots'),
+            element['status'] == 'Unsupported'
+        ))
+
+    def _parse_elements(self, elements):
+        final = {}
+        min_slot, disk_map = self._map_disks_to_enclosure_slots()
+        for slot, element in filter(lambda x: not self._elements_to_ignore(x[1]), elements.items()):
+            try:
+                element_type = ELEMENT_TYPES[element['type']]
+            except KeyError:
+                # means the element type that's being
+                # reported to us is unknown so log it
+                # and continue on
+                logger.warning('Unknown element type: %r for %r', element['type'], self.devname)
+                continue
+
+            try:
+                element_status = ELEMENT_DESC[element['status'][0]]
+            except KeyError:
+                # means the elements status reported by the enclosure
+                # is not mapped so just report unknown
+                element_status = 'UNKNOWN'
+
+            if element_type[0] not in final:
+                # first time seeing this element type so add it
+                final[element_type[0]] = {}
+
+            # convert list of integers representing the elements
+            # raw status to an integer so it can be converted
+            # appropriately based on the element type
+            value_raw = 0
+            for val in element['status']:
+                value_raw = (value_raw << 8) + val
+
+            parsed = {slot: {
+                'descriptor': element['descriptor'].strip(),
+                'status': element_status,
+                'value': element_type[1](value_raw),
+                'value_raw': value_raw,
+            }}
+            if element_type[0] == 'Array Device Slot':
+                # see docstring in `self._map_disks_to_enclosure_slots` for
+                # why we have to get the min_slot
+                orig_slot = slot - 1 if min_slot == 0 else slot
+                parsed[slot]['dev'] = disk_map.get(orig_slot, None)
+                parsed[slot]['original'] = {
+                    'enclosure_id': self.encid,
+                    'enclosure_sg': self.sg,
+                    'enclosure_bsg': self.bsg,
+                    'descriptor': f'slot{orig_slot}',
+                    'slot': orig_slot,
+                }
+
+            final[element_type[0]].update(parsed)
+
+        return final

--- a/src/middlewared/middlewared/plugins/enclosure_/identification.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/identification.py
@@ -1,0 +1,70 @@
+def r20_variants_or_mini(model, dmi):
+    """If this is an r20 variant then we return the model
+    with the TRUENAS- suffix stripped. Otherwise, if this is
+    a MINI then we just return the entire string.
+
+    NOTE: this information is burned in by the production team
+    into the motherboard (SMBIOS) before we ship the system
+    """
+    if dmi in ('TRUENAS-R20', 'TRUENAS-R20A', 'TRUENAS-R20B'):
+        return model, True
+    elif dmi.startswith(('TRUENAS-MINI', 'FREENAS-MINI')):
+        # minis do not have the TRUENAS- prefix removed
+        return dmi, True
+    else:
+        return '', False
+
+
+def get_enclosure_model_and_controller(key, dmi):
+    """This maps the enclosure to the respective platform.
+    the 'key' is the concatenated string of t10 vendor and product
+    info returned by a standard INQUIRY command to the enclosure
+    device.
+    """
+    model = dmi.removeprefix('TRUENAS-').removesuffix('-HA')
+    match key:
+        case 'ECStream_4024Sp' | 'ECStream_4024Ss' | 'iX_4024Sp' | 'iX_4024Ss':
+            # M series
+            return model, True
+        case 'CELESTIC_P3215-O' | 'CELESTIC_P3217-B':
+            # X series
+            return model, True
+        case 'ECStream_FS1' | 'ECStream_FS2' | 'ECStream_DSS212Sp' | 'ECStream_DSS212Ss':
+            # R series
+            return model, True
+        case 'iX_FS1' | 'iX_FS2' | 'iX_DSS212Sp' | 'iX_DSS212Ss':
+            # more R series
+            return model, True
+        case 'iX_TrueNAS R20p' | 'iX_TrueNAS 2012Sp' | 'iX_TrueNAS SMC SC826-P':
+            # R20
+            return model, True
+        case 'AHCI_SGPIOEnclosure':
+            # R20 variants or MINIs
+            return r20_variants_or_mini(model, dmi)
+        case 'iX_eDrawer4048S1' | 'iX_eDrawer4048S2':
+            # R50
+            return model, True
+
+        # JBODS
+        case 'ECStream_3U16RJ-AC.r3':
+            return 'E16', False
+        case 'Storage_1729':
+            return 'E24', False
+        case 'QUANTA _JB9 SIM':
+            return 'E60', False
+        case 'CELESTIC_X2012':
+            return 'ES12', False
+        case 'ECStream_4024J' | 'iX_4024J':
+            return 'ES24', False
+        case 'ECStream_2024Jp' | 'ECStream_2024Js' | 'iX_2024Jp' | 'iX_2024Js':
+            return 'ES24F', False
+        case 'CELESTIC_R0904':
+            return 'ES60', False
+        case 'HGST_H4060-J':
+            return 'ES60G2', False
+        case 'HGST_H4102-J':
+            return 'ES102', False
+        case 'VikingES_NDS-41022-BB':
+            return 'ES102S', False
+        case _:
+            return '', False

--- a/src/middlewared/middlewared/plugins/enclosure_/map2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map2.py
@@ -1,0 +1,69 @@
+from .slot_mappings import get_mapping_info
+
+
+def map_enclosures(enclosures):
+    mapped = [{'id': 'mapped_enclosure_0', 'elements': {'Array Device Slot': {}}}]
+    jbods = []
+    for enclosure in enclosures:
+        if not enclosure['controller']:
+            # we're on a platform that has a JBOD attached so we
+            # want to place these in another list so we don't lose
+            # them during the mapping process
+            jbods.append(enclosure)
+            continue
+
+        mapped_info = get_mapping_info(enclosure['dmi'], enclosures)
+        if mapped_info is None:
+            # X/M/F series don't need to be mapped
+            return enclosures
+
+        vers_key = 'DEFAULT'
+        if not mapped_info['any_version']:
+            # platforms can have different "versions" which
+            # means that they can be ever so slightly cabled
+            # differently which leads to us having to map the
+            # drives based on how they're cabled
+            # (hence the "version")
+            for key, vers in mapped_info['versions'].items():
+                if enclosure['revision'] == key:
+                    vers_key = vers
+                    break
+
+        for key, _dsm in mapped_info['versions'][vers_key].items():
+            # now that we know what product "version" we're on, we need to be
+            # sure and pull the drive mappings based on the enclosures unique
+            # (non-changing) id. The non-changing id that uniquely identifies
+            # the enclosure is different between each platform
+            if (disk_slots_mapping := _dsm.get(enclosure[key])) is not None:
+                break
+        else:
+            raise LookupError(f'Enclosure {enclosure["name"]!r} not found in mapping')
+
+        for orig_slot, orig_info in enclosure['elements']['Array Device Slot'].items():
+            mapped_slot = disk_slots_mapping[orig_slot]['mapped_slot']
+            mapped[0]['elements']['Array Device Slot'].update({
+                mapped_slot: {
+                    'descriptor': f'Disk #{mapped_slot}',
+                    'status': orig_info['status'],
+                    'value': orig_info['value'],
+                    'value_raw': orig_info['value_raw'],
+                    'dev': orig_info['dev'],
+                    'original': {
+                        # the main purpose of the `original` key is so that
+                        # we have quick access when a user requests to identify
+                        # or fault a drive slot led. Since platforms can have
+                        # 100's (or 1k+) disk slots, the only components we
+                        # care about when lighting up a disk is to get the
+                        # 1. enclosure scsi generice device (i.e. /dev/sg0)
+                        # 2. the original slot of the disk (if it was mapped)
+                        'enclosure_id': enclosure['id'],
+                        'enclosure_sg': enclosure['sg'],
+                        'enclosure_bsg': enclosure['bsg'],
+                        'descriptor': orig_info['descriptor'],
+                        'slot': orig_slot
+                    }
+                }
+            })
+
+    # we've mapped the head-unit but we don't want to lose the JBOD information
+    return mapped + jbods

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -1,0 +1,203 @@
+import pathlib
+import re
+
+from pyudev import Context, Devices, DeviceNotFoundAtPathError
+
+RE_SLOT = re.compile(r'^0-([0-9]+)$')
+
+
+def fake_nvme_enclosure(model, num_of_nvme_slots, mapped):
+    """This function takes the nvme devices that been mapped
+    to their respective slots and then creates a "fake" enclosure
+    device that matches (similarly) to what our real enclosure
+    mapping code does (map_enclosures()). It's _VERY_ important
+    that the keys in the `fake_enclosure` dictionary exist because
+    our generic enclosure mapping logic expects certain top-level
+    keys.
+
+    Furthermore, we generate DMI (SMBIOS) information for this
+    "fake" enclosure because our enclosure mapping logic has to have
+    a guaranteed unique key for each enclosure so it can properly
+    map the disks accordingly
+    """
+    dmi = f'{model.lower()}_nvme_enclosure'
+    fake_enclosure = {
+        'id': dmi,
+        'dmi': dmi,
+        'sg': None,
+        'bsg': None,
+        'name': f'{model} NVMe Enclosure',
+        'controller': True,
+        'status': ['OK'],
+        'elements': {'Array Device Slot': {}}
+    }
+    for slot in range(1, num_of_nvme_slots + 1):
+        device = mapped.get(slot, None)
+        if device is not None:
+            status = 'OK'
+            value_raw = '0x1000000'
+        else:
+            status = 'Not Installed'
+            value_raw = '0x0500000'
+
+        fake_enclosure['elements']['Array Device Slot'][slot] = {
+            'descriptor': f'Disk #{slot}',
+            'status': status,
+            'value': None,
+            'value_raw': value_raw,
+            'dev': device,
+            'original': {
+                'enclosure_id': dmi,
+                'enclosure_sg': None,
+                'enclosure_bsg': None,
+                'descriptor': f'slot{slot}',
+                'slot': slot,
+            }
+        }
+
+    return [fake_enclosure]
+
+
+def map_plx_nvme(model, ctx):
+    num_of_nvme_slots = 4  # nvme plx bridge used on m50/60 and r50bm have 4 nvme drive bays
+    addresses_to_slots = {
+        (slot / 'address').read_text().strip(): slot.name
+        for slot in pathlib.Path('/sys/bus/pci/slots').iterdir()
+    }
+    mapped = dict()
+    for i in filter(lambda x: x.attributes.get('path') == b'\\_SB_.PC03.BR3A', ctx.list_devices(subsystem='acpi')):
+        try:
+            physical_node = Devices.from_path(ctx, f'{i.sys_path}/physical_node')
+        except DeviceNotFoundAtPathError:
+            # happens when there are no rear-nvme drives plugged in
+            pass
+        else:
+            for child in physical_node.children:
+                if child.properties.get('SUBSYSTEM') != 'block':
+                    continue
+
+                try:
+                    controller_sys_name = child.parent.parent.sys_name
+                except AttributeError:
+                    continue
+
+                if (slot := addresses_to_slots.get(controller_sys_name.split('.')[0])) is None:
+                    continue
+
+                if not (m := re.match(RE_SLOT, slot)):
+                    continue
+
+                slot = int(m.group(1))
+                if model == 'R50BM':
+                    # When adding this code and testing on internal R50BM, the starting slot
+                    # number for the rear nvme drive bays starts at 2 and goes to 5. This means
+                    # we're always off by 1. The easiest solution is to just check for this
+                    # specific platform and subtract 1 from the slot number to keep everything
+                    # in check.
+                    # To make things event more complicated, we found (by testing on internal hardware)
+                    # that slot 2 on OS is actually slot 3 and vice versa. This means we need to swap
+                    # those 2 numbers with each other to keep the webUI lined up with reality.
+                    slot -= 1
+                    if slot == 2:
+                        slot = 3
+                    elif slot == 3:
+                        slot = 2
+
+                mapped[slot] = child.sys_name
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_r50_or_r50b(model, ctx):
+    num_of_nvme_slots = 3 if model == 'R50' else 2  # r50 has 3 rear nvme slots, r50b has 2
+    if model == 'R50':
+        acpihandles = {b'\\_SB_.PC00.RP01.PXSX': 3, b'\\_SB_.PC01.BR1A.OCL0': 1, b'\\_SB_.PC01.BR1B.OCL1': 2}
+    else:
+        acpihandles = {b'\\_SB_.PC03.BR3A': 2, b'\\_SB_.PC00.RP01.PXSX': 1}
+
+    mapped = dict()
+    for i in filter(lambda x: x.attributes.get('path') in acpihandles, ctx.list_devices(subsystem='acpi')):
+        acpi_handle = i.attributes.get('path')
+        try:
+            phys_node = Devices.from_path(ctx, f'{i.sys_path}/physical_node')
+        except DeviceNotFoundAtPathError:
+            break
+
+        slot = acpihandles[acpi_handle]
+        for nvme in filter(lambda x: x.sys_name.startswith('nvme') and x.subsystem == 'block', phys_node.children):
+            mapped[slot] = nvme.sys_name
+            break
+        else:
+            mapped[slot] = None
+
+        if len(mapped) == num_of_nvme_slots:
+            # there can be (and often is) TONS of acpi devices on
+            # any given system so once we've mapped the total # of
+            # nvme drives, we break out early as to be as efficient
+            # as possible
+            break
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_r30_or_fseries(model, ctx):
+    num_of_nvme_slots = 16 if model == 'R30' else 24  # r30 has 16 nvme slots, fseries has 24 (all nvme flash)
+    nvmes = {}
+    for i in ctx.list_devices(subsystem='nvme'):
+        try:
+            namespace_dev = Devices.from_path(ctx, f'{i.sys_path}/{i.sys_name}n1')
+        except DeviceNotFoundAtPathError:
+            # no namespace for the device
+            continue
+        else:
+            try:
+                # i.parent.sys_name looks like 0000:80:40.0
+                # namespace_dev.sys_name looks like nvme1n1
+                nvmes[i.parent.sys_name[:-2]] = namespace_dev.sys_name
+            except (IndexError, AttributeError):
+                continue
+
+    # the keys in this dictionary are the physical pcie slot ids
+    # and the values are the slots that the webUI uses to map them
+    # to their physical locations in a human manageable way
+    if model == 'R30':
+        webui_map = {
+            '27': 1, '26': 7, '25': 2, '24': 8,
+            '37': 3, '36': 9, '35': 4, '34': 10,
+            '45': 5, '47': 11, '40': 6, '41': 12,
+            '38': 14, '39': 16, '43': 13, '44': 15,
+        }
+    else:
+        # f-series vendor is nice to us and nvme phys slots start at 1
+        # and increment in a human readable way already
+        webui_map = {
+            '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6,
+            '7': 7, '8': 8, '9': 9, '10': 10, '11': 11, '12': 12,
+            '13': 13, '14': 14, '15': 15, '16': 16, '17': 17, '18': 18,
+            '19': 19, '20': 20, '21': 21, '22': 22, '23': 23, '24': 24,
+        }
+
+    mapped = {}
+    for i in pathlib.Path('/sys/bus/pci/slots').iterdir():
+        addr = (i / 'address').read_text().strip()
+        if (nvme := nvmes.get(addr, None)) and (mapped_slot := webui_map.get(i.name, None)):
+            mapped[mapped_slot] = nvme
+
+    return fake_nvme_enclosure(model, num_of_nvme_slots, mapped)
+
+
+def map_nvme(dmi):
+    # mapping nvme drives only pertains to these models
+    models = ('R30', 'R50', 'R50B', 'R50BM', 'M50', 'M60', 'F60', 'F100', 'F130')
+    if not (model := dmi.removeprefix('TRUENAS-').removesuffix('-HA')) or (model not in models):
+        return []
+
+    ctx = Context()
+    if model in ('R50', 'R50B'):
+        return map_r50_or_r50b(model, ctx)
+    elif model in ('R30', 'F60', 'F100', 'F130'):
+        # all nvme systems which we need to handle separately
+        return map_r30_or_fseries(model, ctx)
+    else:
+        # M50, M60 and R50BM use same plx nvme bridge
+        return map_plx_nvme(model, ctx)

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -1,0 +1,431 @@
+def get_slot_info(model, enclosures=None):
+    """This function returns a dictionary that maps
+    drives from their original slots to their mapped slots. This
+    is done solely for the purpose of displaying the enclosure
+    information to the end-user in a logical way.
+    (i.e. /dev/sda is cabled to slot 5 at OS level, so we need
+    to map it back to slot 1, etc).
+
+    The keys of the dictionary serve a very particular purpose
+    and will be described as follows:
+        `any_versions When set to `True`, it means that versions of the
+            platform DO NOT MATTER and all versions (there may only be 1)
+            ship with the same drive mapping.
+
+        `versions` is a dictionary with many nested keys that
+            represent different versions of the same platform.
+            Sometimes (not often) we have to make a change to a
+            platform because, for example, a particlar part is
+            no longer available. We keep the same platform, but
+            instead ship with a different piece of hardware.
+            Completely transparent to the end-user but, obviously,
+            needs to be tracked on our side.
+
+        `versions->[vers_key]` is a dictionary that represents the
+            version. So, for example, if we ship an R20 and the
+            `any_versions` key is True, then we will access the
+            `versions->DEFAULT` key by "default". However, if
+            `any_versions` is False, then there should be another
+            top-level key that represents the identifier for that
+            version on the platform.
+            (i.e. {'versions':
+                      'DEFAULT': ...
+                      '1.0': ...
+                      '2.0': ...
+                      etc ...
+                  }
+            )
+
+            NOTE: the version key has to be obtained via SMBIOS
+            since we need a value that isn't dynamic and gurantees
+            uniqueness. There are exceptions, of course, but this
+            is the preferred way of determining the version.
+
+        `versions->[vers_key]->[unique_identifier]` is a top-level
+            key that represents a non-changing, guaranteed unique
+            identifier for the enclosure that needs to be mapped.
+            For example:
+            {'versions': {
+                'DEFAULT': {
+                    'product': {}
+                }
+            }}
+            The `product` key up above represents the top-level key
+            that we can use to access the dictionary that is returned
+            from `map_enclosures` function. In this example, the
+            `product` key represents the "product" string that is returned
+            from a standard INQUIRY command sent to the enclosure device.
+
+            It is VERY important that the key placed here is using some
+            identifier that is _GUARANTEED_ to be unique for the enclosure
+            that you're trying to map. If this is not unique, then the
+            entire mapping process will NOT work. It's almost a necessity
+            to use a key that is from the hardware (INQUIRY or SMBIOS).
+            There is 1 exception to this and that's when we're mapping
+            the systems that we sell that utilize the virtual AHCI enclosure
+            driver. This enumerates the disks using an `id` that is
+            hard-coded in the kernel module which guarantees its uniqueness.
+
+
+        `versions->[vers_key]->[unique_identifier]->[unique_id_value]` is a
+            top-level key that represents the value that is returned by accessing
+            the object from the `map_enclosures` function via the unique id
+            key that was discussed up above. For example:
+            {'versions': {
+                'DEFAULT': {
+                    'product': {'eDrawer4048S1' : {}}
+                }
+            }}
+            In this example the `eDrawer4048S1` is the value expected to be returned
+            from the `product` key from the dictionary returned in the `map_enclosures`
+            function. Again, the `product` key is found via an INQUIRY response
+            and the `eDrawer4048S1` is the value that is returned from said INQUIRY.
+
+        `versions->[vers_key]->[unique_identifier]->[unique_id_value]->[slot_mapping] is
+            a dictionary that is used to map the original drive slots to their mapped
+            slots. For example:
+            {'versions': {
+                'DEFAULT': {
+                    'product': {'eDrawer4048S1' : {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        5: {'orig_slot': 5, 'mapped_slot': 2},
+                    }}
+                }
+            }}
+            The `1` key is the original slot and the dictionary value for that key
+            should be self-explanatory. This is essentially where and how the drives
+            get mapped.
+
+    We use a complex nested dictionary for a couple reasons.
+        1. performance is good when accessing the top-level keys
+        2. flexibility is also good since we're able to essentially
+            add any type of "key" at any point in the nested object
+            to represent a particular change in any of our platforms
+            that need it.
+        3. necessity because the logic that is required to map all of
+            our enclosures is quite complex and this was the best mix
+            of performance/maintability.
+    """
+    if model == 'R40':
+        # We need a bit more logic because the R40 doesn't have a
+        # predictable guaranteed unique identifier. This means that
+        # we need to find one. The best that we can do is to use the
+        # enclosures logical id and map the 1st set of 24 drives to
+        # the smaller id while mapping the 2nd set of 24 drives to the larger id.
+        ses_logical_ids = {int(f'0x{i["id"]}', 16): i['id'] for i in enclosures if i['controller']}
+        min_id, max_id = min(ses_logical_ids), max(ses_logical_ids)
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        ses_logical_ids[min_id]: {
+                            # 1 - 24
+                            i: {'orig_slot': i, 'mapped_slot': i} for i in range(1, 25)
+                        },
+                        ses_logical_ids[max_id]: {
+                            # 25 - 48
+                            i: {'orig_slot': i, 'mapped_slot': j} for i, j in zip(range(1, 25), range(25, 49))
+                        }
+                    }
+                }
+            }
+        }
+    elif model in ('R50', 'R50B', 'R50BM'):
+        # these platforms share same enclosure and mapping
+        # but it's important to always map the eDrawer4048S1
+        # enclosure device to drives 1 - 24
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'product': {
+                        'eDrawer4048S1': {
+                            # 1 - 24
+                            i: {'orig_slot': i, 'mapped_slot': i} for i in range(1, 25)
+                        },
+                        'eDrawer4048S2': {
+                            # 25 - 48
+                            i: {'orig_slot': i, 'mapped_slot': j} for i, j in zip(range(1, 25), range(25, 49))
+                        }
+                    },
+                    'id': {
+                        'r50_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
+                            3: {'orig_slot': 3, 'mapped_slot': 51},
+                        },
+                        'r50b_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
+                        },
+                        'r50bm_nvme_enclosure': {
+                            1: {'orig_slot': 1, 'mapped_slot': 49},
+                            2: {'orig_slot': 2, 'mapped_slot': 50},
+                            3: {'orig_slot': 3, 'mapped_slot': 51},
+                            4: {'orig_slot': 4, 'mapped_slot': 52},
+                        },
+                    }
+                }
+            }
+        }
+    elif model == 'R10':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            5: {'orig_slot': 5, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            13: {'orig_slot': 13, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6},
+                            10: {'orig_slot': 10, 'mapped_slot': 7},
+                            14: {'orig_slot': 14, 'mapped_slot': 8},
+                            3: {'orig_slot': 3, 'mapped_slot': 9},
+                            7: {'orig_slot': 7, 'mapped_slot': 10},
+                            11: {'orig_slot': 11, 'mapped_slot': 11},
+                            15: {'orig_slot': 15, 'mapped_slot': 12},
+                            4: {'orig_slot': 4, 'mapped_slot': 13},
+                            8: {'orig_slot': 8, 'mapped_slot': 14},
+                            12: {'orig_slot': 12, 'mapped_slot': 15},
+                            16: {'orig_slot': 16, 'mapped_slot': 16}
+                        }
+                    }
+                }
+            }
+        }
+    elif model in ('R20', 'R20B'):
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            3: {'orig_slot': 3, 'mapped_slot': 1},
+                            6: {'orig_slot': 6, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            12: {'orig_slot': 12, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            8: {'orig_slot': 8, 'mapped_slot': 7},
+                            11: {'orig_slot': 11, 'mapped_slot': 8},
+                            1: {'orig_slot': 1, 'mapped_slot': 9},
+                            4: {'orig_slot': 4, 'mapped_slot': 10},
+                            7: {'orig_slot': 7, 'mapped_slot': 11},
+                            10: {'orig_slot': 10, 'mapped_slot': 12}
+                        }
+                    },
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 13},
+                            2: {'orig_slot': 2, 'mapped_slot': 14}
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'R20A':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'model': {
+                        model: {
+                            3: {'orig_slot': 3, 'mapped_slot': 1},
+                            6: {'orig_slot': 6, 'mapped_slot': 2},
+                            9: {'orig_slot': 9, 'mapped_slot': 3},
+                            12: {'orig_slot': 12, 'mapped_slot': 4},
+                            2: {'orig_slot': 2, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            8: {'orig_slot': 8, 'mapped_slot': 7},
+                            11: {'orig_slot': 11, 'mapped_slot': 8},
+                            1: {'orig_slot': 1, 'mapped_slot': 9},
+                            4: {'orig_slot': 4, 'mapped_slot': 10},
+                            7: {'orig_slot': 7, 'mapped_slot': 11},
+                            10: {'orig_slot': 10, 'mapped_slot': 12}
+                        }
+                    },
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 13},
+                            2: {'orig_slot': 2, 'mapped_slot': 14}
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-3.0-E':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                            5: {'orig_slot': 5, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6}
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-3.0-E+':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                        },
+                        '3000000000000002': {
+                            1: {'orig_slot': 1, 'mapped_slot': 5},
+                            2: {'orig_slot': 2, 'mapped_slot': 6}
+
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-3.0-X':
+        return {
+            'any_version': True,
+            'versions': {
+                # NOTE: 1.0 "version" has same mapping?? (CORE is the same)
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                        },
+                        '3000000000000002': {
+                            1: {'orig_slot': 1, 'mapped_slot': 5},
+                            2: {'orig_slot': 2, 'mapped_slot': 6},
+                            4: {'orig_slot': 4, 'mapped_slot': 7}
+
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-3.0-X+':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 1},
+                            2: {'orig_slot': 2, 'mapped_slot': 2},
+                            3: {'orig_slot': 3, 'mapped_slot': 3},
+                            4: {'orig_slot': 4, 'mapped_slot': 4},
+                            5: {'orig_slot': 5, 'mapped_slot': 5},
+                            6: {'orig_slot': 6, 'mapped_slot': 6},
+                            7: {'orig_slot': 7, 'mapped_slot': 7}
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-3.0-XL+':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000002': {
+                            6: {'orig_slot': 6, 'mapped_slot': 1},
+                        },
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 2},
+                            2: {'orig_slot': 2, 'mapped_slot': 3},
+                            3: {'orig_slot': 3, 'mapped_slot': 4},
+                            4: {'orig_slot': 4, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            6: {'orig_slot': 6, 'mapped_slot': 7},
+                            7: {'orig_slot': 6, 'mapped_slot': 8},
+                            8: {'orig_slot': 6, 'mapped_slot': 9}
+                        }
+                    }
+                }
+            }
+        }
+    elif model == 'MINI-R':
+        return {
+            'any_version': True,
+            'versions': {
+                'DEFAULT': {
+                    'id': {
+                        '3000000000000001': {
+                            1: {'orig_slot': 1, 'mapped_slot': 2},
+                            2: {'orig_slot': 2, 'mapped_slot': 3},
+                            3: {'orig_slot': 3, 'mapped_slot': 4},
+                            4: {'orig_slot': 4, 'mapped_slot': 5},
+                            5: {'orig_slot': 5, 'mapped_slot': 6},
+                            6: {'orig_slot': 6, 'mapped_slot': 7},
+                            7: {'orig_slot': 6, 'mapped_slot': 8}
+                        },
+                        '3000000000000002': {
+                            4: {'orig_slot': 4, 'mapped_slot': 9},
+                            5: {'orig_slot': 5, 'mapped_slot': 10},
+                            6: {'orig_slot': 6, 'mapped_slot': 11},
+                            7: {'orig_slot': 7, 'mapped_slot': 12}
+                        }
+                    }
+                }
+            }
+        }
+    else:
+        return
+
+
+def get_mapping_info(dmi, enclosures=None):
+    """
+    `dmi` is a string representing what was burned
+    into SMBIOS from production team before the
+    system is shipped to the user. There are exceptions
+    to this, of course, one of them being the platforms
+    have nvme drives that represent usable disks but
+    are not physically present where all the other disks
+    are. We still need to map them to slots on the enclosure.
+    """
+    mapping = {
+        'TRUENAS-R10': 'R10',
+        'TRUENAS-R20': 'R20',
+        'TRUENAS-R20A': 'R20A',
+        'TRUENAS-R20B': 'R20B',
+        'TRUENAS-R40': 'R40',
+        'TRUENAS-R50': 'R50',
+        'r50_nvme_enclosure': 'R50',
+        'TRUENAS-R50B': 'R50B',
+        'r50b_nvme_enclosure': 'R50B',
+        'TRUENAS-R50BM': 'R50BM',
+        'r50bm_nvme_enclosure': 'R50BM',
+        'TRUENAS-MINI-3.0-E': 'MINI-3.0-E',
+        'FREENAS-MINI-3.0-E': 'MINI-3.0-E',
+        'TRUENAS-MINI-3.0-E+': 'MINI-3.0-E+',
+        'FREENAS-MINI-3.0-E+': 'MINI-3.0-E+',
+        'TRUENAS-MINI-3.0-X': 'MINI-3.0-X',
+        'FREENAS-MINI-3.0-X': 'MINI-3.0-X',
+        'TRUENAS-MINI-3.0-X+': 'MINI-3.0-X+',
+        'FREENAS-MINI-3.0-X+': 'MINI-3.0-X+',
+        'TRUENAS-MINI-3.0-XL+': 'MINI-3.0-XL+',
+        'FREENAS-MINI-3.0-XL+': 'MINI-3.0-XL+',
+        'TRUENAS-MINI-R': 'MINI-R',
+        'FREENAS-MINI-R': 'MINI-R'
+    }
+    try:
+        get_slot_info(mapping[dmi], enclosures)
+    except KeyError:
+        pass

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_element_types.py
@@ -1,0 +1,321 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import element_types
+
+
+@pytest.mark.parametrize('data', [
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
+    (0x000080, 'RQST mute'),
+    (0x000040, 'Muted'),
+    (0x000010, 'Remind'),
+    (0x000008, 'INFO'),
+    (0x000004, 'NON-CRIT'),
+    (0x000002, 'CRIT'),
+    (0x000001, 'UNRECOV'),
+    (0x000000, None),
+    (0xf000ff, 'Identify on, Fail on, RQST mute, Muted, Remind, INFO, NON-CRIT, CRIT, UNRECOV')
+])
+def test_alarm(data):
+    value_raw, expected_result = data
+    assert element_types.alarm(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x000000, None),
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
+    (0x000001, 'Disabled'),
+    (0xc00001, 'Identify on, Fail on, Disabled'),
+])
+def test_comm(data):
+    value_raw, expected_result = data
+    assert element_types.comm(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x000000, '0.0A'),
+    (0x800000, '0.0A, Identify on'),
+    (0x400000, '0.0A, Fail on'),
+    (0x070000, '0.0A, Crit over'),
+    (0x080000, '0.0A, Warn over'),
+    # 2.5A
+    (0x0000fa, '2.5A'),
+    (0x08010a, '2.66A, Warn over'),
+    (0x070110, '2.72A, Crit over'),
+    # 5.0A
+    (0x0001f4, '5.0A'),
+    (0x080210, '5.28A, Warn over'),
+    (0x070220, '5.44A, Crit over'),
+    # 12.0A
+    (0x0004b0, '12.0A'),
+    (0x0804d0, '12.32A, Warn over'),
+    (0x0704f0, '12.64A, Crit over'),
+])
+def test_current(data):
+    value_raw, expected_result = data
+    assert element_types.current(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x800000, 'Identify on'),
+    (0x000100, 'Warn on'),
+    (0x000200, 'Fail on'),
+    (0x000300, 'Fail on, Warn on'),
+    (0x800100, 'Identify on, Warn on'),
+    (0x800200, 'Identify on, Fail on'),
+    (0x800300, 'Identify on, Fail on, Warn on'),
+    (0x000400, 'Power cycle 1min, power off until manually restored'),
+    (0x000500, 'Warn on, Power cycle 1min, power off until manually restored'),
+    (0x000600, 'Fail on, Power cycle 1min, power off until manually restored'),
+    (0x800400, 'Identify on, Power cycle 1min, power off until manually restored'),
+    (0x0004f0, 'Power cycle 1min, power off for 60min'),
+])
+def test_enclosure(data):
+    value_raw, expected_result = data
+    assert element_types.enclosure(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x100000, '0.0V'),
+    (0x110000, '0.0V, Crit under'),
+    (0x410000, '0.0V, Fail on, Crit under'),
+    (0x810000, '0.0V, Identify on, Crit under'),
+    (0xf10000, '0.0V, Identify on, Fail on, Crit under'),
+    (0x220000, '0.0V, Crit over'),
+    (0x520000, '0.0V, Fail on, Crit over'),
+    (0x820000, '0.0V, Identify on, Crit over'),
+    (0xf20000, '0.0V, Identify on, Fail on, Crit over'),
+    # 2.5V
+    (0x0100f0, '2.4V, Crit under'),
+    (0x0000fa, '2.5V'),
+    (0x020110, '2.72V, Crit over'),
+    # 5.0V
+    (0x0101e4, '4.84V, Crit under'),
+    (0x0001f4, '5.0V'),
+    (0x020210, '5.28V, Crit over'),
+    # 12.0V
+    (0x0104a0, '11.84V, Crit under'),
+    (0x0004b0, '12.0V'),
+    (0x0204d0, '12.32V, Crit over'),
+])
+def test_volt(data):
+    value_raw, expected_result = data
+    assert element_types.volt(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x000000, '0 RPM'),
+    (0x001000, '160 RPM'),
+    (0x010000, '2560 RPM'),
+    (0x6f0000, '17920 RPM'),
+    # Ensure mask works correctly
+    (0xFFFF00, '20470 RPM'),
+])
+def test_cooling(data):
+    value_raw, expected_result = data
+    assert element_types.cooling(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x0000, None),
+    # Check for minimum temperature
+    (0x0100, '-19C'),
+    # Check for an arbitrary temperature
+    (0x8000, '108C'),
+    # Check for maximum temperature
+    (0xFF00, '235C'),
+    # Check that extra bits do not affect the result
+    (0xFFFF, '235C')
+])
+def test_temp(data):
+    value_raw, expected_result = data
+    assert element_types.temp(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x800000, 'Identify on'),
+    (0x400000, 'Do not remove'),
+    (0x80, 'Hot swap'),
+    (0x40, 'Fail on'),
+    (0x20, 'RQST on'),
+    (0x10, 'Off'),
+    (0x800, 'DC overvoltage'),
+    (0x400, 'DC undervoltage'),
+    (0x200, 'DC overcurrent'),
+    (0x8, 'Overtemp fail'),
+    (0x4, 'Overtemp warn'),
+    (0x2, 'AC fail'),
+    (0x1, 'DC fail'),
+    (0x10, 'Off'),
+    # Test with no flags set
+    (0x000000, None),
+    # Test some combinations
+    (0x800400, 'Identify on, DC undervoltage'),
+    (0x40C, 'DC undervoltage, Overtemp fail, Overtemp warn'),
+])
+def test_psu(data):
+    value_raw, expected_result = data
+    assert element_types.psu(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x200, 'Identify on'),
+    (0x20, 'Fault on'),
+    # Test with no flags set
+    (0x0, None),
+    # Test combinations
+    (0x220, 'Identify on, Fault on')
+])
+def test_array_dev(data):
+    value_raw, expected_result = data
+    assert element_types.array_dev(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    # Test each individual flag
+    (0x000000, 'No information'),
+    (0x010000, 'SAS 4x receptacle (SFF-8470) [max 4 phys]'),
+    (0x020000, 'Mini SAS 4x receptacle (SFF-8088) [max 4 phys]'),
+    (0x030000, 'QSFP+ receptacle (SFF-8436) [max 4 phys]'),
+    (0x040000, 'Mini SAS 4x active receptacle (SFF-8088) [max 4 phys]'),
+    (0x050000, 'Mini SAS HD 4x receptacle (SFF-8644) [max 4 phys]'),
+    (0x060000, 'Mini SAS HD 8x receptacle (SFF-8644) [max 8 phys]'),
+    (0x070000, 'Mini SAS HD 16x receptacle (SFF-8644) [max 16 phys]'),
+    (0x080000, 'unknown external connector type: 0x8'),
+    (0x090000, 'unknown external connector type: 0x9'),
+    (0x0a0000, 'unknown external connector type: 0xa'),
+    (0x0b0000, 'unknown external connector type: 0xb'),
+    (0x0c0000, 'unknown external connector type: 0xc'),
+    (0x0d0000, 'unknown external connector type: 0xd'),
+    (0x0e0000, 'unknown external connector type: 0xe'),
+    (0x0f0000, 'Vendor specific external connector'),
+    (0x100000, 'SAS 4i plug (SFF-8484) [max 4 phys]'),
+    (0x110000, 'Mini SAS 4i receptacle (SFF-8087) [max 4 phys]'),
+    (0x120000, 'Mini SAS HD 4i receptacle (SFF-8643) [max 4 phys]'),
+    (0x130000, 'Mini SAS HD 8i receptacle (SFF-8643) [max 8 phys]'),
+    (0x140000, 'Mini SAS HD 16i receptacle (SFF-8643) [max 16 phys]'),
+    (0x150000, 'SlimSAS 4i (SFF-8654) [max 4 phys]'),
+    (0x160000, 'SlimSAS 8i (SFF-8654) [max 8 phys]'),
+    (0x170000, 'SAS MiniLink 4i (SFF-8612) [max 4 phys]'),
+    (0x180000, 'SAS MiniLink 8i (SFF-8612) [max 8 phys]'),
+    (0x190000, 'unknown internal wide connector type: 0x19'),
+    (0x200000, 'SAS Drive backplane receptacle (SFF-8482) [max 2 phys]'),
+    (0x210000, 'SATA host plug [max 1 phy]'),
+    (0x220000, 'SAS Drive plug (SFF-8482) [max 2 phys]'),
+    (0x230000, 'SATA device plug [max 1 phy]'),
+    (0x240000, 'Micro SAS receptacle [max 2 phys]'),
+    (0x250000, 'Micro SATA device plug [max 1 phy]'),
+    (0x260000, 'Micro SAS plug (SFF-8486) [max 2 phys]'),
+    (0x270000, 'Micro SAS/SATA plug (SFF-8486) [max 2 phys]'),
+    (0x280000, '12 Gbit/s SAS Drive backplane receptacle (SFF-8680) [max 2 phys]'),
+    (0x290000, '12 Gbit/s SAS Drive Plug (SFF-8680) [max 2 phys]'),
+    (0x2a0000, 'Multifunction 12 Gbit/s 6x Unshielded receptacle connector receptacle (SFF-8639) [max 6 phys]'),
+    (0x2b0000, 'Multifunction 12 Gbit/s 6x Unshielded receptacle connector plug (SFF-8639) [max 6 phys]'),
+    (0x2c0000, 'SAS Multilink Drive backplane receptacle (SFF-8630) [max 4 phys]'),
+    (0x2d0000, 'SAS Multilink Drive backplane plug (SFF-8630) [max 4 phys]'),
+    (0x2e0000, 'unknown internal connector to end device type: 0x2e'),
+    (0x2f0000, 'SAS virtual connector [max 1 phy]'),
+    (0x300000, 'reserved for internal connector type: 0x30'),
+    (0x310000, 'reserved for internal connector type: 0x31'),
+    (0x320000, 'reserved for internal connector type: 0x32'),
+    (0x330000, 'reserved for internal connector type: 0x33'),
+    (0x340000, 'reserved for internal connector type: 0x34'),
+    (0x350000, 'reserved for internal connector type: 0x35'),
+    (0x360000, 'reserved for internal connector type: 0x36'),
+    (0x370000, 'reserved for internal connector type: 0x37'),
+    (0x380000, 'reserved for internal connector type: 0x38'),
+    (0x390000, 'reserved for internal connector type: 0x39'),
+    (0x3a0000, 'reserved for internal connector type: 0x3a'),
+    (0x3b0000, 'reserved for internal connector type: 0x3b'),
+    (0x3c0000, 'reserved for internal connector type: 0x3c'),
+    (0x3d0000, 'reserved for internal connector type: 0x3d'),
+    (0x3e0000, 'reserved for internal connector type: 0x3e'),
+    (0x3f0000, 'Vendor specific internal connector'),
+    (0x400000, 'SAS High Density Drive backplane receptacle (SFF-8631) [max 8 phys]'),
+    (0x410000, 'SAS High Density Drive backplane plug (SFF-8631) [max 8 phys]'),
+    (0x420000, 'reserved connector type: 0x42'),
+    (0x430000, 'reserved connector type: 0x43'),
+    (0x440000, 'reserved connector type: 0x44'),
+    (0x450000, 'reserved connector type: 0x45'),
+    (0x460000, 'reserved connector type: 0x46'),
+    (0x470000, 'reserved connector type: 0x47'),
+    (0x480000, 'reserved connector type: 0x48'),
+    (0x490000, 'reserved connector type: 0x49'),
+    (0x4a0000, 'reserved connector type: 0x4a'),
+    (0x4b0000, 'reserved connector type: 0x4b'),
+    (0x4c0000, 'reserved connector type: 0x4c'),
+    (0x4d0000, 'reserved connector type: 0x4d'),
+    (0x4e0000, 'reserved connector type: 0x4e'),
+    (0x4f0000, 'reserved connector type: 0x4f'),
+    (0x500000, 'reserved connector type: 0x50'),
+    (0x510000, 'reserved connector type: 0x51'),
+    (0x520000, 'reserved connector type: 0x52'),
+    (0x530000, 'reserved connector type: 0x53'),
+    (0x540000, 'reserved connector type: 0x54'),
+    (0x550000, 'reserved connector type: 0x55'),
+    (0x560000, 'reserved connector type: 0x56'),
+    (0x570000, 'reserved connector type: 0x57'),
+    (0x580000, 'reserved connector type: 0x58'),
+    (0x590000, 'reserved connector type: 0x59'),
+    (0x5a0000, 'reserved connector type: 0x5a'),
+    (0x5b0000, 'reserved connector type: 0x5b'),
+    (0x5c0000, 'reserved connector type: 0x5c'),
+    (0x5d0000, 'reserved connector type: 0x5d'),
+    (0x5e0000, 'reserved connector type: 0x5e'),
+    (0x5f0000, 'reserved connector type: 0x5f'),
+    (0x600000, 'reserved connector type: 0x60'),
+    (0x610000, 'reserved connector type: 0x61'),
+    (0x620000, 'reserved connector type: 0x62'),
+    (0x630000, 'reserved connector type: 0x63'),
+    (0x640000, 'reserved connector type: 0x64'),
+    (0x650000, 'reserved connector type: 0x65'),
+    (0x660000, 'reserved connector type: 0x66'),
+    (0x670000, 'reserved connector type: 0x67'),
+    (0x680000, 'reserved connector type: 0x68'),
+    (0x690000, 'reserved connector type: 0x69'),
+    (0x6a0000, 'reserved connector type: 0x6a'),
+    (0x6b0000, 'reserved connector type: 0x6b'),
+    (0x6c0000, 'reserved connector type: 0x6c'),
+    (0x6d0000, 'reserved connector type: 0x6d'),
+    (0x6e0000, 'reserved connector type: 0x6e'),
+    (0x6f0000, 'reserved connector type: 0x6f'),
+    (0x700000, 'vendor specific connector type: 0x70'),
+    (0x710000, 'vendor specific connector type: 0x71'),
+    (0x720000, 'vendor specific connector type: 0x72'),
+    (0x730000, 'vendor specific connector type: 0x73'),
+    (0x740000, 'vendor specific connector type: 0x74'),
+    (0x750000, 'vendor specific connector type: 0x75'),
+    (0x760000, 'vendor specific connector type: 0x76'),
+    (0x770000, 'vendor specific connector type: 0x77'),
+    (0x780000, 'vendor specific connector type: 0x78'),
+    (0x790000, 'vendor specific connector type: 0x79'),
+    (0x7a0000, 'vendor specific connector type: 0x7a'),
+    (0x7b0000, 'vendor specific connector type: 0x7b'),
+    (0x7c0000, 'vendor specific connector type: 0x7c'),
+    (0x7d0000, 'vendor specific connector type: 0x7d'),
+    (0x7e0000, 'vendor specific connector type: 0x7e'),
+    (0x7f0000, 'vendor specific connector type: 0x7f'),
+    # Test out of bounds connector type
+    (0x800000, 'No information'),
+    # Test connector type with fail on
+    (0x220040, 'SAS Drive plug (SFF-8482) [max 2 phys], Fail on'),
+    # Test out of bounds connector type with fail on
+    (0x800040, 'No information, Fail on')
+])
+def test_sas_conn(data):
+    value_raw, expected_result = data
+    assert element_types.sas_conn(value_raw) == expected_result
+
+
+@pytest.mark.parametrize('data', [
+    (0x0000, None),
+    (0x800000, 'Identify on'),
+    (0x400000, 'Fail on'),
+    (0xC00000, 'Identify on, Fail on')
+])
+def test_sas_exp(data):
+    value_raw, expected_result = data
+    assert element_types.sas_exp(value_raw) == expected_result

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_identification.py
@@ -1,0 +1,56 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import identification
+
+
+@pytest.mark.parametrize('data', [
+    # M series
+    ('ECStream_4024Sp', 'TRUENAS-M40', ('M40', True)),
+    ('ECStream_4024Ss', 'TRUENAS-M40', ('M40', True)),
+    ('iX_4024Sp', 'TRUENAS-M40', ('M40', True)),
+    ('iX_4024Ss', 'TRUENAS-M40', ('M40', True)),
+    # X series
+    ('CELESTIC_P3215-O', 'TRUENAS-X20', ('X20', True)),
+    ('CELESTIC_P3217-B', 'TRUENAS-X20', ('X20', True)),
+    # R series (just uses dmi info for model)
+    ('ECStream_FS1', 'TRUENAS-R10', ('R10', True)),
+    ('ECStream_FS2', 'TRUENAS-R20', ('R20', True)),
+    ('ECStream_DSS212Sp', 'TRUENAS-R50', ('R50', True)),
+    ('ECStream_DSS212Ss', 'TRUENAS-R40', ('R40', True)),
+    ('iX_FS1', 'TRUENAS-R10', ('R10', True)),
+    ('iX_FS2', 'TRUENAS-R10', ('R10', True)),
+    ('iX_DSS212Sp', 'TRUENAS-R10', ('R10', True)),
+    ('iX_DSS212Ss', 'TRUENAS-R10', ('R10', True)),
+    # R20
+    ('iX_TrueNAS R20p', 'TRUENAS-R20', ('R20', True)),
+    ('iX_TrueNAS 2012Sp', 'TRUENAS-R20', ('R20', True)),
+    ('iX_TrueNAS SMC SC826-P', 'TRUENAS-R20', ('R20', True)),
+    # R20 variants (and minis)
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20', ('R20', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20A', ('R20A', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-R20B', ('R20B', True)),
+    ('AHCI_SGPIOEnclosure', 'TRUENAS-MINI-R', ('TRUENAS-MINI-R', True)),
+    ('AHCI_SGPIOEnclosure', 'FREENAS-MINI-X', ('FREENAS-MINI-X', True)),
+    ('AHCI_SGPIOEnclosure', 'OOPS', ('', False)),
+    # R50
+    ('iX_eDrawer4048S1', 'TRUENAS-R50', ('R50', True)),
+    ('iX_eDrawer4048S2', 'TRUENAS-R50', ('R50', True)),
+    # JBODS
+    ('ECStream_3U16RJ-AC.r3', 'TRUENAS-F60', ('E16', False)),
+    ('Storage_1729', 'TRUENAS-F60', ('E24', False)),
+    ('QUANTA _JB9 SIM', 'TRUENAS-F60', ('E60', False)),
+    ('CELESTIC_X2012', 'TRUENAS-F60', ('ES12', False)),
+    ('ECStream_4024J', 'TRUENAS-F60', ('ES24', False)),
+    ('iX_4024J', 'TRUENAS-F60', ('ES24', False)),
+    ('ECStream_2024Jp', 'TRUENAS-F60', ('ES24F', False)),
+    ('ECStream_2024Js', 'TRUENAS-F60', ('ES24F', False)),
+    ('iX_2024Jp', 'TRUENAS-F60', ('ES24F', False)),
+    ('iX_2024Js', 'TRUENAS-F60', ('ES24F', False)),
+    ('CELESTIC_R0904', 'TRUENAS-F60', ('ES60', False)),
+    ('HGST_H4102-J', 'TRUENAS-F60', ('ES102', False)),
+    ('HGST_H4060-J', 'TRUENAS-M60', ('ES60G2', False)),
+    ('VikingES_NDS-41022-BB', 'TRUENAS-F60', ('ES102S', False))
+])
+def test_get_enclosure_model_and_controller(data):
+    key, dmi, expected_result = data
+    assert identification.get_enclosure_model_and_controller(key, dmi) == expected_result

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_slot_mappings.py
@@ -1,0 +1,344 @@
+import pytest
+
+from middlewared.plugins.enclosure_ import slot_mappings
+
+
+@pytest.mark.parametrize('data', [
+    ('R50', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        i: {'orig_slot': i, 'mapped_slot': i} for i in range(1, 25)
+                    },
+                    'eDrawer4048S2': {
+                        i: {'orig_slot': i, 'mapped_slot': j} for i, j in zip(range(1, 25), range(25, 49))
+                    }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
+                    }
+                }
+            }
+        }
+    }),
+    ('R50B', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        i: {'orig_slot': i, 'mapped_slot': i} for i in range(1, 25)
+                    },
+                    'eDrawer4048S2': {
+                        i: {'orig_slot': i, 'mapped_slot': j} for i, j in zip(range(1, 25), range(25, 49))
+                    }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
+                    }
+                }
+            }
+        }
+    }),
+    ('R50BM', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'product': {
+                    'eDrawer4048S1': {
+                        i: {'orig_slot': i, 'mapped_slot': i} for i in range(1, 25)
+                    },
+                    'eDrawer4048S2': {
+                        i: {'orig_slot': i, 'mapped_slot': j} for i, j in zip(range(1, 25), range(25, 49))
+                    }
+                },
+                'id': {
+                    'r50_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                    },
+                    'r50b_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                    },
+                    'r50bm_nvme_enclosure': {
+                        1: {'orig_slot': 1, 'mapped_slot': 49},
+                        2: {'orig_slot': 2, 'mapped_slot': 50},
+                        3: {'orig_slot': 3, 'mapped_slot': 51},
+                        4: {'orig_slot': 4, 'mapped_slot': 52},
+                    }
+                }
+            }
+        }
+    }),
+    ('R10', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R10': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        5: {'orig_slot': 5, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        13: {'orig_slot': 13, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        10: {'orig_slot': 10, 'mapped_slot': 7},
+                        14: {'orig_slot': 14, 'mapped_slot': 8},
+                        3: {'orig_slot': 3, 'mapped_slot': 9},
+                        7: {'orig_slot': 7, 'mapped_slot': 10},
+                        11: {'orig_slot': 11, 'mapped_slot': 11},
+                        15: {'orig_slot': 15, 'mapped_slot': 12},
+                        4: {'orig_slot': 4, 'mapped_slot': 13},
+                        8: {'orig_slot': 8, 'mapped_slot': 14},
+                        12: {'orig_slot': 12, 'mapped_slot': 15},
+                        16: {'orig_slot': 16, 'mapped_slot': 16}
+                    }
+                }
+            }
+        }
+    }),
+    ('R20', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }
+    }),
+    ('R20B', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20B': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }
+    }),
+    ('R20A', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'model': {
+                    'R20A': {
+                        3: {'orig_slot': 3, 'mapped_slot': 1},
+                        6: {'orig_slot': 6, 'mapped_slot': 2},
+                        9: {'orig_slot': 9, 'mapped_slot': 3},
+                        12: {'orig_slot': 12, 'mapped_slot': 4},
+                        2: {'orig_slot': 2, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        8: {'orig_slot': 8, 'mapped_slot': 7},
+                        11: {'orig_slot': 11, 'mapped_slot': 8},
+                        1: {'orig_slot': 1, 'mapped_slot': 9},
+                        4: {'orig_slot': 4, 'mapped_slot': 10},
+                        7: {'orig_slot': 7, 'mapped_slot': 11},
+                        10: {'orig_slot': 10, 'mapped_slot': 12}
+                    }
+                },
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 13},
+                        2: {'orig_slot': 2, 'mapped_slot': 14}
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-3.0-E', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6}
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-3.0-E+', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                    },
+                    '3000000000000002': {
+                        1: {'orig_slot': 1, 'mapped_slot': 5},
+                        2: {'orig_slot': 2, 'mapped_slot': 6}
+
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-3.0-X', {
+        'any_version': True,
+        'versions': {
+            # TODO: 1.0 "version" has same mapping?? (CORE is the same)
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                    },
+                    '3000000000000002': {
+                        1: {'orig_slot': 1, 'mapped_slot': 5},
+                        2: {'orig_slot': 2, 'mapped_slot': 6},
+                        4: {'orig_slot': 4, 'mapped_slot': 7}
+
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-3.0-X+', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 1},
+                        2: {'orig_slot': 2, 'mapped_slot': 2},
+                        3: {'orig_slot': 3, 'mapped_slot': 3},
+                        4: {'orig_slot': 4, 'mapped_slot': 4},
+                        5: {'orig_slot': 5, 'mapped_slot': 5},
+                        6: {'orig_slot': 6, 'mapped_slot': 6},
+                        7: {'orig_slot': 7, 'mapped_slot': 7}
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-3.0-XL+', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000002': {
+                        6: {'orig_slot': 6, 'mapped_slot': 1},
+                    },
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 2},
+                        2: {'orig_slot': 2, 'mapped_slot': 3},
+                        3: {'orig_slot': 3, 'mapped_slot': 4},
+                        4: {'orig_slot': 4, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        6: {'orig_slot': 6, 'mapped_slot': 7},
+                        7: {'orig_slot': 6, 'mapped_slot': 8},
+                        8: {'orig_slot': 6, 'mapped_slot': 9}
+                    }
+                }
+            }
+        }
+    }),
+    ('MINI-R', {
+        'any_version': True,
+        'versions': {
+            'DEFAULT': {
+                'id': {
+                    '3000000000000001': {
+                        1: {'orig_slot': 1, 'mapped_slot': 2},
+                        2: {'orig_slot': 2, 'mapped_slot': 3},
+                        3: {'orig_slot': 3, 'mapped_slot': 4},
+                        4: {'orig_slot': 4, 'mapped_slot': 5},
+                        5: {'orig_slot': 5, 'mapped_slot': 6},
+                        6: {'orig_slot': 6, 'mapped_slot': 7},
+                        7: {'orig_slot': 6, 'mapped_slot': 8}
+                    },
+                    '3000000000000002': {
+                        4: {'orig_slot': 4, 'mapped_slot': 9},
+                        5: {'orig_slot': 5, 'mapped_slot': 10},
+                        6: {'orig_slot': 6, 'mapped_slot': 11},
+                        7: {'orig_slot': 7, 'mapped_slot': 12}
+                    }
+                }
+            }
+        }
+    }),
+    ('BAD-MODEL', None)
+])
+def test_slot_mappings(data):
+    model, expected_result = data
+    assert slot_mappings.get_slot_info(model) == expected_result

--- a/src/middlewared/middlewared/utils/scsi_generic.py
+++ b/src/middlewared/middlewared/utils/scsi_generic.py
@@ -1,0 +1,114 @@
+import ctypes
+import fcntl
+import os
+
+# SG_IO ioctl command constant
+SG_IO = 0x2285
+
+# SCSI sense buffer size constant
+SG_MAX_SENSE = 32
+
+# Other necessary constants
+SG_DXFER_FROM_DEV = -3
+SG_DXFER_NONE = 0
+SG_FLAG_DIRECT_IO = 1
+SG_INFO_OK = 0
+
+# SCSI Enclosure Services command
+SES_RECEIVE_DIAGNOSTIC = 0x1C
+SES_ENCLOSURE_STATUS_PAGE_CODE = 0x02
+INQUIRY = 0x12
+
+
+class sg_io_hdr_v3(ctypes.Structure):
+    _fields_ = [
+        ("interface_id", ctypes.c_int),
+        ("dxfer_direction", ctypes.c_int),
+        ("cmd_len", ctypes.c_ubyte),
+        ("mx_sb_len", ctypes.c_ubyte),
+        ("iovec_count", ctypes.c_ushort),
+        ("dxfer_len", ctypes.c_uint),
+        ("dxferp", ctypes.c_void_p),
+        ("cmdp", ctypes.c_void_p),
+        ("sbp", ctypes.c_void_p),
+        ("timeout", ctypes.c_uint),
+        ("flags", ctypes.c_uint),
+        ("pack_id", ctypes.c_int),
+        ("usr_ptr", ctypes.c_void_p),
+        ("status", ctypes.c_ubyte),
+        ("masked_status", ctypes.c_ubyte),
+        ("msg_status", ctypes.c_ubyte),
+        ("sb_len_wr", ctypes.c_ubyte),
+        ("host_status", ctypes.c_ushort),
+        ("driver_status", ctypes.c_ushort),
+        ("resid", ctypes.c_int),
+        ("duration", ctypes.c_uint),
+        ("info", ctypes.c_uint),
+    ]
+
+
+def get_sgio_hdr_structure(cdb, dxfer_len, timeout=60000):
+    # Create a buffer for the sense data
+    sense_buffer = (ctypes.c_ubyte * SG_MAX_SENSE)()
+    results_buffer = (ctypes.c_ubyte * dxfer_len)()
+
+    hdr = sg_io_hdr_v3()
+    hdr.interface_id = ord('S')
+    hdr.cmd_len = len(cdb)
+    hdr.cmdp = ctypes.cast(cdb, ctypes.c_void_p)
+    hdr.dxfer_direction = SG_DXFER_FROM_DEV
+    hdr.dxfer_len = dxfer_len
+    hdr.dxferp = ctypes.cast(results_buffer, ctypes.c_void_p)
+    hdr.sbp = ctypes.cast(sense_buffer, ctypes.c_void_p)
+    hdr.mx_sb_len = len(sense_buffer)
+    hdr.timeout = timeout
+
+    return hdr, results_buffer, sense_buffer
+
+
+def do_io(device, hdr):
+    fd = os.open(device, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        # Make the ioctl call
+        if fcntl.ioctl(fd, SG_IO, hdr) != 0:
+            raise OSError("SG_IO ioctl failed")
+        elif (hdr.info & SG_INFO_OK) != 0:
+            raise OSError("SG_IO ioctl indicated failure")
+    finally:
+        # Close the device
+        os.close(fd)
+
+
+def inquiry(device):
+    dxfer_len = 0x38
+    cdb = (ctypes.c_ubyte * 6)(INQUIRY, 0x00, 0x00, 0x00, dxfer_len, 0x00)
+    hdr, results_buffer, sense_buffer = get_sgio_hdr_structure(cdb, dxfer_len)
+    do_io(device, hdr)
+
+    # Table 148 in SPC-5
+    t10_vendor_start, t10_vendor_end, t10_final = 8, (15 + 1), ''
+    product_ident_start, product_ident_end, product_ident_final = t10_vendor_end, (31 + 1), ''
+    product_rev_start, product_rev_end, product_rev_final = product_ident_end, (35 + 1), ''
+    serial_start, serial_end, serial_final = product_rev_end, (55 + 1), ''
+
+    for char in results_buffer[t10_vendor_start:t10_vendor_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        t10_final += _ascii
+
+    for char in results_buffer[product_ident_start:product_ident_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        product_ident_final += _ascii
+
+    for char in results_buffer[product_rev_start:product_rev_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        product_rev_final += _ascii
+
+    for char in results_buffer[serial_start:serial_end]:
+        if (_ascii := chr(char)) in (' ', '\x00'):
+            continue
+        serial_final += _ascii
+
+    return {'vendor': t10_final, 'product': product_ident_final, 'revision': product_rev_final, 'serial': serial_final}


### PR DESCRIPTION
This backports the `enclosure2` logic to `stable/cobia` branch because the performance benefits are too great to not have. Furthermore, this code is isolated and written in a way where nothing actually depends on it. The risk for regression is basically 0.

Now that this has been backported, I can change `alert/license_status.py` to call `enclosure2.query` which gives us the performance benefits described in https://github.com/truenas/middleware/pull/12054.

The reason why this is being done is because we're seeing that it's taking 240seconds+ to "log in" on an HA system during certain scenarios. I saw this on an internal system and implemented the changes mentioned up above.