### PR TITLE
NAS-125732 / 23.10.2 / Handle and log exception while normalizing cpu temp (by Qubad786)

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -68,10 +68,15 @@ class Service(SimpleService):
                 cpu_data[chip_name] = cpu_d
         except sensors.SensorsError as error:
             self.error(error)
-            return None
+
+        try:
+            cpu_temps = cpu_temperatures(cpu_data)
+        except Exception as error:
+            self.error(error)
+            cpu_temps = {}
 
         data = {}
-        for core, temp in cpu_temperatures(cpu_data).items():
+        for core, temp in cpu_temps.items():
             data[str(core)] = temp
 
         return data or {str(i): 0 for i in range(cpu_info()['core_count'])}


### PR DESCRIPTION
## Problem
The netdata python.d plugin is presently not handling and logging exceptions that may occur during the normalization process of CPU temperature data. As a consequence, the CPU temperature fails to execute due to an unhandled exception.

## Solution
To address this, exceptions that may arise during the normalization of CPU temperature data are now handled and logged appropriately. In case of an error, default data is returned, and the error is logged to facilitate debugging in the normalization process.

Original PR: https://github.com/truenas/middleware/pull/12733
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125732