### PR TITLE
NAS-125362 / 23.10.2 / Fix edge case for getting CPU temperature on AMD machines (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/utils/cpu.py
+++ b/src/middlewared/middlewared/utils/cpu.py
@@ -76,5 +76,8 @@ def amd_cpu_temperatures(amd_metrics: dict) -> dict:
         'Tctl' in amd_sensors and amd_sensors['Tctl'] and isinstance(amd_sensors['Tctl'], (int, float))
     ):
         return dict(enumerate([amd_sensors['Tctl']] * core_count))
-    elif 'temp1' in amd_sensors and 'temp1_input' in amd_sensors['temp1']:
-        return dict(enumerate([amd_sensors['temp1']['temp1_input']] * core_count))
+    elif 'temp1' in amd_sensors:
+        if isinstance(amd_sensors['temp1'], float):
+            return dict(enumerate([amd_sensors['temp1']] * core_count))
+        elif 'temp1_input' in amd_sensors['temp1']:
+            return dict(enumerate([amd_sensors['temp1']['temp1_input']] * core_count))


### PR DESCRIPTION
## Problem

For some AMD CPUs that have a single core, the temperature sensor sends a float value instead of a list. However, We expect a list, leading to a type error.

## Solution

This edge case is now handled in the AMD CPU temperature function.

Original PR: https://github.com/truenas/middleware/pull/12755
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125362