### PR TITLE
NAS-123965 / 24.04 / Convert all relevant realtime stats in bytes

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
@@ -17,7 +17,7 @@ def get_memory_info(netdata_metrics: dict) -> dict:
         'page_tables': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'PageTables', 0), multiplier=1024 * 1024,
         ),
-        'swap_cache': meminfo['SwapCached'],
+        'swap_cache': normalize_value(meminfo['SwapCached'], multiplier=1024),
         'slab_cache': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'Slab', 0), multiplier=1024 * 1024,
         ),
@@ -39,22 +39,22 @@ def get_memory_info(netdata_metrics: dict) -> dict:
     }
 
     extra = {
-        'inactive': meminfo['Inactive'],
+        'inactive': normalize_value(meminfo['Inactive'], multiplier=1024),
         'committed': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'mem.committed', 'Committed_AS', 0), multiplier=1024 * 1024,
         ),
-        'active': meminfo['Active'],
+        'active': normalize_value(meminfo['Active'], multiplier=1024),
         'vmalloc_used': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'VmallocUsed', 0), multiplier=1024 * 1024,
         ),
-        'mapped': meminfo['Mapped'],
+        'mapped': normalize_value(meminfo['Mapped'], multiplier=1024),
     }
 
     swap = {
         'used': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'system.swap', 'used', 0), multiplier=1024 * 1024,
         ),
-        'total': meminfo['SwapTotal'],
+        'total': normalize_value(meminfo['SwapTotal'], multiplier=1024),
     }
 
     return {

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -637,7 +637,7 @@ def test_memory_stats():
         assert memory_stats['classes']['page_tables'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'PageTables', 0), multiplier=1024 * 1024
         )
-        assert memory_stats['classes']['swap_cache'] == 1921024
+        assert memory_stats['classes']['swap_cache'] == 1921024 * 1024
         assert memory_stats['classes']['slab_cache'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'Slab', 0), multiplier=1024 * 1024
         )
@@ -656,16 +656,16 @@ def test_memory_stats():
         assert memory_stats['classes']['apps'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.ram', 'used', 0), multiplier=1024 * 1024
         )
-        assert memory_stats['extra']['inactive'] == 1413009408
+        assert memory_stats['extra']['inactive'] == 1413009408 * 1024
         assert memory_stats['extra']['committed'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.committed', 'Committed_AS', 0), multiplier=1024 * 1024,
         )
-        assert memory_stats['extra']['active'] == 69398528
+        assert memory_stats['extra']['active'] == 69398528 * 1024
         assert memory_stats['extra']['vmalloc_used'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'VmallocUsed', 0), multiplier=1024 * 1024
         )
-        assert memory_stats['extra']['mapped'] == 56082432
+        assert memory_stats['extra']['mapped'] == 56082432 * 1024
         assert memory_stats['swap']['used'] == normalize_value(
             safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.swap', 'used', 0), multiplier=1024 * 1024,
         )
-        assert memory_stats['swap']['total'] == 2144333824
+        assert memory_stats['swap']['total'] == 2144333824 * 1024


### PR DESCRIPTION
## Context

All the real-time reporting statistics are now standardized to bytes. These changes are aimed at reducing complexity in the user interface.