### PR TITLE
NAS-124327 / 23.10 / Fix crash in cluster.management.add_nodes (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -572,7 +572,10 @@ class ClusterManagement(Service):
             # count being added, perhaps going so far as to allow users to
             # temporarily run without the volume spread to all servers while
             # shipping hardware
-            vol = self.middleware.call_sync('gluster.volume.get_instance', root_dir_setup['volume_name'])
+            vol = self.middleware.call_sync(
+                'gluster.volume.get_instance',
+                ctdb_config['root_dir_config']['volume_name']
+            )
         else:
             # Cluster has expanded and we're healthy now. If following fails, the cluster will still
             # continue serving data / be healthy, but manual intervention may be required to complete


### PR DESCRIPTION
The add_nodes API has a non-default option to skip creating a gluster brick on the node being added to the cluster. There are some cases where we may want to add a node to the cluster without actually expanding the gluster volume onto it.

Original PR: https://github.com/truenas/middleware/pull/12185
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124327