### PR TITLE
NAS-125291 / 23.10.1 / Fix failing CI tests that were due to filesystem.mkdir chanages (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -430,12 +430,12 @@ class UserService(CRUDService):
                 # target path may have RESTRICTED aclmode. Correct permissions
                 # get set in below `filesystem.setperm` call which strips ACL
                 # if present to strictly enforce `mode`.
-                self.middleware.call_sync('filesystem.mkdir', target, {
-                    'mode': mode,
-                    'raise_chmod_error': False
+                self.middleware.call_sync('filesystem.mkdir', {
+                    'path': target,
+                    'options': {'mode': mode, 'raise_chmod_error': False}
                 })
-            except FileExistsError:
-                if not os.path.isdir(target):
+            except CallError as e:
+                if e.errno == errno.EEXIST and not os.path.isdir(target):
                     raise CallError(
                         'Path for home directory already '
                         'exists and is not a directory',
@@ -1387,7 +1387,7 @@ class UserService(CRUDService):
         if not os.path.isdir(sshpath):
             # Since this is security sensitive, we allow raising exception here
             # if mode fails to be set to 0o700
-            self.middleware.call_sync('filesystem.mkdir', sshpath, {'mode': '700'})
+            self.middleware.call_sync('filesystem.mkdir', {'path': sshpath, 'options': {'mode': '700'}})
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')
 

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -129,16 +129,22 @@ class FilesystemService(Service):
         mntinfo = getmntinfo()
         return filter_list(list(mntinfo.values()), filters, options)
 
-    @accepts(
+    @accepts(Dict(
+        'filesystem_mkdir',
         Str('path'),
         Dict(
             'options',
             UnixPerm('mode', default='755'),
             Bool('raise_chmod_error', default=True)
         ),
-    )
+    ), deprecated=[(
+        lambda args: len(args) == 1 and isinstance(args[0], str),
+        lambda mkdir_path: [{
+            'path': mkdir_path
+        }]
+    )])
     @returns(Ref('path_entry'))
-    def mkdir(self, path, options):
+    def mkdir(self, data):
         """
         Create a directory at the specified path.
 
@@ -153,7 +159,8 @@ class FilesystemService(Service):
         indicate the current permissions on the directory and not the permissions specified
         in the mkdir payload
         """
-        path = self.resolve_cluster_path(path)
+        path = self.resolve_cluster_path(data['path'])
+        options = data['options']
         is_clustered = path.startswith("/cluster")
         mode = int(options['mode'], 8)
 
@@ -165,7 +172,7 @@ class FilesystemService(Service):
             raise CallError(f'{path}: path already exists.', errno.EEXIST)
 
         realpath = os.path.realpath(path)
-        if not is_clustered and not realpath.startswith('/mnt/'):
+        if not is_clustered and not realpath.startswith(('/mnt/', '/root/.ssh', '/home/admin/.ssh')):
             raise CallError(f'{path}: path not permitted', errno.EPERM)
 
         os.mkdir(path, mode=mode)

--- a/src/middlewared/middlewared/test/integration/assets/filesystem.py
+++ b/src/middlewared/middlewared/test/integration/assets/filesystem.py
@@ -4,8 +4,8 @@ from middlewared.test.integration.utils import call, ssh
 
 
 @contextlib.contextmanager
-def directory(path):
-    call('filesystem.mkdir', path)
+def directory(path, options=None):
+    call('filesystem.mkdir', {'path': path} | options or {})
 
     try:
         yield path

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -110,18 +110,14 @@ def test_05_set_immutable_flag_on_path(request):
 
     with directory(t_path) as d:
         for flag_set in (True, False):
-            POST('/filesystem/set_immutable/', {'set_flag': flag_set, 'path': d})
+            call('filesystem.set_immutable',  flag_set, d)
             # We test 2 things
             # 1) Writing content to the parent path fails/succeeds based on "set"
             # 2) "is_immutable_set" returns sane response
-            results = POST('/filesystem/mkdir', f'{t_child_path}_{flag_set}')
-            assert results.status_code == (500 if flag_set else 200), results.text
+            call('filesystem.mkdir', f'{t_child_path}_{flag_set}')
 
-            results = POST('/filesystem/is_immutable/', t_path)
-            assert results.status_code == 200, results.text
-            result = results.json()
-            assert isinstance(result, bool) is True, results.text
-            assert result == flag_set, 'Immutable flag is still not set' if flag_set else 'Immutable flag is still set'
+            is_immutable = call('filesystem.is_immutable', t_path)
+            assert is_immutable == flag_set, 'Immutable flag is still not set' if flag_set else 'Immutable flag is still set'
 
 
 def test_06_test_filesystem_listdir_exclude_non_mounts():
@@ -386,6 +382,6 @@ def test_type_filter(file_and_directory, query, result):
 def test_mkdir_mode():
     with dataset("test_mkdir_mode") as ds:
         testdir = os.path.join("/mnt", ds, "testdir")
-        call("filesystem.mkdir", testdir, {'mode': '777'})
+        call("filesystem.mkdir", {'path': testdir, 'mode': '777'})
         st = call("filesystem.stat", testdir)
         assert stat.S_IMODE(st["mode"]) == 0o777


### PR DESCRIPTION
This shifts some tests from REST to websocket calls (general incremental improvements to our testing), adds ability to use new options in our `directory` test asset, and allows creating .ssh directory for root and admin users (which are not under /mnt).

Original PR: https://github.com/truenas/middleware/pull/12546
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125291