### PR TITLE
NAS-125618 / 24.04 / Allow users to set own passwords

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1484,7 +1484,10 @@ class UserService(CRUDService):
 
         verrors = ValidationErrors()
         is_full_admin = credential_has_full_admin(app.authenticated_credentials)
-        authenticated_user = app.authenticated_credentials.user['username']
+        authenticated_user = None
+
+        if app.authenticated_credentials.is_user_session:
+            authenticated_user = app.authenticated_credentials.user['username']
 
         username = data['username']
         password = data['new_password']

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1468,9 +1468,6 @@ class UserService(CRUDService):
         * account has password authentication disabled
         * account is locked
 
-        `skip_password_check` option may be specified if authorized session
-        is has FULL_ADMIN role.
-
         NOTE: when authenticated session has less than FULL_ADMIN role,
         password changes will be rejected if the payload does not match the
         currently-authenticated user.

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -74,6 +74,15 @@ class EtcService(Service):
         'truenas_nvdimm': [
             {'type': 'py', 'path': 'truenas_nvdimm', 'checkpoint': 'post_init'},
         ],
+        'shadow': {
+            'ctx': [
+                {'method': 'user.query'},
+                {'method': 'cluster.utils.is_clustered'}
+            ],
+            'entries': [
+                {'type': 'mako', 'path': 'shadow', 'group': 'shadow', 'mode': 0o0640},
+            ]
+        },
         'user': {
             'ctx': [
                 {'method': 'user.query'},

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -37,7 +37,7 @@ def app_credential_full_admin_or_user(
     if app is None:
         return True
 
-    return credential_credential_full_admin_or_user(app.authenticated_credentials, username)
+    return credential_full_admin_or_user(app.authenticated_credentials, username)
 
 
 def privileges_group_mapping(

--- a/tests/api2/test_password_reset.py
+++ b/tests/api2/test_password_reset.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import errno
+import pytest
+import secrets
+import string
+
+from middlewared.service_exception import CallError, ValidationErrors
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.account import unprivileged_user
+from middlewared.test.integration.utils import call, client
+
+
+TEST_USERNAME = 'testpasswduser'
+TEST_USERNAME_2 = 'testpasswduser2'
+TEST_GROUPNAME = 'testpasswdgroup'
+TEST_PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+TEST_PASSWORD_2 = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+TEST_PASSWORD2 = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+TEST_PASSWORD2_2 = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+
+def test_restricted_user_password_reset():
+    with unprivileged_user(
+        username=TEST_USERNAME,
+        group_name=TEST_GROUPNAME,
+        privilege_name='TEST_PASSWD_RESET_PRIVILEGE',
+        allowlist=[],
+        web_shell=False,
+        roles=['READONLY']
+    ) as acct:
+        with client(auth=(acct.username, acct.password)) as c:
+            # Password reset using existing password and current user should work
+            c.call('user.password_reset', {
+                'username': acct.username,
+                'old_password': acct.password,
+                'new_password': TEST_PASSWORD
+            })
+
+            # Should be able to create new client session with new password
+            with client(auth=(acct.username, TEST_PASSWORD)) as c2:
+                c2.call('auth.me')
+
+        # FULL_ADMIN privileges should also allow password reset:
+        call('user.password_reset', {
+            'username': acct.username,
+            'old_password': TEST_PASSWORD,
+            'new_password': TEST_PASSWORD_2
+        })
+
+        # FULL_ADMIN should also be able to skip password checks
+        call('user.password_reset', {
+            'username': acct.username,
+            'new_password': TEST_PASSWORD_2,
+            'options': {'skip_password_check': True},
+        })
+
+        group_id = call('group.query', [['group', '=', TEST_GROUPNAME]], {'get': True})['id']
+
+        # Create additional user with READONLY privilege
+        with user({
+           'username': TEST_USERNAME_2,
+           'full_name': TEST_USERNAME_2,
+           'group_create': True,
+           'groups': [group_id],
+           'smb': False,
+           'password': TEST_PASSWORD2
+        }) as u:
+            with client(auth=(TEST_USERNAME_2, TEST_PASSWORD2)) as c2:
+                # Limited users should not be able to change other
+                # passwords of other users
+                with pytest.raises(CallError) as ve:
+                    c2.call('user.password_reset', {
+                        'username': acct.username,
+                        'old_password': TEST_PASSWORD_2,
+                        'new_password': 'CANARY'
+                    })
+
+                assert ve.value.errno == errno.EPERM
+
+                with pytest.raises(ValidationErrors) as ve:
+                    # Limited users should not be able to skip password checks
+                    c2.call('user.password_reset', {
+                        'username': TEST_USERNAME_2,
+                        'new_password': 'CANARY',
+                        'options': {'skip_password_check': True}
+                    })
+
+            call("user.update", u['id'], {'password_disabled': True})
+            with pytest.raises(ValidationErrors) as ve:
+                # This should fail because we've disabled password auth
+                call('user.password_reset', {
+                    'username': TEST_USERNAME_2,
+                    'old_password': TEST_PASSWORD2,
+                    'new_password': 'CANARY'
+                })
+
+            call("user.update", u['id'], {
+                'password_disabled': False,
+                'locked': True
+            })
+
+            with pytest.raises(ValidationErrors) as ve:
+                # This should fail because we've locked account
+                call('user.password_reset', {
+                    'username': TEST_USERNAME_2,
+                    'old_password': TEST_PASSWORD2,
+                    'new_password': 'CANARY'
+                })
+
+            call("user.update", u['id'], {
+                'password_disabled': False,
+                'locked': False
+            })
+
+            # Unlocking user should allow password reset to succeed
+            with client(auth=(TEST_USERNAME_2, TEST_PASSWORD2)) as c2:
+                c2.call('user.password_reset', {
+                    'username': TEST_USERNAME_2,
+                    'old_password': TEST_PASSWORD2,
+                    'new_password': TEST_PASSWORD2_2
+                })


### PR DESCRIPTION
This commit adds a new API endpoint user.set_password that may be used to change the password of a given user.

NOTE: when authenticated session has less than FULL_ADMIN role, password changes will be rejected if the payload does not match the currently-authenticated user.

API keys granting access to this endpoint will be able to reset password of any user.