### PR TITLE
NAS-125579 / 24.04 / Make sure we gracefully handle certificate rotation for k3s

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/client.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/k8s/client.py
@@ -55,7 +55,9 @@ class ClientMixin:
             except ClientConnectorError:
                 remove_initialized_config()
                 if retry <= 0:
-                    raise
+                    raise ApiException(f'Client connection error raised from {endpoint!r} endpoint')
+            except Exception as e:
+                raise ApiException(f'Failed {endpoint!r} call: {e!r}')
             retry -= 1
 
 


### PR DESCRIPTION
Our k8s client caches k3s certificates used to make requests to kube-api server, however we run into problems in the case when those certs are about to expire and k3s auto-rotates them on it's own. In that case we run into client connection errors because the cert we specify is not valid and this has been gracefully handled to remove the cache we have and get latest certs which are to be used for the request.