### PR TITLE
NAS-124626 / 23.10.0 / Add share_type preset for mixed SMB/NFS (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -439,7 +439,7 @@ class PoolDatasetService(CRUDService):
         Inheritable(Str('casesensitivity', enum=['SENSITIVE', 'INSENSITIVE']), has_default=False),
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
         Inheritable(Str('acltype', enum=['OFF', 'NFSV4', 'POSIX']), has_default=False),
-        Str('share_type', default='GENERIC', enum=['GENERIC', 'SMB', 'APPS']),
+        Str('share_type', default='GENERIC', enum=['GENERIC', 'MULTIPROTOCOL', 'SMB', 'APPS']),
         Inheritable(Str('xattr', default='SA', enum=['ON', 'SA'])),
         Ref('encryption_options'),
         Bool('encryption', default=False),
@@ -570,6 +570,11 @@ class PoolDatasetService(CRUDService):
                 'flags': {'BASIC': 'INHERIT'},
                 'type': 'ALLOW'
             })
+        elif data['share_type'] == 'MULTIPROTOCOL':
+            data['casesensitivity'] = 'SENSITIVE'
+            data['atime'] = 'OFF'
+            data['acltype'] = 'NFSV4'
+            data['aclmode'] = 'PASSTHROUGH'
 
         if acl_to_set:
             try:

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -479,3 +479,11 @@ def test_33_simplified_charts_api(request):
         acl = results.json()['acl']
         assert check_for_entry(acl, 'USER', USER_TO_ADD, {'READ': True, 'WRITE': True, 'EXECUTE': True}, True), str(acl)
         assert check_for_entry(acl, 'GROUP', GROUP_TO_ADD, {'READ': True, 'WRITE': False, 'EXECUTE': True}, True), str(acl)
+
+
+def test_34_multiprotocol_share_type_preset(request):
+    with create_dataset(pool_name, 'MULTIPROTOCOL', options={'share_type': 'MULTIPROTOCOL'}) as ds:
+        assert ds['acltype']['value'] == 'NFSV4'
+        assert ds['aclmode']['value'] == 'PASSTHROUGH'
+        assert ds['casesensitivity']['value'] == 'SENSITIVE'
+        assert ds['atime']['value'] == 'OFF'


### PR DESCRIPTION
In principle in Linux this is less of a problem than in FreeBSD because of proper inotify support, and kernel oplocks. Add a share_type preset that provides user with dataset settings that are likely to make SMB and NFS clients happier.

Original PR: https://github.com/truenas/middleware/pull/12332
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124626