### PR TITLE
NAS-125685 / 23.10.2 / Prevent locking out root / admin user (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -1,0 +1,5 @@
+import enum
+
+
+class LocalAdminGroups(enum.IntEnum):
+    BUILTIN_ADMINISTRATORS = 544


### PR DESCRIPTION
If builtin_administrators is removed from Local Administrators privilege then root and admin user will not be able to authenticate via middlware APIs.

Original PR: https://github.com/truenas/middleware/pull/12707
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125685