### PR TITLE
NAS-125730 / 24.04 / Small optimization to check for 2fa required

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -433,7 +433,7 @@ class AuthService(Service):
         """
         Returns true if two-factor authorization is required for authorizing user's login.
         """
-        user_authenticated = await self.middleware.call('auth.authenticate', username, password) 
+        user_authenticated = await self.middleware.call('auth.authenticate', username, password)
         return user_authenticated and (
             await self.middleware.call('auth.twofactor.config')
         )['enabled'] and '2FA' in user_authenticated['account_attributes']

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -433,14 +433,10 @@ class AuthService(Service):
         """
         Returns true if two-factor authorization is required for authorizing user's login.
         """
-        user_authenticated = await self.check_user(username, password)
+        user_authenticated = await self.middleware.call('auth.authenticate', username, password) 
         return user_authenticated and (
             await self.middleware.call('auth.twofactor.config')
-        )['enabled'] and bool(
-            await self.middleware.call(
-                'user.query', [['username', '=', username], ['twofactor_auth_configured', '=', True]]
-            )
-        )
+        )['enabled'] and '2FA' in user_authenticated['account_attributes']
 
     @cli_private
     @no_auth_required


### PR DESCRIPTION
We now store 2FA flag in account_attributes to indicate whether two-factor authentication is required. This eliminates an extra user.query call.