### PR TITLE
NAS-125084 / 24.04 / Fix typo in READONLY role

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -25,7 +25,7 @@ ROLES = {
                                               'FILESYSTEM_DATA_WRITE']),
 
     'FULL_ADMIN': Role(full_admin=True),
-    'READONLY': Role(includes=['FILESYSTEM_READ_ATTRS']),
+    'READONLY': Role(includes=['FILESYSTEM_ATTRS_READ']),
 
     'SHARING_ISCSI_EXTENT_READ': Role(),
     'SHARING_ISCSI_EXTENT_WRITE': Role(includes=['SHARING_ISCSI_EXTENT_READ']),


### PR DESCRIPTION
Constants were renamed during review process, and the item granting READONLY role ability to read file attributes was missed resulting in READONLY being unable to read filesystem-related attributes.