### PR TITLE
NAS-125285 / 24.04 / Fix regression caused by typo in NAS-123754

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -453,7 +453,14 @@ class UserService(CRUDService):
         if create:
             target = os.path.join(path, username)
             try:
-                self.middleware.call_sync('filesystem.mkdir', path, {'mode': mode})
+                # We do not raise exception on chmod error here because the
+                # target path may have RESTRICTED aclmode. Correct permissions
+                # get set in below `filesystem.setperm` call which strips ACL
+                # if present to strictly enforce `mode`.
+                self.middleware.call_sync('filesystem.mkdir', target, {
+                    'mode': mode,
+                    'raise_chmod_error': False
+                })
             except FileExistsError:
                 if not os.path.isdir(target):
                     raise CallError(
@@ -1405,6 +1412,8 @@ class UserService(CRUDService):
             return
 
         if not os.path.isdir(sshpath):
+            # Since this is security sensitive, we allow raising exception here
+            # if mode fails to be set to 0o700
             self.middleware.call_sync('filesystem.mkdir', sshpath, {'mode': '700'})
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')


### PR DESCRIPTION
NAS-123754 among other things slightly refactored how new user home directories were created so that internal middleware filesystem.mkdir was used instead of os.mkdir. This was missed in limited CI run prior to merge.