### PR TITLE
NAS-124264 / 22.12.4 / hide failover CRUD from midcli (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -49,7 +49,7 @@ class FailoverService(ConfigService):
     class Config:
         datastore = 'system.failover'
         datastore_extend = 'failover.failover_extend'
-        cli_namespace = 'system.failover'
+        cli_private = True
 
     ENTRY = Dict(
         'failover_entry',

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -206,6 +206,9 @@ class RemoteClient(object):
 
 class FailoverService(Service):
 
+    class Config:
+        cli_private = True
+
     CLIENT = RemoteClient()
 
     @private


### PR DESCRIPTION
Literally, every other plugin in `failover_` is marked as `private=True`. This is the CRUD endpoint for the failover related api endpoints but there is no reason to provide those to midcli so this marks it as cli_private = True to prevent the endpoints from showing up in midcli program.

Original PR: https://github.com/truenas/middleware/pull/12161
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124264