### PR TITLE
NAS-125877 / 23.10.2 / Make sure we don't exhaust /var/run with catalogs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -18,7 +18,11 @@ class CatalogService(Service):
         """
         Refresh all available catalogs from upstream.
         """
-        catalogs = await self.middleware.call('catalog.query')
+        catalogs = await self.middleware.call(
+            'catalog.query', [
+                ['id', '=', OFFICIAL_LABEL]
+            ] if await self.middleware.call('catalog.cannot_be_added') else []
+        )
         catalog_len = len(catalogs)
         for index, catalog in enumerate(catalogs):
             job.set_progress((index / catalog_len) * 100, f'Syncing {catalog["id"]} catalog')

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -21,7 +21,9 @@ class CatalogService(Service):
         catalogs = await self.middleware.call(
             'catalog.query', [
                 ['id', '=', OFFICIAL_LABEL]
-            ] if await self.middleware.call('catalog.cannot_be_added') else []
+            ] if await self.middleware.call('catalog.cannot_be_added') or not await self.middleware.call(
+                'catalog.dataset_mounted'
+            ) else []
         )
         catalog_len = len(catalogs)
         for index, catalog in enumerate(catalogs):

--- a/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/sync_catalogs.py
@@ -46,8 +46,14 @@ class CatalogService(Service):
         """
         try:
             catalog = await self.middleware.call('catalog.get_instance', catalog_label)
-            if catalog_label != OFFICIAL_LABEL and await self.middleware.call('catalog.cannot_be_added'):
-                raise CallError('Cannot sync non-official catalogs when apps are not configured')
+            if catalog_label != OFFICIAL_LABEL and (
+                await self.middleware.call('catalog.cannot_be_added') or not await self.middleware.call(
+                    'catalog.dataset_mounted'
+                )
+            ):
+                raise CallError(
+                    'Cannot sync non-official catalogs when apps are not configured or catalog dataset is not mounted'
+                )
 
             job.set_progress(5, 'Updating catalog repository')
             await self.middleware.call('catalog.update_git_repository', catalog)

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -196,12 +196,11 @@ class CatalogService(CRUDService):
     @private
     async def dataset_mounted(self):
         if k8s_dataset := (await self.middleware.call('kubernetes.config'))['dataset']:
-            if catalog_ds := await self.middleware.call(
+            return bool(await self.middleware.call(
                 'filesystem.mount_info', [
                     ['mount_source', '=', os.path.join(k8s_dataset, 'catalogs')], ['fs_type', '=', 'zfs'],
                 ],
-            ):
-                return catalog_ds[0]['mountpoint']
+            ))
 
         return False
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -197,11 +197,11 @@ class CatalogService(CRUDService):
     async def dataset_mounted(self):
         if k8s_dataset := (await self.middleware.call('kubernetes.config'))['dataset']:
             if catalog_ds := await self.middleware.call(
-                'zfs.dataset.query', [['id', '=', os.path.join(k8s_dataset, 'catalogs')]], {
-                    'extra': {'properties': ['mounted']}
-                }
+                'filesystem.mount_info', [
+                    ['mount_source', '=', os.path.join(k8s_dataset, 'catalogs')], ['fs_type', '=', 'zfs'],
+                ],
             ):
-                return catalog_ds[0]['properties']['mounted']['parsed']
+                return catalog_ds[0]['mountpoint']
 
         return False
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -218,6 +218,11 @@ class CatalogService(CRUDService):
         # We normalize the label
         data['label'] = data['label'].upper()
 
+        if not await self.middleware.call('kubernetes.pool_configured'):
+            verrors.add('catalog_create.label', 'Catalogs cannot be added until apps pool is configured')
+        elif (await self.middleware.call('kubernetes.config'))['passthrough_mode']:
+            verrors.add('catalog_create.label', 'Catalogs cannot be added when passthrough mode is enabled for apps')
+
         if await self.query([['id', '=', data['label']]]):
             verrors.add('catalog_create.label', 'A catalog with specified label already exists', errno=errno.EEXIST)
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -194,6 +194,18 @@ class CatalogService(CRUDService):
         verrors.check()
 
     @private
+    async def dataset_mounted(self):
+        if k8s_dataset := (await self.middleware.call('kubernetes.config'))['dataset']:
+            if catalog_ds := await self.middleware.call(
+                'zfs.dataset.query', [['id', '=', os.path.join(k8s_dataset, 'catalogs')]], {
+                    'extra': {'properties': ['mounted']}
+                }
+            ):
+                return catalog_ds[0]['properties']['mounted']['parsed']
+
+        return False
+
+    @private
     async def cannot_be_added(self):
         if not await self.middleware.call('kubernetes.pool_configured'):
             return 'Catalogs cannot be added until apps pool is configured'

--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -66,14 +66,14 @@ def test_create_new_catalog_with_configured_pool():
         'repository': 'https://github.com/truenas/charts.git',
         'branch': 'acl-tests'
     }) as catalog_obj:
-        assert ssh(f'[ -d {catalog_obj["location"]} ] && exit 0 || exit 1', check=False) is True
+        assert ssh(f'[ -d {catalog_obj["location"]} ] && echo 0 || echo 1').strip() == '0'
 
 
 def test_catalog_sync_with_unconfigured_pool(kubernetes_pool):
     with unconfigured_kubernetes(kubernetes_pool):
         call('catalog.sync_all', job=True)
         assert ssh(
-            f'ls {CATALOG_SYNC_TMP_PATH}', complete_response=True
+            f'ls {CATALOG_SYNC_TMP_PATH}'
         ).strip() == 'github_com_truenas_charts_git_master'
         with pytest.raises(ClientException) as ve:
             call('catalog.sync', TEST_SECOND_CATALOG_NAME, job=True)
@@ -85,6 +85,6 @@ def test_catalog_sync_with_unconfigured_pool(kubernetes_pool):
 def test_catalog_sync_with_configured_pool(kubernetes_pool):
     call('catalog.sync_all', job=True)
     assert set(
-        ssh(f'ls /mnt/{kubernetes_pool["name"]}/ix-applications/catalogs', complete_response=True).strip().split()
+        ssh(f'ls /mnt/{kubernetes_pool["name"]}/ix-applications/catalogs').strip().split()
     ) == {'github_com_truenas_charts_git_master', 'github_com_truenas_charts_git_test'}
     assert call('catalog.sync', TEST_SECOND_CATALOG_NAME, job=True) is None

--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -1,0 +1,102 @@
+import pytest
+
+import contextlib
+import os
+
+import shutil
+
+from middlewared.client.client import ValidationErrors, ClientException
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.assets.catalog import catalog
+from middlewared.test.integration.utils import call
+
+from middlewared.utils import MIDDLEWARE_RUN_DIR
+
+from auto_config import pool_name
+
+
+TEST_CATALOG_NAME = 'TEST_CATALOG'
+TEST_SECOND_CATALOG_NAME = 'TEST_SECOND_CATALOG'
+CATALOG_SYNC_TMP_PATH = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-applications', 'catalogs')
+
+
+@contextlib.contextmanager
+def unconfigured_kubernetes():
+    call('kubernetes.update', {'pool': None}, job=True)
+    shutil.rmtree(CATALOG_SYNC_TMP_PATH, ignore_errors=True)
+    try:
+        yield call('kubernetes.config')
+    finally:
+        call('kubernetes.update', {'pool': None}, job=True)
+
+
+@contextlib.contextmanager
+def configured_kubernetes(pool_info):
+    call('kubernetes.update', {'pool': pool_info['name']}, job=True)
+    try:
+        yield call('kubernetes.config')
+    finally:
+        call('kubernetes.update', {'pool': None}, job=True)
+
+
+@pytest.fixture(scope='module')
+def kubernetes_pool():
+    with another_pool() as k3s_pool:
+        call('kubernetes.update', {'pool': k3s_pool['name']}, job=True)
+        with catalog({
+            'force': True,
+            'preferred_trains': ['tests'],
+            'label': TEST_SECOND_CATALOG_NAME,
+            'repository': 'https://github.com/truenas/charts.git',
+            'branch': 'test'
+        }):
+            try:
+                yield k3s_pool
+            finally:
+                call('kubernetes.update', {'pool': pool_name}, job=True)
+
+
+def test_create_new_catalog_with_unconfigured_pool():
+    with unconfigured_kubernetes():
+        with pytest.raises(ValidationErrors) as ve:
+            with catalog({
+                'force': True,
+                'preferred_trains': ['tests'],
+                'label': TEST_CATALOG_NAME,
+                'repository': 'https://github.com/truenas/charts.git',
+                'branch': 'acl-tests'
+            }):
+                pass
+        assert ve.value.errors[0].errmsg == 'Catalogs cannot be added until apps pool is configured'
+        assert ve.value.errors[0].attribute == 'catalog_create.label'
+
+
+def test_create_new_catalog_with_configured_pool(kubernetes_pool):
+    with configured_kubernetes(kubernetes_pool):
+        with catalog({
+            'force': True,
+            'preferred_trains': ['tests'],
+            'label': TEST_CATALOG_NAME,
+            'repository': 'https://github.com/truenas/charts.git',
+            'branch': 'acl-tests'
+        }) as catalog_obj:
+            assert os.path.exists(catalog_obj['location'])
+
+
+def test_catalog_sync_with_unconfigured_pool():
+    with unconfigured_kubernetes():
+        call('catalog.sync_all', job=True)
+        assert os.listdir(CATALOG_SYNC_TMP_PATH) == ['github_com_truenas_charts_git_master']
+        with pytest.raises(ClientException) as ve:
+            call('catalog.sync', TEST_SECOND_CATALOG_NAME, job=True)
+
+        assert ve.value.error == '[EFAULT] Cannot sync non-official catalogs when apps' \
+                                 ' are not configured or catalog dataset is not mounted'
+
+
+def test_catalog_sync_with_configured_pool(kubernetes_pool):
+    with configured_kubernetes(kubernetes_pool) as k3s_config:
+        call('catalog.sync_all', job=True)
+        assert set(os.listdir(f'/mnt/{k3s_config["dataset"]}/catalogs')) == {'github_com_truenas_charts_git_master',
+                                                                             'github_com_truenas_charts_git_test'}
+        assert call('catalog.sync', TEST_SECOND_CATALOG_NAME, job=True) is None


### PR DESCRIPTION
This PR adds changes to make sure we don't exhaust /var/run by cloning in catalogs. These are the changes we are introducing to prevent this scenario from happening:

1. Make sure we can't add more catalogs if apps pool is not configured
2. Do not sync non official catalogs if apps pool is not configured as it will result in tmpfs being exhausted
3. Make sure we don't sync non-official catalogs if apps pool's root dataset is locked

Original PR: https://github.com/truenas/middleware/pull/12839
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125877