### PR TITLE
NAS-124784 / 23.10.1 / Skip zero values when determining aggregated values in reporting (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -36,6 +36,7 @@ class GraphBase(metaclass=GraphMeta):
     title = None
     uses_identifiers = True
     vertical_label = None
+    skip_zero_values_in_aggregation = False
 
     AGG_MAP = {
         'min': min,
@@ -111,7 +112,7 @@ class GraphBase(metaclass=GraphMeta):
                 value = row[idx]
 
                 # Skip None values
-                if value is None:
+                if value is None or (self.skip_zero_values_in_aggregation and value == 0):
                     continue
 
                 # Update the aggregation values

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -25,6 +25,7 @@ class CPUTempPlugin(GraphBase):
     title = 'CPU Temperature'
     uses_identifiers = False
     vertical_label = 'Celsius'
+    skip_zero_values_in_aggregation = True
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
         return 'cputemp.temperatures'
@@ -221,6 +222,7 @@ class DiskTempPlugin(GraphBase):
     title = 'Disks Temperature'
     vertical_label = 'Celsius'
     disk_mapping = {}
+    skip_zero_values_in_aggregation = True
 
     def get_title(self):
         return 'Disk Temperature {identifier}'


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b101da1b1f939b60662cd1224c5e2587f1f621cf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 24a08ecd8393f59aeecdcfcc4e68cfbe554f1d8e

# Problem
When the system is down, Netdata normalizes that time interval with zero, ultimately affecting min-max values in aggregation.

# Solution
To address this, a `skip_zero` flag has been added in aggregation. This flag ensures that zero values are not considered when determining min-max values. This is particularly effective for reporting charts where values cannot be zero, such as temperature.

Original PR: https://github.com/truenas/middleware/pull/12532
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124784