### PR TITLE
NAS-125641 / 24.04 / Lift limitations of OVMF option collection

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -60,7 +60,7 @@ class VMModel(sa.Model):
 
 @functools.cache
 def ovmf_options():
-    return [path for path in os.listdir('/usr/share/OVMF') if re.findall(r'^OVMF_CODE[^\.]*.fd', path)]
+    return [path for path in os.listdir('/usr/share/OVMF') if re.findall(r'^OVMF_CODE.*.fd', path)]
 
 
 class VMService(CRUDService, VMSupervisorMixin):


### PR DESCRIPTION
Change ovmf_options to collect all available images from disk, instead of limiting to the base ones.