### PR TITLE
NAS-125048 / 13.1 / Fix NFS bindip configuration at boot

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-nfsbind
+++ b/src/freenas/etc/ix.rc.d/ix-nfsbind
@@ -4,9 +4,10 @@
 #
 
 # PROVIDE: ix-nfsbind
-# REQUIRE: middlewared
+# REQUIRE: middlewared NETWORKING
 # BEFORE: mountd gssd nfsuserd nfsd
 
+source /etc/rc.subr
 
 nfs_bindip() {
 	# We need to make sure the NFS bind IP exists

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -564,7 +564,6 @@ async def pool_post_import(middleware, pool):
     path = f'/mnt/{pool["name"]}'
     for share in await middleware.call('sharing.nfs.query'):
         if any(filter(lambda x: x == path or x.startswith(f'{path}/'), share['paths'])):
-            await middleware.call('etc.generate', 'rc')
             middleware.create_task(middleware.call('service.reload', 'nfs'))
             break
 

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -564,6 +564,7 @@ async def pool_post_import(middleware, pool):
     path = f'/mnt/{pool["name"]}'
     for share in await middleware.call('sharing.nfs.query'):
         if any(filter(lambda x: x == path or x.startswith(f'{path}/'), share['paths'])):
+            await middleware.call('etc.generate', 'rc')
             middleware.create_task(middleware.call('service.reload', 'nfs'))
             break
 


### PR DESCRIPTION
### The problem
The NFS bindip cannot be configured if the selected IP address is not functional.  This setting is in `/etc/rc.conf.freebsd`.  NFS is started and configured _before_ the network is started.  NFS has a post network start event handler that will restrart NFS if bindip is configured in the DB.

However, the NFS bindip _setting_ was blocked at boot during the initial configuration run because the network subsystem had not yet completed startup.  This resulted in no NFS bindip configuration.

### The fix
In the post network start handler, regenerate `rc.conf.freebsd` before restarting NFS.