### PR TITLE
NAS-124605 / 24.04 / Add API for generating audit reports

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -1,5 +1,6 @@
 import csv
 import errno
+import json
 import middlewared.sqlalchemy as sa
 import os
 import time
@@ -237,6 +238,10 @@ class AuditService(ConfigService):
                     writer = csv.DictWriter(f, fieldnames=fieldnames)
                     writer.writeheader()
                     for entry in res:
+                        if entry.get('service_data'):
+                            entry['service_data'] = json.dumps(entry['service_data'])
+                        if entry.get('event_data'):
+                            entry['event_data'] = json.dumps(entry['event_data'])
                         writer.writerow(entry)
                 case 'JSON':
                     ejson.dump(res, f, indent=4)

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -215,6 +215,12 @@ class AuditService(ConfigService):
         if data['query-options'].get('count') is True:
             raise CallError('Raw row count may not be exported', errno.EINVAL)
 
+        if data['query-options'].get('get') is True:
+            raise CallError(
+                'Use of "get" query-option is not supported for export',
+                errno.EINVAL
+            )
+
         export_format = data.pop('export_format')
         if not (res := self.middleware.call_sync('audit.query', data)):
             raise CallError('No entries were returned by query.', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -283,7 +283,8 @@ class AuditService(ConfigService):
         Remove old audit reports. Precision is not of high priority. In most
         circumstances users will download the report within a few minutes.
         """
-        cutoff = int(time.time()) - 86400
+        retention = self.middleware.call_sync('audit.config')['retention']
+        cutoff = int(time.time()) - (retention * 86400)
         try:
             with os.scandir(AUDIT_REPORTS_DIR) as it:
                 for entry in it:

--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -244,3 +244,10 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
                     "%s: failed to enforce retention on audit DB.",
                     svc, exc_info=True
                 )
+        try:
+            self.middleware.call_sync('audit.cleanup_reports')
+        except Exception:
+            self.logger.warning(
+                'Cleanup of auditing report directory failed',
+                exc_info=True
+            )

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -1,4 +1,5 @@
 import middlewared.sqlalchemy as sa
+import os
 
 from sqlalchemy import Table
 from sqlalchemy.ext.declarative import declarative_base
@@ -11,6 +12,7 @@ AUDIT_DEFAULT_RESERVATION = 0
 AUDIT_DEFAULT_QUOTA = 0
 AUDIT_DEFAULT_FILL_CRITICAL = 95
 AUDIT_DEFAULT_FILL_WARNING = 80
+AUDIT_REPORTS_DIR = os.path.join(AUDIT_DATASET_PATH, 'reports')
 
 AuditBase = declarative_base()
 

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -103,7 +103,7 @@ def test_audit_query(initialize_for_smb_tests):
     sleep(10)
     ops = call('audit.query', {
         'services': ['SMB'],
-        'query-filters': [['user', '=', SMBUSER]],
+        'query-filters': [['username', '=', SMBUSER]],
         'query-options': {'count': True}
     })
     assert ops > 0

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -114,7 +114,7 @@ def test_audit_query(initialize_for_smb_tests):
 def test_audit_export(request):
     depends(request, ["AUDIT_OPS_PERFORMED"], scope="session")
     for backend in ['CSV', 'JSON', 'YAML']:
-        report_path = call('audit.export', {'export_format': backend})
+        report_path = call('audit.export', {'export_format': backend}, job=True)
         assert report_path.startswith('/audit/reports/root/')
         st = call('filesystem.stat', report_path)
         assert st['size'] != 0, str(st)

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -4,6 +4,7 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call
 from protocols import smb_connection
+from pytest_dependency import depends
 from time import sleep
 
 import os
@@ -86,6 +87,7 @@ def test_audit_config_updates(request):
     assert new_config['quota_fill_critical'] == 80
 
 
+@pytest.mark.dependency(name="AUDIT_OPS_PERFORMED")
 def test_audit_query(initialize_for_smb_tests):
     share = initialize_for_smb_tests['share']
     with smb_connection(
@@ -107,3 +109,12 @@ def test_audit_query(initialize_for_smb_tests):
         'query-options': {'count': True}
     })
     assert ops > 0
+
+
+def test_audit_export(request):
+    depends(request, ["AUDIT_OPS_PERFORMED"], scope="session")
+    for backend in ['CSV', 'JSON', 'YAML']:
+        report_path = call('audit.export', {'export_format': backend})
+        assert report_path.startswith('/audit/reports/root/')
+        st = call('filesystem.stat', report_path)
+        assert st['size'] != 0, str(st)


### PR DESCRIPTION
This provides an API for generating an audit report based on our query-filters and query-options for services (same API details as audit.query), but adds an additional parameter to specify format. When the endpoint is called a file in the specified format is written to a file in a directory (based on currently-authenticated user's username) within /audit/reports. The path for the newly-created file is return to caller, and may be used to fetch file either through scp or middleware filesystem.get API.