### PR TITLE
NAS-124432 / 24.04 / Ensure iSCSI extents have a non-empty serial number (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-10-02_21-57_extent_serial.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-10-02_21-57_extent_serial.py
@@ -1,0 +1,50 @@
+"""Ensure iSCSI extents have a non-empty serial number.
+
+Revision ID: fa33f4ae6427
+Revises: b06ea181e7dd
+Create Date: 2023-10-02 21:57:49.452962+00:00
+
+"""
+from alembic import op
+import secrets
+
+
+# revision identifiers, used by Alembic.
+revision = 'fa33f4ae6427'
+down_revision = 'b06ea181e7dd'
+branch_labels = None
+depends_on = None
+
+
+def generate_serial(used_serials, tries=10):
+    for i in range(tries):
+        serial = secrets.token_hex()[:15]
+        if serial not in used_serials:
+            return serial
+
+
+def upgrade():
+    # We wish to ensure that every iSCSI extent has a (unique) serial number
+    # assigned (but that said we will only change the serial number if
+    # previously empty)
+    conn = op.get_bind()
+    tofix = []
+    for (ident,) in conn.execute("SELECT id FROM services_iscsitargetextent WHERE iscsi_target_extent_serial == null or iscsi_target_extent_serial == ''"):
+        tofix.append(ident)
+    if tofix:
+        serials = []
+        for (serial,) in conn.execute("SELECT iscsi_target_extent_serial FROM services_iscsitargetextent"):
+            if serial not in [None, '']:
+                serials.append(serial)
+        for ident in tofix:
+            serial = generate_serial(serials)
+            if serial:
+                conn.execute(
+                    "UPDATE services_iscsitargetextent SET iscsi_target_extent_serial = ? WHERE id = ?",
+                    serial, ident
+                )
+                serials.append(serial)
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-03_17-08_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-03_17-08_merge.py
@@ -1,0 +1,24 @@
+"""Merge
+
+Revision ID: 3df553b07a99
+Revises: 2b9a98464a33, fa33f4ae6427
+Create Date: 2023-10-03 17:08:38.778513+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3df553b07a99'
+down_revision = ('2b9a98464a33', 'fa33f4ae6427')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Starting in COBIA we require a valid serial number to be specified for each iSCSI target extent, in order to support ALUA.  This gets applied to the scst config as `t10_dev_id`.

NAS-124425 is the defect that tracks the code changes so that going forward a serial number will always be generated when an extent is created.

This related defect (NAS-124432) is to modify the contents of the database to repair any *previously created* iSCSI extents.  It does this by performing an alembic migration (without a schema change).

As recommended in the relevant [documentation](http://docs.middleware.ixsystems.net/database/migrations.html#backporting-migrations), the first PR for this issue was to handle the backport.  **This** PR is the forward-port and subsequent merge heads.

Original PR: https://github.com/truenas/middleware/pull/12238
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124432