### PR TITLE
NAS-125498 / 24.04 / Always map wildcard allowlist to FULL_ADMIN

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -351,6 +351,9 @@ class PrivilegeService(CRUDService):
                 compose['allowlist'].extend(self.middleware.role_manager.allowlist_for_role(role))
 
             for item in privilege['allowlist']:
+                if item == {'method': '*', 'resource': '*'} and 'FULL_ADMIN' not in compose['roles']:
+                    compose['roles'] |= self.middleware.role_manager.roles_for_role('FULL_ADMIN')
+
                 compose['allowlist'].append(item)
 
             compose['web_shell'] |= privilege['web_shell']


### PR DESCRIPTION
Currently the default administrator privilege in TrueNAS has wildcard allowlist without explicitly specifying roles configuraiton. This is sufficient for proper behavior from backend perspective, but is less than fully clear from API consumer perspective if they only look at the roles set. This commit maps the wildcard allowlist entry to FULL_ADMIN in roles set to make the actual permissions clearer.