### PR TITLE
NAS-124864 / 23.10.1 / properly toggle ARC sysctls (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -150,6 +150,12 @@ async def __event_system_shutdown(middleware, event_type, args):
 
 
 async def setup(middleware):
+    # it's _very_ important that we run this before we do
+    # any type of VM initialization. We have to capture the
+    # zfs c_max value before we start manipulating these
+    # sysctls during vm start/stop
+    await middleware.call('sysctl.store_default_arc_max')
+
     if await middleware.call('system.ready'):
         middleware.create_task(middleware.call('vm.initialize_vms', 5))  # We use a short timeout here deliberately
     middleware.event_subscribe('system.ready', __event_system_ready)

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,7 +1,9 @@
 from middlewared.test.integration.utils import call
+from middlewared.plugins.sysctl.sysctl_info import DEFAULT_ARC_MAX_FILE
 
 
 def test_sysctl_arc_max_is_set():
-    """Middleware should have set this value early in boot phase
-    and this should return a number"""
-    assert call('sysctl.get_default_arc_max')
+    """Middleware should have created this file and written a number
+    to it early in the boot process. That's why we check it here in
+    this test so early"""
+    assert call('filesystem.stat', DEFAULT_ARC_MAX_FILE)['size']

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,5 +1,9 @@
 from middlewared.test.integration.utils import call
-from middlewared.plugins.sysctl.sysctl_info import DEFAULT_ARC_MAX_FILE
+
+# this is found in middlewared.plugins.sysctl.sysctl_info
+# but the client running the tests isn't guaranteed to have
+# the middlewared application installed locally
+DEFAULT_ARC_MAX_FILE = '/var/run/middleware/default_arc_max'
 
 
 def test_sysctl_arc_max_is_set():

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,0 +1,7 @@
+from middlewared.test.integration.utils import call
+
+
+def test_sysctl_arc_max_is_set():
+    """Middleware should have set this value early in boot phase
+    and this should return a number"""
+    assert call('sysctl.get_default_arc_max')


### PR DESCRIPTION
Upstream ZFS removed the ARC MAX == 50% of available RAM recently. We need to update the VM plugin as well. Instead of halving memory in the VM plugin, we simply store the "default" ARC max value before we initialize any VMs. We use that as a high water mark since duplicating the openzfs logic inside middleware isn't the right approach (since upstream can change this calculation at any time)

Original PR: https://github.com/truenas/middleware/pull/12504
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124864