### PR TITLE
NAS-125212 / 24.04 / fix smb.update stall waiting for sentinel file

### DIFF
--- a/debian/debian/ix-preinit.service
+++ b/debian/debian/ix-preinit.service
@@ -9,8 +9,6 @@ After=ix-zfs.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# clear the ix-netif completion marker
-ExecStart=rm -f /var/run/middleware/ix-netif-complete
 ExecStart=midclt call -job initshutdownscript.execute_init_tasks PREINIT
 StandardOutput=null
 StandardError=null

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -504,7 +504,7 @@ class SMBService(TDBWrapConfigService):
         """
         found_sentinel = False
         while timeout >= 0 and not found_sentinel:
-            if os.path.exists(NETIF_COMPLETE_SENTINEL):
+            if await self.middleware.run_in_thread(os.path.exists, NETIF_COMPLETE_SENTINEL):
                 found_sentinel = True
 
             timeout -= 1

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -504,11 +504,8 @@ class SMBService(TDBWrapConfigService):
         """
         found_sentinel = False
         while timeout >= 0 and not found_sentinel:
-            try:
-                os.remove(NETIF_COMPLETE_SENTINEL)
+            if os.path.exists(NETIF_COMPLETE_SENTINEL):
                 found_sentinel = True
-            except FileNotFoundError:
-                pass
 
             timeout -= 1
             if timeout <= 0:


### PR DESCRIPTION
At boot, smb.configure holds up waiting for the network subsystem to complete configuration.  To achieve this a sentinel file is generated at the completion of network configuration.  The sentinel file was removed after smb.configure detected it's presence.  However, without the sentinel subsequent calls to smb.update would stall (timeout waiting for the sentinel)

The sentinel file is created in /var/run/middleware. The /var/run/middleware directory is tmpfs and starts with zero files on every boot. We do not need to actively manage the removal of the ix-netif-sentinel. 

This change eliminates the stall on calling smb.update during runtime