### PR TITLE
NAS-125324 / 23.10.1 / fix R50 in enclosure2 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -48,7 +48,7 @@ class Enclosure:
             # being unable to determine the model means many other things will not work
             self.should_ignore = True
         elif all((
-            (not any((self.is_rseries, self.is_mini))),
+            (not any((self.is_r20_series, self.is_mini))),
             self.vendor == 'AHCI',
             self.product == 'SGPIOEnclosure',
         )):
@@ -218,6 +218,8 @@ class Enclosure:
             any((self.is_mini, self.is_r20_series))
         )):
             idkey, idvalue = 'id', self.encid
+        elif self.is_r50_series:
+            idkey, idvalue = 'product', self.product
 
         # Now we know the specific enclosure we're on and the specific
         # key we need to use to pull out the drive slot mapping


### PR DESCRIPTION
This fixes the R50 series platform in the new enclosure2 code. I'm working on adding tests in another PR and will push those soon which will, in theory, catch situations like this.

Original PR: https://github.com/truenas/middleware/pull/12556
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125324