### PR TITLE
NAS-125801 / 24.04 / Allow READONLY role to access various public endpoints

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol_/schema.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol_/schema.py
@@ -13,7 +13,7 @@ class DNSAuthenticatorService(Service):
         super(DNSAuthenticatorService, self).__init__(*args, **kwargs)
         self.schemas = self.get_authenticator_schemas()
 
-    @accepts()
+    @accepts(roles=['READONLY'])
     @returns(List(
         title='Authenticator Schemas',
         items=[Dict(

--- a/src/middlewared/middlewared/plugins/device.py
+++ b/src/middlewared/middlewared/plugins/device.py
@@ -7,7 +7,7 @@ class DeviceService(Service):
     class Config:
         cli_namespace = 'system.device'
 
-    @accepts(Str('type', enum=['SERIAL', 'DISK', 'GPU']))
+    @accepts(Str('type', enum=['SERIAL', 'DISK', 'GPU']), roles=['READONLY'])
     @returns(OROperator(
         List('serial_info', items=[Dict(
             'serial_info',

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -499,7 +499,7 @@ class IdmapDomainService(TDBWrapCRUDService):
 
         return False
 
-    @accepts()
+    @accepts(roles=['READONLY'])
     async def backend_options(self):
         """
         This returns full information about idmap backend options. Not all
@@ -509,6 +509,7 @@ class IdmapDomainService(TDBWrapCRUDService):
 
     @accepts(
         Str('idmap_backend', enum=[x.name for x in IdmapBackend]),
+        roles=['READONLY']
     )
     async def options_choices(self, backend):
         """
@@ -516,7 +517,7 @@ class IdmapDomainService(TDBWrapCRUDService):
         """
         return IdmapBackend[backend].supported_keys()
 
-    @accepts()
+    @accepts(roles=['READONLY'])
     async def backend_choices(self):
         """
         Returns array of valid idmap backend choices per directory service.

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -509,7 +509,6 @@ class IdmapDomainService(TDBWrapCRUDService):
 
     @accepts(
         Str('idmap_backend', enum=[x.name for x in IdmapBackend]),
-        roles=['READONLY']
     )
     async def options_choices(self, backend):
         """
@@ -517,7 +516,7 @@ class IdmapDomainService(TDBWrapCRUDService):
         """
         return IdmapBackend[backend].supported_keys()
 
-    @accepts(roles=['READONLY'])
+    @accepts()
     async def backend_choices(self):
         """
         Returns array of valid idmap backend choices per directory service.

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1763,7 +1763,7 @@ class SharingSMBService(SharingService):
             )
 
     @private
-    @accepts(Dict('share_validate_payload', Str('name')))
+    @accepts(Dict('share_validate_payload', Str('name')), roles=['READONLY'])
     async def share_precheck(self, data):
         verrors = ValidationErrors()
         ad_enabled = (await self.middleware.call('activedirectory.config'))['enable']

--- a/src/middlewared/middlewared/plugins/smb_/status.py
+++ b/src/middlewared/middlewared/plugins/smb_/status.py
@@ -37,7 +37,7 @@ class SMBService(Service):
             Str('restrict_user', default=''),
             Str('restrict_session', default=''),
             Bool('resolve_uids', default=True),
-        ), roles=['SHARING_SMB_WRITE']
+        ), roles=['SHARING_SMB_WRITE', 'READONLY']
     )
     def status(self, info_level, filters, options, status_options):
         """

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -148,7 +148,7 @@ class VMWareService(CRUDService):
         Str('hostname', required=True),
         Str('username', required=True),
         Str('password', private=True, required=True),
-    ))
+    ), roles=['READONLY'])
     def get_datastores(self, data):
         """
         Get datastores from VMWare.
@@ -342,7 +342,7 @@ class VMWareService(CRUDService):
 
         return datastores
 
-    @accepts(Int('pk'))
+    @accepts(Int('pk'), roles=['READONLY'])
     async def get_virtual_machines(self, pk):
         """
         Returns Virtual Machines on the VMWare host identified by `pk`.
@@ -368,7 +368,7 @@ class VMWareService(CRUDService):
             vms[vm.config.uuid] = data
         return vms
 
-    @accepts(Str('dataset'), Bool('recursive'))
+    @accepts(Str('dataset'), Bool('recursive'), roles=['READONLY'])
     def dataset_has_vms(self, dataset, recursive):
         """
         Returns "true" if `dataset` is configured with a VMWare snapshot


### PR DESCRIPTION
This commit allows READONLY admins to access various public API endpoints in smb, idmap, acme, and device plugins that provide basic information about the services.