### PR TITLE
NAS-125187 / 24.04 / Allow limited users to interact with own jobs

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -527,11 +527,6 @@ class Job:
 
     def __encode__(self, raw_result=True):
         exc_info = None
-        if self.credentials and self.credentials.is_user_session:
-            username = self.credentials.user['username']
-        else:
-            username = None
-
         if self.exc_info:
             etype = self.exc_info[0]
             evalue = self.exc_info[1]
@@ -569,7 +564,6 @@ class Job:
             'state': self.state.name,
             'time_started': self.time_started,
             'time_finished': self.time_finished,
-            'user': username,
             'credentials': (
                 {
                     'type': self.credentials.class_name(),

--- a/src/middlewared/middlewared/plugins/account_/privilege_utils.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege_utils.py
@@ -1,3 +1,10 @@
+def credential_has_full_admin(credential):
+    if credential.is_user_session and 'FULL_ADMIN' in credential.user['privilege']['roles']:
+       return True
+
+    return credential.allowlist.full_admin
+
+
 def privileges_group_mapping(
     privileges: list,
     group_ids: list,

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -188,9 +188,14 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
         self.token_manager.destroy(self.token)
 
     def dump(self):
-        return {
+        data = {
             "parent": dump_credentials(self.token.parent_credentials),
         }
+        if self.is_user_session:
+            data["username"] = self.user["username"]
+
+        return data
+
 
 
 def is_internal_session(session):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -166,9 +166,14 @@ class Session:
 
 class TokenSessionManagerCredentials(SessionManagerCredentials):
     def __init__(self, token_manager, token):
+        root_credentials = token.root_credentials()
+
         self.token_manager = token_manager
         self.token = token
-        self.is_user_session = token.root_credentials().is_user_session
+        self.is_user_session = root_credentials.is_user_session
+        if self.is_user_session:
+            self.user = root_credentials.user
+            self.allowlist = root_credentials.allowlist
 
     def is_valid(self):
         return self.token.is_valid()

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -199,7 +199,7 @@ class CoreService(Service):
         ),
         register=True,
     ))
-    @pass_app()
+    @pass_app(rest=True)
     def get_jobs(self, app, filters, options):
         """
         Get information about long-running jobs.
@@ -274,7 +274,7 @@ class CoreService(Service):
 
     @no_authz_required
     @accepts(Int('id'))
-    @pass_app()
+    @pass_app(rest=True)
     def job_abort(self, app, id_):
         job = self.middleware.jobs[id_]
         self.__check_job_owned_by_session(job, app)

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -1,10 +1,13 @@
 import fnmatch
 import re
 
+ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
+
 
 class Allowlist:
     def __init__(self, allowlist):
         self.exact = {}
+        self.full_admin = ALLOW_LIST_FULL_ADMIN in allowlist
         self.patterns = {}
         for entry in allowlist:
             method = entry["method"]


### PR DESCRIPTION
This commit alters behavior of job-related core plugin methods in the following ways:

1. Authorization is no longer required for core.get_jobs, core.job_wait, and core.job_abort.
2. Non-admin users calling core.get_jobs will only receive info about their own jobs
3. Non-admin users will only be able to wait for, abort, or modify their own jobs

To achieve this a few minor changes were made:
1. Allowlist object now stores boolean indicating whether the allow list contained an unrestrained full access entry
2. TokenSessionManagerCredentials now contains a reference to the user info from the token's root (originating) credentials.
3. Job encoding now includes a `user` key that contains the username for user sessions. In case of API key or internal jobs, this will be None / null.