### PR TITLE
NAS-125487 / 24.10 / Use stderr from zectl failures for CallError

### DIFF
--- a/src/middlewared/middlewared/plugins/bootenv.py
+++ b/src/middlewared/middlewared/plugins/bootenv.py
@@ -165,7 +165,7 @@ class BootEnvService(CRUDService):
         try:
             subprocess.run([self.BE_TOOL, 'activate', oid], capture_output=True, text=True, check=True)
         except subprocess.CalledProcessError as cpe:
-            raise CallError(f'Failed to activate BE: {cpe.stdout.strip()}')
+            raise CallError(f'Failed to activate BE: {cpe.stderr.strip()}')
         else:
             return True
 
@@ -224,7 +224,7 @@ class BootEnvService(CRUDService):
         try:
             await run(args, encoding='utf8', check=True)
         except subprocess.CalledProcessError as cpe:
-            raise CallError(f'Failed to create boot environment: {cpe.stdout}')
+            raise CallError(f'Failed to create boot environment: {cpe.stderr}')
         return data['name']
 
     @accepts(Str('id'), Dict(
@@ -274,5 +274,5 @@ class BootEnvService(CRUDService):
         try:
             await run(self.BE_TOOL, 'destroy', '-F', be['id'], encoding='utf8', check=True)
         except subprocess.CalledProcessError as cpe:
-            raise CallError(f'Failed to delete boot environment: {cpe.stdout}')
+            raise CallError(f'Failed to delete boot environment: {cpe.stderr}')
         return True


### PR DESCRIPTION
The zectl command on failure conditions will print to stderr rather than stdout. This means we were losing information about errors on bootenv operations.