### PR TITLE
NAS-125548 / 23.10.2 / Retry starting truecommand after a small delay if TC container is down (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -44,11 +44,17 @@ class TruecommandService(Service, TruecommandAPIMixin):
                 )
                 if status.get('tc_state') == 'running':
                     await self.middleware.call('truecommand.dismiss_alerts')
+                    await self.middleware.call('truecommand.start_truecommand_service')
                 else:
                     await self.middleware.call('truecommand.dismiss_alerts', True)
                     await self.middleware.call('alert.oneshot_create', 'TruecommandContainerHealth', None)
 
-                await self.middleware.call('truecommand.start_truecommand_service')
+                    asyncio.get_event_loop().call_later(
+                        self.POLLING_GAP_MINUTES * 60,
+                        lambda: self.middleware.create_task(
+                            self.middleware.call('truecommand.start_truecommand_service')
+                        ),
+                    )
 
                 break
 


### PR DESCRIPTION
This commit fixes an issue where if tc container is down, we immediately try to start wireguard service which will initiate a health check which is destined to fail and we will continue stop/start cycle. So adding a delay of 5 minutes before each time we initiate this.

Original PR: https://github.com/truenas/middleware/pull/12775
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125548