### PR TITLE
NAS-125012 / 23.10.1 / fix memory leak using mutable global variables (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -10,7 +10,8 @@ class InterfaceService(Service):
 
     @private
     async def internal_interfaces(self):
-        result = netif.INTERNAL_INTERFACES
+        # expicit call to list() is important here
+        result = list(netif.INTERNAL_INTERFACES)
         result.extend(await self.middleware.call('failover.internal_interface.detect'))
         if (await self.middleware.call('truenas.get_chassis_hardware')).startswith('TRUENAS-F'):
             # The eno1 interface needs to be masked on the f-series platform because

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
@@ -1,16 +1,15 @@
-# -*- coding=utf-8 -*-
-import logging
 import subprocess
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["bitmask_to_set", "INTERNAL_INTERFACES", "run"]
 
 
-INTERNAL_INTERFACES = [
+# Keep this as an immutable type since this
+# is used all over the place and we don't want
+# the contents to change
+INTERNAL_INTERFACES = (
     "wg", "lo", "tun", "tap", "docker", "veth", "kube-bridge", "kube-dummy-if", "vnet",
     "macvtap", "ix", "tailscale",
-]
+)
 
 
 def bitmask_to_set(n, enumeration):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1918,7 +1918,8 @@ async def udevd_ifnet_hook(middleware, data):
         return
 
     iface = data.get('INTERFACE')
-    if iface is None or iface.startswith(tuple(netif.CLONED_PREFIXES)):
+    ignore = netif.CLONED_PREFIXES + netif.INTERNAL_INTERFACES
+    if iface is None or iface.startswith(ignore):
         # if the udevd event for the interface doesn't have a name (doubt this happens on SCALE)
         # or if the interface startswith CLONED_PREFIXES, then we return since we only care about
         # physical interfaces that are hot-plugged into the system.


### PR DESCRIPTION
Revert b95d161c1c5b74f7391186cb80e6d369ee4965d6 since it's not a valid fix and only masks the real problem. The real problem is that a regression was introduced in f03e9fb8744684fa4f6aa0d978e2bb8dce26b458 whereby we keep `append`'ing and `extend`'ing the contents of the global mutable variable (INTERNAL_INTERFACES). This list grows every time the `interface.internal_interfaces` method is called.

This was fixed once before in the past but was introduced again. To try and prevent this from happening again, `INTERNAL_INTERFACES` has been converted to an immutable type. While I'm here, I've also converted `CLONED_PREFIXES` to an immutable type even though there were no instances where that was growing.

Original PR: https://github.com/truenas/middleware/pull/12441
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125012