### PR TITLE
NAS-125287 / 24.04 / fix ES60G2 enclosure identification (FW change)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -570,7 +570,7 @@ class Enclosure(object):
             self.model = "ES102G2"
         elif self.encname.startswith("CELESTIC R0904"):
             self.model = "ES60"
-        elif self.encname.startswith("HGST H4060-J 3010"):
+        elif self.encname.startswith("HGST H4060-J"):
             self.model = "ES60G2"
         elif ES24_REGEX.match(self.encname):
             self.model = "ES24"


### PR DESCRIPTION
The ES60G2's firmware was updated but our string matching is a bit too strict and matches the specific firmware revision. This removes the firmware revision portion of the string at bequest of platform team.