### PR TITLE
NAS-125485 / 24.04 / Fix overly-strict netbios name regex

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -891,6 +891,7 @@ def test__uuid_schema(value, expected_to_fail):
     ('canary', False),
     ('CaNary', False),
     ('can_ary', False),
+    ('can-ary', False),
     ('LOCAL', True),
 ])
 def test__netbiosname_schema(value, expected_to_fail):
@@ -915,6 +916,7 @@ def test__netbiosname_schema(value, expected_to_fail):
     ('canary', False),
     ('CaNary', False),
     ('can_ary', False),
+    ('can-ary', False),
     ('LOCAL', True),
 ])
 def test__netbiosdomain_schema(value, expected_to_fail):

--- a/src/middlewared/middlewared/schema/string_schema.py
+++ b/src/middlewared/middlewared/schema/string_schema.py
@@ -26,7 +26,7 @@ from .utils import RESERVED_WORDS
 
 # NetBIOS domain names allow using a dot "." to define a NetBIOS scope
 # This is not true for NetBIOS computer names
-RE_NETBIOSNAME = re.compile(r"^(?![0-9]*$)[a-zA-Z0-9\\-_!@#\$%^&\(\)'\{\}~]{1,15}$")
+RE_NETBIOSNAME = re.compile(r"^(?![0-9]*$)[a-zA-Z0-9-_!@#\$%^&\(\)'\{\}~]{1,15}$")
 RE_NETBIOSDOM = re.compile(r"^(?![0-9]*$)[a-zA-Z0-9\.\-_!@#\$%^&\(\)'\{\}~]{1,15}$")
 
 


### PR DESCRIPTION
We should allow dashes in netbios names.