### PR TITLE
fix: https://ixsystems.atlassian.net/browse/NAS-124487

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info.py
@@ -125,11 +125,15 @@ class DiskService(Service):
     def get_disk_from_partition(self, part_name):
         if not os.path.exists(os.path.join('/dev', part_name)):
             return None
-        with open(os.path.join('/sys/class/block', part_name, 'partition'), 'r') as f:
-            part_num = f.read().strip()
-        if part_name.startswith(('nvme', 'pmem')):
-            # nvme/pmem partitions would be like nvmen1p1 where disk is nvmen1
-            part_num = f'p{part_num}'
+        try:
+            with open(os.path.join('/sys/class/block', part_name, 'partition'), 'r') as f:
+                part_num = f.read().strip()
+        except FileNotFoundError:
+            return part_name
+        else:
+            if part_name.startswith(('nvme', 'pmem')):
+                # nvme/pmem partitions would be like nvmen1p1 where disk is nvmen1
+                part_num = f'p{part_num}'
         return part_name.rsplit(part_num, 1)[0].strip()
 
     @private


### PR DESCRIPTION
I am making another pull request with this after the previous one was cancelled.

Whatever you think about the issue, it is not acceptable to read file without checking if it is present and then crashing storage UI, k3s and docker in the process. How it happens is of no consequence.

This is not feature request, this pull request is fixing unsanitized code. You may 100% ignore how I discovered it, but the code is unsanitized in a major way.

I also do not think that importing zpool should crash storage UI, k3s and docker under any circumstances.

I am willing to improve it any way, so it passes and even track why disks are reported as unused, it will be similar issue.