### PR TITLE
NAS-122931 / 24.04 / Reduce the time to check if truecommand connection is active

### DIFF
--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -141,7 +141,7 @@ class TruecommandService(Service):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
                 asyncio.get_event_loop().call_later(
-                    HEALTH_CHECK_SECONDS,
+                    30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
                     lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),
                 )
             else:


### PR DESCRIPTION
This commit adds changes to reduce the time to check if truecommand connection is active to 30 seconds instead of 30 minutes after setting up the interfaces and everything because the latter was way too long and system only updated the status before if truecommand.config was explicitly called. Setting it to 30 seconds works nicely and is enough to ensure the relevant wireguard interface is up and everything.