### PR TITLE
NAS-125545 / 23.10.2 / Do not scale workloads which are using hostpaths which don't exist (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -120,6 +120,10 @@ def normalized_port_value(protocol: str, port: int) -> str:
     return '' if ((protocol == 'http' and port == 80) or (protocol == 'https' and port == 443)) else f':{port}'
 
 
+def get_non_existent_host_paths(paths: list) -> list:
+    return [path for path in paths if not os.path.exists(path)]
+
+
 SCALEABLE_RESOURCES = [
     Resources.DEPLOYMENT,
     Resources.STATEFULSET,


### PR DESCRIPTION
This PR adds changes to not scale workloads which have host paths which don't exist as in this case k3s automatically creates those paths which can be problematic as if a user tries to create a dataset which has the same mountpoint as the path, dataset creation will fail as we make sure that the dataset's mountpoint does not exist when we attempt to create it.

Original PR: https://github.com/truenas/middleware/pull/12702
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125545