### PR TITLE
NAS-125714 / 24.04 / Add more error handling for broken system dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -299,11 +299,16 @@ class UserService(CRUDService):
 
         username_sid = {}
         if 'SMB' in additional_information:
-            for u in await self.middleware.call("smb.passdb_list", True):
-                username_sid.update({u['Unix username']: {
-                    'nt_name': u['NT username'],
-                    'sid': u['User SID'],
-                }})
+            try:
+                for u in await self.middleware.call("smb.passdb_list", True):
+                    username_sid.update({u['Unix username']: {
+                        'nt_name': u['NT username'],
+                        'sid': u['User SID'],
+                    }})
+            except Exception:
+                # Failure to retrieve passdb list often means that system dataset is
+                # broken
+                self.logger.error('Failed to retrieve passdb information', exc_info=True)
 
         if dssearch:
             ds_state = await self.middleware.call('directoryservices.get_state')
@@ -1059,6 +1064,7 @@ class UserService(CRUDService):
         if not data['username'] and data['uid'] is None:
             verrors.add('get_user_obj.username', 'Either "username" or "uid" must be specified')
         verrors.check()
+
         return await self.middleware.call(
             'dscache.get_uncached_user', data['username'], data['uid'], data['get_groups'], data['sid_info']
         )
@@ -1711,7 +1717,16 @@ class GroupService(CRUDService):
                 ds_groups = await self.middleware.call('dscache.query', 'GROUPS', filters, options)
 
         if 'SMB' in additional_information:
-            smb_groupmap = await self.middleware.call("smb.groupmap_list")
+            try:
+                smb_groupmap = await self.middleware.call("smb.groupmap_list")
+            except Exception:
+                # If system dataset has failed to properly initialize / is broken
+                # then looking up groupmaps will fail.
+                self.logger.error('Failed to retrieve SMB groupmap.', exc_info=True)
+                smb_groupmap = {
+                    'local': {},
+                    'local_builtins': {}
+                }
 
         result = await self.middleware.call(
             'datastore.query', self._config.datastore, [], datastore_options

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -426,6 +426,10 @@ class DSCache(Service):
                     'id': user_obj['pw_uid'],
                 })
             except CallError as e:
+                # ENOENT means no winbindd entry for user
+                # ENOTCONN means winbindd is stopped / can't be started
+                # EAGAIN means the system dataset is hosed and needs to be fixed,
+                # but we need to let it through so that it's very clear in logs
                 if e.errno not in (errno.ENOENT, errno.ENOTCONN):
                     self.logger.error('Failed to retrieve SID for uid: %d', u.pw_uid, exc_info=True)
                 sid = None


### PR DESCRIPTION
There are some edge cases with regard to SMB passdb and groupmap interactions where user.query and group.query will fail if the system dataset is broken. Rather than failing these calls we should simply omit the SMB-related information so that dependent calls do not fail.