### PR TITLE
NAS-125867 / 24.04 / add `apply_remote` to ipmi.lan.update

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -152,14 +152,15 @@ class IPMILanService(CRUDService):
             the configuration to the remote controller.
         """
         verrors = ValidationErrors()
+        schema = 'ipmi.lan.update'
         if not self.middleware.call_sync('ipmi.is_loaded'):
-            verrors.add('ipmi.update', '/dev/ipmi0 could not be found')
+            verrors.add(schema, '/dev/ipmi0 could not be found')
         elif id_ not in self.channels():
-            verrors.add('ipmi.update', f'IPMI channel number {id_!r} not found')
+            verrors.add(schema, f'IPMI channel number {id_!r} not found')
         elif not data.get('dhcp'):
             for k in ['ipaddress', 'netmask', 'gateway']:
                 if not data.get(k):
-                    verrors.add(f'ipmi_update.{k}', 'This field is required when dhcp is false.')
+                    verrors.add(schema, f'{k} field is required when dhcp is false.')
         verrors.check()
 
         # It's _very_ important to pop this key so that
@@ -173,4 +174,4 @@ class IPMILanService(CRUDService):
             try:
                 return self.middleware.call_sync('failover.call_remote', 'ipmi.lan.update', [id_, data])
             except Exception as e:
-                raise ValidationError('ipmi_lan.update', f'Failed to apply IPMI config on remote controller: {e}')
+                raise ValidationError(schema, f'Failed to apply IPMI config on remote controller: {e}')

--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -71,7 +71,7 @@ class IPMILanService(CRUDService):
         namespace = 'ipmi.lan'
         cli_namespace = 'network.ipmi'
 
-    @accepts(roles=['READONLY'])
+    @accepts(roles=['IPMI_READ'])
     @returns(List('lan_channels', items=[Int('lan_channel')]))
     def channels(self):
         """Return a list of available IPMI channels."""
@@ -83,7 +83,7 @@ class IPMILanService(CRUDService):
 
         return channels
 
-    @filterable
+    @filterable(roles=['IPMI_READ'])
     def query(self, filters, options):
         """Query available IPMI Channels with `query-filters` and `query-options`."""
         result = []
@@ -135,7 +135,8 @@ class IPMILanService(CRUDService):
             Int('vlan', validators=[Range(0, 4094)], null=True),
             Bool('apply_remote', default=False),
             register=True
-        )
+        ),
+        roles=['IPMI_WRITE'],
     )
     def do_update(self, id_, data):
         """

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -11,7 +11,6 @@ class Role:
         receive permissions granted by all the included roles.
     :ivar full_admin: if `True` then this role will allow calling all methods.
     """
-
     includes: [str] = field(default_factory=list)
     full_admin: bool = False
     builtin: bool = True
@@ -29,6 +28,9 @@ ROLES = {
 
     'KMIP_READ': Role(),
     'KMIP_WRITE': Role(includes=['KMIP_READ']),
+
+    'IPMI_READ': Role(),
+    'IPMI_WRITE': Role(includes=['IPMI_READ']),
 
     'FILESYSTEM_ATTRS_READ': Role(),
     'FILESYSTEM_ATTRS_WRITE': Role(includes=['FILESYSTEM_ATTRS_READ']),
@@ -53,6 +55,7 @@ ROLES = {
                                'DATASET_READ',
                                'ENCLOSURE_READ',
                                'FAILOVER_READ',
+                               'IPMI_READ',
                                'KMIP_READ',
                                'FILESYSTEM_ATTRS_READ',
                                'NETWORK_GENERAL_READ',


### PR DESCRIPTION
This adds a boolean value to `ipmi.lan.update` endpoint so the webUI team can stop calling `failover.call_remote`. This is necessary because we're now applying RBAC policies to the various endpoints and we're leaving `failover.call_remote` as accessible to root only.

Changes implemented here:
1. move the subprocess related logic to its own function `apply_config`
2. add an `apply_remote` boolean to the schema which when set to True will apply the config to the remote controller
3. add role information