### PR TITLE
NAS-125381 / 23.10.2 / Allow valid usb devices where their text is null (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -34,7 +34,7 @@ class VMDeviceService(Service):
             return capability
         required_keys = set(self.get_capability_keys())
         capability_info = {}
-        for element in filter(lambda e: e.tag in required_keys and e.text, capability):
+        for element in filter(lambda e: e.tag in required_keys, capability):
             capability_info[element.tag] = element.text
             if element.tag in ('product', 'vendor') and element.get('id'):
                 capability_info[f'{element.tag}_id'] = element.get('id')


### PR DESCRIPTION
## Problem
Certain valid USB devices are being filtered out because their vendor/product ID contains only the ID without accompanying text. The vendor and product IDs are what make these devices valid.

## Solution
Remove the condition that checks for the availability of text in the vendor/product ID filter to include these devices.

Sample xml
```
<device>
  <name>usb_1_14</name>
  <path>/sys/devices/pci0000:00/0000:00:14.0/usb1/1-14</path>
  <devnode type='dev'>/dev/bus/usb/001/007</devnode>
  <parent>usb_usb1</parent>
  <driver>
    <name>usb</name>
  </driver>
  <capability type='usb_device'>
    <bus>1</bus>
    <device>7</device>
    <product id='0x0032' />
    <vendor id='0x8087'>Intel Corp.</vendor>
  </capability>
</device>
```

Original PR: https://github.com/truenas/middleware/pull/12571
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125381