### PR TITLE
Fix returns decorator for querying available apps

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Bool, Dict, List, Ref, returns, Str
+from middlewared.schema import accepts, Bool, Datetime, Dict, List, Ref, returns, Str
 from middlewared.service import filterable, filterable_returns, Service
 from middlewared.utils import filter_list
 
@@ -27,6 +27,8 @@ class AppService(Service):
         'available_apps',
         Bool('healthy', required=True),
         Bool('installed', required=True),
+        Bool('recommended', required=True),
+        Datetime('last_update', required=True),
         List('categories', required=True),
         List('maintainers', required=True),
         List('tags', required=True),
@@ -39,9 +41,9 @@ class AppService(Service):
         Str('location', required=True),
         Str('healthy_error', required=True, null=True),
         Str('home', required=True),
-        Str('last_update', required=True),
         Str('latest_version', required=True),
         Str('latest_app_version', required=True),
+        Str('latest_human_version', required=True),
         Str('icon_url', required=True),
         Str('train', required=True),
         Str('catalog', required=True),

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -159,7 +159,7 @@ class CatalogService(Service):
         for train in data:
             for item in data[train]:
                 data[train][item].update({
-                    **{k: v for k, v in get_item_details_base().items() if k not in data[train][item]},
+                    **{k: v for k, v in get_item_details_base(False).items() if k not in data[train][item]},
                     'location': os.path.join(catalog['location'], train, item),
                 })
                 if data[train][item]['last_update']:


### PR DESCRIPTION
This PR fixes returns decorator when querying available apps so it correctly reflects the data being returned. It becomes a problem when this endpoint is used in integration tests and with call methods being audited, it fails to pass that and the test fails (not to mention that it should correctly reflect the returned state obviously).