### PR TITLE
NAS-124594 / 23.10.1 / Make sure SSH settings reflect newer user secret

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -135,7 +135,7 @@ class UserService(Service):
                 }
             )
 
-        if await self.middleware.call('auth.twofactor.config')['services']['ssh']:
+        if (await self.middleware.call('auth.twofactor.config'))['services']['ssh']:
             # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
             await self.middleware.call('service.reload', 'ssh')
 

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -135,4 +135,8 @@ class UserService(Service):
                 }
             )
 
+        if await self.middleware.call('auth.twofactor.config')['services']['ssh']:
+            # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
+            await self.middleware.call('service.reload', 'ssh')
+
         return await self.translate_username(username)


### PR DESCRIPTION
This PR fixes an issue where whenever a user's secret is renewed we make sure to reflect that in SSH settings as if it's not reloaded, it will continue using older secret.