### PR TITLE
When possible reuse websocket sessions in tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -7,11 +7,60 @@ import requests
 from middlewared.client import Client
 from middlewared.client.utils import undefined
 
-__all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url"]
+__all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url", "PersistentCtx"]
+
+
+class ClientCtx:
+    conn = None
+
+    def setup(self, *, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None):
+        if auth is None:
+            raise ValueError('Authentication is required for client context wrapper')
+
+        elif auth is undefined:
+            auth = ("root", password())
+
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+
+        self.conn = Client(
+            host_websocket_uri(host_ip),
+            py_exceptions=py_exceptions,
+            log_py_exceptions=log_py_exceptions
+        )
+
+        try:
+            logged_in = self.conn.call("auth.login", *auth)
+            if auth_required:
+                assert logged_in
+        except Exception:
+            self.conn.close()
+            self.conn = None
+            raise
+
+        return self.conn
+
+    def get_or_setup(self, *args, **kwargs):
+        if self.conn:
+            try:
+                self.conn.ping()
+                return self.conn
+            except Exception:
+                pass
+
+        return self.setup(*args, **kwargs)
+
+
+PersistentCtx = ClientCtx()
 
 
 @contextlib.contextmanager
 def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None):
+    if auth is undefined and host_ip is None and auth_required:
+        yield PersistentCtx.get_or_setup()
+        return
+
     if auth is undefined:
         auth = ("root", password())
 

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
 import contextlib
+import logging
 import os
 
 import requests
@@ -8,6 +9,8 @@ from middlewared.client import Client
 from middlewared.client.utils import undefined
 
 __all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url", "PersistentCtx"]
+
+logger = logging.getLogger(__name__)
 
 
 class ClientCtx:
@@ -47,6 +50,7 @@ class ClientCtx:
                 self.conn.ping()
                 return self.conn
             except Exception:
+                logger.warning("Persistent websocket connection died. Reconnecting.")
                 pass
 
         return self.setup(*args, **kwargs)

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -12,6 +12,17 @@ __all__ = ["client", "host", "host_websocket_uri", "password", "session", "url",
 
 logger = logging.getLogger(__name__)
 
+class PersistentClient(Client):
+    def call(self, method, *params, background=False, callback=None, job=False, timeout=undefined):
+        if self.method.startswith('auth.login'):
+            raise ValueError(
+                'Login related endpoint used with persistent handle. '
+                'Temporary client context should be created by setting `auth=<cred>` as '
+                'a keyword argument for the client() call'
+            )
+
+        return super().call(method, *params, background, callback, job, timeout)
+
 
 class ClientCtx:
     conn = None
@@ -27,7 +38,7 @@ class ClientCtx:
             self.conn.close()
             self.conn = None
 
-        self.conn = Client(
+        self.conn = PersistentClient(
             host_websocket_uri(host_ip),
             py_exceptions=py_exceptions,
             log_py_exceptions=log_py_exceptions

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -19,10 +19,8 @@ class PersistentClient(Client):
         if method.startswith('auth.login') and self.authenticated:
             raise ValueError(
                 'Login related endpoint used with persistent handle. '
-                'Temporary client context should be created by setting `auth=<cred>` as '
-                'a keyword argument for the client() call. Alternatively, the test developer '
-                'may decide to import PersistentCtx from this module and call '
-                'PersistentCtx.setup method in order to replace the persistent client connection.'
+                'Please specify `reuse_conn=False` as a keyword argument '
+                'for the client connection.'
             )
 
         return super().call(method, *args, **kwargs)
@@ -84,8 +82,8 @@ PersistentCtx = ClientCtx()
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None):
-    if auth is undefined and host_ip is None and auth_required:
+def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, reuse_conn=True):
+    if reuse_conn and auth is undefined and host_ip is None and auth_required:
         yield PersistentCtx.get_or_setup()
         return
 

--- a/tests/api2/test_account_privilege_authentication.py
+++ b/tests/api2/test_account_privilege_authentication.py
@@ -169,7 +169,7 @@ def test_token_auth_fails_to_call_forbidden_method(unprivileged_user_token):
 
 
 def test_drop_privileges(unprivileged_user_token):
-    with client() as c:
+    with client(reuse_conn=False) as c:
         # This should drop privileges for the current root session
         assert c.call("auth.login_with_token", unprivileged_user_token)
 


### PR DESCRIPTION
This is a minor optimization to open and use a single websocket client connection for the duration of the test. API consumers (for instance for HA tests) can import the PersistentCtx and run setup method with relevant arguments.