### PR TITLE
NAS-125184 / 24.04 / Fix cli breakage when it calls core.get_methods

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/pci.py
@@ -190,7 +190,7 @@ class VMDeviceService(Service):
         return self.get_all_pci_devices_details()
 
     @accepts(Str('gpu_pci_id', empty=False))
-    @returns(List(Str('pci_ids')))
+    @returns(List(items=[Str('pci_ids')]))
     def get_pci_ids_for_gpu_isolation(self, gpu_pci_id):
         """
         Get PCI IDs of devices which are required to be isolated for `gpu_pci_id` GPU isolation.


### PR DESCRIPTION
cli was causing an exception in middleware when it called call('core.get_methods', None, "CLI")