### PR TITLE
NAS-124776 / 23.10.0.1 / Make sure we don't mount any unencrypted datasets on pool import (by sonicaj) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -486,6 +486,11 @@ class FailoverEventsService(Service):
                     logger.warning('Failed to set cachefile property for %r', vol['name'], exc_info=True)
                 """
 
+            # If root dataset was encrypted, it would not be mounted at this point regardless of it being
+            # key/passphrase encrypted - so we make sure that nothing at this point in time is mounted beneath it
+            # if that pool has datasets which are unencrypted
+            self.run_call('pool.handle_unencrypted_datasets_on_import', vol['name'])
+
             logger.info('Successfully imported %r', vol['name'])
 
             # try to unlock the zfs datasets (if any)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -227,6 +227,7 @@ class PoolService(Service):
             self.logger.error('Unhandled exception importing %r', vol_name, exc_info=True)
             return False
 
+        self.middleware.call_sync('pool.handle_unencrypted_datasets_on_import', vol_name)
         self.logger.debug('SUCCESS importing %r with guid: %r', vol_name, vol_guid)
         return True
 

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -168,7 +168,7 @@ class PoolService(Service):
 
         # We want to set immutable flag on all of locked datasets
         for encrypted_ds in await self.middleware.call(
-                'pool.dataset.query_encrypted_datasets', pool_name, {'key_loaded': False}
+            'pool.dataset.query_encrypted_datasets', pool_name, {'key_loaded': False}
         ):
             encrypted_mountpoint = os.path.join('/mnt', encrypted_ds)
             if os.path.exists(encrypted_mountpoint):

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -368,3 +368,11 @@ class PoolService(Service):
         self.logger.debug('Calling pool.post_import')
         self.middleware.call_hook_sync('pool.post_import', None)
         self.logger.debug('Finished calling pool.post_import')
+
+    @private
+    async def handle_unencrypted_datasets_on_import(self, pool_name):
+        root_ds = await self.middleware.call('pool.dataset.get_instance_quick', pool_name, {
+            'encryption': True,
+        })
+        if not root_ds['encrypted']:
+            return

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -314,10 +314,11 @@ class PoolService(Service):
             # datasets where any upper path component is encrypted) (i.e. no more /mnt/zz/unencrypted/encrypted).
             # However, we still need to take into consideration the other users that manged to get themselves
             # into this scenario.
-            with contextlib.suppress(CallError):
-                self.logger.debug('Forcefully umounting %r', vol_name)
-                self.middleware.call_sync('zfs.dataset.umount', vol_name, {'force': True})
-                self.logger.debug('Successfully umounted %r', vol_name)
+            if not umount_root_short_circuit:
+                with contextlib.suppress(CallError):
+                    self.logger.debug('Forcefully umounting %r', vol_name)
+                    self.middleware.call_sync('zfs.dataset.umount', vol_name, {'force': True})
+                    self.logger.debug('Successfully umounted %r', vol_name)
 
             pool_mount = f'/mnt/{vol_name}'
             if os.path.exists(pool_mount):

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -238,6 +238,13 @@ class PoolService(Service):
     @private
     def unlock_on_boot_impl(self, vol_name):
         zpool_info = self.middleware.call_sync('pool.handle_unencrypted_datasets_on_import', vol_name)
+        if not zpool_info:
+            self.logger.error(
+                'Unable to retrieve %r root dataset information required for unlocking any relevant encrypted datasets',
+                vol_name
+            )
+            return
+
         umount_root_short_circuit = False
         if zpool_info['key_format']['parsed'] == 'passphrase':
             # passphrase encrypted zpools will _always_ fail to be unlocked at

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -376,3 +376,11 @@ class PoolService(Service):
         })
         if not root_ds['encrypted']:
             return
+
+        # If root ds is encrypted, at this point we know that root dataset has not been mounted yet and neither
+        # unlocked, so if there are any children it has which were unencrypted - we force umount them
+        try:
+            self.middleware.call_sync('zfs.dataset.umount', pool_name, {'force': True})
+            self.logger.debug('Successfully umounted any unencrypted datasets under %r dataset', pool_name)
+        except Exception:
+            self.logger.error('Failed to umount any unencrypted datasets under %r dataset', pool_name, exc_info=True)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -118,6 +118,11 @@ class PoolService(Service):
         else:
             pool_name = new_name
 
+        # Let's umount any datasets if root dataset of the new pool is locked and it has unencrypted datasets
+        # beneath it. This is to prevent the scenario where the root dataset is locked and the child datasets
+        # get mounted
+        await self.handle_unencrypted_datasets_on_import(pool_name)
+
         # set acl properties correctly for given top-level dataset's acltype
         ds = await self.middleware.call(
             'pool.dataset.query',

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -391,7 +391,7 @@ class PoolService(Service):
         # If root ds is encrypted, at this point we know that root dataset has not been mounted yet and neither
         # unlocked, so if there are any children it has which were unencrypted - we force umount them
         try:
-            self.middleware.call_sync('zfs.dataset.umount', pool_name, {'force': True})
+            await self.middleware.call('zfs.dataset.umount', pool_name, {'force': True})
             self.logger.debug('Successfully umounted any unencrypted datasets under %r dataset', pool_name)
         except Exception:
             self.logger.error('Failed to umount any unencrypted datasets under %r dataset', pool_name, exc_info=True)


### PR DESCRIPTION
This PR fixes a case where any unencrypted datasets under encrypted root dataset get mounted before we actually get the chance to unlock root dataset.

Original PR: https://github.com/truenas/middleware/pull/12398
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124776

Original PR: https://github.com/truenas/middleware/pull/12402
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124776