### PR TITLE
NAS-123969 / 24.04 / Handle file not found error in kubernetes stats

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
@@ -64,7 +64,7 @@ class Service(SimpleService):
     def _get_data(self):
         try:
             pods_stats = asyncio.run(Node.get_stats())['pods']
-        except (ClientConnectorError, ApiException):
+        except (ClientConnectorError, ApiException, FileNotFoundError):
             return {}
         data = defaultdict(int)
         self.prepare_pods_charts([pod['podRef']['name'] for pod in pods_stats])


### PR DESCRIPTION
## Problem

In a fresh setup where Kubernetes has not been previously configured, an error occurs due to missing files. Specifically, the error is related to the absence of certain k3s configuration files in the Netdata k3s_stats plugin.

## Solution

Safely handle/accommodate the case where the configuration file is not present when apps are not configured so as to avoid spamming netdata logs.