### PR TITLE
NAS-125621 / 24.04 / Handle missing users and groups in NFS share configuration

### DIFF
--- a/src/middlewared/middlewared/alert/source/nfs_exportsd.py
+++ b/src/middlewared/middlewared/alert/source/nfs_exportsd.py
@@ -1,4 +1,4 @@
-from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
 
 
 class NFSblockedByExportsDirAlertClass(AlertClass, SimpleOneShotAlertClass):
@@ -9,3 +9,19 @@ class NFSblockedByExportsDirAlertClass(AlertClass, SimpleOneShotAlertClass):
 
     async def delete(self, alerts, query):
         return []
+
+
+class NFSexportMappingInvalidNamesAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.ERROR
+    title = "NFS export entry blocked"
+    text = "NFS export for %(path)r contains names that are invalid: %(names)s"
+
+    async def create(self, args):
+        return Alert(NFSexportMappingInvalidNamesAlertClass, args, key=args['id'])
+
+    async def delete(self, alerts, query):
+        return list(filter(
+            lambda alert: alert.args['id'] != query,
+            alerts
+        ))

--- a/src/middlewared/middlewared/alert/source/nfs_exportsd.py
+++ b/src/middlewared/middlewared/alert/source/nfs_exportsd.py
@@ -1,4 +1,4 @@
-from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
 
 
 class NFSblockedByExportsDirAlertClass(AlertClass, SimpleOneShotAlertClass):
@@ -15,13 +15,7 @@ class NFSexportMappingInvalidNamesAlertClass(AlertClass, SimpleOneShotAlertClass
     category = AlertCategory.SHARING
     level = AlertLevel.ERROR
     title = "NFS export entry blocked"
-    text = "NFS export for %(path)r contains names that are invalid: %(names)s"
-
-    async def create(self, args):
-        return Alert(NFSexportMappingInvalidNamesAlertClass, args, key=args['id'])
+    text = "NFS shares have invalid names:\n%(share_list)s"
 
     async def delete(self, alerts, query):
-        return list(filter(
-            lambda alert: alert.args['id'] != query,
-            alerts
-        ))
+        return []

--- a/src/middlewared/middlewared/etc_files/exports.mako
+++ b/src/middlewared/middlewared/etc_files/exports.mako
@@ -11,7 +11,8 @@
         raise_keyerror = False
 
         if usrname := share[f'{map_type}_user']:
-            if uid := middleware.call_sync('user.username_to_uid', usrname):
+            uid = middleware.call_sync('user.username_to_uid', usrname)
+            if uid is not None:
                 map_ids[f'{map_type}_user'] = uid
                 output.append(f'anonuid={uid}')
             else:
@@ -20,7 +21,8 @@
                 raise_keyerror = True
 
         if grpname := share[f'{map_type}_group']:
-            if gid := middleware.call_sync('group.groupname_to_gid', grpname):
+            gid = middleware.call_sync('group.groupname_to_gid', grpname)
+            if gid is not None:
                 map_ids[f'{map_type}_group'] = gid
                 output.append(f'anongid={gid}')
             else:
@@ -40,7 +42,9 @@
         match do_what:
             case 'raise':
                 if map_ids is not None:
-                    invalid_names = ','.join([ v for k, v in map_ids.items() if type in k and v != -1 ])
+                    invalid_names = ','.join([
+                        v for k, v in map_ids.items() if type in k and not isinstance(v, int)
+                    ])
                     middleware.logger.warning(
                         f"{sharepath}: Disabling this NFS share. "
                         f"Mapping invalid names: {invalid_names}"

--- a/src/middlewared/middlewared/plugins/account_/internal_cache.py
+++ b/src/middlewared/middlewared/plugins/account_/internal_cache.py
@@ -20,39 +20,6 @@ class UserService(Service):
         except KeyError:
             raise CallError(f'{username!r} user not found', errno.ENOENT)
 
-    @private
-    async def username_to_uid(self, user_name):
-        '''
-        Return UID of username or None if not found
-        NOTE: The lookup can be slow
-        '''
-        uid = None
-
-        if user_name is not None:
-            try:
-                user = await self.middleware.call('dscache.get_uncached_user', user_name)
-                uid = user['pw_uid']
-            except Exception:
-                pass
-
-        return uid
-
-    @private
-    async def uid_to_username(self, uid):
-        '''
-        Return username associated with the uid or None if not found
-        '''
-        user_name = None
-
-        if uid is not None:
-            try:
-                user = await self.middleware.call('dscache.get_uncached_user', None, uid)
-                user_name = user['pw_name']
-            except Exception:
-                pass
-
-        return user_name
-
 
 class GroupService(Service):
 
@@ -70,35 +37,3 @@ class GroupService(Service):
             return self.SYS_GROUPS[group_name]
         except KeyError:
             raise CallError(f'{group_name!r} group not found', errno.ENOENT)
-
-    @private
-    async def groupname_to_gid(self, group_name):
-        '''
-        Return GID of groupname or None if not found
-        '''
-        gid = None
-
-        if group_name is not None:
-            try:
-                group = await self.middleware.call('dscache.get_uncached_group', group_name)
-                gid = group['gr_gid']
-            except Exception:
-                pass
-
-        return gid
-
-    @private
-    async def gid_to_groupname(self, group_id):
-        '''
-        Return groupname associated with the gid or None if not found
-        '''
-        group_name = None
-
-        if group_id is not None:
-            try:
-                group = await self.middleware.call('dscache.get_uncached_group', None, group_id)
-                group_name = group['gr_name']
-            except Exception:
-                pass
-
-        return group_name

--- a/src/middlewared/middlewared/plugins/account_/internal_cache.py
+++ b/src/middlewared/middlewared/plugins/account_/internal_cache.py
@@ -20,6 +20,39 @@ class UserService(Service):
         except KeyError:
             raise CallError(f'{username!r} user not found', errno.ENOENT)
 
+    @private
+    async def username_to_uid(self, user_name):
+        '''
+        Return UID of username or None if not found
+        NOTE: The lookup can be slow
+        '''
+        uid = None
+
+        if user_name is not None:
+            try:
+                user = await self.middleware.call('dscache.get_uncached_user', user_name)
+                uid = user['pw_uid']
+            except Exception:
+                pass
+
+        return uid
+
+    @private
+    async def uid_to_username(self, uid):
+        '''
+        Return username associated with the uid or None if not found
+        '''
+        user_name = None
+
+        if uid is not None:
+            try:
+                user = await self.middleware.call('dscache.get_uncached_user', None, uid)
+                user_name = user['pw_name']
+            except Exception:
+                pass
+
+        return user_name
+
 
 class GroupService(Service):
 
@@ -37,3 +70,35 @@ class GroupService(Service):
             return self.SYS_GROUPS[group_name]
         except KeyError:
             raise CallError(f'{group_name!r} group not found', errno.ENOENT)
+
+    @private
+    async def groupname_to_gid(self, group_name):
+        '''
+        Return GID of groupname or None if not found
+        '''
+        gid = None
+
+        if group_name is not None:
+            try:
+                group = await self.middleware.call('dscache.get_uncached_group', group_name)
+                gid = group['gr_gid']
+            except Exception:
+                pass
+
+        return gid
+
+    @private
+    async def gid_to_groupname(self, group_id):
+        '''
+        Return groupname associated with the gid or None if not found
+        '''
+        group_name = None
+
+        if group_id is not None:
+            try:
+                group = await self.middleware.call('dscache.get_uncached_group', None, group_id)
+                group_name = group['gr_name']
+            except Exception:
+                pass
+
+        return group_name

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -510,13 +510,15 @@ class SharingNFSService(SharingService):
             elif not map_user and map_group:
                 verrors.add(f"{schema_name}.{k}_user", "This field is required when map group is specified")
             else:
-                user_id = await self.middleware.call('user.username_to_uid', map_user)
-                if user_id is None:
+                try:
+                    await self.middleware.call('user.get_user_obj', {'username': map_user})
+                except KeyError:
                     verrors.add(f"{schema_name}.{k}_user", f"User not found: {map_user}")
 
                 if map_group:
-                    group_id = await self.middleware.call('group.groupname_to_gid', map_group)
-                    if group_id is None:
+                    try:
+                        await self.middleware.call('group.get_group_obj', {'groupname': map_group})
+                    except KeyError:
                         verrors.add(f"{schema_name}.{k}_group", f"Group not found: {map_group}")
 
         if data["maproot_user"] and data["mapall_user"]:

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -512,12 +512,12 @@ class SharingNFSService(SharingService):
                 verrors.add(f"{schema_name}.{k}_user", "This field is required when map group is specified")
             else:
                 user_id = await self.middleware.call('user.username_to_uid', map_user)
-                if not user_id:
+                if user_id is None:
                     verrors.add(f"{schema_name}.{k}_user", f"User not found: {map_user}")
 
                 if map_group:
                     group_id = await self.middleware.call('group.groupname_to_gid', map_group)
-                    if not group_id:
+                    if group_id is None:
                         verrors.add(f"{schema_name}.{k}_group", f"Group not found: {map_group}")
 
         if data["maproot_user"] and data["mapall_user"]:

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -1,4 +1,4 @@
-import contextlib
+# import contextlib
 import enum
 import errno
 import ipaddress
@@ -504,24 +504,21 @@ class SharingNFSService(SharingService):
         verrors.check()
 
         for k in ["maproot", "mapall"]:
-            if not data[f"{k}_user"] and not data[f"{k}_group"]:
+            map_user = data[f"{k}_user"]
+            map_group = data[f"{k}_group"]
+            if not map_user and not map_group:
                 pass
-            elif not data[f"{k}_user"] and data[f"{k}_group"]:
+            elif not map_user and map_group:
                 verrors.add(f"{schema_name}.{k}_user", "This field is required when map group is specified")
             else:
-                user = group = None
-                with contextlib.suppress(KeyError):
-                    user = await self.middleware.call('dscache.get_uncached_user', data[f'{k}_user'])
+                user_id = await self.middleware.call('user.username_to_uid', map_user)
+                if not user_id:
+                    verrors.add(f"{schema_name}.{k}_user", f"User not found: {map_user}")
 
-                if not user:
-                    verrors.add(f"{schema_name}.{k}_user", "User not found")
-
-                if data[f'{k}_group']:
-                    with contextlib.suppress(KeyError):
-                        group = await self.middleware.call('dscache.get_uncached_group', data[f'{k}_group'])
-
-                    if not group:
-                        verrors.add(f"{schema_name}.{k}_group", "Group not found")
+                if map_group:
+                    group_id = await self.middleware.call('group.groupname_to_gid', map_group)
+                    if not group_id:
+                        verrors.add(f"{schema_name}.{k}_group", f"Group not found: {map_group}")
 
         if data["maproot_user"] and data["mapall_user"]:
             verrors.add(f"{schema_name}.mapall_user", "maproot_user disqualifies mapall_user")

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -1,4 +1,3 @@
-# import contextlib
 import enum
 import errno
 import ipaddress

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -380,32 +380,6 @@ def test_11_perform_server_side_copy(request):
         n.server_side_copy('ssc1', 'ssc2')
 
 
-@pytest.mark.parametrize('data', [
-    ({'name': 'root', 'uid': 0, 'gid': 0}),
-    ({'name': 'ftp', 'uid': 121, 'gid': 14}),
-    ({'name': 'bogus', 'uid': None, 'gid': None}),
-])
-def test_15_name_to_id(data):
-    user_id = call('user.username_to_uid', data['name'])
-    assert user_id == data['uid'], f"Expected {data['name']} UID to be {data['uid']}, but found {user_id}"
-
-    group_id = call('group.groupname_to_gid', data['name'])
-    assert group_id == data['gid'], f"Expected {data['name']} GID to be {data['gid']}, but found {group_id}"
-
-
-@pytest.mark.parametrize('data', [
-    ({'name': 'root', 'uid': 0, 'gid': 0}),
-    ({'name': 'ftp', 'uid': 121, 'gid': 14}),
-    ({'name': None, 'uid': 3456, 'gid': 3456}),  # Assumes 3456 is not attached to any name
-])
-def test_15_id_to_name(data):
-    user_name = call('user.uid_to_username', data['uid'])
-    assert user_name == data['name'], f"Expected UID {data['uid']} to be {data['name']}, but found {user_name}"
-
-    group_name = call('group.gid_to_groupname', data['gid'])
-    assert group_name == data['name'], f"Expected GID {data['gid']} to be {data['name']}, but found {group_name}"
-
-
 @pytest.mark.parametrize('nfsd,cores,expected', [
     (50, 1, {'nfsd': 50, 'mountd': 12, 'managed': False}),   # User specifies number of nfsd, expect: 50 nfsd, 12 mountd
     (None, 12, {'nfsd': 12, 'mountd': 3, 'managed': True}),  # Dynamic, expect 12 nfsd and 3 mountd

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -18,8 +18,10 @@ sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, DELETE, wait_on_job
 from functions import make_ws_request
 from auto_config import pool_name, ha, hostname, password, user
-from protocols import SSH_NFS
+from protocols import SSH_NFS, nfs_share
 from middlewared.service_exception import ValidationErrors, ValidationError
+from middlewared.test.integration.assets.account import user as create_user
+from middlewared.test.integration.assets.account import group as create_group
 from middlewared.test.integration.assets.filesystem import directory
 from middlewared.test.integration.utils import call, ssh, mock
 
@@ -265,22 +267,6 @@ def nfs_dataset(name, options=None, acl=None, mode=None):
 
 
 @contextlib.contextmanager
-def nfs_share(path, options=None):
-    results = POST("/sharing/nfs/", {
-        "path": path,
-        **(options or {}),
-    })
-    assert results.status_code == 200, results.text
-    id = results.json()["id"]
-
-    try:
-        yield id
-    finally:
-        result = DELETE(f"/sharing/nfs/id/{id}/")
-        assert result.status_code == 200, result.text
-
-
-@contextlib.contextmanager
 def nfs_config(options=None):
     '''
     Use this to restore settings when changed within a test function.
@@ -394,6 +380,32 @@ def test_11_perform_server_side_copy(request):
         n.server_side_copy('ssc1', 'ssc2')
 
 
+@pytest.mark.parametrize('data', [
+    ({'name': 'root', 'uid': 0, 'gid': 0}),
+    ({'name': 'ftp', 'uid': 121, 'gid': 14}),
+    ({'name': 'bogus', 'uid': None, 'gid': None}),
+])
+def test_15_name_to_id(data):
+    user_id = call('user.username_to_uid', data['name'])
+    assert user_id == data['uid'], f"Expected {data['name']} UID to be {data['uid']}, but found {user_id}"
+
+    group_id = call('group.groupname_to_gid', data['name'])
+    assert group_id == data['gid'], f"Expected {data['name']} GID to be {data['gid']}, but found {group_id}"
+
+
+@pytest.mark.parametrize('data', [
+    ({'name': 'root', 'uid': 0, 'gid': 0}),
+    ({'name': 'ftp', 'uid': 121, 'gid': 14}),
+    ({'name': None, 'uid': 3456, 'gid': 3456}),  # Assumes 3456 is not attached to any name
+])
+def test_15_id_to_name(data):
+    user_name = call('user.uid_to_username', data['uid'])
+    assert user_name == data['name'], f"Expected UID {data['uid']} to be {data['name']}, but found {user_name}"
+
+    group_name = call('group.gid_to_groupname', data['gid'])
+    assert group_name == data['name'], f"Expected GID {data['gid']} to be {data['name']}, but found {group_name}"
+
+
 @pytest.mark.parametrize('nfsd,cores,expected', [
     (50, 1, {'nfsd': 50, 'mountd': 12, 'managed': False}),   # User specifies number of nfsd, expect: 50 nfsd, 12 mountd
     (None, 12, {'nfsd': 12, 'mountd': 3, 'managed': True}),  # Dynamic, expect 12 nfsd and 3 mountd
@@ -413,7 +425,7 @@ def test_19_updating_the_nfs_service(request, nfsd, cores, expected):
     and verifying that the value here was set correctly.
 
     Update:
-    The default setting for 'servers' is 0. This specifies that we dynamically
+    The default setting for 'servers' is None. This specifies that we dynamically
     determine the number of nfsd to start based on the capabilities of the system.
     In this state, we choose one nfsd for each CPU core.
     The user can override the dynamic calculation by specifying a
@@ -674,12 +686,11 @@ def test_34_check_nfs_share_maproot(request):
         *(sec=sys,rw,anonuid=65534,anongid=65534,subtree_check)
     """
     depends(request, ["NFSID_SHARE_CREATED"], scope="session")
-    payload = {
+
+    call('sharing.nfs.update', nfsid, {
         'maproot_user': 'nobody',
         'maproot_group': 'nogroup'
-    }
-    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
-    assert results.status_code == 200, results.text
+    })
 
     parsed = parse_exports()
     assert len(parsed) == 1, str(parsed)
@@ -690,14 +701,12 @@ def test_34_check_nfs_share_maproot(request):
 
     """
     setting maproot_user and maproot_group to root should
-    cause us to append "not_root_squash" to options.
+    cause us to append "no_root_squash" to options.
     """
-    payload = {
+    call('sharing.nfs.update', nfsid, {
         'maproot_user': 'root',
         'maproot_group': 'root'
-    }
-    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
-    assert results.status_code == 200, results.text
+    })
 
     parsed = parse_exports()
     assert len(parsed) == 1, str(parsed)
@@ -721,12 +730,10 @@ def test_34_check_nfs_share_maproot(request):
             assert 'no_root_squash' not in params, str(parsed)
             assert not any(filter(lambda x: x.startswith('anon'), params)), str(parsed)
 
-    payload = {
+    call('sharing.nfs.update', nfsid, {
         'maproot_user': '',
         'maproot_group': ''
-    }
-    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
-    assert results.status_code == 200, results.text
+    })
 
     parsed = parse_exports()
     assert len(parsed) == 1, str(parsed)
@@ -745,12 +752,11 @@ def test_35_check_nfs_share_mapall(request):
         *(sec=sys,rw,all_squash,anonuid=65534,anongid=65534,subtree_check)
     """
     depends(request, ["NFSID_SHARE_CREATED"], scope="session")
-    payload = {
+
+    call('sharing.nfs.update', nfsid, {
         'mapall_user': 'nobody',
         'mapall_group': 'nogroup'
-    }
-    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
-    assert results.status_code == 200, results.text
+    })
 
     parsed = parse_exports()
     assert len(parsed) == 1, str(parsed)
@@ -760,12 +766,10 @@ def test_35_check_nfs_share_mapall(request):
     assert 'anongid=65534' in params, str(parsed)
     assert 'all_squash' in params, str(parsed)
 
-    payload = {
+    call('sharing.nfs.update', nfsid, {
         'mapall_user': '',
         'mapall_group': ''
-    }
-    results = PUT(f"/sharing/nfs/id/{nfsid}/", payload)
-    assert results.status_code == 200, results.text
+    })
 
     parsed = parse_exports()
     assert len(parsed) == 1, str(parsed)
@@ -1415,7 +1419,111 @@ def test_48_syslog_filters(request):
         assert "rpc.mountd" not in res, f"Did not expect to find 'rpc.mountd' in the output but found:\n{res}"
 
 
-def test_50_stoping_nfs_service(request):
+@pytest.mark.parametrize('type,data', [
+    ('InvalidAssignment', [
+        {'maproot_user': 'baduser'}, 'maproot_user', 'User not found: baduser'
+    ]),
+    ('InvalidAssignment', [
+        {'maproot_group': 'badgroup'}, 'maproot_user', 'This field is required when map group is specified'
+    ]),
+    ('InvalidAssignment', [
+        {'mapall_user': 'baduser'}, 'mapall_user', 'User not found: baduser'
+    ]),
+    ('InvalidAssignment', [
+        {'mapall_group': 'badgroup'}, 'mapall_user', 'This field is required when map group is specified'
+    ]),
+    ('MissingUser', [
+        'maproot_user', 'missinguser'
+    ]),
+    ('MissingUser', [
+        'mapall_user', 'missinguser'
+    ]),
+    ('MissingGroup', [
+        'maproot_group', 'missingroup'
+    ]),
+    ('MissingGroup', [
+        'mapall_group', 'missingroup'
+    ]),
+])
+def test_50_nfs_invalid_user_group_mapping(request, type, data):
+    '''
+    Verify we properly trap and handle invalid user and group mapping
+    Two conditions:
+        1) Catch invalid assignments
+        2) Catch invalid settings at NFS start
+    '''
+    depends(request, ["NFSID_SHARE_CREATED"], scope="session")
+
+    ''' Local helper routine '''
+    def run_missing_usrgrp_test(usrgrp, tmp_path, share, usrgrpInst):
+        parsed = parse_exports()
+        assert len(parsed) == 2, str(parsed)
+        this_share = [entry for entry in parsed if entry['path'] == f'{tmp_path}']
+        assert len(this_share) == 1, f"Did not find share {tmp_path}.\nexports = {parsed}"
+
+        # Remove the user/group and restart nfs
+        call(f'{usrgrp}.delete', usrgrpInst['id'])
+        call('service.restart', 'nfs')
+
+        # An alert should be generated
+        alerts = call('alert.list')
+        this_alert = [entry for entry in alerts if entry['key'] == f'"share{share}{testkey}"']
+        assert len(this_alert) == 1, f"Did not find alert for 'share{share}{testkey}'.\n{alerts}"
+
+        # The NFS export should have been removed
+        parsed = parse_exports()
+        assert len(parsed) == 1, str(parsed)
+        this_share = [entry for entry in parsed if entry['path'] == f'{tmp_path}']
+        assert len(this_share) == 0, f"Unexpectedly found share {tmp_path}.\nexports = {parsed}"
+
+        # Modify share to map with a built-in user or group and restart NFS
+        call('sharing.nfs.update', share, {data[0]: "ftp"})
+        call('service.restart', 'nfs')
+
+        # The alert should be cleared
+        alerts = call('alert.list')
+        this_alert = [entry for entry in alerts if entry['key'] == f'"share{share}{testkey}"']
+        assert len(this_alert) == 0, f"Unexpectedly found alert 'share{share}{testkey}'.\n{alerts}"
+
+        # Share should have been restored
+        parsed = parse_exports()
+        assert len(parsed) == 2, str(parsed)
+        this_share = [entry for entry in parsed if entry['path'] == f'{tmp_path}']
+        assert len(this_share) == 1, f"Did not find share {tmp_path}.\nexports = {parsed}"
+
+    ''' Test Processing '''
+    with directory(f'{NFS_PATH}/sub1') as tmp_path:
+        match type:
+
+            case 'InvalidAssignment':
+                payload = {'path': tmp_path} | data[0]
+                with pytest.raises(ValidationErrors) as ve:
+                    call("sharing.nfs.create", payload)
+                assert ve.value.errors == [ValidationError('sharingnfs_create.' + f'{data[1]}', data[2], 22)]
+
+            case 'MissingUser':
+                usrname = data[1]
+                testkey, testval = data[0].split('_')
+
+                usr_payload = {'username': usrname, 'full_name': usrname,
+                               'group_create': True, 'password': 'abadpassword'}
+                mapping = {data[0]: usrname}
+                with create_user(usr_payload) as usrInst:
+                    with nfs_share(tmp_path, mapping) as share:
+                        run_missing_usrgrp_test(testval, tmp_path, share, usrInst)
+
+            case 'MissingGroup':
+                # Use a built-in user for the group test
+                grpname = data[1]
+                testkey, testval = data[0].split('_')
+
+                mapping = {f"{testkey}_user": 'ftp', data[0]: grpname}
+                with create_group({'name': grpname}) as grpInst:
+                    with nfs_share(tmp_path, mapping) as share:
+                        run_missing_usrgrp_test(testval, tmp_path, share, grpInst)
+
+
+def test_70_stoping_nfs_service(request):
     # Restore original settings before we stop
     restore_nfs_config()
     payload = {"service": "nfs"}
@@ -1424,12 +1532,12 @@ def test_50_stoping_nfs_service(request):
     sleep(1)
 
 
-def test_51_checking_to_see_if_nfs_service_is_stop(request):
+def test_71_checking_to_see_if_nfs_service_is_stop(request):
     results = GET("/service?service=nfs")
     assert results.json()[0]["state"] == "STOPPED", results.text
 
 
-def test_52_check_adjusting_threadpool_mode(request):
+def test_72_check_adjusting_threadpool_mode(request):
     """
     Verify that NFS thread pool configuration can be adjusted
     through private API endpoints.
@@ -1449,23 +1557,23 @@ def test_52_check_adjusting_threadpool_mode(request):
         assert res['result'] == m, res
 
 
-def test_54_disable_nfs_service_at_boot(request):
+def test_74_disable_nfs_service_at_boot(request):
     results = PUT("/service/id/nfs/", {"enable": False})
     assert results.status_code == 200, results.text
 
 
-def test_55_checking_nfs_disable_at_boot(request):
+def test_75_checking_nfs_disable_at_boot(request):
     results = GET("/service?service=nfs")
     assert results.json()[0]['enable'] is False, results.text
 
 
-def test_56_destroying_smb_dataset(request):
+def test_76_destroying_smb_dataset(request):
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text
 
 
 @pytest.mark.parametrize('exports', ['missing', 'empty'])
-def test_60_start_nfs_service_with_missing_or_empty_exports(request, exports):
+def test_80_start_nfs_service_with_missing_or_empty_exports(request, exports):
     '''
     NAS-123498: Eliminate conditions on exports for service start
     The goal is to make the NFS server behavior similar to the other protocols
@@ -1496,7 +1604,7 @@ def test_60_start_nfs_service_with_missing_or_empty_exports(request, exports):
 
 
 @pytest.mark.parametrize('expect_NFS_start', [False, True])
-def test_62_files_in_exportsd(request, expect_NFS_start):
+def test_82_files_in_exportsd(request, expect_NFS_start):
     '''
     Any files in /etc/exports.d are potentially dangerous, especially zfs.exports.
     We implemented protections against rogue exports files.

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1493,34 +1493,33 @@ def test_50_nfs_invalid_user_group_mapping(request, type, data):
 
     ''' Test Processing '''
     with directory(f'{NFS_PATH}/sub1') as tmp_path:
-        match type:
 
-            case 'InvalidAssignment':
-                payload = {'path': tmp_path} | data[0]
-                with pytest.raises(ValidationErrors) as ve:
-                    call("sharing.nfs.create", payload)
-                assert ve.value.errors == [ValidationError('sharingnfs_create.' + f'{data[1]}', data[2], 22)]
+        if type == 'InvalidAssignment':
+            payload = {'path': tmp_path} | data[0]
+            with pytest.raises(ValidationErrors) as ve:
+                call("sharing.nfs.create", payload)
+            assert ve.value.errors == [ValidationError('sharingnfs_create.' + f'{data[1]}', data[2], 22)]
 
-            case 'MissingUser':
-                usrname = data[1]
-                testkey, testval = data[0].split('_')
+        elif type == 'MissingUser':
+            usrname = data[1]
+            testkey, testval = data[0].split('_')
 
-                usr_payload = {'username': usrname, 'full_name': usrname,
-                               'group_create': True, 'password': 'abadpassword'}
-                mapping = {data[0]: usrname}
-                with create_user(usr_payload) as usrInst:
-                    with nfs_share(tmp_path, mapping) as share:
-                        run_missing_usrgrp_test(testval, tmp_path, share, usrInst)
+            usr_payload = {'username': usrname, 'full_name': usrname,
+                           'group_create': True, 'password': 'abadpassword'}
+            mapping = {data[0]: usrname}
+            with create_user(usr_payload) as usrInst:
+                with nfs_share(tmp_path, mapping) as share:
+                    run_missing_usrgrp_test(testval, tmp_path, share, usrInst)
 
-            case 'MissingGroup':
-                # Use a built-in user for the group test
-                grpname = data[1]
-                testkey, testval = data[0].split('_')
+        elif type == 'MissingGroup':
+            # Use a built-in user for the group test
+            grpname = data[1]
+            testkey, testval = data[0].split('_')
 
-                mapping = {f"{testkey}_user": 'ftp', data[0]: grpname}
-                with create_group({'name': grpname}) as grpInst:
-                    with nfs_share(tmp_path, mapping) as share:
-                        run_missing_usrgrp_test(testval, tmp_path, share, grpInst)
+            mapping = {f"{testkey}_user": 'ftp', data[0]: grpname}
+            with create_group({'name': grpname}) as grpInst:
+                with nfs_share(tmp_path, mapping) as share:
+                    run_missing_usrgrp_test(testval, tmp_path, share, grpInst)
 
 
 def test_70_stoping_nfs_service(request):

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -225,7 +225,7 @@ def restore_nfs_config():
     Restore the NFS configuration to the settings saved by save_nfs_config.
     This should be called _before_ NFS is shutdown to ensure the NFS conf file in /etc
     matches the DB settings.
-    This is called at the start of test_50_stoping_nfs_service.
+    This is called at the start of stopping_nfs_service.
     '''
     set_conf_cmd = {'msg': 'method', 'method': 'nfs.update', 'params': [NFS_CONFIG.default_nfs_config]}
     res = make_ws_request(ip, set_conf_cmd)
@@ -1467,8 +1467,8 @@ def test_50_nfs_invalid_user_group_mapping(request, type, data):
 
         # An alert should be generated
         alerts = call('alert.list')
-        this_alert = [entry for entry in alerts if entry['key'] == f'"share{share}{testkey}"']
-        assert len(this_alert) == 1, f"Did not find alert for 'share{share}{testkey}'.\n{alerts}"
+        this_alert = [entry for entry in alerts if entry['klass'] == "NFSexportMappingInvalidNames"]
+        assert len(this_alert) == 1, f"Did not find alert for 'NFSexportMappingInvalidNames'.\n{alerts}"
 
         # The NFS export should have been removed
         parsed = parse_exports()
@@ -1482,8 +1482,8 @@ def test_50_nfs_invalid_user_group_mapping(request, type, data):
 
         # The alert should be cleared
         alerts = call('alert.list')
-        this_alert = [entry for entry in alerts if entry['key'] == f'"share{share}{testkey}"']
-        assert len(this_alert) == 0, f"Unexpectedly found alert 'share{share}{testkey}'.\n{alerts}"
+        this_alert = [entry for entry in alerts if entry['key'] == "NFSexportMappingInvalidNames"]
+        assert len(this_alert) == 0, f"Unexpectedly found alert 'NFSexportMappingInvalidNames'.\n{alerts}"
 
         # Share should have been restored
         parsed = parse_exports()
@@ -1522,7 +1522,7 @@ def test_50_nfs_invalid_user_group_mapping(request, type, data):
                     run_missing_usrgrp_test(testval, tmp_path, share, grpInst)
 
 
-def test_70_stoping_nfs_service(request):
+def test_70_stopping_nfs_service(request):
     # Restore original settings before we stop
     restore_nfs_config()
     payload = {"service": "nfs"}


### PR DESCRIPTION
### Problem
On upgrade, if `maproot` or `mapall` is configured on an NFS share and the user or group is deleted as part of the upgrade, then all NFS shares end up disabled.

### Fix
- In nfs exports mako add check for required users or groups and disable NFS shares that use missing users or groups.
- Add oneshot alert when missing user or group is detected.   Remove oneshot alert when share configuration is repaired.
- Enhance reporting on attempt to configure NFS share with invalid user or group setting

### Other fixes/improvements
- Add CI test for missing user and group with NFS `maproot` and `mapall` configuration options
- Some refactoring of the NFS CI test module