### PR TITLE
NAS-125577 / 24.04 / allow READONLY role to get NFS client status

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -31,7 +31,8 @@ class NFSService(Service):
         return entries
 
     # NFS_WRITE because this exposes hostnames and IP addresses
-    @filterable(roles=['SHARING_NFS_WRITE'])
+    # READONLY is considered administrative-level permission
+    @filterable(roles=['READONLY', 'SHARING_NFS_WRITE'])
     def get_nfs3_clients(self, filters, options):
         """
         Read contents of rmtab. This information may not
@@ -70,7 +71,8 @@ class NFSService(Service):
         return states or []
 
     # NFS_WRITE because this exposes hostnames, IP addresses and other details
-    @filterable(roles=['SHARING_NFS_WRITE'])
+    # READONLY is considered administrative-level permission
+    @filterable(roles=['READONLY', 'SHARING_NFS_WRITE'])
     @filterable_returns(Dict(
         'client',
         Str('id'),


### PR DESCRIPTION
READONLY is being treated as conferring administrative-level privileges to the server (ability to see unredacted sensitive information). This commit adds ability for the role to see NFS session information.