### PR TITLE
NAS-125820 / 23.10.1.1 / Fix config data being exposed for chart releases (by Qubad786) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/alert/source/applications.py
+++ b/src/middlewared/middlewared/alert/source/applications.py
@@ -38,7 +38,7 @@ class ChartReleaseUpdateAlertClass(AlertClass, OneShotAlertClass):
     text = 'An update is available for "%(name)s" application.'
 
     async def create(self, args):
-        return Alert(ChartReleaseUpdateAlertClass, args, _key=args['id'])
+        return Alert(ChartReleaseUpdateAlertClass, args, _key=args['name'])
 
     async def delete(self, alerts, query):
         return list(filter(

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -58,7 +58,7 @@ class ChartReleaseService(Service):
         Str('release_name'),
         Dict(
             'upgrade_options',
-            Dict('values', additional_attrs=True),
+            Dict('values', additional_attrs=True, private=True),
             Str('item_version', default='latest'),
         )
     )
@@ -360,7 +360,7 @@ class ChartReleaseService(Service):
         }
         for application in await self.middleware.call('chart.release.query', chart_releases_filters):
             if application['container_images_update_available']:
-                await self.middleware.call('alert.oneshot_create', 'ChartReleaseUpdate', application)
+                await self.middleware.call('alert.oneshot_create', 'ChartReleaseUpdate', {'name': application['id']})
                 continue
 
             app_id = f'{application["catalog"]}_{application["catalog_train"]}_{application["chart_metadata"]["name"]}'
@@ -381,7 +381,7 @@ class ChartReleaseService(Service):
             return
 
         if parse_version(latest_version) > parse_version(application['chart_metadata']['version']):
-            await self.middleware.call('alert.oneshot_create', 'ChartReleaseUpdate', application)
+            await self.middleware.call('alert.oneshot_create', 'ChartReleaseUpdate', {'name': application['id']})
         else:
             await self.middleware.call('alert.oneshot_delete', 'ChartReleaseUpdate', application['id'])
 


### PR DESCRIPTION
### Problem

The alert framework received chart release data as is, exposing sensitive information present in `chart.release.query` via the alerts' endpoint.

### Fix

This PR fixes the issue by sending only the chart ID instead of the complete query to the alert framework, ensuring data privacy and security.

Original PR: https://github.com/truenas/middleware/pull/12809
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125820

Original PR: https://github.com/truenas/middleware/pull/12811
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125820