### PR TITLE
Add ability to flag methods / service class as internal

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1348,6 +1348,9 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         :return:
         """
         args = []
+        if app is not None and (serviceobj._config.internal or hasattr(methodobj, '_internal')):
+            raise CallError('This method may only be called internally')
+
         if hasattr(methodobj, '_pass_app'):
             if methodobj._pass_app['require'] and app is None:
                 raise CallError('`app` is required')

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -3,7 +3,7 @@ import hmac
 
 import pam
 
-from middlewared.service import CallError, Service, pass_app, private
+from middlewared.service import CallError, internal, Service, pass_app, private
 
 
 class AuthService(Service):
@@ -47,17 +47,10 @@ class AuthService(Service):
 
         return await self.authenticate_user({'username': username}, user_info)
 
-    @private
-    @pass_app()
-    def check_unixhash(self, app, password, unixhash):
+    @internal
+    def check_unixhash(self, password, unixhash):
         # This method is vulnerable to timing attacks and so should not
         # be exposed to external API consumers in any way.
-        #
-        # FIXME: remove pass_app() and replace with some other decorator
-        # to flag as internal once functionality added.
-        if app is not None:
-            raise CallError("This method may not be called externally")
-
         if unixhash in ('x', '*'):
             return False
 

--- a/src/middlewared/middlewared/service/__init__.py
+++ b/src/middlewared/middlewared/service/__init__.py
@@ -9,7 +9,7 @@ from .config_service import ConfigService # noqa
 from .core_service import CoreService, MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH # noqa
 from .crud_service import CRUDService # noqa
 from .decorators import ( # noqa
-    cli_private, filterable, filterable_returns, item_method, job, lock, no_auth_required,
+    cli_private, filterable, filterable_returns, internal, item_method, job, lock, no_auth_required,
     no_authz_required, pass_app, periodic, private, rest_api_metadata, skip_arg, threaded,
 )
 from .service import Service # noqa

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -19,6 +19,7 @@ def service_config(klass, config):
         'namespace': namespace,
         'namespace_alias': None,
         'private': False,
+        'internal': False,
         'thread_pool': None,
         'process_pool': None,
         'cli_namespace': None,

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -261,6 +261,9 @@ class CoreService(Service):
         return job.abort()
 
     def _should_list_service(self, name, service, target):
+        if service._config.internal is True:
+            return False
+
         if service._config.private is True:
             if not (target == 'REST' and name == 'resttest'):
                 return False
@@ -365,7 +368,7 @@ class CoreService(Service):
                     continue
 
                 # Skip private methods
-                if hasattr(method, '_private'):
+                if hasattr(method, '_private') or hasattr(method, '_internal'):
                     continue
                 if target == 'CLI' and hasattr(method, '_cli_private'):
                     continue

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -209,6 +209,12 @@ def private(fn):
     return fn
 
 
+def internal(fn):
+    """Method is invalid for external callers. Not exposed in public API"""
+    fn._internal = True
+    return fn
+
+
 def rest_api_metadata(extra_methods=None):
     """
     Allow having endpoints specify explicit rest methods.


### PR DESCRIPTION
Internal service classes and methods are not available to external callers. This is to prevent inadvertent exposure of sensitive APIs to external websocket clients. This also redacts the method or class from public API.