### PR TITLE
Try to make sure we are able to retrieve relevant PCI device information always

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -1,3 +1,5 @@
+import contextlib
+import os
 from xml.etree import ElementTree as etree
 
 
@@ -23,3 +25,11 @@ def get_virsh_command_args():
 
 def convert_pci_id_to_vm_pci_slot(pci_id: str) -> str:
     return f'pci_{pci_id.replace(".", "_").replace(":", "_")}'
+
+
+def get_pci_device_class(pci_path: str) -> str:
+    with contextlib.suppress(FileNotFoundError):
+        with open(os.path.join(pci_path, 'class'), 'r') as r:
+            return r.read().strip()
+
+    return ''

--- a/src/middlewared/middlewared/utils/gpu.py
+++ b/src/middlewared/middlewared/utils/gpu.py
@@ -6,12 +6,15 @@ from middlewared.service_exception import CallError
 
 
 RE_PCI_ADDR = re.compile(r'(?P<domain>.*):(?P<bus>.*):(?P<slot>.*)\.')
-SENSITIVE_PCI_DEVICE_TYPES = (
-    'PCI Bridge',
-    'ISA Bridge',
-    'RAM memory',
-    'SMBus',
-)
+
+# get capability classes for relevant pci devices from
+# https://github.com/pciutils/pciutils/blob/3d2d69cbc55016c4850ab7333de8e3884ec9d498/lib/header.h#L1429
+SENSITIVE_PCI_DEVICE_TYPES = {
+    '0x0604': 'PCI Bridge',
+    '0x0601': 'ISA Bridge',
+    '0x0500': 'RAM memory',
+    '0x0c05': 'SMBus',
+}
 
 
 def get_gpus():
@@ -56,7 +59,8 @@ def get_gpus():
                 'vm_pci_slot': f'pci_{child["PCI_SLOT_NAME"].replace(".", "_").replace(":", "_")}',
             })
             critical |= any(
-                k.lower() in child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '').lower() for k in SENSITIVE_PCI_DEVICE_TYPES
+                k.lower() in child.get('ID_PCI_SUBCLASS_FROM_DATABASE', '').lower()
+                for k in SENSITIVE_PCI_DEVICE_TYPES.values()
             )
 
         gpus.append({


### PR DESCRIPTION
A user was facing an issue where we were marking a PCI device as critical because we were not able to determine it's controller type as udev was not giving us the required data. Now that information was being used to determine if a PCI device should be marked as critical and as we did not had the required information - we marked the device as critical.

This PR adds changes to use capability class to determine if the pci device is critical or not as we are able to retrieve that from sysfs as well if udev is not able to provide it to us (for the user in question, this information was available in udev as well).