### PR TITLE
NAS-124508 / 24.04 / Prevent setting empty string for SMB guest

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -723,7 +723,7 @@ class SMBService(TDBWrapConfigService):
                         f'NetBIOS name [{new[i]}] conflicts with workgroup name.'
                     )
 
-        if new['guest']:
+        if new['guest'] is not None:
             if new['guest'] == 'root':
                 verrors.add('smb_update.guest', '"root" is not a permitted guest account')
 

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -46,7 +46,7 @@ def initialize_for_smb_tests(request):
                 finally:
                     call('smb.update', {
                         'enable_smb1': False,
-                        'guest': ''
+                        'guest': 'nobody'
                     })
                     call('service.stop', 'cifs')
 


### PR DESCRIPTION
Failure to resolve guest name will prevent SMB service from starting.