### PR TITLE
NAS-125388 / 24.04 / Disable rpc.mountd logging with mountd_log NFS config setting

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -4,6 +4,8 @@
     adv_conf = render_ctx['system.advanced.config']
 
     audit_filters = [f'filter(f_tnaudit_{svc.lower()});' for svc, vers in AUDITED_SERVICES]
+
+    nfs_conf = render_ctx['nfs.config']
 %>\
 ##################
 # TrueNAS filters
@@ -44,8 +46,14 @@ filter f_app_mounts {
   program("systemd") and match("mount:" value("MESSAGE")) and match("docker" value("MESSAGE")); or
   program("systemd") and match("mount:" value("MESSAGE")) and match("kubelet" value("MESSAGE"));
 };
+filter f_nfs_mountd {
+  program("rpc.mountd") and level(debug..notice);
+};
 
 filter f_truenas_exclude {
+% if not nfs_conf['mountd_log']:
+  not filter(f_nfs_mountd) and
+% endif
   not filter(f_tnaudit_all) and
   not filter(f_k3s) and
   not filter(f_containerd) and

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -250,6 +250,7 @@ class EtcService(Service):
         'syslogd': {
             'ctx': [
                 {'method': 'system.advanced.config'},
+                {'method': 'nfs.query'},
             ],
             'entries': [
                 {'type': 'mako', 'path': 'syslog-ng/syslog-ng.conf'},

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -243,6 +243,9 @@ class NFSService(SystemServiceService):
 
         await self._update_service(old, new, "restart")
 
+        if old['mountd_log'] != new['mountd_log']:
+            await self._service_change("syslogd", "reload")
+
         return await self.config()
 
 

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -20,7 +20,7 @@ from functions import make_ws_request
 from auto_config import pool_name, ha, hostname, password, user
 from protocols import SSH_NFS
 from middlewared.test.integration.assets.filesystem import directory
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, ssh
 
 if ha and "virtual_ip" in os.environ:
     ip = os.environ["virtual_ip"]
@@ -1268,21 +1268,29 @@ def test_48_syslog_filters(request):
     This test checks the function of the mountd_log setting to filter
     rpc.mountd messages that have priority DEBUG to NOTICE.
     We performing loopback mounts on the remote TrueNAS server and
-    then check the syslog for rpc.mountd messages.
+    then check the syslog for rpc.mountd messages.  Outside of SSH_NFS
+    we test the umount case.
     """
     depends(request, ["NFSID_SHARE_CREATED"], scope="session")
     with nfs_config() as db_conf:
-        with SSH_NFS(ip, NFS_PATH, vers=3, user=user, password=password, ip=ip):
-            assert db_conf['mountd_log'] is True
 
-    # with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
-    #     results = GET('/nfs/get_nfs4_clients/', payload={
-    #         'query-filters': [],
-    #         'query-options': {'count': True}
-    #     })
-    #     assert results.status_code == 200, results.text
-    #     assert results.json() == 1, results.text
-    #     assert db_conf['']
+        # Confirm default setting: mountd logging enabled
+        assert db_conf['mountd_log'] is True
+        with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
+            res = ssh("tail -5 /var/log/syslog")
+            assert "rpc.mountd" in res, f"Expected to find 'rpc.mountd' in the output but found:\n{res}"
+
+        res = ssh("tail -5 /var/log/syslog")
+        assert "rpc.mountd" in res, f"Expected to find 'rpc.mountd' in the output but found:\n{res}"
+
+        # Disable mountd logging
+        call("nfs.update", {"mountd_log": False})
+        with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
+            res = ssh("tail -5 /var/log/syslog")
+            assert "rpc.mountd" not in res, f"Did not expect to find 'rpc.mountd' in the output but found:\n{res}"
+
+        res = ssh("tail -5 /var/log/syslog")
+        assert "rpc.mountd" not in res, f"Did not expect to find 'rpc.mountd' in the output but found:\n{res}"
 
 
 def test_50_stoping_nfs_service(request):

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1272,10 +1272,10 @@ def test_48_syslog_filters(request):
     we test the umount case.
     """
     depends(request, ["NFSID_SHARE_CREATED"], scope="session")
-    with nfs_config() as db_conf:
+    with nfs_config():
 
         # Confirm default setting: mountd logging enabled
-        assert db_conf['mountd_log'] is True
+        call("nfs.update", {"mountd_log": True})
         with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
             res = ssh("tail -5 /var/log/syslog")
             assert "rpc.mountd" in res, f"Expected to find 'rpc.mountd' in the output but found:\n{res}"

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1263,6 +1263,28 @@ def test_46_set_bind_ip():
         assert ip in rpc_conf.get('-h'), f"rpc_conf = {rpc_conf}"
 
 
+def test_48_syslog_filters(request):
+    """
+    This test checks the function of the mountd_log setting to filter
+    rpc.mountd messages that have priority DEBUG to NOTICE.
+    We performing loopback mounts on the remote TrueNAS server and
+    then check the syslog for rpc.mountd messages.
+    """
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
+    with nfs_config() as db_conf:
+        with SSH_NFS(ip, NFS_PATH, vers=3, user=user, password=password, ip=ip):
+            assert db_conf['mountd_log'] is True
+
+    # with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
+    #     results = GET('/nfs/get_nfs4_clients/', payload={
+    #         'query-filters': [],
+    #         'query-options': {'count': True}
+    #     })
+    #     assert results.status_code == 200, results.text
+    #     assert results.json() == 1, results.text
+    #     assert db_conf['']
+
+
 def test_50_stoping_nfs_service(request):
     # Restore original settings before we stop
     restore_nfs_config()


### PR DESCRIPTION
Recent Linux kernels generate a log message for every client mount and umount and each running mountd repeats the message.
This can generate substantial amount of log traffic.  The PR provides the ability to disable the high-volume messages.

The `mountd_log` setting in nfs.config is used as the enable/disable flag, where `True` enables the mountd logging and `False` disables mountd logging.  In both states, error and higher priority messages from mountd will still be logged.

Logging is enabled in the current default state.  Logging can be disabled with: `midclt call nfs.config '{"mountd_log": true}'`