### PR TITLE
NAS-124486 / 22.12.4.1 / Update "toggled" share acl on sharesec update (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -306,6 +306,7 @@ class ShareSec(CRUDService):
             ae_list.append(await self._ae_to_string(entry))
 
         await self._sharesec(share=data['share_name'], action='--replace', args=','.join(ae_list))
+        await self.dup_share_acl(data['share_name'].lower(), f'#{data["share_name"].lower()}')
         if not db_commit:
             return
 


### PR DESCRIPTION
There are various ways that users can encrypt, decrypt, enable and disable SMB paths and shares. Some operations require removing the SMB share from our shares list, which automatically removes the share acl entry. To prevent this we store a copy of it prefixed by a `#` character when share path is encrypted and when share is decrypted we restore from the backup copy. This logic had some gaps in it whereby a reboot when the backup was out-of-sync from the current one, the current share ACL could be replaced. This commit plugs the gap by immediately duplicating the ACL on setacl calls.

This issue does not impact Cobia and later since SMB share ACL handling was substantially refactored.

Original PR: https://github.com/truenas/middleware/pull/12252
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124486