### PR TITLE
Remove ad_bindpw key from ActiveDirectory API test

### DIFF
--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -34,7 +34,6 @@ ad_data_type = {
     'id': int,
     'domainname': str,
     'bindname': str,
-    'bindpw': str,
     'verbose_logging': bool,
     'allow_trusted_doms': bool,
     'use_default_domain': bool,


### PR DESCRIPTION
The particular test causing regression in cobia pipeline was removed as part of refactor of AD test in dragonfish nightlies.

Backporting full change that removed the test would be more impactful than desired for existing stable branch.