### PR TITLE
NAS-124686 / 24.04 / auditing - validate select against available columns

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -479,3 +479,4 @@ class AuditService(ConfigService):
 
     @private
     async def json_schemas(self):
+        return AUDIT_EVENT_SMB_JSON_SCHEMAS

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -17,6 +17,7 @@ from .utils import (
     AUDIT_REPORTS_DIR,
     AUDITED_SERVICES,
 )
+from .schema.smb import AUDIT_EVENT_SMB_JSON_SCHEMAS, AUDIT_EVENT_SMB_PARAM_SET
 from middlewared.client import ejson
 from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.schema import (
@@ -182,6 +183,20 @@ class AuditService(ConfigService):
         """
         results = []
         sql_filters = data['query-options']['force_sql_filters']
+
+        verrors = ValidationErrors()
+        if (select := data['query-options'].get('select')):
+            for idx, entry in enumerate(select):
+                if isinstance(entry, list):
+                    entry = entry[0]
+
+                if entry not in AUDIT_EVENT_SMB_PARAM_SET:
+                    verrors.add(
+                        f'audit.query.query-options.select.{idx}',
+                        f'{entry}: column does not exist'
+                    )
+
+        verrors.check()
 
         if sql_filters:
             filters = data['query-filters']
@@ -461,3 +476,6 @@ class AuditService(ConfigService):
             await self.middleware.call('audit.update_audit_dataset', audit_config)
         except Exception:
             self.logger.error('Failed to apply auditing dataset configuration.', exc_info=True)
+
+    @private
+    async def json_schemas(self):

--- a/src/middlewared/middlewared/plugins/audit/schema/common.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/common.py
@@ -1,0 +1,154 @@
+import enum
+
+from copy import deepcopy
+from middlewared.schema import (
+    Dict,
+    Int,
+    List,
+    Str,
+)
+
+
+class AuditEnum(enum.Enum):
+    def __str__(self):
+        return str(self.value)
+
+
+class AuditSchema(Dict):
+    def extend(self, *attrs, **kwargs):
+        for i in attrs:
+            self.attrs[i.name] = i
+
+        for k, v in self.conditional_defaults.items():
+            if k not in self.attrs:
+                raise ValueError(f'Specified attribute {k!r} not found.')
+            for k_v in ('filters', 'attrs'):
+                if k_v not in v:
+                    raise ValueError(f'Conditional defaults must have {k_v} specified.')
+            for attr in v['attrs']:
+                if attr not in self.attrs:
+                    raise ValueError(f'Specified attribute {attr} not found.')
+
+        if self.strict:
+            for attr in self.attrs.values():
+                if attr.required:
+                    if attr.has_default:
+                        raise ValueError(
+                            f'Attribute {attr.name} is required and has default value at the same time, '
+                            'this is forbidden in strict mode'
+                        )
+                else:
+                    if not attr.has_default:
+                        raise ValueError(
+                            f'Attribute {attr.name} is not required and does not have default value, '
+                            'this is forbidden in strict mode'
+                        )
+
+
+class AuditEventParam(AuditEnum):
+    AUDIT_ID = 'audit_id'
+    TIMESTAMP = 'timestamp'
+    MESSAGE_TIMESTAMP = 'message_timestamp'
+    ADDRESS = 'address'
+    USERNAME = 'username'
+    SESSION = 'session'
+    SERVICE = 'service'
+    SERVICE_DATA = 'service_data'
+    EVENT = 'event'
+    EVENT_DATA = 'event_data'
+    SUCCESS = 'success'
+
+
+class AuditFileHandleType(AuditEnum):
+    DEV_INO = 'DEV_INO'
+    UUID = 'UUID'
+
+
+class AuditResultType(AuditEnum):
+    UNIX = 'UNIX'
+    NTSTATUS = 'NTSTATUS'
+
+
+class AuditFileType(AuditEnum):
+    BLOCK = 'BLOCK'
+    CHARACTER = 'CHARACTER'
+    FIFO = 'FIFO'
+    REGULAR = 'REGULAR'
+    DIRECTORY = 'DIRECTORY'
+    SYMLINK = 'SYMLINK'
+
+
+AUDIT_VERS = Dict(
+    'vers',
+    Int('major', required=True),
+    Int('minor', required=True)
+)
+
+
+AUDIT_RESULT_NTSTATUS = Dict(
+    'result',
+    Str('type', enum=[AuditResultType.NTSTATUS.name]),
+    Int('value_raw'),
+    Str('value_parsed')
+)
+
+
+AUDIT_RESULT_UNIX = Dict(
+    'result',
+    Str('type', enum=[AuditResultType.UNIX.name]),
+    Int('value_raw'),
+    Str('value_parsed')
+)
+
+
+AUDIT_FILE_HANDLE = Dict(
+    'handle',
+    Str('type', enum=[x.name for x in AuditFileHandleType]),
+    Str('value')
+)
+
+
+AUDIT_FILE = Dict(
+    'file',
+    Str('type', enum=[x.name for x in AuditFileType]),
+    Str('name'),
+    Str('stream'),
+    Str('path'),
+    Str('snap')
+)
+
+
+AUDIT_UNIX_TOKEN = Dict(
+    'unix_token',
+    Int('uid'),
+    Int('gid'),
+    List('groups', items=[Int('group_id')]),
+)
+
+
+def audit_schema_from_base(schema, new_name, *args):
+    new_schema = deepcopy(schema)
+    new_schema.extend(*args)
+    new_schema.name = new_name
+    return new_schema
+
+
+
+def convert_schema_to_set(schema_list):
+    def add_to_set(key, val, current_name):
+        if current_name:
+            current_name += '.'
+
+        current_name += val['title']
+        schema_set.add(current_name)
+
+        if val['type'] == 'object':
+            for subkey, subval in val['properties'].items():
+                add_to_set(subkey, subval, current_name)
+
+    schema_set = set()
+    for entry in schema_list:
+        for key, val in entry['properties'].items():
+            add_to_set(key, val, '')
+
+    return schema_set

--- a/src/middlewared/middlewared/plugins/audit/schema/smb.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/smb.py
@@ -1,0 +1,382 @@
+from .common import (
+    AuditEnum,
+    AuditEventParam,
+    AuditSchema,
+    AUDIT_VERS,
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_RESULT_UNIX,
+    AuditFileType,
+    AUDIT_FILE,
+    AUDIT_FILE_HANDLE,
+    audit_schema_from_base,
+    AUDIT_UNIX_TOKEN,
+    convert_schema_to_set
+)
+from middlewared.schema import (
+    Bool,
+    Dict,
+    Int,
+    IPAddr,
+    Str,
+    UUID
+)
+
+
+class AuditSmbCreateDisp(AuditEnum):
+    """
+    This enum contains all possible values of the SMB2 CREATE CreateDisposition.
+    """
+    SUPERSEDE = 'SUPERSEDE'
+    OVERWRITE_IF = 'OVERWRITE_IF'
+    OPEN = 'OPEN'
+    CREATE = 'CREATE'
+    OPEN_IF = 'OPEN_IF'
+    UNKNOWN = 'UNKNOWN'
+
+
+class AuditSmbEventType(AuditEnum):
+    """
+    This enum contains all possible SMB audit events. Values correspond with
+    `event` written to auditing SQLite database.
+    """
+    CONNECT = 'CONNECT'
+    DISCONNECT = 'DISCONNECT'
+    CREATE = 'CREATE'
+    CLOSE = 'CLOSE'
+    READ = 'READ'
+    WRITE = 'WRITE'
+    OFFLOAD_READ = 'OFFLOAD_READ'
+    OFFLOAD_WRITE = 'OFFLOAD_WRITE'
+    RENAME = 'RENAME'
+    UNLINK = 'UNLINK'
+    SET_ACL = 'SET_ACL'
+    SET_ATTR = 'SET_ATTR'
+    SET_QUOTA = 'SET_QUOTA'
+    FSCTL = 'FSCTL'
+
+
+class AuditSetattrType(AuditEnum):
+    DOSMODE = 'DOSMODE'
+    TIMESTAMP = 'TIMESTAMP'
+
+
+"""
+Below are schema class instances for `event_data` for SMB audit events.
+"""
+
+
+AUDIT_EVENT_DATA_SMB_CONNECT = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Str('host'),
+    AUDIT_UNIX_TOKEN,
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_DISCONNECT = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Str('host'),
+    AUDIT_UNIX_TOKEN,
+    Dict(
+        'operations',
+        Str('create'),
+        Str('close'),
+        Str('read'),
+        Str('write')
+    ),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_CREATE = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict(
+        'parameters',
+        Str('DesiredAccess'),
+        Str('FileAttributes'),
+        Str('ShareAccess'),
+        Str('CreateDisposition', enum=[x.name for x in AuditSmbCreateDisp]),
+        Str('CreateOptions')
+    ),
+    Str('file_type', enum=[x.name for x in AuditFileType]),
+    AUDIT_FILE,
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS,
+)
+
+
+AUDIT_EVENT_DATA_SMB_CLOSE = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict('file', AUDIT_FILE_HANDLE),
+    Dict(
+        'operations',
+        Str('read_cnt'),
+        Str('read_bytes'),
+        Str('write_cnt'),
+        Str('write_bytes')
+    ),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_SET_ATTR = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Str('attr_type', enum=[x.name for x in AuditSetattrType]),
+    Str('dosmode'),
+    Dict('ts'),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_RENAME = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict(
+        'src_file',
+        Str('file_type', enum=[x.name for x in AuditFileType]),
+        Str('path'),
+        Str('stream'),
+        Str('snap')
+    ),
+    Dict(
+        'dst_file',
+        Str('path'),
+        Str('stream'),
+        Str('snap'),
+    ),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_UNLINK = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    AUDIT_FILE,
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_READ = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_WRITE = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_OFFLOAD_READ = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_OFFLOAD_WRITE = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_SET_ACL = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    AUDIT_FILE,
+    Str('secinfo'),
+    Str('sd'),
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_FSCTL = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict(
+        'function',
+        Str('raw'),
+        Str('parsed')
+    ),
+    Dict('file', AUDIT_FILE_HANDLE),
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS
+)
+
+
+AUDIT_EVENT_DATA_SMB_SET_QUOTA = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Dict(
+        'qt',
+        Str('type', enum=['USER', 'GROUP']),
+        Str('bsize'),
+        Str('soflimit'),
+        Str('hardlimit'),
+        Str('isoftlimit'),
+        Str('ihardlimit')
+    ),
+    AUDIT_RESULT_UNIX,
+    AUDIT_VERS
+)
+
+
+"""
+Below are schema classes for the full SMB audit events that are written to the
+auditing database and returned in `audit.query` requests. We start with a generic
+base instance and then extend a copy of the generalized event with event-specific
+`event_data` defined above.
+"""
+
+AUDIT_EVENT_SMB_SCHEMAS = []
+
+
+AUDIT_EVENT_SMB_BASE_SCHEMA = AuditSchema(
+    'audit_entry_smb',
+    UUID(AuditEventParam.AUDIT_ID.value),
+    Int(AuditEventParam.MESSAGE_TIMESTAMP.value),
+    Dict(AuditEventParam.TIMESTAMP.value),
+    IPAddr(AuditEventParam.ADDRESS.value),
+    Str(AuditEventParam.USERNAME.value),
+    UUID(AuditEventParam.SESSION.value),
+    Str(AuditEventParam.SERVICE.value, enum=['SMB']),
+    Dict(
+        AuditEventParam.SERVICE_DATA.value,
+        AUDIT_VERS,
+        Str('service'),
+        Str('session_id'),
+        Str('tcon_id')
+    ),
+    Bool('success')
+)
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_connect',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.CONNECT.name]),
+    AUDIT_EVENT_DATA_SMB_CONNECT
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_disconnect',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.DISCONNECT.name]),
+    AUDIT_EVENT_DATA_SMB_DISCONNECT
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_create',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.CREATE.name]),
+    AUDIT_EVENT_DATA_SMB_CREATE
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_close',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.CLOSE.name]),
+    AUDIT_EVENT_DATA_SMB_CLOSE
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_setattr',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.SET_ATTR.name]),
+    AUDIT_EVENT_DATA_SMB_SET_ATTR
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_rename',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.RENAME.name]),
+    AUDIT_EVENT_DATA_SMB_RENAME
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_unlink',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.UNLINK.name]),
+    AUDIT_EVENT_DATA_SMB_UNLINK
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_read',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.READ.name]),
+    AUDIT_EVENT_DATA_SMB_READ
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_write',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.WRITE.name]),
+    AUDIT_EVENT_DATA_SMB_WRITE
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_offload_read',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.OFFLOAD_READ.name]),
+    AUDIT_EVENT_DATA_SMB_OFFLOAD_READ
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_offload_write',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.OFFLOAD_WRITE.name]),
+    AUDIT_EVENT_DATA_SMB_OFFLOAD_WRITE
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_set_acl',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.SET_ACL.name]),
+    AUDIT_EVENT_DATA_SMB_SET_ACL
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_fsctl',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.FSCTL.name]),
+    AUDIT_EVENT_DATA_SMB_FSCTL
+))
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_set_quota',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.SET_QUOTA.name]),
+    AUDIT_EVENT_DATA_SMB_SET_QUOTA
+))
+
+
+AUDIT_EVENT_SMB_JSON_SCHEMAS = [
+    schema.to_json_schema() for schema in AUDIT_EVENT_SMB_SCHEMAS
+]
+
+
+AUDIT_EVENT_SMB_PARAM_SET = convert_schema_to_set(AUDIT_EVENT_SMB_JSON_SCHEMAS)


### PR DESCRIPTION
This PR adds schema info for all SMB auditing events and validates API user `select` query-options against possible keys in SMB auditing events to give better feedback if user has typoed a column.