### PR TITLE
NAS-124779 / 24.04 / Send network stats in bytes

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
@@ -17,11 +17,11 @@ def get_interface_stats(netdata_metrics: dict, interfaces: typing.List[str]) -> 
         if link_state:
             data[interface_name]['received_bytes'] = normalize_value(
                 safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'received', 0),
-                multiplier=1000,
+                multiplier=1000, divisor=8
             ) / NETDATA_UPDATE_EVERY
             data[interface_name]['sent_bytes'] = normalize_value(
                 safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'sent', 0),
-                multiplier=1000,
+                multiplier=1000, divisor=8
             ) / NETDATA_UPDATE_EVERY
             data[interface_name].update({
                 'received_bytes_rate': data[interface_name]['received_bytes'] / NETDATA_UPDATE_EVERY,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -617,10 +617,10 @@ def test_network_stats():
     for interface_name, metrics in get_interface_stats(NETDATA_ALL_METRICS, interfaces).items():
         assert metrics['received_bytes'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, f'net.{interface_name}', 'received', 0),
-            multiplier=1000) / NETDATA_UPDATE_EVERY
+            multiplier=1000, divisor=8) / NETDATA_UPDATE_EVERY
         assert metrics['sent_bytes'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, f'net.{interface_name}', 'sent', 0),
-            multiplier=1000) / NETDATA_UPDATE_EVERY
+            multiplier=1000, divisor=8) / NETDATA_UPDATE_EVERY
         assert metrics['received_bytes_rate'] == metrics['received_bytes'] / NETDATA_UPDATE_EVERY
         assert metrics['sent_bytes_rate'] == metrics['sent_bytes'] / NETDATA_UPDATE_EVERY
         assert metrics['speed'] == normalize_value(safely_retrieve_dimension(


### PR DESCRIPTION
**Problem:**

Presently, Netdata is sending network statistics in kilobits, but in the middleware, these values are being interpreted as kilobytes. This results in inflated reported network statistics in the UI, both for sent and received data.

**Solution:**

The solution involves appropriately converting the Netdata values to bytes in order to accurately represent the network statistics. This adjustment will ensure the consistency and correctness of the reported data in the UI.