### PR TITLE
NAS-125088 / 13.1 / fix failover.upgrade_pending and utils.can_update (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/utils.py
+++ b/src/middlewared/middlewared/plugins/update_/utils.py
@@ -13,9 +13,35 @@ SEP = re.compile(r"[-.]")
 
 def can_update(old_version, new_version):
     for x, y in itertools.zip_longest(SEP.split(old_version), SEP.split(new_version), fillvalue=''):
-        if x < y:
+        if x.startswith('U') and x[1:].isdigit():
+            x = x[1:]
+        if y.startswith('U') and y[1:].isdigit():
+            y = y[1:]
+
+        for special in ['CUSTOM']:
+            if x == special and y != special:
+                return False
+            elif x != special and y == special:
+                return True
+
+        if not x.isdigit() and (y.isdigit() or y == ''):
             return True
-        if 'MASTER' in x and 'INTERNAL' in y:
+        if (x.isdigit() or x == '') and not y.isdigit():
+            return False
+
+        if x == 'MASTER' and y != 'MASTER':
+            return False
+        elif x != 'MASTER' and y == 'MASTER':
+            return True
+
+        if (x == 'INTERNAL') != (y == 'INTERNAL'):
+            return True
+
+        if x.isdigit() and y.isdigit():
+            x = int(x)
+            y = int(y)
+
+        if x < y:
             return True
         if x > y:
             return False


### PR DESCRIPTION
This simply catches up our CORE code-base with what we do in SCALE. We've fixed numerous bugs in update logic on SCALE but never back ported to CORE.

Original PR: https://github.com/truenas/middleware/pull/12457
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125088