### PR TITLE
NAS-124987 / 23.10.1 / Correctly retrieve used ips (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -18,4 +18,4 @@ class InterfaceService(Service):
             # can be obtained from platform team.
             result.append('eno1')
 
-        return result
+        return result.copy()


### PR DESCRIPTION
This commit adds changes to create a copy of internal interfaces which we retrieve because in places we manipulate the list and remove interaces like loopback device which results in tracebacks in various places as `interface.ip_in_use` errors out.
```
❯ midclt call interface.ip_in_use '{"any": true, "static": false, "loopback": true}' | jq
list.remove(x): x not in list
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 201, in call_method
    result = await self.middleware._call(message['method'], serviceobj, methodobj, params, app=self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1367, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1265, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 181, in nf
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 50, in nf
    res = f(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/network.py", line 1854, in ip_in_use
    ignore_nics.remove('lo')
ValueError: list.remove(x): x not in list
```

Original PR: https://github.com/truenas/middleware/pull/12433
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124987