### PR TITLE
NAS-125770 / 24.04 / set SHARING_SMB role prefix for SMB service

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -241,6 +241,7 @@ class SMBService(TDBWrapConfigService):
         datastore_extend = 'smb.smb_extend'
         datastore_prefix = 'cifs_srv_'
         cli_namespace = 'service.smb'
+        role_prefix = 'SHARING_SMB'
 
     LP_CTX = param.LoadParm(SMBPath.STUBCONF.platform())
 


### PR DESCRIPTION
This was accidentally omitted when developing roles for SMB.