### PR TITLE
NAS-124118 / 24.04 / optimize reporting/events.py

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -81,9 +81,7 @@ class RealtimeEventSource(EventSource):
                 'memory': get_memory_info(netdata_metrics),
                 'virtual_memory': psutil.virtual_memory()._asdict(),
                 'cpu': get_cpu_stats(netdata_metrics, cores),
-                'disks': get_disk_stats(
-                    netdata_metrics, list(self.middleware.call_sync('device.get_disks', False, True))
-                ),
+                'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
                 'interfaces': get_interface_stats(
                     netdata_metrics, [i['name'] for i in self.middleware.call_sync('interface.query')]
                 ),

--- a/tests/api2/test_device_get_disk_names.py
+++ b/tests/api2/test_device_get_disk_names.py
@@ -1,0 +1,5 @@
+from middlewared.test.integration.utils import call
+
+
+def test_device_get_disk_names():
+    assert set(list(call('device.get_disks', False, True))) == set(call('device.get_disk_names'))


### PR DESCRIPTION
I generated a flame graph of the main middleware process on an internal system with ~1.2k disks. The flame graph included 40,293 samples. Of those samples, 27,837 (69.09%) of them were spent on line 85 in the `reporting/events.py` script.

After looking at line 85, I realized that we're casting the dictionary to a list which just pulls out the keys of the dictionary. The keys of the dictionary from `device.get_disks` are simply block device names for the disks on the system. This is too expensive to call just to get the names of the disks so I added a new function `device.get_disk_names`.

The function that I've added is ~150% faster than the old method. The returned output is the exact same.