### PR TITLE
NAS-125310 / 23.10.1 / add new firmware for ES60G2 to enclosure2 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -165,7 +165,7 @@ class Enclosure:
             case 'HGST_H4102-J':
                 self.model = JbodModels.ES102.value
                 self.controller = False
-            case 'VikingES_NDS-41022-BB':
+            case 'VikingES_NDS-41022-BB' | 'VikingES_VDS-41022-BB':
                 self.model = JbodModels.ES102G2.value
                 self.controller = False
             case _:


### PR DESCRIPTION
This adds the new firmware (identified during QE cycle) to the enclosure2 namespace. Was explicitly done in a separate PR so ticket tracking could be kept separate since the original PR was back ported all the way back to 13.0 but enclosure2 only exists in Cobia/DF.

Original PR: https://github.com/truenas/middleware/pull/12553
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125310