### PR TITLE
NAS-125391 / 24.04 / Fix crash in auth plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -649,12 +649,12 @@ async def check_permission(middleware, app):
         else:
             try:
                 query = {
-                    'username': await middleware.call(
+                    'username': (await middleware.call(
                         'datastore.query',
                         'account.bsdusers',
                         [['uid', '=', origin.uid]],
                         {'get': True, 'prefix': 'bsdusr_'},
-                    )['username'],
+                    ))['username'],
                 }
                 local = True
             except MatchNotFound:


### PR DESCRIPTION
Seen in CI run:

```
2023/11/27 12:45:07] (ERROR) middlewared.call_hook():1314 - Failed to run hook core.on_connect:<function check_permission at 0x7fa38de4fe20>(*(), **{'app': <middlewared.main.Application object at 0x7fa32ed976d0>})
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1307, in call_hook
    await fut
  File "/usr/lib/python3/dist-packages/middlewared/plugins/auth.py", line 652, in check_permission
    'username': await middleware.call(
                      ^^^^^^^^^^^^^^^^
TypeError: 'coroutine' object is not subscriptable
```