### PR TITLE
NAS-126015 / 24.04 / Fix Authorization of remote middleware in HA

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -5,6 +5,7 @@ from middlewared.utils.allowlist import Allowlist
 
 class SessionManagerCredentials:
     is_user_session = False
+    allowlist = None
 
     @classmethod
     def class_name(cls):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -177,7 +177,8 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
         self.is_user_session = root_credentials.is_user_session
         if self.is_user_session:
             self.user = root_credentials.user
-            self.allowlist = root_credentials.allowlist
+
+        self.allowlist = root_credentials.allowlist
 
     def is_valid(self):
         return self.token.is_valid()

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -1,4 +1,6 @@
 import enum
+from middlewared.auth import (RootTcpSocketSessionManagerCredentials,
+                              TrueNasNodeSessionManagerCredentials)
 from middlewared.role import ROLES
 
 
@@ -26,6 +28,15 @@ def privilege_has_webui_access(privilege: dict) -> bool:
 def credential_has_full_admin(credential: object) -> bool:
     if credential.is_user_session and 'FULL_ADMIN' in credential.user['privilege']['roles']:
         return True
+
+    if isinstance(credential, (
+        RootTcpSocketSessionManagerCredentials,
+        TrueNasNodeSessionManagerCredentials
+    )):
+        return True
+
+    if credential.allowlist is None:
+        return False
 
     return credential.allowlist.full_admin
 


### PR DESCRIPTION
Observed in middleware log on HA CI runs. In various situations call_remote was failing in an authorization check to see whether the credential had full-admin privileges via allowlist (for example when determining whether credential is allowed to start/stop services). This PR checks whether the credential is de-facto root (via other node or root TCP session) and returns that it has full admin privileges.

To safeguard against AttributeError on allowlist checks, set allowlist=None on SessionManagerCredentials class.