### PR TITLE
NAS-125557 / 24.04 / Fix ACL flag integration test in apps

### DIFF
--- a/tests/api2/test_chart_release_acl_apply.py
+++ b/tests/api2/test_chart_release_acl_apply.py
@@ -31,7 +31,7 @@ def hostpath_dir(path: str, non_empty: bool = False):
     if not path_exists(path):
         call('filesystem.mkdir', path)
     if non_empty:
-        (Path(path) / 'test1').touch()
+        ssh(f'touch {path}/test1')
 
     try:
         yield path


### PR DESCRIPTION
## Problem

Earlier we were creating a file but it was being done on the runner and not the actual NAS where it should have been created.


## Solution

Make sure we create the file on the NAS itself and not the runner.