### PR TITLE
NAS-124562 / 24.04 / fix typo causing TypeError crash

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -265,7 +265,7 @@ class PoolService(Service):
             elif uj.result['failed']:
                 self.logger.error(
                     'FAILED unlocking the following datasets: %r for pool %r',
-                    ', '.join(uj.result['failed'], vol_name)
+                    ', '.join(uj.result['failed']), vol_name
                 )
             else:
                 self.logger.debug('SUCCESS unlocking encrypted dataset(s) (if any) for %r', vol_name)


### PR DESCRIPTION
Typo which leads to a TypeError crash during importing of pools at boot. A regression introduced in https://github.com/truenas/middleware/pull/12202