### PR TITLE
NAS-124864 / 24.04 / Update VM teardown memory changes

### DIFF
--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -20,9 +20,7 @@ class SysctlService(Service):
         return cp.stdout.decode().split('=')[-1].strip()
 
     def get_default_arc_max(self):
-        # Default value of arc max on systems
-        # https://github.com/truenas/zfs/blob/f38f3a4a3ee430a15fa221ba9fc2b6b8fd17c040/module/os/linux/zfs/arc_os.c#L85
-        return psutil.virtual_memory().total // 2
+        return psutil.virtual_memory().total
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -20,6 +20,7 @@ class SysctlService(Service):
         return cp.stdout.decode().split('=')[-1].strip()
 
     def get_default_arc_max(self):
+        # This is the default value for arc_max on linux (https://github.com/openzfs/zfs/pull/15437)
         return psutil.virtual_memory().total
 
     def get_arc_max(self):

--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -1,11 +1,10 @@
 import os
-import psutil
 
 from middlewared.service import CallError, Service
-from middlewared.utils import run
-
+from middlewared.utils import run, MIDDLEWARE_RUN_DIR
 
 ZFS_MODULE_PARAMS_PATH = '/sys/module/zfs/parameters'
+DEFAULT_ARC_MAX_FILE = f'{MIDDLEWARE_RUN_DIR}/default_arc_max'
 
 
 class SysctlService(Service):
@@ -19,9 +18,21 @@ class SysctlService(Service):
             raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
         return cp.stdout.decode().split('=')[-1].strip()
 
+    def store_default_arc_max(self):
+        """This method should be called _BEFORE_ we initialize any VMs
+        so that we can capture what the ARC max value was before we start
+        changing the various ARC sysctls based on VM memory configurations"""
+        val = self.get_arcstats()['c_max']
+        with open(DEFAULT_ARC_MAX_FILE, 'w') as f:
+            f.write(str(val))
+        return val
+
     def get_default_arc_max(self):
-        # This is the default value for arc_max on linux (https://github.com/openzfs/zfs/pull/15437)
-        return psutil.virtual_memory().total
+        try:
+            with open(DEFAULT_ARC_MAX_FILE) as f:
+                return int(f.read())
+        except FileNotFoundError:
+            return self.store_default_arc_max()
 
     def get_arc_max(self):
         return self.get_arcstats()['c_max']
@@ -36,17 +47,17 @@ class SysctlService(Service):
         return int(cp.stdout.decode().strip())
 
     def get_arcstats(self):
-        path = '/proc/spl/kstat/zfs/arcstats'
-        if not os.path.exists(path):
-            raise CallError(f'Unable to locate {path}')
-
-        with open(path, 'r') as f:
-            data = f.read()
-
         stats = {}
-        for line in filter(lambda l: l and len(l.split()) == 3, map(str.strip, data.split('\n'))):
-            key, _type, data = line.split()
-            stats[key.strip()] = int(data.strip()) if data.strip().isdigit() else data
+        with open('/proc/spl/kstat/zfs/arcstats') as f:
+            for lineno, line in enumerate(f, start=1):
+                if lineno > 2:  # skip first 2 lines
+                    try:
+                        key, _, value = line.strip().split()
+                        key, value = key.strip(), value.strip()
+                    except ValueError:
+                        continue
+                    else:
+                        stats[key] = int(value) if value.isdigit() else value
 
         return stats
 

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -150,6 +150,12 @@ async def __event_system_shutdown(middleware, event_type, args):
 
 
 async def setup(middleware):
+    # it's _very_ important that we run this before we do
+    # any type of VM initialization. We have to capture the
+    # zfs c_max value before we start manipulating these
+    # sysctls during vm start/stop
+    await middleware.call('sysctl.store_default_arc_max')
+
     if await middleware.call('system.ready'):
         middleware.create_task(middleware.call('vm.initialize_vms', 5))  # We use a short timeout here deliberately
     middleware.event_subscribe('system.ready', __event_system_ready)


### PR DESCRIPTION
This PR adds changes to remove the default arc max size which was defined earlier as half of what the memory is but with recent changes in openzfs, that is not the case now and we should make appropriate amends.