### PR TITLE
NAS-125627 / 24.04 / Do not try to restart winbindd when sysdataset missing

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -284,6 +284,14 @@ class IdmapDomainService(TDBWrapCRUDService):
             if not retry or e.error_code != wbclient.WBC_ERR_WINBIND_NOT_AVAILABLE:
                 raise e
 
+        if not self.middleware.call_sync('systemdataset.sysdataset_path'):
+            raise CallError(
+                'Unexpected filesystem mounted in the system dataset path. '
+                'This may indicate a failure to initialize the system dataset '
+                'and may be resolved by reviewing and fixing errors in the system '
+                'dataset configuration.', errno.EAGAIN
+            )
+
         self.middleware.call_sync('service.start', 'idmap', {'silent': False})
         return self.__wbclient_ctx(False)
 


### PR DESCRIPTION
There is potential to have a race between middleware idmap operations and system dataset move. If system dataset path is not set (which can happen when we have system dataset migration in progress) we should raise an exception.