### PR TITLE
NAS-125237 / 24.04 / fix regression in update.download_update

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -468,8 +468,8 @@ def format_alert(alert, node_map):
     return (f"{node_map[alert.node]} - " if node_map else "") + alert.formatted
 
 
-def ellipsis(s, l):
-    if len(s) <= l:
-        return s
+def ellipsis(a, b):
+    if len(a) <= b:
+        return a
 
-    return s[:(l - 1)] + "…"
+    return a[:(b - 1)] + "…"

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -326,7 +326,7 @@ class FilePresenceAlertSource(AlertSource):
     klass = NotImplemented
 
     async def check(self):
-        if os.path.exists(self.path):
+        if await self.middleware.run_in_thread(os.path.exists, self.path):
             return Alert(self.klass)
 
 

--- a/src/middlewared/middlewared/alert/service/slack.py
+++ b/src/middlewared/middlewared/alert/service/slack.py
@@ -23,7 +23,13 @@ class SlackAlertService(ThreadedAlertService):
             self.attributes["url"],
             headers={"Content-type": "application/json"},
             data=json.dumps({
-                "text": html.escape(html2text.html2text(self._format_alerts(alerts, gone_alerts, new_alerts)), quote=False),
+                "text": html.escape(
+                    html2text.html2text(
+                        self._format_alerts(
+                            alerts, gone_alerts, new_alerts
+                        )
+                    ), quote=False
+                ),
             }),
             timeout=INTERNET_TIMEOUT,
         )

--- a/src/middlewared/middlewared/alert/source/ntp.py
+++ b/src/middlewared/middlewared/alert/source/ntp.py
@@ -43,7 +43,5 @@ class NTPHealthCheckAlertSource(AlertSource):
         if peer.offset_in_secs < 300:
             return
 
-        return Alert(
-            NTPHealthCheckAlertClass,
-            {'reason': f'{peer.remote} has an offset of {peer.offset_in_secs}, which exceeds permitted value of 5 minutes.'}
-        )
+        msg = f'{peer.remote} has an offset of {peer.offset_in_secs}, which exceeds permitted value of 5 minutes.'
+        return Alert(NTPHealthCheckAlertClass, {'reason': msg})

--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -6,7 +6,7 @@ class UpdateFailedAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.CRITICAL
     title = "Update Failed"
-    text = "Update failed. See /data/update.failed for details."
+    text = f"Update failed. See {UPDATE_FAILED_SENTINEL} for details."
 
 
 class UpdateFailedAlertSource(FilePresenceAlertSource):

--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -1,16 +1,5 @@
-import logging
-
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, FilePresenceAlertSource
-
-
-log = logging.getLogger("update_check_alertmod")
-
-
-class HasUpdateAlertClass(AlertClass):
-    category = AlertCategory.SYSTEM
-    level = AlertLevel.INFO
-    title = "Update Available"
-    text = "A system update is available. Go to System -> Update to download and apply the update."
+from middlewared.plugins.update_.utils import UPDATE_FAILED_SENTINEL
 
 
 class UpdateFailedAlertClass(AlertClass):
@@ -21,5 +10,5 @@ class UpdateFailedAlertClass(AlertClass):
 
 
 class UpdateFailedAlertSource(FilePresenceAlertSource):
-    path = "/data/update.failed"
+    path = UPDATE_FAILED_SENTINEL
     klass = UpdateFailedAlertClass

--- a/src/middlewared/middlewared/alert/source/vmware_login.py
+++ b/src/middlewared/middlewared/alert/source/vmware_login.py
@@ -1,4 +1,4 @@
-from middlewared.alert.base import AlertClass, OneShotAlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+from middlewared.alert.base import AlertClass, OneShotAlertClass, AlertCategory, AlertLevel, Alert
 
 
 class VMWareLoginFailedAlertClass(AlertClass, OneShotAlertClass):

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -306,9 +306,7 @@ class UpdateService(Service):
     @private
     async def download_update(self, *args):
         await self.middleware.call('network.general.will_perform_activity', 'update')
-        success = await self.middleware.call('update.download_impl', *args)
-        await self.middleware.call('alert.alert_source_clear_run', 'HasUpdate')
-        return success
+        return await self.middleware.call('update.download_impl', *args)
 
     @accepts(
         Str('path'),

--- a/src/middlewared/middlewared/plugins/update_/utils.py
+++ b/src/middlewared/middlewared/plugins/update_/utils.py
@@ -8,11 +8,9 @@ from middlewared.utils import MIDDLEWARE_RUN_DIR
 
 DEFAULT_SCALE_UPDATE_SERVER = "https://update.ixsystems.com/scale"
 SCALE_MANIFEST_FILE = "/data/manifest.json"
-
 DOWNLOAD_UPDATE_FILE = "update.sqsh"
-
 UPLOAD_LOCATION = os.path.join(MIDDLEWARE_RUN_DIR, "upload_image")
-
+UPDATE_FAILED_SENTINEL = "/data/update.failed"
 SEP = re.compile(r"[-.]")
 
 


### PR DESCRIPTION
This traceback occurred on a user running a nightly image when they tried to use the webUI to update.
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update.py", line 310, in download_update
    await self.middleware.call('alert.alert_source_clear_run', 'HasUpdate')
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1399, in call
    return await self._call(
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1353, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1251, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/alert.py", line 943, in alert_source_clear_run
    raise CallError(f"Alert source {name!r} not found.", errno.ENOENT)
middlewared.service_exception.CallError: [ENOENT] Alert source 'HasUpdate' not found.
```

This is a regression that occurred by this commit https://github.com/truenas/middleware/pull/12380. However, after reviewing the commit that caused the regression and then investigating this update code a bit more, I discovered many issues.

1. `HasUpdateAlertClass` isn't used in SCALE and hasn't been used in SCALE since its inception so remove it
2. Remove the call that clears the `HasUpdate` alert which is what causes this traceback in the first place
3. Stop performing blocking I/O in a coroutine for the `FilePresenceAlertSource` class
4. fix a TOUTOC issue in `gather_update_failed_from_mountpoint`
5. The string `/data/update.failed` was referenced in many files and so I created a constant global variable and fixed the references accordingly
6. fix some flake8 issues while I'm here