### PR TITLE
NAS-125573 / 24.04 / Add webui_access flag to composed privilege

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -4,7 +4,7 @@ import errno
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, SID, Str, Patch
 from middlewared.service import CallError, CRUDService, filter_list, private, ValidationErrors
 from middlewared.service_exception import MatchNotFound
-from middlewared.utils.privilege import privileges_group_mapping
+from middlewared.utils.privilege import privilege_has_webui_access, privileges_group_mapping
 import middlewared.sqlalchemy as sa
 
 
@@ -344,6 +344,7 @@ class PrivilegeService(CRUDService):
             'roles': set(),
             'allowlist': [],
             'web_shell': False,
+            'webui_access': False,
         }
         for privilege in privileges:
             for role in privilege['roles']:
@@ -358,6 +359,7 @@ class PrivilegeService(CRUDService):
                 compose['allowlist'].append(item)
 
             compose['web_shell'] |= privilege['web_shell']
+            compose['webui_access'] |= privilege_has_webui_access(privilege)
 
         return compose
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_privilege.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_privilege.py
@@ -1,0 +1,34 @@
+import pytest
+import types
+
+from middlewared.auth import UserSessionManagerCredentials
+from middlewared.utils.privilege import (
+    app_credential_full_admin_or_user,
+    credential_has_full_admin,
+    credential_full_admin_or_user,
+    privilege_has_webui_access,
+)
+
+
+@pytest.mark.parametrize('privilege,expected', [
+    ({'roles': ['READONLY'], 'allowlist': []}, True),
+    ({'roles': ['SHARING_MANAGER'], 'allowlist': []}, True),
+    ({'roles': ['FULL_ADMIN'], 'allowlist': []}, True),
+    ({'roles': ['SHARING_SMB_READ'], 'allowlist': []}, False),
+])
+def test_privilege_has_webui_access(privilege, expected):
+    assert privilege_has_webui_access(privilege) == expected
+
+
+@pytest.mark.parametrize('credential,expected', [
+    ({'username': 'BOB', 'privilege': {'allowlist': [], 'roles': ['READONLY']}}, False),
+    ({'username': 'BOB', 'privilege': {'allowlist': [], 'roles': ['FULL_ADMIN']}}, True),
+    ({'username': 'BOB', 'privilege': {'allowlist': [{'method': '*', 'resource': '*'}], 'roles': []}}, True),
+])
+def test_privilege_has_full_admin(credential,expected):
+    user_cred = UserSessionManagerCredentials(credential)
+    assert credential_has_full_admin(user_cred) == expected
+    assert credential_full_admin_or_user(user_cred, 'canary') == expected
+    assert credential_full_admin_or_user(user_cred, 'BOB')
+
+    assert app_credential_full_admin_or_user(types.SimpleNamespace(authenticated_credentials=user_cred), 'canary') == expected

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -1,3 +1,23 @@
+from middlewared.role import ROLES
+
+
+def privilege_has_webui_access(privilege: dict) -> bool:
+    """
+    This method determines whether the specified privilege is sufficient
+    to grant WebUI access. Current check is whether any of the roles for
+    the privilege entry are not builtin, where "builtin" means an
+    internal role that is used for defining access to particular methods
+    (as opposed to non-builtin ones that were developed explicitly for
+    assignment by administrators).
+
+    The actual check performed here may change at a future time if we
+    decide to add explicit `webui_access` flag to privilege.
+
+    Returns True if privilege grants webui access and False if it does not.
+    """
+    return not any(ROLES[role].builtin for role in privilege['roles'])
+
+
 def credential_has_full_admin(credential: object) -> bool:
     if credential.is_user_session and 'FULL_ADMIN' in credential.user['privilege']['roles']:
         return True


### PR DESCRIPTION
This adds flag to composed privilege (for example in auth.me output) that can be used by the webui team to determine whether and authenticated session should have webui access. Current algorithm is to check whether credential has one of non-builtin roles (READONLY, FULL_ADMIN, SHARING_MANAGER).