### PR TITLE
NAS-124425 / 24.04 / Fatal Error message appears post start of iSCSI service containing multiple targets and file extents

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -2494,7 +2494,7 @@ def test_28_portal_access(request):
                             assert MB_100 == _read_capacity16(s)
 
 
-def test_29_multiple_extents(request):
+def test_29_multiple_extents():
     """
     Verify that an iSCSI client can access multiple target LUNs
     when multiple extents are configured.
@@ -2527,7 +2527,7 @@ def test_29_multiple_extents(request):
                                 with pytest.raises(AssertionError) as ve:
                                     with file_extent(pool_name, dataset_name, "target.extent3", filesize=MB_512,
                                                      extent_name="extent3", serial=extent1_config['serial']):
-                                        assert False, "Should not have been able to duplicate extent serial."
+                                        pass
                                 assert 'Serial number must be unique' in str(ve), ve
 
                                 with file_extent(pool_name, dataset_name, "target.extent3", filesize=MB_512,


### PR DESCRIPTION
Starting in COBIA we require a valid serial number to be specified for each iSCSI target extent, in order to support ALUA.  This gets applied to the scst config as `t10_dev_id`.

Previously _some_ paths through our code auto-generated a serial number, but another path did not.  This PR rectifies this deficiency by enhancing `extent_serial` to also generate on the empty string.

Furthermore, we also now ensure that serial numbers are unique.

Finally, add some tests.