### PR TITLE
NAS-125287 / 23.10.1 / fix ES60G2 enclosure identification (FW change) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -533,7 +533,7 @@ class Enclosure(object):
             self.model = "ES102G2"
         elif self.encname.startswith("CELESTIC R0904"):
             self.model = "ES60"
-        elif self.encname.startswith("HGST H4060-J 3010"):
+        elif self.encname.startswith("HGST H4060-J"):
             self.model = "ES60G2"
         elif ES24_REGEX.match(self.encname):
             self.model = "ES24"


### PR DESCRIPTION
The ES60G2's firmware was updated but our string matching is a bit too strict and matches the specific firmware revision. This removes the firmware revision portion of the string at bequest of platform team.

Original PR: https://github.com/truenas/middleware/pull/12538
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125287