### PR TITLE
NAS-126010 / 23.10.2 / Add systemd_unit_timeout and make longer for ISCSITargetService (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -29,6 +29,7 @@ class Job(SDObject):
 class SimpleService(ServiceInterface, IdentifiableServiceInterface):
     systemd_unit = NotImplemented
     systemd_async_start = False
+    systemd_unit_timeout = 5
 
     async def systemd_extra_units(self):
         return []
@@ -71,8 +72,8 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
     def _get_systemd_unit_name(self):
         return f"{self.systemd_unit}.service".encode()
 
-    async def _unit_action(self, action, wait=True, timeout=5):
-        return await self.middleware.run_in_thread(self._unit_action_sync, action, wait, timeout)
+    async def _unit_action(self, action, wait=True):
+        return await self.middleware.run_in_thread(self._unit_action_sync, action, wait, self.systemd_unit_timeout)
 
     def _unit_action_sync(self, action, wait, timeout):
         unit = self._get_systemd_unit()

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -6,6 +6,7 @@ from .base import SimpleService
 class ISCSITargetService(SimpleService):
     name = "iscsitarget"
     reloadable = True
+    systemd_unit_timeout = 30
 
     etc = ["scst", "scst_targets"]
 


### PR DESCRIPTION
Previously we had a hard-coded timeout of 5 seconds on `systemctl` operations on services.  This is inadequate for iSCSI (`scst`), especially when a large number of targets are present and `ALUA` is enabled.

Original PR: https://github.com/truenas/middleware/pull/12833
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126010