### PR TITLE
NAS-124126 / 23.10 / raise better validation error on improper home dir (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -384,11 +384,16 @@ class UserService(CRUDService):
                 errno.EEXIST
             )
 
-        if not data['home'].startswith('/mnt/'):
+        if not data['home'].startswith('/mnt'):
             verrors.add(
                 f'{schema}.home',
-                '"Home Directory" must begin with /mnt/ or set to '
+                '"Home Directory" must begin with /mnt or set to '
                 f'{DEFAULT_HOME_PATH}.'
+            )
+        elif data['home'] in ('/mnt', '/mnt/'):
+            verrors.add(
+                f'{schema}.home',
+                '"Home Directory" cannot be at root of "/mnt"'
             )
 
         if verrors:


### PR DESCRIPTION
When using the webUI to create a new user and choosing to create the home directory, if you choose `/mnt` an error message gets raised stating `Home Directory must begin with /mnt/ ...`. This really confused me because I clearly had chosen `/mnt`. The issue is that we're checking for a literal `/mnt/` so the validation error is misleading.

To remedy this and keep the same short-circuits in place, change the `startswith(` check to just `/mnt` to catch the obvious errors. Add another short-circuit branch to check to see if the home directory is a literal `/mnt` or `/mnt/` and raise a proper validation error message as well.

Original PR: https://github.com/truenas/middleware/pull/12115
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124126