### PR TITLE
NAS-125060 / 24.04 / Add no_authz_required fixture

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -345,6 +345,8 @@ class Application:
                 if not self.authenticated:
                     self.send_error(message, ErrnoMixin.ENOTAUTHENTICATED, 'Not authenticated')
                     error = True
+                elif hasattr(methodobj, '_no_authz_required'):
+                    pass
                 elif not self.authenticated_credentials.authorize('CALL', message['method']):
                     self.send_error(message, errno.EACCES, 'Not authorized')
                     error = True

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -13,7 +13,7 @@ from middlewared.auth import (SessionManagerCredentials, UserSessionManagerCrede
                               TrueNasNodeSessionManagerCredentials)
 from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, Password, Patch, returns, Str
 from middlewared.service import (
-    Service, filterable, filterable_returns, filter_list, no_auth_required,
+    Service, filterable, filterable_returns, filter_list, no_auth_required, no_authz_required,
     pass_app, private, cli_private, CallError,
 )
 from middlewared.service_exception import MatchNotFound
@@ -516,6 +516,7 @@ class AuthService(Service):
         self.session_manager.logout(app)
         return True
 
+    @no_authz_required
     @accepts()
     @returns(
         Patch(

--- a/src/middlewared/middlewared/service/__init__.py
+++ b/src/middlewared/middlewared/service/__init__.py
@@ -9,8 +9,8 @@ from .config_service import ConfigService # noqa
 from .core_service import CoreService, MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH # noqa
 from .crud_service import CRUDService # noqa
 from .decorators import ( # noqa
-    cli_private, filterable, filterable_returns, item_method, job, lock, no_auth_required, pass_app,
-    periodic, private, rest_api_metadata, skip_arg, threaded,
+    cli_private, filterable, filterable_returns, item_method, job, lock, no_auth_required,
+    no_authz_required, pass_app, periodic, private, rest_api_metadata, skip_arg, threaded,
 )
 from .service import Service # noqa
 from .service_mixin import ServiceChangeMixin # noqa

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -339,6 +339,7 @@ class CoreService(Service):
 
                 method_name = f'{name}.{attr}'
                 no_auth_required = hasattr(method, '_no_auth_required')
+                no_authz_required = hasattr(method, '_no_authz_required')
 
                 # Skip methods that are not allowed for the currently authenticated credentials
                 if app is not None:
@@ -346,7 +347,7 @@ class CoreService(Service):
                         if not app.authenticated_credentials:
                             continue
 
-                        if not app.authenticated_credentials.authorize('CALL', method_name):
+                        if not no_authz_required and not app.authenticated_credentials.authorize('CALL', method_name):
                             continue
 
                 examples = defaultdict(list)

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -170,6 +170,12 @@ def no_auth_required(fn):
     return fn
 
 
+def no_authz_required(fn):
+    """Authorization not required to use the given method."""
+    fn._no_authz_required = True
+    return fn
+
+
 def pass_app(*, require=False, rest=False):
     """Pass the application instance as parameter to the method."""
     def wrapper(fn):

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -74,6 +74,7 @@ def test_read_role_can_call_method(role, method, params):
     ("user.get_instance", [1]),
     ("user.query", []),
     ("user.shell_choices", []),
+    ("auth.me", []),
 ])
 def test_readonly_can_call_method(method, params):
     with unprivileged_user_client(["READONLY"]) as c:


### PR DESCRIPTION
There are situations where we want methods to be callable by all authenticated users whilst disallowing unauthenticated users. This commit adds a decorator `no_authz_required` to mirror existing `no_auth_required`.