### PR TITLE
NAS-125258 / 23.10.1 / account for ES102G2 firmware change (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -526,7 +526,10 @@ class Enclosure(object):
             self.model = "E16"
         elif self.encname.startswith("HGST H4102-J"):
             self.model = "ES102"
-        elif self.encname.startswith("VikingES NDS-41022-BB"):
+        elif self.encname.startswith((
+            "VikingES NDS-41022-BB",
+            "VikingES VDS-41022-BB",
+        )):
             self.model = "ES102G2"
         elif self.encname.startswith("CELESTIC R0904"):
             self.model = "ES60"


### PR DESCRIPTION
QE found that the latest firmware provided by OEM changed a single character in the product name. (N -> V). By design, this prevents proper identification of the JBOD since, technically, the firmware changed. Platform team has given the "okay" to proceed by also adding this string as one to check for the ES102G2.

Original PR: https://github.com/truenas/middleware/pull/12516
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125258