### PR TITLE
NAS-123668 / 24.04 / Enable exporting reporting data to graphite

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-09-07_19-50_add_exporting_table_for_reporting.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-09-07_19-50_add_exporting_table_for_reporting.py
@@ -1,0 +1,61 @@
+"""Add exporting table for reporting
+
+Revision ID: 3e16b0a74d78
+Revises: e915a3b8fff6
+Create Date: 2023-09-07 19:50:42.678757+00:00
+
+"""
+import json
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.sql import text
+
+
+revision = '3e16b0a74d78'
+down_revision = 'e915a3b8fff6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'reporting_exporters',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('enabled', sa.Boolean(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('attributes', sa.TEXT(), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_reporting_exports'))
+    )
+
+    conn = op.get_bind()
+
+    for graphite_ip in filter(lambda ip: bool(ip[0]), conn.execute('SELECT graphite FROM system_reporting').fetchall()):
+        attributes = {
+            'destination_ip': graphite_ip[0],
+            'destination_port': 2003,
+            'prefix': 'dragonfish',
+            'hostname': 'truenas',
+            'update_every': 1,
+            'buffer_on_failures': 10,
+            'send_names_instead_of_ids': True,
+            'matching_charts': '*'
+        }
+        query = text(
+            'INSERT INTO reporting_exporters (enabled, type, name, attributes) VALUES '
+            '(:enabled, :type, :name, :attributes)'
+        )
+        conn.execute(
+            query,
+            enabled=True,
+            type='GRAPHITE',
+            name='netdata',
+            attributes=json.dumps(attributes)
+        )
+
+    op.drop_table('system_reporting')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/netdata/exporting.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/exporting.conf.mako
@@ -1,0 +1,15 @@
+<%
+    graphite_confs = middleware.call_sync('reporting.exporters.query', [['type', '=', 'GRAPHITE']])
+%>\
+% for graphite_conf in graphite_confs:
+[${graphite_conf['type'].lower()}:${graphite_conf['name']}]
+    enabled = ${"yes" if graphite_conf['enabled'] else "no"}
+    destination = ${graphite_conf['attributes']['destination_ip']}:${graphite_conf['attributes']['destination_port']}
+    prefix = ${graphite_conf['attributes']['prefix']}
+    hostname = ${graphite_conf['attributes']['hostname']}
+    send configured labels = no
+    update every = ${graphite_conf['attributes']['update_every']}
+    buffer on failures = ${graphite_conf['attributes']['buffer_on_failures']}
+    send names instead of ids = ${"yes" if graphite_conf['attributes']['send_names_instead_of_ids'] else "no"}
+    send charts matching = ${graphite_conf['attributes']['matching_charts']}
+% endfor

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -92,6 +92,7 @@ class EtcService(Service):
         'netdata': [
             {'type': 'mako', 'path': 'netdata/netdata.conf', 'checkpoint': 'pool_import'},
             {'type': 'mako', 'path': 'netdata/charts.d/exclude_netdata.conf', 'checkpoint': 'pool_import'},
+            {'type': 'mako', 'path': 'netdata/exporting.conf'},
         ],
         'fstab': [
             {'type': 'mako', 'path': 'fstab'},

--- a/src/middlewared/middlewared/plugins/reporting/export.py
+++ b/src/middlewared/middlewared/plugins/reporting/export.py
@@ -1,0 +1,164 @@
+import middlewared.sqlalchemy as sa
+
+from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Str, returns
+from middlewared.service import CRUDService, private, ValidationErrors
+
+from .exporters.factory import export_factory
+
+
+class ReportingExportsModel(sa.Model):
+    __tablename__ = 'reporting_exporters'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    enabled = sa.Column(sa.Boolean())
+    type = sa.Column(sa.String())
+    name = sa.Column(sa.String())
+    attributes = sa.Column(sa.JSON())
+
+
+class ReportingExportsService(CRUDService):
+
+    class Config:
+        namespace = 'reporting.exporters'
+        datastore = 'reporting.exporters'
+        cli_namespace = 'reporting.exporters'
+
+    ENTRY = Dict(
+        'reporting_exporter_entry',
+        Int('id', required=True),
+        Bool('enabled', required=True),
+        Str(
+            'type', enum=[authenticator for authenticator in export_factory.get_exporters()],
+            required=True,
+        ),
+        Dict(
+            'attributes',
+            additional_attrs=True,
+            description='Specific attributes of each `exporter`'
+        ),
+        Str('name', description='User defined name of exporter configuration', required=True),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(ReportingExportsService, self).__init__(*args, **kwargs)
+        self.exporters = self.get_exporter_schemas()
+
+    @private
+    async def common_validation(self, data, schema_name, old=None):
+        verrors = ValidationErrors()
+        filters = [['name', '!=', old['name']]] if old else []
+        filters.append(['name', '=', data['name']])
+        if await self.query(filters):
+            verrors.add(f'{schema_name}.name', 'Specified name is already in use')
+
+        if data['type'] not in self.exporters:
+            verrors.add(
+                f'{schema_name}.type',
+                f'System does not support {data["type"]} as a reporting exporter type.'
+            )
+        else:
+            exporter_obj = self.get_exporter_object(data)
+            try:
+                data['attributes'] = await exporter_obj.validate_config(data['attributes'])
+            except ValidationErrors as ve:
+                verrors.extend(ve)
+
+        verrors.check()
+
+    async def do_create(self, data):
+        """
+        Create a specific reporting exporter configuration containing required details for exporting reporting metrics.
+        """
+        await self.common_validation(data, 'reporting_exporter_create')
+
+        oid = await self.middleware.call(
+            'datastore.insert',
+            self._config.datastore,
+            data,
+        )
+
+        if data['enabled']:
+            # Only restart if this is enabled
+            await self.middleware.call('service.restart', 'netdata')
+
+        return await self.get_instance(oid)
+
+    @accepts(
+        Int('id'),
+        Patch(
+            'reporting_exporter_entry',
+            'reporting_exporter_update',
+            ('rm', {'name': 'id'}),
+            ('rm', {'name': 'type'}),
+            ('attr', {'update': True}),
+        ),
+    )
+    async def do_update(self, oid, data):
+        """
+        Update Reporting Exporter of `id`.
+        """
+        old = await self.get_instance(oid)
+        new = old.copy()
+        attrs = data.pop('attributes', {})
+        new.update(data)
+        new['attributes'].update(attrs)  # this is to be done separately so as to not overwrite the dict
+
+        await self.common_validation(new, 'reporting_exporter_update', old)
+
+        await self.middleware.call(
+            'datastore.update',
+            self._config.datastore,
+            oid,
+            new
+        )
+
+        await self.middleware.call('service.restart', 'netdata')
+
+        return await self.get_instance(oid)
+
+    async def do_delete(self, oid):
+        """
+        Delete Reporting Exporter of `id`.
+        """
+        await self.middleware.call(
+            'datastore.delete',
+            self._config.datastore,
+            oid,
+        )
+        await self.middleware.call('service.restart', 'netdata')
+        return True
+
+    @accepts()
+    @returns(List(
+        title='Reporting Exporter Schemas',
+        items=[Dict(
+            'schema_entry',
+            Str('key', required=True),
+            List(
+                'schema',
+                items=[Dict(
+                    'attribute_schema',
+                    additional_attrs=True,
+                    title='Attribute Schema',
+                )],
+            ),
+            title='Reporting Exporter Schema'
+        )],
+    ))
+    def exporter_schemas(self):
+        """
+        Get the schemas for all the reporting export types we support with their respective attributes
+        required for successfully exporting reporting metrics to them.
+        """
+        return [
+            {'schema': [v.to_json_schema() for v in value.attrs.values()], 'key': key}
+            for key, value in self.exporters.items()
+        ]
+
+    @private
+    def get_exporter_object(self, data):
+        return export_factory.exporter(data['type'])()
+
+    @private
+    def get_exporter_schemas(self):
+        return {k: klass.SCHEMA for k, klass in export_factory.get_exporters().items()}

--- a/src/middlewared/middlewared/plugins/reporting/exporters/base.py
+++ b/src/middlewared/middlewared/plugins/reporting/exporters/base.py
@@ -1,0 +1,8 @@
+class Export:
+
+    NAME = NotImplementedError()
+    SCHEMA = NotImplementedError()
+
+    @staticmethod
+    async def validate_config(data):
+        raise NotImplementedError()

--- a/src/middlewared/middlewared/plugins/reporting/exporters/factory.py
+++ b/src/middlewared/middlewared/plugins/reporting/exporters/factory.py
@@ -1,0 +1,30 @@
+import errno
+
+from middlewared.service_exception import CallError
+
+from .graphite import GraphiteExporter
+
+
+class ExportFactory:
+
+    def __init__(self):
+        self._creators = {}
+
+    def register(self, exporter):
+        self._creators[exporter.NAME.upper()] = exporter
+
+    def exporter(self, name):
+        name = name.upper()
+        if name not in self._creators:
+            raise CallError(f'Unable to locate {name!r} exporter', errno=errno.ENOENT)
+        return self._creators[name]
+
+    def get_exporters(self):
+        return self._creators
+
+
+export_factory = ExportFactory()
+for exporter_type in [
+    GraphiteExporter,
+]:
+    export_factory.register(exporter_type)

--- a/src/middlewared/middlewared/plugins/reporting/exporters/graphite.py
+++ b/src/middlewared/middlewared/plugins/reporting/exporters/graphite.py
@@ -1,0 +1,25 @@
+from middlewared.schema import accepts, Bool, Dict, Int, Str
+from middlewared.validators import Port, Range
+
+from .base import Export
+
+
+class GraphiteExporter(Export):
+
+    NAME = 'graphite'
+    SCHEMA = Dict(
+        'graphite',
+        Str('destination_ip', required=True),
+        Int('destination_port', required=True, validators=[Port()]),
+        Str('prefix', default='dragonfish'),
+        Str('hostname', default='truenas'),
+        Int('update_every', validators=[Range(min_=1)], default=1),
+        Int('buffer_on_failures', validators=[Range(min_=1)], default=10),
+        Bool('send_names_instead_of_ids', default=True),
+        Str('matching_charts', default='*'),
+    )
+
+    @staticmethod
+    @accepts(SCHEMA)
+    async def validate_config(data):
+        return data


### PR DESCRIPTION
## Context

It was requested that we add ability to export reporting data to graphite similar to what we used to do before and while we are doing this also make sure the approach is implementation agnostic so we can add more relevant export types as well.

Here changes have been made to the reporting system to ensure that the configuration aligns with the use of Netdata for reporting. Specifically, the reporting system is updated to support Netdata's metrics export to Graphite, as Collectd is no longer used. This involves creating a new endpoint within the reporting system, such as `reporting.exporters`, which exposes methods for creating, deleting, and updating Netdata export configurations.

The following parameters should be specified to enable Graphite as the reporting destination for Netdata:

1. **enable**: This parameter enables a specific instance of the export.
2. **name**: It specifies a unique instance name for Netdata. If multiple instances are configured, each must have a distinct name.
3. **attributes.destination_ip**: This parameter sets the IP address of the Graphite server.
4. **attributes.destination_port**: It specifies the port on which the Graphite server is listening.
5. **attributes.prefix**: This parameter defines a prefix that will be prepended to all Netdata metrics sent to Graphite.
6. **attributes.hostname**: It is used to specify the hostname to append to the metrics after the prefix.
7. **attributes.update_every**: This parameter determines the interval at which metrics are updated.
8. **attributes.buffer_on_failures**: It specifies the tolerance for update failures.
9. **attributes.send_names_instead_of_ids**: This option controls whether to send chart names instead of IDs.
10. **attributes.matching_charts**: This parameter allows specifying a regular expression for Netdata charts that should be sent to the Graphite server.
11. **type**: Currently, only `GRAPHITE` is supported. This parameter simplifies the integration of other exporters available in Netdata.

By implementing these changes and ensuring that the reporting system is aligned with Netdata's Graphite export configuration, the reporting process will be accurate and efficient and the approach is generic too so we can add more exporters in the future with ease.

## References

- [Netdata Documentation](https://learn.netdata.cloud/docs/agent/collectors/plugins.d.plugin/graphite.plugin)
- [Netdata Exporting Ref](https://learn.netdata.cloud/docs/exporting/exporting-reference)