### PR TITLE
NAS-124684 / 24.04 / Move krb5 ccache directory from /tmp

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf.mako
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.mako
@@ -3,10 +3,11 @@
 # $FreeBSD$
 #
 <%
+        import enum
         import logging
         logger = logging.getLogger(__name__)
         from middlewared.utils import filter_list
-        from middlewared.plugins.kerberos import KRB_AppDefaults, KRB_LibDefaults
+        from middlewared.plugins.kerberos import KRB_AppDefaults, KRB_LibDefaults, krb5ccache
 
         def parse_defaults(section_name, section_conf, db_def=None):
             default_section = "krb5_main"
@@ -54,6 +55,7 @@
         }}
 
         libdefaults = {'krb5_main': {
+            KRB_LibDefaults.DEFAULT_CC_NAME.parm(): krb5ccache.SYSTEM.value,
             KRB_LibDefaults.DNS_LOOKUP_REALM.parm(): 'true',
             KRB_LibDefaults.DNS_LOOKUP_KDC.parm(): 'true',
             KRB_LibDefaults.TICKET_LIFETIME.parm(): '24h',

--- a/src/middlewared/middlewared/etc_files/krb5.conf.mako
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.mako
@@ -3,7 +3,6 @@
 # $FreeBSD$
 #
 <%
-        import enum
         import logging
         logger = logging.getLogger(__name__)
         from middlewared.utils import filter_list

--- a/src/middlewared/middlewared/etc_files/krb5.conf.mako
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.mako
@@ -55,7 +55,7 @@
         }}
 
         libdefaults = {'krb5_main': {
-            KRB_LibDefaults.DEFAULT_CC_NAME.parm(): krb5ccache.SYSTEM.value,
+            KRB_LibDefaults.DEFAULT_CC_NAME.parm(): 'FILE:' + krb5ccache.SYSTEM.value,
             KRB_LibDefaults.DNS_LOOKUP_REALM.parm(): 'true',
             KRB_LibDefaults.DNS_LOOKUP_KDC.parm(): 'true',
             KRB_LibDefaults.TICKET_LIFETIME.parm(): '24h',

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -25,9 +25,9 @@ class keytab(enum.Enum):
 
 
 class krb5ccache(enum.Enum):
-    SYSTEM = '/tmp/krb5cc_0'
+    SYSTEM = f'{MIDDLEWARE_RUN_DIR}/krb5cc_0'
     TEMP = f'{MIDDLEWARE_RUN_DIR}/krb5cc_middleware_temp'
-    USER = '/tmp/krb5cc_'
+    USER = f'{MIDDLEWARE_RUN_DIR}/krb5cc_'
 
 
 class krb_tkt_flag(enum.Enum):
@@ -68,8 +68,8 @@ class KRB_LibDefaults(enum.Enum):
     ALLOW_WEAK_CRYPTO = ('allow_weak_crypto', 'boolean')
     CLOCKSKEW = ('clockskew', 'time')
     KDC_TIMEOUT = ('kdc_timeout', 'time')
-    DEFAULT_CC_TYPE = ('default_cc_type', 'cctype')
-    DEFAULT_CC_NAME = ('default_cc_name', 'ccname')
+    DEFAULT_CC_TYPE = ('ccache_type', 'cctype')
+    DEFAULT_CC_NAME = ('default_ccache_name', 'ccname')
     DEFAULT_ETYPES = ('default_etypes', 'etypes')
     DEFAULT_AS_ETYPES = ('default_as_etypes', 'etypes')
     DEFAULT_TGS_ETYPES = ('default_tgs_etypes', 'etypes')

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -204,13 +204,16 @@ class KerberosService(TDBWrapConfigService):
             return
 
         def write_libdefaults(krb_file):
-            krb5ccache_parm = KRB_LibDefaults.DEFAULT_CC_NAME.parm()
+            dflt_realm = KRB_LibDefaults.DEFAULT_REALM.parm()
+            dnslookup_realm = KRB_LibDefaults.DNS_LOOKUP_REALM.parm()
+            dnslookup_kdc = KRB_LibDefaults.DNS_LOOKUP_KDC.parm()
+            ccache_dir = KRB_LibDefaults.DEFAULT_CC_NAME.parm()
 
             krb_file.write('[libdefaults]\n')
-            krb_file.write(f'\tdefault_realm = {realm}\n')
-            krb_file.write('\tdns_lookup_realm = false\n')
-            krb_file.write(f'\tdns_lookup_kdc = {"false" if kdc else "true"}\n')
-            krb_file.write(f'\t{krb5ccache_parm} = FILE:{krb5ccache.SYSTEM.value}\n')
+            krb_file.write(f'\t{dflt_realm} = {realm}\n')
+            krb_file.write(f'\t{dnslookup_realm} = false\n')
+            krb_file.write(f'\t{dnslookup_kdc} = {"false" if kdc else "true"}\n')
+            krb_file.write(f'\t{ccache_dir} = FILE:{krb5ccache.SYSTEM.value}\n')
 
         def write_realms(krb_file):
             krb_file.write('[realms]\n')

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -204,10 +204,13 @@ class KerberosService(TDBWrapConfigService):
             return
 
         def write_libdefaults(krb_file):
+            krb5ccache_parm = KRB_LibDefaults.DEFAULT_CC_NAME.parm()
+
             krb_file.write('[libdefaults]\n')
             krb_file.write(f'\tdefault_realm = {realm}\n')
             krb_file.write('\tdns_lookup_realm = false\n')
             krb_file.write(f'\tdns_lookup_kdc = {"false" if kdc else "true"}\n')
+            krb_file.write(f'\t{krb5ccache_parm} = FILE:{krb5ccache.SYSTEM.value}\n')
 
         def write_realms(krb_file):
             krb_file.write('[realms]\n')

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -18,7 +18,7 @@ results_xml = f'{workdir}/results/'
 localHome = os.path.expanduser('~')
 dotsshPath = localHome + '/.ssh'
 keyPath = localHome + '/.ssh/test_id_rsa'
-isns_ip='10.234.24.50' # isns01.qe.ixsystems.net
+isns_ip = '10.234.24.50'  # isns01.qe.ixsystems.net
 pool_name = "tank"
 
 ixautomation_dot_conf_url = "https://raw.githubusercontent.com/iXsystems/" \


### PR DESCRIPTION
### Problem
The default location of the 'system' Kerberos credential cache is /tmp.   This directory is managed by systemd and is cleaned asynchronously.  This results in anomalous authentication failures.

### Fix
Store the credential cache in a different location.   The Kerberos subsystem provides a mechanism (krb5.conf) to use a different path for the cache.  