### PR TITLE
NAS-125546 / 24.04 / Make the bandwidth test more resilient.

### DIFF
--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -184,7 +184,7 @@ def validate_proftp_conf():
     assert ftpConf['timeout_notransfer'] == int(parsed['TimeoutNoTransfer'][1])
 
     # Some settings are present in the conf file only if 'on'
-    assert xlat[ftpConf['rootlogin']] == conv('RootLogin'),\
+    assert xlat[ftpConf['rootlogin']] == conv('RootLogin'), \
         f"RootLogin expected {xlat[ftpConf['rootlogin']]} or no setting, but found {conv('RootLogin')}"
 
     if ftpConf['onlyanonymous']:
@@ -218,7 +218,7 @@ def validate_proftp_conf():
         assert motd == ftpConf['banner'], f"\nproftpd.motd = \'{motd}\'\nbanner = \'{ftpConf['banner']}\'"
 
     expect_umask = f"{ftpConf['filemask']} {ftpConf['dirmask']}"
-    assert expect_umask == parsed['Umask'][1],\
+    assert expect_umask == parsed['Umask'][1], \
         f"Found unexpected Umask entry: expected '{expect_umask}', found '{parsed['Umask'][1]}'"
     assert xlat[ftpConf['fxp']] == parsed['AllowForeignAddress'][1]
     if ftpConf['resume']:
@@ -237,7 +237,7 @@ def validate_proftp_conf():
 
     if ftpConf['passiveportsmin']:
         expect_setting = f"{ftpConf['passiveportsmin']} {ftpConf['passiveportsmax']}"
-        assert expect_setting == parsed['PassivePorts'][1],\
+        assert expect_setting == parsed['PassivePorts'][1], \
             f"Found unexpected PassivePorts entry: expected '{expect_setting}', found '{parsed['PassivePorts'][1]}'"
 
     if ftpConf['localuserbw']:
@@ -274,7 +274,7 @@ def validate_proftp_conf():
                 if ftpConf[f'tls_opt_{k}']:
                     tls_options.append(v)
 
-            assert set(tls_options) == set(parsed['TLSOptions'][1].split()),\
+            assert set(tls_options) == set(parsed['TLSOptions'][1].split()), \
                 f"--- Unexpected difference ---\ntls_options:\n{set(tls_options)}"\
                 f"\nparsed['TLSOptions']\n{set(parsed['TLSOptions'][1].split())}"
         assert ftpConf['tls_policy'] == parsed['TLSRequired'][1]
@@ -640,12 +640,12 @@ def ftp_download_files_test(test_data=None, run_data=None):
         cmd = f"RETR {f['name']}"
         try:
             res = ftp.retrlines(cmd, found_contents.append)
-            assert f['expect_to_pass'] is True,\
+            assert f['expect_to_pass'] is True, \
                 f"Expected file download failure for {f['name']}, but passed: {f}"
             assert res.startswith('226 Transfer complete'), "Detected download failure"
             assert expected_contents in found_contents
         except all_errors as e:
-            assert f['expect_to_pass'] is False,\
+            assert f['expect_to_pass'] is False, \
                 f"Expected file download success for {f['name']}, but failed: {e.args}"
 
 
@@ -666,11 +666,11 @@ def ftp_upload_files_test(test_data=None, run_data=None):
                 try:
                     cmd = f"STOR {f['name']}"
                     res = ftp.storlines(cmd, tmpfile)
-                    assert f['expect_to_pass'] is True,\
+                    assert f['expect_to_pass'] is True, \
                         f"Expected file add failure for {f['name']}, but passed: {f}"
                     assert res.startswith('226 Transfer complete'), "Detected upload failure"
                 except all_errors as e:
-                    assert f['expect_to_pass'] is False,\
+                    assert f['expect_to_pass'] is False, \
                         f"Expected file add success for {f['name']}, but failed: {e.args}"
     finally:
         # Clean up
@@ -688,10 +688,10 @@ def ftp_delete_files_test(test_data=None, run_data=None):
     for f in run_data:
         try:
             ftp.delete(f['name'])
-            assert f['expect_to_pass'] is True,\
+            assert f['expect_to_pass'] is True, \
                 f"Expected file delete failure for {f['name']}, but passed: {f}"
         except all_errors as e:
-            assert f['expect_to_pass'] is False,\
+            assert f['expect_to_pass'] is False, \
                 f"Expected file delete success for {f['name']}, but failed: {e.args}"
 
 
@@ -707,7 +707,7 @@ def ftp_add_dirs_test(test_data=None, run_data=None):
             res = ftp.mkd(d['name'])
             assert d['name'] in res
         except all_errors as e:
-            assert d['expect_to_pass'] is False,\
+            assert d['expect_to_pass'] is False, \
                 f"Expected deletion success for {d['name']}, but failed: {e.args}"
 
 
@@ -721,10 +721,10 @@ def ftp_remove_dirs_test(test_data=None, run_data=None):
     for d in run_data:
         try:
             ftp.rmd(d['name'])
-            assert d['expect_to_pass'] is True,\
+            assert d['expect_to_pass'] is True, \
                 f"Expected deletion failure for {d['name']}, but passed: {d}"
         except all_errors as e:
-            assert d['expect_to_pass'] is False,\
+            assert d['expect_to_pass'] is False, \
                 f"Expected deletion success for {d['name']}, but failed: {e.args}"
 
 #
@@ -944,7 +944,7 @@ def test_031_anon_login(request, setting, ftpConfig):
         ftpObj = ftpdata.ftp
         try:
             res = ftpObj.login()
-            assert setting is True,\
+            assert setting is True, \
                 f"Unexpected behavior: onlyanonymous={ftpConfig['onlyanonymous']}, but login successfull: {res}"
 
             # The following assumes the login was successfull
@@ -1105,6 +1105,7 @@ def test_056_no_xfer_timeout(request):
             assert chkstr in str(e), e
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=5)  # Can sometimes getoside the range
 @pytest.mark.parametrize('testwho,ftp_setup_func', [
     ('anon', ftp_anon_ds_and_srvr_conn),
     ('local', ftp_user_ds_and_srvr_conn),
@@ -1143,13 +1144,13 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
             ElapsedTime = int(ftp_upload_binary_file(ftpObj, localfname, ftpfname))
             xfer_rate = int(FileSize / ElapsedTime)
             # This typically will match exactly, but in actual testing this might vary
-            assert (ulRate - 8) <= xfer_rate <= (ulRate + 8),\
+            assert (ulRate - 8) <= xfer_rate <= (ulRate + 20), \
                 f"Failed upload rate limiter: Expected {ulRate}, but sensed rate is {xfer_rate}"
 
             ElapsedTime = int(ftp_download_binary_file(ftpObj, ftpfname, localfname))
             xfer_rate = int(FileSize / ElapsedTime)
             # Allow for variance
-            assert (dlRate - 8) <= xfer_rate <= (dlRate + 8),\
+            assert (dlRate - 8) <= xfer_rate <= (dlRate + 20), \
                 f"Failed download rate limiter: Expected {dlRate}, but sensed rate is {xfer_rate}"
         except all_errors as e:
             assert False, f"Unexpected failure: {e}"


### PR DESCRIPTION
Added 'flaky' decorator with retries.
Widened the acceptance range from +8KB to +20KB
Fix flake8 issues.