### PR TITLE
NAS-126067 / 24.04 / Fix NFS manage-gids conf setting

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -8,6 +8,7 @@
     # but mount storms at restart benefit from additional mountd.  As such, we recommend
     # the number of mountd be 1/4 the number of nfsd.
     num_mountd = max(int(num_nfsd / 4), 1)
+    manage_gids = 'y' if config["userd_manage_gids"] else 'n'
 %>
 [nfsd]
 syslog = 1
@@ -32,9 +33,7 @@ threads = ${num_mountd}
 % if config['mountd_port']:
 port = ${config['mountd_port']}
 % endif
-% if config['userd_manage_gids']:
-manage-gids = ${config['userd_manage_gids']}
-% endif
+manage-gids = ${manage_gids}
 
 [statd]
 % if config['rpcstatd_port']:

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -65,6 +65,10 @@ def parse_exports():
 
 
 def parse_server_config(fname="local.conf"):
+    '''
+    Debian will read to /etc/default/nfs-common and then /etc/nfs.conf
+    All TrueNAS NFS settings are in /etc/nfs.conf.d/local.conf as overrides
+    '''
     results = SSH_TEST(f"cat /etc/nfs.conf.d/{fname}", user, password, ip)
     assert results['result'] is True, f"rc={results['returncode']}, {results['output']}, {results['stderr']}"
     conf = results['stdout'].splitlines()
@@ -85,6 +89,10 @@ def parse_server_config(fname="local.conf"):
 
 
 def parse_rpcbind_config():
+    '''
+    In Debian 12 (Bookwork) rpcbind uses /etc/default/rpcbind.
+    Look for /etc/rpcbind.conf in future releases.
+    '''
     results = SSH_TEST("cat /etc/default/rpcbind", user, password, ip)
     assert results['result'] is True, f"rc={results['returncode']}, {results['output']}, {results['stderr']}"
     conf = results['stdout'].splitlines()
@@ -1494,6 +1502,45 @@ def test_50_nfs_invalid_user_group_mapping(request, type, data):
             with create_group({'name': grpname}) as grpInst:
                 with nfs_share(tmp_path, mapping) as share:
                     run_missing_usrgrp_test(testval, tmp_path, share, grpInst)
+
+
+@pytest.mark.parametrize('state,expected', [
+    (None, 'n'),   # Test default state
+    (True, 'y'),
+    (False, 'n')
+])
+def test_52_manage_gids(request, state, expected):
+    '''
+    The nfsd_manage_gids setting is called "Support > 16 groups" in the webui.
+    It is that and, to a greater extent, defines the GIDs that are used for permissions.
+
+    If NOT enabled, then the expectation is that the groups to which the user belongs
+    are defined on the _client_ and NOT the server.  It also means groups to which the user
+    belongs are passed in on the NFS commands from the client.  The file object GID is
+    checked against the passed in list of GIDs.  This is also where the 16 group
+    limitation is enforced.  The NFS protocol allows passing up to 16 groups per user.
+
+    If nfsd_manage_gids is enabled, the groups to which the user belong are defined
+    on the server.  In this condition, the server confirms the user is a member of
+    the file object GID.
+
+    NAS-126067:  Debian changed the 'default' setting to manage_gids in /etc/nfs.conf
+    from undefined to "manage_gids = y".
+
+    TEST:   Confirm manage_gids is set in /etc/nfs.conf.d/local/conf for
+            both the enable and disable states
+
+    TODO: Add client-side and server-side test from client when available
+    '''
+    with nfs_config():
+
+        if state is not None:
+            nfs_db = call("nfs.update", {"userd_manage_gids": state})
+        else:
+            nfs_db = call("nfs.config")
+
+        s = parse_server_config()
+        assert s['mountd']['manage-gids'] == expected, str(s)
 
 
 def test_70_stopping_nfs_service(request):

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1535,9 +1535,7 @@ def test_52_manage_gids(request, state, expected):
     with nfs_config():
 
         if state is not None:
-            nfs_db = call("nfs.update", {"userd_manage_gids": state})
-        else:
-            nfs_db = call("nfs.config")
+            call("nfs.update", {"userd_manage_gids": state})
 
         s = parse_server_config()
         assert s['mountd']['manage-gids'] == expected, str(s)


### PR DESCRIPTION
`manage-gids` in the `mountd` section of `/etc/nfs.conf` was enabled In the Debian Bookworm release.
This effected our management of the setting.
The setting was also incorrectly being set with 'True' or 'False'.  The correct settings are 'y' or 'n', respectively.
