### PR TITLE
NAS-124935 / 24.04 / Add SMB AUTHENTICATION audit events

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -23,7 +23,7 @@ from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.schema import (
     accepts, Bool, Dict, Int, List, Patch, Ref, returns, Str, UUID
 )
-from middlewared.service import filterable_returns, job, private, ConfigService
+from middlewared.service import filterable, filterable_returns, job, private, ConfigService
 from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.utils import filter_list
 from middlewared.utils.functools import cache
@@ -478,5 +478,6 @@ class AuditService(ConfigService):
             self.logger.error('Failed to apply auditing dataset configuration.', exc_info=True)
 
     @private
-    async def json_schemas(self):
-        return AUDIT_EVENT_SMB_JSON_SCHEMAS
+    @filterable
+    async def json_schemas(self, filters, options):
+        return filter_list(AUDIT_EVENT_SMB_JSON_SCHEMAS, filters, options)

--- a/src/middlewared/middlewared/plugins/audit/schema/smb.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/smb.py
@@ -333,7 +333,7 @@ AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
 
 AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
     AUDIT_EVENT_SMB_BASE_SCHEMA,
-    'audit_entry_smb_setattr',
+    'audit_entry_smb_set_attr',
     Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.SET_ATTR.name]),
     AUDIT_EVENT_DATA_SMB_SET_ATTR
 ))

--- a/src/middlewared/middlewared/plugins/audit/schema/smb.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/smb.py
@@ -39,6 +39,7 @@ class AuditSmbEventType(AuditEnum):
     This enum contains all possible SMB audit events. Values correspond with
     `event` written to auditing SQLite database.
     """
+    AUTHENTICATION = 'AUTHENTICATION'
     CONNECT = 'CONNECT'
     DISCONNECT = 'DISCONNECT'
     CREATE = 'CREATE'
@@ -63,6 +64,33 @@ class AuditSetattrType(AuditEnum):
 """
 Below are schema class instances for `event_data` for SMB audit events.
 """
+
+
+AUDIT_EVENT_DATA_SMB_AUTHENTICATION = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    Str('logonId'),
+    Int('logonType'),
+    Str('localAddress'),
+    Str('remoteAddress'),
+    Str('serviceDescription'),
+    Str('authDescription'),
+    Str('clientDomain'),
+    Str('clientAccount'),
+    Str('workstation'),
+    Str('becameAccount'),
+    Str('becameDomain'),
+    Str('becameSid'),
+    Str('mappedAccount'),
+    Str('mappedDomain'),
+    Str('netlogonComputer'),
+    Str('netlogonTrustAccount'),
+    Str('netlogonNegotiateFlags'),
+    Str('netlogonSecureChannelType'),
+    Str('netlogonTrustAccountSid'),
+    Str('passwordType'),
+    AUDIT_RESULT_NTSTATUS,
+    AUDIT_VERS,
+)
 
 
 AUDIT_EVENT_DATA_SMB_CONNECT = Dict(
@@ -239,6 +267,7 @@ base instance and then extend a copy of the generalized event with event-specifi
 `event_data` defined above.
 """
 
+
 AUDIT_EVENT_SMB_SCHEMAS = []
 
 
@@ -260,6 +289,14 @@ AUDIT_EVENT_SMB_BASE_SCHEMA = AuditSchema(
     ),
     Bool('success')
 )
+
+
+AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SMB_BASE_SCHEMA,
+    'audit_entry_smb_authentication',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSmbEventType.AUTHENTICATION.name]),
+    AUDIT_EVENT_DATA_SMB_AUTHENTICATION
+))
 
 
 AUDIT_EVENT_SMB_SCHEMAS.append(audit_schema_from_base(

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -812,7 +812,7 @@ class SMBService(TDBWrapConfigService):
 
         if new['enable_smb1']:
             if audited_shares := await self.middleware.call(
-                'sharing.smb.query', [['audit.enable', '=', True]], {'select': ['audit']}
+                'sharing.smb.query', [['audit.enable', '=', True]], {'select': ['audit', 'name']}
             ):
                 verrors.add(
                     'smb_update.enable_smb1',

--- a/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
+++ b/src/middlewared/middlewared/plugins/smb_/smbconf/reg_global_smb.py
@@ -86,13 +86,12 @@ class GlobalSchema(RegistrySchema):
 
     def set_log_level(entry, val, data_in, data_out):
         loglevelint = int(LOGLEVEL_MAP.inv.get(val, 1))
-        loglevel = f"{loglevelint} auth_json_audit:3@/var/log/samba4/auth_audit.log"
         if data_in['syslog']:
             logging = f'syslog@{"3" if loglevelint > 3 else loglevelint} file'
         else:
             logging = "file"
         data_out.update({
-            "log level": {"parsed": loglevel},
+            "log level": {"parsed": str(loglevelint)},
             "logging": {"parsed": logging},
         })
         return

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -410,7 +410,8 @@ def test_060_audit_log(request):
             assert new_data['audit']['ignore_list'] == ['builtin_users'], str(new_data['audit'])
 
             # Verify that being member of group in ignore list is sufficient to avoid new messages
-            assert len(do_audit_ops(s['name'])) == len(events)
+            # By default authentication attempts are always logged
+            assert len(do_audit_ops(s['name'])) == len(events + 1)
 
             new_data = call('sharing.smb.update', s['id'], {'audit': {'watch_list': ['builtin_users']}})
             assert new_data['audit']['enable'], str(new_data['audit'])
@@ -418,8 +419,9 @@ def test_060_audit_log(request):
             assert new_data['audit']['watch_list'] == ['builtin_users'], str(new_data['audit'])
 
             # Verify that watch_list takes precedence
+            # By default authentication attempts are always logged
             new_events = do_audit_ops(s['name'])
-            assert len(new_events) > len(events)
+            assert len(new_events) > len(events + 2)
 
             new_data = call('sharing.smb.update', s['id'], {'audit': {'enable': False}})
             assert new_data['audit']['enable'] is False, str(new_data['audit'])

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -378,7 +378,7 @@ def do_audit_ops(svc):
         c.close(fd, True)
 
     sleep(AUDIT_WAIT)
-    return call('auditbackend.query', 'SMB')
+    return call('auditbackend.query', 'SMB', [['event', '!=', 'AUTHENTICATION']])
 
 
 def test_060_audit_log(request):
@@ -411,7 +411,7 @@ def test_060_audit_log(request):
 
             # Verify that being member of group in ignore list is sufficient to avoid new messages
             # By default authentication attempts are always logged
-            assert len(do_audit_ops(s['name'])) == len(events + 1)
+            assert do_audit_ops(s['name']) == events
 
             new_data = call('sharing.smb.update', s['id'], {'audit': {'watch_list': ['builtin_users']}})
             assert new_data['audit']['enable'], str(new_data['audit'])
@@ -421,7 +421,7 @@ def test_060_audit_log(request):
             # Verify that watch_list takes precedence
             # By default authentication attempts are always logged
             new_events = do_audit_ops(s['name'])
-            assert len(new_events) > len(events + 2)
+            assert len(new_events) > len(events)
 
             new_data = call('sharing.smb.update', s['id'], {'audit': {'enable': False}})
             assert new_data['audit']['enable'] is False, str(new_data['audit'])
@@ -429,7 +429,7 @@ def test_060_audit_log(request):
             assert new_data['audit']['watch_list'] == ['builtin_users'], str(new_data['audit'])
 
             # Verify that disabling audit prevents new messages from being written
-            assert len(do_audit_ops(s['name'])) == len(new_events)
+            assert do_audit_ops(s['name'])) == new_events
 
 
 @pytest.mark.parametrize('torture_test', [


### PR DESCRIPTION
Now that we have centralized place for audit-style information, remove the handling whereby we wrote auth_audit events into a separate samba log file in favor of direct insertion into our auditing DB. If we need auth info from users, it is simple enough to just request a dump of it from them when troubleshooting.