### PR TITLE
NAS-125274 / 24.04 / add serial number information to smart alert (if possible)

### DIFF
--- a/src/freenas/usr/local/libexec/smart_alert.py
+++ b/src/freenas/usr/local/libexec/smart_alert.py
@@ -21,7 +21,7 @@ def main():
         dev_name = device.removeprefix("/dev/")
         info = c.call("device.get_disk", dev_name, False, True)
         if info is not None and (serial := info.get(dev_name)):
-            " ".join([device, f"({serial!r})"])
+            device = " ".join([device, f"({serial!r})"])
 
         c.call("alert.oneshot_create", "SMART", {"device": device, "message": message})
 

--- a/src/freenas/usr/local/libexec/smart_alert.py
+++ b/src/freenas/usr/local/libexec/smart_alert.py
@@ -18,6 +18,11 @@ def main():
         return
 
     with Client() as c:
+        dev_name = device.removeprefix("/dev/")
+        info = c.call("device.get_disk", dev_name, False, True)
+        if info is not None and (serial := info.get(dev_name)):
+            " ".join([device, f"({serial!r})"])
+
         c.call("alert.oneshot_create", "SMART", {"device": device, "message": message})
 
 

--- a/src/freenas/usr/local/libexec/smart_alert.py
+++ b/src/freenas/usr/local/libexec/smart_alert.py
@@ -20,7 +20,7 @@ def main():
     with Client() as c:
         dev_name = device.removeprefix("/dev/")
         info = c.call("device.get_disk", dev_name, False, True)
-        if info is not None and (serial := info.get(dev_name)):
+        if info is not None and (serial := info['serial']):
             device = " ".join([device, f"({serial!r})"])
 
         c.call("alert.oneshot_create", "SMART", {"device": device, "message": message})

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -226,14 +226,18 @@ class DeviceService(Service):
         return default
 
     @private
-    def get_disk(self, name):
+    def get_disk(self, name, get_partitions=False, serial_only=False):
         context = pyudev.Context()
         try:
             block_device = pyudev.Devices.from_name(context, 'block', name)
+            if serial_only:
+                return {name: self.get_disk_serial(block_device)}
+            else:
+                return self.get_disk_details(context, block_device, get_partitions)
         except pyudev.DeviceNotFoundByNameError:
-            return None
-
-        return self.get_disk_details(context, block_device)
+            return
+        except Exception:
+            self.logger.debug('Failed to retrieve disk details for %s', name, exc_info=True)
 
     def _get_type_and_rotation_rate(self, disk_data, device_path):
         if disk_data['rota']:

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -231,7 +231,7 @@ class DeviceService(Service):
         try:
             block_device = pyudev.Devices.from_name(context, 'block', name)
             if serial_only:
-                return {name: self.get_disk_serial(block_device)}
+                return {'serial': self.get_disk_serial(block_device)}
             else:
                 return self.get_disk_details(context, block_device, get_partitions)
         except pyudev.DeviceNotFoundByNameError:


### PR DESCRIPTION
The automatic alert that we generate in `smart_alert.py` (called by `smartd`) only gives the block device name (i.e. `/dev/sda`). Those names change frequently so we need to try and append the serial number of the drive. This does that by doing 2 things:
1. fix the `device.get_disk` api to match `device.get_disks`
2. call `device.get_disk` in `smart_alert.py` and add the serial number information to the alert