### PR TITLE
NAS-125839 / 24.04 / Fix `privilege.local_administrators` being empty if `privilege.always…

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -84,6 +84,10 @@ def crypted_password(cleartext):
     ))
 
 
+def unixhash_is_valid(unixhash):
+    return unixhash not in ("x", "*")
+
+
 def nt_password(cleartext):
     nthash = hashlib.new('md4', cleartext.encode('utf-16le')).digest()
     return binascii.hexlify(nthash).decode().upper()

--- a/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
+++ b/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.account import unixhash_is_valid
 from middlewared.schema import accepts, Int, List
 from middlewared.service import filter_list, Service, private
 
@@ -41,7 +42,7 @@ class GroupService(Service):
             if membership["user"]["bsdusr_password_disabled"]:
                 continue
 
-            if membership["user"]["bsdusr_unixhash"] in ("x", "*"):
+            if not unixhash_is_valid(membership["user"]["bsdusr_unixhash"]):
                 continue
 
             result.append({k.removeprefix("bsdusr_"): v for k, v in membership["user"].items()})

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -1,6 +1,7 @@
 import enum
 import errno
 
+from middlewared.plugins.account import unixhash_is_valid
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, SID, Str, Patch
 from middlewared.service import CallError, CRUDService, filter_list, private, ValidationErrors
 from middlewared.service_exception import MatchNotFound
@@ -405,7 +406,7 @@ class PrivilegeService(CRUDService):
             [['username', '=', 'root']],
             {'get': True},
         )
-        users = await self.local_administrators([root_user['id']], groups)
+        users = await self.local_administrators([root_user['id']], users, groups)
         if not users:
             value = True
         else:
@@ -421,8 +422,10 @@ class PrivilegeService(CRUDService):
         return value
 
     @private
-    async def local_administrators(self, exclude_user_ids=None, groups=None):
+    async def local_administrators(self, exclude_user_ids=None, users=None, groups=None):
         exclude_user_ids = exclude_user_ids or []
+        if users is None:
+            users = await self.middleware.call('user.query')
         if groups is None:
             groups = await self.middleware.call('group.query')
 
@@ -432,12 +435,24 @@ class PrivilegeService(CRUDService):
             [['builtin_name', '=', BuiltinPrivileges.LOCAL_ADMINISTRATOR.value]],
             {'get': True},
         )
-        return await self.middleware.call(
+        local_administrators = await self.middleware.call(
             'group.get_password_enabled_users',
             local_administrator_privilege['local_groups'],
             exclude_user_ids,
             groups,
         )
+        if not local_administrators:
+            root_user = filter_list(
+                users,
+                [['username', '=', 'root']],
+                {'get': True},
+            )
+            if root_user['id'] not in exclude_user_ids:
+                if unixhash_is_valid(root_user['unixhash']):
+                    # This can only be if `always_has_root_password_enabled` is `True`
+                    local_administrators = [root_user]
+
+        return local_administrators
 
 
 async def setup(middleware):

--- a/tests/api2/test_account_privilege.py
+++ b/tests/api2/test_account_privilege.py
@@ -4,8 +4,8 @@ import types
 import pytest
 
 from middlewared.service_exception import CallError, ValidationErrors
-from middlewared.test.integration.assets.account import group
-from middlewared.test.integration.utils import call, mock
+from middlewared.test.integration.assets.account import group, root_with_password_disabled
+from middlewared.test.integration.utils import call, client, mock
 
 
 def test_change_local_administrator_groups_to_invalid():
@@ -115,3 +115,11 @@ def test_remove_only_local_administrator_password_enabled_user():
         "After disabling password for this user no password-enabled local user will have built-in privilege "
         "'Local Administrator'."
     )
+
+
+def test_password_disabled_root_is_a_local_administrator():
+    with root_with_password_disabled():
+        local_administrators = call("privilege.local_administrators")
+
+        assert len(local_administrators) == 1
+        assert local_administrators[0]["username"] == "root"


### PR DESCRIPTION
…_has_root_password_enabled` is `True`