### PR TITLE
NAS-125126 / 24.04 / Safely get actual memory of a vm

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor.py
@@ -89,7 +89,7 @@ class VMSupervisor(LibvirtConnectionMixin):
 
     def memory_usage(self):
         # We return this in bytes
-        return self.domain.memoryStats()['actual'] * 1024
+        return self.domain.memoryStats().get('actual', 0) * 1024
 
     def __define_domain(self):
         if self._domain:


### PR DESCRIPTION
This commit adds changes to cover an exception traceback i noticed in one of the debugs. I was not able to reproduce the issue but changes have been made to safely retrieve this.

```
File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/memory.py", line 65, in get_memory_usage_internal
    return self._memory_info(vm['name'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/vm_supervisor.py", line 93, in _memory_info
    return self.vms[vm_name].memory_usage()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/vm/supervisor/supervisor.py", line 92, in memory_usage
    return self.domain.memoryStats()['actual'] * 1024
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'actual'
```