### PR TITLE
NAS-123903 / 24.04 / Add initial test support for NFSv41 acl_flag

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -248,6 +248,7 @@ class ACLBase(ServicePartBase):
                 'nfs41_flags',
                 Bool('autoinherit', default=False),
                 Bool('protected', default=False),
+                Bool('defaulted', default=False),
             ),
             Str('acltype', enum=[x.name for x in ACLType], null=True),
             Dict(

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -312,6 +312,7 @@ class FilesystemService(Service, ACLBase):
         na41flags = output.pop('nfs41_flags')
         output['nfs41_flags'] = {
             "protected": na41flags['PROTECTED'],
+            "defaulted": na41flags['DEFAULTED'],
             "autoinherit": na41flags['AUTOINHERIT']
         }
         output['acltype'] = 'NFS4'

--- a/tests/protocols/nfs_proto.py
+++ b/tests/protocols/nfs_proto.py
@@ -290,6 +290,30 @@ class SSH_NFS(NFS):
         if setfacl['result'] is False:
             raise RuntimeError(setfacl['stderr'])
 
+    def getaclflag(self, path):
+        self.validate(path)
+        # nfs4_getfacl has no knowledge of acl_flags, use nfs4xfr_getfacl instead
+        getfacl = SSH_TEST(
+            f"nfs4xdr_getfacl {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if getfacl['result'] is False:
+            raise RuntimeError(getfacl['stderr'])
+        for line in getfacl['stdout'].split('\n'):
+            if line.startswith('# ACL flags:'):
+                return line.split(':')[1].strip()
+        raise RuntimeError('Could not find acl_flag')
+
+    def setaclflag(self, path, value):
+        self.validate(path)
+        # nfs4_setfacl has no knowledge of acl_flags, use nfs4xfr_setfacl instead
+        getfacl = SSH_TEST(
+            f"nfs4xdr_setfacl -p {value} {self._localpath}/{path}",
+            self._user, self._password, self._ip
+        )
+        if getfacl['result'] is False:
+            raise RuntimeError(getfacl['stderr'])
+
     def getxattr(self, path, xattr_name):
         self.validate(path)
 


### PR DESCRIPTION
Add initial testing for NFSv4.1 `acl_flag`

This is done by enhancing test_43_check_nfsv4_acl_support to handle multiple NFS versions (NFSv4.2, NFSv4.1 & NFSv4.0) and then test setting each available value (`auto-inherit`, `protected`, `defaulted`) for `acl_flag`.

Add missing `defaulted` support to our middleware filesystem plugin (for test purposes).

----
**NOTE:** This PR is **WIP** for the time being, until the underlying linux kernel [PR](https://github.com/truenas/linux/pull/142) lands.