### PR TITLE
NAS-124128 / 23.10 / Improve performance for netdata retrieving graphs data (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -1,11 +1,17 @@
+import typing
+
 import aiohttp
 import aiohttp.client_exceptions
 import asyncio
 import contextlib
 import json
+import logging
 
 from .exceptions import ApiException, ClientConnectError
 from .utils import NETDATA_URI, NETDATA_REQUEST_TIMEOUT
+
+
+logger = logging.getLogger(__name__)
 
 
 class ClientMixin:
@@ -41,3 +47,66 @@ class ClientMixin:
                 return json.loads(output)
         except aiohttp.client_exceptions.ContentTypeError as e:
             raise ApiException(f'Malformed response received from {resource!r} endpoint: {e}')
+
+    @classmethod
+    async def fetch(cls, uri: str, session: aiohttp.ClientSession, identifier: typing.Optional[str]) -> dict:
+        output = ''
+        response = {'error': None, 'data': None, 'uri': uri, 'identifier': identifier}
+        async with session.get(uri) as call_resp:
+            if call_resp.status != 200:
+                response['error'] = f'Received {call_resp.status!r} response code from {uri!r}'
+            else:
+                try:
+                    async for line in call_resp.content.iter_any():
+                        output += line.decode(errors='ignore')
+
+                    response['data'] = json.loads(output)
+                except aiohttp.client_exceptions.ContentTypeError as e:
+                    response['error'] = f'Malformed response received from {uri!r} endpoint: {e}'
+                except json.JSONDecodeError:
+                    response['error'] = f'Failed to decode response from {uri!r}'
+
+        return response
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def multiple_requests(
+        cls, resources: typing.List[typing.Tuple[str, str]], timeout: int = NETDATA_REQUEST_TIMEOUT, version: str = 'v1'
+    ) -> typing.List[dict]:
+        assert version in ('v1', 'v2'), f'Invalid API version {version!r}'
+
+        uri = f'{NETDATA_URI}/{version}'
+        tasks = []
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+                for identifier, resource in resources:
+                    resource = resource.removeprefix('/')
+                    tasks.append(cls.fetch(f'{uri}/{resource}', session, identifier))
+
+                yield await asyncio.gather(*tasks)
+
+        except (asyncio.TimeoutError, aiohttp.ClientResponseError) as e:
+            raise ApiException(f'Failed {resources!r} call: {e!r}')
+        except (aiohttp.client_exceptions.ClientConnectorError, aiohttp.client_exceptions.ClientOSError) as e:
+            raise ClientConnectError(f'Failed to connect to {uri!r}: {e!r}')
+
+    @classmethod
+    async def api_calls(
+        cls, resources: typing.List[typing.Tuple[str, str]], timeout: int = NETDATA_REQUEST_TIMEOUT, version: str = 'v1'
+    ) -> typing.List[typing.Tuple[typing.Optional[str], dict]]:
+        responses = []
+        try:
+            async with cls.multiple_requests(resources, timeout, version) as tasks:
+                for task in tasks:
+                    if task['error']:
+                        responses.append((task['identifier'], {
+                            'labels': ['time'],
+                            'data': [],
+                        }))
+                        logger.debug(f'Failed to fetch api response from {task["uri"]}. Reason {task["error"]}')
+                    else:
+                        responses.append((task['identifier'], task['data']))
+        except (ApiException, ClientConnectError):
+            logger.debug('Failed to connect to netdata', exc_info=True)
+
+        return responses

--- a/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/connector.py
@@ -1,4 +1,5 @@
 import errno
+import typing
 
 from .client import ClientMixin
 from .exceptions import ApiException
@@ -38,3 +39,14 @@ class Netdata(ClientMixin):
             f'data?chart={chart}&options=null2zero{get_query_parameters(query_params)}',
             version='v1',
         )
+
+    @classmethod
+    async def get_charts_metrics(
+        cls, charts: dict, parameters: dict
+    ) -> typing.List[typing.Tuple[typing.Optional[str], dict]]:
+        """Get metrics for multiple charts"""
+        query_params = get_query_parameters(parameters)
+        return await cls.api_calls([
+            (identifier, f'data?chart={chart_name}&options=null2zero{query_params}')
+            for identifier, chart_name in charts.items()
+        ])


### PR DESCRIPTION
## Problem
The Netdata graph export function currently generates a substantial number of API calls, resulting in a high volume of open file descriptors and extended processing time.

## Solution

To address this issue, modifications have been implemented in the Netdata API code to support multiple calls. This enhancement has led to a reduction improvement in processing time by approximately 10 seconds during graph exports involving 1200 disks.
This also resolves the file descriptors issue we were seeing where we ran out of them - solution to address this has been to use a connection pool instead of making separate requests.

Original PR: https://github.com/truenas/middleware/pull/12214
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124128