### PR TITLE
NAS-125285 / 23.10.1 / Fix regression caused by typo in NAS-123754 (#12534)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -426,7 +426,14 @@ class UserService(CRUDService):
         if create:
             target = os.path.join(path, username)
             try:
-                self.middleware.call_sync('filesystem.mkdir', path, {'mode': mode})
+                # We do not raise exception on chmod error here because the
+                # target path may have RESTRICTED aclmode. Correct permissions
+                # get set in below `filesystem.setperm` call which strips ACL
+                # if present to strictly enforce `mode`.
+                self.middleware.call_sync('filesystem.mkdir', target, {
+                    'mode': mode,
+                    'raise_chmod_error': False
+                })
             except FileExistsError:
                 if not os.path.isdir(target):
                     raise CallError(
@@ -1378,6 +1385,8 @@ class UserService(CRUDService):
             return
 
         if not os.path.isdir(sshpath):
+            # Since this is security sensitive, we allow raising exception here
+            # if mode fails to be set to 0o700
             self.middleware.call_sync('filesystem.mkdir', sshpath, {'mode': '700'})
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -134,12 +134,24 @@ class FilesystemService(Service):
         Dict(
             'options',
             UnixPerm('mode', default='755'),
+            Bool('raise_chmod_error', default=True)
         ),
     )
     @returns(Ref('path_entry'))
     def mkdir(self, path, options):
         """
         Create a directory at the specified path.
+
+        The following options are supported:
+
+        `mode` - specify the permissions to set on the new directory (0o755 is default).
+        `raise_chmod_error` - choose whether to raise an exception if the attempt to set
+        mode fails. In this case, the newly created directory will be removed to prevent
+        use with unintended permissions.
+
+        NOTE: if chmod error is skipped, the resulting `mode` key in mkdir response will
+        indicate the current permissions on the directory and not the permissions specified
+        in the mkdir payload
         """
         path = self.resolve_cluster_path(path)
         is_clustered = path.startswith("/cluster")
@@ -160,7 +172,18 @@ class FilesystemService(Service):
         stat = p.stat()
         if statlib.S_IMODE(stat.st_mode) != mode:
             # This may happen if requested mode is greater than umask
-            os.chmod(path, mode)
+            # or if underlying dataset has restricted aclmode and ACL is present
+            try:
+                os.chmod(path, mode)
+            except Exception:
+                if options['raise_chmod_error']:
+                    os.rmdir(path)
+                    raise
+
+                self.logger.debug(
+                    '%s: failed to set mode %s on path after mkdir call',
+                    path, options['mode'], exc_info=True
+                )
 
         return {
             'name': p.parts[-1],


### PR DESCRIPTION
This fixes string being used for path in mkdir request in accounts plugin and also makes error handling configurable of filesystem.mkdir requests. In case of chmod failure during filesystem.mkdir processing API user can either ignore errors (but will have to do own validation that the `mode` in response is acceptable), or allow backend to raise an exception on chmod failure (in which case newly-created directory will be removed to prevent its use).