### PR TITLE
NAS-125109 / 23.10.1 / Prevent password_disable for SMB users (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -668,6 +668,14 @@ class UserService(CRUDService):
             except CallError as e:
                 verrors.add('user_update.password_disabled', e.errmsg)
 
+            if (has_smb := data.get('smb')) is None:
+                has_smb = user.get('smb')
+
+            if has_smb:
+                verrors.add(
+                    'user_update.password_disabled', 'Password authentication may not be disabled for SMB users.'
+                )
+
         if 'group' in data:
             group = self.middleware.call_sync('datastore.query', 'account.bsdgroups', [
                 ('id', '=', data['group'])
@@ -1222,18 +1230,18 @@ class UserService(CRUDService):
                 )
 
             if data.get('smb'):
-                smb_users = await self.middleware.call('datastore.query',
-                                                       'account.bsdusers',
-                                                       [('smb', '=', True)] + exclude_filter,
-                                                       {'prefix': 'bsdusr_'})
-
-                if filter_list(smb_users, [['username', 'C=', data['username']]]):
+                if filter_list(users, [['username', 'C=', data['username'], ['smb', '=', True]]]):
                     verrors.add(
                         f'{schema}.smb',
                         f'Username "{data["username"]}" conflicts with existing SMB user. Note that SMB '
                         f'usernames are case-insensitive.',
                         errno.EEXIST,
                     )
+
+        if not pk and data.get('smb') and data.get('password_disabled'):
+            verrors.add(
+                f'{schema}.password_disabled', 'Password authentication may not be disabled for SMB users.'
+            )
 
         password = data.get('password')
         if not pk and not password and not data.get('password_disabled'):

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -668,14 +668,6 @@ class UserService(CRUDService):
             except CallError as e:
                 verrors.add('user_update.password_disabled', e.errmsg)
 
-            if (has_smb := data.get('smb')) is None:
-                has_smb = user.get('smb')
-
-            if has_smb:
-                verrors.add(
-                    'user_update.password_disabled', 'Password authentication may not be disabled for SMB users.'
-                )
-
         if 'group' in data:
             group = self.middleware.call_sync('datastore.query', 'account.bsdgroups', [
                 ('id', '=', data['group'])
@@ -704,7 +696,7 @@ class UserService(CRUDService):
         else:
             group_ids.extend(user['groups'])
 
-        self.middleware.call_sync('user.common_validation', verrors, data, 'user_update', group_ids, pk)
+        self.middleware.call_sync('user.common_validation', verrors, data, 'user_update', group_ids, user)
 
         try:
             st = os.stat(user.get("home", DEFAULT_HOME_PATH)).st_mode
@@ -1179,8 +1171,9 @@ class UserService(CRUDService):
             raise CallError(f"Failed to copy homedir [{home_old}] to [{home_new}]: {do_copy.stderr.decode()}")
 
     @private
-    async def common_validation(self, verrors, data, schema, group_ids, pk=None):
-        exclude_filter = [('id', '!=', pk)] if pk else []
+    async def common_validation(self, verrors, data, schema, group_ids, old=None):
+        exclude_filter = [('id', '!=', old['id'])] if old else []
+        combined = data if not old else old | data
 
         users = await self.middleware.call(
             'datastore.query',
@@ -1230,7 +1223,7 @@ class UserService(CRUDService):
                 )
 
             if data.get('smb'):
-                if filter_list(users, [['username', 'C=', data['username'], ['smb', '=', True]]]):
+                if filter_list(users, [['username', 'C=', data['username']], ['smb', '=', True]]):
                     verrors.add(
                         f'{schema}.smb',
                         f'Username "{data["username"]}" conflicts with existing SMB user. Note that SMB '
@@ -1238,13 +1231,13 @@ class UserService(CRUDService):
                         errno.EEXIST,
                     )
 
-        if not pk and data.get('smb') and data.get('password_disabled'):
+        if combined['smb'] and combined['password_disabled']:
             verrors.add(
                 f'{schema}.password_disabled', 'Password authentication may not be disabled for SMB users.'
             )
 
         password = data.get('password')
-        if not pk and not password and not data.get('password_disabled'):
+        if not old and not password and not data.get('password_disabled'):
             verrors.add(f'{schema}.password', 'Password is required')
         elif data.get('password_disabled') and password:
             verrors.add(


### PR DESCRIPTION
At present SMB authentication for local users requires some form of NT hash. User expectation of disabling password-based auth for local users on SMB access is ambiguous at best, and so we should just raise a ValidationError and have user make some other choices regarding parameter combination.

Original PR: https://github.com/truenas/middleware/pull/12488
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125109