### PR TITLE
NAS-123948 / 24.04 / fix webUI zpool creation page

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -45,6 +45,12 @@ class DiskService(Service):
         for i in await self.middleware.call(
             'datastore.query', 'storage.disk', [['disk_expiretime', '=', None]], {'prefix': 'disk_'}
         ):
+            if not i['size']:
+                # seen on an internal system during QA. The disk had actually been spun down
+                # by OS because it had so many errors so the size was an empty string in our db
+                # SMART data reported the following for the disk: "device is NOT READY (e.g. spun down, busy)"
+                continue
+
             serial_to_disk[(i['serial'], i['lunid'])].append(i)
 
             if i['name'] in in_use_disks_imported:


### PR DESCRIPTION
On an internal system, we have a drive that has failed in a "fun" way. The drive was reporting as being spun down which resulted in the size of the disk to be reported as 0 by the OS. The problem is that the front-end code depends on size being a valid number and if it isn't, the entire zpool creation wizard breaks and the user is unable to create a zpool.

This makes it so that `disk.get_unused` doesn't return drives that don't report a size.