### PR TITLE
NAS-124295 / 23.10 / Use username in provisioning uri (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -26,7 +26,8 @@ class UserService(Service):
             user_twofactor_config['secret'], interval=twofactor_config['interval'],
             digits=twofactor_config['otp_digits'],
         ).provisioning_uri(
-            f'{await self.middleware.call("system.hostname")}@{await self.middleware.call("system.product_name")}',
+            f'{username}-{await self.middleware.call("system.hostname")}'
+            f'@{await self.middleware.call("system.product_name")}',
             'iXsystems'
         )
 


### PR DESCRIPTION
This commit adds changes to include username in provisioning uri so that it is better readable in the authenticator app as to which user the uri belongs to.

Original PR: https://github.com/truenas/middleware/pull/12164
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124295