### PR TITLE
NAS-125835 / 24.04 / Add tests for webui_access privilege flag

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -388,6 +388,7 @@ class PrivilegeService(CRUDService):
             'roles': {'FULL_ADMIN'},
             'allowlist': [{'method': '*', 'resource': '*'}],
             'web_shell': True,
+            'webui_access': True,
         }
 
     previous_always_has_root_password_enabled_value = None

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -12,6 +12,7 @@ def test_works():
     assert user["pw_uid"] == 0
     assert user["pw_name"] == "root"
     assert user['two_factor_config'] is not None
+    assert user['privilege']['webui_access']
 
 
 def test_works_for_token():
@@ -87,5 +88,6 @@ def test_distinguishes_attributes():
             assert me['two_factor_config'] is not None
             assert 'SYS_ADMIN' not in me['account_attributes']
             assert 'LOCAL' in me['account_attributes']
+            assert me['privilege']['webui_access']
 
     assert not call("datastore.query", "account.bsdusers_webui_attribute", [["uid", "=", admin["uid"]]])


### PR DESCRIPTION
This test validates that users with FULL_ADMIN privilege also have webui_access flag set. It also catches an edge case for sessions authenticated via unix domain socket not having key present.