### PR TITLE
NAS-124086 / 23.10 / Hide system reporting queries commands in SCALE CLI (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/graphs.py
@@ -4,7 +4,9 @@ import time
 import typing
 
 from middlewared.schema import accepts, Dict, List, Patch, Ref, returns, Str, Timestamp
-from middlewared.service import CallError, filterable, filterable_returns, private, Service, ValidationErrors
+from middlewared.service import (
+    CallError, cli_private, filterable, filterable_returns, private, Service, ValidationErrors
+)
 from middlewared.utils import filter_list
 from middlewared.validators import Range
 
@@ -35,6 +37,7 @@ class ReportingService(Service):
         attr.validators = [Range(min=1)]
         attr.default = 1
 
+    @cli_private
     @accepts(
         Str('name', required=True),
         Patch(
@@ -68,6 +71,7 @@ class ReportingService(Service):
             if result is not None
         ]
 
+    @cli_private
     @filterable
     @filterable_returns(Dict(
         'graph',
@@ -82,6 +86,7 @@ class ReportingService(Service):
         """
         return filter_list([await i.as_dict() for i in self.__graphs.values()], filters, options)
 
+    @cli_private
     @accepts(
         List('graphs', items=[
             Dict(

--- a/src/middlewared/middlewared/plugins/reporting/update.py
+++ b/src/middlewared/middlewared/plugins/reporting/update.py
@@ -4,8 +4,10 @@ import errno
 import middlewared.sqlalchemy as sa
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Ref, returns, Str
-from middlewared.service import CallError, ConfigService, filterable, filterable_returns, private, ValidationErrors
-from middlewared.utils import filter_list, run
+from middlewared.service import (
+    CallError, cli_private, ConfigService, filterable, filterable_returns, private, ValidationErrors
+)
+from middlewared.utils import filter_list
 from middlewared.validators import Range
 
 from .rrd_utils import RRD_PLUGINS
@@ -134,6 +136,7 @@ class ReportingService(ConfigService):
         Clear reporting database.
         """
 
+    @cli_private
     @filterable
     @filterable_returns(Dict(
         'graph',
@@ -177,6 +180,7 @@ class ReportingService(ConfigService):
                 endtime = f'now-{page}{unit}'
         return starttime, endtime
 
+    @cli_private
     @accepts(
         List('graphs', items=[
             Dict(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c5820ea6578055a69e6b06b906128c1bd03d3515

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 72ba33d2d3dce18b8537e04c056198e261f71a94

**Observation:**

Reporting includes a number of query/get commands that are not formatted or functional to view in the CLI. 

**Applied Change:**

Made the graphs related system reporting commands private to CLI

Original PR: https://github.com/truenas/middleware/pull/12153
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124086