### PR TITLE
NAS-124477 / 23.10.1 / add 'ON' as a compression choice (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -16,7 +16,7 @@ RE_DRAID_SPARE_DISKS = re.compile(r':\d*s')
 RE_DRAID_NAME = re.compile(r'draid\d:\d+d:\d+c:\d+s-\d+')
 ZFS_CHECKSUM_CHOICES = ['ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN', 'EDONR']
 ZFS_COMPRESSION_ALGORITHM_CHOICES = [
-    'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-FAST', 'ZLE', 'LZJB',
+    'ON', 'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-FAST', 'ZLE', 'LZJB',
 ] + [f'ZSTD-{i}' for i in range(1, 20)] + [
     f'ZSTD-FAST-{i}' for i in itertools.chain(range(1, 11), range(20, 110, 10), range(500, 1500, 500))
 ]


### PR DESCRIPTION
The `compression=on` property value is a valid choice but often isn't seen anymore since it's considered a legacy value. Upstream changed the default years ago but we have certain users that create a zpool on a <= freenas 11 (yes freenas) and then import said zpool on SCALE. When this happens, we raise a validation error stating "on" is an invalid choice which is incorrect.

Original PR: https://github.com/truenas/middleware/pull/12280
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124477