### PR TITLE
NAS-125590 / 13.1 / Create nut user for ups service

### DIFF
--- a/src/middlewared/middlewared/assets/account/builtin/freebsd/group
+++ b/src/middlewared/middlewared/assets/account/builtin/freebsd/group
@@ -29,6 +29,7 @@ www:*:80:
 ntpd:*:123:
 avahi:*:200:
 messagebus:*:201:
+nut:*:316:
 nslcd:*:389:
 consul:*:469:
 nomad:*:472:

--- a/src/middlewared/middlewared/assets/account/builtin/freebsd/passwd
+++ b/src/middlewared/middlewared/assets/account/builtin/freebsd/passwd
@@ -16,6 +16,7 @@ proxy:*:62:62:Packet Filter pseudo-user:/nonexistent:/usr/sbin/nologin
 _pflogd:*:64:64:pflogd privsep user:/var/empty:/usr/sbin/nologin
 _dhcp:*:65:65:dhcp programs:/var/empty:/usr/sbin/nologin
 uucp:*:66:66:UUCP pseudo-user:/var/spool/uucppublic:/usr/local/libexec/uucp/uucico
+nut:*:316:316:nut:/nonexistent:/bin/sh
 pop:*:68:6:Post Office Owner:/nonexistent:/usr/sbin/nologin
 auditdistd:*:78:77:Auditdistd unprivileged user:/var/empty:/usr/sbin/nologin
 ladvd:*:79:78:ladvd user:/var/empty:/usr/sbin/nologin

--- a/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
+++ b/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
@@ -12,8 +12,8 @@ def generate_ups_config(middleware):
     os.makedirs(UPS_CONFPATH)
     os.makedirs(UPS_VARPATH, exist_ok=True)
 
-    uucp_group = middleware.call_sync('group.query', [['group', '=', 'uucp']], {'get': True})
-    os.chown(UPS_VARPATH, 0, uucp_group['gid'])
+    nut_group = middleware.call_sync('group.query', [['group', '=', 'nut']], {'get': True})
+    os.chown(UPS_VARPATH, 0, nut_group['gid'])
     os.chmod(UPS_VARPATH, 0o770)
 
 

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -19,7 +19,6 @@ DEFAULT_ETC_PERMS = 0o644
 
 class EtcUSR(enum.IntEnum):
     ROOT = 0
-    UUCP = 66
     NSLCD = 110
     MINIO = 473
     WEBDAV = 666
@@ -28,9 +27,8 @@ class EtcUSR(enum.IntEnum):
 class EtcGRP(enum.IntEnum):
     ROOT = 0
     SHADOW = 42
-    UUCP = 66
     NSLCD = 115
-    NUT = 126
+    NUT = 316
     MINIO = 473
     WEBDAV = 666
 
@@ -248,11 +246,11 @@ class EtcService(Service):
         ],
         'ups': [
             {'type': 'py', 'path': 'local/nut/ups_config'},
-            {'type': 'mako', 'path': 'local/nut/ups.conf', 'owner': 'root', 'group': EtcGRP.UUCP, 'mode': 0o440},
-            {'type': 'mako', 'path': 'local/nut/upsd.conf', 'owner': 'root', 'group': EtcGRP.UUCP, 'mode': 0o440},
-            {'type': 'mako', 'path': 'local/nut/upsd.users', 'owner': 'root', 'group': EtcGRP.UUCP, 'mode': 0o440},
-            {'type': 'mako', 'path': 'local/nut/upsmon.conf', 'owner': 'root', 'group': EtcGRP.UUCP, 'mode': 0o440},
-            {'type': 'mako', 'path': 'local/nut/upssched.conf', 'owner': 'root', 'group': EtcGRP.UUCP, 'mode': 0o440},
+            {'type': 'mako', 'path': 'local/nut/ups.conf', 'owner': 'root', 'group': EtcGRP.NUT, 'mode': 0o440},
+            {'type': 'mako', 'path': 'local/nut/upsd.conf', 'owner': 'root', 'group': EtcGRP.NUT, 'mode': 0o440},
+            {'type': 'mako', 'path': 'local/nut/upsd.users', 'owner': 'root', 'group': EtcGRP.NUT, 'mode': 0o440},
+            {'type': 'mako', 'path': 'local/nut/upsmon.conf', 'owner': 'root', 'group': EtcGRP.NUT, 'mode': 0o440},
+            {'type': 'mako', 'path': 'local/nut/upssched.conf', 'owner': 'root', 'group': EtcGRP.NUT, 'mode': 0o440},
             {'type': 'py', 'path': 'local/nut/ups_perms'}
         ],
         'rsync': [


### PR DESCRIPTION
## Problem
In CORE 13.1, the user being used for upsmon service has been changed from `uccp` to `nut`. This alteration in the username is causing the Nut UPS service to crash.

## Solution
The previous user `uccp` has been replaced with the `nut` user to ensure the UPS service starts properly.