### PR TITLE
NAS-124086 / 24.04 / Hide system reporting queries commands in SCALE CLI

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/graphs.py
@@ -4,7 +4,9 @@ import time
 import typing
 
 from middlewared.schema import accepts, Dict, List, Ref, returns, Str
-from middlewared.service import CallError, filterable, filterable_returns, private, Service, ValidationErrors
+from middlewared.service import (
+    CallError, cli_private, filterable, filterable_returns, private, Service, ValidationErrors
+)
 from middlewared.utils import filter_list
 
 from .netdata import GRAPH_PLUGINS
@@ -30,6 +32,7 @@ class ReportingService(Service):
     async def graph_names(self):
         return list(self.__graphs.keys())
 
+    @cli_private
     @accepts(
         Str('name', required=True),
         Ref('reporting_query'),
@@ -55,6 +58,7 @@ class ReportingService(Service):
             if result is not None
         ]
 
+    @cli_private
     @filterable
     @filterable_returns(Dict(
         'reporting_graph',
@@ -70,6 +74,7 @@ class ReportingService(Service):
         """
         return filter_list([await i.as_dict() for i in self.__graphs.values()], filters, options)
 
+    @cli_private
     @accepts(
         List('graphs', items=[
             Dict(

--- a/src/middlewared/middlewared/plugins/reporting/update.py
+++ b/src/middlewared/middlewared/plugins/reporting/update.py
@@ -1,5 +1,5 @@
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, returns, Str, Timestamp
-from middlewared.service import filterable, filterable_returns, Service, private
+from middlewared.service import cli_private, filterable, filterable_returns, Service, private
 from middlewared.validators import Range
 
 from .netdata import GRAPH_PLUGINS
@@ -11,11 +11,13 @@ class ReportingService(Service):
         datastore = 'system.reporting'
         cli_namespace = 'system.reporting'
 
+    @cli_private
     @filterable
     @filterable_returns(Ref('reporting_graph'))
     async def graphs(self, filters, options):
         return await self.middleware.call('reporting.netdata_graphs', filters, options)
 
+    @cli_private
     @accepts(
         List('graphs', items=[
             Dict(
@@ -69,6 +71,7 @@ class ReportingService(Service):
     async def get_all(self, query):
         return await self.middleware.call('reporting.netdata_get_all', query)
 
+    @cli_private
     @accepts(
         Str('name', required=True),
         Ref('reporting_query'),


### PR DESCRIPTION
**Observation:**

Reporting includes a number of query/get commands that are not formatted or functional to view in the CLI. 

**Applied Change:**

Made the graphs related system reporting commands private to CLI