### PR TITLE
NAS-124845 / 23.10.0.1 / Fix regression in remote syslog (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -74,7 +74,7 @@ def generate_syslog_remote_destination(middleware, advanced_config):
 
         result += ' };\n'
         result += f'log {{ source({LOG_SOURCE}); filter({LOG_FILTER_PREFIX}{advanced_config["sysloglevel"].lower()});'
-        result += 'destination(loghost); }};\n'
+        result += 'destination(loghost); };\n'
 
     return result
 


### PR DESCRIPTION
This removes an unnecessary closing brace in the syslog-ng directive for remote syslog target.

Original PR: https://github.com/truenas/middleware/pull/12403
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124845