### PR TITLE
NAS-125481 / 23.10.2 / Raise exceptions if SMB not configured (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1238,6 +1238,11 @@ class UserService(CRUDService):
                         errno.EEXIST,
                     )
 
+        if combined['smb'] and not await self.middleware.call('smb.is_configured'):
+            verrors.add(
+                f'{schema}.smb', 'SMB users may not be configured while SMB service backend is unitialized.'
+            )
+
         if combined['smb'] and combined['password_disabled']:
             verrors.add(
                 f'{schema}.password_disabled', 'Password authentication may not be disabled for SMB users.'
@@ -1804,6 +1809,11 @@ class GroupService(CRUDService):
                     f'{schema}.name',
                     'Name is already in use by a clustered group.'
                 )
+
+        if data.get('smb') and not await self.middleware.call('smb.is_configured'):
+            verrors.add(
+                f'{schema}.smb', 'SMB groups may not be configured while SMB service backend is unitialized.'
+            )
 
         if 'name' in data:
             if data.get('smb'):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -571,8 +571,8 @@ class SMBService(TDBWrapConfigService):
         if ha_mode != SMBHAMODE.CLUSTERED and passdb_backend.startswith("tdbsam"):
             job.set_progress(40, 'Synchronizing passdb and groupmap.')
             await self.middleware.call('etc.generate', 'user')
-            pdb_job = await self.middleware.call("smb.synchronize_passdb")
-            grp_job = await self.middleware.call("smb.synchronize_group_mappings")
+            pdb_job = await self.middleware.call("smb.synchronize_passdb", True)
+            grp_job = await self.middleware.call("smb.synchronize_group_mappings", True)
             await pdb_job.wait()
             await grp_job.wait()
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -409,7 +409,7 @@ class SMBService(Service):
 
     @private
     @job(lock="groupmap_sync")
-    async def synchronize_group_mappings(self, job):
+    async def synchronize_group_mappings(self, job, bypass_sentinel_check=False):
         """
         This method does the following:
         1) prepares payload for a batch groupmap operation. These are added to two arrays:
@@ -427,6 +427,12 @@ class SMBService(Service):
 
         if (await self.middleware.call('smb.get_smb_ha_mode')) == 'CLUSTERED':
             return
+
+        if not bypass_sentinel_check and not await self.middleware.call('smb.is_configured'):
+            raise CallError(
+                "SMB server configuration is not complete. "
+                "This may indicate system dataset setup failure."
+            )
 
         groupmap = await self.groupmap_list()
         must_remove_cache = False

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -14,7 +14,11 @@ import stat
 import pytest
 from pytest_dependency import depends
 
+from middlewared.client import ClientException
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.account import user as user_asset
 from middlewared.test.integration.assets.pool import dataset as dataset_asset
+from middlewared.test.integration.utils import call, ssh
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
@@ -26,6 +30,7 @@ DEFAULT_HOMEDIR_OCTAL = 0o40700
 group_id = GET(f'/group/?group={GROUP}', controller_a=ha).json()[0]['id']
 dataset = f"{pool_name}/test_homes"
 dataset_url = dataset.replace('/', '%2F')
+SMB_CONFIGURED_SENTINEL = '/var/run/samba/.configured'
 
 home_files = {
     "~/": oct(DEFAULT_HOMEDIR_OCTAL),
@@ -811,3 +816,34 @@ def test_60_immutable_user_validation(payload, request):
 
     results = PUT(f"/user/id/{user_id}", payload)
     assert results.status_code == 422, results.text
+
+
+@contextmanager
+def toggle_smb_configured():
+    ssh(f'rm {SMB_CONFIGURED_SENTINEL}')
+    assert call('smb.is_configured') is False
+    try:
+        yield
+    finally:
+        call('smb.set_configured')
+
+
+def test_061_check_smb_configured_sentinel():
+    assert call('smb.is_configured')
+    with toggle_smb_configured():
+        # Check that ValidationError is properly raised
+        with pytest.raises(ValidationErrors):
+            with user_asset({
+                'username': 'doug',
+                'full_name': 'doug',
+                'group_create': True,
+                'password': 'squirrel',
+                'smb': True
+            }, get_instance=False):
+                pass
+
+        with pytest.raises(ClientException):
+            call('smb.synchronize_passdb', job=True)
+
+    assert call('smb.is_configured')
+    call('smb.synchronize_passdb', job=True)


### PR DESCRIPTION
We should not proceed with passdb and groupmap synchronization if SMB has not been properly configured. Passdb interaction in a broken state can lead to SMB_ASSERT() in pdbedit and other tools due to global sam sid failing to initialize (possibly due to missing path components).

In case of creating user / group this should raise ValidationError.

NOTE: these exceptions will not be user-facing unless in very unusual circumstances (like broken system dataset configuration) and so their primary purpose is to focus developer attention on root cause.

Original PR: https://github.com/truenas/middleware/pull/12609
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125481