### PR TITLE
NAS-124557 / 23.10.1 / Allow nsupdate to set non-private IP addresses (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/dns.py
+++ b/src/middlewared/middlewared/plugins/network_/dns.py
@@ -116,7 +116,7 @@ class DNSService(Service):
                     Str('type', enum=['A', 'AAAA'], default='A'),
                     Int('ttl', default=3600),
                     IPAddr('address', required=True, excluded_address_types=[
-                        'MULTICAST', 'GLOBAL', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED'
+                        'MULTICAST', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED'
                     ]),
                     Bool('do_ptr', default=True)
                 )


### PR DESCRIPTION
This commit includes two principle changes:
1) the nsupdate endpoint now allows GLOBAL addresses 
2) validation for IP addresses to register happens earlier in activedirectory.update so that we can raise proper validation error and redirect user to either disable the automatic DNS update or fix the server configuration prior to joining AD. As things stand, this can cause an exception mid-join and leave server in semi-deployed state.

Future enhancement will be to allow users to select which addresses to register in DNS. At that point, we can safely allow global addresses.

Original PR: https://github.com/truenas/middleware/pull/12281
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124557