### PR TITLE
NAS-125236 / 24.04 / remove import from middlewared.plugins in test_007

### DIFF
--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,5 +1,9 @@
 from middlewared.test.integration.utils import call
-from middlewared.plugins.sysctl.sysctl_info import DEFAULT_ARC_MAX_FILE
+
+# this is found in middlewared.plugins.sysctl.sysctl_info
+# but the client running the tests isn't guaranteed to have
+# the middlewared application installed locally
+DEFAULT_ARC_MAX_FILE = '/var/run/middleware/default_arc_max'
 
 
 def test_sysctl_arc_max_is_set():


### PR DESCRIPTION
(cherry picked from commit 6cc1fb1be706ccfc5a757fcca080eca6a0e206f5) I merged the master PR (https://github.com/truenas/middleware/pull/12504) but forgot to push my local commit which fixes the tests. No need for backport since I included this commit in the original backport.