### PR TITLE
NAS-124584 / 13.1 / Decrease alert priority of zpool upgrade to NOTICE (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/volume_version.py
+++ b/src/middlewared/middlewared/alert/source/volume_version.py
@@ -6,7 +6,7 @@ from middlewared.alert.schedule import IntervalSchedule
 
 class VolumeVersionAlertClass(AlertClass):
     category = AlertCategory.STORAGE
-    level = AlertLevel.WARNING
+    level = AlertLevel.NOTICE
     title = "New Feature Flags Are Available for Pool"
     text = (
         "New ZFS version or feature flags are available for pool(s) %s. Upgrading pools is a one-time process that can "


### PR DESCRIPTION
Placing this as a warning encourages users to upgrade pool when it's not really necessary and should be evaluated carefully by the administrator.

Original PR: https://github.com/truenas/middleware/pull/12299
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124584