### PR TITLE
NAS-124719 / 24.04 / Fix cases where Str is used instead of Password

### DIFF
--- a/src/middlewared/middlewared/alert/service/aws_sns.py
+++ b/src/middlewared/middlewared/alert/service/aws_sns.py
@@ -1,7 +1,7 @@
 import boto3
 
 from middlewared.alert.base import ThreadedAlertService
-from middlewared.schema import Dict, Str
+from middlewared.schema import Dict, Password, Str
 
 
 class AWSSNSAlertService(ThreadedAlertService):
@@ -12,7 +12,7 @@ class AWSSNSAlertService(ThreadedAlertService):
         Str("region", required=True, empty=False),
         Str("topic_arn", required=True, empty=False),
         Str("aws_access_key_id", required=True, empty=False),
-        Str("aws_secret_access_key", required=True, empty=False),
+        Password("aws_secret_access_key", required=True, empty=False),
         strict=True,
     )
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, returns, Str, LocalUsername
+from middlewared.schema import accepts, Bool, Dict, Int, List, Password, Patch, returns, Str, LocalUsername
 from middlewared.service import (
     CallError, CRUDService, ValidationErrors, no_auth_required, pass_app, private, filterable, job
 )
@@ -472,7 +472,7 @@ class UserService(CRUDService):
         Str('shell', default='/usr/bin/zsh'),
         Str('full_name', required=True),
         Str('email', validators=[Email()], null=True, default=None),
-        Str('password', private=True),
+        Password('password'),
         Bool('password_disabled', default=False),
         Bool('ssh_password_enabled', default=False),
         Bool('locked', default=False),
@@ -1070,7 +1070,7 @@ class UserService(CRUDService):
 
     @no_auth_required
     @accepts(
-        Str('password'),
+        Password('password'),
         Dict('options')
     )
     @returns()
@@ -1086,7 +1086,7 @@ class UserService(CRUDService):
     @no_auth_required
     @accepts(
         Str('username', enum=['root', 'admin']),
-        Str('password'),
+        Password('password'),
         Dict(
             'options',
             Dict(

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -1,7 +1,7 @@
 import errno
 import pyotp
 
-from middlewared.schema import accepts, Bool, Dict, Int, Ref, returns, Str
+from middlewared.schema import accepts, Bool, Dict, Int, Password, Ref, returns, Str
 from middlewared.service import CallError, private, Service
 from middlewared.validators import Range
 
@@ -63,7 +63,7 @@ class UserService(Service):
             'otp_digits': user_twofactor_config['otp_digits'],
         }
 
-    @accepts(Str('username'), Str('token', null=True))
+    @accepts(Str('username'), Password('token', null=True))
     @returns(Bool('token_verified'))
     def verify_twofactor_token(self, username, token):
         """

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/cloudflare.py
@@ -2,7 +2,7 @@ import logging
 
 from certbot_dns_cloudflare._internal.dns_cloudflare import _CloudflareClient
 
-from middlewared.schema import accepts, Dict, Str, ValidationErrors
+from middlewared.schema import accepts, Dict, Password, Str, ValidationErrors
 from middlewared.service import skip_arg
 
 from .base import Authenticator
@@ -18,8 +18,8 @@ class CloudFlareAuthenticator(Authenticator):
     SCHEMA = Dict(
         'cloudflare',
         Str('cloudflare_email', empty=False, null=True, title='Cloudflare Email'),
-        Str('api_key', empty=False, null=True, title='API Key'),
-        Str('api_token', empty=False, null=True, title='API Token'),
+        Password('api_key', empty=False, null=True, title='API Key'),
+        Password('api_token', empty=False, null=True, title='API Token'),
     )
 
     def initialize_credentials(self):

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/ovh.py
@@ -3,7 +3,7 @@ import logging
 from lexicon.providers.ovh import ENDPOINTS
 from certbot_dns_ovh._internal.dns_ovh import _OVHLexiconClient
 
-from middlewared.schema import accepts, Dict, Str
+from middlewared.schema import accepts, Dict, Password, Str
 from middlewared.service import skip_arg
 
 from .base import Authenticator
@@ -20,7 +20,7 @@ class OVHAuthenticator(Authenticator):
     SCHEMA = Dict(
         'OVH',
         Str('application_key', empty=False, null=False, title='OVH Application Key', required=True),
-        Str('application_secret', empty=False, null=False, title='OVH Application Secret', required=True),
+        Password('application_secret', empty=False, null=False, title='OVH Application Secret', required=True),
         Str('consumer_key', empty=False, null=False, title='OVH Consumer Key', required=True),
         Str('endpoint', empty=False, default='ovh-eu', title='OVH Endpoint', enum=OVH_ENDPOINTS, required=True),
     )

--- a/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/route53.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/authenticators/route53.py
@@ -5,7 +5,7 @@ import time
 
 from botocore import exceptions as boto_exceptions
 
-from middlewared.schema import accepts, Dict, Str
+from middlewared.schema import accepts, Dict, Password, Str
 from middlewared.service import CallError, skip_arg
 
 from .base import Authenticator
@@ -17,7 +17,7 @@ class Route53Authenticator(Authenticator):
     SCHEMA = Dict(
         'route53',
         Str('access_key_id', required=True, empty=False, title='Access Key Id'),
-        Str('secret_access_key', required=True, empty=False, title='Secret Access Key'),
+        Password('secret_access_key', required=True, empty=False, title='Secret Access Key'),
     )
 
     def initialize_credentials(self):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -11,7 +11,7 @@ from middlewared.auth import (SessionManagerCredentials, UserSessionManagerCrede
                               UnixSocketSessionManagerCredentials, RootTcpSocketSessionManagerCredentials,
                               LoginPasswordSessionManagerCredentials, ApiKeySessionManagerCredentials,
                               TrueNasNodeSessionManagerCredentials)
-from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, Patch, returns, Str
+from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, Password, Patch, returns, Str
 from middlewared.service import (
     Service, filterable, filterable_returns, filter_list, no_auth_required,
     pass_app, private, cli_private, CallError,
@@ -317,7 +317,7 @@ class AuthService(Service):
             raise CallError("\n".join(["Unable to terminate all sessions:"] + errors))
 
     @cli_private
-    @accepts(Str('username'), Str('password'))
+    @accepts(Str('username'), Password('password'))
     @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
     async def check_user(self, username, password):
         """
@@ -326,7 +326,7 @@ class AuthService(Service):
         return await self.check_password(username, password)
 
     @cli_private
-    @accepts(Str('username'), Str('password'))
+    @accepts(Str('username'), Password('password'))
     @returns(Bool(description='Is `true` if `username` was successfully validated with provided `password`'))
     async def check_password(self, username, password):
         """
@@ -340,7 +340,7 @@ class AuthService(Service):
         Dict('attrs', additional_attrs=True),
         Bool('match_origin', default=False),
     )
-    @returns(Str('token'))
+    @returns(Password('token'))
     @pass_app(rest=True)
     def generate_token(self, app, ttl, attrs, match_origin):
         """
@@ -430,7 +430,7 @@ class AuthService(Service):
 
     @cli_private
     @no_auth_required
-    @accepts(Str('username'), Str('password', private=True), Str('otp_token', null=True, default=None))
+    @accepts(Str('username'), Password('password'), Password('otp_token', null=True, default=None))
     @returns(Bool('successful_login'))
     @pass_app()
     async def login(self, app, username, password, otp_token):
@@ -464,7 +464,7 @@ class AuthService(Service):
 
     @cli_private
     @no_auth_required
-    @accepts(Str('api_key'))
+    @accepts(Password('api_key'))
     @returns(Bool('successful_login'))
     @pass_app()
     async def login_with_api_key(self, app, api_key):
@@ -479,7 +479,7 @@ class AuthService(Service):
 
     @cli_private
     @no_auth_required
-    @accepts(Str('token'))
+    @accepts(Password('token'))
     @returns(Bool('successful_login'))
     @pass_app()
     async def login_with_token(self, app, token):

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -2,7 +2,7 @@ from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel,
 from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.plugins.cloud.crud import CloudTaskServiceMixin
 from middlewared.plugins.cloud.model import CloudTaskModelMixin, cloud_task_schema
-from middlewared.schema import accepts, Cron, Dict, Int, Patch, Str
+from middlewared.schema import accepts, Cron, Dict, Int, Password, Patch, Str
 from middlewared.service import ValidationErrors, private, TaskPathService
 import middlewared.sqlalchemy as sa
 from middlewared.utils.path import FSLocation
@@ -59,7 +59,7 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
     @accepts(Dict(
         "cloud_backup_create",
         *cloud_task_schema,
-        Str("password", required=True, empty=False),
+        Password("password", required=True, empty=False),
         register=True,
     ))
     async def do_create(self, cloud_backup):

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -4,7 +4,7 @@ from middlewared.plugins.cloud.crud import CloudTaskServiceMixin
 from middlewared.plugins.cloud.model import CloudTaskModelMixin, cloud_task_schema
 from middlewared.plugins.cloud.path import get_remote_path, check_local_path
 from middlewared.plugins.cloud.remotes import REMOTES, remote_classes
-from middlewared.schema import accepts, Bool, Cron, Dict, Int, Patch, Str
+from middlewared.schema import accepts, Bool, Cron, Dict, Int, Password, Patch, Str
 from middlewared.service import (
     CallError, CRUDService, ValidationErrors, item_method, job, private, TaskPathService,
 )
@@ -798,7 +798,7 @@ class CloudSyncService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin):
 
         Bool("encryption", default=False),
         Bool("filename_encryption", default=False),
-        Str("encryption_password", default=""),
+        Password("encryption_password", default=""),
         Str("encryption_salt", default=""),
 
         Bool("create_empty_src_dirs", default=False),

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_accounts.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_accounts.py
@@ -1,7 +1,7 @@
 import json
 import time
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Str, LocalUsername
+from middlewared.schema import accepts, Bool, Dict, Int, List, Password, Patch, Str, LocalUsername
 from middlewared.service import CRUDService, filterable, private, Service, ValidationErrors
 from middlewared.service_exception import CallError, MatchNotFound, ValidationError
 from middlewared.utils import filter_list
@@ -156,7 +156,7 @@ class ClusterUserService(CRUDService):
         'ctdb_account_user',
         LocalUsername('username', required=True),
         Str('full_name', required=True),
-        Str('password', private=True, required=True),
+        Password('password', required=True),
         Bool('locked', default=False),
         register=True
     ))

--- a/src/middlewared/middlewared/plugins/cluster_linux/management.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/management.py
@@ -5,7 +5,7 @@ from time import sleep
 
 from middlewared.client import Client, ClientException
 from middlewared.utils import filter_list
-from middlewared.schema import Bool, Dict, IPAddr, Int, List, OROperator, Ref, returns, Str
+from middlewared.schema import Bool, Dict, IPAddr, Int, List, OROperator, Password, Ref, returns, Str
 from middlewared.service import accepts, job, private, Service, ValidationErrors
 from middlewared.service_exception import CallError
 from middlewared.plugins.cluster_linux.utils import CTDBConfig
@@ -443,15 +443,15 @@ class ClusterManagement(Service):
                     Dict(
                         'plain_cred',
                         Str('username', required=True),
-                        Str('password', required=True, private=True)
+                        Password('password', required=True)
                     ),
                     Dict(
                         'authentication_token',
-                        Str('auth_token', required=True, private=True),
+                        Password('auth_token', required=True),
                     ),
                     Dict(
                         'api_key',
-                        Str('api_key', required=True, private=True),
+                        Password('api_key', required=True),
                     ),
                     name='remote_credential',
                 ),

--- a/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
@@ -5,7 +5,7 @@ import pathlib
 
 from middlewared.utils import run
 from middlewared.validators import URL
-from middlewared.schema import Dict, Str
+from middlewared.schema import Dict, Password, Str
 from middlewared.service import (job, accepts, private, CallError,
                                  Service, ValidationErrors)
 from .utils import GlusterConfig
@@ -66,8 +66,8 @@ class GlusterEventsdService(Service):
     @accepts(Dict(
         'webhook_create',
         Str('url', required=True, validators=[URL()]),
-        Str('bearer_token', required=False),
-        Str('secret', required=False),
+        Password('bearer_token', required=False),
+        Password('secret', required=False),
     ))
     @job(lock=EVENTSD_CRE_OR_DEL)
     def create(self, job, data):

--- a/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/local_events.py
@@ -8,7 +8,7 @@ import os
 import time
 
 from middlewared.service_exception import CallError, ValidationError
-from middlewared.schema import Dict, Str, Bool, returns
+from middlewared.schema import Dict, Str, Bool, Password, returns
 from middlewared.service import (accepts, Service,
                                  private, ValidationErrors)
 from .utils import GlusterConfig
@@ -97,7 +97,7 @@ class GlusterLocalEventsService(Service):
                 )
 
     @accepts()
-    @returns(Str())
+    @returns(Password())
     def get_set_jwt_secret(self):
         """
         Return the secret key used to encode/decode
@@ -123,7 +123,7 @@ class GlusterLocalEventsService(Service):
 
     @accepts(Dict(
         'add_secret',
-        Str('secret', required=True),
+        Password('secret', required=True),
         Bool('force', default=False),
     ))
     @returns()

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -4,7 +4,7 @@ import errno
 import datetime
 import wbclient
 
-from middlewared.schema import accepts, Bool, Dict, Int, Patch, Ref, Str, LDAP_DN, OROperator
+from middlewared.schema import accepts, Bool, Dict, Int, Password, Patch, Ref, Str, LDAP_DN, OROperator
 from middlewared.service import CallError, TDBWrapCRUDService, job, private, ValidationErrors, filterable
 from middlewared.service_exception import MatchNotFound
 from middlewared.plugins.directoryservices import SSL
@@ -657,7 +657,7 @@ class IdmapDomainService(TDBWrapCRUDService):
                 'idmap_ldap_options',
                 LDAP_DN('ldap_base_dn'),
                 LDAP_DN('ldap_user_dn'),
-                Str('ldap_user_dn_password', private=True),
+                Password('ldap_user_dn_password'),
                 Str('ldap_url'),
                 Bool('readonly', default=False),
                 Ref('ldap_ssl_choice', 'ssl'),
@@ -678,7 +678,7 @@ class IdmapDomainService(TDBWrapCRUDService):
                 Str('ldap_domain'),
                 Str('ldap_url'),
                 LDAP_DN('ldap_user_dn'),
-                Str('ldap_user_dn_password', private=True),
+                Password('ldap_user_dn_password'),
                 Ref('ldap_ssl_choice', 'ssl'),
                 Bool('validate_certificates', default=True),
             ),

--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -1,6 +1,6 @@
 import middlewared.sqlalchemy as sa
 
-from middlewared.schema import accepts, Dict, Int, Patch, Str
+from middlewared.schema import accepts, Dict, Int, Password, Patch, Str
 from middlewared.service import CallError, CRUDService, private, ValidationErrors
 
 
@@ -27,9 +27,9 @@ class iSCSITargetAuthCredentialService(CRUDService):
         'iscsi_auth_create',
         Int('tag', required=True),
         Str('user', required=True),
-        Str('secret', required=True),
+        Password('secret', required=True),
         Str('peeruser', default=''),
-        Str('peersecret', default=''),
+        Password('peersecret', default=''),
         register=True
     ))
     async def do_create(self, data):

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -9,7 +9,7 @@ import subprocess
 import contextlib
 import time
 from middlewared.plugins.idmap import DSType
-from middlewared.schema import accepts, returns, Dict, Int, List, Patch, Str, OROperator, Ref, Datetime, Bool
+from middlewared.schema import accepts, returns, Dict, Int, List, Patch, Str, OROperator, Password, Ref, Datetime, Bool
 from middlewared.service import CallError, TDBWrapConfigService, TDBWrapCRUDService, job, periodic, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR, run, Popen
@@ -402,7 +402,7 @@ class KerberosService(TDBWrapConfigService):
             Dict(
                 'kerberos_username_password',
                 Str('username', required=True),
-                Str('password', required=True, private=True),
+                Password('password', required=True),
                 register=True
             ),
             Dict(

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -11,7 +11,7 @@ import ssl
 
 from middlewared.client import Client, ClientException
 from middlewared.service_exception import CallError
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Ref, returns, Str, ValidationErrors
+from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Password, Ref, returns, Str, ValidationErrors
 from middlewared.service import CRUDService, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run
@@ -548,12 +548,12 @@ class KeychainCredentialService(CRUDService):
             Str("name", required=True),
             Str("url", required=True, validators=[URL()]),
             Bool("verify_ssl", default=True),
-            Str("token", private=True),
+            Password("token"),
             Str("admin_username", default="root"),
-            Str("password", private=True),
-            Str("otp_token", private=True),
+            Password("password"),
+            Password("otp_token"),
             Str("username", default="root"),
-            Int("private_key", required=True),
+            Int("private_key", required=True, private=True),
             Int("connect_timeout", default=10),
             Bool("sudo", default=False),
             register=True,

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Ref, returns, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Password, Patch, Ref, returns, Str
 from middlewared.service import CallError, ConfigService, ValidationErrors, job, periodic, private
 import middlewared.sqlalchemy as sa
 from middlewared.utils import osc, BRAND
@@ -89,12 +89,12 @@ class MailService(ConfigService):
         Str('security', enum=['PLAIN', 'SSL', 'TLS'], required=True),
         Bool('smtp', required=True),
         Str('user', null=True, required=True),
-        Str('pass', private=True, null=True, required=True),
+        Password('pass', null=True, required=True),
         Dict(
             'oauth',
             Str('client_id'),
             Str('client_secret'),
-            Str('refresh_token'),
+            Password('refresh_token'),
             null=True,
             private=True,
             required=True,
@@ -117,7 +117,7 @@ class MailService(ConfigService):
                     'oauth',
                     Str('client_id', required=True),
                     Str('client_secret', required=True),
-                    Str('refresh_token', required=True),
+                    Password('refresh_token', required=True),
                     null=True,
                     private=True,
                 )

--- a/src/middlewared/middlewared/plugins/smb_/util_sd.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_sd.py
@@ -3,7 +3,7 @@ import enum
 import json
 import subprocess
 
-from middlewared.schema import Bool, Dict, Str, accepts
+from middlewared.schema import Bool, Dict, Password, Str, accepts
 from middlewared.service import private, CallError, Service
 from middlewared.plugins.smb import SMBCmd
 
@@ -152,7 +152,7 @@ class SMBService(Service):
             Str('share', required=True),
             Str('path', default='\\'),
             Str('username', required=True),
-            Str('password', required=True),
+            Password('password', required=True),
             Dict(
                 'options',
                 Bool('use_kerberos', default=False),

--- a/src/middlewared/middlewared/plugins/snmp.py
+++ b/src/middlewared/middlewared/plugins/snmp.py
@@ -1,7 +1,7 @@
 import middlewared.sqlalchemy as sa
 
 from middlewared.common.ports import ServicePortDelegate
-from middlewared.schema import Bool, Dict, Int, Str
+from middlewared.schema import Bool, Dict, Int, Password, Str
 from middlewared.service import SystemServiceService, ValidationErrors
 from middlewared.validators import Email, Match, Or, Range
 
@@ -42,9 +42,9 @@ class SNMPService(SystemServiceService):
         Str('community', validators=[Match(r'^[-_.a-zA-Z0-9\s]*$')], default='public', required=True),
         Str('v3_username', max_length=20, required=True),
         Str('v3_authtype', enum=['', 'MD5', 'SHA'], required=True),
-        Str('v3_password', required=True),
+        Password('v3_password', required=True),
         Str('v3_privproto', enum=[None, 'AES', 'DES'], null=True, required=True),
-        Str('v3_privpassphrase', required=True, null=True),
+        Password('v3_privpassphrase', required=True, null=True),
         Int('loglevel', validators=[Range(min_=0, max_=7)], required=True),
         Str('options', max_length=None, required=True),
         Bool('zilstat', required=True),

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -11,7 +11,7 @@ import requests
 
 from middlewared.pipe import Pipes
 from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
-from middlewared.schema import accepts, Bool, Dict, Int, List, returns, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Password, returns, Str
 from middlewared.service import CallError, ConfigService, job, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.network import INTERNET_TIMEOUT
@@ -142,7 +142,7 @@ class SupportService(ConfigService):
             ['secondary_phone', 'Secondary Contact Phone'],
         ]
 
-    @accepts(Str('token', default=''))
+    @accepts(Password('token', default=''))
     @returns(Dict(additional_attrs=True, example={'API': '11008', 'WebUI': '10004'}))
     async def fetch_categories(self, token):
         """
@@ -174,7 +174,7 @@ class SupportService(ConfigService):
         Str('body', required=True, max_length=None),
         Str('category', required=True),
         Bool('attach_debug', default=False),
-        Str('token', private=True),
+        Password('token'),
         Str('type', enum=['BUG', 'FEATURE']),
         Str('criticality'),
         Str('environment', max_length=None),
@@ -318,7 +318,7 @@ class SupportService(ConfigService):
         'attach_ticket',
         Int('ticket', required=True),
         Str('filename', required=True, max_length=None),
-        Str('token', private=True),
+        Password('token'),
     ))
     @returns()
     @job(pipes=["input"])

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 import middlewared.sqlalchemy as sa
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, returns, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Password, returns, Str
 from middlewared.service import ConfigService, private, ValidationErrors
 from middlewared.validators import Range
 
@@ -190,7 +190,7 @@ class SystemAdvancedService(ConfigService):
             'system_advanced_entry', 'system_advanced_update',
             ('rm', {'name': 'id'}),
             ('rm', {'name': 'anonstats_token'}),
-            ('add', Str('sed_passwd', private=True)),
+            ('add', Password('sed_passwd')),
             ('attr', {'update': True}),
         )
     )
@@ -293,7 +293,7 @@ class SystemAdvancedService(ConfigService):
         return await self.config()
 
     @accepts()
-    @returns(Str('sed_global_password'))
+    @returns(Password('sed_global_password'))
     async def sed_global_password(self):
         """
         Returns configured global SED password.

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -2,7 +2,7 @@ import asyncio
 
 import middlewared.sqlalchemy as sa
 
-from middlewared.schema import Bool, Dict, Int, IPAddr, Str
+from middlewared.schema import Bool, Dict, Int, IPAddr, Password, Str
 from middlewared.service import accepts, ConfigService, private, ValidationErrors
 from middlewared.validators import Range
 
@@ -38,7 +38,7 @@ class TruecommandService(ConfigService):
     ENTRY = Dict(
         'truecommand_entry',
         Int('id', required=True),
-        Str('api_key', required=True, null=True),
+        Password('api_key', required=True, null=True),
         Str('status', required=True, enum=[s.value for s in Status]),
         Str('status_reason', required=True, enum=[s.value for s in StatusReason]),
         Str('remote_url', required=True, null=True),
@@ -81,7 +81,7 @@ class TruecommandService(ConfigService):
         Dict(
             'truecommand_update',
             Bool('enabled'),
-            Str('api_key', null=True, validators=[Range(min_=16, max_=16)]),
+            Password('api_key', null=True, validators=[Range(min_=16, max_=16)]),
         )
     )
     async def do_update(self, data):

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -6,7 +6,7 @@ import ssl
 import uuid
 
 from middlewared.async_validators import resolve_hostname
-from middlewared.schema import accepts, Any, Bool, Dict, Int, Str, Patch
+from middlewared.schema import accepts, Any, Bool, Dict, Int, Str, Password, Patch
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 
@@ -76,7 +76,7 @@ class VMWareService(CRUDService):
             Str('datastore', required=True),
             Str('filesystem', required=True),
             Str('hostname', required=True),
-            Str('password', private=True, required=True),
+            Password('password', required=True),
             Str('username', required=True),
             register=True
         )

--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -5,7 +5,7 @@ from middlewared.service import job
 from middlewared.service_exception import ValidationErrors
 from middlewared.schema import (
     accepts, Bool, Cron, Dict, Dir, File, Float, Int, IPAddr, List, Str, URI,
-    UnixPerm, UUID, LocalUsername, NetbiosName, NetbiosDomain
+    Password, UnixPerm, UUID, LocalUsername, NetbiosName, NetbiosDomain
 )
 from middlewared.plugins.cluster_linux.management import GlusterVolname, MAX_VOLNAME_LENGTH
 from middlewared.validators import QueryFilters, QueryOptions
@@ -387,6 +387,9 @@ def test__schema_dict_error_handler():
     ([Dict('b', Str('c', private=True))], [{'c': 'secret'}], [{'c': '********'}]),
     ([Dict('b', Str('c', private=True)), Dict('d', Str('e'))], [{'c': 'secret'}], [{'c': '********'}]),
     ([Dict('b', Str('c')), Dict('d', Str('c', private=True))], [{'c': 'secret'}], ['********']),
+    ([Dict('b', Password('c'))], [{'c': 'secret'}], [{'c': '********'}]),
+    ([Dict('b', Password('c')), Dict('d', Str('e'))], [{'c': 'secret'}], [{'c': '********'}]),
+    ([Dict('b', Str('c')), Dict('d', Password('c'))], [{'c': 'secret'}], ['********']),
 ])
 def test__schema_list_private_items(items, value, expected):
     assert List('a', items=items).dump(value) == expected

--- a/src/middlewared/middlewared/rclone/remote/box.py
+++ b/src/middlewared/middlewared/rclone/remote/box.py
@@ -1,5 +1,5 @@
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Str
+from middlewared.schema import Password, Str
 
 
 class BoxRcloneRemote(BaseRcloneRemote):
@@ -10,8 +10,8 @@ class BoxRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("client_id", title="OAuth Client ID", default=""),
-        Str("client_secret", title="OAuth Client Secret", default=""),
-        Str("token", title="Access Token", required=True, max_length=None),
+        Password("client_secret", title="OAuth Client Secret", default=""),
+        Password("token", title="Access Token", required=True, max_length=None),
     ]
     credentials_oauth = True
     refresh_credentials = ["token"]

--- a/src/middlewared/middlewared/rclone/remote/dropbox.py
+++ b/src/middlewared/middlewared/rclone/remote/dropbox.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Int, Str
+from middlewared.schema import Int, Password, Str
 from middlewared.validators import Range
 
 
@@ -13,8 +13,8 @@ class DropboxRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("client_id", title="OAuth Client ID", default=""),
-        Str("client_secret", title="OAuth Client Secret", default=""),
-        Str("token", title="Access Token", required=True, max_length=None),
+        Password("client_secret", title="OAuth Client Secret", default=""),
+        Password("token", title="Access Token", required=True, max_length=None),
     ]
     credentials_oauth = True
 

--- a/src/middlewared/middlewared/rclone/remote/google_drive.py
+++ b/src/middlewared/middlewared/rclone/remote/google_drive.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Bool, Str
+from middlewared.schema import Bool, Password, Str
 
 
 class GoogleDriveRcloneRemote(BaseRcloneRemote):
@@ -14,8 +14,8 @@ class GoogleDriveRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("client_id", title="OAuth Client ID", default=""),
-        Str("client_secret", title="OAuth Client Secret", default=""),
-        Str("token", title="Access Token", required=True, max_length=None),
+        Password("client_secret", title="OAuth Client Secret", default=""),
+        Password("token", title="Access Token", required=True, max_length=None),
         Str("team_drive", title="Team Drive ID (if connecting to Team Drive)"),
     ]
     credentials_oauth = True

--- a/src/middlewared/middlewared/rclone/remote/pcloud.py
+++ b/src/middlewared/middlewared/rclone/remote/pcloud.py
@@ -1,5 +1,5 @@
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Str
+from middlewared.schema import Password, Str
 
 
 class PcloudRcloneRemote(BaseRcloneRemote):
@@ -10,8 +10,8 @@ class PcloudRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("client_id", title="OAuth Client ID", default=""),
-        Str("client_secret", title="OAuth Client Secret", default=""),
-        Str("token", title="Access Token", required=True, max_length=None),
+        Password("client_secret", title="OAuth Client Secret", default=""),
+        Password("token", title="Access Token", required=True, max_length=None),
         Str("hostname", title="API hostname"),
     ]
     credentials_oauth = True

--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -4,7 +4,7 @@ import boto3
 from botocore.client import Config
 
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Bool, Int, Str
+from middlewared.schema import Bool, Int, Password, Str
 from middlewared.utils.lang import undefined
 
 
@@ -20,7 +20,7 @@ class S3RcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("access_key_id", title="Access Key ID", required=True),
-        Str("secret_access_key", title="Secret Access Key", required=True),
+        Password("secret_access_key", title="Secret Access Key", required=True),
         Str("endpoint", title="Endpoint URL", default=""),
         Str("region", title="Region", default=""),
         Bool("skip_region", title="Endpoint does not support regions", default=False),

--- a/src/middlewared/middlewared/rclone/remote/storjix.py
+++ b/src/middlewared/middlewared/rclone/remote/storjix.py
@@ -8,7 +8,7 @@ import botocore
 import requests
 
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Str
+from middlewared.schema import Password, Str
 from middlewared.service_exception import CallError
 from middlewared.utils.network import INTERNET_TIMEOUT
 
@@ -27,7 +27,7 @@ class StorjIxRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("access_key_id", title="Access Key ID", required=True),
-        Str("secret_access_key", title="Secret Access Key", required=True),
+        Password("secret_access_key", title="Secret Access Key", required=True),
     ]
 
     task_schema = []

--- a/src/middlewared/middlewared/rclone/remote/swift.py
+++ b/src/middlewared/middlewared/rclone/remote/swift.py
@@ -1,5 +1,5 @@
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Str, Int
+from middlewared.schema import Password, Str, Int
 
 
 class OpenStackSwiftRcloneRemote(BaseRcloneRemote):
@@ -16,7 +16,7 @@ class OpenStackSwiftRcloneRemote(BaseRcloneRemote):
     credentials_schema = [
         Str("user", required=True,
             title="User name (OS_USERNAME)"),
-        Str("key", required=True,
+        Password("key", required=True,
             title="API key or password (OS_PASSWORD)"),
         Str("auth", required=True,
             title="Authentication URL for server (OS_AUTH_URL)"),
@@ -38,14 +38,14 @@ class OpenStackSwiftRcloneRemote(BaseRcloneRemote):
             title="Region name (OS_REGION_NAME)"),
         Str("storage_url", default="",
             title="Storage URL (OS_STORAGE_URL)"),
-        Str("auth_token", default="",
+        Password("auth_token", default="",
             title="Auth Token from alternate authentication (OS_AUTH_TOKEN)"),
         Str("application_credential_id", default="",
             title="Application Credential ID (OS_APPLICATION_CREDENTIAL_ID)"),
         Str("application_credential_name", default="",
             title="Application Credential Name "
                   "(OS_APPLICATION_CREDENTIAL_NAME)"),
-        Str("application_credential_secret", default="",
+        Password("application_credential_secret", default="",
             title="Application Credential Secret "
                   "(OS_APPLICATION_CREDENTIAL_SECRET)"),
         Int("auth_version", enum=[0, 1, 2, 3],

--- a/src/middlewared/middlewared/rclone/remote/yandex.py
+++ b/src/middlewared/middlewared/rclone/remote/yandex.py
@@ -1,5 +1,5 @@
 from middlewared.rclone.base import BaseRcloneRemote
-from middlewared.schema import Str
+from middlewared.schema import Password, Str
 
 
 class YandexRcloneRemote(BaseRcloneRemote):
@@ -12,7 +12,7 @@ class YandexRcloneRemote(BaseRcloneRemote):
 
     credentials_schema = [
         Str("client_id", title="OAuth Client ID", default=""),
-        Str("client_secret", title="OAuth Client Secret", default=""),
+        Password("client_secret", title="OAuth Client Secret", default=""),
         Str("token", title="Access Token", required=True, max_length=None),
     ]
     credentials_oauth = True

--- a/src/middlewared/middlewared/schema/string_schema.py
+++ b/src/middlewared/middlewared/schema/string_schema.py
@@ -100,8 +100,7 @@ class Path(Str):
 
 class Password(Str):
     def __init__(self, *args, **kwargs):
-        self.private = True
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **(kwargs | {'private': True}))
 
 
 class SID(Str):


### PR DESCRIPTION
The Password class ensures that the string being handled is treated as private and redacted from relevant logs. This commit fixes many cases where the incorrect class was used for hanlding passwords. In some of the instances, the Str had the private parameter set and so there is no functional change, but it's beneficial to clearly mark places where passwords are being handled as such in the codebase.

For the purpose of this PR, API keys and tokens are also treated as password-equivalent strings.