### PR TITLE
NAS-124264 / 24.04 / hide failover CRUD from midcli

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -50,7 +50,7 @@ class FailoverService(ConfigService):
     class Config:
         datastore = 'system.failover'
         datastore_extend = 'failover.failover_extend'
-        cli_namespace = 'system.failover'
+        cli_private = True
 
     ENTRY = Dict(
         'failover_entry',

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -205,6 +205,9 @@ class RemoteClient(object):
 
 class FailoverService(Service):
 
+    class Config:
+        cli_private = True
+
     CLIENT = RemoteClient()
 
     @private


### PR DESCRIPTION
Literally, every other plugin in `failover_` is marked as `private=True`. This is the CRUD endpoint for the failover related api endpoints but there is no reason to provide those to midcli so this marks it as cli_private = True to prevent the endpoints from showing up in midcli program.