### PR TITLE
NAS-125336 / 24.04 / Expand tests for filesystem.mkdir

### DIFF
--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -3,6 +3,7 @@
 # Author: Eric Turgeon
 # License: BSD
 
+import errno
 import pytest
 import stat
 import sys
@@ -13,6 +14,7 @@ sys.path.append(apifolder)
 from copy import deepcopy
 from functions import POST, PUT, SSH_TEST, wait_on_job
 from auto_config import pool_name, ip, user, password
+from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.filesystem import directory
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, ssh
@@ -114,7 +116,11 @@ def test_05_set_immutable_flag_on_path(request):
             # We test 2 things
             # 1) Writing content to the parent path fails/succeeds based on "set"
             # 2) "is_immutable_set" returns sane response
-            call('filesystem.mkdir', f'{t_child_path}_{flag_set}')
+            if flag_set:
+                with pytest.raises(PermissionError):
+                    call('filesystem.mkdir', f'{t_child_path}_{flag_set}')
+            else:
+                call('filesystem.mkdir', f'{t_child_path}_{flag_set}')
 
             is_immutable = call('filesystem.is_immutable', t_path)
             assert is_immutable == flag_set, 'Immutable flag is still not set' if flag_set else 'Immutable flag is still set'
@@ -382,6 +388,27 @@ def test_type_filter(file_and_directory, query, result):
 def test_mkdir_mode():
     with dataset("test_mkdir_mode") as ds:
         testdir = os.path.join("/mnt", ds, "testdir")
-        call("filesystem.mkdir", {'path': testdir, 'mode': '777'})
+        call("filesystem.mkdir", {'path': testdir, 'options': {'mode': '777'}})
         st = call("filesystem.stat", testdir)
         assert stat.S_IMODE(st["mode"]) == 0o777
+
+
+def test_mkdir_chmod_failure():
+    with dataset("test_mkdir_chmod", {"share_type": "SMB"}) as ds:
+        testdir = os.path.join("/mnt", ds, "testdir")
+        with pytest.raises(PermissionError):
+            call("filesystem.mkdir", {'path': testdir, 'options': {'mode': '777'}})
+
+        with pytest.raises(CallError) as ce:
+            call("filesystem.stat", testdir)
+
+        assert ce.value.errno == errno.ENOENT
+
+        mkdir_st = call("filesystem.mkdir", {'path': testdir, 'options': {'mode': '777', 'raise_chmod_error': False}})
+
+        st = call("filesystem.stat", testdir)
+        # Verify that mode output returned from mkdir matches what was actually set
+        assert st['mode'] == mkdir_st['mode']
+
+        # mkdir succeeded, but chmod failed so we get mode based on inherited ACL (SMB preset) 
+        assert stat.S_IMODE(st["mode"]) == 0o770


### PR DESCRIPTION
This commit fixes some broken filesystem tests and also expands testing for filesystem.mkdir endpoint so that behavior of raise_chmod_error is validated.