### PR TITLE
NAS-125067 / 24.04 / Always allow authenticated users to set webui prefs

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -539,6 +539,7 @@ class AuthService(Service):
 
         return {**user, 'attributes': attributes}
 
+    @no_authz_required
     @accepts(
         Str('key'),
         Any('value'),

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -98,3 +98,11 @@ def test_readonly_can_not_call_method():
             c.call("filesystem.mkdir", "/foo")
 
         assert ve.value.errno == errno.EACCES
+
+
+def test_limited_user_can_set_own_attributes():
+    with unprivileged_user_client(["READONLY"]) as c:
+        c.call("auth.set_attribute", "foo", "bar")
+        attrs = c.call("auth.me")["attributes"]
+        assert "foo" in attrs
+        assert attrs["foo"] == "bar"


### PR DESCRIPTION
The attributes dictionary contains webui preferences as determined
by the UI team. Users should be able to write to their own settings
regardless of privileges granted to them.