### PR TITLE
NAS-125469 / 24.04 / Ensure that gid 65534 resolves to nogroup

### DIFF
--- a/src/middlewared/middlewared/etc_files/group.mako
+++ b/src/middlewared/middlewared/etc_files/group.mako
@@ -111,12 +111,17 @@
                 continue
 
             match this_entry['gid']:
+                # This catches entries with duplicate gids and puts them in
+                # Linux order where appropriate. It's unlikely that more
+                # entries will be needed, but if the situation arises, this
+                # should be expanded for the relevant GIDs (otherwise an error
+                # message will be logged)
                 case 0:
-                    # root, wheel
+                    # root (Linux), wheel (FreeBSD)
                     groups.append(this_entry)
                     groups.append(next_entry)
                 case 65534:
-                    # nobody, nogroup
+                    # nobody (FreeBSD), nogroup (Linux)
                     groups.append(next_entry)
                     groups.append(this_entry)
                 case _:

--- a/tests/api2/test_210_group.py
+++ b/tests/api2/test_210_group.py
@@ -338,7 +338,12 @@ def test_31_verify_group_deleted(request):
     assert results.status_code == 500, results.text
 
 
-@pytest.mark.parametrize('group', [{"nogroup": 65534}, {"nobody": 65534}])
+@pytest.mark.parametrize('group', [
+    {"root": 0},
+    {"wheel": 0},
+    {"nogroup": 65534},
+    {"nobody": 65534}
+])
 def test_35_check_builtin_groups(group):
     """
     This check verifies the existence of targeted built-in groups
@@ -346,3 +351,23 @@ def test_35_check_builtin_groups(group):
     g_name, g_id = list(group.items())[0]
     gr = call("group.get_group_obj", {"groupname": g_name})
     assert gr['gr_gid'] == g_id, f"{g_name}:  expected gid {g_id}, but got {gr['gr_gid']}"
+
+
+@pytest.mark.parametrize('nss_obj', [
+    ('group', 'root', 0),
+    ('group', 'nogroup', 65534)
+])
+def test_36_check_builtin_duplicate_id_order(nss_obj):
+    # For compatibility with FreeBSD-based SCALE versions we
+    # map "wheel" to gid 0 and "nogroup" to gid 65534. This validate
+    # lookups by gid to return expected Linux names.
+    nss_type, name, xid = nss_obj
+    if nss_type == "group":
+        xid_key = "gid"
+        name_key = "gr_name"
+    else:
+        xid_key = "uid"
+        name_key = "pw_name"
+
+    obj = call(f"{nss_type}.get_{nss_type}_obj", {xid_key: xid})
+    assert obj[name_key] == name


### PR DESCRIPTION
Adding some FreeBSD compatibility with regard to group name nobody caused behavior change where 65534 resolved to the FreeBSD group nobody rather than the Linux group nogroup.