### PR TITLE
NAS-124672 / 23.10.1 / Add validator for CTDB private IP addresses (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -456,7 +456,9 @@ class ClusterManagement(Service):
                     name='remote_credential',
                 ),
                 Str('hostname', required=True),
-                IPAddr('private_address', required=True),
+                IPAddr('private_address', required=True, excluded_address_types=[
+                    'MULTICAST', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED', 'GLOBAL'
+                ]),
                 Str('brick_path', required=True),
                 required=True,
                 register=True
@@ -726,7 +728,9 @@ class ClusterManagement(Service):
         Dict(
             'local_node_configuration',
             Str('hostname', required=True),
-            IPAddr('private_address', required=True),
+            IPAddr('private_address', required=True, excluded_address_types=[
+                'MULTICAST', 'LOOPBACK', 'LINK_LOCAL', 'RESERVED', 'GLOBAL'
+            ]),
             Str('brick_path', required=True),
             required=True,
         ),


### PR DESCRIPTION
Force RFC-1918 addresses for inter-node traffic on TrueNAS clusters.

Original PR: https://github.com/truenas/middleware/pull/12341
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124672