### PR TITLE
NAS-124297 / 23.10.0 / Add empty password validation when cloning a VM (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -4,7 +4,8 @@ import uuid
 
 from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.schema import accepts, Bool, Int, returns, Str
-from middlewared.service import CallError, item_method, Service
+from middlewared.service import CallError, item_method, Service, private
+from middlewared.service_exception import ValidationErrors
 
 
 ZVOL_CLONE_SUFFIX = '_clone'
@@ -78,6 +79,7 @@ class VMService(Service):
         If not provided it will append the next number available to the VM name.
         """
         vm = await self.middleware.call('vm.get_instance', id)
+        await self.validate(vm)
 
         origin_name = vm['name']
         del vm['id']
@@ -137,3 +139,15 @@ class VMService(Service):
         self.logger.info('VM cloned from {0} to {1}'.format(origin_name, vm['name']))
 
         return True
+
+    @private
+    async def validate(self, vm):
+        verrors = ValidationErrors()
+        for index, device in enumerate(vm['devices']):
+            if device['dtype'] == 'DISPLAY' and not device['attributes'].get('password'):
+                verrors.add(
+                    f'vm.devices.{index}.attributes.password',
+                    'Password must be configured for display device in order to clone the VM.'
+                )
+
+        verrors.check()


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 86ba40456defb451a0dd8816f9d6e1d0dd7ea80f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 6479c651bf1771d997a1041552ec3462ef21014a

## Problem

When cloning a VM which has a display device where no password is configured (which was allowed in earlier versions of SCALE) - cloning the VM fails with a traceback as we are not able to clone the display device in question.

## Solution

Properly validate the VM before cloning ensuring that it's display devices have a password configured and raise a validation error before trying to clone the VM.

Original PR: https://github.com/truenas/middleware/pull/12243
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124297