### PR TITLE
NAS-125085 / 24.04 / Do not apply no_authz_required for API keys

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -4,6 +4,8 @@ from middlewared.utils.allowlist import Allowlist
 
 
 class SessionManagerCredentials:
+    is_user_session = False
+
     @classmethod
     def class_name(cls):
         return re.sub(
@@ -38,6 +40,7 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
     def __init__(self, user):
         self.user = user
         self.allowlist = Allowlist(user["privilege"]["allowlist"])
+        self.is_user_session = True
 
     def authorize(self, method, resource):
         return self.allowlist.authorize(method, resource)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -345,7 +345,13 @@ class Application:
                 if not self.authenticated:
                     self.send_error(message, ErrnoMixin.ENOTAUTHENTICATED, 'Not authenticated')
                     error = True
-                elif hasattr(methodobj, '_no_authz_required'):
+
+                # Some methods require authentication to the NAS (a valid account)
+                # but not explicit authorization. In this case the authorization
+                # check is bypassed as long as it is a user session. API keys
+                # explicitly whitelist particular methods and are used for targeted
+                # purposes, and so authorization is _always_ enforced.
+                elif self.authenticated_credentials.is_user_session and hasattr(methodobj, '_no_authz_required'):
                     pass
                 elif not self.authenticated_credentials.authorize('CALL', message['method']):
                     self.send_error(message, errno.EACCES, 'Not authorized')

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -168,6 +168,7 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
     def __init__(self, token_manager, token):
         self.token_manager = token_manager
         self.token = token
+        self.is_user_session = token.root_credentials().is_user_session
 
     def is_valid(self):
         return self.token.is_valid()

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -6,6 +6,7 @@ import pytest
 from middlewared.client import ClientException
 from middlewared.test.integration.assets.account import unprivileged_user_client
 from middlewared.test.integration.assets.pool import dataset, snapshot
+from middlewared.test.integration.utils import client
 
 logger = logging.getLogger(__name__)
 
@@ -106,3 +107,12 @@ def test_limited_user_can_set_own_attributes():
         attrs = c.call("auth.me")["attributes"]
         assert "foo" in attrs
         assert attrs["foo"] == "bar"
+
+
+def test_limited_user_auth_token_behavior():
+    with unprivileged_user_client(["READONLY"]) as c:
+        auth_token = c.call("auth.generate_token")
+
+        with client(auth=None) as c2:
+            assert c2.call("auth.login_with_token", auth_token)
+            c2.call("auth.me")

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -59,6 +59,34 @@ def test_denied_api_key_websocket(request):
         assert results['result'] is False
 
 
+def test_denied_api_key_noauthz(request):
+    with api_key([{"method": "CALL", "resource": "system.info"}]) as key:
+        auth_token = None
+
+        with client(auth=None) as c:
+            assert c.call("auth.login_with_api_key", key)
+
+            # verify API key works as expected
+            c.call('system.info')
+
+            # system.product_type has no_authz_required
+            # this should fail do to lack of authorization for
+            # API key
+            with pytest.raises(Exception):
+                c.call("system.version")
+
+            auth_token = c.call("auth.generate_token")
+
+        with client(auth=None) as c:
+            assert c.call("auth.login_with_token", auth_token)
+
+            # verify that token has same access rights
+            c.call('system.info')
+
+            with pytest.raises(Exception):
+                c.call("system.version")
+
+
 def test_api_key_auth_session_list_terminate():
     with api_key([{"method": "CALL", "resource": "system.info"}]) as key:
         with client(auth=None) as c:


### PR DESCRIPTION
When an administrator generates an API key they explicity whitelist one or more API methods that may be called via the key. This means that authorizations checks for API keys must always be strict to avoid unexpected access being granted.