### PR TITLE
NAS-125558 / 24.04 / dont exc_info=True in usage_/firstboot.py

### DIFF
--- a/src/middlewared/middlewared/plugins/usage_/firstboot.py
+++ b/src/middlewared/middlewared/plugins/usage_/firstboot.py
@@ -19,9 +19,9 @@ class UsageService(Service):
                     'system_hash': _hash,
                     'firstboot': [{'version': version}]
                 })
-            except Exception:
+            except Exception as e:
                 retries -= 1
                 if not retries:
-                    self.logger.error('Failed to send firstboot statistics', exc_info=True)
+                    self.logger.error('Failed to send firstboot statistics: %s', e)
             else:
                 break


### PR DESCRIPTION
There is no reason to log the entire call stack here. It's actually quite large (since it eventually goes through aiohttp). I'm investigating an unrelated issue and the system I'm on obviously fails here because there are no DNS servers by the time this is called.