### PR TITLE
NAS-124777 / 23.10.1 / Add handling for local user / group 2fa (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -337,12 +337,18 @@ class DSCache(Service):
                                                         who_str, who_id, False, True)
                     entry = await self.middleware.call('idmap.synthetic_user',
                                                        ds.lower(), pwdobj)
+                    if entry is None:
+                        return None
+
                     entry['sid'] = pwdobj['sid_info']['sid']
                 else:
                     grpobj = await self.middleware.call('dscache.get_uncached_group',
                                                         who_str, who_id, True)
                     entry = await self.middleware.call('idmap.synthetic_group',
                                                        ds.lower(), grpobj)
+                    if entry is None:
+                        return None
+
                     entry['sid'] = grpobj['sid_info']['sid']
 
                 await self.insert(ds, data['idtype'], entry)

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1164,6 +1164,11 @@ class IdmapDomainService(TDBWrapCRUDService):
     @private
     async def synthetic_user(self, ds, passwd):
         idmap_info = await self.get_idmap_info(ds, passwd['pw_uid'])
+        if idmap_info[0] is None:
+            # ID doesn't match one of our configured idmap ranges.
+            # This means it's probably local
+            return None
+
         sid = await self.middleware.run_in_thread(self.unixid_to_sid, {"id": passwd['pw_uid'], "id_type": "USER"})
         rid = int(sid.rsplit('-', 1)[1])
         return {
@@ -1192,6 +1197,11 @@ class IdmapDomainService(TDBWrapCRUDService):
     @private
     async def synthetic_group(self, ds, grp):
         idmap_info = await self.get_idmap_info(ds, grp['gr_gid'])
+        if idmap_info[0] is None:
+            # ID doesn't match one of our configured idmap ranges.
+            # This means it's probably local
+            return None
+
         sid = await self.middleware.run_in_thread(self.unixid_to_sid, {"id": grp['gr_gid'], "id_type": "GROUP"})
         rid = int(sid.rsplit('-', 1)[1])
         return {

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -11,6 +11,8 @@ from functions import PUT, POST, GET, SSH_TEST, wait_on_job
 from assets.REST.directory_services import active_directory, override_nameservers
 from auto_config import ip, hostname, password, user
 from pytest_dependency import depends
+from middlewared.test.integration.assets.account import user as create_user
+from middlewared.test.integration.utils import call
 
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
@@ -283,3 +285,15 @@ def test_11_check_lazy_initialization_of_users_and_groups_by_id(request):
     })
     assert results.status_code == 200, results.text
     assert len(results.json()) == 1, results.text
+
+    with create_user({
+        'username': 'canary',
+        'full_name': 'canary',
+        'group_create': True,
+        'password': 'canary',
+        'smb': True
+    }) as u:
+        user_data = call('user.translate_username', 'canary')
+        assert u['id'] == user_data['id'], str(user_data)
+        assert u['uid'] == user_data['uid'], str(user_data)
+        assert user_data['local'] is True, str(user_data)


### PR DESCRIPTION
When 2fa is enabled we look up user / group object info via user.translate_user to get consistent data structures containing SID information for DS and local users. Since the initial step of this goes through nss (which doesn't report back to us with nss module actually resolved the name), we pass along the resulting passwd or group dict to a winbind query which validates the uid/gid against our currently configured domains. This PR adds handling for when resolution fails so that we return None type which falls through to initial user.query allowing it to proceed with the local user / group database.

Original PR: https://github.com/truenas/middleware/pull/12388
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124777