### PR TITLE
NAS-125576 / 24.04 / Define roles for static alert info

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -27,7 +27,7 @@ from middlewared.alert.base import UnavailableException, AlertService as _AlertS
 from middlewared.client.client import ReserveFDException
 from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, Patch, returns, Ref, Str
 from middlewared.service import (
-    ConfigService, CRUDService, no_authz_required, Service, ValidationErrors,
+    ConfigService, CRUDService, Service, ValidationErrors,
     job, periodic, private,
 )
 from middlewared.service_exception import CallError
@@ -276,8 +276,7 @@ class AlertService(Service):
     async def terminate(self):
         await self.flush_alerts()
 
-    @accepts()
-    @no_authz_required
+    @accepts(roles=['ALERT_LIST_READ'])
     @returns(List('alert_policies', items=[Str('policy', enum=POLICIES)]))
     async def list_policies(self):
         """
@@ -285,8 +284,7 @@ class AlertService(Service):
         """
         return POLICIES
 
-    @accepts()
-    @no_authz_required
+    @accepts(roles=['ALERT_LIST_READ'])
     @returns(List('categories', items=[Dict(
         'category',
         Str('id'),
@@ -984,7 +982,6 @@ class AlertServiceService(CRUDService):
     )
 
     @accepts()
-    @no_authz_required
     @returns(List('alert_service_types', items=[Dict(
         'alert_service_type',
         Str('name', required=True),


### PR DESCRIPTION
This commit allows users with ALERT_LIST_READ to read static alert-related data (available categories, policies).