### PR TITLE
NAS-124361 / 23.10 / Define ids when running cert tests (by sonicaj)

### DIFF
--- a/tests/api2/test_certs.py
+++ b/tests/api2/test_certs.py
@@ -507,7 +507,7 @@ def test_certificate_lifetime_validation(life_time, should_work):
         '''),
         False,
     )
-])
+], ids=['valid_cert', 'invalid_cert', 'invalid_cert'])
 def test_importing_certificate_validation(certificate, private_key, should_work):
     cert_params = {'certificate': certificate, 'privatekey': private_key}
     if should_work:


### PR DESCRIPTION
This commit adds a fix where pytest was dumping entire certificate during execution as it is a parameter but then all of this is an unnecessary noise and has subsequently been fixed.

Original PR: https://github.com/truenas/middleware/pull/12216
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124361