### PR TITLE
NAS-125287 / 13.0 / fix ES60G2 enclosure identification (FW change) (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/enclosure_class.py
@@ -65,7 +65,7 @@ class Enclosure(object):
             model = 'ES24F'
         elif self.encname.startswith('CELESTIC R0904'):
             model = 'ES60'
-        elif self.encname.startswith('HGST H4060-J 3010'):
+        elif self.encname.startswith('HGST H4060-J'):
             model = 'ES60G2'
         elif self.encname.startswith('HGST H4102-J'):
             model = 'ES102'


### PR DESCRIPTION
The ES60G2's firmware was updated but our string matching is a bit too strict and matches the specific firmware revision. This removes the firmware revision portion of the string at bequest of platform team.

Original PR: https://github.com/truenas/middleware/pull/12538
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125287