### PR TITLE
NAS-122711 / 13.0 / add ES102S to CORE (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
@@ -67,6 +67,8 @@ class Enclosure(object):
             model = 'ES60'
         elif self.encname.startswith('HGST H4102-J'):
             model = 'ES102'
+        elif self.encname.startswith("VikingES NDS-41022-BB"):
+            model = "ES102S"
 
         return model, controller
 

--- a/src/middlewared/middlewared/utils/license.py
+++ b/src/middlewared/middlewared/utils/license.py
@@ -8,4 +8,5 @@ LICENSE_ADDHW_MAPPING = {
     7: "ES24F",
     8: "ES60S",
     9: "ES102",
+    10: "ES102S",
 }


### PR DESCRIPTION
This was missed when originally adding the ES102S enclosure platform to SCALE.

Original PR: https://github.com/truenas/middleware/pull/12149
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122711