### PR TITLE
NAS-126045 / 23.10.2 / Fix ALUA support for multi-lun iSCSI targets (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -1,4 +1,5 @@
 <%
+    import itertools
     import os
 
     from collections import defaultdict
@@ -133,7 +134,7 @@
     hosts_iqns = middleware.call_sync('iscsi.host.get_hosts_iqns')
 
     if alua_enabled and failover_status == "BACKUP":
-        cml = calc_copy_manager_luns(logged_in_targets.values(), True)
+        cml = calc_copy_manager_luns(list(itertools.chain.from_iterable(logged_in_targets.values())), True)
     else:
         cml = calc_copy_manager_luns(all_extent_names)
 %>\
@@ -152,15 +153,18 @@ cluster_name HA
 % if is_ha:
 HANDLER dev_disk {
 %     if alua_enabled and failover_status == "BACKUP":
-%         for name, value in logged_in_targets.items():
-%             if value:
-        DEVICE ${value} {
+%         for name, devices in logged_in_targets.items():
+%             if devices:
+%                 for device in devices:
+
+        DEVICE ${device} {
 ## Sanity check to ensure the MASTER target is in cluster_mode, if so then so are we
 ## Note we use a similar check to determine whether the target will be enabled.
 %                 if name in cluster_mode_targets:
             cluster_mode 1
 %                 endif
         }
+%                 endfor
 %             endif
 %         endfor
 %     endif
@@ -320,10 +324,12 @@ TARGET_DRIVER iscsi {
 ##
 %   if alua_enabled and failover_status == "BACKUP":
 <%
-    DEVICE = logged_in_targets.get(target['name'], None)
+    devices = logged_in_targets.get(target['name'], None)
 %>\
-%       if DEVICE:
-            LUN 0 ${DEVICE}
+%       if devices:
+%           for device in devices:
+            LUN ${device.split(':')[-1]} ${device}
+%           endfor
 %       endif
 %   else:
 ${retrieve_luns(target['id'], ' ' * 4)}\
@@ -406,9 +412,11 @@ DEVICE_GROUP targets {
 ##
 %     if failover_status == "BACKUP":
 DEVICE_GROUP targets {
-%         for name, value in logged_in_targets.items():
-%             if value:
-        DEVICE ${value}
+%         for name, devices in logged_in_targets.items():
+%             if devices:
+%                 for device in devices:
+        DEVICE ${device}
+%                 endfor
 %             endif
 %         endfor
 

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -444,15 +444,14 @@ class iSCSITargetService(CRUDService):
     @private
     def logged_in_iqns(self):
         """
-        :return: dict keyed by iqn, with the unsurfaced disk name as the value
+        :return: dict keyed by iqn, with list of the unsurfaced disk names as the value
         """
-        results = {}
+        results = defaultdict(list)
         p = pathlib.Path('/sys/devices/platform')
         for targetname in p.glob('host*/session*/iscsi_session/session*/targetname'):
             iqn = targetname.read_text().strip()
             for disk in targetname.parent.glob('device/target*/*/scsi_disk'):
-                results[iqn] = disk.parent.name
-                break
+                results[iqn].append(disk.parent.name)
         return results
 
     @private
@@ -476,7 +475,7 @@ class iSCSITargetService(CRUDService):
         When called on a HA BACKUP node will attempt to login to all internal HA targets,
         used in ALUA.
 
-        :return: dict keyed by target name, with the unsurfaced disk name or None as the value
+        :return: dict keyed by target name, with list of the unsurfaced disk names or None as the value
         """
         targets = await self.middleware.call('iscsi.target.query')
         global_basename = (await self.middleware.call('iscsi.global.config'))['basename']


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 45ac3bee0d381f89705913ac16d7ba725685c7c5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 11c0506d4f5848a34bdbc525922fa4cea43be6d8

Fix ALUA support for multi-lun iSCSI targets.

Change the return type of `logged_in_iqns` (and `login_ha_targets`) so that **ALL** devices corresponding to each target are returned.  (Now return dict values of a list that will contain e.g. `["13:0:0:0", "13:0:0:1"]` rather than a single string `"13:0:0:1"` (or `"13:0:0:1"`) as previously was the case.)

Update `scst.conf.mako` to take advantage of this new information.

Finally add a corresponding unit test `test_32_multi_lun_targets`.  This will check targets on regular SCALE, or HA SCALE both with and without ALUA enabled.


Original PR: https://github.com/truenas/middleware/pull/12848
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126045