### PR TITLE
NAS-124451 / 24.04 / add -f (force) flag to import_on_boot()

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -211,6 +211,7 @@ class PoolService(Service):
             vol_guid,  # the GUID of the zpool
             '-R', '/mnt',  # altroot
             '-m',  # import pool with missing log device(s)
+            '-f',  # force import since hostid can change (upgrade from CORE to SCALE changes it, for example)
             '-o', f'cachefile={ZPOOL_CACHE_FILE}' if set_cachefile else 'cachefile=none',
         ]
         try:


### PR DESCRIPTION
The `-f` flag is needed because the hostid can change. It changes, for example, when upgrading from CORE to SCALE. It also changes if the zpool being imported is from another system.