### PR TITLE
NAS-124567 / 13.1 / rename ES102S to ES102G2 (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
@@ -70,7 +70,7 @@ class Enclosure(object):
         elif self.encname.startswith('HGST H4102-J'):
             model = 'ES102'
         elif self.encname.startswith('VikingES NDS-41022-BB'):
-            model = 'ES102S'
+            model = 'ES102G2'
 
         return model, controller
 

--- a/src/middlewared/middlewared/utils/license.py
+++ b/src/middlewared/middlewared/utils/license.py
@@ -8,6 +8,6 @@ LICENSE_ADDHW_MAPPING = {
     7: "ES24F",
     8: "ES60S",
     9: "ES102",
-    10: "ES102S",
+    10: "ES102G2",
     11: "ES60G2",
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4edfc39a6a5d6e02e86118c4da71c9eb50c4a0d4

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f38fe6266abe78a733638e526bead2d5e2a879bd

At the bequest of the platform team.

Original PR: https://github.com/truenas/middleware/pull/12289
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124567