### PR TITLE
NAS-124312 / 24.04 / Add flag outlining if cpu temperatures are being retrieved

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
+++ b/src/middlewared/middlewared/plugins/reporting/cpu_temperatures.py
@@ -7,6 +7,9 @@ class ReportingService(Service):
     async def cpu_temperatures(self):
         netdata_metrics = await self.middleware.call('netdata.get_all_metrics')
         data = {}
+        temp_retrieved = False
         for core, cpu_temp in netdata_metrics.get('cputemp.temperatures', {'dimensions': {}})['dimensions'].items():
             data[core] = cpu_temp['value']
-        return data
+            if not temp_retrieved:
+                temp_retrieved = bool(cpu_temp['value'])
+        return data if temp_retrieved else {}

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -88,8 +88,7 @@ class RealtimeEventSource(EventSource):
             }
 
             # CPU temperature
-            data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures')
-            data['cpu']['temperature'] = {k: 2732 + int(v * 10) for k, v in data['cpu']['temperature_celsius'].items()}
+            data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures') or None
 
             self.send_event('ADDED', fields=data)
             time.sleep(interval)


### PR DESCRIPTION
**Motivation:**

The UI necessitates a flag to indicate the availability of cpu temperature data.

**Change:**

This PR addresses the requirement by setting the `cpu_temperatures_retrieved` flag to True when temperature values are available for machine.