### PR TITLE
NAS-126011 / 23.10.2 / Do not include HA peer iSCSI ALUA sessions in global.iscsi.sessions (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -39,6 +39,8 @@ class ISCSIGlobalService(Service):
         base_path = '/sys/kernel/scst_tgt/targets/iscsi'
         for target_dir in glob.glob(f'{base_path}/{global_info["basename"]}*'):
             target = target_dir.rsplit('/', 1)[-1]
+            if target.startswith(f'{global_info["basename"]}:HA:'):
+                continue
             for session in os.listdir(os.path.join(target_dir, 'sessions')):
                 session_dir = os.path.join(target_dir, 'sessions', session)
                 ip_file = glob.glob(f'{session_dir}/*/ip')


### PR DESCRIPTION
The WebUI uses this API to warn the user wrt restarting iSCSI service.

If ALUA is enabled we will _always_ have sessions from the peer controller, so do not report these "internal" sessions here.

Original PR: https://github.com/truenas/middleware/pull/12835
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126011