### PR TITLE
NAS-122626 / 24.04 / Allow specifying interval/otp digits at per user level for 2FA

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
@@ -1,0 +1,22 @@
+"""
+2FA Per user settings
+
+Revision ID: 0a95d753f6d3
+Revises: 3df553b07a99
+Create Date: 2023-10-08 16:22:17.935672+00:00
+"""
+from alembic import op
+
+
+revision = '0a95d753f6d3'
+down_revision = '3df553b07a99'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
@@ -23,11 +23,10 @@ def upgrade():
         batch_op.add_column(sa.Column('window', sa.INTEGER(), nullable=False, server_default='0'))
 
     conn = op.get_bind()
-    twofactor_config = list(map(
-        dict, conn.execute('SELECT * FROM system_twofactorauthentication').fetchall()
-    ))
 
-    if twofactor_config:
+    if twofactor_config := list(map(
+        dict, conn.execute('SELECT * FROM system_twofactorauthentication').fetchall()
+    )):
         twofactor_config = twofactor_config[0]
         for row in map(dict, conn.execute('SELECT id FROM account_twofactor_user_auth').fetchall()):
             conn.execute(

--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
@@ -5,6 +5,8 @@ Revision ID: 0a95d753f6d3
 Revises: 3df553b07a99
 Create Date: 2023-10-08 16:22:17.935672+00:00
 """
+import sqlalchemy as sa
+
 from alembic import op
 
 
@@ -15,7 +17,10 @@ depends_on = None
 
 
 def upgrade():
-    pass
+    with op.batch_alter_table('account_twofactor_user_auth', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('interval', sa.INTEGER(), nullable=False, server_default='30'))
+        batch_op.add_column(sa.Column('otp_digits', sa.INTEGER(), nullable=False, server_default='6'))
+        batch_op.add_column(sa.Column('window', sa.INTEGER(), nullable=False, server_default='0'))
 
 
 def downgrade():

--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-08_16-22_2fa_per_user_settings.py
@@ -22,6 +22,11 @@ def upgrade():
         batch_op.add_column(sa.Column('otp_digits', sa.INTEGER(), nullable=False, server_default='6'))
         batch_op.add_column(sa.Column('window', sa.INTEGER(), nullable=False, server_default='0'))
 
+    with op.batch_alter_table('system_twofactorauthentication', schema=None) as batch_op:
+        batch_op.drop_column('interval')
+        batch_op.drop_column('otp_digits')
+        batch_op.drop_column('window')
+
 
 def downgrade():
     pass

--- a/src/middlewared/middlewared/alembic/versions/24.04/2023-10-11_16-22_2fa_per_user_settings.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2023-10-11_16-22_2fa_per_user_settings.py
@@ -2,8 +2,8 @@
 2FA Per user settings
 
 Revision ID: 0a95d753f6d3
-Revises: 3df553b07a99
-Create Date: 2023-10-08 16:22:17.935672+00:00
+Revises: 6f338216a965
+Create Date: 2023-10-11 16:22:17.935672+00:00
 """
 import sqlalchemy as sa
 
@@ -11,7 +11,7 @@ from alembic import op
 
 
 revision = '0a95d753f6d3'
-down_revision = '3df553b07a99'
+down_revision = '6f338216a965'
 branch_labels = None
 depends_on = None
 
@@ -20,7 +20,6 @@ def upgrade():
     with op.batch_alter_table('account_twofactor_user_auth', schema=None) as batch_op:
         batch_op.add_column(sa.Column('interval', sa.INTEGER(), nullable=False, server_default='30'))
         batch_op.add_column(sa.Column('otp_digits', sa.INTEGER(), nullable=False, server_default='6'))
-        batch_op.add_column(sa.Column('window', sa.INTEGER(), nullable=False, server_default='0'))
 
     conn = op.get_bind()
 
@@ -30,15 +29,14 @@ def upgrade():
         twofactor_config = twofactor_config[0]
         for row in map(dict, conn.execute('SELECT id FROM account_twofactor_user_auth').fetchall()):
             conn.execute(
-                'UPDATE account_twofactor_user_auth SET interval = ?, otp_digits = ?, window = ? WHERE id = ?', [
-                    twofactor_config['interval'], twofactor_config['otp_digits'], twofactor_config['window'], row['id']
+                'UPDATE account_twofactor_user_auth SET interval = ?, otp_digits = ? WHERE id = ?', [
+                    twofactor_config['interval'], twofactor_config['otp_digits'], row['id']
                 ]
             )
 
     with op.batch_alter_table('system_twofactorauthentication', schema=None) as batch_op:
         batch_op.drop_column('interval')
         batch_op.drop_column('otp_digits')
-        batch_op.drop_column('window')
 
 
 def downgrade():

--- a/src/middlewared/middlewared/etc_files/local/users.oath.mako
+++ b/src/middlewared/middlewared/etc_files/local/users.oath.mako
@@ -9,5 +9,5 @@
 		raise FileShouldNotExist()
 %>\
 % for user in users:
-${f'HOTP/T{twofactor_auth["interval"]}/{twofactor_auth["otp_digits"]}'}	${user['username']}	-	${user['secret_hex']}
+${f'HOTP/T{user["interval"]}/{user["otp_digits"]}'}	${user['username']}	-	${user['secret_hex']}
 % endfor

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -182,7 +182,7 @@ class UserService(Service):
                 }
             )
 
-        if await self.middleware.call('auth.twofactor.config')['services']['ssh']:
+        if (await self.middleware.call('auth.twofactor.config'))['services']['ssh']:
             # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
             await self.middleware.call('service.reload', 'ssh')
 

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -115,6 +115,14 @@ class UserService(Service):
     async def renew_2fa_secret(self, username, twofactor_options):
         """
         Renew `username` user's two-factor authentication secret.
+
+        `2fa_configuration_options.otp_digits` represents number of allowed digits in the OTP.
+
+        `2fa_configuration_options.window` extends the validity to `2fa_configuration_options.window` many counter
+        ticks before and after the current one.
+
+        `2fa_configuration_options.interval` is time duration in seconds specifying OTP expiration time
+        from it's creation time.
         """
         user = await self.translate_username(username)
         twofactor_auth = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -40,7 +40,6 @@ class UserService(Service):
         'user_twofactor_config',
         Str('provisioning_uri', null=True),
         Bool('secret_configured'),
-        Int('window', validators=[Range(min_=0)]),
         Int('interval', validators=[Range(min_=5)]),
         Int('otp_digits', validators=[Range(min_=6, max_=8)]),
     ))
@@ -60,7 +59,6 @@ class UserService(Service):
         return {
             'provisioning_uri': provisioning_uri,
             'secret_configured': bool(user_twofactor_config['secret']),
-            'window': user_twofactor_config['window'],
             'interval': user_twofactor_config['interval'],
             'otp_digits': user_twofactor_config['otp_digits'],
         }
@@ -83,8 +81,8 @@ class UserService(Service):
             'auth.twofactor.get_user_config', user['id' if user['local'] else 'sid'], user['local'],
         )
         totp = pyotp.totp.TOTP(
-            user_twofactor_config['secret'], interval=twofactor_config['interval'],
-            digits=twofactor_config['otp_digits'],
+            user_twofactor_config['secret'], interval=user_twofactor_config['interval'],
+            digits=user_twofactor_config['otp_digits'],
         )
         return totp.verify(token or '', valid_window=twofactor_config['window'])
 
@@ -139,7 +137,6 @@ class UserService(Service):
         Dict(
             '2fa_configuration_options',
             Int('otp_digits', validators=[Range(min_=6, max_=8)], required=True),
-            Int('window', validators=[Range(min_=0)], required=True),
             Int('interval', validators=[Range(min_=5)], required=True),
             update=True,
         )
@@ -150,9 +147,6 @@ class UserService(Service):
         Renew `username` user's two-factor authentication secret.
 
         `2fa_configuration_options.otp_digits` represents number of allowed digits in the OTP.
-
-        `2fa_configuration_options.window` extends the validity to `2fa_configuration_options.window` many counter
-        ticks before and after the current one.
 
         `2fa_configuration_options.interval` is time duration in seconds specifying OTP expiration time
         from it's creation time.

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -182,4 +182,8 @@ class UserService(Service):
                 }
             )
 
+        if await self.middleware.call('auth.twofactor.config')['services']['ssh']:
+            # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
+            await self.middleware.call('service.reload', 'ssh')
+
         return await self.translate_username(username)

--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -16,15 +16,15 @@ class TwoFactoryUserAuthModel(sa.Model):
     secret = sa.Column(sa.EncryptedText(), nullable=True, default=None)
     user_id = sa.Column(sa.ForeignKey('account_bsdusers.id', ondelete='CASCADE'), index=True, nullable=True)
     user_sid = sa.Column(sa.String(length=255), nullable=True, index=True, unique=True)
+    otp_digits = sa.Column(sa.Integer(), default=6)
+    window = sa.Column(sa.Integer(), default=0)
+    interval = sa.Column(sa.Integer(), default=30)
 
 
 class TwoFactorAuthModel(sa.Model):
     __tablename__ = 'system_twofactorauthentication'
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    otp_digits = sa.Column(sa.Integer(), default=6)
-    window = sa.Column(sa.Integer(), default=0)
-    interval = sa.Column(sa.Integer(), default=30)
     services = sa.Column(sa.JSON(), default={})
     enabled = sa.Column(sa.Boolean(), default=False)
 

--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -99,6 +99,9 @@ class TwoFactorAuthService(ConfigService):
                 'secret': None,
                 filters[0][0]: user_id,
                 'exists': False,
+                'window': 0,
+                'interval': 30,
+                'otp_digits': 6,
             }
 
     @private

--- a/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
+++ b/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
@@ -8,19 +8,18 @@ from middlewared.test.integration.utils import call
 @contextlib.contextmanager
 def enabled_twofactor_auth():
     try:
-        yield call('auth.twofactor.update', {'enabled': True, 'window': 3, 'interval': 60})
+        yield call('auth.twofactor.update', {'enabled': True, 'window': 3})
     finally:
-        call('auth.twofactor.update', {'enabled': False, 'window': 0, 'interval': 30})
+        call('auth.twofactor.update', {'enabled': False, 'window': 0})
 
 
 def get_user_secret(user_id: int, get: typing.Optional[bool] = True) -> typing.Union[dict, list]:
     return call('datastore.query', 'account.twofactor_user_auth', [['user_id', '=', user_id]], {'get': get})
 
 
-def get_2fa_totp_token(secret: str) -> str:
-    twofactor_config = call('auth.twofactor.config')
+def get_2fa_totp_token(users_config: dict) -> str:
     return pyotp.TOTP(
-        secret,
-        interval=twofactor_config['interval'],
-        digits=twofactor_config['otp_digits'],
+        users_config['secret'],
+        interval=users_config['interval'],
+        digits=users_config['otp_digits'],
     ).now()

--- a/tests/api2/test_twofactor_auth.py
+++ b/tests/api2/test_twofactor_auth.py
@@ -16,6 +16,7 @@ TEST_USERNAME_2 = 'test2fauser2'
 TEST_PASSWORD = 'testpassword'
 TEST_PASSWORD_2 = 'testpassword2'
 TEST_GID = 544
+TEST_TWOFACTOR_INTERVAL = {'interval': 60}
 
 
 @contextlib.contextmanager
@@ -43,8 +44,12 @@ def test_secret_generation_for_user():
         assert get_user_secret(user_obj['id'], False) != []
         assert get_user_secret(user_obj['id'])['secret'] is None
 
-        call('user.renew_2fa_secret', user_obj['username'])
-        assert get_user_secret(user_obj['id'])['secret'] is not None
+        call('user.renew_2fa_secret', user_obj['username'], {'interval': 70, 'otp_digits': 8})
+
+        user_secret_obj = get_user_secret(user_obj['id'])
+        assert user_secret_obj['secret'] is not None
+        for k, v in (('interval', 70), ('otp_digits', 8)):
+            assert user_secret_obj[k] == v
 
 
 def test_login_without_otp_for_user_without_2fa():
@@ -64,10 +69,10 @@ def test_login_with_otp_for_user_with_2fa():
         'full_name': TEST_USERNAME_2,
     }) as user_obj:
         with enabled_twofactor_auth():
-            call('user.renew_2fa_secret', user_obj['username'])
+            call('user.renew_2fa_secret', user_obj['username'], TEST_TWOFACTOR_INTERVAL)
             assert call(
                 'auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2,
-                get_2fa_totp_token(get_user_secret(user_obj['id'])['secret'])
+                get_2fa_totp_token(get_user_secret(user_obj['id']))
             ) is not None
 
 
@@ -78,20 +83,20 @@ def test_user_2fa_secret_renewal():
         'full_name': TEST_USERNAME_2,
     }) as user_obj:
         with enabled_twofactor_auth():
-            call('user.renew_2fa_secret', user_obj['username'])
+            call('user.renew_2fa_secret', user_obj['username'], TEST_TWOFACTOR_INTERVAL)
             assert call(
                 'auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2,
-                get_2fa_totp_token(get_user_secret(user_obj['id'])['secret'])
+                get_2fa_totp_token(get_user_secret(user_obj['id']))
             ) is not None
-            secret = get_user_secret(user_obj['id'])['secret']
+            secret = get_user_secret(user_obj['id'])
 
-            call('user.renew_2fa_secret', user_obj['username'])
+            call('user.renew_2fa_secret', user_obj['username'], TEST_TWOFACTOR_INTERVAL)
             call('user.get_instance', user_obj['id'])
             assert get_user_secret(user_obj['id'])['secret'] != secret
 
             assert call(
                 'auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2,
-                get_2fa_totp_token(get_user_secret(user_obj['id'])['secret'])
+                get_2fa_totp_token(get_user_secret(user_obj['id']))
             ) is not None
 
 
@@ -109,17 +114,17 @@ def test_multiple_users_login_with_otp():
                 'password': TEST_PASSWORD_2,
                 'full_name': TEST_USERNAME_2,
             }) as second_user:
-                call('user.renew_2fa_secret', second_user['username'])
+                call('user.renew_2fa_secret', second_user['username'], TEST_TWOFACTOR_INTERVAL)
                 assert call(
                     'auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2,
-                    get_2fa_totp_token(get_user_secret(second_user['id'])['secret'])
+                    get_2fa_totp_token(get_user_secret(second_user['id']))
                 ) is not None
 
                 assert call('auth.get_login_user', TEST_USERNAME_2, TEST_PASSWORD_2) is None
 
-                call('user.renew_2fa_secret', first_user['username'])
+                call('user.renew_2fa_secret', first_user['username'], TEST_TWOFACTOR_INTERVAL)
 
                 assert call(
                     'auth.get_login_user', TEST_USERNAME, TEST_PASSWORD,
-                    get_2fa_totp_token(get_user_secret(first_user['id'])['secret'])
+                    get_2fa_totp_token(get_user_secret(first_user['id']))
                 ) is not None


### PR DESCRIPTION
This PR adds changes to have `interval` and `otp_digits` be specified at user level for both AD and local users. This helps making it more configurable and a user can change his own settings instead of this being applied at a global level which resulted in all the existing users secret to be renewed because secret depends on this.