### PR TITLE
NAS-124370 / 24.04 / dont start dhcp on eno1 on fseries

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -10,4 +10,12 @@ class InterfaceService(Service):
 
     @private
     async def internal_interfaces(self):
-        return netif.INTERNAL_INTERFACES + await self.middleware.call('failover.internal_interface.detect')
+        result = netif.INTERNAL_INTERFACES
+        result.extend(await self.middleware.call('failover.internal_interface.detect'))
+        if await self.middleware.call('truenas.get_chassis_hardware').startswith('TRUENAS-F'):
+            # The eno1 interface needs to be masked on the f-series platform because
+            # this interface is shared with the BMC. Details for why this is done
+            # can be obtained from platform team.
+            result.append('eno1')
+
+        return result

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -179,14 +179,8 @@ class InterfaceService(CRUDService):
             for i in self.middleware.call_sync('datastore.query', 'network.interfaces')
         }
         ha_hardware = self.middleware.call_sync('system.is_ha_capable')
-        ignore = self.middleware.call_sync('failover.internal_interfaces')
+        ignore = self.middleware.call_sync('interface.internal_interfaces')
         fseries = self.middleware.call_sync('truenas.get_chassis_hardware').startswith('TRUENAS-F')
-        if fseries:
-            # The eno1 interface needs to be masked on the f-series platform because
-            # this interface is shared with the BMC. Details for why this is done
-            # can be obtained from platform team.
-            ignore.append('eno1')
-
         for name, iface in netif.list_interfaces().items():
             if (name in ignore) or (iface.cloned and name not in configs):
                 continue


### PR DESCRIPTION
When an f-series is installed cleanly and boots up the 1st time, by design , we start DHCP on all the physical interfaces on the system. With the f-series, we mask the `eno1` interface since it's shared with IPMI.

To ensure this interface is ignored, I added `eno1` check in the `interface.internal_interfaces` method which is what all consumers should be calling. Since I added this logic to that method, I was able to simplify `interface.query` but more importantly, the `interface.sync` method will now ignore `eno1` on the f-series platform when the system boots for the first time.