### PR TITLE
NAS-124628 / 23.10.1 / Fix filtering behavior for user and group queries (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -491,17 +491,14 @@ class DSCache(Service):
 
         `objtype`: 'USERS' or 'GROUPS'
         """
-        res = []
         ds_state = await self.middleware.call('directoryservices.get_state')
         enabled_ds = None
         extra = options.get("extra", {})
         get_smb = 'SMB' in extra.get('additional_information', [])
-        options.pop('get', None)  # This needs to happen as otherwise `res` will become a list of keys of user attrs
+        options.pop('get', None)
 
         is_name_check = bool(filters and len(filters) == 1 and filters[0][0] in ['username', 'name'])
         is_id_check = bool(filters and len(filters) == 1 and filters[0][0] in ['uid', 'gid'])
-
-        res.extend((await self.middleware.call(f'{objtype.lower()[:-1]}.query', filters, options)))
 
         for dstype, state in ds_state.items():
             if state != 'DISABLED':
@@ -509,13 +506,9 @@ class DSCache(Service):
                 break
 
         if not enabled_ds:
-            return res
+            return []
 
         if (is_name_check or is_id_check) and filters[0][1] == '=':
-            # exists in local sqlite database, return results
-            if res:
-                return res
-
             key = 'who' if is_name_check else 'id'
             entry = await self.retrieve(enabled_ds.upper(), {
                 'idtype': objtype[:-1],
@@ -530,12 +523,7 @@ class DSCache(Service):
                 entry['sid'] = None
                 entry['nt_name'] = None
 
-        entries_by_id = sorted(entries, key=lambda i: i['id'])
-        res.extend(filter_list(entries_by_id, filters, options))
-
-        # FIXME: This is broken and will break with groups/users as well, filters/options should be
-        #  respected here, let's fix this please
-        return res
+        return sorted(entries, key=lambda i: i['id'])
 
     @job(lock="dscache_refresh")
     async def refresh(self, job):


### PR DESCRIPTION
This commit removes a legacy behavior for the private method dscache.query. In this case dscache.query calls would also retrieve the local users datastore and return unified results. This was due to some design constraints when replacing the user and group cache in our legacy django webui in TrueNAS 11.2. As of SCALE the webui no longer directly calls dscache.query to get user / group lists and so we can safely remove this oddity.

The primary motivation for removing this legacy behavior is to fix how query-options are applied to query results.

Original PR: https://github.com/truenas/middleware/pull/12333
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124628