### PR TITLE
Expand includes for READONLY role

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -25,7 +25,14 @@ ROLES = {
                                               'FILESYSTEM_DATA_WRITE']),
 
     'FULL_ADMIN': Role(full_admin=True),
-    'READONLY': Role(includes=['ALERT_LIST_READ', 'FILESYSTEM_ATTRS_READ', 'NETWORK_GENERAL_READ']),
+    'READONLY': Role(includes=['ALERT_LIST_READ',
+                               'FILESYSTEM_ATTRS_READ',
+                               'NETWORK_GENERAL_READ',
+                               'SHARING_READ',
+                               'KEYCHAIN_CREDENTIAL_READ',
+                               'REPLICATION_TASK_CONFIG_READ',
+                               'REPLICATION_TASK_READ',
+                               'SNAPSHOT_TASK_READ']),
 
     # Alert roles
     'ALERT_LIST_READ': Role(),


### PR DESCRIPTION
This is per request of webui team as it helps to simplify what portions of UI to turn off for different users based on role.

READONLY already implicitly grants these roles, this makes the relationship explicit when we compose the roles set for auth.me output.