### PR TITLE
NAS-125397 / 24.04 / Fix check that alert should have been cleared

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1401,4 +1401,4 @@ def test_62_files_in_exportsd(request, expect_NFS_start):
             # Find alert
             assert any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts
         else:  # Alert should have been cleared
-            assert any(alert["klass"] != "NFSblockedByExportsDir" for alert in alerts), alerts
+            assert not any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts


### PR DESCRIPTION
We need to ensure that the `NFSblockedByExportsDir` alert does NOT exist. not merely that another event exists.