### PR TITLE
NAS-125713 / 24.04 / Do not store and use hardware addresses for non-physical interfaces (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/23.10/2023-10-24_14-28_network_interface_link_address.py
+++ b/src/middlewared/middlewared/alembic/versions/23.10/2023-10-24_14-28_network_interface_link_address.py
@@ -27,7 +27,9 @@ def upgrade():
     sqlite_autoincrement=True
     )
     op.execute("INSERT INTO network_interface_link_address (interface, link_address, link_address_b) "
-               "SELECT int_interface, int_link_address, int_link_address_b FROM network_interfaces")
+               "SELECT int_interface, int_link_address, int_link_address_b FROM network_interfaces "
+               "WHERE NOT (int_link_address LIKE 'bond%' OR int_link_address LIKE 'br%' "
+               "OR int_link_address LIKE 'lagg%' OR int_link_address LIKE 'vlan%')")
     with op.batch_alter_table('network_interfaces', schema=None) as batch_op:
         batch_op.drop_column('int_link_address')
         batch_op.drop_column('int_link_address_b')


### PR DESCRIPTION
VLANs have the same hardware address as their parent interface which will cause confusion in the network interface migration process:

```
[2023/12/14 05:24:45] (INFO) middlewared.setup():202 - Interface 'ens5f4' is now 'vlan370' (matched by link address '00:07:43:40:60:50')
[2023/12/14 05:24:45] (INFO) middlewared.rename():111 - Renaming interface 'ens5f4' to 'vlan370'
```

Original PR: https://github.com/truenas/middleware/pull/12717
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125713