### PR TITLE
No longer shortcut alua_enabled when license contains FIBRECHANNEL

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -192,8 +192,9 @@ class ISCSIGlobalService(SystemServiceService):
         if not await self.middleware.call('failover.licensed'):
             return False
 
-        license_ = await self.middleware.call('system.license')
-        if license_ is not None and 'FIBRECHANNEL' in license_['features']:
-            return True
+        # TODO: FIBRECHANNEL not currently supported in SCALE
+        # license_ = await self.middleware.call('system.license')
+        # if license_ is not None and 'FIBRECHANNEL' in license_['features']:
+        #     return True
 
         return (await self.middleware.call('iscsi.global.config'))['alua']


### PR DESCRIPTION
This is not valid for SCALE as currently fibrechannel is not supported.