### PR TITLE
NAS-124473 / 23.10.1 / Fix regression in create_cluster (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -59,6 +59,9 @@ class ClusterPeerConnection:
     def __do_connect(self):
         c = Client(f'ws://{self.private_address}:6000/websocket')
         cred = self.credentials
+        if cred is None:
+            raise CallError('No credential provided')
+
         if (auth_token := cred.get('auth_token')):
             authenticated = c.call('auth.login_with_token', auth_token)
         elif (auth_key := cred.get('api_key')):
@@ -82,9 +85,6 @@ class ClusterPeerConnection:
         self.local = kwargs.get('local')
         self.conn = None
         self.call_fn = None
-
-        if self.credentials is None:
-            raise CallError('No credential provided')
 
         if not self.local:
             self.__do_connect()


### PR DESCRIPTION
A fix to enhance validation to catch invalid cluster peer configuation early in setup caused regression due to checking for credential for the local node.

Original PR: https://github.com/truenas/middleware/pull/12249
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124473