### PR TITLE
NAS-125985 / 24.04 / Add SMB client tests for ZFS ACL compatibiltiy

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/smb.py
+++ b/src/middlewared/middlewared/test/integration/assets/smb.py
@@ -1,12 +1,21 @@
 # -*- coding=utf-8 -*-
 import contextlib
 import logging
+import os
+import sys
 
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, ssh
+
+try:
+    apifolder = os.getcwd()
+    sys.path.append(apifolder)
+    from auto_config import ip as default_ip
+except ImportError:
+    default_ip = None
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["smb_share"]
+__all__ = ["smb_share", "smb_mount"]
 
 
 @contextlib.contextmanager
@@ -23,3 +32,21 @@ def smb_share(path, name, options=None):
     finally:
         call("sharing.smb.delete", share["id"])
         call("service.stop", "cifs")
+
+
+@contextlib.contextmanager
+def smb_mount(share, username, password, local_path='/mnt/cifs', options=None, ip=default_ip):
+    mount_options = [f'username={username}', f'password={password}'] + (options or [])
+    mount_cmd = [
+        'mount.cifs', f'//{ip}/{share}', local_path,
+        '-o', ','.join(mount_options)
+    ]
+
+    mount_string = ' '.join(mount_cmd)
+
+    ssh(f'mkdir {local_path}; {mount_string}')
+
+    try:
+        yield local_path
+    finally:
+        ssh(f'umount {local_path}; rmdir {local_path}')

--- a/tests/api2/test_smb_client.py
+++ b/tests/api2/test_smb_client.py
@@ -1,0 +1,185 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.account import user, group
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.smb import smb_share, smb_mount
+from middlewared.test.integration.utils import call, client, ssh
+
+
+PERMSET = {
+    "READ_DATA": False,
+    "WRITE_DATA": False,
+    "APPEND_DATA": False,
+    "READ_NAMED_ATTRS": False,
+    "WRITE_NAMED_ATTRS": False,
+    "EXECUTE": False,
+    "DELETE_CHILD": False,
+    "READ_ATTRIBUTES": False,
+    "WRITE_ATTRIBUTES": False,
+    "DELETE": False,
+    "READ_ACL": False,
+    "WRITE_ACL": False,
+    "WRITE_OWNER": False,
+    "SYNCHRONIZE": True
+}
+
+SAMPLE_ENTRY = {
+    "tag": "GROUP",
+    "id": 666,
+    "type": "ALLOW",
+    "perms": PERMSET,
+    "flags": {"BASIC": "INHERIT"}
+}
+
+PERSISTENT_ACL = [
+    {
+        "tag": "GROUP",
+        "id": 545,
+        "type": "ALLOW",
+        "perms": {"BASIC": "FULL_CONTROL"},
+        "flags": {"BASIC": "INHERIT"}
+    }
+]
+
+@pytest.fixture(scope='module')
+def setup_smb_tests(request):
+    with dataset('smbclient-testing', data={'share_type': 'SMB'}) as ds:
+        with user({
+            'username': 'smbuser',
+            'full_name': 'smbuser',
+            'group_create': True,
+            'password': 'Abcd1234$'
+        }) as u:
+            with smb_share(os.path.join('/mnt', ds), 'client_share') as s:
+                try:
+                    call('service.start', 'cifs')
+                    yield {'dataset': ds, 'share': s, 'user': u}
+                finally:
+                    call('service.stop', 'cifs')
+
+
+@pytest.fixture(scope='module')
+def mount_share(setup_smb_tests):
+    with smb_mount(setup_smb_tests['share']['name'], 'smbuser', 'Abcd1234$') as mp:
+        yield setup_smb_tests | {'mountpoint': mp}
+
+
+def compare_acls(local_path, share_path):
+    local_acl = call('filesystem.getacl', local_path)
+    local_acl.pop('path')
+    smb_acl = call('filesystem.getacl', share_path)
+    smb_acl.pop('path')
+    assert local_acl == smb_acl
+
+
+def test_smb_mount(request, mount_share):
+    assert call('filesystem.statfs', mount_share['mountpoint'])['fstype'] == 'cifs'
+
+
+def test_acl_share_root(request, mount_share):
+    compare_acls(mount_share['share']['path'], mount_share['mountpoint'])
+
+
+def test_acl_share_subdir(request, mount_share):
+    call('filesystem.mkdir', {
+        'path': os.path.join(mount_share['share']['path'], 'testdir'),
+        'options': {'raise_chmod_error': False},
+    })
+
+    compare_acls(
+        os.path.join(mount_share['share']['path'], 'testdir'),
+        os.path.join(mount_share['mountpoint'], 'testdir')
+    )
+
+
+def test_acl_share_file(request, mount_share):
+    ssh(f'touch {os.path.join(mount_share["share"]["path"], "testfile")}')
+
+    compare_acls(
+        os.path.join(mount_share['share']['path'], 'testfile'),
+        os.path.join(mount_share['mountpoint'], 'testfile')
+    )
+
+
+@pytest.mark.parametrize('perm', PERMSET.keys())
+def test_acl_share_permissions(request, mount_share, perm):
+    assert call('filesystem.statfs', mount_share['mountpoint'])['fstype'] == 'cifs'
+
+    SAMPLE_ENTRY['perms'] | {perm: True}
+    payload = {
+        'path': mount_share['share']['path'],
+        'dacl': [SAMPLE_ENTRY] + PERSISTENT_ACL
+    }
+    call('filesystem.setacl', payload, job=True)
+    compare_acls(mount_share['share']['path'], mount_share['mountpoint'])
+
+
+@pytest.mark.parametrize('flagset', [
+    {
+        'FILE_INHERIT': True,
+        'DIRECTORY_INHERIT': True,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': False,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': True,
+        'DIRECTORY_INHERIT': False,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': False,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': False,
+        'DIRECTORY_INHERIT': True,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': False,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': False,
+        'DIRECTORY_INHERIT': False,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': False,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': True,
+        'DIRECTORY_INHERIT': False,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': True,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': False,
+        'DIRECTORY_INHERIT': True,
+        'NO_PROPAGATE_INHERIT': False,
+        'INHERIT_ONLY': True,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': True,
+        'DIRECTORY_INHERIT': False,
+        'NO_PROPAGATE_INHERIT': True,
+        'INHERIT_ONLY': True,
+        'INHERITED': False,
+    },
+    {
+        'FILE_INHERIT': False,
+        'DIRECTORY_INHERIT': True,
+        'NO_PROPAGATE_INHERIT': True,
+        'INHERIT_ONLY': True,
+        'INHERITED': False,
+    }
+])
+def test_acl_share_flags(request, mount_share, flagset):
+    assert call('filesystem.statfs', mount_share['mountpoint'])['fstype'] == 'cifs'
+
+    SAMPLE_ENTRY['flags'] = flagset
+    payload = {
+        'path': mount_share['share']['path'],
+        'dacl': [SAMPLE_ENTRY] + PERSISTENT_ACL
+    }
+    call('filesystem.setacl', payload, job=True)
+    compare_acls(mount_share['share']['path'], mount_share['mountpoint'])

--- a/tests/api2/test_smb_client.py
+++ b/tests/api2/test_smb_client.py
@@ -42,6 +42,9 @@ PERSISTENT_ACL = [
     }
 ]
 
+TMP_SMB_USER_PASSWORD = 'Abcd1234$'
+
+
 @pytest.fixture(scope='module')
 def setup_smb_tests(request):
     with dataset('smbclient-testing', data={'share_type': 'SMB'}) as ds:
@@ -49,7 +52,7 @@ def setup_smb_tests(request):
             'username': 'smbuser',
             'full_name': 'smbuser',
             'group_create': True,
-            'password': 'Abcd1234$'
+            'password': TMP_SMB_USER_PASSWORD
         }) as u:
             with smb_share(os.path.join('/mnt', ds), 'client_share') as s:
                 try:

--- a/tests/api2/test_smb_client.py
+++ b/tests/api2/test_smb_client.py
@@ -64,7 +64,7 @@ def setup_smb_tests(request):
 
 @pytest.fixture(scope='module')
 def mount_share(setup_smb_tests):
-    with smb_mount(setup_smb_tests['share']['name'], 'smbuser', 'Abcd1234$') as mp:
+    with smb_mount(setup_smb_tests['share']['name'], 'smbuser', TMP_SMB_USER_PASSWORD) as mp:
         yield setup_smb_tests | {'mountpoint': mp}
 
 


### PR DESCRIPTION
This commit adds basic tests for the SMB client mount option that maps NT security descriptor to a ZFS ACL xattr. Tests are via loopback mount to ensure that all SIDs in the security descriptor will be properly mapped to Unix IDs.