### PR TITLE
NAS-124827 / 24.04 / Only run disable-rootfs-protection when running on SCALE

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -18,8 +18,6 @@ PACKAGES=(
     python3-pytest-dependency
     python3-pytest-rerunfailures
     python3-pytest-timeout
-    # samba / libsmb
-    python3-samba
     # `snmpwalk` to test `snmp-agent`
     snmp
     # Used by the integration test runner

--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -18,6 +18,8 @@ PACKAGES=(
     python3-pytest-dependency
     python3-pytest-rerunfailures
     python3-pytest-timeout
+    # samba / libsmb
+    python3-samba
     # `snmpwalk` to test `snmp-agent`
     snmp
     # Used by the integration test runner
@@ -27,7 +29,11 @@ PACKAGES=(
 )
 PIP_PACKAGES=()
 
-/usr/local/libexec/disable-rootfs-protection
+if [ -f /usr/local/libexec/disable-rootfs-protection ]; then
+    # Running on SCALE
+    /usr/local/libexec/disable-rootfs-protection
+fi
+
 apt update
 apt install -y "${PACKAGES[@]}"
 if [ "${#PIP_PACKAGES[@]}" -gt 0 ]; then


### PR DESCRIPTION
Also, only run `disable-rootfs-protection` when running on SCALE

These issues were encountered when running in a **fresh** environment.