### PR TITLE
NAS-125004 / 24.04 / Give temporary datasets unique names in tests

### DIFF
--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -364,7 +364,7 @@ def test_10_acl_path_execute_validation():
 
 @pytest.fixture(scope="module")
 def file_and_directory():
-    with dataset("test") as ds:
+    with dataset("test_file_and_directory") as ds:
         ssh(f"mkdir /mnt/{ds}/test-directory")
         ssh(f"touch /mnt/{ds}/test-file")
         yield ds

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("role", ["SNAPSHOT_READ", "SNAPSHOT_WRITE"])
 def test_can_read_with_read_or_write_role(role):
-    with dataset("test") as ds:
+    with dataset("test_snapshot_read") as ds:
         with snapshot(ds, "test"):
             with unprivileged_user_client([role]) as c:
                 assert len(c.call("zfs.snapshot.query", [["dataset", "=", ds]])) == 1
 
 
 def test_can_not_write_with_read_role():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_write1") as ds:
         with unprivileged_user_client(["SNAPSHOT_READ"]) as c:
             with pytest.raises(ClientException) as ve:
                 c.call("zfs.snapshot.create", {
@@ -31,7 +31,7 @@ def test_can_not_write_with_read_role():
 
 
 def test_write_with_write_role():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_write2") as ds:
         with unprivileged_user_client(["SNAPSHOT_WRITE"]) as c:
             c.call("zfs.snapshot.create", {
                 "dataset": ds,
@@ -40,14 +40,14 @@ def test_write_with_write_role():
 
 
 def test_can_delete_with_write_role_with_separate_delete():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_delete1") as ds:
         with snapshot(ds, "test") as id:
             with unprivileged_user_client(["SNAPSHOT_DELETE"]) as c:
                 c.call("zfs.snapshot.delete", id)
 
 
 def test_can_not_delete_with_write_role_with_separate_delete():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_delete2") as ds:
         with snapshot(ds, "test") as id:
             with unprivileged_user_client(["SNAPSHOT_WRITE"]) as c:
                 with pytest.raises(ClientException) as ve:

--- a/tests/api2/test_cloud_sync.py
+++ b/tests/api2/test_cloud_sync.py
@@ -93,7 +93,7 @@ def test_ftp_subfolder(request, anonymous, defaultroot, has_leading_slash):
 
 @pytest.mark.parametrize("has_zvol_sibling", [True, False])
 def test_snapshot(request, has_zvol_sibling):
-    with dataset("test") as ds:
+    with dataset("test_cloudsync_snapshot") as ds:
         ssh(f"mkdir -p /mnt/{ds}/dir1/dir2")
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/dir1/dir2/blob bs=1M count=1")
 
@@ -139,7 +139,7 @@ def test_sync_onetime(request):
 
 
 def test_abort(request):
-    with dataset("test") as ds:
+    with dataset("test_cloudsync_abort") as ds:
         ssh(f"dd if=/dev/urandom of=/mnt/{ds}/blob bs=1M count=1")
 
         with local_ftp_task({
@@ -205,7 +205,7 @@ def test_create_empty_src_dirs(request, create_empty_src_dirs):
 
 
 def test_state_persist():
-    with dataset("test") as ds:
+    with dataset("test_cloudsync_state_persist") as ds:
         with local_ftp_task({
             "path": f"/mnt/{ds}",
         }) as task:
@@ -222,7 +222,7 @@ if ha:
     def test_state_failover():
         assert call("failover.status") == "MASTER"
 
-        with dataset("test") as ds:
+        with dataset("test_cloudsync_state_failover") as ds:
             with local_ftp_task({"path": f"/mnt/{ds}"}) as task:
                 call("cloudsync.sync", task["id"], job=True)
                 time.sleep(5)  # Job sending is not synchronous, allow it to propagate

--- a/tests/api2/test_cloud_sync_config.py
+++ b/tests/api2/test_cloud_sync_config.py
@@ -15,7 +15,7 @@ sys.path.append(apifolder)
 
 def test_rclone_config_writer_bool(request):
     #
-    with dataset("test") as ds:
+    with dataset("test_cloud_sync_config") as ds:
         with credential({
             "name": "Google Cloud Storage",
             "provider": "GOOGLE_CLOUD_STORAGE",

--- a/tests/api2/test_cloud_sync_custom_s3.py
+++ b/tests/api2/test_cloud_sync_custom_s3.py
@@ -26,7 +26,7 @@ sys.path.append(apifolder)
     )
 ])
 def test_custom_s3(request, credential_attributes, result):
-    with dataset("test") as ds:
+    with dataset("test_cloudsync_custom_s3") as ds:
         with credential({
             "name": "S3",
             "provider": "S3",

--- a/tests/api2/test_cloudsync_storj.py
+++ b/tests/api2/test_cloudsync_storj.py
@@ -70,7 +70,7 @@ def test_storj_list_directory(storj_credential):
 
 def test_storj_sync(request, storj_credential):
 
-    with dataset("test") as ds:
+    with dataset("test_storj_sync") as ds:
         with task({
             "direction": "PULL",
             "transfer_mode": "COPY",

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -10,13 +10,13 @@ from middlewared.test.integration.assets.account import unprivileged_user_client
 
 @pytest.fixture(scope="session")
 def ds():
-    with dataset("test") as ds:
+    with dataset("nfs_crud_test1") as ds:
         yield ds
 
 
 @pytest.fixture(scope="session")
 def share():
-    with dataset("test2") as ds:
+    with dataset("nfs_crud_test2") as ds:
         with nfs_share(ds) as share:
             yield share
 

--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -6,7 +6,7 @@ from middlewared.test.integration.utils import call
 
 @pytest.mark.parametrize("child", ["a/b", "a/b/c"])
 def test_pool_dataset_create_ancestors(child):
-    with dataset("test") as test_ds:
+    with dataset("ancestors_create_test") as test_ds:
         name = f"{test_ds}/{child}"
         call("pool.dataset.create", {"name": name, "create_ancestors": True})
         call("pool.dataset.get_instance", name)

--- a/tests/api2/test_pool_dataset_details.py
+++ b/tests/api2/test_pool_dataset_details.py
@@ -7,8 +7,8 @@ from middlewared.test.integration.utils import call, ssh
 
 @pytest.fixture(scope="module")
 def cloud_sync_fixture():
-    with dataset("test") as test_ds:
-        with dataset("other") as other_ds:
+    with dataset("test_pool_dataset_details") as test_ds:
+        with dataset("test_pool_dataset_details_other") as other_ds:
             with local_ftp_task({
                 "path": f"/mnt/{pool}",
             }) as task:

--- a/tests/api2/test_pool_dataset_encrypted.py
+++ b/tests/api2/test_pool_dataset_encrypted.py
@@ -19,7 +19,7 @@ def encryption_props():
 
 
 def test_delete_locked_dataset():
-    with dataset("test", encryption_props()) as ds:
+    with dataset("test_delete_locked_dataset", encryption_props()) as ds:
         call("pool.dataset.lock", ds, job=True)
 
     with pytest.raises(CallError) as ve:
@@ -29,7 +29,7 @@ def test_delete_locked_dataset():
 
 
 def test_unencrypted_dataset_within_encrypted_dataset():
-    with dataset("test", encryption_props()) as ds:
+    with dataset("test_pool_dataset_witin_encryted", encryption_props()) as ds:
         with pytest.raises(ValidationErrors) as ve:
             call("pool.dataset.create", {
                 "name": f"{ds}/child",

--- a/tests/api2/test_pool_dataset_set_quota.py
+++ b/tests/api2/test_pool_dataset_set_quota.py
@@ -17,7 +17,7 @@ sys.path.append(os.getcwd())
     (["GROUPOBJ", "groupobj quota on gid"]),
 ])
 def test_errors(request, id, quota_type, error):
-    with dataset("test") as ds:
+    with dataset("test_pool_dataset_setquota") as ds:
         with pytest.raises(ValidationErrors) as ve:
             call("pool.dataset.set_quota", ds, [{"quota_type": quota_type, "id": id, "quota_value": 5242880}])
 

--- a/tests/api2/test_pool_dataset_snapshot_count.py
+++ b/tests/api2/test_pool_dataset_snapshot_count.py
@@ -11,7 +11,7 @@ sys.path.append(os.getcwd())
 
 
 def test_empty_for_locked_root_dataset():
-    with dataset("test") as ds:
+    with dataset("test_pool_dataset_snapshot_count") as ds:
         for i in range(7):
             call("zfs.snapshot.create", {"dataset": ds, "name": f"snap-{i}"})
 

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -10,13 +10,13 @@ from middlewared.test.integration.assets.account import unprivileged_user_client
 
 @pytest.fixture(scope="session")
 def ds():
-    with dataset("test") as ds:
+    with dataset("smb_crud_test") as ds:
         yield ds
 
 
 @pytest.fixture(scope="session")
 def share():
-    with dataset("test2") as ds:
+    with dataset("smb_crud_test2") as ds:
         with smb_share(f"/mnt/{ds}", "test2") as share:
             yield share
 

--- a/tests/api2/test_zfs_snapshot_events.py
+++ b/tests/api2/test_zfs_snapshot_events.py
@@ -10,7 +10,7 @@ from middlewared.test.integration.utils import client
 
 
 def test_create():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_events_create") as ds:
         with client() as c:
             events = []
 
@@ -27,7 +27,7 @@ def test_create():
 
 
 def test_delete():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_events_delete") as ds:
         with client() as c:
             c.call("zfs.snapshot.create", {"dataset": ds, "name": "test"})
 
@@ -46,7 +46,7 @@ def test_delete():
 
 
 def test_delete_with_dependent_clone():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_events_dependent_clone") as ds:
         with client() as c:
             c.call("zfs.snapshot.create", {"dataset": ds, "name": "test"})
             c.call("zfs.snapshot.clone", {"snapshot": f"{ds}@test", "dataset_dst": f"{ds}/clone01"})
@@ -64,7 +64,7 @@ def test_delete_with_dependent_clone():
 
 
 def test_delete_nonexistent_snapshot():
-    with dataset("test") as ds:
+    with dataset("test_snapshot_events_nonexistent_snapshot") as ds:
         with client() as c:
             c.call("zfs.snapshot.create", {"dataset": ds, "name": "test"})
 

--- a/tests/api2/test_zfs_snapshot_hold.py
+++ b/tests/api2/test_zfs_snapshot_hold.py
@@ -5,13 +5,13 @@ from middlewared.test.integration.utils import call
 
 
 def test_normal_snapshot():
-    with dataset("test") as ds:
+    with dataset("test_normal_hold") as ds:
         with snapshot(ds, "test") as id:
             assert call("zfs.snapshot.get_instance", id, {"extra": {"holds": True}})["holds"] == {}
 
 
 def test_held_snapshot():
-    with dataset("test") as ds:
+    with dataset("test_held_snapshot") as ds:
         with snapshot(ds, "test") as id:
             call("zfs.snapshot.hold", id)
 
@@ -21,8 +21,8 @@ def test_held_snapshot():
 
 
 def test_held_snapshot_tree():
-    with dataset("test") as ds:
-        with dataset("test/child") as ds2:
+    with dataset("test_snapshot_tree") as ds:
+        with dataset("test_snapshot_tree/child") as ds2:
             with snapshot(ds, "test", recursive=True) as id:
                 id2 = f"{ds2}@test"
 


### PR DESCRIPTION
This helps identify places where perhaps teardown of dataset is failing.