### PR TITLE
Add a webui crypto service for UI consuming crypto plugin endpoints

### DIFF
--- a/src/middlewared/middlewared/plugins/webui/crypto.py
+++ b/src/middlewared/middlewared/plugins/webui/crypto.py
@@ -1,0 +1,22 @@
+from middlewared.schema import accepts, Int
+from middlewared.service import Service
+
+
+class WebUICryptoService(Service):
+
+    class Config:
+        namespace = 'webui.crypto'
+        private = True
+        cli_private = True
+
+    @accepts(roles=['READONLY'])
+    async def certificate_profiles(self):
+        return await self.middleware.call('certificate.profiles')
+
+    @accepts(roles=['READONLY'])
+    async def certificateauthority_profiles(self):
+        return await self.middleware.call('certificateauthority.profiles')
+
+    @accepts(Int('cert_id'), roles=['READONLY'])
+    async def get_certificate_domain_names(self, cert_id):
+        return await self.middleware.call('certificate.get_domain_names', cert_id)

--- a/tests/api2/test_webui_crypto_service.py
+++ b/tests/api2/test_webui_crypto_service.py
@@ -1,0 +1,46 @@
+import errno
+import pytest
+
+from middlewared.client import ClientException
+from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.utils import call
+
+
+@pytest.mark.parametrize('role,endpoint,valid_role', (
+    ('READONLY', 'webui.crypto.certificate_profiles', True),
+    ('READONLY', 'webui.crypto.certificateauthority_profiles', True),
+    ('NETWORK_INTERFACE_WRITE', 'webui.crypto.certificate_profiles', False),
+    ('NETWORK_INTERFACE_WRITE', 'webui.crypto.certificateauthority_profiles', False),
+))
+def test_ui_crypto_profiles_readonly_role(role, endpoint, valid_role):
+    with unprivileged_user_client(roles=[role]) as c:
+        if valid_role:
+            c.call(endpoint)
+        else:
+            with pytest.raises(ClientException) as ve:
+                c.call(endpoint)
+
+            assert ve.value.errno == errno.EACCES
+            assert ve.value.error == 'Not authorized'
+
+
+@pytest.mark.parametrize('role,valid_role', (
+    ('READONLY', True),
+    ('NETWORK_INTERFACE_WRITE', False),
+))
+def test_ui_crypto_domain_names_readonly_role(role, valid_role):
+    default_certificate = call('certificate.query', [('name', '=', 'truenas_default')])
+    if not default_certificate:
+        pytest.skip('Default certificate does not exist which is required for this test')
+    else:
+        default_certificate = default_certificate[0]
+
+    with unprivileged_user_client(roles=[role]) as c:
+        if valid_role:
+            c.call('webui.crypto.get_domain_names', default_certificate['id'])
+        else:
+            with pytest.raises(ClientException) as ve:
+                c.call('webui.crypto.get_domain_names', default_certificate['id'])
+
+            assert ve.value.errno == errno.EACCES
+            assert ve.value.error == 'Not authorized'

--- a/tests/api2/test_webui_crypto_service.py
+++ b/tests/api2/test_webui_crypto_service.py
@@ -37,10 +37,10 @@ def test_ui_crypto_domain_names_readonly_role(role, valid_role):
 
     with unprivileged_user_client(roles=[role]) as c:
         if valid_role:
-            c.call('webui.crypto.get_domain_names', default_certificate['id'])
+            c.call('webui.crypto.get_certificate_domain_names', default_certificate['id'])
         else:
             with pytest.raises(ClientException) as ve:
-                c.call('webui.crypto.get_domain_names', default_certificate['id'])
+                c.call('webui.crypto.get_certificate_domain_names', default_certificate['id'])
 
             assert ve.value.errno == errno.EACCES
             assert ve.value.error == 'Not authorized'


### PR DESCRIPTION
This PR adds changes to add a service which webui can consume for certain crypto plugin endpoints which it requires to make sure certificate subsystem works as intended. Integration tests have also been added.