### PR TITLE
NAS-125226 / 24.04 / Robustize iSCSI HA ALUA test

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -3,6 +3,7 @@ import enum
 import ipaddress
 import os
 import random
+import requests
 import socket
 import string
 import sys
@@ -1802,8 +1803,8 @@ def _verify_ha_inquiry(s, serial_number, naa, tpgs=0,
     assert naa == _device_identification(s)['naa']
 
 
-def _get_node():
-    results = GET('/failover/node')
+def _get_node(timeout=None):
+    results = GET('/failover/node', timeout=timeout)
     assert results.status_code == 200, results.text
     return results.text.replace('"', '').replace("'", "")
 
@@ -1918,6 +1919,7 @@ def _ha_reboot_master(delay=900):
     Reboot the MASTER node and wait for both the new MASTER
     and new BACKUP to become available.
     """
+    get_node_timeout = 20
     orig_master_node = _get_node()
     new_master_node = other_node(orig_master_node)
 
@@ -1928,12 +1930,15 @@ def _ha_reboot_master(delay=900):
     new_master = False
     while not new_master:
         try:
-            if _get_node() == new_master_node:
+            # There are times when we don't get a response at all (albeit
+            # in a bhyte HA-VM pair), so add a timeout to catch this situation.
+            if _get_node(timeout=get_node_timeout) == new_master_node:
                 new_master = True
                 break
+        except requests.exceptions.Timeout:
+            delay = delay - get_node_timeout
         except Exception:
-            pass
-        delay = delay - 1
+            delay = delay - 1
         if delay <= 0:
             break
         print("Waiting for MASTER")
@@ -1980,6 +1985,7 @@ def _ha_reboot_master(delay=900):
 
 
 @pytest.mark.dependency(name="iscsi_alua_config")
+@pytest.mark.timeout(900)
 def test_19_alua_config(request):
     """
     Test various aspects of ALUA configuration.

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -1970,7 +1970,8 @@ def _ha_reboot_master(delay=900):
     in_progress = True
     while in_progress:
         try:
-            if in_progress := _get_ha_failover_in_progress():
+            in_progress = _get_ha_failover_in_progress()
+            if not in_progress:
                 break
         except Exception:
             pass

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -35,16 +35,17 @@ def GET(testpath, payload=None, controller_a=False, **optional):
     complete_uri = testpath if testpath.startswith('http') else f'{url}{testpath}'
     if optional.get('force_ssl', False):
         complete_uri = RE_HTTPS.sub(r'https\1', complete_uri)
+    timeout = optional.get('timeout', None)
 
     if testpath.startswith('http'):
-        getit = requests.get(complete_uri)
+        getit = requests.get(complete_uri, timeout=timeout)
     else:
         if optional.pop("anonymous", False):
             auth = None
         else:
             auth = optional.pop("auth", authentication)
         getit = requests.get(complete_uri, headers=dict(header, **optional.get("headers", {})),
-                             auth=auth, data=json.dumps(data), verify=False)
+                             auth=auth, data=json.dumps(data), verify=False, timeout=timeout)
     return getit
 
 


### PR DESCRIPTION
The iSCSI test `test_19_alua_config` has passed reliably when run against real hardware, but equally failed on a regular basis when run (by [Jenkins](https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/HA%20API%20Tests%20-%20TrueNAS%20SCALE%20(Full%20-%20Nightly%20ISO)/)) against a bhyve-based HA VM pair.  Test timing issues either being exposed or not.

The typical failure was a socket timeout in `_get_node` called from `_ha_reboot_master`, shortly after the reboot call.  It is likely the controller is sent the request, but does not respond before rebooting.

This PR addresses this by adding a optional `timeout` our our test `GET` function, then supply a timeout when calling `_get_node` from `_ha_reboot_master`.

It also fixes a logic flaw (inverted check) wrt `in_progress`.

(FWIW, Jenkins run [#288](https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/HA%20API%20Tests%20-%20TrueNAS%20SCALE%20from%20branch%20(Caleb)/288/) passed with these changes.)

---
Since this is test-only (i.e. no TrueNAS) changes, I'm going to suggest we also backport to 23.10.1.  Please add label if you agree.