### PR TITLE
NAS-125496 / 24.04 / Add primary-group roles to user.query output

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -224,7 +224,7 @@ class UserService(CRUDService):
         user['twofactor_auth_configured'] = bool(ctx['user_2fa_mapping'][user['id']])
 
         user_roles = set()
-        for g in user['groups']:
+        for g in user['groups'] + [user['group']['id']]:
             if not (entry := ctx['roles_mapping'].get(g)):
                 continue
 


### PR DESCRIPTION
This corrects an oversight when adding roles to user.query results in which only auxiliary group roles were added.