### PR TITLE
NAS-125055 / 24.04 / Add roles for SMB share ACL and status

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1873,7 +1873,7 @@ class SharingSMBService(SharingService):
 
         return data
 
-    @accepts()
+    @accepts(roles=['SHARING_SMB_READ'])
     async def presets(self):
         """
         Retrieve pre-defined configuration sets for specific use-cases. These parameter

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1898,7 +1898,7 @@ class SharingSMBService(SharingService):
             ),
         ], default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]),
         register=True
-    ))
+    ), roles=['SHARING_SMB_WRITE'])
     @returns(Ref('smb_share_acl'))
     async def setacl(self, data):
         """
@@ -1980,7 +1980,7 @@ class SharingSMBService(SharingService):
             })
         return await self.getacl({'share_name': data['share_name']})
 
-    @accepts(Dict('smb_getacl', Str('share_name', required=True)))
+    @accepts(Dict('smb_getacl', Str('share_name', required=True)), roles=['SHARING_SMB_READ'])
     @returns(Ref('smb_share_acl'))
     async def getacl(self, data):
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/smb_/status.py
+++ b/src/middlewared/middlewared/plugins/smb_/status.py
@@ -30,12 +30,13 @@ class SMBService(Service):
         Str('info_level', enum=[x.name for x in InfoLevel], default=InfoLevel.ALL.name),
         Ref('query-filters'),
         Ref('query-options'),
-        Dict('status_options',
-             Bool('verbose', default=True),
-             Bool('fast', default=False),
-             Str('restrict_user', default=''),
-             Str('restrict_session', default=''),
-             )
+        Dict(
+            'status_options',
+            Bool('verbose', default=True),
+            Bool('fast', default=False),
+            Str('restrict_user', default=''),
+            Str('restrict_session', default=''),
+        ), roles=['SHARING_SMB_WRITE']
     )
     def status(self, info_level, filters, options, status_options):
         """
@@ -127,7 +128,7 @@ class SMBService(Service):
 
         return filter_list(to_filter, filters, options)
 
-    @accepts()
+    @accepts(roles=['SHARING_SMB_READ'])
     def client_count(self):
         """
         Return currently connected clients count.

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -121,7 +121,7 @@ def test_002_check_client_count(request):
         password=SMB_PWD,
         smb1=False
     ) as c:
-        assert c.call("smb.client_count") == 1
+        assert call("smb.client_count") == 1
 
 
 @pytest.mark.dependency(name="SHARE_IS_WRITABLE")

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -112,6 +112,18 @@ def test_001_initialize_smb_servce(initialize_for_smb_tests):
     TEST_DATA.update(initialize_for_smb_tests)
 
 
+def test_002_check_client_count(request):
+    depends(request, ["SMB_SHARE_CREATED"])
+    with smb_connection(
+        host=ip,
+        share=SMB_NAME,
+        username=SMB_USER,
+        password=SMB_PWD,
+        smb1=False
+    ) as c:
+        assert c.call("smb.client_count") == 1
+
+
 @pytest.mark.dependency(name="SHARE_IS_WRITABLE")
 def test_009_share_is_writable(request):
     """

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -42,6 +42,18 @@ def test_read_role_cant_write(ds, share, role):
             c.call("sharing.smb.delete", share["id"])
         assert ve.value.errno == errno.EACCES
 
+        # READ access should allow reading ACL
+        c.call("sharing.smb.getacl", share["name"])
+
+        with pytest.raises(ClientException) as ve:
+            c.call("sharing.smb.setacl", {"share_name": share["name"]})
+        assert ve.value.errno == errno.EACCES
+
+        # Gathering session info should be more administrative-level op
+        with pytest.raises(ClientException) as ve:
+            c.call("smb.status")
+        assert ve.value.errno == errno.EACCES
+
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])
 def test_write_role_can_write(ds, role):
@@ -51,3 +63,8 @@ def test_write_role_can_write(ds, role):
         c.call("sharing.smb.update", share["id"], {})
 
         c.call("sharing.smb.delete", share["id"])
+
+        # READ access should allow reading ACL
+        c.call("sharing.smb.getacl", share["name"])
+        c.call("sharing.smb.setacl", {"share_name": share["name"]})
+        c.call("smb.status")


### PR DESCRIPTION
This allows properly authorized users to view / set SMB share ACL and view SMB status.