### PR TITLE
NAS-125559 / 24.04 / stop more netdata connection log spam

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -106,7 +106,7 @@ class ClientMixin:
                         logger.debug(f'Failed to fetch api response from {task["uri"]}. Reason {task["error"]}')
                     else:
                         responses.append((task['identifier'], task['data']))
-        except (ApiException, ClientConnectError):
-            logger.debug('Failed to connect to netdata', exc_info=True)
+        except Exception as e:
+            logger.debug('Failed to connect to netdata: %s', e)
 
         return responses

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -3,8 +3,6 @@ import statistics
 import typing
 
 from .connector import Netdata
-from .exceptions import ClientConnectError
-
 
 GRAPH_PLUGINS = {}
 RE_GRAPH_PLUGIN = re.compile(r'^(?P<name>.+)Plugin$')
@@ -53,8 +51,8 @@ class GraphBase(metaclass=GraphMeta):
     async def all_charts(self) -> typing.Dict[str, dict]:
         try:
             return await Netdata.get_charts()
-        except ClientConnectError:
-            self.middleware.logger.debug('Failed to connect to netdata', exc_info=True)
+        except Exception as e:
+            self.middleware.logger.warning('Failed to connect to netdata: %s', e)
             return {}
 
     def get_title(self) -> str:


### PR DESCRIPTION
These endpoints are called incessantly (especially on our HA systems) so doing exc_info=True is entirely too verbose and just fills up `middlewared.log` I noticed this on an internal HA system for which I'm investigating an unrelated problem.