### PR TITLE
NAS-124620 / 23.10.1 / Remove /var/tmp usages in middleware (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -19,13 +19,6 @@ class HasUpdateAlertClass(AlertClass):
     text = "A system update is available. Go to System -> Update to download and apply the update."
 
 
-class UpdateNotAppliedAlertClass(AlertClass):
-    category = AlertCategory.SYSTEM
-    level = AlertLevel.WARNING
-    title = "Update Not Applied"
-    text = "%s"
-
-
 class UpdateFailedAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.CRITICAL

--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -1,11 +1,5 @@
 import logging
 
-try:
-    from freenasOS import Update
-    from freenasOS.Update import PendingUpdates
-except ImportError:
-    Update = PendingUpdates = None
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, FilePresenceAlertSource
 
 

--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -1,6 +1,3 @@
-from datetime import timedelta
-import os
-import json
 import logging
 
 try:
@@ -9,10 +6,8 @@ try:
 except ImportError:
     Update = PendingUpdates = None
 
-from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, FilePresenceAlertSource, ThreadedAlertSource
-from middlewared.alert.schedule import IntervalSchedule
+from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, FilePresenceAlertSource
 
-UPDATE_APPLIED_SENTINEL = "/tmp/.updateapplied"
 
 log = logging.getLogger("update_check_alertmod")
 
@@ -29,29 +24,6 @@ class UpdateNotAppliedAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "Update Not Applied"
     text = "%s"
-
-
-class UpdateNotAppliedAlertSource(ThreadedAlertSource):
-    schedule = IntervalSchedule(timedelta(minutes=10))
-
-    def check_sync(self):
-        if os.path.exists(UPDATE_APPLIED_SENTINEL):
-            try:
-                with open(UPDATE_APPLIED_SENTINEL, "rb") as f:
-                    data = json.loads(f.read().decode("utf8"))
-            except Exception:
-                log.error(
-                    "Could not load UPDATE APPLIED SENTINEL located at {0}".format(
-                        UPDATE_APPLIED_SENTINEL
-                    ),
-                    exc_info=True
-                )
-                return
-
-            if is_update_applied:
-                update_applied, msg = is_update_applied(data["update_version"], create_alert=False)
-                if update_applied:
-                    return Alert(UpdateNotAppliedAlertClass, msg)
 
 
 class UpdateFailedAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -17,67 +17,11 @@ UPDATE_APPLIED_SENTINEL = "/tmp/.updateapplied"
 log = logging.getLogger("update_check_alertmod")
 
 
-# FIXME: use update plugin
-def is_update_applied(update_version):
-    if Update is None:
-        return False
-    active_be_msg = 'Please reboot the system to activate this update.'
-    # TODO: The below boot env name should really be obtained from the update code
-    # for now we just duplicate that code here
-    if update_version.startswith(Update.Avatar() + "-"):
-        update_boot_env = update_version[len(Update.Avatar() + "-"):]
-    else:
-        update_boot_env = "%s-%s" % (Update.Avatar(), update_version)
-
-    found = False
-    msg = ''
-    for clone in Update.ListClones():
-        if clone['realname'] == update_boot_env:
-            if clone['active'] != 'R':
-                active_be_msg = 'Please activate {0} via'.format(update_boot_env) + \
-                                ' the Boot Environment Tab and Reboot to use this updated version.'
-            msg = 'Update: {0} has already been applied. {1}'.format(update_version, active_be_msg)
-            found = True
-            break
-
-    return (found, msg)
-
-
 class HasUpdateAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.INFO
     title = "Update Available"
     text = "A system update is available. Go to System -> Update to download and apply the update."
-
-
-class HasUpdateAlertSource(ThreadedAlertSource):
-    schedule = IntervalSchedule(timedelta(hours=1))
-
-    run_on_backup_node = False
-
-    def check_sync(self):
-        try:
-            self.middleware.call_sync("datastore.query", "system.update", [], {"get": True})
-        except IndexError:
-            self.middleware.call_sync("datastore.insert", "system.update", {
-                "upd_autocheck": True,
-                "upd_train": "",
-            })
-
-        path = self.middleware.call_sync("update.get_update_location")
-        if not path:
-            return
-
-
-        updates = None
-        try:
-            if PendingUpdates:
-                updates = PendingUpdates(path)
-        except Exception:
-            pass
-
-        if updates:
-            return Alert(HasUpdateAlertClass)
 
 
 class UpdateNotAppliedAlertClass(AlertClass):

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -3,8 +3,6 @@
     import ipaddress
     import os
 
-    from middlewared.utils import MIDDLEWARE_RUN_DIR
-
     # Let's ensure that /var/log/nginx directory exists
     if not os.path.exists('/var/log/nginx'):
         os.makedirs('/var/log/nginx')
@@ -118,9 +116,6 @@ http {
     server_tokens off;
 
     gzip  on;
-    #upload_store /var/tmp/firmware;
-    client_body_temp_path ${os.path.join(MIDDLEWARE_RUN_DIR, 'nginx_firmware')};
-
     access_log off;
     error_log syslog:server=unix:/dev/log,nohostname;
 

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -3,6 +3,8 @@
     import ipaddress
     import os
 
+    from middlewared.utils import MIDDLEWARE_RUN_DIR
+
     # Let's ensure that /var/log/nginx directory exists
     if not os.path.exists('/var/log/nginx'):
         os.makedirs('/var/log/nginx')
@@ -117,7 +119,7 @@ http {
 
     gzip  on;
     #upload_store /var/tmp/firmware;
-    client_body_temp_path /var/tmp/firmware;
+    client_body_temp_path ${os.path.join(MIDDLEWARE_RUN_DIR, 'nginx_firmware')};
 
     access_log off;
     error_log syslog:server=unix:/dev/log,nohostname;

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -7,14 +7,14 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.schema import Any, Bool, Dict, Float, List, Patch, Str, ValidationErrors
 from middlewared.service import accepts, CallError, CRUDService, job, private
-from middlewared.utils import filter_list
+from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.validators import Match
 
 from .utils import convert_repository_to_path, get_cache_key
 
 OFFICIAL_ENTERPRISE_TRAIN = 'enterprise'
 OFFICIAL_LABEL = 'TRUENAS'
-TMP_IX_APPS_DIR = '/tmp/ix-applications'
+TMP_IX_APPS_DIR = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-applications')
 
 
 class CatalogModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/failover_/fenced.py
+++ b/src/middlewared/middlewared/plugins/failover_/fenced.py
@@ -10,7 +10,7 @@ from middlewared.utils.cgroups import move_to_root_cgroups
 from fenced.fence import ExitCode as FencedExitCodes
 
 
-PID_FILE = os.path.join(MIDDLEWARE_RUN_DIR, '.fenced-pid')
+PID_FILE = os.path.join(MIDDLEWARE_RUN_DIR, 'fenced.pid')
 IS_ALIVE_SIGNAL = 0
 
 

--- a/src/middlewared/middlewared/plugins/failover_/fenced.py
+++ b/src/middlewared/middlewared/plugins/failover_/fenced.py
@@ -5,11 +5,12 @@ import os
 import signal
 
 from middlewared.service import Service, CallError
+from middlewared.utils import MIDDLEWARE_RUN_DIR
 from middlewared.utils.cgroups import move_to_root_cgroups
 from fenced.fence import ExitCode as FencedExitCodes
 
 
-PID_FILE = '/tmp/.fenced-pid'
+PID_FILE = os.path.join(MIDDLEWARE_RUN_DIR, '.fenced.pid')
 IS_ALIVE_SIGNAL = 0
 
 

--- a/src/middlewared/middlewared/plugins/failover_/fenced.py
+++ b/src/middlewared/middlewared/plugins/failover_/fenced.py
@@ -10,7 +10,7 @@ from middlewared.utils.cgroups import move_to_root_cgroups
 from fenced.fence import ExitCode as FencedExitCodes
 
 
-PID_FILE = os.path.join(MIDDLEWARE_RUN_DIR, '.fenced.pid')
+PID_FILE = os.path.join(MIDDLEWARE_RUN_DIR, '.fenced-pid')
 IS_ALIVE_SIGNAL = 0
 
 

--- a/src/middlewared/middlewared/plugins/update_/upload_location_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/upload_location_linux.py
@@ -17,6 +17,7 @@ class UpdateService(Service):
 
     @private
     def create_upload_location(self):
+        os.makedirs(UPLOAD_LOCATION, exist_ok=True)
         if not os.path.ismount(UPLOAD_LOCATION):
             subprocess.run(["mount", "-o", "size=2800M", "-t", "tmpfs", "none", UPLOAD_LOCATION], **run_kw)
 

--- a/src/middlewared/middlewared/plugins/update_/utils.py
+++ b/src/middlewared/middlewared/plugins/update_/utils.py
@@ -11,7 +11,7 @@ SCALE_MANIFEST_FILE = "/data/manifest.json"
 
 DOWNLOAD_UPDATE_FILE = "update.sqsh"
 
-UPLOAD_LOCATION = os.path.join(MIDDLEWARE_RUN_DIR, "upload_firmware")
+UPLOAD_LOCATION = os.path.join(MIDDLEWARE_RUN_DIR, "upload_image")
 
 SEP = re.compile(r"[-.]")
 

--- a/src/middlewared/middlewared/plugins/update_/utils.py
+++ b/src/middlewared/middlewared/plugins/update_/utils.py
@@ -1,14 +1,17 @@
 # -*- coding=utf-8 -*-
 import configparser
 import itertools
+import os
 import re
+
+from middlewared.utils import MIDDLEWARE_RUN_DIR
 
 DEFAULT_SCALE_UPDATE_SERVER = "https://update.ixsystems.com/scale"
 SCALE_MANIFEST_FILE = "/data/manifest.json"
 
 DOWNLOAD_UPDATE_FILE = "update.sqsh"
 
-UPLOAD_LOCATION = "/var/tmp/firmware"
+UPLOAD_LOCATION = os.path.join(MIDDLEWARE_RUN_DIR, "upload_firmware")
 
 SEP = re.compile(r"[-.]")
 


### PR DESCRIPTION
This PR adds changes to use middlewared run directory instead of consuming /var/tmp directly. Also while at it, changes have been made to remove outdated source alerts which are not being consumed anymore.

Original PR: https://github.com/truenas/middleware/pull/12380
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124620