### PR TITLE
NAS-125269 / 23.10.1 / micro-optimize load_modules and unblock alert.load (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -207,7 +207,7 @@ class AlertService(Service):
         })
 
     @private
-    async def load(self):
+    def load_impl(self):
         for module in load_modules(os.path.join(get_middlewared_dir(), "alert", "source")):
             for cls in load_classes(module, AlertSource, (FilePresenceAlertSource, ThreadedAlertSource)):
                 source = cls(self.middleware)
@@ -220,6 +220,10 @@ class AlertService(Service):
         ):
             for cls in load_classes(module, _AlertService, (ThreadedAlertService, ProThreadedAlertService)):
                 ALERT_SERVICES_FACTORIES[cls.name()] = cls
+
+    @private
+    async def load(self):
+        await self.middleware.run_in_thread(self.load_impl)
 
     @private
     async def initialize(self, load=True):


### PR DESCRIPTION
This does 2 primary things:
1. micro-optimize `load_modules()`
2. stop blocking main event loop in `alert.load`

Original PR: https://github.com/truenas/middleware/pull/12524
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125269