### PR TITLE
NAS-124184 / 24.04 / Add support for FreeIPA netgroups

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -601,6 +601,7 @@ class LDAPService(TDBWrapConfigService):
             aux_params = [
                 f'base passwd cn=users,cn=accounts,{default_naming_context}',
                 f'base group cn=groups,cn=accounts,{default_naming_context}',
+                f'base netgroup cn=ng,cn=compat,{default_naming_context}',
             ]
             data.update({
                 'schema': 'RFC2307BIS',

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -100,7 +100,6 @@ def test_07_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
 def test_10_verify_support_for_netgroups(request):
     """
     'getent netgroup' should be able to retrieve netgroup
-    TODO: Add an ixgroup to the FreeIPA server with some known users or hosts
     """
     depends(request, ["FREEIPA_NSS_WORKING"], scope="session")
     res = SSH_TEST("getent netgroup ixtestusers", user, password, ip)

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -6,14 +6,17 @@ import os
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import (
-    GET,
-    POST,
-)
+from functions import GET, POST, SSH_TEST
 from assets.REST.directory_services import ldap
-from auto_config import dev_test
+from middlewared.test.integration.utils import call
+from auto_config import ha, dev_test, user, password
 # comment pytestmark for development testing with --dev-test
 pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
+
+if ha and "virtual_ip" in os.environ:
+    ip = os.environ["virtual_ip"]
+else:
+    from auto_config import ip
 
 try:
     from config import (
@@ -30,6 +33,18 @@ except ImportError:
 
 @pytest.fixture(scope="module")
 def do_freeipa_connection(request):
+    # Confirm DNS forward
+    res = SSH_TEST(f"host {FREEIPA_HOSTNAME}", user, password, ip)
+    assert res['result'] is True, res
+    # stdout: "<FREEIPA_HOSTNAME> has address <FREEIPA_IP>"
+    assert res['stdout'].split()[-1] == FREEIPA_IP
+
+    # DNS reverse
+    res = SSH_TEST(f"host {FREEIPA_IP}", user, password, ip)
+    assert res['result'] is True, res
+    # stdout: <FREEIPA_IP_reverse_format>.in-addr.arpa domain name pointer <FREEIPA_HOSTNAME>.
+    assert res['stdout'].split()[-1] == FREEIPA_HOSTNAME + "."
+
     with ldap(
         FREEIPA_BASEDN,
         FREEIPA_BINDDN,
@@ -54,12 +69,22 @@ def test_02_verify_ldap_enable_is_true(request):
     assert results.json()["enable"] is True, results.text
 
 
+@pytest.mark.dependency(name="FREEIPA_VALID_CONFIG")
+def test_05_verify_config(request):
+    depends(request, ["setup_freeipa"], scope="session")
+    ldap_config = call('ldap.config')
+    assert 'RFC2307BIS' == ldap_config['schema']
+    assert "base passwd cn=users,cn=accounts" in ldap_config['auxiliary_parameters']
+    assert "base group cn=groups,cn=accounts" in ldap_config['auxiliary_parameters']
+    assert "base netgroup cn=ng,cn=compat" in ldap_config['auxiliary_parameters']
+
+
 @pytest.mark.dependency(name="FREEIPA_NSS_WORKING")
-def test_03_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
+def test_07_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
     """
     get_user_obj is a wrapper around the pwd module.
     """
-    depends(request, ["setup_freeipa"], scope="session")
+    depends(request, ["FREEIPA_VALID_CONFIG"], scope="session")
     payload = {
         "username": "ixauto_restricted",
         "get_groups": True
@@ -69,4 +94,22 @@ def test_03_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
     pwd_obj = results.json()
     assert pwd_obj['pw_uid'] == 925000003
     assert pwd_obj['pw_gid'] == 925000003
-    assert len(pwd_obj['grouplist']) > 1
+    assert len(pwd_obj['grouplist']) >= 1, pwd_obj['grouplist']
+
+
+@pytest.mark.skip(reason="Update and enable this when FreeIPA test infrastructure is ready")
+def test_10_verify_support_for_netgroups(request):
+    """
+    'getent netgroup' should be able to retrieve netgroup
+    TODO: Add an ixgroup to the FreeIPA server with some known users or hosts
+    """
+    depends(request, ["FREEIPA_NSS_WORKING"], scope="session")
+    res = SSH_TEST("getent netgroup ixgroup", user, password, ip)
+    assert res['result'] is True, f"Failed to find netgroup 'ixgroup', returncode={res['returncode']}"
+
+    # Confirm expected set of users or hosts
+    ixgroup = res['stdout'].split()[1:]
+
+    # Confirm number of entries and some elements
+    assert len(ixgroup) == 3, ixgroup
+    assert any("testuser1" in sub for sub in ixgroup), ixgroup

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -97,14 +97,13 @@ def test_07_verify_that_the_freeipa_user_id_exist_on_the_nas(request):
     assert len(pwd_obj['grouplist']) >= 1, pwd_obj['grouplist']
 
 
-@pytest.mark.skip(reason="Update and enable this when FreeIPA test infrastructure is ready")
 def test_10_verify_support_for_netgroups(request):
     """
     'getent netgroup' should be able to retrieve netgroup
     TODO: Add an ixgroup to the FreeIPA server with some known users or hosts
     """
     depends(request, ["FREEIPA_NSS_WORKING"], scope="session")
-    res = SSH_TEST("getent netgroup ixgroup", user, password, ip)
+    res = SSH_TEST("getent netgroup ixtestusers", user, password, ip)
     assert res['result'] is True, f"Failed to find netgroup 'ixgroup', returncode={res['returncode']}"
 
     # Confirm expected set of users or hosts


### PR DESCRIPTION
* Updated plugins/ldap.py to include netgroups for FreeIPA
* Updated test_278_freeipa.py 
    - Small amount of refactoring
    - Added test for config settings
    - Added forward and reverse DNS test
    - Added test for retrieving netgroups 
