### PR TITLE
NAS-125481 / 24.04 / Raise exceptions if SMB not configured

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1265,6 +1265,11 @@ class UserService(CRUDService):
                         errno.EEXIST,
                     )
 
+        if combined['smb'] and not await self.middleware.call('smb.is_configured'):
+            verrors.add(
+                f'{schema}.smb', 'SMB users may not be configured while SMB service backend is unitialized.'
+            )
+
         if combined['smb'] and combined['password_disabled']:
             verrors.add(
                 f'{schema}.password_disabled', 'Password authentication may not be disabled for SMB users.'
@@ -1845,6 +1850,11 @@ class GroupService(CRUDService):
                     f'{schema}.name',
                     'Name is already in use by a clustered group.'
                 )
+
+        if data.get('smb') and not await self.middleware.call('smb.is_configured'):
+            verrors.add(
+                f'{schema}.smb', 'SMB groups may not be configured while SMB service backend is unitialized.'
+            )
 
         if 'name' in data:
             if data.get('smb'):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -609,8 +609,8 @@ class SMBService(TDBWrapConfigService):
         if ha_mode != SMBHAMODE.CLUSTERED and passdb_backend.startswith("tdbsam"):
             job.set_progress(40, 'Synchronizing passdb and groupmap.')
             await self.middleware.call('etc.generate', 'user')
-            pdb_job = await self.middleware.call("smb.synchronize_passdb")
-            grp_job = await self.middleware.call("smb.synchronize_group_mappings")
+            pdb_job = await self.middleware.call("smb.synchronize_passdb", True)
+            grp_job = await self.middleware.call("smb.synchronize_group_mappings", True)
             await pdb_job.wait()
             await grp_job.wait()
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -409,7 +409,7 @@ class SMBService(Service):
 
     @private
     @job(lock="groupmap_sync")
-    async def synchronize_group_mappings(self, job):
+    async def synchronize_group_mappings(self, job, bypass_sentinel_check=False):
         """
         This method does the following:
         1) prepares payload for a batch groupmap operation. These are added to two arrays:
@@ -427,6 +427,12 @@ class SMBService(Service):
 
         if (await self.middleware.call('smb.get_smb_ha_mode')) == 'CLUSTERED':
             return
+
+        if not bypass_sentinel_check and not await self.middleware.call('smb.is_configured'):
+            raise CallError(
+                "SMB server configuration is not complete. "
+                "This may indicate system dataset setup failure."
+            )
 
         groupmap = await self.groupmap_list()
         must_remove_cache = False


### PR DESCRIPTION
We should not proceed with passdb and groupmap synchronization if SMB has not been properly configured. Passdb interaction in a broken state can lead to SMB_ASSERT() in pdbedit and other tools due to global sam sid failing to initialize (possibly due to missing path components).

In case of creating user / group this should raise ValidationError.

NOTE: these exceptions will not be user-facing unless in very unusual circumstances (like broken system dataset configuration) and so their primary purpose is to focus developer attention on root cause.