### PR TITLE
NAS-125112 / 24.04 / Toggle readonly property on dataset underlying root 

### DIFF
--- a/tests/api2/test_tunables.py
+++ b/tests/api2/test_tunables.py
@@ -149,3 +149,16 @@ def test_zfs_lifecycle():
         call("tunable.delete", tunable["id"], job=True)
 
         assert_default_value()
+
+
+def test_arc_max_set():
+    tunable = call("tunable.create", {"type": "ZFS", "var": "zfs_arc_max", "value": 8675309}, job=True)
+    try:
+        val = ssh("cat /sys/module/zfs/parameters/zfs_arc_max")
+    finally:
+        call("tunable.delete", tunable["id"], job=True)
+
+    assert int(val.strip()) == 8675309
+
+    mount_info = call("filesystem.mount_info", [["mountpoint", "=", "/"]], {"get": True})
+    assert "RO" in mount_info["super_opts"]


### PR DESCRIPTION
We sometimes need to toggle readonly when changing tunables.