### PR TITLE
NAS-125040 / 24.04 / Fix debug archive name

### DIFF
--- a/src/middlewared/middlewared/plugins/system/utils.py
+++ b/src/middlewared/middlewared/plugins/system/utils.py
@@ -27,8 +27,9 @@ class Lifecycle:
 
 
 def get_debug_execution_dir(system_dataset_path: str, iteration: typing.Optional[int] = 0) -> str:
-    return os.path.join(MIDDLEWARE_RUN_DIR, f'ixdiagnose-{iteration}') if system_dataset_path is None else os.path.join(
-        system_dataset_path, f'ixdiagnose-{iteration}'
+    debug_name = f'ixdiagnose-{iteration}' if iteration else 'ixdiagnose'
+    return os.path.join(MIDDLEWARE_RUN_DIR, debug_name) if system_dataset_path is None else os.path.join(
+        system_dataset_path, debug_name
     )
 
 


### PR DESCRIPTION
## Problem

Whenever a debug is generated, the archive file is named as `ixdiagnose-X` with X being iteration number of the attempt made to generate the debug however with the exception handling we have in place, it is almost always guarenteed to pass on the first attempt and having `-0` suffix is not helpful.

## Solution

If on the first attempt debug generation succeeds, we don't add a suffix `-0` in that case to the debug archive name.