### PR TITLE
NAS-124896 / 24.04 / add HA KVM detection

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -170,6 +170,7 @@ class FailoverService(ConfigService):
           SUBLIGHT (h-series)
           PUMA (x-series)
           BHYVE (HA VMs for CI)
+          IXKVM (HA VMs (on KVM) for CI)
           MANUAL (everything else)
         """
         return (await self.middleware.call('failover.ha_mode'))[0]

--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -19,6 +19,8 @@ class InternalInterfaceService(Service):
         hardware = self.middleware.call_sync('failover.hardware')
         if hardware == 'BHYVE':
             return ['enp0s6f1']
+        elif hardware == 'IXKVM':
+            return ['enp1s0']
         elif hardware == 'ECHOSTREAM':
             # z-series
             for i in Path('/sys/class/net/').iterdir():


### PR DESCRIPTION
Similar to what we do when we run our CI against HA VMs running on BHYVE hypervisors, we now have HA VMs working on KVM hypervisor. This adds the necessary changes to our code to detect such an environment and configure the system accordingly.