### PR TITLE
Fix ORing in options to dict

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/filesystem.py
+++ b/src/middlewared/middlewared/test/integration/assets/filesystem.py
@@ -5,7 +5,7 @@ from middlewared.test.integration.utils import call, ssh
 
 @contextlib.contextmanager
 def directory(path, options=None):
-    call('filesystem.mkdir', {'path': path} | options or {})
+    call('filesystem.mkdir', {'path': path} | (options or {}))
 
     try:
         yield path


### PR DESCRIPTION
Fix recently introduced breakage in test
```
    @contextlib.contextmanager
    def directory(path, options=None):
>       call('filesystem.mkdir', {'path': path} | options or {})
E       TypeError: unsupported operand type(s) for |: 'dict' and 'NoneType'
```