### PR TITLE
NAS-125792 / 24.04 / Expand roles configuration for interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/capabilities.py
+++ b/src/middlewared/middlewared/plugins/interface/capabilities.py
@@ -27,7 +27,7 @@ class InterfaceCapabilitiesService(Service):
             )
         verrors.check()
 
-    @accepts(Str('name', required=True))
+    @accepts(Str('name', required=True), roles=['NETWORK_INTERFACE_READ'])
     @returns(Dict(
         'capabilties',
         List('enabled', items=[Str('capability')], required=True),
@@ -49,7 +49,7 @@ class InterfaceCapabilitiesService(Service):
         Str('name', required=True),
         List('capabilties', required=True),
         Str('action', enum=['ENABLE', 'DISABLE'], required=True),
-    ))
+    ), roles=['NETWORK_INTERFACE_WRITE'])
     @returns(List('capabilities', items=[Str('capability')], required=True))
     def set(self, data):
         """

--- a/src/middlewared/middlewared/plugins/interface/lag_protocols.py
+++ b/src/middlewared/middlewared/plugins/interface/lag_protocols.py
@@ -1,4 +1,4 @@
-from middlewared.service import private, Service
+from middlewared.service import no_authz_required, private, Service
 
 
 class InterfaceService(Service):
@@ -7,5 +7,6 @@ class InterfaceService(Service):
         namespace_alias = 'interfaces'
 
     @private
+    @no_authz_required
     async def lag_supported_protocols(self):
         return ['LACP', 'FAILOVER', 'LOADBALANCE']


### PR DESCRIPTION
Webui calls interface.lag_supported_protocols, which is a private endpoint and therefore not suitable for roles configuration. The data returned is benign and so remove roles check for access to it.

Permit NETWORK_INTERFACE roles to get / set interface capabilities.