### PR TITLE
NAS-124431 / 24.04 / Remove unnecessary spam from middleware logs

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -38,7 +38,7 @@ class NetdataService(Service):
         try:
             return await Netdata.get_all_metrics()
         except ClientConnectError:
-            self.logger.debug('Failed to connect to netdata when retrieving all metrics', exc_info=True)
+            self.logger.debug('Failed to connect to netdata when retrieving all metrics')
             return {}
 
     def calculated_metrics_count(self):


### PR DESCRIPTION
## Context

We were spamming middleware logs unnecessarily with complete stack trace whenever netdata call failed and it was requested that we stop doing that to make the logs easier to debug.