### PR TITLE
NAS-125431 / 23.10.2 / Eliminate log spam as a result of failover.remote_on_disconnect events (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -305,4 +305,4 @@ async def setup(middleware):
     middleware.register_hook('udev.dlm', udev_dlm_hook)
     # Comment out placeholder call for possible future enhancement.
     # await middleware.call('failover.remote_on_connect', remote_status_event)
-    await middleware.call('failover.remote_on_disconnect', remote_down_event)
+    # await middleware.call('failover.remote_on_disconnect', remote_down_event)


### PR DESCRIPTION
`dlm` had some `failover.remote_on_disconnect` processing that (ended up) **only** being used to log.  (The main control was thru the processing of udev events)

Original PR: https://github.com/truenas/middleware/pull/12594
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125431