### PR TITLE
NAS-125731 / 24.04 / Fix edge case while retrieving netdata dimensions

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/utils.py
@@ -11,7 +11,8 @@ def safely_retrieve_dimension(
     """
     with contextlib.suppress(KeyError):
         if dimension:
-            return all_metrics[chart]['dimensions'][dimension]['value']
+            value = all_metrics[chart]['dimensions'][dimension]['value']
+            return value if value is not None else default
         else:
             return {
                 dimension_name: value['value']


### PR DESCRIPTION
## Problem
In certain scenarios, the values of netdata dimensions are `None`, resulting in the return of a `None` value instead of the expected default value. This issue is addressed by modifying the logic to return the dimension's value if it is not `None`; otherwise, the default value is returned.

## Solution
Changes have been implemented to ensure that if the dimension's value is not `None`, it is returned; otherwise, the default value is returned.