### PR TITLE
NAS-125839 / 23.10.2 / Fix `privilege.local_administrators` being empty if `privilege.always… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -72,6 +72,10 @@ def crypted_password(cleartext):
     ))
 
 
+def unixhash_is_valid(unixhash):
+    return unixhash not in ("x", "*")
+
+
 def nt_password(cleartext):
     nthash = hashlib.new('md4', cleartext.encode('utf-16le')).digest()
     return binascii.hexlify(nthash).decode().upper()

--- a/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
+++ b/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.account import unixhash_is_valid
 from middlewared.schema import accepts, Int, List
 from middlewared.service import filter_list, Service, private
 
@@ -41,7 +42,7 @@ class GroupService(Service):
             if membership["user"]["bsdusr_password_disabled"]:
                 continue
 
-            if membership["user"]["bsdusr_unixhash"] in ("x", "*"):
+            if not unixhash_is_valid(membership["user"]["bsdusr_unixhash"]):
                 continue
 
             result.append({k.removeprefix("bsdusr_"): v for k, v in membership["user"].items()})

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -3,6 +3,7 @@ import hmac
 
 import pam
 
+from middlewared.plugins.account import unixhash_is_valid
 from middlewared.service import CallError, Service, private
 
 
@@ -38,7 +39,7 @@ class AuthService(Service):
                 {'get': True, 'prefix': 'bsdusr_'},
             )
 
-            if root['unixhash'] in ('x', '*'):
+            if not unixhash_is_valid(root['unixhash']):
                 return None
 
             if not hmac.compare_digest(crypt.crypt(password, root['unixhash']), root['unixhash']):

--- a/tests/api2/test_account_privilege.py
+++ b/tests/api2/test_account_privilege.py
@@ -4,8 +4,8 @@ import types
 import pytest
 
 from middlewared.service_exception import CallError, ValidationErrors
-from middlewared.test.integration.assets.account import group
-from middlewared.test.integration.utils import call, mock
+from middlewared.test.integration.assets.account import group, root_with_password_disabled
+from middlewared.test.integration.utils import call, client, mock
 
 
 def test_change_local_administrator_groups_to_invalid():
@@ -115,3 +115,11 @@ def test_remove_only_local_administrator_password_enabled_user():
         "After disabling password for this user no password-enabled local user will have built-in privilege "
         "'Local Administrator'."
     )
+
+
+def test_password_disabled_root_is_a_local_administrator():
+    with root_with_password_disabled():
+        local_administrators = call("privilege.local_administrators")
+
+        assert len(local_administrators) == 1
+        assert local_administrators[0]["username"] == "root"


### PR DESCRIPTION
…_has_root_password_enabled` is `True`

Original PR: https://github.com/truenas/middleware/pull/12798
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125839