### PR TITLE
NAS-124190 / 24.04 / mask ipmi usb ethernet on fseries platform

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -25,6 +25,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         self._cloned = any((self.name.startswith(i) for i in CLONED_PREFIXES))
         self._rxq = dev.get_attr('IFLA_NUM_RX_QUEUES') or 1
         self._txq = dev.get_attr('IFLA_NUM_TX_QUEUES') or 1
+        self._bus = dev.get_attr('IFLA_PARENT_DEV_BUS_NAME')
 
     def _read(self, name, type_=str):
         return self._sysfs_read(f"/sys/class/net/{self.name}/{name}", type_)
@@ -34,6 +35,10 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             value = f.read().strip()
 
         return type_(value)
+
+    @property
+    def bus(self):
+        return self._bus
 
     @property
     def orig_name(self):


### PR DESCRIPTION
The fseries platform will add a usb ethernet device when ikvm console is opened up. That's horrible design imo but the fact is that we have to deal with it. This 2 things.

1. on the fseries platform, if a nic has a bus attribute of `usb` then skip it so it doesn't show up in `interface.query` preventing the end-user from using our webUI/API to configure said device
2. stop logging the interface name in the devd hook when an interface is attached and that interface doesn't exist in the database. It's confusing an unnecessary to pollute our logs with messages like these.