### PR TITLE
NAS-125224 / 24.04 / Fix SMB roles CRUD tests

### DIFF
--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -43,7 +43,7 @@ def test_read_role_cant_write(ds, share, role):
         assert ve.value.errno == errno.EACCES
 
         # READ access should allow reading ACL
-        c.call("sharing.smb.getacl", share["name"])
+        c.call("sharing.smb.getacl", {"share_name": share["name"]})
 
         with pytest.raises(ClientException) as ve:
             c.call("sharing.smb.setacl", {"share_name": share["name"]})
@@ -62,9 +62,8 @@ def test_write_role_can_write(ds, role):
 
         c.call("sharing.smb.update", share["id"], {})
 
-        c.call("sharing.smb.delete", share["id"])
-
         # READ access should allow reading ACL
-        c.call("sharing.smb.getacl", share["name"])
+        c.call("sharing.smb.getacl", {"share_name": share["name"]})
         c.call("sharing.smb.setacl", {"share_name": share["name"]})
+        c.call("sharing.smb.delete", share["id"])
         c.call("smb.status")


### PR DESCRIPTION
Some regressions were introduced due to missed cherry-pick back from testing branch that was being used in a jenkins run. This fixes some now-failing tests