### PR TITLE
NAS-124980 / 24.04 / Allow FULL_CONTROL for POSIX ACL in add_to_acl

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -728,7 +728,7 @@ class FilesystemService(Service, ACLBase):
     @private
     def add_to_acl_posix(self, acl, entries):
         def convert_perm(perm):
-            if perm == 'MODIFY':
+            if perm == 'MODIFY' or perm == 'FULL_CONTROL':
                 return {'READ': True, 'WRITE': True, 'EXECUTE': True}
 
             if perm == 'READ':


### PR DESCRIPTION
This allows our apps framework to specify FULL_CONTROL for POSIX ACL. We can't _actually_ give FULL_CONTROL to a user or group under POSIX1E ACLs (only owner will be able to chown / chmod), but this makes error handling easier in the apps framework.