### PR TITLE
NAS-124377 / 23.10 / No longer shortcut alua_enabled when license contains FIBRECHANNEL (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -192,8 +192,9 @@ class ISCSIGlobalService(SystemServiceService):
         if not await self.middleware.call('failover.licensed'):
             return False
 
-        license = await self.middleware.call('system.license')
-        if license is not None and 'FIBRECHANNEL' in license['features']:
-            return True
+        # TODO: FIBRECHANNEL not currently supported in SCALE
+        # license = await self.middleware.call('system.license')
+        # if license is not None and 'FIBRECHANNEL' in license['features']:
+        #     return True
 
         return (await self.middleware.call('iscsi.global.config'))['alua']


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b894ccf21c81b65420dafef07c206c5a6e056ac9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 433cd09fa4aba2ae0fb5a98483e01ec8a717ae74

This is not valid for SCALE as currently fibrechannel is not supported.

Original PR: https://github.com/truenas/middleware/pull/12209
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124377