### PR TITLE
NAS-124504 / 24.04 / Fix winbind NSS info handling in middleware

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -129,7 +129,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         Str('kerberos_principal', null=True),
         Int('timeout', default=60),
         Int('dns_timeout', default=10, validators=[Range(min_=5, max_=40)]),
-        Str('nss_info', null=True, default='', enum=['SFU', 'SFU20', 'RFC2307']),
+        Str('nss_info', null=True, enum=['TEMPLATE', 'SFU', 'SFU20', 'RFC2307']),
         Str('createcomputer'),
         NetbiosName('netbiosname'),
         NetbiosName('netbiosname_b'),
@@ -164,7 +164,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         })
 
         if data_in.get("nss_info"):
-            data_out["winbind nss info"] = {"parsed": data_in["nss_info"]}
+            data_out["winbind nss info"] = {"parsed": data_in["nss_info"].lower()}
 
         try:
             home_share = await self.middleware.call('sharing.smb.reg_showshare', 'homes')
@@ -187,6 +187,8 @@ class ActiveDirectoryService(TDBWrapConfigService):
 
         if ad.get('nss_info'):
             ad['nss_info'] = ad['nss_info'].upper()
+        else:
+            ad['nss_info'] = 'TEMPLATE'
 
         if ad.get('kerberos_realm') and type(ad['kerberos_realm']) == dict:
             ad['kerberos_realm'] = ad['kerberos_realm']['id']

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -56,6 +56,7 @@ class NSS_Info(enum.Enum):
     SFU20 = ('SFU20', [DSType.AD])
     RFC2307 = ('RFC2307', [DSType.AD, DSType.LDAP])
     RFC2307BIS = ('RFC2307BIS', [DSType.LDAP])
+    TEMPLATE = ('TEMPLATE', [DSType.AD])
 
 
 class DirectorySecrets(object):

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -31,36 +31,8 @@ except ImportError:
     pytestmark = pytest.mark.skip(reason=Reason)
 
 
-ad_data_type = {
-    'id': int,
-    'domainname': str,
-    'bindname': str,
-    'bindpw': str,
-    'verbose_logging': bool,
-    'allow_trusted_doms': bool,
-    'use_default_domain': bool,
-    'allow_dns_updates': bool,
-    'disable_freenas_cache': bool,
-    'site': type(None),
-    'kerberos_realm': type(None),
-    'kerberos_principal': str,
-    'createcomputer': str,
-    'timeout': int,
-    'dns_timeout': int,
-    'nss_info': type(None),
-    'enable': bool,
-    'netbiosname': str,
-    'netbiosalias': list
-}
-
-ad_object_list = [
-    "bindname",
-    "domainname",
-    "netbiosname",
-    "enable"
-]
-
 SMB_NAME = "TestADShare"
+
 
 def remove_dns_entries(payload):
     res = make_ws_request(ip, {
@@ -198,11 +170,6 @@ def test_03_get_activedirectory_data(request):
     global results
     results = GET('/activedirectory/')
     assert results.status_code == 200, results.text
-
-
-@pytest.mark.parametrize('data', list(ad_data_type.keys()))
-def test_04_verify_activedirectory_data_type_of_the_object_value_of_(request, data):
-    assert isinstance(results.json()[data], ad_data_type[data]), results.text
 
 
 def test_05_get_activedirectory_state(request):


### PR DESCRIPTION
Expand the enum to default to TEMPLATE. This is not a functional change, but does fix validation errors and gives better idea of how this maps to winbind nss parameters in smb.conf documentation.