### PR TITLE
NAS-125042 / 24.04 / Add isStopped metadata to chart upgrade

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -285,6 +285,7 @@ class ChartReleaseService(Service):
                 **get_action_context(release_name),
                 'operation': 'UPGRADE',
                 'isUpgrade': True,
+                'isStopped': release_orig['status'] == 'STOPPED',
                 'upgradeMetadata': {
                     'oldChartVersion': release['chart_metadata']['version'],
                     'newChartVersion': catalog_item['version'],


### PR DESCRIPTION
Why is this needed?

[Scenario](https://github.com/truenas/charts/issues/1687):
- User stops the application and there is an upgrade available.
- User clicks upgrade while the application is still stopped.

What is the issue?

Usually applications with databases may have a `pre-upgrade` hook to create a database dump before the application upgrade.
If the application is stopped and an upgrade is triggered, the hook will try to reach the database but the database is stopped. This will lead to a timeout from Helm (unless the script job exists with 0 and do not wait for ever for the database to respond), and the upgrade will be blocked.

This can be both a good and a bad thing.  The good thing is that the upgrade is blocked because a backup could not be created.
But what if the container is broken, cannot start and the upgrade fixes that?

---

Having this extra piece of metadata, will allow the app developer to block the upgrade by throwing a friendly error message,  that the app must be running in order to proceed with the upgrade **or** other option is to use this metadata and skip the `pre-upgrade` job hook completely, so the upgrade can proceed.

Also with that metadata available, App developer can potentially keep all resources scaled down (if the `isStopped` is true).
(Currently after an upgrade the app will go active, regardless of the previous state.)

In case the app developer **keep**  the resources scaled down, the **in-container** upgrade process (that may or may not have) will run once the user hits the start button. That also means, that context will no longer contain the `isUpgrade: True`. This must be taken into consideration by the app developer, on a per case basis.

But at least this gives the "power" to make decision. 

Well that was a lot of info for a single line :D