### PR TITLE
NAS-124799 / 23.10.1 / Fix zfs create ancestors (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -496,7 +496,7 @@ class FilesystemService(Service, ACLBase):
 
             self.middleware.call_sync(
                 'filesystem.check_acl_execute',
-                path, data['dacl'], uid_to_check, gid_to_check
+                path, data['dacl'], uid_to_check, gid_to_check, True
             )
 
             self.setacl_nfs4_internal(path, data['dacl'], do_canon, verrors)
@@ -653,7 +653,7 @@ class FilesystemService(Service, ACLBase):
 
                 self.middleware.call_sync(
                     'filesystem.check_acl_execute',
-                    path, dacl, uid_to_check, gid_to_check
+                    path, dacl, uid_to_check, gid_to_check, True
                 )
             except CallError as e:
                 if e.errno != errno.EPERM:

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -11,6 +11,7 @@ sys.path.append(apifolder)
 from assets.REST.pool import dataset as create_dataset
 from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job, make_ws_request
 from auto_config import ip, pool_name, user, password
+from middlewared.test.integration.utils import call
 
 dataset = f'{pool_name}/dataset1'
 dataset_url = dataset.replace('/', '%2F')
@@ -487,3 +488,11 @@ def test_34_multiprotocol_share_type_preset(request):
         assert ds['aclmode']['value'] == 'PASSTHROUGH'
         assert ds['casesensitivity']['value'] == 'SENSITIVE'
         assert ds['atime']['value'] == 'OFF'
+
+
+def test_35_create_ancestors(request):
+    with create_dataset(pool_name, 'foo/bar/tar', options={'share_type': 'SMB', 'create_ancestors': True}) as ds:
+        assert ds['acltype']['value'] == 'NFSV4'
+        assert ds['aclmode']['value'] == 'RESTRICTED'
+        st = call('filesystem.stat', ds['mountpoint'])
+        assert st['acl'] is True, str(st)


### PR DESCRIPTION
This commit modifies our execute check so that we by default skip
non-existent path components. This is relevant when validating case
where ZFS create_ancestors is specified when creating a new dataset. We
don't want to fail validation on the non-existent path component, but
we do want to validate permissions on any parent datasets that do exist.

Original PR: https://github.com/truenas/middleware/pull/12393
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124799