### PR TITLE
NAS-125719 / 24.04 / prevent web_shell from being enabled for READONLY

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -142,6 +142,13 @@ class PrivilegeService(CRUDService):
                         "None of the members of these groups has password login enabled. At least one grantee of "
                         "the \"Local Administrator\" privilege must have password login enabled."
                     )
+            elif builtin_privilege == BuiltinPrivileges.READONLY:
+                if new["web_shell"]:
+                    verrors.add(
+                        "privilege_update.web_shell",
+                        "Web shell access may not be enabled for the built-in group for "
+                        "read-only administrators."
+                    )
 
         verrors.check()
 


### PR DESCRIPTION
READONLY builtin privilege should not allow having web_shell access enabled since this allows the users to be able to write to the filesystem.