### PR TITLE
NAS-124400 / 24.04 / Remove pre-SQLite 3.30 workaround

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -126,27 +126,6 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
 
                 order_by[i] = wrapper(order_by[i])
 
-            # FIXME: remove this after switching to SQLite 3.30
-            changed = True
-            while changed:
-                changed = False
-                for i, v in enumerate(order_by):
-                    if isinstance(v, UnaryExpression) and v.modifier in (nullsfirst_op, nullslast_op):
-                        if isinstance(v.element, UnaryExpression) and v.element.modifier == desc_op:
-                            root_element = v.element.element
-                        else:
-                            root_element = v.element
-
-                        order_by = order_by[:i] + [
-                            {
-                                nullsfirst_op: root_element != None,  # noqa
-                                nullslast_op: root_element == None,  # noqa
-                            }[v.modifier],
-                            v.element,
-                        ] + order_by[i + 1:]
-                        changed = True
-                        break
-
             qs = qs.order_by(*order_by)
 
         if options['offset']:


### PR DESCRIPTION
It was introduced by e1054f7b2e04ce75225742a1b3c5f02644829c6a along with some tests that now pass even with this bit removed