### PR TITLE
NAS-124428 / 24.04 / Add support for more complex filters

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -83,7 +83,8 @@ Javascript:
       ["locked", "=", false]
     ]
 
-The following is an invalid example because the first array member is a conjunction of multiple conditions rather than a single condition.
+The following is valid example that returns users who are either enabled or have password authentication enabled with two-factor authentication disabled.
+
 Javascript:
     :::javascript
     ["OR",
@@ -114,7 +115,8 @@ Javascript:
       ["group.bsdgrp_gid", "=", 3000],
     ]
 
-If a key contains a literal dot (".") in its name, then it must be escaped via a double backlash.
+If a key contains a literal dot (".") in its name, then it must be escaped via a double backslash.
+
 Javascript:
     :::javascript
     [

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -302,9 +302,9 @@ class filters(object):
 
         This allows us to do a simple check of list length to determine whether
         we have a conjunction or disjunction.
+
+        Recursion depth is checked when validate_filters is called above.
         """
-        # NOTE: max recursion depth is validated prior to
-        # this.
         if len(the_filter) == 2:
             # OR check
             op, value = the_filter


### PR DESCRIPTION
This adds support for more flexible usage of OR condition in our query-filters. For example, users will be able to filter by (a || (b & c)). Validation is also added for depth of filters to prevent API consumers from making extremely ill-advised queries. We can expand validation as-needed.

This may slightly increase time-complexity of evaluation of `OR` conditions (isinstance() check added), but most common case of simple conditions has no impact.