### PR TITLE
NAS-125593 / 24.04 / Make SHARING_MANAGER role a superset of READONLY

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -113,7 +113,8 @@ ROLES = {
                                           'SNAPSHOT_WRITE'],
                                 builtin=False),
 
-    'SHARING_MANAGER': Role(includes=['DATASET_WRITE',
+    'SHARING_MANAGER': Role(includes=['READONLY',
+                                      'DATASET_WRITE',
                                       'SHARING_WRITE',
                                       'FILESYSTEM_ATTRS_WRITE'],
                             builtin=False)


### PR DESCRIPTION
Per request from webui team, grant the SHARING_MANAGER role all rights that READONLY has.