### PR TITLE
NAS-124348 / 24.04 / Add flag showing if a display device is available for a VM

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -100,7 +100,11 @@ class VMService(CRUDService, VMSupervisorMixin):
             self._check_setup_connection()
         for row in rows:
             status[row['id']] = self.status_impl(row)
-        return {'status': status}
+
+        return {
+            'status': status,
+            'display_device_info': extra.get('retrieve_display_available_info', False)
+        }
 
     @accepts()
     @returns(Dict(
@@ -119,6 +123,9 @@ class VMService(CRUDService, VMSupervisorMixin):
             [('vm', '=', vm['id'])],
             {'force_sql_filters': True},
         )
+        if context['display_device_info']:
+            vm['display_available'] = any(device['dtype'] == 'DISPLAY' for device in vm['devices'])
+
         vm['status'] = context['status'][vm['id']]
         return vm
 

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -103,7 +103,6 @@ class VMService(CRUDService, VMSupervisorMixin):
 
         return {
             'status': status,
-            'display_device_info': extra.get('retrieve_display_available_info', False)
         }
 
     @accepts()
@@ -123,9 +122,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             [('vm', '=', vm['id'])],
             {'force_sql_filters': True},
         )
-        if context['display_device_info']:
-            vm['display_available'] = any(device['dtype'] == 'DISPLAY' for device in vm['devices'])
-
+        vm['display_available'] = any(device['dtype'] == 'DISPLAY' for device in vm['devices'])
         vm['status'] = context['status'][vm['id']]
         return vm
 


### PR DESCRIPTION
This commit adds changes for UI to be able to see if a display device is available for a VM. Consumer can use following call to retrieve this information:

```
midclt call vm.query | jq .
```