### PR TITLE
NAS-124749 / 23.10.1 / Add BLAKE3 checksum option (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/utils.py
+++ b/src/middlewared/middlewared/plugins/pool_/utils.py
@@ -14,7 +14,7 @@ DATASET_DATABASE_MODEL_NAME = 'storage.encrypteddataset'
 RE_DRAID_DATA_DISKS = re.compile(r':\d*d')
 RE_DRAID_SPARE_DISKS = re.compile(r':\d*s')
 RE_DRAID_NAME = re.compile(r'draid\d:\d+d:\d+c:\d+s-\d+')
-ZFS_CHECKSUM_CHOICES = ['ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN', 'EDONR']
+ZFS_CHECKSUM_CHOICES = ['ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN', 'EDONR', 'BLAKE3']
 ZFS_COMPRESSION_ALGORITHM_CHOICES = [
     'ON', 'OFF', 'LZ4', 'GZIP', 'GZIP-1', 'GZIP-9', 'ZSTD', 'ZSTD-FAST', 'ZLE', 'LZJB',
 ] + [f'ZSTD-{i}' for i in range(1, 20)] + [


### PR DESCRIPTION
### Context

This PR adds the required change to include BLAKE3 as an option for checksum in dataset creation.

Original PR: https://github.com/truenas/middleware/pull/12493
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124749