### PR TITLE
NAS-125574 / 24.04 / Expand output of system.info

### DIFF
--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -163,6 +163,9 @@ class SystemService(Service):
         mem_info = await self.middleware.call('system.mem_info')
         birthday = await self.middleware.call('system.birthday')
         timezone_setting = (await self.middleware.call('datastore.config', 'system.settings'))['stg_timezone']
+        host_id = await self.middleware.call('system.host_id')
+        is_production = await self.middleware.call('truenas.is_production')
+        ix_hardware = await self.middleware.call('system.is_ix_hardware')
 
         return {
             'version': await self.middleware.call('system.version'),
@@ -185,6 +188,9 @@ class SystemService(Service):
             'timezone': timezone_setting,
             'system_manufacturer': dmidecode['system-manufacturer'] if dmidecode['system-manufacturer'] else None,
             'ecc_memory': dmidecode['ecc-memory'],
+            'host_id': host_id,
+            'production': is_production,
+            'ix_hardware': ix_hardware,
         }
 
     @private

--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -152,6 +152,9 @@ class SystemService(Service):
         Str('timezone', required=True),
         Str('system_manufacturer', required=True, null=True),
         Bool('ecc_memory', required=True),
+        Str('host_id', required=True),
+        Bool('production', required=True),
+        Bool('ix_hardware', required=True),
     ))
     async def info(self):
         """


### PR DESCRIPTION
This expands system.info output to include whether hardware is from iX, the system hostid, and whether system is in production. This reduces number of separate API endpoints that webui has to call.