### PR TITLE
NAS-125841 / 23.10.1.1 / Gracefully handle case for aggregating disk temperatures when no temperatures have been retrieved (by Qubad786) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -130,9 +130,9 @@ class DiskService(Service):
         for disk in self.middleware.call_sync('reporting.netdata_graph', 'disktemp', opts):
             if disk['identifier'] in names:
                 final[disk['identifier']] = {
-                    'min': disk['aggregations']['min']['temperature_value'],
-                    'max': disk['aggregations']['max']['temperature_value'],
-                    'avg': disk['aggregations']['mean']['temperature_value'],
+                    'min': disk['aggregations']['min'].get('temperature_value', None),
+                    'max': disk['aggregations']['max'].get('temperature_value', None),
+                    'avg': disk['aggregations']['mean'].get('temperature_value', None),
                 }
 
         return final


### PR DESCRIPTION
## Problem
The `skip_zero_values_in_aggregation` flag is set to true in the disktemp graph. As a result, aggregation calculations are skipped if all the disk temperature values are zero. In some cases, temperature values might not exist, causing a key error when retrieving disk temperature from the `temperature_agg` API.

## Solution
Now, the `temperature_agg` is retrieved safely, and default null values are returned to prevent the key error.

Original PR: https://github.com/truenas/middleware/pull/12806
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125841

Original PR: https://github.com/truenas/middleware/pull/12808
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125841