### PR TITLE
NAS-125106 / 24.04 / Allow specifying force flag for ACL based questions

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/validation.py
@@ -17,6 +17,7 @@ validation_mapping = {
     'validations/nodePort': 'port_available_on_node',
     'validations/hostPath': 'custom_host_path',
     'normalize/ixVolume': 'ix_mount_path',
+    'normalize/acl': 'acl_entries',
     'validations/lockedHostPath': 'locked_host_path',
     'validations/hostPathAttachments': 'host_path_attachments',
 }
@@ -190,6 +191,16 @@ class ChartReleaseService(Service):
             verrors.add(schema_name, 'Dataset name should not be empty.')
         elif not validate_dataset_name(path):
             verrors.add(schema_name, f'Invalid dataset name {path}. "test1, ix-test, ix_test" are valid examples.')
+
+    @private
+    def validate_acl_entries(self, verrors, value, question, schema_name, release_data):
+        try:
+            if value.get('path') and next(
+                Path(value['path']).iterdir(), None
+            ) and not value.get('options', {}).get('force'):
+                verrors.add(schema_name, f'{value["path"]}: path contains existing data and `force` was not specified')
+        except FileNotFoundError:
+            verrors.add(schema_name, f'{value["path"]}: path does not exist')
 
     @private
     async def validate_locked_host_path(self, verrors, path, question, schema_name, release_data):

--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -883,7 +883,7 @@ class FilesystemService(Service, ACLBase):
         self._common_perm_path_validate('filesystem.add_to_acl', data, verrors)
         verrors.check()
 
-        if os.listdir(data['path']) and not data['options']['force']:
+        if next(Path(data['path']).iterdir(), None) and not data['options']['force']:
             raise CallError(
                 f'{data["path"]}: path contains existing data '
                 'and `force` was not specified', errno.EPERM

--- a/tests/api2/test_chart_release_acl_apply.py
+++ b/tests/api2/test_chart_release_acl_apply.py
@@ -1,11 +1,11 @@
 import contextlib
 import os
-import sys
+import pytest
 
+from pathlib import Path
 from pytest_dependency import depends
-apifolder = os.getcwd()
-sys.path.append(apifolder)
 
+from middlewared.client.client import ValidationErrors
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.apps import chart_release
 from middlewared.test.integration.assets.catalog import catalog
@@ -27,9 +27,11 @@ def path_is_dir(path: str) -> bool:
 
 
 @contextlib.contextmanager
-def hostpath_dir(path: str):
+def hostpath_dir(path: str, non_empty: bool = False):
     if not path_exists(path):
         call('filesystem.mkdir', path)
+    if non_empty:
+        (Path(path) / 'test1').touch()
 
     try:
         yield path
@@ -122,3 +124,91 @@ def test_03_acl_normalization(request):
                 assert any(
                     acl['id'] == USER_ID and acl['perms']['READ'] for acl in call('filesystem.getacl', tmp_dir)['acl']
                 ) is True
+
+
+def test_04_acl_entries_force_flag_disabled_non_empty_path(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+
+    k8s_pool = call('kubernetes.config')['pool']
+    with hostpath_dir(os.path.join('/mnt', k8s_pool, 'acl-test-dir'), True) as tmp_dir:
+        with catalog({
+            'force': True,
+            'preferred_trains': ['tests'],
+            'label': 'ACLTEST',
+            'repository': 'https://github.com/truenas/charts.git',
+            'branch': 'acl-tests'
+        }) as catalog_obj:
+            with pytest.raises(ValidationErrors) as ei:
+                with chart_release({
+                    'catalog': catalog_obj['label'],
+                    'item': 'syncthing-with-acl',
+                    'release_name': 'syncthing-acl-force-enabled',
+                    'train': 'tests',
+                    'values': {
+                        'aclEntries': [{
+                            'path': tmp_dir,
+                            'entries': [{'id_type': 'USER', 'id': USER_ID, 'access': 'READ'}],
+                            'options': {'force': False}
+                        }],
+                    }
+                }):
+                    assert ei.value.errors[0].errmsg == (
+                        f'{tmp_dir}: path contains existing data and `force` was not specified'
+                    )
+
+
+def test_05_acl_entries_force_flag_enabled_non_empty_path(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+
+    k8s_pool = call('kubernetes.config')['pool']
+    with hostpath_dir(os.path.join('/mnt', k8s_pool, 'acl-test-dir'), True) as tmp_dir:
+        with catalog({
+            'force': True,
+            'preferred_trains': ['tests'],
+            'label': 'ACLTEST',
+            'repository': 'https://github.com/truenas/charts.git',
+            'branch': 'acl-tests'
+        }) as catalog_obj:
+            with chart_release({
+                'catalog': catalog_obj['label'],
+                'item': 'syncthing-with-acl',
+                'release_name': 'syncthing-acl-force-enabled',
+                'train': 'tests',
+                'values': {
+                    'aclEntries': [{
+                        'path': tmp_dir,
+                        'entries': [{'id_type': 'USER', 'id': USER_ID, 'access': 'READ'}],
+                        'options': {'force': True}
+                    }],
+                }
+            }):
+                assert any(
+                    acl['id'] == USER_ID and acl['perms']['READ'] for acl in call('filesystem.getacl', tmp_dir)['acl']
+                ) is True
+
+
+def test_06_acl_entries_path_not_found_validation(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    tmp_dir = '/tmp/test_file'
+    with catalog({
+        'force': True,
+        'preferred_trains': ['tests'],
+        'label': 'ACLTEST',
+        'repository': 'https://github.com/truenas/charts.git',
+        'branch': 'acl-tests'
+    }) as catalog_obj:
+        with pytest.raises(ValidationErrors) as ei:
+            with chart_release({
+                'catalog': catalog_obj['label'],
+                'item': 'syncthing-with-acl',
+                'release_name': 'syncthing-acl-force-enabled',
+                'train': 'tests',
+                'values': {
+                    'aclEntries': [{
+                        'path': tmp_dir,
+                        'entries': [{'id_type': 'USER', 'id': USER_ID, 'access': 'READ'}],
+                        'options': {'force': False}
+                    }],
+                }
+            }):
+                assert ei.value.errors[0].errmsg == f'{tmp_dir}: path does not exist'


### PR DESCRIPTION
### Context

Applying ACL to a non-empty path with force flag disabled gives a traceback of error message.

### Change

This PR will add the change to handle validation more appropriately and raise a friendly error message for user.