### PR TITLE
NAS-124207 / 24.04 / fix enclosure mapping for platforms with nvme

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -439,9 +439,9 @@ class EnclosureService(Service):
         mapped = [
             {
                 "id": "mapped_enclosure_0",
-                "bsg": controller_enclosures[0]["bsg"],
+                "bsg": original_enclosure["bsg"],
                 "name": "Drive Bays",
-                "model": controller_enclosures[0]["model"],
+                "model": original_enclosure["model"],
                 "controller": True,
                 "elements": [
                     {

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme.py
@@ -40,6 +40,7 @@ class EnclosureService(Service):
         return [
             {
                 "id": id_,
+                "bsg": None,
                 "name": name,
                 "model": model,
                 "controller": True,


### PR DESCRIPTION
There are 2 problems being fixed.
1. this is crashing with `KeyError` on platforms that have rear nvme drive bays (R50 variants). It's crashing because the nvme mapping logic is missing a top-level `bsg` key. Add a top-level `bsg` key to the nvme mapping plugin.
2. On the R50 platforms, we were using `controller_enclosures[0]` always so that means all 48 drives got mapped to the first expander in the head-unit. The R50 variants have 2 expanders in the head-unit. 1-24 and 25-48.

Without these changes, it's impossible to use the webUI/API to create zpools since `enclosure.query` is called somewhere in the code-path.