### PR TITLE
NAS-124758 / 24.04 / NFS and directory service should wait for dependent services

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -14,6 +14,8 @@ RemainAfterExit=yes
 ExecStartPre=-midclt call etc.generate_checkpoint pre_interface_sync
 ExecStart=-midclt -t 120 call interface.sync true
 ExecStartPost=midclt call etc.generate_checkpoint interface_sync
+# Set netif complete sentinel
+ExecStartPost=touch /var/run/middleware/ix-netif-complete
 StandardOutput=null
 
 [Install]

--- a/debian/debian/ix-preinit.service
+++ b/debian/debian/ix-preinit.service
@@ -9,6 +9,8 @@ After=ix-zfs.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# clear the ix-netif completion marker
+ExecStart=rm -f /var/run/middleware/ix-netif-complete
 ExecStart=midclt call -job initshutdownscript.execute_init_tasks PREINIT
 StandardOutput=null
 StandardError=null

--- a/src/freenas/etc/systemd/system/nfs-server.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/nfs-server.service.d/override.conf
@@ -1,2 +1,3 @@
 [Unit]
 ConditionDirectoryNotEmpty=!/etc/exports.d
+After=nslcd.service

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -502,7 +502,6 @@ class SMBService(TDBWrapConfigService):
         """
         while timeout >= 0:
             if os.path.exists(NETIF_COMPLETE_SENTINEL):
-                self.logger.debug("MCGdebug - got netif complete sentinel")
                 os.remove(NETIF_COMPLETE_SENTINEL)
                 return
 
@@ -546,7 +545,6 @@ class SMBService(TDBWrapConfigService):
         We cannot continue without network.
         Wait here until we see the ix-netif completion sentinel.
         """
-        self.logger.debug("MCGdebug - wait for ix-netif completion")
         job.set_progress(20, 'Wait for ix-netif completion.')
         await self.netif_wait()
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -496,7 +496,7 @@ class SMBService(TDBWrapConfigService):
             await asyncio.sleep(1)
 
     @private
-    async def netif_wait(self, timeout=90):
+    async def netif_wait(self, timeout=120):
         """
         Wait for for the ix-netif sentinel file
         and confirm connectivity with some targeted tests.


### PR DESCRIPTION
Under some configurations, NFS can be dependent on nslcd and directory service, AD or LDAP (IPA) are nearly always dependent on the network subsystem.
Under some conditions and configurations, NFS and directory service would start before their dependent services.

NFS and nslcd are mostly managed by systemd.
To address NFS dependency on nslcd:  Added `After=nslcd` criteria to nfs-server unit file.

Directory Service is managed by middleware and, if enabled, is started as part of smb.configure.
To address Directory Service dependency on the network subsystem:  Added a sentinel file generated in the ix-netif unit file.  SMB `configure` will wait for the sentinel file before starting Directory Service.

Also did some cosmetic clean up of smb.py for flake8.