### PR TITLE
NAS-124824 / 24.04 / UPS service auto start fix

### DIFF
--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -25,6 +25,7 @@ disable snmp-agent.service
 disable ssh*
 disable wg-quick*
 disable nut-*
+disable nut.target
 disable wsdd.service
 disable libvirtd.service
 disable winbind.service

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -8,9 +8,9 @@ class UPSService(SimpleService):
 
     async def systemd_extra_units(self):
         if (await self.middleware.call("ups.config"))["mode"] == "MASTER":
-            return ["nut-driver-enumerator", "nut-server"]
+            return ["nut-driver-enumerator", "nut-server", "nut.target"]
         else:
-            return []
+            return ["nut.target"]
 
     async def before_start(self):
         await self.middleware.call("ups.dismiss_alerts")


### PR DESCRIPTION
### Issue
Upstream introduced `nut.target` unit, which was not present in codebase previously upstream.

Inclusion of `nut.target` and its default enabling on fresh install caused `nut-monitor` service to start automatically even if it was disabled. 

### Fix

The issue is fixed by disabling the `nut.target` in preset and grouping it to start with the start of UPS service.