### PR TITLE
NAS-124054 / 24.04 / Mount /tmp filesystem noexec

### DIFF
--- a/src/freenas/etc/systemd/system/tmp.mount
+++ b/src/freenas/etc/systemd/system/tmp.mount
@@ -23,7 +23,7 @@ After=swap.target
 What=tmpfs
 Where=/tmp
 Type=tmpfs
-Options=mode=1777,strictatime,nosuid,nodev
+Options=mode=1777,strictatime,nosuid,noexec,nodev
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
This is generally good practice and required per STIG on some Linux distros.