### PR TITLE
NAS-124566 / 23.10.0 / another regression with R50 enclosure mgmt (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map.py
@@ -390,6 +390,7 @@ class EnclosureService(Service):
         controller_enclosures = list(filter(lambda x: x['controller'], enclosures))
         elements = []
         has_slot_status = False
+        model = bsg = None
         for slot, mapping in enumerate(slots, 1):
             try:
                 original_enclosure = controller_enclosures[mapping.num]
@@ -434,14 +435,17 @@ class EnclosureService(Service):
                                             "is not present on this system", mapping.slot, mapping.num, k)
                         has_slot_status = False
 
+            if model is None and not original_enclosure["id"].endswith(("plx_enclosure", "nvme_enclosure")):
+                model = original_enclosure["model"]
+
             elements.append(element)
 
         mapped = [
             {
                 "id": "mapped_enclosure_0",
-                "bsg": original_enclosure["bsg"],
+                "bsg": bsg,
                 "name": "Drive Bays",
-                "model": original_enclosure["model"],
+                "model": model,
                 "controller": True,
                 "elements": [
                     {


### PR DESCRIPTION
Fixing YET ANOTHER R50 series enclosure mapping issue. https://github.com/truenas/middleware/pull/12160 fixed a regression but introduced another. The last enclosure in the list that we create is the plx or nvme "fake" enclosure that we generate. If we set the model for the `mapped_enclosure_0` to the model of the fake nvme enclosure, the webUI explodes and becomes, literally, unavailable (by design). This tries to fix it as best as possible by just ignoring those enclosures and setting the model once.

NOTE: this is not an issue in the enclosure2 rewrite but the webUI isn't using that endpoint, yet so this will have to limp us along.

Original PR: https://github.com/truenas/middleware/pull/12288
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124566