### PR TITLE
NAS-125631 / 24.10 / Disable mocking support in stable releases

### DIFF
--- a/src/middlewared/middlewared/plugins/test/mock.py
+++ b/src/middlewared/middlewared/plugins/test/mock.py
@@ -1,3 +1,4 @@
+import errno
 from middlewared.service import CallError, Service
 
 
@@ -6,6 +7,9 @@ class TestService(Service):
         private = True
 
     async def set_mock(self, name, args, description):
+        if await self.middleware.call('system.is_stable'):
+            raise CallError("Mocked methods may not be set in stable releases.", errno.EPERM)
+
         if isinstance(description, str):
             exec(description)
             try:

--- a/tests/api2/test_mock_disable.py
+++ b/tests/api2/test_mock_disable.py
@@ -1,0 +1,14 @@
+import errno
+import pytest
+
+from middlewared.service_exception import CallError
+from middlewared.test.integration.utils import call, mock
+
+
+def test_disable_mock_on_stable_release():
+    with mock("system.is_stable", return_value=True):
+        with pytest.raises(CallError) as ve:
+            with mock("vmware.connect", return_value=None):
+                pass
+
+        assert ve.value.errno == errno.EPERM


### PR DESCRIPTION
Development and testing tools should be disabled for published releases.