### PR TITLE
NAS-124396 / 24.04 / Fix raising validation error for vm devices port utilization

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -121,7 +121,7 @@ class DISPLAY(Device):
             verrors.add('attributes.bind', 'Requested bind address is not valid')
 
     def validate_port_attrs(self, device, verrors=None):
-        verrors = verrors or ValidationErrors()
+        verrors = ValidationErrors() if verrors is None else verrors
         display_devices_ports = self.middleware.call_sync(
             'vm.all_used_display_device_ports', [['id', '!=', device.get('id')]]
         )


### PR DESCRIPTION
### Issue

The VM display device was allowed to be created with a port that was already in use by some other display device. 

Validations error was not raised for port already in use because verrors was being initialized again in the `validate_port_attrs` function hence loosing the captured errors.

### Change

Fixed the error raise issue for its validation.