### PR TITLE
NAS-124087 / 23.10-RC.1 / retaste disks on standby on any pool create/delete op (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -764,4 +764,4 @@ async def retaste_disks_on_standby_hook(middleware, *args, **kwargs):
 
 
 async def setup(middleware):
-    await self.middleware.register_hook('pool.post_create_or_update', retaste_disks_on_standby_hook)
+    middleware.register_hook('pool.post_create_or_update', retaste_disks_on_standby_hook)


### PR DESCRIPTION
Symlinks in `/dev/disk/by-partuuid` don't get populated on the standby controller on failover unless on fresh boot OR the active controller tells the standby to "retaste" the disks.

We were retesting the disks on pool create, but we were not doing it on pool update. This means, for example, if a new vdev was added on active controller and a failover occurred after. The standby would fail to import the pool because sysfs would not have the proper symlinks in place. This fixes it so that any pool.create/update operation triggers a retasting of the disks on the standby controller.

Original PR: https://github.com/truenas/middleware/pull/12105
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124087