### PR TITLE
NAS-125787 / 24.04 / Add SUPPORT_READ and SUPPORT_WRITE roles

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -59,6 +59,7 @@ class SupportService(ConfigService):
     class Config:
         datastore = 'system.support'
         cli_namespace = 'system.support'
+        role_prefix = 'SUPPORT'
 
     ENTRY = Dict(
         'support_entry',
@@ -100,7 +101,7 @@ class SupportService(ConfigService):
 
         return await self.config()
 
-    @accepts()
+    @accepts(roles=['SUPPORT_READ'])
     @returns(Bool('proactive_support_is_available'))
     async def is_available(self):
         """
@@ -116,7 +117,7 @@ class SupportService(ConfigService):
 
         return license_['contract_type'] in ['SILVER', 'GOLD']
 
-    @accepts()
+    @accepts(roles=['SUPPORT_READ'])
     @returns(Bool('proactive_support_is_available_and_enabled'))
     async def is_available_and_enabled(self):
         """
@@ -125,7 +126,7 @@ class SupportService(ConfigService):
 
         return await self.is_available() and (await self.config())['enabled']
 
-    @accepts()
+    @accepts(roles=['SUPPORT_READ'])
     @returns(List('support_fields', items=[List('support_field', items=[Str('field')])]))
     async def fields(self):
         """
@@ -142,7 +143,7 @@ class SupportService(ConfigService):
             ['secondary_phone', 'Secondary Contact Phone'],
         ]
 
-    @accepts(Password('token', default=''))
+    @accepts(Password('token', default=''), roles=['SUPPORT_READ'])
     @returns(Dict(additional_attrs=True, example={'API': '11008', 'WebUI': '10004'}))
     async def fetch_categories(self, token):
         """
@@ -182,7 +183,7 @@ class SupportService(ConfigService):
         Str('name'),
         Str('email', validators=[Email()]),
         List('cc', items=[Str('email', validators=[Email()])])
-    ))
+    ), roles=['SUPPORT_WRITE', 'READONLY'])
     @returns(Dict(
         'new_ticket_response',
         Int('ticket', null=True),
@@ -319,7 +320,7 @@ class SupportService(ConfigService):
         Int('ticket', required=True),
         Str('filename', required=True, max_length=None),
         Password('token'),
-    ))
+    ), roles=['SUPPORT_WRITE', 'READONLY'])
     @returns()
     @job(pipes=["input"])
     def attach_ticket(self, job, data):
@@ -355,7 +356,7 @@ class SupportService(ConfigService):
         if data['error']:
             raise CallError(data['message'], errno.EINVAL)
 
-    @accepts()
+    @accepts(roles=['SUPPORT_READ'])
     @returns(Int())
     async def attach_ticket_max_size(self):
         """

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -80,7 +80,7 @@ class TrueNASService(Service):
         dmi = await self.middleware.call('system.dmidecode_info')
         return get_chassis_hardware(dmi)
 
-    @accepts()
+    @accepts(roles=['READONLY'])
     @returns(Str('eula', max_length=None, null=True))
     @cli_private
     def get_eula(self):
@@ -92,7 +92,7 @@ class TrueNASService(Service):
         with open(EULA_FILE, 'r', encoding='utf8') as f:
             return f.read()
 
-    @accepts()
+    @accepts(roles=['READONLY'])
     @returns(Bool('system_eula_accepted'))
     @cli_private
     async def is_eula_accepted(self):

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -28,6 +28,9 @@ ROLES = {
                                               'FILESYSTEM_DATA_WRITE']),
     'REPORTING_READ': Role(),
 
+    'SUPPORT_READ': Role(),
+    'SUPPORT_WRITE': Role(),
+
     'SYSTEM_AUDIT_READ': Role(),
     'SYSTEM_AUDIT_WRITE': Role(),
 
@@ -45,6 +48,7 @@ ROLES = {
                                'REPLICATION_TASK_READ',
                                'SERVICE_READ',
                                'SNAPSHOT_TASK_READ',
+                               'SUPPORT_READ',
                                'SYSTEM_AUDIT_READ'],
                      builtin=False),
 

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -29,7 +29,7 @@ ROLES = {
     'REPORTING_READ': Role(),
 
     'SUPPORT_READ': Role(),
-    'SUPPORT_WRITE': Role(),
+    'SUPPORT_WRITE': Role(includes=['SUPPORT_READ']),
 
     'SYSTEM_AUDIT_READ': Role(),
     'SYSTEM_AUDIT_WRITE': Role(),


### PR DESCRIPTION
This commit adds SUPPORT_READ and SUPPORT_WRITE roles with ability to manage details of support plugin. READONLY is granted SUPPORT_READ as well as ability to generate tickets.