### PR TITLE
NAS-124585 / 23.10.1 / Ensure we always generate debug (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/utils.py
+++ b/src/middlewared/middlewared/plugins/system/utils.py
@@ -1,6 +1,9 @@
 import enum
 import os
 import re
+import typing
+
+from middlewared.utils import MIDDLEWARE_RUN_DIR
 
 
 DEBUG_MAX_SIZE = 30
@@ -23,8 +26,10 @@ class Lifecycle:
         self.SYSTEM_SHUTTING_DOWN = False
 
 
-def get_debug_execution_dir(system_dataset_path: str) -> str:
-    return '/var/tmp/ixdiagnose' if system_dataset_path is None else os.path.join(system_dataset_path, 'ixdiagnose')
+def get_debug_execution_dir(system_dataset_path: str, iteration: typing.Optional[int] = 0) -> str:
+    return os.path.join(MIDDLEWARE_RUN_DIR, f'ixdiagnose-{iteration}') if system_dataset_path is None else os.path.join(
+        system_dataset_path, f'ixdiagnose-{iteration}'
+    )
 
 
 lifecycle_conf = Lifecycle()


### PR DESCRIPTION
## Problem
In certain scenarios (which i have not been able to reproduce), the `shutils.rmtree` operation fails to remove an existing debug directory. This failure results in a "Compressed path already exists" call error.

## Solution
To mitigate this error and ensure that we always generate a debug no matter what, a new directory will be created if an unexpected issue occurs during the removal of the debug directory. This adjustment ensures the smooth execution of the operation and prevents the error from being triggered.

Original PR: https://github.com/truenas/middleware/pull/12314
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124585