### PR TITLE
NAS-125252 / 24.04 / Remove node from TSP during ctdb teardown

### DIFF
--- a/cluster-tests/tests/cleanup/test_cluster_cleanup.py
+++ b/cluster-tests/tests/cleanup/test_cluster_cleanup.py
@@ -132,3 +132,11 @@ def test_verify_ctdb_teardown(ip, request):
         ans = make_ws_request(ip, payload)
         assert ans.get('error') is None, ans
         assert len(ans['result']) == 0, ans['result']
+
+    ans = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'gluster.peer.query'
+    })
+
+    assert ans.get('error') is None, ans
+    assert len(ans['result']) == 0, ans['result']

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
@@ -612,8 +612,11 @@ class CtdbRootDirService(Service):
         wipe_config_job = await self.middleware.call('cluster.utils.wipe_config')
         await wipe_config_job.wait()
 
-        job.set_progress(99, 'Disabling cluster service')
+        job.set_progress(90, 'Disabling cluster service')
         await self.middleware.call('service.update', 'glusterd', {'enable': False})
         await self.middleware.call('smb.reset_smb_ha_mode')
 
+        job.set_progress(95, 'Deleting node from trusted storage pool')
+        peer_delete_job = await self.middleware.call('gluster.peer.delete', config['uuid']) 
+        await peer_delete_job.wait()
         job.set_progress(100, 'CTDB root directory teardown complete.')

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
@@ -616,7 +616,9 @@ class CtdbRootDirService(Service):
         await self.middleware.call('service.update', 'glusterd', {'enable': False})
         await self.middleware.call('smb.reset_smb_ha_mode')
 
-        job.set_progress(95, 'Deleting node from trusted storage pool')
-        peer_delete_job = await self.middleware.call('gluster.peer.delete', config['uuid']) 
-        await peer_delete_job.wait()
+        job.set_progress(95, 'Detaching trusted storage pool')
+        if await self.middleware.call('gluster.peer.query'):
+            detach_all_job = await self.middleware.call('gluster.peer.detach_all')
+            await detach_all_job.wait()
+
         job.set_progress(100, 'CTDB root directory teardown complete.')

--- a/src/middlewared/middlewared/plugins/gluster_linux/peer.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/peer.py
@@ -166,6 +166,14 @@ class GlusterPeerService(CRUDService):
                 'enable': False, 'node_uuid': peer_uuid
             })
 
+    @private
+    @job(lock=GLUSTER_JOB_LOCK)
+    async def detach_all(self, job):
+        if await self.middleware.call('cluster.utils.is_clustered'):
+            raise CallError('Detaching all peers from cluster may not be performed while clustering enabled')
+
+        await self.middleware.call('gluster.method.run', peer.detach_all)
+
     @accepts(Dict(
         'peer_status',
         Bool('localhost', default=True),


### PR DESCRIPTION
This simplifies cluster cleanup for the TrueCommand team for the highly unusual case where a user has deployed a TrueNAS cluster and wants to rip out the clustering configuration without a full server OS reinstall or rolling back from snapshot. Such a situation may occur as part of CI pipelines where clustering is repeatedly configured and torn down without server reinstalls.