### PR TITLE
NAS-124575 / 24.04 / Cleanup global settings after removing homes share

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1212,6 +1212,12 @@ class SharingSMBService(SharingService):
 
             check_mdns = True
 
+        # Homes shares require pam restrictions to be enabled (global setting)
+        # so that we auto-generate the home directory via pam_mkhomedir.
+        # Hence, we need to redo the global settings after changing homedir.
+        if new.get('home') is not None and old['home'] != new['home']:
+            do_global_reload = True
+
         if do_global_reload:
             await self.middleware.call('smb.initialize_globals')
             if (await self.middleware.call('activedirectory.get_state')) == 'HEALTHY':
@@ -1262,6 +1268,9 @@ class SharingSMBService(SharingService):
 
         if share['timemachine']:
             await self.middleware.call('service.reload', 'mdns')
+
+        if share_name == 'homes':
+            await self.middleware.call('smb.initialize_globals')
 
         return result
 


### PR DESCRIPTION
Homes share may be removed by either updating the share so that home=False or deleting the share. After these changes have been committed, we need to rebuild our global SMB config to remove the "obey pam restrictions" parameter.