### PR TITLE
NAS-124492 / 23.10.1 / Fix abusive test of SMB registry config (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -35,4 +35,5 @@ class CIFSService(SimpleService):
         await self.middleware.call('service.reload', 'mdns')
 
     async def before_reload(self):
-        await self.middleware.call("sharing.smb.sync_registry")
+        sync_job = await self.middleware.call("sharing.smb.sync_registry")
+        await sync_job.wait()

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -301,7 +301,7 @@ with regard to homes shares
 
 @pytest.mark.dependency(name="HOME_SHARE_CREATED")
 def test_015_create_homes_share(request):
-    depends(request, ["SMB_DATASET_CREATED"])
+    depends(request, ["SHARES_CREATED"])
 
     HOME_PATH = os.path.join(smb_registry_mp, 'HOME_SHARE')
     call('filesystem.mkdir', HOME_PATH)


### PR DESCRIPTION
An abusive test was being skipped due to dependency no longer being set. When it was re-enabled, the test failed due to race in the SMB service reload method. This commit fixes the test dependency and waits for the registry sync to finish before reloading the SMB service.

Original PR: https://github.com/truenas/middleware/pull/12261
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124492