### PR TITLE
NAS-125782 / 23.10.2 / Reduce log spamming from reporting plugin (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -103,7 +103,6 @@ class ClientMixin:
                             'labels': ['time'],
                             'data': [],
                         }))
-                        logger.debug(f'Failed to fetch api response from {task["uri"]}. Reason {task["error"]}')
                     else:
                         responses.append((task['identifier'], task['data']))
         except Exception as e:


### PR DESCRIPTION
### Context

Log is unnecessarily spamming the debug and we are gracefully handling the issue elsewhere so better not log it here.

Original PR: https://github.com/truenas/middleware/pull/12759
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125782