### PR TITLE
NAS-124012 / 23.10 / Safely retrieve coredump exe attr (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/coredump.py
+++ b/src/middlewared/middlewared/plugins/system/coredump.py
@@ -21,7 +21,7 @@ class SystemService(Service):
                         'gid': core['COREDUMP_GID'],
                         'unit': core.get('COREDUMP_UNIT'),
                         'sig': core['COREDUMP_SIGNAL'],
-                        'exe': core['COREDUMP_EXE'],
+                        'exe': core.get('COREDUMP_EXE'),
                     }
                     if 'COREDUMP_FILENAME' not in core or not isinstance(core['COREDUMP_FILENAME'], str):
                         coredump['corefile'] = 'none'


### PR DESCRIPTION
This commit adds changes to safely retrieve coredump exe attr because we are seeing it not being present in our integration tests.

```

[2023/09/07 03:32:17] (WARNING) SystemService.coredumps():32 - Failed to obtain coredump information
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/system/coredump.py", line 24, in coredumps
    'exe': core['COREDUMP_EXE'],
           ~~~~^^^^^^^^^^^^^^^^
KeyError: 'COREDUMP_EXE'
[2023/09/07 03:32:17] (DEBUG) mid
```

Original PR: https://github.com/truenas/middleware/pull/12067
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124012