### PR TITLE
NAS-125771 / 23.10.2 / add special handling for fseries (by yocalebo)

### DIFF
--- a/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f0np0.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f0np0.link
@@ -1,0 +1,17 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on pci path name
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:87:00.0 pci-0000:8d:00.0
+Driver=mlx5_core
+Type=ether
+
+[Link]
+Name=enp200s0f0np0

--- a/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f1np1.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f1np1.link
@@ -1,0 +1,17 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on pci path name
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:87:00.1 pci-0000:8d:00.1
+Driver=mlx5_core
+Type=ether
+
+[Link]
+Name=enp200s0f1np1


### PR DESCRIPTION
The f-series HA system has a quirk with a specific
hardware configuration that shows up when 2x pcie
slots are filled with add-on NICs. This has something
to do with the AMD NTB hardware mapping but the end
result is that the A controller's NIC name will be
enp135* and the B controller's NIC name will be enp141*.
This breaks effectively everything related to our HA
logic. To mitigate this issue, this link file will
match on pci path name and rename the interface name
accordingly.

Original PR: https://github.com/truenas/middleware/pull/12782
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125771