### PR TITLE
NAS-125636 / 24.04 / Restrict config reset to root / admin account

### DIFF
--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -246,6 +246,13 @@ class ConfigService(Service):
         If `reboot` is true this job will reboot the system after its completed with a delay of 10
         seconds.
         """
+        job.set_progress(0, 'Performing credential check')
+        if job.credentials is None:
+            raise CallError('Unable to check credentials')
+
+        if job.credentials.is_user_session and 'SYS_ADMIN' not in job.credentials.user['account_attributes']):
+            raise CallError('Configuration reset is limited to local SYS_ADMIN account ("root" or "admin")')
+
         job.set_progress(5, 'Removing cluster information (if any)')
         cjob = self.middleware.call_sync('ctdb.shared.volume.teardown', True)
         cjob.wait_sync()

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -250,7 +250,7 @@ class ConfigService(Service):
         if job.credentials is None:
             raise CallError('Unable to check credentials')
 
-        if job.credentials.is_user_session and 'SYS_ADMIN' not in job.credentials.user['account_attributes']):
+        if job.credentials.is_user_session and 'SYS_ADMIN' not in job.credentials.user['account_attributes']:
             raise CallError('Configuration reset is limited to local SYS_ADMIN account ("root" or "admin")')
 
         job.set_progress(5, 'Removing cluster information (if any)')


### PR DESCRIPTION
Configuration reset is an incredibly destructive action that is inappropriate to expose to more than the root account.