### PR TITLE
NAS-125566 / 23.10.2 / Fix LDAP middleware authentication tests (by anodos325)

### DIFF
--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -113,7 +113,7 @@ def test_09_account_privilege_authentication(request):
             "allowlist": [{"method": "CALL", "resource": "system.info"}],
             "web_shell": False,
         }):
-            with client(auth=(f"{LDAPUSER}@", LDAPPASSWORD)) as c:
+            with client(auth=(LDAPUSER, LDAPPASSWORD)) as c:
                 methods = c.call("core.get_methods")
 
             assert "system.info" in methods


### PR DESCRIPTION
This fixes a broken LDAP authentication test and adds error handling for edge case LDAP configurations where idmap.known_domains will not be possible.

Original PR: https://github.com/truenas/middleware/pull/12650
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125566