### PR TITLE
NAS-125562 / 23.10.1 / Fix more log spam (network activity feature) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -115,10 +115,7 @@ class ACMERegistrationService(CRUDService):
         # 3) SAVE REGISTRATION OBJECT
         # 4) SAVE REGISTRATION BODY
 
-        self.middleware.call_sync('network.general.will_perform_activity', 'acme')
-
         verrors = ValidationErrors()
-
         directory = self.get_directory(data['acme_directory_uri'])
         if not isinstance(directory, messages.Directory):
             verrors.add(

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -464,12 +464,12 @@ class MailService(ConfigService):
                                         queue.message['To'].split(', '),
                                         queue.message.as_string())
                         server.quit()
-                except Exception as e:
-                    if isinstance(e, DenyNetworkActivity):
-                        self.logger.warning('Sending message from queue denied')
-                    else:
-                        self.logger.debug('Sending message from queue failed', exc_info=True)
-
+                except DenyNetworkActivity:
+                    # no reason to queue up email since network activity was
+                    # explicitly denied by end-user
+                    mq.queue.remove(queue)
+                except Exception:
+                    self.logger.debug('Sending message from queue failed', exc_info=True)
                     queue.attempts += 1
                     if queue.attempts >= mq.MAX_ATTEMPTS:
                         mq.queue.remove(queue)

--- a/src/middlewared/middlewared/plugins/truecommand/connection.py
+++ b/src/middlewared/middlewared/plugins/truecommand/connection.py
@@ -9,7 +9,11 @@ class TruecommandAPIMixin:
     PORTAL_URI = 'https://portal.ixsystems.com/api'
 
     async def _post_call(self, options=None, payload=None):
-        await self.middleware.call('network.general.will_perform_activity', 'truecommand')
+        try:
+            await self.middleware.call('network.general.will_perform_activity', 'truecommand')
+        except Exception:
+            return {'error': 'Network activity denied for TrueCommand service'}
+
         options = options or {}
         timeout = options.get('timeout', 15)
         response = {'error': None, 'response': {}}

--- a/src/middlewared/middlewared/plugins/truecommand/connection.py
+++ b/src/middlewared/middlewared/plugins/truecommand/connection.py
@@ -9,9 +9,7 @@ class TruecommandAPIMixin:
     PORTAL_URI = 'https://portal.ixsystems.com/api'
 
     async def _post_call(self, options=None, payload=None):
-        try:
-            await self.middleware.call('network.general.will_perform_activity', 'truecommand')
-        except Exception:
+        if not await self.middleware.call('network.general.can_perform_activity', 'truecommand'):
             return {'error': 'Network activity denied for TrueCommand service'}
 
         options = options or {}

--- a/src/middlewared/middlewared/plugins/vmware_/snapshot_delete.py
+++ b/src/middlewared/middlewared/plugins/vmware_/snapshot_delete.py
@@ -33,7 +33,8 @@ class VMWareService(Service):
     @periodic(PENDING_SNAPSHOT_DELETE_INTERVAL.total_seconds(), run_on_start=False)
     @private
     async def delete_pending_snapshots(self):
-        await self.middleware.call("network.general.will_perform_activity", "vmware")
+        if not await self.middleware.call("network.general.can_perform_activity", "vmware"):
+            return
 
         for pending_snapshot_delete in await self.middleware.call(
             "datastore.query",


### PR DESCRIPTION
This entire feature wasn't designed/thought about very well. It's flawed in many aspects but without the changes in this PR we're spamming our log files when someone does `Deny All` (even though that's not actually happening) in the webUI.

This squashes the most obvious log spam use-cases. (This was found on an internal HA system for which I'm troubleshooting an unrelated issue)

Original PR: https://github.com/truenas/middleware/pull/12645
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125562