### PR TITLE
NAS-124557 / 24.04 / Allow nsupdate to set non-private IP addresses

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -323,7 +323,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',
                         f'{addr}: automatic DNS update would result in registering a reserved '
-                        'IP address. Users may disable automatic DNS updates and manually. '
+                        'IP address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
                     break
@@ -332,7 +332,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',
                         f'{addr}: automatic DNS update would result in registering a global '
-                        'IP address. Users may disable automatic DNS updates and manually. '
+                        'IP address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
                     break
@@ -341,7 +341,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',
                         f'{addr}: automatic DNS update would result in registering a loopback '
-                        'address. Users may disable automatic DNS updates and manually. '
+                        'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
                     break
@@ -350,7 +350,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',
                         f'{addr}: automatic DNS update would result in registering a link-local '
-                        'address. Users may disable automatic DNS updates and manually. '
+                        'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
                     break
@@ -359,7 +359,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',
                         f'{addr}: automatic DNS update would result in registering a multicast '
-                        'address. Users may disable automatic DNS updates and manually. '
+                        'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
                     break

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -326,7 +326,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'IP address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
-                    break
 
                 if addr.is_global:
                     verrors.add(
@@ -335,7 +334,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'IP address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
-                    break
 
                 if addr.is_loopback:
                     verrors.add(
@@ -344,7 +342,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
-                    break
 
                 if addr.is_link_local:
                     verrors.add(
@@ -353,7 +350,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
-                    break
 
                 if addr.is_multicast:
                     verrors.add(
@@ -362,7 +358,6 @@ class ActiveDirectoryService(TDBWrapConfigService):
                         'address. Users may disable automatic DNS updates and manually '
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
-                    break
 
     @accepts(Ref('activedirectory_update'))
     @returns(Patch(

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import errno
 import json
+import ipaddress
 import os
 import time
 import contextlib
@@ -265,7 +266,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if not new["enable"]:
             return
 
-        if await self.middleware.call('smb.get_smb_ha_mode') == 'CLUSTERED':
+        if (ha_mode := await self.middleware.call('smb.get_smb_ha_mode')) == 'CLUSTERED':
             if not await self.middleware.call('ctdb.general.ips'):
                 verrors.add(
                     'activedirectory_update.enable',
@@ -301,6 +302,67 @@ class ActiveDirectoryService(TDBWrapConfigService):
                 "activedirectory_update.domainname",
                 "AD domain name is required."
             )
+
+        if new['allow_dns_updates']:
+            smb = await self.middleware.call('smb.config')
+            addresses = await self.middleware.call(
+                'activedirectory.get_ipaddresses', new, smb, ha_mode
+            )
+
+            if not addresses:
+                verrors.add(
+                    'activedirectory_update.allow_dns_updates',
+                    'No server IP addresses passed DNS validation. '
+                    'This may indicate an improperly configured reverse zone. '
+                    'Review middleware log files for details regarding errors encountered.',
+                )
+
+            for a in addresses:
+                addr = ipaddress.ip_address(a)
+                if addr.is_reserved:
+                    verrors.add(
+                        'activedirectory_update.allow_dns_updates',
+                        f'{addr}: automatic DNS update would result in registering a reserved '
+                        'IP address. Users may disable automatic DNS updates and manually. '
+                        'configure DNS A and AAAA records as needed for their domain.'
+                    )
+                    break
+
+                if addr.is_global:
+                    verrors.add(
+                        'activedirectory_update.allow_dns_updates',
+                        f'{addr}: automatic DNS update would result in registering a global '
+                        'IP address. Users may disable automatic DNS updates and manually. '
+                        'configure DNS A and AAAA records as needed for their domain.'
+                    )
+                    break
+
+                if addr.is_loopback:
+                    verrors.add(
+                        'activedirectory_update.allow_dns_updates',
+                        f'{addr}: automatic DNS update would result in registering a loopback '
+                        'address. Users may disable automatic DNS updates and manually. '
+                        'configure DNS A and AAAA records as needed for their domain.'
+                    )
+                    break
+
+                if addr.is_link_local:
+                    verrors.add(
+                        'activedirectory_update.allow_dns_updates',
+                        f'{addr}: automatic DNS update would result in registering a link-local '
+                        'address. Users may disable automatic DNS updates and manually. '
+                        'configure DNS A and AAAA records as needed for their domain.'
+                    )
+                    break
+
+                if addr.is_multicast:
+                    verrors.add(
+                        'activedirectory_update.allow_dns_updates',
+                        f'{addr}: automatic DNS update would result in registering a multicast '
+                        'address. Users may disable automatic DNS updates and manually. '
+                        'configure DNS A and AAAA records as needed for their domain.'
+                    )
+                    break
 
     @accepts(Ref('activedirectory_update'))
     @returns(Patch(

--- a/src/middlewared/middlewared/plugins/network_/dns.py
+++ b/src/middlewared/middlewared/plugins/network_/dns.py
@@ -116,7 +116,7 @@ class DNSService(Service):
                     Str('type', enum=['A', 'AAAA'], default='A'),
                     Int('ttl', default=3600),
                     IPAddr('address', required=True, excluded_address_types=[
-                        'MULTICAST', 'GLOBAL', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED'
+                        'MULTICAST', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED'
                     ]),
                     Bool('do_ptr', default=True)
                 )


### PR DESCRIPTION
This commit includes two principle changes:
1) the nsupdate endpoint now allows GLOBAL addresses 
2) validation for IP addresses to register happens earlier in activedirectory.update so that we can raise proper validation error and redirect user to either disable the automatic DNS update or fix the server configuration prior to joining AD. As things stand, this can cause an exception mid-join and leave server in semi-deployed state.

Future enhancement will be to allow users to select which addresses to register in DNS. At that point, we can safely allow global addresses.