### PR TITLE
NAS-125788 / 24.04 / Add roles for manipulating local accounts

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -157,6 +157,7 @@ class UserService(CRUDService):
         datastore_extend_context = 'user.user_extend_context'
         datastore_prefix = 'bsdusr_'
         cli_namespace = 'account.user'
+        role_prefix = 'ACCOUNT'
 
     # FIXME: Please see if dscache can potentially alter result(s) format, without ad, it doesn't seem to
     ENTRY = Patch(
@@ -1029,7 +1030,7 @@ class UserService(CRUDService):
         Int('uid', default=None),
         Bool('get_groups', default=False),
         Bool('sid_info', default=False),
-    ))
+    ), roles=['ACCOUNT_READ'])
     @returns(Dict(
         'user_information',
         Str('pw_name'),
@@ -1069,7 +1070,7 @@ class UserService(CRUDService):
             'dscache.get_uncached_user', data['username'], data['uid'], data['get_groups'], data['sid_info']
         )
 
-    @accepts()
+    @accepts(roles=['ACCOUNT_READ'])
     @returns(Int('next_available_uid'))
     async def get_next_uid(self):
         """
@@ -1606,6 +1607,7 @@ class GroupService(CRUDService):
         datastore_extend = 'group.group_extend'
         datastore_extend_context = 'group.group_extend_context'
         cli_namespace = 'account.group'
+        role_prefix = 'ACCOUNT'
 
     ENTRY = Patch(
         'group_create', 'group_entry',
@@ -1931,7 +1933,7 @@ class GroupService(CRUDService):
 
         return pk
 
-    @accepts()
+    @accepts(roles=['ACCOUNT_READ'])
     @returns(Int('next_available_gid'))
     async def get_next_gid(self):
         """
@@ -1955,7 +1957,7 @@ class GroupService(CRUDService):
         'get_group_obj',
         Str('groupname', default=None),
         Int('gid', default=None)
-    ))
+    ), roles=['ACCOUNT_READ'])
     @returns(Dict(
         'group_info',
         Str('gr_name'),

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -18,6 +18,9 @@ class Role:
 
 
 ROLES = {
+    'ACCOUNT_READ': Role(),
+    'ACCOUNT_WRITE': Role(),
+
     'AUTH_SESSIONS_READ': Role(),
     'AUTH_SESSIONS_WRITE': Role(includes=['AUTH_SESSIONS_READ']),
     'FILESYSTEM_ATTRS_READ': Role(),
@@ -33,6 +36,7 @@ ROLES = {
 
     'FULL_ADMIN': Role(full_admin=True, builtin=False),
     'READONLY': Role(includes=['ALERT_LIST_READ',
+                               'ACCOUNT_READ',
                                'AUTH_SESSIONS_READ',
                                'CLOUD_SYNC_READ',
                                'DATASET_READ',

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -19,7 +19,7 @@ class Role:
 
 ROLES = {
     'ACCOUNT_READ': Role(),
-    'ACCOUNT_WRITE': Role(),
+    'ACCOUNT_WRITE': Role(includes=['ACCOUNT_READ']),
 
     'AUTH_SESSIONS_READ': Role(),
     'AUTH_SESSIONS_WRITE': Role(includes=['AUTH_SESSIONS_READ']),


### PR DESCRIPTION
ACCOUNT_READ - allows reading user / group information
ACCOUNT_WRITE - allows creating, updating, and deleting local users and groups