### PR TITLE
NAS-125070 / 24.04 / Allow all authenticated users to get basic state info

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -11,7 +11,7 @@ from dns.exception import DNSException
 from middlewared.plugins.gluster_linux.utils import GlusterConfig
 from middlewared.schema import Bool, returns
 from middlewared.service import (Service, ValidationErrors, accepts, job,
-                                 private)
+                                 private, no_authz_required)
 from middlewared.service_exception import CallError
 from middlewared.utils.path import CLUSTER_PATH_PREFIX
 
@@ -22,6 +22,7 @@ class ClusterUtils(Service):
         namespace = 'cluster.utils'
         cli_namespace = 'service.cluster.utils'
 
+    @no_authz_required
     @accepts()
     @returns(Bool('is_clustered'))
     async def is_clustered(self):

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -7,7 +7,7 @@ import errno
 
 from base64 import b64encode, b64decode
 from middlewared.schema import accepts, Dict, List, OROperator, Ref, returns, Str
-from middlewared.service import Service, private, job
+from middlewared.service import no_authz_required, Service, private, job
 from middlewared.plugins.smb import SMBCmd, SMBPath
 from middlewared.service_exception import CallError
 from middlewared.utils import run
@@ -141,6 +141,7 @@ class DirectoryServices(Service):
         service = "directoryservices"
         cli_namespace = "directory_service"
 
+    @no_authz_required
     @accepts()
     @returns(Dict(
         'directory_services_states',

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -14,7 +14,8 @@ from functools import partial
 from middlewared.auth import is_ha_connection, TrueNasNodeSessionManagerCredentials
 from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str, returns, Patch
 from middlewared.service import (
-    job, no_auth_required, pass_app, private, CallError, ConfigService, ValidationError, ValidationErrors
+    job, no_auth_required, no_authz_required, pass_app, private, CallError, ConfigService,
+    ValidationError, ValidationErrors
 )
 import middlewared.sqlalchemy as sa
 from middlewared.plugins.auth import AuthService
@@ -134,6 +135,7 @@ class FailoverService(ConfigService):
         else:
             raise CallError('Unable to change node state in MANUAL mode')
 
+    @no_authz_required
     @accepts()
     @returns(Bool())
     def licensed(self):

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -5,7 +5,7 @@ from licenselib.license import ContractType, Features, License
 from pathlib import Path
 
 from middlewared.schema import accepts, Bool, returns, Str
-from middlewared.service import CallError, no_auth_required, private, Service
+from middlewared.service import CallError, no_auth_required, no_authz_required, private, Service
 from middlewared.utils import sw_info
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
@@ -78,6 +78,7 @@ class SystemService(Service):
         """
         return "TrueNAS"
 
+    @no_authz_required
     @accepts()
     @returns(Str('truenas_version_shortname'))
     def version_short(self):
@@ -105,12 +106,14 @@ class SystemService(Service):
             else:
                 return f'{base_url}/#{"".join(to_format)}'
 
+    @no_authz_required
     @accepts()
     @returns(Str('truenas_version'))
     def version(self):
         """Returns the full name of the software version of the system."""
         return sw_info()['fullname']
 
+    @no_authz_required
     @accepts()
     @returns(Str('is_stable'))
     def is_stable(self):


### PR DESCRIPTION
This allows all authenticated users to retrieve the following info:

* directory services state (HEALTHY, DISABLED, FAULTED)
* whether system is licensed for failover
* truenas version information

These are required for basic UI info on login