### PR TITLE
NAS-124310 / 24.04 / Clarify replica node count

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -16,6 +16,7 @@ from middlewared.validators import Range
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
 MAX_VOLNAME_LENGTH = 64
+REPLICA_NODE_COUNT = 3
 
 
 class GlusterVolname(Str):
@@ -43,7 +44,8 @@ class GlusterVolname(Str):
             verrors.add(self.name, f'Gluster volume name must contain no more than {MAX_VOLNAME_LENGTH} characters')
 
         if any((char not in self.valid_chars for char in value)):
-            verrors.add(self.name,
+            verrors.add(
+                self.name,
                 'Gluster volume name must consist of only alphanumeric characters, underscore (_), and dash (-)'
             )
 
@@ -648,7 +650,7 @@ class ClusterManagement(Service):
             layout = {}
 
         elif volume_type.endswith('REPLICATE'):
-            total_bricks = 3 * brick_layout['replica_distribute']
+            total_bricks = REPLICA_NODE_COUNT * brick_layout['replica_distribute']
             if total_bricks != brick_cnt:
                 verrors.add(
                     f'{schema}.replica',
@@ -659,7 +661,7 @@ class ClusterManagement(Service):
                     'divisible by three.'
                 )
 
-            layout = {'replica': brick_layout['replica']}
+            layout = {'replica': REPLICA_NODE_COUNT}
 
         elif volume_type.endswith('DISPERSE'):
             bricks_per_subvol = brick_layout['disperse_data'] + brick_layout['disperse_redundancy']


### PR DESCRIPTION
We force replica=3 to ensure that user always has replica count that avoids split-brain scenarios.