### PR TITLE
NAS-125866 / 24.04 / add READONLY to pool.validate_name

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -726,7 +726,7 @@ class PoolService(CRUDService):
         await self.middleware.call_hook('pool.post_create_or_update', pool=pool)
         return pool
 
-    @accepts(Str('pool_name'))
+    @accepts(Str('pool_name'), roles=['READONLY'])
     @returns()
     def validate_name(self, pool_name):
         """


### PR DESCRIPTION
Adds the `READONLY` role to `pool.validate_name` method required by the UI team. While this endpoint is only ever called during pool creation, to keep the logic as simple as possible we can allow this to be used by `READONLY`.