### PR TITLE
NAS-125614 / 24.04 / More clustering teardown improvements

### DIFF
--- a/cluster-tests/tests/cleanup/test_cluster_cleanup.py
+++ b/cluster-tests/tests/cleanup/test_cluster_cleanup.py
@@ -141,6 +141,14 @@ def test_verify_ctdb_teardown(ip, request):
     assert ans.get('error') is None, ans
     assert len(ans['result']) == 0, ans['result']
 
+    ans = make_ws_request(ip, {
+        'msg': 'method',
+        'method': 'smb.getparm',
+        'params': ['clustering', 'global']
+    })
+    assert ans.get('error') is None, ans
+    assert ans['result'] is False, ans['result']
+
 
 @pytest.mark.parametrize('ip', CLUSTER_IPS)
 def test_verify_ctdb_teardown_force(ip, request):

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_root_dir.py
@@ -601,12 +601,10 @@ class CtdbRootDirService(Service):
                     # If someone calls this method, we expect that all other gluster volumes
                     # have been destroyed
                     raise CallError(f'{vol["name"]!r} must be removed before deleting {config["volume_name"]!r}')
-        else:
-            # we have to stop gluster service because it spawns a bunch of child processes
-            # for the ctdb shared volume. This also stops ctdb, smb and unmounts all the
-            # FUSE mountpoints.
-            job.set_progress(50, 'Stopping cluster services')
-            await self.middleware.call('service.stop', 'glusterd')
+
+        # This also stops ctdb, smb and unmounts all the FUSE mountpoints.
+        job.set_progress(50, 'Stopping cluster services')
+        await self.middleware.call('service.stop', 'glusterd')
 
         job.set_progress(75, 'Removing cluster related configuration files and directories.')
         wipe_config_job = await self.middleware.call('cluster.utils.wipe_config')
@@ -615,6 +613,7 @@ class CtdbRootDirService(Service):
         job.set_progress(90, 'Disabling cluster service')
         await self.middleware.call('service.update', 'glusterd', {'enable': False})
         await self.middleware.call('smb.reset_smb_ha_mode')
+        await self.middleware.call('etc.generate', 'smb')
 
         job.set_progress(95, 'Detaching trusted storage pool')
         if await self.middleware.call('gluster.peer.query'):

--- a/src/middlewared/middlewared/plugins/service_/services/glusterd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/glusterd.py
@@ -44,7 +44,6 @@ class GlusterdService(SimpleService):
             if await self.middleware.call('service.started', svc):
                 await self.middleware.call('service.stop', svc)
 
-        await self.middleware.call('service.stop', 'ctdb')
         umount_job = await self.middleware.call('gluster.fuse.umount', {'all': True})
         await umount_job.wait()
 


### PR DESCRIPTION
This commit adds more handling for clustering teardown for the true command team.

* regenerate smb.conf during cluster teardown job.
* always stop glusterfs service (along with ctdb and smb)