### PR TITLE
NAS-124627 / 24.04 / Correctly retrieve iommu groups information

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -9,6 +9,8 @@ from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, returns, Str
 from middlewared.service import private, Service
 from middlewared.utils.gpu import SENSITIVE_PCI_DEVICE_TYPES
 
+
+RE_DEVICE_NAME = re.compile(r'(\w+):(\w+):(\w+).(\w+)')
 RE_DEVICE_PATH = re.compile(r'pci_(\w+)_(\w+)_(\w+)_(\w+)')
 
 
@@ -29,7 +31,7 @@ class VMDeviceService(Service):
         final = dict()
         try:
             for i in pathlib.Path('/sys/kernel/iommu_groups').glob('*/devices/*'):
-                if not i.is_dir() or not i.parent.parent.name.isdigit():
+                if not i.is_dir() or not i.parent.parent.name.isdigit() or not RE_DEVICE_NAME.fullmatch(i.name):
                     continue
 
                 iommu_group = int(i.parent.parent.name)

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_pci_device_iommu_groups.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_pci_device_iommu_groups.py
@@ -1,0 +1,91 @@
+from pathlib import PosixPath
+from unittest.mock import Mock, patch
+
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.plugins.vm.pci import VMDeviceService
+
+
+DEVICES_PATH = [
+    PosixPath('/sys/kernel/iommu_groups/55/devices/0000:64:0a.1'),
+    PosixPath('/sys/kernel/iommu_groups/83/devices/0000:b2:0f.0'),
+    PosixPath('/sys/kernel/iommu_groups/17/devices/0000:00:04.0'),
+    PosixPath('/sys/kernel/iommu_groups/45/devices/0000:16:0e.2'),
+    PosixPath('/sys/kernel/iommu_groups/45/devices/0000:16:0e.0'),
+    PosixPath('/sys/kernel/iommu_groups/45a/devices/0000:16:0e.7'),
+    PosixPath('/sys/kernel/iommu_groups/45/devices/test_file')
+]
+IOMMU_GROUPS = {
+    '0000:64:0a.1': {
+        'number': 55,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x64',
+                'slot': '0x0a',
+                'function': '0x1'
+            }
+        ]
+    },
+    '0000:b2:0f.0': {
+        'number': 83,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0xb2',
+                'slot': '0x0f',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:00:04.0': {
+        'number': 17,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x00',
+                'slot': '0x04',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:16:0e.2': {
+        'number': 45,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:16:0e.0': {
+        'number': 45,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+}
+
+
+def test_iommu_groups():
+    with patch('middlewared.plugins.vm.pci.pathlib.PosixPath.is_dir', Mock(return_value=True)):
+        with patch('middlewared.plugins.vm.pci.pathlib.Path.glob', Mock(return_value=DEVICES_PATH)):
+            assert VMDeviceService(Middleware()).get_iommu_groups_info() == IOMMU_GROUPS


### PR DESCRIPTION
This PR adds changes to correctly retrieve iommu groups as we were not validating the directory names properly and that resulted in normalization logic failing.