### PR TITLE
Add SHARING_MANAGER to builtin privilege enum

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -11,6 +11,7 @@ import middlewared.sqlalchemy as sa
 class BuiltinPrivileges(enum.Enum):
     LOCAL_ADMINISTRATOR = "LOCAL_ADMINISTRATOR"
     READONLY = "READONLY"
+    SHARING_MANAGER = "SHARING_MANAGER"
 
 
 class PrivilegeModel(sa.Model):


### PR DESCRIPTION
This fixes an oversight during intial work to add new builtin roles / privileges.