### PR TITLE
NAS-125335 / 24.04 / Add validation for SMB share name

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 import stat
 import subprocess
+import unicodedata
 import uuid
 
 from copy import deepcopy
@@ -31,6 +32,7 @@ from middlewared.utils.path import FSLocation, path_location, is_child_realpath
 NETIF_COMPLETE_SENTINEL = f"{MIDDLEWARE_RUN_DIR}/ix-netif-complete"
 CONFIGURED_SENTINEL = '/var/run/samba/.configured'
 SMB_AUDIT_DEFAULTS = {'enable': False, 'watch_list': [], 'ignore_list': []}
+INVALID_SHARE_NAME_CHARACTERS = {'%', '<', '>', '*', '?', '|', '/', '\\', '+', '=', ';', ':', '"', ',', '[', ']'}
 
 
 class SMBHAMODE(enum.IntEnum):
@@ -1690,11 +1692,33 @@ class SharingSMBService(SharingService):
                 'of SMB share.'
             )
 
-        if data.get('name') and data['name'].lower() in ['global', 'homes', 'printers']:
-            verrors.add(
-                f'{schema_name}.name',
-                f'{data["name"]} is a reserved section name, please select another one'
-            )
+        if data.get('name'):
+            # Standards for SMB share name are defined in MS-FSCC 2.1.6
+            # We are slighly more strict in that blacklist all unicode control characters
+
+            has_control_characters = False
+            if data['name'].lower() in ['global', 'homes', 'printers']:
+                verrors.add(
+                    f'{schema_name}.name',
+                    f'{data["name"]} is a reserved section name, please select another one'
+                )
+
+            invalid_characters = INVALID_SHARE_NAME_CHARACTERS & set(data['name'])
+            if invalid_characters:
+                verrors.add(
+                    f'{schema_name}.name',
+                    f'Share name contains the following invalid characters: {", ".join(invalid_characters)}'
+                )
+
+            for char in data['name']:
+                if unicodedata.category(char) == 'Cc':
+                    has_control_characters = True
+                    break
+
+            if has_control_characters:
+                verrors.add(
+                    f'{schema_name}.name', 'Share name contains unicode control characters.'
+                )
 
         if data.get('path_suffix') and len(data['path_suffix'].split('/')) > 2:
             verrors.add(f'{schema_name}.name',

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -7,14 +7,17 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import (ip, pool_name)
 from functions import GET, POST
+from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
 from protocols import MS_RPC
 
 
 SMB_USER = "smbrpcuser"
 SMB_PWD = "smb1234#!@"
+INVALID_SHARE_NAME_CHARACTERS = {'%', '<', '>', '*', '?', '|', '/', '\\', '+', '=', ';', ':', '"', ',', '[', ']'}
 
 @pytest.fixture(scope="module")
 def setup_smb_share(request):
@@ -94,3 +97,32 @@ def test_003_access_based_share_enum(setup_smb_user, setup_smb_share):
     with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
         shares = hdl.shares()
         assert len(shares) == 1, str({"enum": shares, "shares": results.json()})
+
+
+def test_share_name_restricutions(setup_smb_share):
+    first_share = setup_smb_share['share']
+    ds_name = setup_smb_share['dataset']
+
+    for char in INVALID_SHARE_NAME_CHARACTERS:
+        # First try updating existing share's name
+        with pytest.raises(ValidationErrors) as ve:
+            call('sharing.smb.update', first_share['id'], {'name': f'CANARY{char}'})
+
+        assert 'Share name contains the following invalid characters' in ve.value.errors[0].errmsg
+
+        # Now try creating new share
+        with pytest.raises(ValidationErrors) as ve:
+            call('sharing.smb.create', {'path': os.path.join('/mnt', ds_name), 'name': f'CANARY{char}'})
+
+        assert 'Share name contains the following invalid characters' in ve.value.errors[0].errmsg
+
+
+    with pytest.raises(ValidationErrors) as ve:
+        call('sharing.smb.update', first_share['id'], {'name': 'CANARY\x85'})
+
+    assert 'Share name contains unicode control characters' in ve.value.errors[0].errmsg
+
+    with pytest.raises(ValidationErrors) as ve:
+        call('sharing.smb.create', {'path': os.path.join('/mnt', ds_name), 'name': 'CANARY\x85'})
+
+    assert 'Share name contains unicode control characters' in ve.value.errors[0].errmsg


### PR DESCRIPTION
TrueNAS SMB share name validation allowed invalid characters, which
resulted in share that was created being rejected by libsmbconf.

This commit validates that share name minimally meets requirements
from MS-FSCC 2.1.6

```
* A share name MUST be no more than 80 characters in length.

* The following characters are illegal in a share name:
  " \ / [ ] : | < > + = ; , * ?

* Control characters in range 0x00 through 0x1F, inclusive, are illegal in a share name.

* All other Unicode characters are legal.
```

Extended requirements for TrueNAS are as follows:
* the % (percent) character is also illegal
* all unicode control characters are prohibited