### PR TITLE
NAS-124009 / 23.10 / Add some handling for RuntimeError in tdb library (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -251,6 +251,9 @@ def get_snapshot_count_cached(middleware, lz, datasets, prefetch=False, update_d
 
     iter_datasets(out, datasets, tdb_entries, batch_ops, get_entry_fn)
     if batch_ops:
-        middleware.call_sync('tdb.batch_ops', {'name': 'snapshot_count', 'ops': batch_ops})
+        try:
+            middleware.call_sync('tdb.batch_ops', {'name': 'snapshot_count', 'ops': batch_ops})
+        except Exception:
+            pass
 
     return out


### PR DESCRIPTION
A user presented an unreproducible issue in which attempted batch operations on a TDB handle failed with TDB_ERR_LOCK when trying to obtain a transaction lock.

Since no additional collateral or steps to reproduce were provided it's unclear whether these changes would fix the underlying issue that was reported. This PR tries to minimize impact of libary errors by closing the handle (thereby releasing locks held by the current process) on RuntimeError. The library error will be passed on to the caller, but subsequent calls will have a new handle on the file and presumably not encounter the issue.

Original PR: https://github.com/truenas/middleware/pull/12066
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124009