### PR TITLE
NAS-125642 / 24.04 / Enable discard for VM disks

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -32,7 +32,7 @@ class StorageDevice(Device):
         return create_element(
             'disk', type=self.TYPE, device='disk', attribute_dict={
                 'children': [
-                    create_element('driver', name='qemu', type='raw', cache='none', io=iotype.lower()),
+                    create_element('driver', name='qemu', type='raw', cache='none', io=iotype.lower(), discard='unmap'),
                     self.create_source_element(),
                     create_element(
                         'target', bus='sata' if not virtio else 'virtio',

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -127,7 +127,7 @@ def test_nic_xml(vm_data, expected_xml):
             'iotype': 'THREADS',
         },
         'dtype': 'DISK',
-    }]}, '<devices><disk type="block" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" />'
+    }]}, '<devices><disk type="block" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source dev="/dev/zvol/pool/boot_1" /><target bus="sata" dev="sda" /><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
@@ -151,7 +151,7 @@ def test_disk_xml(vm_data, expected_xml):
             'iotype': 'THREADS',
         },
         'dtype': 'RAW',
-    }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" />'
+    }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
@@ -164,7 +164,7 @@ def test_disk_xml(vm_data, expected_xml):
             'iotype': 'THREADS',
         },
         'dtype': 'RAW',
-    }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" />'
+    }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><boot order="1" />'
          '<blockio logical_block_size="512" physical_block_size="512" /></disk>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'


### PR DESCRIPTION
Adding discard setting to disk, allowing VM images to shrink on physical disk. Setting should be supported by all available disk types.

Partially solves https://ixsystems.atlassian.net/browse/NAS-113503 (without transition to virtio-scsi).

