### PR TITLE
NAS-124705 / 24.04 / Remove existence test that uses hard-coded path

### DIFF
--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -310,9 +310,6 @@ def test_05_kinit_as_ad_user(setup_nfs_share):
     assert error is None, str(error)
     assert res['result'] is True
 
-    res = SSH_TEST(f'test -f /tmp/krb5cc_{setup_nfs_share[1]["uid"]}', user, password, ip)
-    assert res['result'] is True, res['stderr']
-
     results = POST('/service/restart/', {'service': 'nfs'})
     assert results.status_code == 200, results.text
 


### PR DESCRIPTION
Removed failing test for existence of a krb5 credential cache in /tmp. 
It was using a hard-coded path that's no longer valid and there is other validation that covers this file existence check.