### PR TITLE
NAS-126058 / 24.04 / Fix roles

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -25,7 +25,7 @@ class SessionManagerCredentials:
         return True
 
     def has_role(self, role):
-        return True
+        return False
 
     def notify_used(self):
         pass

--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -22,7 +22,7 @@ class SessionManagerCredentials:
         return True
 
     def authorize(self, method, resource):
-        return True
+        return False
 
     def has_role(self, role):
         return False
@@ -60,7 +60,11 @@ class UnixSocketSessionManagerCredentials(UserSessionManagerCredentials):
 
 
 class RootTcpSocketSessionManagerCredentials(SessionManagerCredentials):
-    pass
+    def __init__(self):
+        self.is_user_session = True
+
+    def authorize(self, method, resource):
+        return True
 
 
 class LoginPasswordSessionManagerCredentials(UserSessionManagerCredentials):
@@ -84,7 +88,8 @@ class ApiKeySessionManagerCredentials(SessionManagerCredentials):
 
 
 class TrueNasNodeSessionManagerCredentials(SessionManagerCredentials):
-    pass
+    def authorize(self, method, resource):
+        return True
 
 
 def is_ha_connection(remote_addr, remote_port):

--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -59,12 +59,8 @@ class UnixSocketSessionManagerCredentials(UserSessionManagerCredentials):
     pass
 
 
-class RootTcpSocketSessionManagerCredentials(SessionManagerCredentials):
-    def __init__(self):
-        self.is_user_session = True
-
-    def authorize(self, method, resource):
-        return True
+class RootTcpSocketSessionManagerCredentials(UserSessionManagerCredentials):
+    pass
 
 
 class LoginPasswordSessionManagerCredentials(UserSessionManagerCredentials):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1459,7 +1459,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             success = True
 
             if app.authenticated_credentials:
-                if not (
+                if app.authenticated_credentials.is_user_session and not (
                     credential_has_full_admin(app.authenticated_credentials) or
                     (
                         serviceobj._config.role_prefix and

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1459,7 +1459,13 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             success = True
 
             if app.authenticated_credentials:
-                if not credential_has_full_admin(app.authenticated_credentials):
+                if not (
+                    credential_has_full_admin(app.authenticated_credentials) or
+                    (
+                        serviceobj._config.role_prefix and
+                        app.authenticated_credentials.has_role(f'{serviceobj._config.role_prefix}_WRITE')
+                    )
+                ):
                     if hasattr(methodobj, "returns") and methodobj.returns:
                         schema = methodobj.returns[0]
                         if isinstance(schema, OROperator):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -20,6 +20,7 @@ from .utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
 from .utils.nginx import get_remote_addr_port
 from .utils.origin import UnixSocketOrigin, TCPIPOrigin
 from .utils.plugins import LoadPluginsMixin
+from .utils.privilege import credential_has_full_admin
 from .utils.profile import profile_wrap
 from .utils.service.call import ServiceCallMixin
 from .utils.syslog import syslog_message
@@ -1458,7 +1459,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             success = True
 
             if app.authenticated_credentials:
-                if app.authenticated_credentials.has_role("READONLY"):
+                if not credential_has_full_admin(app.authenticated_credentials):
                     if hasattr(methodobj, "returns") and methodobj.returns:
                         schema = methodobj.returns[0]
                         if isinstance(schema, OROperator):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -685,7 +685,8 @@ async def check_permission(middleware, app):
                 pass
             else:
                 if euid == 0:
-                    await AuthService.session_manager.login(app, RootTcpSocketSessionManagerCredentials())
+                    user = await middleware.call('auth.authenticate_root')
+                    await AuthService.session_manager.login(app, RootTcpSocketSessionManagerCredentials(user))
                     return
 
 

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -186,6 +186,9 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
     def authorize(self, method, resource):
         return self.token.parent_credentials.authorize(method, resource)
 
+    def has_role(self, role):
+        return self.token.parent_credentials.has_role(role)
+
     def notify_used(self):
         self.token.notify_used()
 

--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -1,6 +1,7 @@
 import enum
 from middlewared.utils.privilege import credential_has_full_admin
 
+
 class ServiceWriteRole(enum.Enum):
     CIFS = 'SHARING_SMB_WRITE'
     NFS = 'SHARING_NFS_WRITE'

--- a/src/middlewared/middlewared/test/integration/assets/account.py
+++ b/src/middlewared/middlewared/test/integration/assets/account.py
@@ -1,4 +1,6 @@
 import contextlib
+import random
+import string
 import types
 
 from middlewared.service_exception import InstanceNotFound
@@ -72,15 +74,17 @@ def unprivileged_user(*, username, group_name, privilege_name, allowlist, web_sh
 
 @contextlib.contextmanager
 def unprivileged_user_client(roles=None, allowlist=None):
+    suffix = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
     with unprivileged_user(
-        username="unprivileged",
-        group_name="unprivileged_users",
-        privilege_name="Unprivileged users",
+        username=f"unprivileged_{suffix}",
+        group_name=f"unprivileged_users_{suffix}",
+        privilege_name=f"Unprivileged users ({suffix})",
         allowlist=allowlist or [],
         roles=roles or [],
         web_shell=False,
     ) as t:
         with client(auth=(t.username, t.password)) as c:
+            c.username = t.username
             yield c
 
 

--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -172,3 +172,10 @@ def test_config(readonly_client, service, redacted_fields):
 
     for k in redacted_fields:
         assert result[k] == REDACTED
+
+
+def test_fields_are_visible_if_has_write_access():
+    with unprivileged_user_client(["ACCOUNT_WRITE"]) as c:
+        result = c.call(f"user.get_instance", 1)
+
+    assert result["unixhash"] != REDACTED

--- a/tests/api2/test_account_query_roles.py
+++ b/tests/api2/test_account_query_roles.py
@@ -4,16 +4,16 @@ from middlewared.test.integration.assets.account import unprivileged_user_client
 
 
 @pytest.mark.parametrize("role", ["READONLY", "FULL_ADMIN"])
-def test_user_role_in_account(request, role):
+def test_user_role_in_account(role):
     with unprivileged_user_client(roles=[role]) as c:
-        this_user = c.call("user.query", [["username", "=", "unprivileged"]], {"get": True})
+        this_user = c.call("user.query", [["username", "=", c.username]], {"get": True})
 
         assert this_user['roles'] == [role]
 
 
-def test_user_role_full_admin_map(request):
+def test_user_role_full_admin_map():
     with unprivileged_user_client(allowlist=[{"method": "*", "resource": "*"}]) as c:
-        this_user = c.call("user.query", [["username", "=", "unprivileged"]], {"get": True})
+        this_user = c.call("user.query", [["username", "=", c.username]], {"get": True})
 
         assert "FULL_ADMIN" in this_user["roles"]
         assert "HAS_ALLOW_LIST" in this_user["roles"]

--- a/tests/api2/test_job_credentials.py
+++ b/tests/api2/test_job_credentials.py
@@ -15,4 +15,4 @@ def test_job_credentials():
 
             job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
 
-            assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": "unprivileged"}}
+            assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": c.username}}


### PR DESCRIPTION
* Credentials had all roles by default. This will be a huge security risk if we start using. roles to determine if users can execute certain things. We should default to `False`, credentials must have roles explicitly.
* As a consequence, token credentials (all WebUI sessions) had all roles, including `READONLY` role. This made the middleware redact all private variables for all return values for WebUI even if we were root.
* `has_role("READONLY")` is a weird way to determine whether we should redact private variables for return values. Should we just only show them to full admins?
* As for the original issue (SMART test schema being inconsistent with the actual return value and failing to redact private variables), let's fix this once we have SMART tests available to non-privileged users.