### PR TITLE
NAS-125052 / 24.04 / Add roles to filesystem plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -30,7 +30,7 @@ class FilesystemService(Service):
     class Config:
         cli_private = True
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(Bool())
     def is_immutable(self, path):
         """
@@ -67,7 +67,7 @@ class FilesystemService(Service):
     def set_dosmode(self, data):
         return dosmode.set_dosflags(data['path'], data['dosmode'])
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(Ref('dosmode'))
     def get_dosmode(self, path):
         return dosmode.get_dosflags(path)
@@ -129,7 +129,7 @@ class FilesystemService(Service):
         mntinfo = getmntinfo()
         return filter_list(list(mntinfo.values()), filters, options)
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_DATA_WRITE'])
     @returns(Ref('path_entry'))
     def mkdir(self, path):
         """
@@ -214,7 +214,12 @@ class FilesystemService(Service):
 
         return out
 
-    @accepts(Str('path', required=True), Ref('query-filters'), Ref('query-options'))
+    @accepts(
+        Str('path', required=True),
+        Ref('query-filters'),
+        Ref('query-options'),
+        roles=['FILESYSTEM_ATTRS_READ']
+    )
     @filterable_returns(Dict(
         'path_entry',
         Str('name', required=True),
@@ -326,7 +331,7 @@ class FilesystemService(Service):
 
         return filter_list(rv, filters=filters or [], options=options or {})
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(Dict(
         'path_stats',
         Str('realpath', required=True),
@@ -483,7 +488,7 @@ class FilesystemService(Service):
             os.chmod(path, mode)
         return True
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(Dict(
         'path_statfs',
         List('flags', required=True),
@@ -574,7 +579,7 @@ class FilesystemService(Service):
             result[f'{k}_str'] = str(result[k])
         return result
 
-    @accepts(Str('path'))
+    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(Bool('paths_acl_is_trivial'))
     def acl_is_trivial(self, path):
         """

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -180,7 +180,7 @@ class ACLBase(ServicePartBase):
                 Bool('traverse', default=False),
                 Bool('canonicalize', default=True)
             )
-        )
+        ), roles=['FILESYSTEM_ATTRS_WRITE']
     )
     @returns()
     @job(lock="perm_change")
@@ -224,6 +224,7 @@ class ACLBase(ServicePartBase):
         Str('path'),
         Bool('simplified', default=True),
         Bool('resolve_ids', default=False),
+        roles=['FILESYSTEM_ATTRS_READ']
     )
     @returns(Dict(
         'truenas_acl',
@@ -281,7 +282,8 @@ class ACLBase(ServicePartBase):
                 Bool('recursive', default=False),
                 Bool('traverse', default=False)
             )
-        )
+        ),
+        roles=['FILESYSTEM_ATTRS_WRITE']
     )
     @returns()
     @job(lock="perm_change")
@@ -313,7 +315,8 @@ class ACLBase(ServicePartBase):
                 Bool('recursive', default=False),
                 Bool('traverse', default=False),
             )
-        )
+        ),
+        roles=['FILESYSTEM_ATTRS_WRITE']
     )
     @returns()
     @job(lock="perm_change")
@@ -386,7 +389,7 @@ class ACLBase(ServicePartBase):
             'options',
             Bool('force', default=False),
         )
-    ))
+    ), roles=['FILESYSTEM_ATTRS_WRITE'])
     @job()
     def add_to_acl(self, job, data):
         """

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -65,7 +65,7 @@ class ACLTemplateService(CRUDService):
         Str("comment"),
         OROperator(Ref('nfs4_acl'), Ref('posix1e_acl'), name='acl', required=True),
         register=True
-    ))
+    ), roles=['FILESYSTEM_ATTRS_WRITE'])
     async def do_create(self, data):
         """
         Create a new filesystem ACL template.
@@ -94,7 +94,8 @@ class ACLTemplateService(CRUDService):
             'acltemplate_create',
             'acltemplate_update',
             ('attr', {'update': True})
-        )
+        ),
+        roles=['FILESYSTEM_ATTRS_WRITE']
     )
     async def do_update(self, id_, data):
         """
@@ -266,8 +267,8 @@ class ACLTemplateService(CRUDService):
             Bool("canonicalize", default=False),
             Bool("ensure_builtins", default=False),
             Bool("resolve_names", default=False),
-        )
-    ))
+        ),
+    ), roles=['FILESYSTEM_ATTRS_READ'])
     @returns(List(
         'templates',
         items=[Ref('acltemplate_entry')]

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -12,7 +12,7 @@ class PoolDatasetService(Service):
     class Config:
         namespace = 'pool.dataset'
 
-    @accepts()
+    @accepts(roles=['DATASET_READ', 'READONLY'])
     @returns(List(
         'dataset_details',
         example=[{

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -17,8 +17,15 @@ class Role:
 
 
 ROLES = {
+    'FILESYSTEM_ATTRS_READ': Role(),
+    'FILESYSTEM_ATTRS_WRITE': Role(includes=['FILESYSTEM_ATTRS_READ']),
+    'FILESYSTEM_DATA_READ': Role(),
+    'FILESYSTEM_DATA_WRITE': Role(includes=['FILESYSTEM_DATA_READ']),
+    'FILESYSTEM_FULL_CONTROL': Role(includes=['FILESYSTEM_ATTRS_WRITE',
+                                              'FILESYSTEM_DATA_WRITE']),
+
     'FULL_ADMIN': Role(full_admin=True),
-    'READONLY': Role(),
+    'READONLY': Role(includes=['FILESYSTEM_READ_ATTRS']),
 
     'SHARING_ISCSI_EXTENT_READ': Role(),
     'SHARING_ISCSI_EXTENT_WRITE': Role(includes=['SHARING_ISCSI_EXTENT_READ']),
@@ -55,8 +62,10 @@ ROLES = {
                                           'REPLICATION_TASK_WRITE',
                                           'SNAPSHOT_TASK_WRITE',
                                           'SNAPSHOT_WRITE']),
+
     'SHARING_MANAGER': Role(includes=['DATASET_WRITE',
-                                      'SHARING_WRITE'])
+                                      'SHARING_WRITE',
+                                      'FILESYSTEM_ATTRS_WRITE'])
 }
 
 

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -75,6 +75,11 @@ def test_read_role_can_call_method(role, method, params):
     ("user.query", []),
     ("user.shell_choices", []),
     ("auth.me", []),
+    ("filesystem.listdir", ["/"]),
+    ("filesystem.stat", ["/"]),
+    ("filesystem.getacl", ["/"]),
+    ("filesystem.acltemplate.by_path", [{"path": "/"}]),
+    ("pool.dataset.details", []),
 ])
 def test_readonly_can_call_method(method, params):
     with unprivileged_user_client(["READONLY"]) as c:
@@ -85,5 +90,11 @@ def test_readonly_can_not_call_method():
     with unprivileged_user_client(["READONLY"]) as c:
         with pytest.raises(ClientException) as ve:
             c.call("user.create")
+
+        assert ve.value.errno == errno.EACCES
+
+        with pytest.raises(ClientException) as ve:
+            # fails with EPERM if API access granted
+            c.call("filesystem.mkdir", "/foo")
 
         assert ve.value.errno == errno.EACCES


### PR DESCRIPTION
This commit adds filesystem specific roles, and grants FILESYSTEM_READ_ATTRS to the READONLY role since this is required to render many webui components. The SHARING_MANAGER role is granted FILESYSTEM_WRITE_ATTRS so that it is allowed to chown, setperm, setacl, etc.