### PR TITLE
Add private endpoint for webui to pre-validate SMB share

### DIFF
--- a/tests/api2/test_simple_share.py
+++ b/tests/api2/test_simple_share.py
@@ -1,0 +1,39 @@
+# -*- coding=utf-8 -*-
+import pytest
+import secrets
+import string
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import call
+
+
+PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+
+def test__smb_simple_share_validation():
+    assert call('user.query', [['smb', '=', True]], {'count': True}) == 0
+
+    with pytest.raises(ValidationErrors):
+        call('sharing.smb.share_precheck')
+
+    with user({
+        "username": "simple_share_user",
+        "full_name": "simple_share_user",
+        "group_create": True,
+        "password": PASSWD,
+        "smb": True,
+    }):
+        # First check that basic call of this endpoint succeeds
+        call('sharing.smb.share_precheck')
+
+        # Verify works with basic share name
+        call('sharing.smb.share_precheck', {'name': 'test_share'})
+
+        # Verify raises error if share name invalid
+        with pytest.raises(ValidationErrors):
+            call('sharing.smb.share_precheck', {'name': 'test_share*'})
+
+        # Another variant of invalid name
+        with pytest.raises(ValidationErrors):
+            call('sharing.smb.share_precheck', {'name': 'gLobaL'})


### PR DESCRIPTION
This endpoint was requested by webui team to facilitate simpler share configuration and have validation that is more restrictive than our normal validation (in that it requires local SMB user to exist if AD isn't configured).

This PR also slightly refactors SMB share name validation.