### PR TITLE
NAS-124182 / 23.10.0 / Fix disk temperature graph (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -235,12 +235,21 @@ class DiskTempPlugin(GraphBase):
                     self.disk_mapping[disk.id] = k
                     break
 
+    def query_parameters(self) -> dict:
+        query_params = super().query_parameters()
+        query_params['options'] += '|natural-points'
+        return query_params
+
     async def get_identifiers(self) -> typing.Optional[list]:
         return list(self.disk_mapping.keys())
 
     def normalize_metrics(self, metrics) -> dict:
         metrics = super().normalize_metrics(metrics)
         metrics['legend'][1] = 'temperature_value'
+        if metrics['data'] and metrics['data'][-1] and metrics['data'][-1][-1] == 0:
+            # we will now remove last entry of data as when end if sometimes is specified as time which does not
+            # exist in netdata database, netdata adds a last entry of 0 which we don't want to show
+            metrics['data'].pop()
         return metrics
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -22,11 +22,11 @@ def calculate_disk_space_for_netdata(metric_intervals: dict, days: int) -> int:
 
 def convert_unit(unit: str, page: int) -> int:
     return {
-        'HOUR': 60,
-        'DAY': 60 * 24,
-        'WEEK': 60 * 24 * 7,
-        'MONTH': 60 * 24 * 30,
-        'YEAR': 60 * 24 * 365,
+        'HOUR': 60 * 60,
+        'DAY': 60 * 60 * 24,
+        'WEEK': 60 * 60 * 24 * 7,
+        'MONTH': 60 * 60 * 24 * 30,
+        'YEAR': 60 * 60 * 24 * 365,
     }[unit] * page
 
 
@@ -129,7 +129,7 @@ def get_metrics_approximation(disk_count: int, core_count: int, interface_count:
             # cputemp
             'cputemp.temperatures': core_count,
         },
-        1800: {  # smartd_logs
+        60: {  # smartd_logs
             'smart_log.temperature_celsius': disk_count}
     }
     return {

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,expected_output', [
-    (4, 2, 1, 2, {1: 354, 1800: 4}),
-    (1600, 32, 4, 4, {1: 44001, 1800: 1600}),
-    (10, 16, 2, 2, {1: 761, 1800: 10}),
+    (4, 2, 1, 2, {1: 354, 60: 4}),
+    (1600, 32, 4, 4, {1: 44001, 60: 1600}),
+    (10, 16, 2, 2, {1: 761, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(disk_count, core_count, interface_count, pool_count, expected_output):
     assert get_metrics_approximation(disk_count, core_count, interface_count, pool_count) == expected_output
@@ -14,9 +14,9 @@ def test_netdata_metrics_count_approximation(disk_count, core_count, interface_c
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,days,expected_output', [
     (4, 2, 1, 2, 7, 204),
-    (1600, 32, 4, 4, 4, 14502),
+    (1600, 32, 4, 4, 4, 14511),
     (10, 16, 2, 2, 3, 188),
-    (1600, 32, 4, 4, 18, 65261),
+    (1600, 32, 4, 4, 18, 65299),
 ])
 def test_netdata_disk_space_approximation(disk_count, core_count, interface_count, pool_count, days, expected_output):
     assert calculate_disk_space_for_netdata(get_metrics_approximation(


### PR DESCRIPTION
## Problem
The primary issue stems from receiving zero values in `reporting.netdata_get_data` for `disktemp` metrics. This problem is exacerbated by the relatively large time interval, which can be as long as 30 minutes. With such a lengthy interval, Netdata only collects data once in that time frame. Consequently, when attempting to retrieve data for every second, Netdata often lacks current values, resulting in it repeating previous values to fill the gaps. Additionally, the Netdata `disktemp` plugin has a 30-minute sleep interval, causing it to lag by that duration. This delay means Netdata lacks data for the current 30 minutes, leading to zero values on service restart or when the system boots up. Furthermore, a minor issue in the middleware relates to an incorrect time interval for data retrieval.

## Solution
To address these challenges, several changes have been implemented. First, the time interval has been reduced to one minute. Cached data is returned for the first 30 minutes, and then data is updated after that period. Additionally, the time interval for data retrieval in the middleware has been corrected. To mitigate the repetition of values in Netdata, a flag is employed to provide real-time-based values, enhancing the accuracy and consistency of the reported data so that netdata does not fill in gaps itself but rather just reports values it actually collected at specified interval.

These adjustments ensure that the `disktemp` metrics are more accurately collected and reported, addressing the problem of zero values and data gaps.

Original PR: https://github.com/truenas/middleware/pull/12245
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124182