### PR TITLE
NAS-124669 / 24.04 / Remove extra zeros for all graphs if coming from netdata

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -79,6 +79,10 @@ class GraphBase(metaclass=GraphMeta):
 
     def normalize_metrics(self, metrics) -> dict:
         metrics['legend'] = metrics.pop('labels')
+        if metrics['data'] and metrics['data'][-1] and all(m == 0 for m in metrics['data'][-1][1:]):
+            # we will now remove last entry of data as when end if sometimes is specified as time which does not
+            # exist in netdata database, netdata adds a last entry of 0 which we don't want to show
+            metrics['data'].pop()
         return metrics
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
@@ -144,7 +148,7 @@ class GraphBase(metaclass=GraphMeta):
     def query_parameters(self) -> dict:
         return {
             'format': 'json',
-            'options': 'flip|null2zero',
+            'options': 'flip|null2zero|natural-points',
             'points': 2999,  # max supported points are 3000 in UI, we keep 2999 because netdata accounts for index 0
             'group': 'average',
             'gtime': 0,

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -235,11 +235,6 @@ class DiskTempPlugin(GraphBase):
                     self.disk_mapping[disk.id] = k
                     break
 
-    def query_parameters(self) -> dict:
-        query_params = super().query_parameters()
-        query_params['options'] += '|natural-points'
-        return query_params
-
     async def get_identifiers(self) -> typing.Optional[list]:
         return list(self.disk_mapping.keys())
 
@@ -252,10 +247,6 @@ class DiskTempPlugin(GraphBase):
         else:
             metrics['legend'][1] = 'temperature_value'
 
-        if metrics['data'] and metrics['data'][-1] and metrics['data'][-1][-1] == 0:
-            # we will now remove last entry of data as when end if sometimes is specified as time which does not
-            # exist in netdata database, netdata adds a last entry of 0 which we don't want to show
-            metrics['data'].pop()
         return metrics
 
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:


### PR DESCRIPTION
**Problem:**

There are instances where the UI queries data from Netdata using a timestamp that doesn't exist in Netdata's records. In such cases, Netdata returns a value of 0. This results in the minimum value remaining at 0, which is incorrect. However, sometimes the UI reports the correct value.

**Solution:**

To address this issue, a new "natural-points" flag has been introduced. This flag ensures that Netdata will not return data for a timestamp that doesn't exist. Additionally, a check has been added to the normalization process. This check ensures that if the last value is zero, it will be removed. These changes allow for the correct reporting of minimum values.