### PR TITLE
NAS-125216 / 24.04 / Switch default home path to /var/empty

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -641,7 +641,7 @@ class UserService(CRUDService):
             gm_job = self.middleware.call_sync('smb.synchronize_passdb')
             gm_job.wait_sync()
 
-        if os.path.isdir(SKEL_PATH) and os.path.exists(data['home']):
+        if os.path.isdir(SKEL_PATH) and os.path.exists(data['home']) and data['home'] not in DEFAULT_HOME_PATHS:
             for f in os.listdir(SKEL_PATH):
                 if f.startswith('dot'):
                     dest_file = os.path.join(data['home'], f[3:])

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -158,12 +158,13 @@ def test_05_verify_user_exists(request):
     assert pw['pw_uid'] == next_uid, results.text
     assert pw['pw_shell'] == SHELL, results.text
     assert pw['pw_gecos'] == 'Test User', results.text
-    assert pw['pw_dir'] == '/nonexistent', results.text
+    assert pw['pw_dir'] == '/var/empty', results.text
 
     # At this point, we're not an SMB user
     assert pw['sid_info'] is not None, results.text
     assert pw['sid_info']['domain_information']['online'], results.text
     assert pw['sid_info']['domain_information']['activedirectory'] is False, results.text
+
 
 def test_06_get_user_info(request):
     depends(request, ["user_02", "user_01"])

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -28,7 +28,7 @@ def setup_smb_user(request):
         "username": SMB_USER,
         "full_name": SMB_USER,
         "group_create": True,
-        "home": "/nonexistent",
+        "home": "/var/empty",
         "password": SMB_PWD,
     }) as u:
         yield u


### PR DESCRIPTION
PAM session checks require that home directory actually exist, which is causing various CI tests to fail because the PAM check prevents su to the limited user account. /var/empty exists and is immutable, this has the side-benefit of preventing situations where pam_mkhomedir may try to create the directory /nonexistent leading to users sharing same writable home directory.