### PR TITLE
NAS-125304 / 24.04 / Add NFS share_type and ability to get inherited ACL

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_base.py
@@ -135,24 +135,25 @@ class ACLType(enum.Enum):
                 # File and this entry doesn't inherit on files
                 continue
 
-            if isdir and not flags.get('DIRECTORY_INHERIT', False):
-                if flags['NO_PROPAGATE_INHERIT']:
-                    # doesn't apply to this dir and shouldn't apply to contents.
-                    continue
+            if isdir:
+                if not flags.get('DIRECTORY_INHERIT', False):
+                    if flags['NO_PROPAGATE_INHERIT']:
+                        # doesn't apply to this dir and shouldn't apply to contents.
+                        continue
 
-                # This is a directoy ACL and we have entry that only applies to files.
-                flags['INHERIT_ONLY'] = True
-            elif flags.get('INHERIT_ONLY', False):
+                    # This is a directoy ACL and we have entry that only applies to files.
+                    flags['INHERIT_ONLY'] = True
+                elif flags.get('INHERIT_ONLY', False):
+                    flags['INHERIT_ONLY'] = False
+                elif flags.get('NO_PROPAGATE_INHERIT'):
+                    flags['DIRECTORY_INHERIT'] = False
+                    flags['FILE_INHERIT'] = False
+                    flags['NO_PROPAGATE_INHERIT'] = False
+            else:
+                flags['DIRECTORY_INHERIT'] = False
+                flags['FILE_INHERIT'] = False
+                flags['NO_PROPAGATE_INHERIT'] = False
                 flags['INHERIT_ONLY'] = False
-            elif flags.get('NO_PROPAGATE_INHERIT'):
-                flags['DIRECTORY_INHERIT'] = False
-                flags['FILE_INHERIT'] = False
-                flags['NO_PROPAGATE_INHERIT'] = False
-
-            if not isdir:
-                flags['DIRECTORY_INHERIT'] = False
-                flags['FILE_INHERIT'] = False
-                flags['NO_PROPAGATE_INHERIT'] = False
 
             inherited.append({
                 'tag': entry['tag'],

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -912,3 +912,14 @@ class FilesystemService(Service, ACLBase):
         })
 
         return job.wrap_sync(setacl_job)
+
+    def get_inherited_acl(self, data):
+        init_path = data['path']
+        verrors = ValidationErrors()
+        self._common_perm_path_validate('filesystem.add_to_acl', data, verrors)
+        verrors.check()
+
+        current_acl = self.getacl(data['path'], False)
+        acltype = ACLType[current_acl['acltype']]
+
+        return acltype.calculate_inherited(current_acl, data['options']['directory'])

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_acl_inherit.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_acl_inherit.py
@@ -1,0 +1,177 @@
+import pytest
+
+from copy import deepcopy
+from middlewared.plugins.filesystem_.acl_base import ACLType
+
+
+NFS4_ACL = {'acl': [
+    {
+        'tag': 'GROUP',
+        'id': 100,
+        'perms': { 'BASIC': 'FULL_CONTROL' },
+        'flags': {
+            'FILE_INHERIT': True,
+            'DIRECTORY_INHERIT': True,
+            'INHERIT_ONLY': False,
+            'NO_PROPAGATE_INHERIT': False,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+    {
+        'tag': 'GROUP',
+        'id': 200,
+        'perms': { 'BASIC': 'MODIFY' },
+        'flags': {
+            'FILE_INHERIT': False,
+            'DIRECTORY_INHERIT': True,
+            'INHERIT_ONLY': False,
+            'NO_PROPAGATE_INHERIT': False,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+    {
+        'tag': 'GROUP',
+        'id': 300,
+        'perms': { 'BASIC': 'MODIFY' },
+        'flags': {
+            'FILE_INHERIT': True,
+            'DIRECTORY_INHERIT': False,
+            'INHERIT_ONLY': True,
+            'NO_PROPAGATE_INHERIT': False,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+    {
+        'tag': 'GROUP',
+        'id': 400,
+        'perms': { 'BASIC': 'MODIFY' },
+        'flags': {
+            'FILE_INHERIT': True,
+            'DIRECTORY_INHERIT': True,
+            'INHERIT_ONLY': True,
+            'NO_PROPAGATE_INHERIT': True,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+    {
+        'tag': 'GROUP',
+        'id': 500,
+        'perms': { 'BASIC': 'MODIFY' },
+        'flags': {
+            'FILE_INHERIT': False,
+            'DIRECTORY_INHERIT': False,
+            'INHERIT_ONLY': False,
+            'NO_PROPAGATE_INHERIT': False,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+    {
+        'tag': 'GROUP',
+        'id': 600,
+        'perms': { 'BASIC': 'MODIFY' },
+        'flags': {
+            'FILE_INHERIT': True,
+            'DIRECTORY_INHERIT': True,
+            'INHERIT_ONLY': False,
+            'NO_PROPAGATE_INHERIT': True,
+            'INHERITED': False
+        },
+        'type': 'ALLOW'
+    },
+], 'acltype': 'NFS4', 'trivial': False, 'uid': 0, 'gid': 0, 'path': '/mnt/dozer/SHARE'}
+
+
+def test__nfs4_acl_inheritance():
+    dir_inherited = ACLType.NFS4.calculate_inherited(deepcopy(NFS4_ACL), True)
+    file_inherited = ACLType.NFS4.calculate_inherited(deepcopy(NFS4_ACL), False)
+
+    for entry in dir_inherited:
+        match entry['id']:
+            case 100:
+                expected = {
+                    'FILE_INHERIT': True,
+                    'DIRECTORY_INHERIT': True,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 200:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': True,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 300:
+                expected = {
+                    'FILE_INHERIT': True,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': True,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 400:
+                expected = {
+                    'FILE_INHERIT': True,
+                    'DIRECTORY_INHERIT': True,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': True,
+                    'INHERITED': True
+                }
+            case 600:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case _:
+                assert False, f'Unexpected entry: {entry["id"]}'
+
+        assert entry['flags'] == expected, f'{entry["id"]}: flags do not match'
+
+    for entry in file_inherited:
+        match entry['id']:
+            case 100:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 300:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 400:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case 600:
+                expected = {
+                    'FILE_INHERIT': False,
+                    'DIRECTORY_INHERIT': False,
+                    'INHERIT_ONLY': False,
+                    'NO_PROPAGATE_INHERIT': False,
+                    'INHERITED': True
+                }
+            case _:
+                assert False, f'Unexpected entry: {entry["id"]}'
+
+        assert entry['flags'] == expected, f'{entry["id"]}: flags do not match'

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -12,6 +12,7 @@ sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
 from auto_config import ip, pool_name, user, password
 from pytest_dependency import depends
+from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user as create_user
 from middlewared.test.integration.assets.pool import dataset as make_dataset
 from middlewared.test.integration.utils import call, ssh
@@ -934,8 +935,12 @@ def test_30_acl_inherit_nested_dataset():
         acl1 = call('filesystem.getacl', os.path.join('/mnt', ds1))
         assert any(x['id'] == 666 for x in acl1['acl'])
 
-        with make_dataset("acl_test_inherit1/acl_test_inherit2", data={'share_type': 'APPS'}) as ds2:
+        with pytest.raises(ValidationErrors):
+            # ACL on parent dataset prevents adding APPS group to ACL. Fail.
+            with make_dataset("acl_test_inherit1/acl_test_inherit2", data={'share_type': 'APPS'}):
+                pass
+
+        with make_dataset("acl_test_inherit1/acl_test_inherit2", data={'share_type': 'NFS'}) as ds2:
             acl2 = call('filesystem.getacl', os.path.join('/mnt', ds2))
             assert acl1['acltype'] == acl2['acltype']
             assert any(x['id'] == 666 for x in acl2['acl'])
-            assert any(x['id'] == 568 for x in acl2['acl'])


### PR DESCRIPTION
Webui team requested ability to also specify NFS share_type. At present it is identical to multiprotocol share.
This PR also fixes a longstanding issue with using share_type preset to create a child of an existing NFSv4 dataset that has an ACL already set. In this edge-case we will now generate an inherited ACL based on the parent dataset's ACL (with a few modifications) rather than applying a default to it.