### PR TITLE
NAS-125452 / 24.04 / Validation for USB device not being available

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -75,18 +75,21 @@ class USB(Device):
     def xml(self, *args, **kwargs):
         controller_mapping = kwargs.pop('controller_mapping')
         details = self.get_details()['capability']
-        return create_element(
-            'hostdev', mode='subsystem', type='usb', managed='yes', attribute_dict={
-                'children': [
-                    create_element('source', attribute_dict={'children': [
-                        create_element('vendor', id=details['vendor_id']),
-                        create_element('product', id=details['product_id']),
-                        create_element('address', bus=details['bus'], device=details['device']),
-                    ]}),
-                    create_element('address', type='usb', bus=str(controller_mapping[self.controller_type])),
-                ]
-            }
-        )
+        if self.is_available():
+            return create_element(
+                'hostdev', mode='subsystem', type='usb', managed='yes', attribute_dict={
+                    'children': [
+                        create_element('source', attribute_dict={'children': [
+                            create_element('vendor', id=details['vendor_id']),
+                            create_element('product', id=details['product_id']),
+                            create_element('address', bus=details['bus'], device=details['device']),
+                        ]}),
+                        create_element('address', type='usb', bus=str(controller_mapping[self.controller_type])),
+                    ]
+                }
+            )
+        else:
+            return []
 
     def _validate(self, device, verrors, old=None, vm_instance=None, update=True):
         if device['attributes']['device'] and device['attributes']['usb']:

--- a/src/middlewared/middlewared/plugins/vm/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/usb.py
@@ -34,7 +34,7 @@ class VMDeviceService(Service):
             return capability
         required_keys = set(self.get_capability_keys())
         capability_info = {}
-        for element in filter(lambda e: e.tag in required_keys, capability):
+        for element in filter(lambda e: e.tag in required_keys and e.text is not None, capability):
             capability_info[element.tag] = element.text
             if element.tag in ('product', 'vendor') and element.get('id'):
                 capability_info[f'{element.tag}_id'] = element.get('id')


### PR DESCRIPTION
### Problem

Unavailability of USB device due to any reasons was causing issues in XML creation. For a user this was happening because his printer had power saving mode enabled and it went to sleep which resulted in TrueNAS not being able to retrieve the USB details which are required/relevant for defining domain of a VM using USB device or starting one.


### Solution

Base of the problem was a missing check for presence of None values in the USB capability dict we made and available flag should be accounting for this and relevant usages have been covered so if any user runs into this scenario we have it properly handled.