### PR TITLE
NAS-124784 / 24.04 / Skip zero values when determining aggregated values in reporting

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -36,6 +36,7 @@ class GraphBase(metaclass=GraphMeta):
     title = None
     uses_identifiers = True
     vertical_label = None
+    skip_zero_values_in_aggregation = False
 
     AGG_MAP = {
         'min': min,
@@ -111,7 +112,7 @@ class GraphBase(metaclass=GraphMeta):
                 value = row[idx]
 
                 # Skip None values
-                if value is None:
+                if value is None or (self.skip_zero_values_in_aggregation and value == 0):
                     continue
 
                 # Update the aggregation values

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -25,6 +25,7 @@ class CPUTempPlugin(GraphBase):
     title = 'CPU Temperature'
     uses_identifiers = False
     vertical_label = 'Celsius'
+    skip_zero_values_in_aggregation = True
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
         return 'cputemp.temperatures'
@@ -221,6 +222,7 @@ class DiskTempPlugin(GraphBase):
     title = 'Disks Temperature'
     vertical_label = 'Celsius'
     disk_mapping = {}
+    skip_zero_values_in_aggregation = True
 
     def get_title(self):
         return 'Disk Temperature {identifier}'
@@ -320,6 +322,7 @@ class UPSTemperaturePlugin(GraphBase):
 
     title = 'UPS Temperature'
     vertical_label = 'Temperature'
+    skip_zero_values_in_aggregation = True
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
         return 'nut_ups.temp'


### PR DESCRIPTION
# Problem
When the system is down, Netdata normalizes that time interval with zero, ultimately affecting min-max values in aggregation.

# Solution
To address this, a `skip_zero` flag has been added in aggregation. This flag ensures that zero values are not considered when determining min-max values. This is particularly effective for reporting charts where values cannot be zero, such as temperature.