### PR TITLE
NAS-125550 / 23.10.2 / fix regression in boot.py:setup() (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -285,9 +285,15 @@ class BootService(Service):
 async def setup(middleware):
     global BOOT_POOL_NAME
 
-    pools = dict([line.split() for line in (
-        await run('zpool', 'list', '-H', '-o', 'name,compatibility', encoding='utf8')
-    ).stdout.strip().splitlines()])
+    try:
+        pools = dict([line.split('\t') for line in (
+            await run('zpool', 'list', '-H', '-o', 'name,compatibility', encoding='utf8')
+        ).stdout.strip().splitlines()])
+    except Exception:
+        # this isn't fatal, but we need to log something so we can review and fix as needed
+        middleware.logger.warning('Unexpected failure parsing compatibility feature', exc_info=True)
+        return
+
     for i in BOOT_POOL_NAME_VALID:
         if i in pools:
             BOOT_POOL_NAME = i


### PR DESCRIPTION
This regressed in fa7d871b579. Changes introduced there don't take into account that we don't enforce any type of sanity on zpool names. So a zpool created with a space in the name produces the below error. Luckily, `zpool -H` flag always separates the values by tab so we can safely split on tab instead of space.

As a final precaution, however, I wrap it in an `try: except` block so we don't crash here since it's not fatal that we don't apply this setting on middleware start-up. Instead we'll log an error message so we can review them in debug archives and fix the various issues as we come across them.

```
[2023/12/04 11:31:02] (TRACE) middlewared.trace():46 - _console_write 'setting up plugins (boot) [5/109]'
Traceback (most recent call last):
  File "/usr/bin/middlewared", line 12, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1965, in main
    ).run()
      ^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1781, in run
    self.loop.run_until_complete(self.__initialize())
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1847, in __initialize
    await self.__plugins_setup(setup_funcs)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 988, in __plugins_setup
    await call
  File "/usr/lib/python3/dist-packages/middlewared/plugins/boot.py", line 288, in setup
    pools = dict([line.split() for line in (
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: dictionary update sequence element #0 has length 3; 2 is required

Original PR: https://github.com/truenas/middleware/pull/12637
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125550