### PR TITLE
NAS-125566 / 24.04 / Fix LDAP middleware authentication tests

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -335,7 +335,19 @@ class IdmapDomainService(TDBWrapCRUDService):
     @private
     @filterable
     def known_domains(self, query_filters, query_options):
-        entries = [entry.domain_info() for entry in WBClient().all_domains()]
+        try:
+            entries = [entry.domain_info() for entry in WBClient().all_domains()]
+        except wbclient.WBCError as e:
+            match e.error_code:
+                case wbclient.WBC_ERR_INVALID_RESPONSE:
+                    # Our idmap domain is not AD and so this is not expected to succeed
+                    return []
+                case wbclient.WBC_ERR_WINBIND_NOT_AVAILABLE:
+                    # winbindd process is stopped this may be in hot code path. Skip
+                    return []
+                case _:
+                    raise
+
         return filter_list(entries, query_filters, query_options)
 
     @private

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -113,7 +113,7 @@ def test_09_account_privilege_authentication(request):
             "allowlist": [{"method": "CALL", "resource": "system.info"}],
             "web_shell": False,
         }):
-            with client(auth=(f"{LDAPUSER}@", LDAPPASSWORD)) as c:
+            with client(auth=(LDAPUSER, LDAPPASSWORD)) as c:
                 methods = c.call("core.get_methods")
 
             assert "system.info" in methods


### PR DESCRIPTION
This fixes a broken LDAP authentication test and adds error handling for edge case LDAP configurations where idmap.known_domains will not be possible.