### PR TITLE
Shift sysdataset setup to pool.create method

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -649,7 +649,11 @@ class PoolService(CRUDService):
         self.middleware.create_task(self.middleware.call('disk.swaps_configure'))
         self.middleware.create_task(self.middleware.call('pool.restart_services'))
 
+        if (await middleware.call('systemdataset.config'))['pool'] == await middleware.call('boot.pool_name'):
+            await middleware.call('systemdataset.setup')
+
         pool = await self.get_instance(pool_id)
+
         await self.middleware.call_hook('pool.post_create', pool=pool)
         await self.middleware.call_hook('pool.post_create_or_update', pool=pool)
         await self.middleware.call_hook(

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -649,8 +649,8 @@ class PoolService(CRUDService):
         self.middleware.create_task(self.middleware.call('disk.swaps_configure'))
         self.middleware.create_task(self.middleware.call('pool.restart_services'))
 
-        if (await middleware.call('systemdataset.config'))['pool'] == await middleware.call('boot.pool_name'):
-            await middleware.call('systemdataset.setup')
+        if (await self.middleware.call('systemdataset.config'))['pool'] == await self.middleware.call('boot.pool_name'):
+            await self.middleware.call('systemdataset.setup')
 
         pool = await self.get_instance(pool_id)
 

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -699,11 +699,6 @@ class SystemDatasetService(ConfigService):
                     self.middleware.call_sync('service.start', i)
 
 
-async def pool_post_create(middleware, pool):
-    if (await middleware.call('systemdataset.config'))['pool'] == await middleware.call('boot.pool_name'):
-        await middleware.call('systemdataset.setup')
-
-
 async def pool_post_import(middleware, pool):
     """
     On pool import we may need to reconfigure system dataset.


### PR DESCRIPTION
This can be called directly from pool.create job.