### PR TITLE
NAS-124498 / 24.04 / Don't crash if secrets backup lacks last change TS

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -418,8 +418,11 @@ class DirectoryServices(Service):
         if server_secrets is None:
             return {"dbconfig": None, "secrets": passwd_ts}
 
-        stored_ts_bytes = server_secrets[f'SECRETS/MACHINE_LAST_CHANGE_TIME/{domain.upper()}']
-        stored_ts = struct.unpack("<L", b64decode(stored_ts_bytes))[0]
+        try:
+            stored_ts_bytes = server_secrets[f'SECRETS/MACHINE_LAST_CHANGE_TIME/{domain.upper()}']
+            stored_ts = struct.unpack("<L", b64decode(stored_ts_bytes))[0]
+        except KeyError:
+            stored_ts = None
 
         return {"dbconfig": stored_ts, "secrets": passwd_ts}
 


### PR DESCRIPTION
This shouldn't be fatal, we just treat ourselves as not having a backup of domain secrets and write it to config.