### PR TITLE
NAS-124715 / 23.10.1 / Fix netdata disk temperature graph plugin (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -3,7 +3,7 @@ import statistics
 import typing
 
 from .connector import Netdata
-from .exceptions import ClientConnectError, ApiException
+from .exceptions import ClientConnectError
 
 
 GRAPH_PLUGINS = {}

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -245,7 +245,13 @@ class DiskTempPlugin(GraphBase):
 
     def normalize_metrics(self, metrics) -> dict:
         metrics = super().normalize_metrics(metrics)
-        metrics['legend'][1] = 'temperature_value'
+
+        if len(metrics['legend']) < 2:
+            for to_add in {'time', 'temperature_value'} - set(metrics['legend']):
+                metrics['legend'].append(to_add)
+        else:
+            metrics['legend'][1] = 'temperature_value'
+
         if metrics['data'] and metrics['data'][-1] and metrics['data'][-1][-1] == 0:
             # we will now remove last entry of data as when end if sometimes is specified as time which does not
             # exist in netdata database, netdata adds a last entry of 0 which we don't want to show

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_graphs.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_graphs.py
@@ -1,0 +1,43 @@
+import pytest
+
+from unittest.mock import AsyncMock, patch
+
+from middlewared.plugins.reporting.netdata.graphs import (
+    CPUPlugin, CPUTempPlugin, DiskTempPlugin, DISKPlugin, InterfacePlugin, LoadPlugin, MemoryPlugin, SwapPlugin,
+    UptimePlugin, ARCActualRatePlugin, ARCRatePlugin, ARCSizePlugin
+)
+from middlewared.pytest.unit.middleware import Middleware
+
+
+@pytest.mark.parametrize('obj, identifier, legend', [
+    (CPUPlugin, 'cpu', ['time']),
+    (CPUTempPlugin, 'cputemp', ['time']),
+    (DISKPlugin, 'sda', ['time', 'reads', 'writes']),
+    (InterfacePlugin, 'enp1s0', ['time', 'received', 'sent']),
+    (LoadPlugin, 'load', ['time']),
+    (MemoryPlugin, 'memory', ['time']),
+    (SwapPlugin, 'swap', ['time']),
+    (UptimePlugin, 'uptime', ['time']),
+    (ARCActualRatePlugin, 'arcactualrate', ['time']),
+    (ARCRatePlugin, 'arcrate', ['time']),
+    (ARCSizePlugin, 'arcsize', ['time']),
+    (DiskTempPlugin, 'sda', ['time', 'temperature_value']),
+])
+@pytest.mark.asyncio
+async def test_netdata_client_malformed_response_error(obj, identifier, legend):
+    plugin_object = obj(Middleware())
+    plugin_name = plugin_object.__class__.__name__
+
+    api_response = {'error': 'test error', 'data': [], 'identifier': identifier, 'uri': 'http://test_uri'}
+    with patch(
+        'middlewared.plugins.reporting.netdata.connector.ClientMixin.fetch', AsyncMock(return_value=api_response)
+    ):
+        if hasattr(obj, 'disk_mapping'):
+            with patch(f'middlewared.plugins.reporting.netdata.graphs.{plugin_name}.disk_mapping', {identifier: ''}):
+                data = await plugin_object.export_multiple_identifiers({'after': 0, 'before': 0}, [identifier])
+        else:
+            data = await plugin_object.export_multiple_identifiers({'after': 0, 'before': 0}, [identifier])
+
+        assert set(data[0]['legend']) == set(legend)
+        assert data[0]['identifier'] == identifier
+        assert data[0]['data'] == []


### PR DESCRIPTION
This commit fixes an issue where if the netdata call failed for whatever reason, we instead of handling that gracefully resulted in a traceback.

```
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1254, in run_in_thread
    return await self.run_in_executor(self.thread_pool_executor, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1251, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/reporting/netdata/graph_base.py", line 159, in process_chart_metrics
    **self.normalize_metrics(chart_metrics),
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/reporting/netdata/graphs.py", line 248, in normalize_metrics
    metrics['legend'][1] = 'temperature_value'
    ~~~~~~~~~~~~~~~~~^^^
IndexError: list assignment index out of range
```

Original PR: https://github.com/truenas/middleware/pull/12362
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124715