### PR TITLE
NAS-124617 / 23.10.0 / add keepalived override.conf (by yocalebo)

### DIFF
--- a/src/freenas/etc/systemd/system/keepalived.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/keepalived.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/keepalived --dont-fork --log-detail --vrrp


### PR DESCRIPTION
This adds 2 new startup flags while removing 1 from the original `ExecStart` operation that ships with debian's service file.

I add:
- `--log-detail` to get much more detailed log messages
- `--vrrp` which starts up keepalived while enabling on the vrrp subsystem since we're not using IPVS in our implementation

I remove the `$DAEMON_ARGS` argument that gets tacked on the end since we control these by hand and in a very explicit way. Making these changes on a real system proved invaluable for interpreting and understanding a particularly insidious network issue.

Original PR: https://github.com/truenas/middleware/pull/12317
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124617