### PR TITLE
NAS-125457 / 24.04 / Fix regression in AD privilege authentication

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1023,7 +1023,6 @@ class IdmapDomainService(TDBWrapCRUDService):
 
         try:
             client = self.__wbclient_ctx()
-            results = client.sids_to_users_and_groups(sidlist)
             results = client.users_and_groups_to_sids(payload)
         except wbclient.WBCError as e:
             raise CallError(str(e), WBCErr[e.error_code], e.error_code)


### PR DESCRIPTION
Typo during fix of several methods related to idmap bulk operations caused regression in middleware AD authentication. This commit fixes regression and adds coverage for private idmap endpoints that do bulk conversion of SIDS to Unix IDs.