### PR TITLE
NAS-125491 / 24.04 / Allow `force` to bypass check for ctdb root dir

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
@@ -594,8 +594,8 @@ class CtdbRootDirService(Service):
 
         NOTE: THERE IS NO COMING BACK FROM THIS.
         """
-        config = await self.middleware.call('ctdb.root_dir.config')
         if not force:
+            config = await self.middleware.call('ctdb.root_dir.config')
             for vol in await self.middleware.call('gluster.volume.query'):
                 if vol['name'] != config['volume_name']:
                     # If someone calls this method, we expect that all other gluster volumes


### PR DESCRIPTION
This change allows TrueCommand to bypass sanity check for wiping cluster config in case of failed cluster creation.