### PR TITLE
NAS-125710 / 24.04 / Add account_attributes to auth.me output

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -11,7 +11,7 @@ from middlewared.auth import (SessionManagerCredentials, UserSessionManagerCrede
                               UnixSocketSessionManagerCredentials, RootTcpSocketSessionManagerCredentials,
                               LoginPasswordSessionManagerCredentials, ApiKeySessionManagerCredentials,
                               TrueNasNodeSessionManagerCredentials)
-from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, Password, Patch, returns, Str
+from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, Password, Patch, Ref, returns, Str
 from middlewared.service import (
     Service, filterable, filterable_returns, filter_list, no_auth_required, no_authz_required,
     pass_app, private, cli_private, CallError,
@@ -244,6 +244,7 @@ class AuthService(Service):
         Bool('internal'),
         Str('origin'),
         Str('credentials'),
+        Dict('credentials_data', additional_attrs=True),
         Datetime('created_at'),
     ))
     @pass_app()
@@ -474,9 +475,7 @@ class AuthService(Service):
         user = await self.middleware.call('auth.authenticate', username, password)
         twofactor_auth = await self.middleware.call('auth.twofactor.config')
 
-        if user and twofactor_auth['enabled'] and (await self.middleware.call(
-            'user.translate_username', user['username']
-        ))['twofactor_auth_configured']:
+        if user and twofactor_auth['enabled'] and '2FA' in user['account_attributes']:
             # We should run user.verify_twofactor_token regardless of check_user result to prevent guessing
             # passwords with a timing attack
             if not await self.middleware.call('user.verify_twofactor_token', username, otp_token):
@@ -572,6 +571,7 @@ class AuthService(Service):
             'user_information',
             'current_user_information',
             ('add', Dict('attributes', additional_attrs=True)),
+            ('add', Dict('two_factor_config', additional_attrs=True)),
         )
     )
     @pass_app()
@@ -586,7 +586,13 @@ class AuthService(Service):
         else:
             attributes = {}
 
-        return {**user, 'attributes': attributes}
+        try:
+            twofactor_config = await self.middleware.call('user.twofactor_config', user['pw_name'])
+        except Exception:
+            self.logger.error('%s: failed to look up 2fa details', exc_info=True)
+            twofactor_config = None
+
+        return {**user, 'attributes': attributes, 'two_factor_config': twofactor_config}
 
     @no_authz_required
     @accepts(
@@ -625,16 +631,11 @@ class AuthService(Service):
             raise CallError(f'You are logged in using {credentials.class_name()}')
 
         username = credentials.user['username']
-        try:
-            twofactor_config = await self.middleware.call('user.twofactor_config', username)
-        except Exception:
-            self.logger.error('%s: failed to look up 2fa details', exc_info=True)
-            twofactor_config = None
 
         return {
             **(await self.middleware.call('user.get_user_obj', {'username': username})),
             'privilege': credentials.user['privilege'],
-            'two_factor_config': twofactor_config
+            'account_attributes': credentials.user['account_attributes']
         }
 
     async def _attributes(self, user):

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -3,7 +3,7 @@ import hmac
 
 import pam
 
-from middlewared.service import CallError, Service, private
+from middlewared.service import CallError, Service, pass_app, private
 
 
 class AuthService(Service):
@@ -13,38 +13,55 @@ class AuthService(Service):
 
     @private
     async def authenticate(self, username, password):
-        # root and admin must always be local
-        # since they may be used by system processes we
-        # optimize away the more complex translate_username call
-        if username in ('root', 'admin'):
-            local = True
-
+        if user_info := (await self.middleware.call(
+            'datastore.query', 'account.bsdusers',
+            [('username', '=', username)],
+            {'prefix': 'bsdusr_', 'select': ['id', 'unixhash', 'uid']},
+        )):
+            user_info = user_info[0] | {'local': True}
+            unixhash = user_info.pop('unixhash')
         else:
-            local = bool(await self.middleware.call(
-                'datastore.query',
-                'account.bsdusers',
-                [('username', '=', username)],
-                {'prefix': 'bsdusr_', 'count': True},
-            ))
+            user_info = {'id': None, 'uid': None, 'local': False}
+            unixhash = None
 
+        # The following provides way for root user to avoid getting locked out
+        # of webui via due to PAM enforcing password policies on the root
+        # account. Specifically, some legacy users have configured the root
+        # account so its password has password_disabled = true. We have to
+        # maintain the old middleware authentication code (bypassing PAM) to
+        # prevent this.
+        #
+        # In all failure cases libpam_authenticate is called so that timing
+        # is consistent with pam_fail_delay
         if username == 'root' and await self.middleware.call('privilege.always_has_root_password_enabled'):
-            root = await self.middleware.call(
-                'datastore.query',
-                'account.bsdusers',
-                [('username', '=', 'root')],
-                {'get': True, 'prefix': 'bsdusr_'},
-            )
-
-            if root['unixhash'] in ('x', '*'):
+            if unixhash in ('x', '*'):
+                await self.middleware.call('auth.libpam_authenticate', username, password)
                 return None
 
-            if not hmac.compare_digest(crypt.crypt(password, root['unixhash']), root['unixhash']):
+            if not await self.middleware.call('auth.check_unixhash', password, unixhash):
+                await self.middleware.call('auth.libpam_authenticate', username, password)
                 return None
 
         elif not await self.middleware.call('auth.libpam_authenticate', username, password):
             return None
 
-        return await self.authenticate_user({'username': username}, local)
+        return await self.authenticate_user({'username': username}, user_info)
+
+    @private
+    @pass_app()
+    def check_unixhash(self, app, password, unixhash):
+        # This method is vulnerable to timing attacks and so should not
+        # be exposed to external API consumers in any way.
+        #
+        # FIXME: remove pass_app() and replace with some other decorator
+        # to flag as internal once functionality added.
+        if app is not None:
+            raise CallError("This method may not be called externally")
+
+        if unixhash in ('x', '*'):
+            return False
+
+        return hmac.compare_digest(crypt.crypt(password, unixhash), unixhash)
 
     @private
     def libpam_authenticate(self, username, password):
@@ -52,31 +69,47 @@ class AuthService(Service):
         return p.authenticate(username, password, service='middleware')
 
     @private
-    async def authenticate_user(self, query, local):
+    async def authenticate_user(self, query, user_info):
         try:
-            user = await self.middleware.call('user.get_user_obj', {**query, 'get_groups': True, 'sid_info': not local})
+            user = await self.middleware.call('user.get_user_obj', {
+                **query, 'get_groups': True,
+                'sid_info': not user_info['local'],
+            })
         except KeyError:
             return None
 
-        twofactor_enabled = bool((await self.middleware.call(
-            'auth.twofactor.get_user_config',
-            user['pw_uid'] if local else user['sid_info']['sid'],
-            local
-        ))['secret'])
+        if user_info['uid'] is not None and user_info['uid'] != user['pw_uid']:
+            # For some reason there's a mismatch between the passwd file
+            # and what is stored in the TrueNAS configuration.
+            self.logger.error(
+                '%s: rejecting access for local user due to uid [%d] not '
+                'matching expected value [%d]',
+                user['pw_name'], user['pw_uid'], user_info['uid']
+            )
+            return None
 
-        groups = set(user['grouplist'])
-        groups_key = 'local_groups' if local else 'ds_groups'
-
-        account_flags = []
-
-        if local:
-            account_flags.append('LOCAL')
+        if user_info['local']:
+            twofactor_id = user_info['id']
+            groups_key = 'local_groups'
+            account_flags = ['LOCAL']
         else:
-            account_flags.append('DIRECTORY_SERVICE')
+            twofactor_id = user['sid_info']['sid']
+            groups_key = 'ds_groups'
+            account_flags = ['DIRECTORY_SERVICE']
             if user['sid_info']['domain_information']['activedirectory']:
                 account_flags.append('ACTIVE_DIRECTORY')
             else:
                 account_flags.append('LDAP')
+
+        # Two-factor authentication token is keyed by SID for activedirectory
+        # users.
+        twofactor_id = user_info['id'] if user_info['local'] else user['sid_info']['sid']
+        twofactor_enabled = bool((await self.middleware.call(
+            'auth.twofactor.get_user_config',
+            twofactor_id, user_info['local']
+        ))['secret'])
+
+        groups = set(user['grouplist'])
 
         if twofactor_enabled:
             account_flags.append('2FA')

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -20,15 +20,12 @@ class AuthService(Service):
             local = True
 
         else:
-            try:
-                # We should use this method to translate username to make sure all the different variations
-                # of ad usernames are properly handled as the old logic was not taking them into account
-                user = await self.middleware.call('user.translate_username', username)
-            except CallError:
-                local = True
-            else:
-                username = user['username']
-                local = user['local']
+            local = bool(await self.middleware.call(
+                'datastore.query',
+                'account.bsdusers',
+                [('username', '=', username)],
+                {'prefix': 'bsdusr_', 'count': True},
+            ))
 
         if username == 'root' and await self.middleware.call('privilege.always_has_root_password_enabled'):
             root = await self.middleware.call(
@@ -43,6 +40,7 @@ class AuthService(Service):
 
             if not hmac.compare_digest(crypt.crypt(password, root['unixhash']), root['unixhash']):
                 return None
+
         elif not await self.middleware.call('auth.libpam_authenticate', username, password):
             return None
 
@@ -56,12 +54,35 @@ class AuthService(Service):
     @private
     async def authenticate_user(self, query, local):
         try:
-            user = await self.middleware.call('user.get_user_obj', {**query, 'get_groups': True})
+            user = await self.middleware.call('user.get_user_obj', {**query, 'get_groups': True, 'sid_info': not local})
         except KeyError:
             return None
 
+        twofactor_enabled = bool((await self.middleware.call(
+            'auth.twofactor.get_user_config',
+            user['pw_uid'] if local else user['sid_info']['sid'],
+            local
+        ))['secret'])
+
         groups = set(user['grouplist'])
         groups_key = 'local_groups' if local else 'ds_groups'
+
+        account_flags = []
+
+        if local:
+            account_flags.append('LOCAL')
+        else:
+            account_flags.append('DIRECTORY_SERVICE')
+            if user['sid_info']['domain_information']['activedirectory']:
+                account_flags.append('ACTIVE_DIRECTORY')
+            else:
+                account_flags.append('LDAP')
+
+        if twofactor_enabled:
+            account_flags.append('2FA')
+
+        if user['pw_uid'] in (0, 950):
+            account_flags.append('SYS_ADMIN')
 
         privileges = await self.middleware.call('privilege.privileges_for_groups', groups_key, groups)
         if not privileges:
@@ -69,6 +90,7 @@ class AuthService(Service):
 
         return {
             'username': user['pw_name'],
+            'account_attributes': account_flags,
             'privilege': await self.middleware.call('privilege.compose_privilege', privileges),
         }
 
@@ -76,5 +98,6 @@ class AuthService(Service):
     async def authenticate_root(self):
         return {
             'username': 'root',
+            'account_attributes': ['LOCAL', 'SYS_ADMIN'],
             'privilege': await self.middleware.call('privilege.full_privilege'),
         }

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -430,6 +430,10 @@ def test_10_account_privilege_authentication(request, set_product_type):
             }):
                 with client(auth=(f"limiteduser@{AD_DOMAIN}", ADPASSWORD)) as c:
                     methods = c.call("core.get_methods")
+                    me = c.call("auth.me")
+
+                    assert 'DIRECTORY_SERVICE' in me['account_attributes']
+                    assert 'ACTIVE_DIRECTORY' in me['account_attributes']
 
                 assert "system.info" in methods
                 assert "pool.create" not in methods

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -25,6 +25,8 @@ def test_works_for_token():
         assert user["pw_uid"] == 0
         assert user["pw_name"] == "root"
         assert user['two_factor_config'] is not None
+        assert 'SYS_ADMIN' in user['account_attributes']
+        assert 'LOCAL' in user['account_attributes']
 
 
 def test_does_not_work_for_api_key():
@@ -83,5 +85,7 @@ def test_distinguishes_attributes():
             me = c.call("auth.me")
             assert me["attributes"]["test"] == "new_value"
             assert me['two_factor_config'] is not None
+            assert 'SYS_ADMIN' not in me['account_attributes']
+            assert 'LOCAL' in me['account_attributes']
 
     assert not call("datastore.query", "account.bsdusers_webui_attribute", [["uid", "=", admin["uid"]]])


### PR DESCRIPTION
This adds specific account-related flags to user credentials that webui can evaluate whether user is local, our special system administrator account, etc. This is implemented as a list so that we have capability to expand what is presented without having to modify API.

This commit also removes two indirect calls to `user.query` during `auth.authenticate`.