### PR TITLE
NAS-125930 / 23.10.2 / Fix validation for permitted keys in AD plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -252,7 +252,7 @@ class ActiveDirectoryService(TDBWrapConfigService):
         if new["enable"] and old["enable"] and new["kerberos_realm"] != old["kerberos_realm"]:
             verrors.add(
                 "activedirectory_update.kerberos_realm",
-                "Kerberos realm may not be be altered while the AD service is enabled. "
+                "Kerberos realm may not be altered while the AD service is enabled. "
                 "This is to avoid introducing possible configuration errors that may result "
                 "in a production outage."
             )
@@ -487,8 +487,11 @@ class ActiveDirectoryService(TDBWrapConfigService):
                 'timeout',
                 'dns_timeout'
             ]
-            for entry in new.keys():
-                if new[entry] != old[entry] and entry not in permitted_keys:
+            for entry in old.keys():
+                if entry not in new or entry in permitted_keys:
+                    continue
+
+                if new[entry] != old[entry]:
                     raise ValidationError(
                         f'activedirectory.{entry}',
                         'Parameter may not be changed while the Active Directory service is enabled.'

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -13,6 +13,7 @@ from auto_config import pool_name, ip, user, password, ha
 from functions import GET, POST, PUT, DELETE, SSH_TEST, cmd_test, make_ws_request, wait_on_job
 from protocols import smb_connection, smb_share
 
+from middlewared.service_exception import ValidationErrors, ValidationError
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.privilege import privilege
 from middlewared.test.integration.utils import call, client
@@ -223,6 +224,21 @@ def test_07_enable_leave_activedirectory(request):
         createcomputer=AD_COMPUTER_OU,
         dns_timeout=15
     ) as ad:
+        # We should be able to change some parameters when joined to AD
+        call('activedirectory.update', {'domainname': AD_DOMAIN, 'verbose_logging': True})
+
+        # Changing kerberos realm should raise ValidationError
+        with pytest.raises(ValidationErrors) as ve:
+            call('activedirectory.update', {'domainname': AD_DOMAIN, 'kerberos_realm': None})
+
+        assert ve.value.errors[0].errmsg.startswith('Kerberos realm may not be altered')
+
+        # This should be caught by our catchall
+        with pytest.raises(ValidationError) as ve:
+            call('activedirectory.update', {'domainname': AD_DOMAIN, 'createcomputer': ''})
+
+        assert ve.value.errmsg.startswith('Parameter may not be changed')
+
         # Verify that we're not leaking passwords into middleware log
         cmd = f"""grep -R "{ADPASSWORD}" /var/log/middlewared.log"""
         results = SSH_TEST(cmd, user, password, ip)


### PR DESCRIPTION
Removing ad_bindpw column from the TrueNAS config file broke validation for parameters while AD is enabled.

Original PR: https://github.com/truenas/middleware/pull/12816
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125930