### PR TITLE
NAS-124052 / 24.04 / Account for source datasets which are not encryption root themselves when retrieving encrypted keys

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -379,7 +379,10 @@ class PoolDatasetService(Service):
         for source_ds in task['source_datasets']:
             for ds_name, key in mapping[source_ds].items():
                 for dataset in (dataset_mapping[ds_name] if include_encryption_root_children else [{'id': ds_name}]):
-                    result[dataset['id'].replace(source_ds, source_mapping[source_ds], 1)] = key
+                    result[dataset['id'].replace(
+                        source_ds if len(source_ds) <= len(dataset['id']) else dataset['id'],
+                        source_mapping[source_ds], 1
+                    )] = key
 
         return result
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -341,12 +341,12 @@ class PoolDatasetService(Service):
 
         mapping = {}
         for source_ds in task['source_datasets']:
-            source_ds_details = await self.middleware.call('pool.dataset.get_instance', source_ds, {'extra': {
+            source_ds_details = await self.middleware.call('pool.dataset.query', [['id', '=', source_ds]], {'extra': {
                 'properties': ['encryptionroot'],
                 'retrieve_children': False,
             }})
-            if source_ds_details['encryption_root'] != source_ds:
-                filters = ['name', '=', source_ds_details['encryption_root']]
+            if source_ds_details and source_ds_details[0]['encryption_root'] != source_ds:
+                filters = ['name', '=', source_ds_details[0]['encryption_root']]
             else:
                 if task['recursive']:
                     filters = ['OR', [['name', '=', source_ds], ['name', '^', f'{source_ds}/']]]

--- a/tests/api2/test_dataset_encryption_keys_in_replication.py
+++ b/tests/api2/test_dataset_encryption_keys_in_replication.py
@@ -71,6 +71,23 @@ def test_single_source_recursive_replication():
                         make_assertions([src], task['id'], dst, [dst, f'{dst}/{child_src.rsplit("/", 1)[-1]}'])
 
 
+def test_single_source_child_encrypted_replication():
+    with dataset('source_test', encryption_props()) as src:
+        with dataset(f'{src.rsplit("/", 1)[-1]}/child_source_test', encryption_props()) as child_src:
+            with dataset('parent_destination', encryption_props()) as parent_ds:
+                with dataset(f'{parent_ds.rsplit("/", 1)[-1]}/destination_test') as dst:
+                    with replication_task({
+                        **BASE_REPLICATION,
+                        'name': 'encryption_replication_test',
+                        'source_datasets': [child_src],
+                        'target_dataset': dst,
+                        'name_regex': '.+',
+                        'auto': False,
+                        'recursive': True,
+                    }) as task:
+                        make_assertions([child_src], task['id'], dst, [dst])
+
+
 def test_multiple_source_replication():
     with dataset('source_test1', encryption_props()) as src1:
         with dataset('source_test2', encryption_props()) as src2:


### PR DESCRIPTION
This PR adds changes so that we account for source datasets which are not encrypted root themselves and we retrieve their encryption keys properly so that they can be downloaded from the UI and used on the target system after replication has completed to properly unlock target datasets.