### PR TITLE
NAS-125783 / 24.04 / Add query-filters for timestamps

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -132,6 +132,19 @@ Javascript:
     ]
 
 
+${'####'} Datetime information
+
+Some query results may include datetime information encoded in JSON object via
+key with designator `.$date`. In this case, query filter using an ISO-8601
+timestamp may be used. For example:
+
+Javascript:
+
+    :::javascript
+    [
+      ['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']
+    ]
+
 
 ${'###'} Query Options
 
@@ -232,20 +245,6 @@ Javascript:
     {
       "order_by": ["size", "-devname", "nulls_first:-expiretime"]
     }
-
-
-${'####'} Datetime information
-
-Some query results may include datetime information encoded in JSON object via
-key with designator `.$date`. In this case, query filter using an ISO-8601
-timestamp may be used. For example:
-
-Javascript:
-
-    :::javascript
-    [
-      ['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']
-    ]
 
 
 ${'####'} Sample SQL statements translated into Query Filters and Query Options

--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -234,6 +234,19 @@ Javascript:
     }
 
 
+${'####'} Datetime information
+
+Some query results may include datetime information encoded in JSON object via
+key with designator `.$date`. In this case, query filter using an ISO-8601
+timestamp may be used. For example:
+
+Javascript:
+
+    :::javascript
+    [
+      ['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']
+    ]
+
 
 ${'####'} Sample SQL statements translated into Query Filters and Query Options
 NOTE: these are examples of syntax translation, they are not intended as queries

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -474,29 +474,28 @@ def test__filter_list_select_as_validation():
         assert 'first item must be a string' in str(ve)
 
 
-def test__filter_list_timestamp():
-    # Test variations of not being ISO-8601 timestamp
-
-    # check for bogus string
+def test__filter_list_timestamp_invalid_string():
     with pytest.raises(ValueError) as ve:
         filter_list([], [["timestamp.$date", "=", "Canary"]])
 
     assert 'must be an ISO-8601 formatted timestamp string' in str(ve)
 
 
-    # check for wrong type
+def test__filter_list_timestamp_invalid_type():
     with pytest.raises(ValueError) as ve:
         filter_list([], [["timestamp.$date", "=", 1]])
 
     assert 'must be an ISO-8601 formatted timestamp string' in str(ve)
 
 
-    # check for invalid operators
+def test__filter_list_timestamp_invalid_operator():
     with pytest.raises(ValueError) as ve:
         filter_list([], [["timestamp.$date", "^", '2023-12-18T16:15:35+00:00']])
 
     assert 'invalid timestamp operation.' in str(ve)
 
+
+def test__filter_list_timestamp():
     # A few basic comparison operators to smoke-check
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '>', '2023-12-18T16:15:35+00:00']])) == 2
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '>=', '2023-12-18T16:15:35+00:00']])) == 3


### PR DESCRIPTION
Audit queries return as a field an ISO-8601 timestamp that's internally converted to a python datetime object and returned to external callers as a JSON object containing $date key. This commit adds special handling for filter-list to allow specifying ISO-8601 timestamp values for `timestamp.$date` key. In this case we will convert the specified string into datetime object during filters validation and use it for comparison with datetime object being handled in backend.