### PR TITLE
NAS-123286 / 13.0 / add ES60G2 to CORE (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
@@ -65,10 +65,12 @@ class Enclosure(object):
             model = 'ES24F'
         elif self.encname.startswith('CELESTIC R0904'):
             model = 'ES60'
+        elif self.encname.startswith('HGST H4060-J 3010'):
+            model = 'ES60G2'
         elif self.encname.startswith('HGST H4102-J'):
             model = 'ES102'
-        elif self.encname.startswith("VikingES NDS-41022-BB"):
-            model = "ES102S"
+        elif self.encname.startswith('VikingES NDS-41022-BB'):
+            model = 'ES102S'
 
         return model, controller
 

--- a/src/middlewared/middlewared/utils/license.py
+++ b/src/middlewared/middlewared/utils/license.py
@@ -9,4 +9,5 @@ LICENSE_ADDHW_MAPPING = {
     8: "ES60S",
     9: "ES102",
     10: "ES102S",
+    11: "ES60G2",
 }


### PR DESCRIPTION
This was missed when originally adding the ES60G2 enclosure platform to SCALE.

Original PR: https://github.com/truenas/middleware/pull/12151
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123286