### PR TITLE
NAS-125533 / 24.04 / Relax authorization requirements

### DIFF
--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -129,8 +129,7 @@ class SystemService(Service):
         buildtime = sw_buildtime()
         return datetime.fromtimestamp(int(buildtime)) if buildtime else buildtime
 
-    @accepts()
-    @no_authz_required
+    @accepts(roles=['SHARING_MANAGER', 'READONLY'])
     @returns(Dict(
         'system_info',
         Str('version', required=True, title='TrueNAS Version'),

--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -130,6 +130,7 @@ class SystemService(Service):
         return datetime.fromtimestamp(int(buildtime)) if buildtime else buildtime
 
     @accepts()
+    @no_authz_required
     @returns(Dict(
         'system_info',
         Str('version', required=True, title='TrueNAS Version'),

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -238,6 +238,7 @@ class SystemService(Service):
         return False
 
     @private
+    @no_authz_required
     async def is_ix_hardware(self):
         product = (await self.middleware.call('system.dmidecode_info'))['system-product-name']
         return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -238,7 +238,6 @@ class SystemService(Service):
         return False
 
     @private
-    @no_authz_required
     async def is_ix_hardware(self):
         product = (await self.middleware.call('system.dmidecode_info'))['system-product-name']
         return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -11,6 +11,7 @@ def test_works():
 
     assert user["pw_uid"] == 0
     assert user["pw_name"] == "root"
+    assert user['two_factor_config'] is not None
 
 
 def test_works_for_token():
@@ -23,6 +24,7 @@ def test_works_for_token():
 
         assert user["pw_uid"] == 0
         assert user["pw_name"] == "root"
+        assert user['two_factor_config'] is not None
 
 
 def test_does_not_work_for_api_key():
@@ -80,5 +82,6 @@ def test_distinguishes_attributes():
 
             me = c.call("auth.me")
             assert me["attributes"]["test"] == "new_value"
+            assert me['two_factor_config'] is not None
 
     assert not call("datastore.query", "account.bsdusers_webui_attribute", [["uid", "=", admin["uid"]]])


### PR DESCRIPTION
* Allow all authorized users to gather some basic hardware info.
* Allow all authenticated users to see their own 2fa config via auth.me.