### PR TITLE
NAS-124876 / 23.10.1 / Add remote syslog test (by anodos325)

### DIFF
--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -1,0 +1,14 @@
+from middlewared.test.integration.utils import call
+
+
+def test_07_check_can_set_remote_syslog(request):
+    """
+    Basic test to validate that setting a remote syslog target
+    doesn't break syslog-ng config
+    """
+    try:
+        data = call('system.advanced.update', {'syslogserver': '127.0.0.1'})
+        assert data['syslogserver'] == '127.0.0.1'
+        call('service.restart', 'syslogd', {'silent': False})
+    finally:
+        call('system.advanced.update', {'syslogserver': ''})


### PR DESCRIPTION
This commit adds a basic test that setting a remote syslog target doesn't break syslog-ng. Proper functional tests are still needed.

Original PR: https://github.com/truenas/middleware/pull/12405
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124876