### PR TITLE
NAS-125623 / 24.10 / Randomize names in privilege test assets

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/account.py
+++ b/src/middlewared/middlewared/test/integration/assets/account.py
@@ -1,4 +1,6 @@
 import contextlib
+import secrets
+import string
 import types
 
 from middlewared.service_exception import InstanceNotFound
@@ -72,10 +74,11 @@ def unprivileged_user(*, username, group_name, privilege_name, allowlist, web_sh
 
 @contextlib.contextmanager
 def unprivileged_user_client(roles=None, allowlist=None):
+    suffix = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(5))
     with unprivileged_user(
-        username="unprivileged",
-        group_name="unprivileged_users",
-        privilege_name="Unprivileged users",
+        username=f"unprivileged_{suffix}",
+        group_name=f"unprivileged_users_{suffix}",
+        privilege_name="Unprivileged users {suffix}",
         allowlist=allowlist or [],
         roles=roles or [],
         web_shell=False,

--- a/tests/api2/test_job_credentials.py
+++ b/tests/api2/test_job_credentials.py
@@ -11,8 +11,10 @@ def test_job_credentials():
             return 42
     """):
         with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
+            username = c.call('auth.me')['pw_name']
+
             job_id = c.call("test.test1")
 
             job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
 
-            assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": "unprivileged"}}
+            assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": username}}


### PR DESCRIPTION
This prevents teardown failure in one test from impacting other tests allowing for faster triage of issues.