### PR TITLE
NAS-118579 / 23.10 / avahi-daemon is not announcing services (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -208,8 +208,12 @@ class mDNSService(object):
                 self.hostname, self.regtype, port, interfaceIndex, txtrecord
             )
             root = xml.Element("service-group")
-            srv_name = xml.Element('name')
-            srv_name.text = self.hostname
+            # We want to use replace-wildcards with %h here, rather than the hostname
+            # because on hostname conflict:
+            # 1. avahi will have to iterate thru names again
+            # 2. avahi currently seems to generate a different postfix for host & service ('-23' vs ' #23')
+            srv_name = xml.Element('name', {'replace-wildcards': 'yes'})
+            srv_name.text = '%h'
             root.append(srv_name)
             for i in interfaceIndex:
                 service = xml.Element('service')

--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -23,8 +23,16 @@ class CIFSService(SimpleService):
 
         await self._systemd_unit("smbd", "start")
 
+    async def after_start(self):
+        # We reconfigure mdns (add SMB service, possibly also ADISK)
+        await self.middleware.call('service.reload', 'mdns')
+
     async def stop(self):
         await self._systemd_unit("smbd", "stop")
+
+    async def after_stop(self):
+        # reconfigure mdns (remove SMB service, possibly also ADISK)
+        await self.middleware.call('service.reload', 'mdns')
 
     async def before_reload(self):
         await self.middleware.call("sharing.smb.sync_registry")

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1049,7 +1049,7 @@ class SharingSMBService(SharingService):
             ret = await self.get_instance(data['id'])
 
         if data['timemachine']:
-            await self.middleware.call('service.restart', 'mdns')
+            await self.middleware.call('service.reload', 'mdns')
 
         return ret
 
@@ -1206,7 +1206,7 @@ class SharingSMBService(SharingService):
             await self._service_change('cifs', 'reload')
 
         if check_mdns or old['timemachine'] != new['timemachine']:
-            await self.middleware.call('service.restart', 'mdns')
+            await self.middleware.call('service.reload', 'mdns')
 
         return await self.get_instance(id)
 
@@ -1243,7 +1243,7 @@ class SharingSMBService(SharingService):
                 self.logger.warn('Failed to remove registry entry for [%s].', share_name, exc_info=True)
 
         if share['timemachine']:
-            await self.middleware.call('service.restart', 'mdns')
+            await self.middleware.call('service.reload', 'mdns')
 
         return result
 

--- a/tests/api2/assets/websocket/server.py
+++ b/tests/api2/assets/websocket/server.py
@@ -35,13 +35,14 @@ def reboot(ip, service_name=None):
         TotalWait = 60  # 1 min
         payload = {
             'msg': 'method', 'method': 'service.query',
-            'params': [['service', '=', service_name]]
+            'params': [[["service", "=", service_name]], {'get': True}]
         }
         while TotalWait > 0:
             try:
                 res = make_ws_request(ip, payload)
                 if res.get('error') is None:
-                    print(res)
+                    if res['result']['state'] == 'RUNNING':
+                        return
             except Exception:
                 pass
             sleep(1)

--- a/tests/api2/assets/websocket/server.py
+++ b/tests/api2/assets/websocket/server.py
@@ -1,0 +1,49 @@
+from time import sleep
+
+from functions import make_ws_request, ping_host
+
+
+def reboot(ip, service_name=None):
+    """Reboot the TrueNAS at the specified IP.
+    Return when it has rebooted."""
+    # Reboot
+    payload = {
+        'msg': 'method', 'method': 'system.reboot',
+        'params': []
+    }
+    res = make_ws_request(ip, payload)
+    assert res.get('error') is None, res
+    # Wait for server to disappear
+    sleep(5)
+    TotalWait = 120  # 3 min
+    while TotalWait > 0 and ping_host(ip, 1) is True:
+        sleep(1)
+        TotalWait -= 1
+    assert ping_host(ip, 1) is not True
+    # Wait for server to return
+    sleep(10)
+    TotalWait = 120  # 3 min
+    while TotalWait > 0 and ping_host(ip, 1) is not True:
+        sleep(1)
+        TotalWait -= 1
+    assert ping_host(ip, 1) is True
+    # ip returns before websocket connection is ready
+    # Wait a few more seconds
+    sleep(10)
+
+    if service_name:
+        TotalWait = 60  # 1 min
+        payload = {
+            'msg': 'method', 'method': 'service.query',
+            'params': [['service', '=', service_name]]
+        }
+        while TotalWait > 0:
+            try:
+                res = make_ws_request(ip, payload)
+                if res.get('error') is None:
+                    print(res)
+            except Exception:
+                pass
+            sleep(1)
+            TotalWait -= 1
+        assert False, f"Failed to detect {service_name} as running following reboot"

--- a/tests/api2/assets/websocket/service.py
+++ b/tests/api2/assets/websocket/service.py
@@ -1,0 +1,98 @@
+import contextlib
+import os
+import sys
+from time import sleep
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from middlewared.test.integration.utils import call
+
+
+@contextlib.contextmanager
+def ensure_service_started(service_name, delay=0):
+    old_value = call('service.started', service_name)
+    if old_value:
+        yield
+    else:
+        call('service.start', service_name)
+        if delay:
+            sleep(delay)
+        try:
+            yield
+        finally:
+            call('service.stop', service_name)
+            if delay:
+                sleep(delay)
+
+
+@contextlib.contextmanager
+def ensure_service_stopped(service_name, delay=0):
+    old_value = call('service.started', service_name)
+    if not old_value:
+        yield
+    else:
+        call('service.stop', service_name)
+        if delay:
+            sleep(delay)
+        try:
+            yield
+        finally:
+            call('service.start', service_name)
+            if delay:
+                sleep(delay)
+
+
+@contextlib.contextmanager
+def ensure_service_enabled(service_name):
+    """Ensure that the specified service is enabled.
+
+    When finished restore the service config to the state
+    upon call."""
+    old_config = call('service.query', [['service', '=', service_name]])[0]
+    try:
+        if old_config['enable']:
+            # No change necessary
+            yield
+        else:
+            # Change necessary, so restore when done
+            call('service.update', old_config['id'], {'enable': True})
+            try:
+                yield
+            finally:
+                call('service.update', old_config['id'], {'enable': False})
+    finally:
+        # Also restore the current state (if necessary)
+        new_config = call('service.query', [['service', '=', service_name]])[0]
+        if new_config['state'] != old_config['state']:
+            if old_config['state'] == 'RUNNING':
+                call('service.start', service_name)
+            else:
+                call('service.stop', service_name)
+
+
+@contextlib.contextmanager
+def ensure_service_disabled(service_name):
+    """Ensure that the specified service is disabled.
+
+    When finished restore the service config to the state
+    upon call."""
+    old_config = call('service.query', [['service', '=', service_name]])[0]
+    try:
+        if not old_config['enable']:
+            # No change necessary
+            yield
+        else:
+            # Change necessary, so restore when done
+            call('service.update', old_config['id'], {'enable': False})
+            try:
+                yield
+            finally:
+                call('service.update', old_config['id'], {'enable': True})
+    finally:
+        # Also restore the current state (if necessary)
+        new_config = call('service.query', [['service', '=', service_name]])[0]
+        if new_config['state'] != old_config['state']:
+            if old_config['state'] == 'RUNNING':
+                call('service.start', service_name)
+            else:
+                call('service.stop', service_name)

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -91,7 +91,7 @@ def ensure_aapl_extensions():
             call('smb.update', {'aapl_extensions': False})
 
 
-def wait_for_avahi_startup(interval=5, timeout=180):
+def wait_for_avahi_startup(interval=5, timeout=300):
     """When tests are running in a QE environment it can take a long
     time for the service to start up completely, because many systems
     can be configured with the same hostname.
@@ -328,6 +328,7 @@ def setup_environment():
         pass
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.dependency(name="servann_001")
 def test_001_initial_config(request):
     """Ensure that the service announcement configuration is as expected."""
@@ -354,6 +355,7 @@ def test_001_initial_config(request):
 # fail.
 # Since the test passes when run with zeroconf library on
 # a suitably connected test-runner, no real need to chase.
+@pytest.mark.timeout(600)
 @skip_avahi_browse_tests
 def test_002_mdns_disabled(request):
     depends(request, ["servann_001"], scope="session")

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -365,7 +365,14 @@ def test_002_mdns_disabled(request):
     ac.check_present(False, False, False, False)
 
 
-@pytest.mark.timeout(720)
+# Setting a VERY long timeout as when this test is run in isolation
+# on jenkins there can be many (20+) hostname clashes which means
+# avahi can take a LONG time to settle down/start up.
+#
+# We could avoid by setting a unique hostname (as is done during a
+# full test run), but it also seems worthwhile exercise to be able
+# to test in such a unsuitable environment.
+@pytest.mark.timeout(900)
 def test_003_mdns_smb_share(request):
     """Perform some mDNS tests wrt SMB and ADISK services."""
     depends(request, ["servann_001"], scope="session")

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+
+# Tests for mDNS/DNS-SD (zeroconf)
+
+import contextlib
+import os
+import random
+import re
+import socket
+import string
+import sys
+from datetime import datetime, timedelta
+from time import sleep
+from typing import cast
+
+import pytest
+from pytest_dependency import depends
+from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from assets.REST.pool import dataset
+from assets.websocket.server import reboot
+from assets.websocket.service import (ensure_service_disabled,
+                                      ensure_service_enabled,
+                                      ensure_service_started,
+                                      ensure_service_stopped)
+from auto_config import ip, password, pool_name, user
+from functions import SSH_TEST
+from protocols import smb_share
+
+from middlewared.test.integration.utils import call, ssh
+
+digits = ''.join(random.choices(string.digits, k=4))
+dataset_name = f"smb-cifs{digits}"
+SMB_NAME1 = f"TestCifsSMB{digits}"
+SMB_PATH1 = f"/mnt/{pool_name}/{dataset_name}"
+
+dataset_name2 = f"other{digits}"
+SMB_NAME2 = f"OtherTestSMB{digits}"
+SMB_PATH2 = f"/mnt/{pool_name}/{dataset_name2}"
+
+# Service names
+TIME_MACHINE = '_adisk._tcp.local.'  # Automatic Disk
+DEVICE_INFO = '_device-info._tcp.local.'  # Device Info
+HTTP = '_http._tcp.local.'
+SMB = '_smb._tcp.local.'
+
+DO_MDNS_REBOOT_TEST = False
+USE_AVAHI_BROWSE = True
+skip_avahi_browse_tests = pytest.mark.skipif(USE_AVAHI_BROWSE, reason="Skip tests broken by use of avahi-browse")
+
+
+def _get_tm_props(rec, key):
+    result = {}
+    for pair in rec['properties'][key].decode('utf-8').split(','):
+        k, v = pair.split('=')
+        result[k] = v
+    return result
+
+
+def allow_settle(delay=3):
+    # Delay slightly to allow things to propagate
+    sleep(delay)
+
+
+@contextlib.contextmanager
+def service_announcement_config(config):
+    if not config:
+        yield
+    else:
+        old_config = call('network.configuration.config')['service_announcement']
+        call('network.configuration.update', {'service_announcement': config})
+        try:
+            yield
+        finally:
+            call('network.configuration.update', {'service_announcement': old_config})
+
+
+@contextlib.contextmanager
+def ensure_aapl_extensions():
+    # First check
+    enabled = call('smb.config')['aapl_extensions']
+    if enabled:
+        yield
+    else:
+        call('smb.update', {'aapl_extensions': True})
+        try:
+            yield
+        finally:
+            call('smb.update', {'aapl_extensions': False})
+
+
+def wait_for_avahi_startup(interval=5, timeout=180):
+    """When tests are running in a QE environment it can take a long
+    time for the service to start up completely, because many systems
+    can be configured with the same hostname.
+
+    This function will detect the most recent avahi-daemon startup and
+    wait for it to complete"""
+    command = 'journalctl --no-pager -u avahi-daemon --since "10 minute ago"'
+    brackets = re.compile(r'[\[\]]+')
+    while timeout > 0:
+        startup = None
+        ssh_out = SSH_TEST(command, user, password, ip)
+        assert ssh_out['result'], str(ssh_out)
+        output = ssh_out['output']
+        # First we just look for the most recent startup command
+        for line in output.split('\n'):
+            if line.endswith('starting up.'):
+                startup = line
+        if startup:
+            pid = brackets.split(startup)[1]
+            completion = f'avahi-daemon[{pid}]: Server startup complete.'
+            for line in output.split('\n'):
+                if completion in line:
+                    # Did we just complete
+                    finish_plus_five = (datetime.strptime(line.split()[2], "%H:%M:%S") + timedelta(seconds=5)).time()
+                    if finish_plus_five > datetime.now().time():
+                        # Wait 5 seconds to ensure services are published
+                        sleep(5)
+                    return True
+        sleep(interval)
+        timeout -= interval
+    return False
+
+
+class ZeroconfCollector:
+
+    def on_service_state_change(self, zeroconf, service_type, name, state_change):
+
+        if state_change is ServiceStateChange.Added:
+            info = zeroconf.get_service_info(service_type, name)
+            if info:
+                item = {}
+                item['addresses'] = [addr for addr in info.parsed_scoped_addresses()]
+                if self.ip not in item['addresses']:
+                    return
+                item['port'] = cast(int, info.port)
+                item['server'] = info.server
+                if info.properties:
+                    item['properties'] = {}
+                    for key, value in info.properties.items():
+                        if key:
+                            item['properties'][key] = value
+                else:
+                    item['properties'] = {}
+                self.result[service_type][name] = item
+                self.update_internal_hostname(item['server'])
+
+    def find_items(self, service_announcement=None, timeout=5):
+        self.result = {}
+        for service in self.SERVICES:
+            self.result[service] = {}
+        with service_announcement_config(service_announcement):
+            assert wait_for_avahi_startup(), "Failed to detect avahi-daemon startup"
+            zeroconf = Zeroconf()
+            ServiceBrowser(zeroconf, self.SERVICES, handlers=[self.on_service_state_change])
+            try:
+                sleep(timeout)
+            finally:
+                zeroconf.close()
+        return self.result
+
+    def clear_cache(self):
+        # No-op for zeroconf collector
+        pass
+
+
+class AvahiBrowserCollector:
+
+    name_to_service = {
+        'Device Info': DEVICE_INFO,
+        'Web Site': HTTP,
+        'Microsoft Windows Network': SMB,
+        'Apple TimeMachine': TIME_MACHINE,
+    }
+
+    def find_items(self, service_announcement=None, timeout=5):
+        self.result = {}
+        for service in self.SERVICES:
+            self.result[service] = {}
+        with service_announcement_config(service_announcement):
+            assert wait_for_avahi_startup(), "Failed to detect avahi-daemon startup"
+            # ssh_out = SSH_TEST("avahi-browse -v --all -t -p --resolve", user, password, ip)
+            # Appears sometimes we need a little more time
+            ssh_out = SSH_TEST("timeout --preserve-status 5 avahi-browse -v --all -p --resolve", user, password, ip)
+            assert ssh_out['result'], str(ssh_out)
+            output = ssh_out['output']
+            for line in output.split('\n'):
+                item = {}
+                items = line.split(';')
+                if len(items) > 1 and items[0] == '=':
+                    if len(items) == 10:
+                        server = items[3]
+                        pub_ip = items[7]
+                        if pub_ip not in self.ips:
+                            continue
+                        item['addresses'] = [pub_ip]
+                        item['port'] = items[8]
+                        item['server'] = items[6]
+                        service_type = AvahiBrowserCollector.name_to_service[items[4]]
+                        key = f"{server}.{service_type}"
+                        item['properties'] = self.process_properties(items[9], service_type)
+                        self.result[service_type][key] = item
+                        self.update_internal_hostname(item['server'])
+        return self.result
+
+    def process_properties(self, txts, service_type):
+        props = {}
+        for txt in txts.split():
+            if txt.startswith('"') and txt.endswith('"'):
+                txt = txt[1:-1]
+                for prop in ['model', 'dk0', 'dk1', 'sys']:
+                    if txt.startswith(f"{prop}="):
+                        props[prop.encode('utf-8')] = txt[len(prop) + 1:].encode('utf-8')
+        return props
+
+    def clear_cache(self):
+        # We need to restart the avahi-daemon to clear cache
+        # print("Clearing cache")
+        ssh("systemctl restart avahi-daemon")
+
+    @staticmethod
+    def get_ipv6(ip):
+        """Given an IPv4 address string, find the IPv6 on the same
+        interface (if present).  Returns either the IPv6 address as
+        a string, or None"""
+        ips = call('network.general.summary')['ips']
+        for interface in ips:
+            matched = False
+            if 'IPV4' in ips[interface]:
+                for ipv4 in ips[interface]['IPV4']:
+                    if ipv4.split('/')[0] == ip:
+                        matched = True
+                        break
+            if matched and 'IPV6' in ips[interface]:
+                for ipv6 in ips[interface]['IPV6']:
+                    return ipv6.split('/')[0]
+        return None
+
+
+class abstractmDNSAnnounceCollector:
+    """
+    Class to help in the discovery (and processing/checking)
+    of services advertised by a particular IP address/server name.
+    """
+    SERVICES = [TIME_MACHINE, DEVICE_INFO, HTTP, SMB]
+
+    def __init__(self, ip, tn_hostname):
+        self.ip = socket.gethostbyname(ip)
+        self.hostname = self.tn_hostname = tn_hostname
+
+    def update_internal_hostname(self, published_hostname):
+        """If there has been a conflict then it is possible that a derivative
+        of the original hostname is being used.  Check whether this the
+        published name could be a conflict-resolved name and if so,
+        update the hostname that will be used during checks.
+        """
+        if published_hostname == self.tn_hostname:
+            return
+        possible_new_hostname = published_hostname.split('.')[0]
+        if possible_new_hostname == self.hostname:
+            return
+        # Check whether either 'hostname-...' or '<hostname> #...'
+        if possible_new_hostname.split()[0].split('-')[0] == self.tn_hostname:
+            self.hostname = possible_new_hostname
+
+    def has_service_type(self, hostname, service_type):
+        if not hostname:
+            hostname = self.hostname
+        key = f"{hostname}.{service_type}"
+        return key in self.result[service_type]
+
+    def get_service_type(self, hostname, service_type):
+        if not hostname:
+            hostname = self.hostname
+        key = f"{hostname}.{service_type}"
+        if key in self.result[service_type]:
+            return self.result[service_type][key]
+
+    def has_time_machine(self, hostname=None):
+        return self.has_service_type(hostname, TIME_MACHINE)
+
+    def has_device_info(self, hostname=None):
+        return self.has_service_type(hostname, DEVICE_INFO)
+
+    def has_http(self, hostname=None):
+        return self.has_service_type(hostname, HTTP)
+
+    def has_smb(self, hostname=None):
+        return self.has_service_type(hostname, SMB)
+
+    def time_machine(self, hostname=None):
+        return self.get_service_type(hostname, TIME_MACHINE)
+
+    def check_present(self, device_info=True, http=True, smb=True, time_machine=True, hostname=None):
+        assert self.has_device_info(hostname) == device_info, self.result[DEVICE_INFO]
+        assert self.has_http(hostname) == http, self.result[HTTP]
+        assert self.has_smb(hostname) == smb, self.result[SMB]
+        assert self.has_time_machine(hostname) == time_machine, self.result[TIME_MACHINE]
+
+
+if USE_AVAHI_BROWSE:
+    class mDNSAnnounceCollector(abstractmDNSAnnounceCollector, AvahiBrowserCollector):
+        def __init__(self, ip, tn_hostname):
+            abstractmDNSAnnounceCollector.__init__(self, ip, tn_hostname)
+            # avahi-browse can report either an IPv4 address or the
+            # corresponding IPv6 address if configured on the same interface
+            # So we will expand our inclusion check to encompass both.
+            ipv6 = AvahiBrowserCollector.get_ipv6(self.ip)
+            if ipv6:
+                self.ips = [self.ip, ipv6]
+            else:
+                self.ips = [self.ip]
+else:
+    class mDNSAnnounceCollector(abstractmDNSAnnounceCollector, ZeroconfCollector):
+        pass
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup_environment():
+    try:
+        with ensure_service_disabled('cifs'):
+            with ensure_service_stopped('cifs'):
+                yield
+    finally:
+        pass
+
+
+@pytest.mark.dependency(name="servann_001")
+def test_001_initial_config(request):
+    """Ensure that the service announcement configuration is as expected."""
+    global current_hostname
+
+    network_config = call('network.configuration.config')
+    sa = network_config['service_announcement']
+    current_hostname = network_config['hostname']
+    # At the moment we only care about mdns
+    assert sa['mdns'] is True, sa
+
+    # Let's restart avahi (in case we've updated middleware)
+    call('service.restart', 'mdns')
+    ac = mDNSAnnounceCollector(ip, current_hostname)
+    ac.find_items()
+    ac.check_present(smb=False, time_machine=False)
+
+
+# This test is broken by the use of avahi-browse as when it is
+# called it re-activates the avahi-daemon by means of the
+# avahi-daemon.socket.
+# The DEV and HTTP service files have NOT been deleted upon
+# a service stop, so this reactivation causes the test to
+# fail.
+# Since the test passes when run with zeroconf library on
+# a suitably connected test-runner, no real need to chase.
+@skip_avahi_browse_tests
+def test_002_mdns_disabled(request):
+    depends(request, ["servann_001"], scope="session")
+    ac = mDNSAnnounceCollector(ip, current_hostname)
+    ac.clear_cache()
+    ac.find_items({'mdns': False, 'wsd': True, 'netbios': False})
+    ac.check_present(False, False, False, False)
+
+
+@pytest.mark.timeout(600)
+def test_003_mdns_smb_share(request):
+    """Perform some mDNS tests wrt SMB and ADISK services."""
+    depends(request, ["servann_001"], scope="session")
+
+    # SMB is not started originally
+    ac = mDNSAnnounceCollector(ip, current_hostname)
+    ac.find_items()
+    ac.check_present(smb=False, time_machine=False)
+
+    with dataset(pool_name, dataset_name):
+        with smb_share(SMB_PATH1, {'name': SMB_NAME1, 'comment': 'Test SMB Share'}):
+            # SMB is still not started
+            ac.find_items()
+            ac.check_present(smb=False, time_machine=False)
+            with ensure_service_started('cifs'):
+                allow_settle()
+                ac.find_items()
+                ac.check_present(time_machine=False)
+            # OK, the SMB is stopped again,  Ensure we don't advertise SMB anymore
+            ac.clear_cache()
+            ac.find_items()
+            ac.check_present(smb=False, time_machine=False)
+
+        # Now we're going to setup a time machine share
+        with ensure_aapl_extensions():
+            with ensure_service_started('cifs'):
+                allow_settle()
+                # Check mDNS before we have a time machine share
+                ac.find_items()
+                ac.check_present(time_machine=False)
+                with smb_share(SMB_PATH1, {'name': SMB_NAME1,
+                                           'comment': 'Basic TM SMB Share',
+                                           'purpose': 'TIMEMACHINE'}) as shareID1:
+                    allow_settle()
+                    # Check mDNS now we have a time machine share
+                    ac.find_items()
+                    ac.check_present()
+
+                    # Now read the share details and then check against what mDNS reported
+                    share1 = call('sharing.smb.query', [['id', '=', shareID1]])[0]
+
+                    tm = ac.time_machine()
+                    props = _get_tm_props(tm, b'dk0')
+                    assert props['adVN'] == SMB_NAME1, props
+                    assert props['adVF'] == '0x82', props
+                    assert props['adVU'] == share1['vuid'], props
+                    # Now make another time machine share
+                    with dataset(pool_name, dataset_name2):
+                        with smb_share(SMB_PATH2, {'name': SMB_NAME2,
+                                                   'comment': 'Multiuser TM SMB Share',
+                                                   'purpose': 'ENHANCED_TIMEMACHINE'}) as shareID2:
+                            share2 = call('sharing.smb.query', [['id', '=', shareID2]])[0]
+                            allow_settle()
+                            ac.find_items()
+                            ac.check_present()
+                            tm = ac.time_machine()
+                            props0 = _get_tm_props(tm, b'dk0')
+                            props1 = _get_tm_props(tm, b'dk1')
+                            assert props0['adVF'] == '0x82', props0
+                            assert props1['adVF'] == '0x82', props1
+                            # Let's not make any assumption about which share is which
+                            if props0['adVN'] == SMB_NAME1:
+                                # SHARE 1 in props0
+                                assert props0['adVU'] == share1['vuid'], props0
+                                # SHARE 2 in props1
+                                assert props1['adVN'] == SMB_NAME2, props1
+                                assert props1['adVU'] == share2['vuid'], props1
+                            else:
+                                # SHARE 1 in props1
+                                assert props1['adVN'] == SMB_NAME1, props1
+                                assert props1['adVU'] == share1['vuid'], props1
+                                # SHARE 2 in props0
+                                assert props0['adVN'] == SMB_NAME2, props0
+                                assert props0['adVU'] == share2['vuid'], props0
+                    # Still have one TM share
+                    allow_settle()
+                    ac.find_items()
+                    ac.check_present()
+
+                # Check mDNS now we no longer have a time machine share
+                ac.clear_cache()
+                ac.find_items()
+                ac.check_present(time_machine=False)
+            # Finally check when SMB is stopped again
+            ac.clear_cache()
+            ac.find_items()
+            ac.check_present(smb=False, time_machine=False)
+
+
+if DO_MDNS_REBOOT_TEST:
+    def test_004_reboot_with_mdns_smb_share(request):
+        """Create a time-machine SMB and check that it is published
+        following a reboot."""
+        depends(request, ["servann_001"], scope="session")
+
+        # First let's setup a time machine share
+        with dataset(pool_name, dataset_name):
+            with smb_share(SMB_PATH1, {'name': SMB_NAME1,
+                                       'comment': 'Basic TM SMB Share',
+                                       'purpose': 'TIMEMACHINE'}):
+                with ensure_service_enabled('cifs'):
+                    # Next reboot and then check the expected services
+                    # are advertised.
+                    reboot(ip, 'cifs')
+                    ac = mDNSAnnounceCollector(ip, current_hostname)
+                    ac.find_items()
+                    ac.check_present()

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -365,7 +365,7 @@ def test_002_mdns_disabled(request):
     ac.check_present(False, False, False, False)
 
 
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(720)
 def test_003_mdns_smb_share(request):
     """Perform some mDNS tests wrt SMB and ADISK services."""
     depends(request, ["servann_001"], scope="session")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,3 +12,4 @@ pyotp
 cython-iscsi @ git+https://github.com/truenas/cython-iscsi.git@tester
 PYSCSI @ git+https://github.com/truenas/python-scsi.git@tester
 pysnmplib
+zeroconf


### PR DESCRIPTION
This PR is predominately to add some _basic_ unit tests wrt mDNS service announcement.  More may be added at a later date.

It includes one to check announcements following a reboot, but this is currently turned off (being perhaps too heavyweight for everyday use).

The python [`zeroconf`](https://pypi.org/project/zeroconf/) package is used to discover announcements from the TrueNAS under test.

Original PR: https://github.com/truenas/middleware/pull/12022
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118579