### PR TITLE
NAS-125689 / 24.04 / Make `core.download` no_authz_required, but validate access permissions to called method inside

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -654,23 +654,28 @@ class FilesystemService(Service):
 
 
 class FileFollowTailEventSource(EventSource):
-
     """
     Retrieve last `no_of_lines` specified as an integer argument for a specific `path` and then
     any new lines as they are added. Specified argument has the format `path:no_of_lines` ( `/var/log/messages:3` ).
 
     `no_of_lines` is optional and if it is not specified it defaults to `3`.
 
-    However `path` is required for this.
+    However, `path` is required for this.
     """
 
-    def run_sync(self):
+    def parse_arg(self):
         if ':' in self.arg:
             path, lines = self.arg.rsplit(':', 1)
             lines = int(lines)
         else:
             path = self.arg
             lines = 3
+
+        return path, lines
+
+    def run_sync(self):
+        path, lines = self.parse_arg()
+
         if not os.path.exists(path):
             # FIXME: Error?
             return

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -208,6 +208,26 @@ class CoreService(Service):
         return jobs
 
     @no_authz_required
+    @accepts(Int('id'), Str('filename'), Bool('buffered', default=False))
+    @pass_app(rest=True)
+    async def job_download_logs(self, app, id_, filename, buffered):
+        """
+        Download logs of the job `id`.
+
+        Please see `core.download` method documentation for explanation on `filename` and `buffered` arguments,
+        and return value.
+        """
+        if app is None:
+            job = self.middleware.jobs[id_]
+        else:
+            job = self.__job_by_credential_and_id(app.authenticated_credentials, id_)
+
+        if job.logs_path is None:
+            raise CallError('This job has no logs')
+
+        return (await self._download(app, 'filesystem.get', [job.logs_path], filename, buffered))[1]
+
+    @no_authz_required
     @accepts(Int('id'))
     @job()
     async def job_wait(self, job, id_):
@@ -664,9 +684,13 @@ class CoreService(Service):
 
         Returns the job id and the URL for download.
         """
-        if not app.authenticated_credentials.authorize('CALL', method):
-            raise CallError('Not authorized', errno.EACCES)
+        if app is not None:
+            if not app.authenticated_credentials.authorize('CALL', method):
+                raise CallError('Not authorized', errno.EACCES)
 
+        return await self._download(app, method, args, filename, buffered)
+
+    async def _download(self, app, method, args, filename, buffered):
         job = await self.middleware.call(method, *args, app=app, pipes=Pipes(output=self.middleware.pipe(buffered)))
         token = await self.middleware.call('auth.generate_token', 300, {'filename': filename, 'job': job.id}, app=app)
         self.middleware.fileapp.register_job(job.id, buffered)

--- a/tests/api2/test_job_logs.py
+++ b/tests/api2/test_job_logs.py
@@ -1,0 +1,27 @@
+import requests
+
+from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.utils import mock, url
+
+
+def test_job_download_logs():
+    with mock("test.test1", """    
+        from middlewared.service import job
+
+        @job(logs=True)
+        def mock(self, job, *args):
+            job.logs_fd.write(b'Job logs')
+    """):
+        with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
+            jid = c.call("test.test1")
+
+            c.call("core.job_wait", jid, job=True)
+
+            path = c.call("core.job_download_logs", jid, 'logs.txt')
+
+            r = requests.get(f"{url()}{path}")
+            r.raise_for_status()
+
+            assert r.headers["Content-Disposition"] == "attachment; filename=\"logs.txt\""
+            assert r.headers["Content-Type"] == "application/octet-stream"
+            assert r.text == "Job logs"


### PR DESCRIPTION
UI can continue to use `core.download` as it was doing it before.

The only change wrt to `core.download` is that unprivileged user will not be able to call `filesystem.get`. I looked in the UI code and `filesystem.get` was used for the following cases:
* Download job logs (this will be replaced with `core.job_download_logs`, UI ticket https://ixsystems.atlassian.net/browse/NAS-125918)
* Download CA/CSR/certificates (these are not RBAC yet so no changes are needed)
* Download VM logs (same as above)