### PR TITLE
NAS-124429 / 23.10.1 / Add flag to reporting realtime event source determining netdata's health (by Qubad786)

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+Restart=always

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -76,20 +76,26 @@ class RealtimeEventSource(EventSource):
                 else:
                     break
 
-            data = {
-                'zfs': get_arc_stats(netdata_metrics),  # ZFS ARC Size
-                'memory': get_memory_info(netdata_metrics),
-                'virtual_memory': psutil.virtual_memory()._asdict(),
-                'cpu': get_cpu_stats(netdata_metrics, cores),
-                'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
-                'interfaces': get_interface_stats(
-                    netdata_metrics, [i['name'] for i in self.middleware.call_sync('interface.query')]
-                ),
-            }
+            if failed_to_connect := not bool(netdata_metrics):
+                data = {'failed_to_connect': failed_to_connect}
+            else:
+                data = {
+                    'zfs': get_arc_stats(netdata_metrics),  # ZFS ARC Size
+                    'memory': get_memory_info(netdata_metrics),
+                    'virtual_memory': psutil.virtual_memory()._asdict(),
+                    'cpu': get_cpu_stats(netdata_metrics, cores),
+                    'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
+                    'interfaces': get_interface_stats(
+                        netdata_metrics, [i['name'] for i in self.middleware.call_sync('interface.query')]
+                    ),
+                    'failed_to_connect': False,
+                }
 
-            # CPU temperature
-            data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures')
-            data['cpu']['temperature'] = {k: 2732 + int(v * 10) for k, v in data['cpu']['temperature_celsius'].items()}
+                # CPU temperature
+                data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures')
+                data['cpu']['temperature'] = {
+                    k: 2732 + int(v * 10) for k, v in data['cpu']['temperature_celsius'].items()
+                }
 
             self.send_event('ADDED', fields=data)
             time.sleep(interval)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x efa786583654e21813b2fb04d9870c3164d99f2e

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 5a9e300141eab950734cf50a73d96f133a7dbddf

## Problem

The current user interface lacks the ability to verify whether Netdata is operational and correctly receiving data from the `reporting.realtime` event source.

## Solution

To address this limitation, a flag is added to the response from `reporting.realtime` event source. This flag will be set to true if Netdata is not running. Furthermore, changes are made to the Netdata unit file's restart policy, setting it to "always." This ensures that Netdata will automatically restart in case it fails to start for any reason. These improvements enhance the UI's capability to verify and maintain Netdata's functionality.

Original PR: https://github.com/truenas/middleware/pull/12312
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124429