### PR TITLE
NAS-124429 / 24.04 / Add flag to reporting realtime event source determining netdata's health

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+Restart=always


### PR DESCRIPTION
## Problem

The current user interface lacks the ability to verify whether Netdata is operational and correctly receiving data from the `reporting.realtime` event source.

## Solution

To address this limitation, a flag is added to the response from `reporting.realtime` event source. This flag will be set to true if Netdata is not running. Furthermore, changes are made to the Netdata unit file's restart policy, setting it to "always." This ensures that Netdata will automatically restart in case it fails to start for any reason. These improvements enhance the UI's capability to verify and maintain Netdata's functionality.