### PR TITLE
NAS-124317 / 24.04 / Add more error handling for invalid passdb entries

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -55,7 +55,7 @@ class GlobalSchema(RegistrySchema):
             if data_in['clustered']:
                 passdb_backend = 'tdbsam'
             else:
-                passdb_backend = 'tdbsam:/var/run/samba-cache/passdb.tdb'
+                passdb_backend = 'tdbsam:/var/run/samba-cache/private/passdb.tdb'
 
             data_out.update({
                 'passdb backend': {'parsed': passdb_backend},


### PR DESCRIPTION
It's theoretically for users to end up with passdb.tdb containing invalid information due to past configuration mishaps. This adds handling for two cases:
1) totally broken passdb file
2) passdb file with users that have an incorrect `domain` populated.

In both cases remedy is same, nuke the file and redo.