### PR TITLE
NAS-124493 / 23.10.0 / Fix display available usages in vm schema (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -82,10 +82,10 @@ class VMService(Service):
         await self.validate(vm)
 
         origin_name = vm['name']
-        del vm['id']
-        del vm['status']
-        devices = vm.pop('devices')
+        for key in ('id', 'status', 'display_available'):
+            vm.pop(key, None)
 
+        devices = vm.pop('devices')
         vm['name'] = await self.__next_clone_name(vm['name'])
         vm['uuid'] = str(uuid.uuid4())  # We want to use a newer uuid here as it is supposed to be unique per VM
 

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -82,6 +82,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             Int('pid', null=True, required=True),
             Str('domain_state', required=True),
         )),
+        ('add', Bool('display_available')),
         ('add', Int('id')),
     )
 
@@ -324,6 +325,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             'vm_entry',
             'vm_update',
             ('rm', {'name': 'devices'}),
+            ('rm', {'name': 'display_available'}),
             ('rm', {'name': 'status'}),
             ('attr', {'update': True}),
         )
@@ -359,8 +361,9 @@ class VMService(CRUDService, VMSupervisorMixin):
         await self.common_validation(verrors, 'vm_update', new, old=old)
         verrors.check()
 
-        new.pop('devices')
-        new.pop('status', None)
+        for key in ('devices', 'status', 'display_available'):
+            new.pop(key, None)
+
         await self.middleware.call('datastore.update', 'vm.vm', id, new)
 
         vm_data = await self.get_instance(id)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0d39d89583c8e91406bc3352dbb539319a71f7d0
    git cherry-pick -x 4f66e553079fd4855298ae50747a6d762b008122

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 49c8b880dd77b0cc8e41b048e0c6cd737a8f7fbf



Original PR: https://github.com/truenas/middleware/pull/12277
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124493