### PR TITLE
NAS-125009 / 24.04 / Fix scope of role CRUD tests

### DIFF
--- a/tests/api2/test_iscsi_extent_crud_roles.py
+++ b/tests/api2/test_iscsi_extent_crud_roles.py
@@ -8,13 +8,13 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.account import unprivileged_user_client
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def ds():
     with dataset("test", {"type": "VOLUME", "volsize": 1048576}) as ds:
         yield ds
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def share():
     with dataset("test2", {"type": "VOLUME", "volsize": 1048576}) as ds:
         with iscsi_extent({

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -8,13 +8,13 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.account import unprivileged_user_client
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def ds():
     with dataset("nfs_crud_test1") as ds:
         yield ds
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def share():
     with dataset("nfs_crud_test2") as ds:
         with nfs_share(ds) as share:

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -8,13 +8,13 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.account import unprivileged_user_client
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def ds():
     with dataset("smb_crud_test") as ds:
         yield ds
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def share():
     with dataset("smb_crud_test2") as ds:
         with smb_share(f"/mnt/{ds}", "test2") as share:


### PR DESCRIPTION
We want shares and datasets torn down when the series of tests performed in the respective pytest files are complete, as opposed to having them persist for the remaining test run.