### PR TITLE
NAS-124823 / 24.04 / Make sure we mount all datasets we can when doing recursive mount

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -57,7 +57,7 @@ class ZFSDatasetService(Service):
             with libzfs.ZFS() as zfs:
                 dataset = zfs.get_dataset(name)
                 if options['recursive']:
-                    dataset.mount_recursive()
+                    dataset.mount_recursive(ignore_errors=True)
                 else:
                     dataset.mount()
         except libzfs.ZFSException as e:

--- a/tests/api2/test_dataset_mount.py
+++ b/tests/api2/test_dataset_mount.py
@@ -1,0 +1,19 @@
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call, ssh
+
+
+def test_dataset_mount_on_readonly_dataset():
+    src_parent_dataset_name = 'parent_src'
+    with dataset(src_parent_dataset_name) as parent_src:
+        with dataset(f'{src_parent_dataset_name}/child1', {'readonly': 'ON'}) as child1_ds:
+            with dataset(f'{src_parent_dataset_name}/child2', {'readonly': 'ON'}) as child2_ds:
+                call('zfs.dataset.create', {'name': f'{child1_ds}/failed'})
+                call('zfs.dataset.umount', parent_src, {'force': True})
+                call('zfs.dataset.mount', parent_src, {'recursive': True})
+                for source_dataset, mounted in (
+                    (parent_src, 'yes'),
+                    (child1_ds, 'yes'),
+                    (f'{child1_ds}/failed', 'no'),
+                    (child2_ds, 'yes'),
+                ):
+                    assert call('zfs.dataset.get_instance', source_dataset)['properties']['mounted']['value'] == mounted


### PR DESCRIPTION
This commit adds changes to ensure that when we want to recursively mount datasets and if for some reason any dataset fails to mount - we do not stop in mounting the subsequent datasets as shown by the behavior of 'zfs mount -a' as well.