### PR TITLE
NAS-119424 / 24.04 / Convert check for presence of DS_TYPE_DEFAULT_DOMAIN

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/22.12/2023-01-17_15-29_fix-broken-idmap-table.py
+++ b/src/middlewared/middlewared/alembic/versions/22.12/2023-01-17_15-29_fix-broken-idmap-table.py
@@ -32,7 +32,7 @@ def upgrade():
     default_range = (90000001, 100000000)
 
     for row in conn.execute("SELECT * FROM directoryservice_idmap_domain").fetchall():
-        if row['id'] == 5:
+        if row['idmap_domain_name'] == 'DS_TYPE_DEFAULT_DOMAIN':
             # The default domain entry wasn't dropped and so we can skip the rest of this
             return
 
@@ -48,7 +48,7 @@ def upgrade():
         'id': 5,
         'idmap_domain_name': 'DS_TYPE_DEFAULT_DOMAIN',
         'idmap_domain_idmap_backend': 'tdb',
-        'idmap_domain_options': {},
+        'idmap_domain_options': '{}',
         'idmap_domain_range_low': default_range[0],
         'idmap_domain_range_high': default_range[1],
     }

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -941,8 +941,8 @@ class IdmapDomainService(TDBWrapCRUDService):
         In case of registry config for clustered server, this will remove all smb4.conf
         entries for the domain associated with the id.
         """
-        if id_ <= 5:
-            entry = await self.get_instance(id_)
+        entry = await self.get_instance(id_)
+        if entry['name'] in DSType.choices():
             raise CallError(f'Deleting system idmap domain [{entry["name"]}] is not permitted.', errno.EPERM)
 
         ret = await self.direct_delete(id_)


### PR DESCRIPTION
Initial check in this migration was for primary key == 5. This has been hard-coded since FreeNAS 9.3, but in an early angelfish beta a code change was introduced that automatically deleted table entries to prevent update failures in some edge cases. This resulted in a required default idmap table entry being deleted for some users (the precise details are nuanced and covered in the related commits / jira tickets). The situation was rectified and a migration introduced to automatically re-add the missing table entry. It appears that in some cases, users manually added the entry back via shell, but didn't preserve the original primary key that was used to identify the special entry. This has resulted in a handful of users that are unable to upgrade.