### PR TITLE
NAS-125311 / 23.10.1 / Add back received/sent bytes keys

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/ifstat.py
@@ -35,6 +35,10 @@ def get_interface_stats(netdata_metrics: dict, interfaces: typing.List[str]) -> 
                     multiplier=1000, divisor=8
                 ),
             })
+            data[interface_name].update({
+                'received_bytes': data[interface_name]['received_bytes_rate'],
+                'sent_bytes': data[interface_name]['sent_bytes_rate'],
+            })
         else:
             data[interface_name].update({
                 'received_bytes': 0,


### PR DESCRIPTION
## Context

For backwards compatibility due to UI changes involved we are adding `received_bytes/sent_bytes` keys back reflecting `bytes/sec` values.