### PR TITLE
NAS-125057 / 24.04 / Add support for NFS roles

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -54,6 +54,7 @@ class NFSService(SystemServiceService):
         datastore_prefix = "nfs_srv_"
         datastore_extend = 'nfs.nfs_extend'
         cli_namespace = "service.nfs"
+        role_prefix = "SHARING_NFS"
 
     ENTRY = Dict(
         'nfs_entry',

--- a/src/middlewared/middlewared/plugins/nfs_/krb5.py
+++ b/src/middlewared/middlewared/plugins/nfs_/krb5.py
@@ -71,7 +71,7 @@ class NFSService(Service):
         raise CallError('This feature has not yet been implemented for '
                         'the LDAP directory service.', errno=errno.ENOSYS)
 
-    @accepts(Ref('kerberos_username_password'))
+    @accepts(Ref('kerberos_username_password'), roles=['SHARING_NFS_WRITE'])
     @returns(Bool('principal_add_status'))
     async def add_principal(self, data):
         """

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -30,7 +30,8 @@ class NFSService(Service):
 
         return entries
 
-    @filterable
+    # NFS_WRITE because this exposes hostnames and IP addresses
+    @filterable(roles=['SHARING_NFS_WRITE'])
     def get_nfs3_clients(self, filters, options):
         """
         Read contents of rmtab. This information may not
@@ -68,7 +69,8 @@ class NFSService(Service):
         # return empty list in this case
         return states or []
 
-    @filterable
+    # NFS_WRITE because this exposes hostnames, IP addresses and other details
+    @filterable(roles=['SHARING_NFS_WRITE'])
     @filterable_returns(Dict(
         'client',
         Str('id'),
@@ -155,7 +157,7 @@ class NFSService(Service):
 
         return filter_list(clients, filters, options)
 
-    @accepts()
+    @accepts(roles=['SHARING_NFS_READ'])
     @returns(Int('number_of_clients'))
     def client_count(self):
         """

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -6,6 +6,7 @@ from middlewared.client import ClientException
 from middlewared.test.integration.assets.nfs import nfs_share
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.account import unprivileged_user_client
+
 try:
     from config import ADPASSWORD, ADUSERNAME
 except ImportError:
@@ -56,6 +57,7 @@ def test_read_role_cant_write(ds, share, role):
             c.call("nfs.get_nfs4_clients")
         assert ve.value.errno == errno.EACCES
 
+        # This should be blocked before needing to mock any configuration
         with pytest.raises(ClientException) as ve:
             c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
         assert ve.value.errno == errno.EACCES
@@ -70,4 +72,5 @@ def test_write_role_can_write(ds, role):
         c.call("sharing.nfs.delete", share["id"])
         c.call("nfs.get_nfs3_clients")
         c.call("nfs.get_nfs4_clients")
-        c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
+        # Multiple layers of dependencies to mock up this as a successful write
+        # c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})


### PR DESCRIPTION
Added READ role to `nfs.client_count`
Added WRITE role to `nfs.add_principal`, `nfs.get_nfs3_clients` and `nfs.get_nfs4_clients`

Added can-READ CI tests for everything.
Added cannot-WRITE CI tests for everything
Added can-WRITE CI test for everything except `nfs.add_principal` as it requires more than trivial setup, it will be tested in other tests and the cannot-WRITE test is more important.