### PR TITLE
NAS-124029 / 23.10 / Mark chart.release create/update method values as private (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -358,7 +358,7 @@ class ChartReleaseService(CRUDService):
     @accepts(
         Dict(
             'chart_release_create',
-            Dict('values', additional_attrs=True),
+            Dict('values', additional_attrs=True, private=True),
             Str('catalog', required=True),
             Str('item', required=True),
             Str(
@@ -509,7 +509,7 @@ class ChartReleaseService(CRUDService):
         Str('chart_release'),
         Dict(
             'chart_release_update',
-            Dict('values', additional_attrs=True),
+            Dict('values', additional_attrs=True, private=True),
         )
     )
     @job(lock=lambda args: f'chart_release_update_{args[0]}')


### PR DESCRIPTION
This commit adds changes to mark chart.release create/update method values as private because they can contain potentially sensitive information like passwords etc for the app. We cannot be fine grained about it at this point because we don't have the app schema at this point when schema is called/validated, so we mark the values as private.

Original PR: https://github.com/truenas/middleware/pull/12080
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124029