### PR TITLE
NAS-126064 / 13.1 / Remove "directory name cache size" parameter from smb4.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -107,8 +107,7 @@
             `dos filemode` was originally set for windows behavior regarding changing owner. This should be
             reviewed for accuracy. `kernel change notify` is disabled because it will result in an open fd for
             every file that is monitored, leading to resource exhaustion on moderately busy servers.
-            `directory name cache size` is a parameter to work around a bug in directory caching in SMB1 for
-            FreeBSD. Recent testing could not reproduce the bug, but the issue is moot since SMB1 is being
+            Recent testing could not reproduce the bug, but the issue is moot since SMB1 is being
             deprecated. `username map` is used to map Microsoft accounts to local accounts
             (bob@microsoft.com to bob). `unix extensions` are legacy SMB1 Unix Extensions. We disable
             by default if SMB1 is disabled.
@@ -122,7 +121,6 @@
                 'disable spoolss': 'Yes',
                 'dos filemode': 'Yes',
                 'kernel change notify': 'No',
-                'directory name cache size': '0',
                 'server multi channel support': 'No',
                 'nsupdate command': '/usr/local/bin/samba-nsupdate -g',
                 'unix charset': db['cifs']['unixcharset'],


### PR DESCRIPTION
This parameter is deprecated and no longer exists in Samba 4.19.