### PR TITLE
NAS-125251 / 24.04 / Fix scale NFS bindip setting

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -23,7 +23,7 @@ vers4 = y
 vers4 = n
 % endif
 % if config['bindip']:
-host = ','.join(config['bindip'])
+host = ${','.join(config['bindip'])}
 % endif
 
 [mountd]

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1229,41 +1229,7 @@ def test_45_check_setting_runtime_debug(request):
         assert res['result'] == disabled, res
 
 
-def test_50_stoping_nfs_service(request):
-    # Restore original settings before we stop
-    restore_nfs_config()
-    payload = {"service": "nfs"}
-    results = POST("/service/stop/", payload)
-    assert results.status_code == 200, results.text
-    sleep(1)
-
-
-def test_51_checking_to_see_if_nfs_service_is_stop(request):
-    results = GET("/service?service=nfs")
-    assert results.json()[0]["state"] == "STOPPED", results.text
-
-
-def test_52_check_adjusting_threadpool_mode(request):
-    """
-    Verify that NFS thread pool configuration can be adjusted
-    through private API endpoints.
-
-    This request will fail if NFS server (or NFS client) is
-    still running.
-    """
-    supported_modes = ["AUTO", "PERCPU", "PERNODE", "GLOBAL"]
-    payload = {'msg': 'method', 'method': None, 'params': []}
-
-    for m in supported_modes:
-        payload.update({'method': 'nfs.set_threadpool_mode', 'params': [m]})
-        make_ws_request(ip, payload)
-
-        payload.update({'method': 'nfs.get_threadpool_mode', 'params': []})
-        res = make_ws_request(ip, payload)
-        assert res['result'] == m, res
-
-
-def test_53_set_bind_ip():
+def test_46_set_bind_ip():
     '''
     This test requires a static IP address
     * Test the private nfs.bindip call
@@ -1296,6 +1262,40 @@ def test_53_set_bind_ip():
         rpc_conf = parse_rpcbind_config()
         assert ip in nfs_conf['nfsd'].get('host'), f"nfs_conf = {nfs_conf}"
         assert ip in rpc_conf.get('-h'), f"rpc_conf = {rpc_conf}"
+
+
+def test_50_stoping_nfs_service(request):
+    # Restore original settings before we stop
+    restore_nfs_config()
+    payload = {"service": "nfs"}
+    results = POST("/service/stop/", payload)
+    assert results.status_code == 200, results.text
+    sleep(1)
+
+
+def test_51_checking_to_see_if_nfs_service_is_stop(request):
+    results = GET("/service?service=nfs")
+    assert results.json()[0]["state"] == "STOPPED", results.text
+
+
+def test_52_check_adjusting_threadpool_mode(request):
+    """
+    Verify that NFS thread pool configuration can be adjusted
+    through private API endpoints.
+
+    This request will fail if NFS server (or NFS client) is
+    still running.
+    """
+    supported_modes = ["AUTO", "PERCPU", "PERNODE", "GLOBAL"]
+    payload = {'msg': 'method', 'method': None, 'params': []}
+
+    for m in supported_modes:
+        payload.update({'method': 'nfs.set_threadpool_mode', 'params': [m]})
+        make_ws_request(ip, payload)
+
+        payload.update({'method': 'nfs.get_threadpool_mode', 'params': []})
+        res = make_ws_request(ip, payload)
+        assert res['result'] == m, res
 
 
 def test_54_disable_nfs_service_at_boot(request):

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -10,6 +10,7 @@ import os
 import contextlib
 import ipaddress
 import urllib.parse
+from copy import copy
 from pytest_dependency import depends
 from time import sleep
 apifolder = os.getcwd()
@@ -18,6 +19,7 @@ from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from functions import make_ws_request
 from auto_config import pool_name, ha, hostname, password, user
 from protocols import SSH_NFS
+from middlewared.test.integration.utils import call
 
 if ha and "virtual_ip" in os.environ:
     ip = os.environ["virtual_ip"]
@@ -74,6 +76,29 @@ def parse_server_config(fname="local.conf"):
 
         k, v = line.split(" = ", 1)
         rv[section].update({k: v})
+
+    return rv
+
+
+def parse_rpcbind_config():
+    results = SSH_TEST("cat /etc/default/rpcbind", user, password, ip)
+    assert results['result'] is True, f"rc={results['returncode']}, {results['output']}, {results['stderr']}"
+    conf = results['stdout'].splitlines()
+    rv = {}
+
+    # With bindip the line of intrest looks like: OPTIONS=-w -h 192.168.40.156
+    for line in conf:
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("OPTIONS"):
+            opts = line.split('=')[1].split()
+            # '-w' is hard-wired, lets confirm that
+            assert len(opts) > 0
+            assert '-w' == opts[0]
+            rv['-w'] = ''
+            # If there are more opts they must the bindip settings
+            if len(opts) == 3:
+                rv[opts[1]] = opts[2]
 
     return rv
 
@@ -259,20 +284,13 @@ def nfs_config(options=None):
     with nfs_config():
         <code that modifies NFS config>
     '''
-    get_conf = {'msg': 'method', 'method': 'nfs.config', 'params': []}
-    restore_conf = {'msg': 'method', 'method': 'nfs.update', 'params': []}
-
     try:
-        res = make_ws_request(ip, get_conf)
-        assert res.get('error') is None, res
+        nfs_db_conf = call("nfs.config")
         excl = ['id', 'v4_krb_enabled', 'v4_owner_major']
-        nfsconf = res['result']
-        [nfsconf.pop(key) for key in excl]
-        restore_conf.update({'params': [nfsconf]})
-        yield
+        [nfs_db_conf.pop(key) for key in excl]
+        yield copy(nfs_db_conf)
     finally:
-        res = make_ws_request(ip, restore_conf)
-        assert res.get('error') is None, res
+        call("nfs.update", nfs_db_conf)
 
 
 # Enable NFS server
@@ -1248,17 +1266,36 @@ def test_52_check_adjusting_threadpool_mode(request):
 def test_53_set_bind_ip():
     '''
     This test requires a static IP address
+    * Test the private nfs.bindip call
+    * Test the actual bindip config setting
+      - Confirm setting in conf files
+      - Confirm service on IP address
     '''
-    res = GET("/nfs/bindip_choices")
-    assert res.status_code == 200, res.text
-    assert ip in res.json(), res.text
+    choices = call("nfs.bindip_choices")
+    assert ip in choices
 
-    res = PUT("/nfs/", {"bindip": [ip]})
-    assert res.status_code == 200, res.text
+    call("nfs.bindip", {"bindip": [ip]})
+    call("nfs.bindip", {"bindip": []})
 
-    # reset to default
-    res = PUT("/nfs/", {"bindip": []})
-    assert res.status_code == 200, res.text
+    # Test config with bindip.  Use choices from above
+    # TODO: check with 'nmap -sT <IP>' from the runner.
+    with nfs_config() as db_conf:
+
+        # Should have no bindip setting
+        nfs_conf = parse_server_config()
+        rpc_conf = parse_rpcbind_config()
+        assert db_conf['bindip'] == []
+        assert nfs_conf['nfsd'].get('host') is None
+        assert rpc_conf.get('-h') is None
+
+        # Set bindip
+        call("nfs.update", {"bindip": [ip]})
+
+        # Confirm we see it in the nfs conf file
+        nfs_conf = parse_server_config()
+        rpc_conf = parse_rpcbind_config()
+        assert nfs_conf['nfsd'].get('host') in ip
+        assert rpc_conf.get('-h') in ip
 
 
 def test_54_disable_nfs_service_at_boot(request):

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1291,11 +1291,11 @@ def test_53_set_bind_ip():
         # Set bindip
         call("nfs.update", {"bindip": [ip]})
 
-        # Confirm we see it in the nfs conf file
+        # Confirm we see it in the nfs and rpc conf files
         nfs_conf = parse_server_config()
         rpc_conf = parse_rpcbind_config()
-        assert nfs_conf['nfsd'].get('host') in ip
-        assert rpc_conf.get('-h') in ip
+        assert ip in nfs_conf['nfsd'].get('host'), f"nfs_conf = {nfs_conf}"
+        assert ip in rpc_conf.get('-h'), f"rpc_conf = {rpc_conf}"
 
 
 def test_54_disable_nfs_service_at_boot(request):


### PR DESCRIPTION
Fixed a typo in the mako file that generated an incorrect setting for NFS bindip

Updated CI tests to confirm the resulting settings for bindip changes.
Also made a few opportunistic cleanup changes.