### PR TITLE
NAS-124416 / 23.10.1 / Add an endpoint to retrieve PCI devices which are to be isolated for VM GPU isolation (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -203,9 +203,7 @@ class VMDeviceService(Service):
         This endpoints retrieves all the PCI devices which are in the same IOMMU group as the GPU and returns their PCI
         IDs so UI can use those and create PCI devices for them and isolate them.
         """
-        gpu = next(
-            (gpu for gpu in get_gpus() if convert_pci_id_to_vm_pci_slot(gpu['addr']['pci_slot']) == gpu_pci_id), None
-        )
+        gpu = next((gpu for gpu in get_gpus() if gpu['addr']['pci_slot'] == gpu_pci_id), None)
         verrors = ValidationErrors()
         if not gpu:
             verrors.add('gpu_pci_id', f'GPU with {gpu_pci_id!r} PCI ID not found')

--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -192,7 +192,17 @@ class VMDeviceService(Service):
     @accepts(Str('gpu_pci_id', empty=False))
     @returns(List(Str('pci_ids')))
     def get_pci_ids_for_gpu_isolation(self, gpu_pci_id):
-        """Get PCI IDs for GPU isolation"""
+        """
+        Get PCI IDs of devices which are required to be isolated for `gpu_pci_id` GPU isolation.
+
+        Basically when a GPU passthrough is desired for a VM, we need to isolate all the devices which are in the same
+        IOMMU group as the GPU. This is required because if we don't do this, the VM will not be able to start because
+        the devices in the same IOMMU group as the GPU will be in use by the host and will not be available for the VM
+        to use.
+
+        This endpoints retrieves all the PCI devices which are in the same IOMMU group as the GPU and returns their PCI
+        IDs so UI can use those and create PCI devices for them and isolate them.
+        """
         gpu = next(
             (gpu for gpu in get_gpus() if convert_pci_id_to_vm_pci_slot(gpu['addr']['pci_slot']) == gpu_pci_id), None
         )

--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -194,7 +194,9 @@ class VMDeviceService(Service):
     @returns(List(Str('pci_ids')))
     def get_pci_ids_for_gpu_isolation(self, gpu_pci_id):
         """Get PCI IDs for GPU isolation"""
-        gpu = next((gpu for gpu in get_gpus() if gpu['pci_id'] == gpu_pci_id), None)
+        gpu = next(
+            (gpu for gpu in get_gpus() if convert_pci_id_to_vm_pci_slot(gpu['addr']['pci_slot']) == gpu_pci_id), None
+        )
         if not gpu:
             raise CallError(f'GPU {gpu_pci_id} not found', errno=errno.ENOENT)
 

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -19,3 +19,7 @@ def create_element(*args, **kwargs):
 
 def get_virsh_command_args():
     return ['virsh', '-c', LIBVIRT_URI]
+
+
+def convert_pci_id_to_vm_pci_slot(pci_id: str) -> str:
+    return f'pci_{pci_id.replace(".", "_").replace(":", "_")}'


### PR DESCRIPTION
This PR adds a new endpoint which UI should use when trying to determine which PCI devices are to be created for isolation when user selects a GPU to be attached to a VM.

Original PR: https://github.com/truenas/middleware/pull/12472
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124416