### PR TITLE
NAS-125584 / 24.04 / Add roles for interacting with auth sessions

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -236,7 +236,7 @@ class AuthService(Service):
         super(AuthService, self).__init__(*args, **kwargs)
         self.session_manager.middleware = self.middleware
 
-    @filterable
+    @filterable(roles=['AUTH_SESSIONS_READ'])
     @filterable_returns(Dict(
         'session',
         Str('id'),
@@ -245,7 +245,7 @@ class AuthService(Service):
         Str('origin'),
         Str('credentials'),
         Datetime('created_at'),
-    ), roles=['AUTH_SESSIONS_READ'])
+    ))
     @pass_app()
     def sessions(self, app, filters, options):
         """

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -245,7 +245,7 @@ class AuthService(Service):
         Str('origin'),
         Str('credentials'),
         Datetime('created_at'),
-    ))
+    ), roles=['AUTH_SESSIONS_READ'])
     @pass_app()
     def sessions(self, app, filters, options):
         """
@@ -294,7 +294,7 @@ class AuthService(Service):
             options,
         )
 
-    @accepts(Str('id'))
+    @accepts(Str('id'), roles=['AUTH_SESSIONS_WRITE'])
     @returns(Bool(description='Is `true` if session was terminated successfully'))
     async def terminate_session(self, id_):
         """
@@ -308,7 +308,7 @@ class AuthService(Service):
 
         await session.app.response.close()
 
-    @accepts()
+    @accepts(roles=['AUTH_SESSIONS_WRITE'])
     @returns()
     @pass_app()
     async def terminate_other_sessions(self, app):

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -18,6 +18,8 @@ class Role:
 
 
 ROLES = {
+    'AUTH_SESSIONS_READ': Role(),
+    'AUTH_SESSIONS_WRITE': Role(includes=['AUTH_SESSIONS_READ']),
     'FILESYSTEM_ATTRS_READ': Role(),
     'FILESYSTEM_ATTRS_WRITE': Role(includes=['FILESYSTEM_ATTRS_READ']),
     'FILESYSTEM_DATA_READ': Role(),
@@ -27,6 +29,7 @@ ROLES = {
 
     'FULL_ADMIN': Role(full_admin=True, builtin=False),
     'READONLY': Role(includes=['ALERT_LIST_READ',
+                               'AUTH_SESSIONS_READ',
                                'FILESYSTEM_ATTRS_READ',
                                'NETWORK_GENERAL_READ',
                                'SHARING_READ',


### PR DESCRIPTION
This commit allows READONLY role to list currently authenticated middleware sessions. AUTH_SESSIONS_WRITE role is defined so that webui can have hint about whether to turn off the terminate sessions button.