### PR TITLE
NAS-123754 / 23.10.1 / Plumb mkdir operations through filesystem.mkdir (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -426,7 +426,7 @@ class UserService(CRUDService):
         if create:
             target = os.path.join(path, username)
             try:
-                os.mkdir(target, mode=int(mode, 8))
+                self.middleware.call_sync('filesystem.mkdir', path, {'mode': mode})
             except FileExistsError:
                 if not os.path.isdir(target):
                     raise CallError(
@@ -1378,7 +1378,7 @@ class UserService(CRUDService):
             return
 
         if not os.path.isdir(sshpath):
-            os.mkdir(sshpath, mode=0o700)
+            self.middleware.call_sync('filesystem.mkdir', sshpath, {'mode': '700'})
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')
 

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -4,6 +4,7 @@
 # License: BSD
 
 import pytest
+import stat
 import sys
 import os
 apifolder = os.getcwd()
@@ -380,3 +381,11 @@ def file_and_directory():
 def test_type_filter(file_and_directory, query, result):
     listdir = call("filesystem.listdir", f"/mnt/{file_and_directory}", query)
     assert {item["name"] for item in listdir} == result, listdir
+
+
+def test_mkdir_mode():
+    with dataset("test_mkdir_mode") as ds:
+        testdir = os.path.join("/mnt", ds, "testdir")
+        call("filesystem.mkdir", testdir, {'mode': '777'})
+        st = call("filesystem.stat", testdir)
+        assert stat.S_IMODE(st["mode"]) == 0o777


### PR DESCRIPTION
These specific calls to os.mkdir can be replaced by filesystem.mkdir API calls. This is to help standardize local filesystem access. Currently the filesystem.mkdir API lacks ability to specify mode when creating a file, but in this case it was deemed redundant since the mkdir operation is subsequently followed by a filesystem.setperm call.

Original PR: https://github.com/truenas/middleware/pull/11969
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123754