### PR TITLE
NAS-125673 / 24.04 / Configure roles for service plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -15,7 +15,7 @@ def app_has_write_privilege_for_service(
         # Internal middleware call
         return True
 
-    if not app.authenticated_credentials is None:
+    if app.authenticated_credentials is None:
         return False
 
     if credential_has_full_admin(app.authenticated_credentials):

--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -1,0 +1,28 @@
+import enum
+from middlewared.utils.privilege import app_credential_full_admin_or_user
+
+class ServiceWriteRole(enum.Enum):
+    CIFS = 'SHARING_SMB_WRITE'
+    NFS = 'SHARING_NFS_WRITE'
+    ISCSITARGET = 'SHARING_ISCSI_WRITE'
+
+
+def app_has_write_privilege_for_service(
+    app: object | None,
+    service: str
+) -> bool:
+    if app_credential_full_admin_or_user(app, None):
+        return True
+
+    if not app.authenticated_credentials:
+        return False
+
+    if app.authenticated_credentials.has_role('SERVICES_WRITE'):
+        return True
+
+    try:
+        required_role = ServiceWriteRole[service.upper()]
+    except KeyError:
+        return False
+
+    return app.authenticated_credentials.has_role(required_role.value)

--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -1,5 +1,5 @@
 import enum
-from middlewared.utils.privilege import app_credential_full_admin_or_user
+from middlewared.utils.privilege import credential_has_full_admin
 
 class ServiceWriteRole(enum.Enum):
     CIFS = 'SHARING_SMB_WRITE'
@@ -11,11 +11,15 @@ def app_has_write_privilege_for_service(
     app: object | None,
     service: str
 ) -> bool:
-    if app_credential_full_admin_or_user(app, None):
+    if app is None:
+        # Internal middleware call
         return True
 
-    if not app.authenticated_credentials:
+    if not app.authenticated_credentials is None:
         return False
+
+    if credential_has_full_admin(app.authenticated_credentials):
+        return True
 
     if app.authenticated_credentials.has_role('SERVICES_WRITE'):
         return True

--- a/src/middlewared/middlewared/pytest/unit/utils/test_privilege.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_privilege.py
@@ -8,6 +8,7 @@ from middlewared.utils.privilege import (
     credential_full_admin_or_user,
     privilege_has_webui_access,
 )
+from middlewared.plugins.service_.utils import app_has_write_privilege_for_service
 
 
 @pytest.mark.parametrize('privilege,expected', [
@@ -32,3 +33,28 @@ def test_privilege_has_full_admin(credential,expected):
     assert credential_full_admin_or_user(user_cred, 'BOB')
 
     assert app_credential_full_admin_or_user(types.SimpleNamespace(authenticated_credentials=user_cred), 'canary') == expected
+
+
+@pytest.mark.parametrize('service,credential,expected', [
+    ('cifs', {'privilege': {'allowlist': [], 'roles': ['READONLY']}}, False),
+    ('cifs', {'privilege': {'allowlist': [], 'roles': ['FULL_ADMIN']}}, True),
+    ('cifs', {'privilege': {'roles': [], 'allowlist': [{'method': '*', 'resource': '*'}]}}, True),
+    ('cifs', {'privilege': {'allowlist': [], 'roles': ['SHARING_SMB_WRITE']}}, True),
+    ('cifs', {'privilege': {'allowlist': [], 'roles': ['SHARING_NFS_WRITE']}}, False),
+    ('cifs', {'privilege': {'allowlist': [], 'roles': ['SHARING_ISCSI_WRITE']}}, False),
+    ('nfs', {'privilege': {'allowlist': [], 'roles': ['READONLY']}}, False),
+    ('nfs', {'privilege': {'allowlist': [], 'roles': ['FULL_ADMIN']}}, True),
+    ('nfs', {'privilege': {'roles': [], 'allowlist': [{'method': '*', 'resource': '*'}]}}, True),
+    ('nfs', {'privilege': {'allowlist': [], 'roles': ['SHARING_SMB_WRITE']}}, False),
+    ('nfs', {'privilege': {'allowlist': [], 'roles': ['SHARING_NFS_WRITE']}}, True),
+    ('nfs', {'privilege': {'allowlist': [], 'roles': ['SHARING_ISCSI_WRITE']}}, False),
+    ('iscsitarget', {'privilege': {'allowlist': [], 'roles': ['READONLY']}}, False),
+    ('iscsitarget', {'privilege': {'allowlist': [], 'roles': ['FULL_ADMIN']}}, True),
+    ('iscsitarget', {'privilege': {'roles': [], 'allowlist': [{'method': '*', 'resource': '*'}]}}, True),
+    ('iscsitarget', {'privilege': {'allowlist': [], 'roles': ['SHARING_SMB_WRITE']}}, False),
+    ('iscsitarget', {'privilege': {'allowlist': [], 'roles': ['SHARING_NFS_WRITE']}}, False),
+    ('iscsitarget', {'privilege': {'allowlist': [], 'roles': ['SHARING_ISCSI_WRITE']}}, True),
+])
+def test_privilege_has_write_to_service(service,credential,expected):
+    user_cred = UserSessionManagerCredentials({'username': 'BOB'} | credential)
+    assert app_has_write_privilege_for_service(types.SimpleNamespace(authenticated_credentials=user_cred), service) == expected

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -40,6 +40,7 @@ ROLES = {
                                'REPORTING_READ',
                                'REPLICATION_TASK_CONFIG_READ',
                                'REPLICATION_TASK_READ',
+                               'SERVICE_READ',
                                'SNAPSHOT_TASK_READ'],
                      builtin=False),
 
@@ -48,6 +49,9 @@ ROLES = {
 
     'CLOUD_SYNC_READ': Role(),
     'CLOUD_SYNC_WRITE': Role(includes=['CLOUD_SYNC_READ']),
+
+    'SERVICE_READ': Role(),
+    'SERVICE_WRITE': Role(),
 
     # Network roles
     'NETWORK_GENERAL_READ': Role(),
@@ -125,7 +129,8 @@ ROLES = {
 
     'SHARING_MANAGER': Role(includes=['DATASET_WRITE',
                                       'SHARING_WRITE',
-                                      'FILESYSTEM_ATTRS_WRITE'],
+                                      'FILESYSTEM_ATTRS_WRITE',
+                                      'SERVICE_READ'],
                             builtin=False)
 }
 

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -74,3 +74,8 @@ def test_write_role_can_write(ds, role):
         c.call("nfs.get_nfs4_clients")
         # Multiple layers of dependencies to mock up this as a successful write
         # c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
+
+        c.call("service.start", "nfs")
+        c.call("service.restart", "nfs")
+        c.call("service.reload", "nfs")
+        c.call("service.stop", "nfs")

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -67,3 +67,8 @@ def test_write_role_can_write(ds, role):
         c.call("sharing.smb.setacl", {"share_name": share["name"]})
         c.call("sharing.smb.delete", share["id"])
         c.call("smb.status")
+
+        c.call("service.start", "cifs")
+        c.call("service.restart", "cifs")
+        c.call("service.reload", "cifs")
+        c.call("service.stop", "cifs")


### PR DESCRIPTION
This commit adds SERVICE_READ and SERVICE_WRITE roles that are allowed to read / write services table configuration and administer services. SERVICE_READ is able to determine service running state. If user has SHARING_NFS_WRITE, SHARING_SMB_WRITE, and SHARING_ISCSI write they will be able to start, stop, restart, etc the respective service. If user has SERVICE_WRITE, then they will be able to manipulate running state of all services.