### PR TITLE
NAS-125836 / 24.04 / Remove udp from NFS CI test.

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -306,7 +306,6 @@ def test_01_creating_the_nfs_server():
         "servers": 10,
         "mountd_port": 618,
         "allow_nonroot": False,
-        "udp": False,
         "rpcstatd_port": 871,
         "rpclockd_port": 32803,
         "protocols": ["NFSV3", "NFSV4"]


### PR DESCRIPTION
UDP has been removed,  the setting in the NFS CI test should also have been removed.
This change removes the erroneous UDP usage.