### PR TITLE
NAS-125569 Don't enclose ipv6 addresses in square brackets in scst.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -261,11 +261,10 @@ TARGET_DRIVER iscsi {
             else:
                 # In an ALUA config, we may have selected the int_vip.  If so just use
                 # the IP pertainng to this node.
-                rawaddr = addr['ip']
-                if alua_enabled and rawaddr in failover_virtual_aliases and rawaddr in listen_ip_choices and '/' in listen_ip_choices[rawaddr]:
-                    pair = listen_ip_choices[rawaddr].split('/')
-                    rawaddr = pair[0] if node == 'A' else pair[1]
-                address = (f'[{rawaddr}]' if ':' in rawaddr else rawaddr)
+                address = addr['ip']
+                if alua_enabled and address in failover_virtual_aliases and address in listen_ip_choices and '/' in listen_ip_choices[address]:
+                    pair = listen_ip_choices[address].split('/')
+                    address = pair[0] if node == 'A' else pair[1]
 
             group_initiators = initiators[group['initiator']]['initiators'] if group['initiator'] else []
             if not has_per_host_access:


### PR DESCRIPTION
When binding an iSCSI portal to an IPv6 address, `middlewared` is adding square brackets to the ipv6 addresses where scst is not expecting any in the initiator target group lines in `/etc/scst.conf` e.g. `INITIATOR *\#[2a10:4741:36:28:e61d:2dff:fe90:80fe]` instead of `INITIATOR *\#2a10:4741:36:28:e61d:2dff:fe90:80fe`.

This locks all initiators out of the target because `scst` is expecting these IPv6 addresses without the square brackets and thus the addresses don't match up.

A very bad poor man's "fix" is  making the iSCSI portal bind to all addresses.

When binding to all addresses, `/etc/scst.conf` is populated with `INITIATOR *\#*` which causes iscsiadm to crap out during target discovery. This is because link-local ipv6 addresses from the TrueNAS box are sent to the client which contain the wrong interface identifier (the one from the server, not the client) and iscsiadm tries to resolve them for some reason, not sure.
```
> iscsiadm --mode discovery --type sendtargets --portal spitfire.storage.235.tdude.co:3260
iscsiadm: Cannot resolve host fe80::225:90ff:fe86:9cd6%enp6s0f2. getaddrinfo error: [Name or service not known]
iscsiadm: cannot resolve fe80::225:90ff:fe86:9cd6%enp6s0f2
iscsiadm: failed to add default portal, ignoring target iqn.2005-10.org.freenas.ctl:csi-pvc-0d87ad71a6444e81-cluster
iscsiadm: failed to add target record
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-0d87ad71a6444e81-cluster
[2a10:4741:36:29:225:90ff:fe86:9cd6]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-0d87ad71a6444e81-cluster
```
You can still manually create and mount targets but discovery is broken.

I manually patched my TrueNAS installation to remove the square brackets and removed the bind to all ip addresses which fixed the bug:
```
> iscsiadm --mode discovery --type sendtargets --portal spitfire.storage.235.tdude.co:3260
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-0d87ad71a6444e81-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-102391b4684e440c-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-203193515dbc4759-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-3d325f86084943d2-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-4562489f2f2c4fb4-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-4a27d18f7f524904-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-67de32d83273469e-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-6f47cb5083fc4820-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-7ea9d4170e4f434b-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-831647229ea54ac0-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-aa34af8dda1544b9-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-bcb4379e6dc34137-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:csi-pvc-f38b673dc4634de3-cluster
[2a10:4741:36:28:e61d:2dff:fe90:80fe]:3260,1 iqn.2005-10.org.freenas.ctl:guigz-backup-root
```

The fix will need to be backported because I'm currently on 22.12 and the file is completely different.