### PR TITLE
NAS-125139 / 23.10.1 / Fix network send/receive rate (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -175,6 +175,10 @@ class InterfaceService(CRUDService):
         additional_attrs=True,
     )
 
+    @private
+    async def query_names_only(self):
+        return [i['int_interface'] for i in await self.middleware.call('datastore.query', 'network.interfaces')]
+
     @filterable
     def query(self, filters, options):
         """

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -86,7 +86,7 @@ class RealtimeEventSource(EventSource):
                     'cpu': get_cpu_stats(netdata_metrics, cores),
                     'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
                     'interfaces': get_interface_stats(
-                        netdata_metrics, [i['name'] for i in self.middleware.call_sync('interface.query')]
+                        netdata_metrics, self.middleware.call_sync('interface.query_names_only')
                     ),
                     'failed_to_connect': False,
                 }

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
@@ -1,8 +1,6 @@
 import collections
 import typing
 
-from middlewared.plugins.reporting.netdata.utils import NETDATA_UPDATE_EVERY
-
 from .utils import normalize_value, safely_retrieve_dimension
 
 
@@ -15,17 +13,27 @@ def get_interface_stats(netdata_metrics: dict, interfaces: typing.List[str]) -> 
             netdata_metrics, f'net_speed.{interface_name}', 'speed', 0), divisor=1000
         )
         if link_state:
-            data[interface_name]['received_bytes'] = normalize_value(
-                safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'received', 0),
-                multiplier=1000, divisor=8
-            ) / NETDATA_UPDATE_EVERY
-            data[interface_name]['sent_bytes'] = normalize_value(
-                safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'sent', 0),
-                multiplier=1000, divisor=8
-            ) / NETDATA_UPDATE_EVERY
+            # In Bluefin, `received_bytes` and `sent_bytes` represent bytes per interval,
+            # while `received_bytes_rate` and `sent_bytes_rate` represent bytes per second.
+            # However, Netdata is currently sending data in kilobits per second.
+            # After converting the Netdata value to bytes per second,
+            # we need to multiply `received_bytes` and `sent_bytes` by the interval
+            # to maintain unit consistency with Bluefin.
+            # https://github.com/truenas/middleware/blob/30dbedbe170b750775e58e7d9c86cfcd00f52730/src/middlewared/
+            # middlewared/plugins/reporting/ifstat.py#L73C17-L73C25
+            # We have removed received_bytes/sent_bytes from the data structure because of the unneeded computation
+            # involved in getting to that and as netdata is giving us kilobit/s already, we just need to convert
+            # it to bytes/s
+
             data[interface_name].update({
-                'received_bytes_rate': data[interface_name]['received_bytes'] / NETDATA_UPDATE_EVERY,
-                'sent_bytes_rate': data[interface_name]['sent_bytes'] / NETDATA_UPDATE_EVERY,
+                'received_bytes_rate': normalize_value(
+                    safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'received', 0),
+                    multiplier=1000, divisor=8
+                ),
+                'sent_bytes_rate': normalize_value(
+                    safely_retrieve_dimension(netdata_metrics, f'net.{interface_name}', 'sent', 0),
+                    multiplier=1000, divisor=8
+                ),
             })
         else:
             data[interface_name].update({

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, mock_open
 
-from middlewared.plugins.reporting.netdata.utils import NETDATA_UPDATE_EVERY
 from middlewared.plugins.reporting.realtime_reporting import (
     get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info,
 )
@@ -615,14 +614,16 @@ def test_disk_stats():
 def test_network_stats():
     interfaces = ['enp1s0']
     for interface_name, metrics in get_interface_stats(NETDATA_ALL_METRICS, interfaces).items():
-        assert metrics['received_bytes'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, f'net.{interface_name}', 'received', 0),
-            multiplier=1000, divisor=8) / NETDATA_UPDATE_EVERY
-        assert metrics['sent_bytes'] == normalize_value(
+        send_bytes_rate = normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, f'net.{interface_name}', 'sent', 0),
-            multiplier=1000, divisor=8) / NETDATA_UPDATE_EVERY
-        assert metrics['received_bytes_rate'] == metrics['received_bytes'] / NETDATA_UPDATE_EVERY
-        assert metrics['sent_bytes_rate'] == metrics['sent_bytes'] / NETDATA_UPDATE_EVERY
+            multiplier=1000, divisor=8
+        )
+        received_bytes_rate = normalize_value(
+            safely_retrieve_dimension(NETDATA_ALL_METRICS, f'net.{interface_name}', 'received', 0),
+            multiplier=1000, divisor=8
+        )
+        assert metrics['received_bytes_rate'] == received_bytes_rate
+        assert metrics['sent_bytes_rate'] == send_bytes_rate
         assert metrics['speed'] == normalize_value(safely_retrieve_dimension(
             NETDATA_ALL_METRICS, f'net_speed.{interface_name}', 'speed', 0), divisor=1000
         )


### PR DESCRIPTION
**Problem:**

When reporting network statistics in the `realtime.reporting` event, the rate of change is miscalculated. Currently, the calculation involves dividing the current value by the interval, but it should be the difference between the current and old values at the current time minus the interval. The interval should remain constant.

**Solution:**

To address this, the solution involves querying the current value from Netdata along with the old value, which is from seconds equal to the interval in the past. The difference between these values is then calculated to accurately report the change in network statistics.

Original PR: https://github.com/truenas/middleware/pull/12502
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125139