### PR TITLE
NAS-125581 / 23.10.2 / prevent more log spam (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -131,7 +131,10 @@ async def chart_release_event(middleware, event_type, args):
     if args['involvedObject']['kind'] != 'Pod' or not is_ix_namespace(args['involvedObject']['namespace']):
         return
 
-    await middleware.call('chart.release.handle_k8s_event', args)
+    try:
+        await middleware.call('chart.release.handle_k8s_event', args)
+    except Exception as e:
+        middleware.logger.warning('Unhandled exception: %s', e)
 
 
 async def setup(middleware):


### PR DESCRIPTION
More log spam that just fills up middlewared.log.

Original PR: https://github.com/truenas/middleware/pull/12657
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125581