### PR TITLE
NAS-124930 / 24.04 / Properly validate interface selected with apps

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -362,12 +362,13 @@ class KubernetesService(ConfigService):
             i['id']: i.get('state', {}).get('link_state') == 'LINK_STATE_UP'
             for i in await self.middleware.call('interface.query')
         }
+        valid_choices = [i for i in filter(lambda k: interface_states.get(k), interfaces)]
         for k in filter(lambda k: data[k], ('route_v4_interface', 'route_v6_interface')):
             err_str = ''
             if data[k] not in interfaces:
-                err_str = f'Please specify a valid interface (i.e {", ".join(interfaces)!r}).'
+                err_str = f'Please specify a valid interface (i.e {", ".join(valid_choices)!r}).'
             elif not interface_states.get(data[k]):
-                err_str = 'Specified interface is not active'
+                err_str = f'Please specify a valid interface which is active (i.e {", ".join(valid_choices)!r}).'
             if err_str:
                 errors.append((k, data[k], err_str))
         return errors

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -366,7 +366,7 @@ class KubernetesService(ConfigService):
         for k in filter(lambda k: data[k], ('route_v4_interface', 'route_v6_interface')):
             err_str = ''
             if data[k] not in interfaces:
-                err_str = 'Please specify a valid interface'
+                err_str = f'Please specify a valid interface (i.e {", ".join(interfaces)!r}).'
             elif not interface_states.get(data[k]):
                 err_str = 'Specified interface is not active'
             if err_str:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -329,9 +329,8 @@ class KubernetesService(ConfigService):
                 'update Kubernetes settings. Currently, k3s cannot be used without a default route.'
             )
 
-        valid_choices = await self.route_interface_choices()
-        for k, _ in await self.validate_interfaces(data):
-            verrors.add(f'{schema}.{k}', f'Please specify a valid interface (i.e {", ".join(valid_choices)!r}).')
+        for k, _, err_s in await self.validate_interfaces(data):
+            verrors.add(f'{schema}.{k}', err_s)
 
         for k in ('route_v4', 'route_v6'):
             gateway = data[f'{k}_gateway']


### PR DESCRIPTION
This PR adds changes to properly validate that the interface specified in apps settings for routing traffic, is actually "UP" at the time it is intended to be used as if the interface link state is down, that is bound to result in a failure when apps are going to try and configure themselves.