### PR TITLE
NAS-124662 / 24.04 / Fix encryption keys not syncing to backup node on middleware restart

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1321,4 +1321,6 @@ async def setup(middleware):
     await middleware.call('failover.remote_on_disconnect', remote_status_event)
 
     if await middleware.call('system.ready'):
-        middleware.create_task(ready_system_sync_keys(middleware))
+        asyncio.get_event_loop().call_later(
+            30, lambda: middleware.create_task( middleware.call('failover.sync_keys_from_remote_node'))
+        )

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1321,6 +1321,9 @@ async def setup(middleware):
     await middleware.call('failover.remote_on_disconnect', remote_status_event)
 
     if await middleware.call('system.ready'):
+        # We add a delay here to give the standby node middleware a chance to boot up because
+        # if we do it asap, it is highly likely that the standby node middleware is not ready
+        # to make connection to the active node middleware.
         asyncio.get_event_loop().call_later(
-            30, lambda: middleware.create_task( middleware.call('failover.sync_keys_from_remote_node'))
+            30, lambda: middleware.create_task(middleware.call('failover.sync_keys_from_remote_node'))
         )

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1267,10 +1267,6 @@ async def service_remote(middleware, service, verb, options):
         middleware.logger.warning('Failed to run %s(%s)', verb, service, exc_info=True)
 
 
-async def ready_system_sync_keys(middleware):
-    await middleware.call('failover.sync_keys_from_remote_node')
-
-
 async def _event_system_ready(middleware, event_type, args):
     # called when system is ready to issue an event in case HA upgrade is pending.
     if await middleware.call('failover.status') in ('MASTER', 'SINGLE'):


### PR DESCRIPTION
This PR fixes an issue where when backup node middleware restarts, we do not sync keys from master node because when we tried to sync the keys on middleware boot - we were not able to talk to active node which is highly likely because middleware has not initialised itself properly at that point, so we add a delay to ensure we only do that once middleware has booted and initialised itself properly.