### PR TITLE
NAS-125794 / 24.04 / Add roles for reporting exporters

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/export.py
+++ b/src/middlewared/middlewared/plugins/reporting/export.py
@@ -22,6 +22,7 @@ class ReportingExportsService(CRUDService):
         namespace = 'reporting.exporters'
         datastore = 'reporting.exporters'
         cli_namespace = 'reporting.exporters'
+        role_prefix = 'REPORTING'
 
     ENTRY = Dict(
         'reporting_exporter_entry',
@@ -128,7 +129,7 @@ class ReportingExportsService(CRUDService):
         await self.middleware.call('service.restart', 'netdata')
         return True
 
-    @accepts()
+    @accepts(roles=['REPORTING_READ'])
     @returns(List(
         title='Reporting Exporter Schemas',
         items=[Dict(

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -30,6 +30,7 @@ ROLES = {
     'FILESYSTEM_FULL_CONTROL': Role(includes=['FILESYSTEM_ATTRS_WRITE',
                                               'FILESYSTEM_DATA_WRITE']),
     'REPORTING_READ': Role(),
+    'REPORTING_WRITE': Role(includes=['REPORTING_READ']),
 
     'SUPPORT_READ': Role(),
     'SUPPORT_WRITE': Role(includes=['SUPPORT_READ']),


### PR DESCRIPTION
This commit adds roles for various reporting.exporters endpoints. REPORTING_READ and REPORTING_WRITE are reused since use-case for finer-grained permissions here is not clear.