### PR TITLE
NAS-124739 / 24.04 / Only enable an iSCSI target if it has an active extent

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -273,7 +273,7 @@ TARGET_DRIVER iscsi {
             for initiator in group_initiators:
                 initiator_portal_access.add(f'{initiator}\#{address}')
 %>\
-%   if associated_targets:
+%   if target['id'] in associated_targets:
 ##
 ## For ALUA rel_tgt_id is tied to controller, if not ALUA don't bother writing it
 ##

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -303,6 +303,9 @@ TARGET_DRIVER iscsi {
 ## per_portal_acl always 1
 ##
         per_portal_acl 1
+%   else:
+## If no associated targets then disable
+        enabled 0
 %   endif
 %   for chap_auth in chap_users:
         IncomingUser "${chap_auth}"


### PR DESCRIPTION
When examining a set of logs noticed that a target was enabled, even though no active targets were associated with it.  Correct the existing check.  Also include a unit test.