### PR TITLE
NAS-124879 / 24.04 / Flush cached SID info on netbios name change

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -915,6 +915,7 @@ class SMBService(TDBWrapConfigService):
             new_sid = await self.middleware.call("smb.get_system_sid")
             await self.middleware.call("smb.set_database_sid", new_sid)
             new_config["cifs_SID"] = new_sid
+            await self.middleware.call('idmap.flush_gencache')
             await self.middleware.call("smb.synchronize_group_mappings")
             srv = (await self.middleware.call("network.configuration.config"))["service_announcement"]
             await self.middleware.call("network.configuration.toggle_announcement", srv)


### PR DESCRIPTION
Our system SID changes on netbios name change and so we need to flush any cached sid-to-name / name-to-sid results. Failing to flush cached entries causes potential for failure to set SMB share ACLs (failure to convert names to SIDs) if server administrator immediately switches to that form before the cached entries time out.