### PR TITLE
NAS-124584 / 24.04 / Decrease alert priority of zpool upgrade to NOTICE

### DIFF
--- a/src/middlewared/middlewared/alert/source/pools.py
+++ b/src/middlewared/middlewared/alert/source/pools.py
@@ -29,7 +29,7 @@ class PoolUSBDisksAlertClass(AlertClass, OneShotAlertClass):
 
 class PoolUpgradedAlertClass(AlertClass, OneShotAlertClass):
     category = AlertCategory.STORAGE
-    level = AlertLevel.WARNING
+    level = AlertLevel.NOTICE
     title = "New Feature Flags Are Available for Pool"
     text = (
         "New ZFS version or feature flags are available for pool '%s'. Upgrading pools is a one-time process that can "


### PR DESCRIPTION
Placing this as a warning encourages users to upgrade pool when it's not really necessary and should be evaluated carefully by the administrator.