### PR TITLE
NAS-114068 / 24.04 / Remove interfaces parameter from aux param blacklist

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1299,7 +1299,6 @@ class SharingSMBService(SharingService):
             'ctdb socket',
             'socket options',
             'include',
-            'interfaces',
             'wide links',
             'insecure wide links'
         ]


### PR DESCRIPTION
Since clustering has been deprecated, we no longer need to blacklist this SMB auxiliary parameter.