### PR TITLE
NAS-125506 / 24.04 / Fix the NFS syslog filter config

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -250,7 +250,7 @@ class EtcService(Service):
         'syslogd': {
             'ctx': [
                 {'method': 'system.advanced.config'},
-                {'method': 'nfs.query'},
+                {'method': 'nfs.config'},
             ],
             'entries': [
                 {'type': 'mako', 'path': 'syslog-ng/syslog-ng.conf'},

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -244,7 +244,7 @@ class NFSService(SystemServiceService):
         await self._update_service(old, new, "restart")
 
         if old['mountd_log'] != new['mountd_log']:
-            await self._service_change("syslogd", "reload")
+            await self.middleware.call('service.reload', 'syslogd')
 
         return await self.config()
 


### PR DESCRIPTION
Fix two issues: 

-  change `nfs.query` to `nfs.config`
-  use middleware call to `service.reload`