### PR TITLE
NAS-124688 / 24.04 / Fix selecting parameters with NULL value in filter_list

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -418,6 +418,13 @@ def test__filter_list_select_as():
     assert entry['data'] == 4
 
 
+def test__filter_list_select_null():
+    data = filter_list(DATA_WITH_NULL, [['number', '=', 4]], {'select': ['foo'], 'get': True})
+    assert len(data) == 1
+    assert 'foo' in data
+    assert data['foo'] is None
+
+
 def test__filter_list_select_as_validation():
     with pytest.raises(ValueError) as ve:
         # too few items in the select list

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -123,7 +123,7 @@ def select_path(obj, path):
     while right:
         left, right = partition(right)
         if isinstance(cur, dict):
-            cur = cur.get(left)
+            cur = cur.get(left, MatchNotFound)
             keys.append(left)
         elif isinstance(cur, (list, tuple)):
             raise ValueError('Selecting by list index is not supported')
@@ -407,7 +407,7 @@ class filters(object):
                     new_name = None
 
                 keys, value = select_path(i, target)
-                if value is None:
+                if value is MatchNotFound:
                     continue
 
                 if new_name is not None:


### PR DESCRIPTION
Select logic was broken for case where the parameter we were selecting had a null value. This fixes the behavior and adds test.