### PR TITLE
NAS-125540 / 24.04 / Add flag indicating whether role is builtin

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege_roles.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege_roles.py
@@ -19,12 +19,24 @@ class PrivilegeService(Service):
     async def roles(self, filters, options):
         """
         Get all available roles.
+
+        Each entry contains the following keys:
+
+        `name` - the internal name of the role
+
+        `includes` - list of other roles that this role includes. When user is
+        granted this role, they will also receive permissions granted by all
+        the included roles.
+
+        `builtin` - role exists for internal backend purposes for access
+        control.
         """
         roles = [
             {
                 "name": name,
                 "title": name,
                 "includes": role.includes,
+                "builtin": role.builtin,
             }
             for name, role in ROLES.items()
         ]

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -14,6 +14,7 @@ class Role:
 
     includes: [str] = field(default_factory=list)
     full_admin: bool = False
+    builtin: bool = True
 
 
 ROLES = {
@@ -24,8 +25,9 @@ ROLES = {
     'FILESYSTEM_FULL_CONTROL': Role(includes=['FILESYSTEM_ATTRS_WRITE',
                                               'FILESYSTEM_DATA_WRITE']),
 
-    'FULL_ADMIN': Role(full_admin=True),
-    'READONLY': Role(includes=['ALERT_LIST_READ', 'FILESYSTEM_ATTRS_READ', 'NETWORK_GENERAL_READ']),
+    'FULL_ADMIN': Role(full_admin=True, builtin=False),
+    'READONLY': Role(includes=['ALERT_LIST_READ', 'FILESYSTEM_ATTRS_READ', 'NETWORK_GENERAL_READ'],
+                     builtin=False),
 
     # Alert roles
     'ALERT_LIST_READ': Role(),
@@ -101,11 +103,13 @@ ROLES = {
                                           'REPLICATION_TASK_CONFIG_WRITE',
                                           'REPLICATION_TASK_WRITE',
                                           'SNAPSHOT_TASK_WRITE',
-                                          'SNAPSHOT_WRITE']),
+                                          'SNAPSHOT_WRITE'],
+                                builtin=False),
 
     'SHARING_MANAGER': Role(includes=['DATASET_WRITE',
                                       'SHARING_WRITE',
-                                      'FILESYSTEM_ATTRS_WRITE'])
+                                      'FILESYSTEM_ATTRS_WRITE'],
+                            builtin=False)
 }
 
 


### PR DESCRIPTION
Some roles exist for internal backend RBAC purposes and should be flagged as such so that webui can de-emphasize.