### PR TITLE
Remove dev_test

### DIFF
--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -1,9 +1,5 @@
 import pytest
-from pytest_dependency import depends
 from middlewared.test.integration.utils import call, pool
-from auto_config import dev_test
-# comment pytestmark for development testing with --dev-test
-pytestmark = pytest.mark.skipif(dev_test, reason='Skipping for test development testing')
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This was removed from master as a small part of https://github.com/truenas/middleware/pull/12117 , which was **NOT** backported to Cobia.

The subsequent https://github.com/truenas/middleware/pull/12158 which **was** backported to Cobia (https://github.com/truenas/middleware/pull/12163), therefore was missing the changes to this file.

Obviously this PR represents _one_ means of resolving the discrepancy.  Backporting https://github.com/truenas/middleware/pull/12117 would be another.
