### PR TITLE
NAS-124017 / 23.10 / Safely validate unlocked datasets (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -160,8 +160,12 @@ class PoolDatasetService(Service):
                 )
 
             if not options['force'] and not ds['force']:
-                if err := dataset_can_be_mounted(ds['name'], os.path.join('/mnt', ds['name'])):
-                    verrors.add(f'unlock_options.datasets.{i}.force', err)
+                if self.middleware.call_sync(
+                    'pool.dataset.get_instance_quick', ds['name'], {'encryption': True}
+                )['locked']:
+                    # We are only concerned to do validation here if the dataset is locked
+                    if err := dataset_can_be_mounted(ds['name'], os.path.join('/mnt', ds['name'])):
+                        verrors.add(f'unlock_options.datasets.{i}.force', err)
 
             keys_supplied[ds['name']] = ds.get('key') or ds.get('passphrase')
 

--- a/tests/api2/test_dataset_unlock_validation.py
+++ b/tests/api2/test_dataset_unlock_validation.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+from middlewared.client.client import ValidationErrors
+
+
+PASSPHRASE = '12345678'
+
+
+def encryption_props():
+    return {
+        'encryption_options': {'generate_key': False, 'passphrase': PASSPHRASE},
+        'encryption': True,
+        'inherit_encryption': False
+    }
+
+
+@pytest.mark.parametrize(
+    'nested_dir,lock_dataset', [('test_dir', True), ('parent/child', True), ('test_dir', False)]
+)
+def test_encrypted_dataset_unlock_mount_validation(nested_dir, lock_dataset):
+    with dataset('test_dataset', encryption_props()) as encrypted_ds:
+        mount_point = os.path.join('/mnt', encrypted_ds)
+
+        if lock_dataset:
+            call('pool.dataset.lock', encrypted_ds, job=True)
+            call('filesystem.set_immutable', False, mount_point)
+
+        ssh(f'mkdir -p {os.path.join(mount_point, nested_dir)}')
+
+        if lock_dataset:
+            with pytest.raises(ValidationErrors) as ve:
+                call(
+                    'pool.dataset.unlock', encrypted_ds.split('/')[0],
+                    {'datasets': [{'passphrase': PASSPHRASE, 'name': encrypted_ds}], 'recursive': True}, job=True
+                )
+
+            assert ve.value.errors[0].attribute == 'unlock_options.datasets.0.force'
+            assert ve.value.errors[0].errmsg == f'\'{mount_point}\' directory is not empty (please provide' \
+                                                ' "force" flag to override this error and file/directory will be' \
+                                                ' renamed once the dataset is unlocked)'
+        else:
+            call(
+                'pool.dataset.unlock', encrypted_ds.split('/')[0],
+                {'datasets': [{'passphrase': PASSPHRASE, 'name': encrypted_ds}], 'recursive': True}, job=True
+            )
+
+    ssh(f'rm -rf {mount_point}')


### PR DESCRIPTION
This commit adds changes to not raise a validation error if a dataset is specified explicitly in the list which is already unlocked. We are not erroring out here because it should be fine as rest of the implementation is not concerned about it being unlocked already and a consumer to be on the safe side can just specify whichever datasets he wants unlocked rather then checking first and only specifying locked ones.

Original PR: https://github.com/truenas/middleware/pull/12076
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124017