### PR TITLE
NAS-124601 / 24.04 / Add an endpoint to retrieve remaining dockerhub registry pull limits

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
@@ -20,6 +20,7 @@ DOCKER_AUTH_SERVICE = 'registry.docker.io'
 DOCKER_MANIFEST_SCHEMA_V1 = 'application/vnd.docker.distribution.manifest.v1+json'
 DOCKER_MANIFEST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.v2+json'
 DOCKER_MANIFEST_LIST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.list.v2+json'
+DOCKER_RATELIMIT_URL = 'https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest'
 CONTAINERD_SOCKET_PATH = '/run/k3s/containerd/containerd.sock'
 
 
@@ -145,6 +146,14 @@ class CRIClientMixin:
         digests = parse_digest_from_schema(response)
         digests.append(response['response_obj'].headers.get(DOCKER_CONTENT_DIGEST_HEADER))
         return digests
+
+    @private
+    async def get_docker_hub_rate_limit_preview(self):
+        return await self._api_call(
+            url=DOCKER_RATELIMIT_URL,
+            headers={'Authorization': f'Bearer {await self._get_token(scope="repository:ratelimitpreview/test:pull")}'},
+            mode='head'
+        )
 
 
 class ContainerdClient:

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/dockerhub_rate_limit.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/dockerhub_rate_limit.py
@@ -1,0 +1,32 @@
+from middlewared.schema import Dict, Int, returns, Str
+from middlewared.service import accepts, Service
+
+from .client import CRIClientMixin
+from .utils import normalize_docker_limits_header
+
+
+class ContainerImagesService(Service):
+
+    class Config:
+        namespace = 'container.image'
+
+    @accepts()
+    @returns(Dict(
+        Int('total_pull_limit', null=True),
+        Int('total_time_limit_in_secs', null=True),
+        Int('remaining_pull_limit', null=True),
+        Int('remaining_time_limit_in_secs', null=True),
+        Str('error', null=True),
+    ))
+    async def dockerhub_rate_limit(self):
+        """
+        Returns the current rate limit information for Docker Hub registry.
+        """
+        limits_header = await CRIClientMixin().get_docker_hub_rate_limit_preview()
+
+        if limits_header.get('response_obj') and hasattr(limits_header['response_obj'], 'headers'):
+            return normalize_docker_limits_header(limits_header['response_obj'].headers)
+
+        return {
+            'error': 'Unable to retrieve rate limit information from registry',
+        }

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/dockerhub_rate_limit.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/dockerhub_rate_limit.py
@@ -12,15 +12,24 @@ class ContainerImagesService(Service):
 
     @accepts()
     @returns(Dict(
-        Int('total_pull_limit', null=True),
-        Int('total_time_limit_in_secs', null=True),
-        Int('remaining_pull_limit', null=True),
-        Int('remaining_time_limit_in_secs', null=True),
+        Int('total_pull_limit', null=True, description='Total pull limit for Docker Hub registry'),
+        Int(
+            'total_time_limit_in_secs', null=True,
+            description='Total time limit in seconds for Docker Hub registry before the limit renews'
+        ),
+        Int('remaining_pull_limit', null=True, description='Remaining pull limit for Docker Hub registry'),
+        Int(
+            'remaining_time_limit_in_secs', null=True,
+            description='Remaining time limit in seconds for Docker Hub registry for the '
+                        'current pull limit to be renewed'
+        ),
         Str('error', null=True),
     ))
     async def dockerhub_rate_limit(self):
         """
         Returns the current rate limit information for Docker Hub registry.
+
+        Please refer to https://docs.docker.com/docker-hub/download-rate-limit/ for more information.
         """
         limits_header = await CRIClientMixin().get_docker_hub_rate_limit_preview()
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/container_images/test_container_images_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.plugins.container_runtime_interface.utils import normalize_reference
+from middlewared.plugins.container_runtime_interface.utils import normalize_reference, normalize_docker_limits_header
 
 
 @pytest.mark.parametrize("reference,expected_results", [
@@ -72,3 +72,69 @@ from middlewared.plugins.container_runtime_interface.utils import normalize_refe
 def test_normalize_reference(reference, expected_results):
     actual_results = normalize_reference(reference)
     assert actual_results == expected_results
+
+
+@pytest.mark.parametrize('header,expected_response', [
+    (
+        {
+            'ratelimit-limit': '100;w=21600',
+            'ratelimit-remaining': '100;w=21600'},
+        {
+          'total_pull_limit': 100,
+          'total_time_limit_in_secs': 21600,
+          'remaining_pull_limit': 100,
+          'remaining_time_limit_in_secs': 21600,
+          'error': None
+        }
+    ),
+    (
+        {
+            'ratelimit-limit': '100;w=21600',
+            'ratelimit-remaining': '97;w=21600'
+        },
+        {
+             'total_pull_limit': 100,
+             'total_time_limit_in_secs': 21600,
+             'remaining_pull_limit': 97,
+             'remaining_time_limit_in_secs': 21600,
+             'error': None
+        }
+    ),
+    (
+        {
+            'ratelimit-limit': '103;w=21',
+            'ratelimit-remaining': '68;w=600'
+        },
+        {
+             'total_pull_limit': 103,
+             'total_time_limit_in_secs': 21,
+             'remaining_pull_limit': 68,
+             'remaining_time_limit_in_secs': 600,
+             'error': None
+        }
+    ),
+    (
+        {
+            'ratelimit-limit': '100;w=21600'
+        },
+        {
+            'error': 'Unable to retrieve rate limit information from registry'
+        }
+    ),
+    (
+        {
+            'ratelimit-remaining': '100;w=21600'
+        },
+        {
+            'error': 'Unable to retrieve rate limit information from registry'
+        }
+    ),
+    (
+        {},
+        {
+            'error': 'Unable to retrieve rate limit information from registry'
+        }
+    ),
+])
+def test_normalize_docker_limits_header(header, expected_response):
+    assert normalize_docker_limits_header(header) == expected_response


### PR DESCRIPTION
This PR adds changes to introduce a new endpoint which returns available pull limits for dockerhub registry. Motivation behind the endpoint is that on app installation, UI can make a call to this endpoint and if `remaining_pull_limit` is less then 5, it would display a warning to the user that it is possible the installation process may get stuck as images wouldn't be pulled if they are coming from dockerhub because user limit to dockerhub has almost/or has been reached and until `remaining_time_limit_in_secs`, it won't be renewed.