### PR TITLE
NAS-124108 / 24.04 / Toggle zfs readonly on /usr during binary mock

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/mock_binary.py
+++ b/src/middlewared/middlewared/test/integration/utils/mock_binary.py
@@ -30,8 +30,16 @@ class BinaryMock:
         return result
 
 
+def set_usr_readonly(value):
+    cmd = 'python3 -c "import libzfs;'
+    cmd += 'hdl = libzfs.ZFS().get_dataset_by_path(\\\"/usr\\\");'
+    cmd += 'hdl.update_properties({\\\"readonly\\\": {\\\"value\\\": '
+    cmd += f'\\\"{value}\\\"' + '}});"'
+    ssh(cmd)
+
 @contextlib.contextmanager
 def mock_binary(path, code="", exitcode=1):
+    set_usr_readonly("off")
     ssh(f"rm -f {RESULT_PATH}")
     ssh(f"mv {path} {path}.bak")
     try:
@@ -57,3 +65,4 @@ def mock_binary(path, code="", exitcode=1):
         yield BinaryMock()
     finally:
         ssh(f"mv {path}.bak {path}")
+        set_usr_readonly("on")


### PR DESCRIPTION
The middleware test utility to mock binaries requires read-write access to /usr. This adds simple utility function to toggle the property for duration of the mocked binary's context. This is so that we can ensure that the other tests occur within regular designed parameters.