### PR TITLE
NAS-124452 / 22.12.5 / fix disk.read_temps()

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -184,12 +184,18 @@ class DiskService(Service):
         if filename.endswith('.ata.csv'):
             if (ft := line.split('\t')) and (temp := list(filter(lambda x: x.startswith(('190;', '194;')), ft))):
                 try:
-                    temp = temp[-1].split(';')[2]
-                except IndexError:
+                    _, value, raw, _ = temp[-1].split(';')
+                except ValueError:
                     return None
-                else:
-                    if temp.isdigit():
-                        return int(temp)
+
+                if not all((value.isdigit(), raw.isdigit())):
+                    return None
+
+                # The low byte is the current temperature
+                # The third lowest is the maximum
+                # The fifth lowest is the minimum
+                value, raw = int(value), int(raw)
+                return raw & 0xFF if raw > 1e6 else min(value, raw)
 
         if filename.endswith('.scsi.csv'):
             if (ft := line.split('\t')) and (temp := list(filter(lambda x: 'temperature' in x, ft))):


### PR DESCRIPTION
Certain drives (ATA) will report their "raw" values for the temperature attribute (190, 194). For reasons not fully understood, something changed between 22.12.3.3 and 22.12.4 which caused this to break.

It's not fully understood if this was something in kernel (we updated kernel in 22.12.4) or if this has always been the case and we're just now getting reports of it. The solution is relatively simple, just convert the raw value if necessary.

I was able to reproduce the change of behavior in-house on real hardware and then confirmed these changes fix the issue.