### PR TITLE
NAS-125418 / 23.10.2 / Fix broken API tests (#12501)

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -692,7 +692,7 @@ def test_53_add_user_to_sudoers(request):
 
 def test_54_disable_password_auth(request):
     depends(request, ["NON_SMB_USER_CREATED"], scope="session")
-    results = PUT(f"/user/id/{testuser_id}", {"password_disabled": True})
+    results = PUT(f"/user/id/{testuser_id}", {"password_disabled": True, "smb": False})
     assert results.status_code == 200, results.text
 
     check_config_file("/etc/shadow", "testuser3:*:18397:0:99999:7:::")

--- a/tests/api2/test_020_account.py
+++ b/tests/api2/test_020_account.py
@@ -18,6 +18,7 @@ def delete_group_delete_users(delete_users):
         "username": "test",
         "group_create": True,
         "full_name": "Test",
+        "smb": False,
         "password_disabled": True,
     })
     assert results.status_code == 200, results.text

--- a/tests/api2/test_ip_auth.py
+++ b/tests/api2/test_ip_auth.py
@@ -18,7 +18,6 @@ def test_tcp_connection_from_localhost(url, root):
             "username": "unprivileged",
             "full_name": "Unprivileged User",
             "group_create": True,
-            "home": f"/nonexistent",
             "password": "test1234",
         }):
             result = ssh(f"sudo -u unprivileged {cmd}", check=False, complete_response=True)

--- a/tests/api2/test_keychain_ssh.py
+++ b/tests/api2/test_keychain_ssh.py
@@ -43,6 +43,7 @@ def test_remote_ssh_semiautomatic_setup_sets_user_attributes():
             "group_create": True,
             "home": f"/mnt/{homedir}",
             "password_disabled": True,
+            "smb": False,
             "shell": "/usr/sbin/nologin",
         }):
             credential = call("keychaincredential.create", {


### PR DESCRIPTION
* Disabling password auth on SMB users raises ValidationError
* PAM session management checks require that homedir exist