### PR TITLE
NAS-126691 / 23.10.2 / fix TypeError crash in failover.vip.check_failover_group

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
+++ b/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
@@ -16,7 +16,7 @@ class DetectVirtualIpStates(Service):
             if ifname in names:
                 # get the list of interfaces that are in the same
                 # failover group as `ifname`.
-                failover_grp_ifaces = names
+                failover_grp_ifaces = names[:]
 
                 # we remove `ifname` since we only care about the other
                 # interfaces in this failover group

--- a/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
+++ b/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
@@ -1,5 +1,4 @@
 from middlewared.service import Service
-from middlewared.plugins.interface.netif import netif
 
 
 class DetectVirtualIpStates(Service):
@@ -9,31 +8,45 @@ class DetectVirtualIpStates(Service):
         namespace = 'failover.vip'
 
     async def check_failover_group(self, ifname, groups):
-
         """
         Check the other members (if any) in failover group for `ifname`
         """
+        failover_grp_ifaces = list()
+        for grp, names in groups.items():
+            if ifname in names:
+                # get the list of interfaces that are in the same
+                # failover group as `ifname`.
+                failover_grp_ifaces = names
 
-        masters, backups = [], []
+                # we remove `ifname` since we only care about the other
+                # interfaces in this failover group
+                failover_grp_ifaces.remove(ifname)
 
-        # get failover group id for `iface`
-        group_id = [group for group, names in groups.items() if ifname in names][0]
+                # An interface can only ever be in a single failover
+                # group so we can break the loop early here
+                break
 
-        # get all interfaces in `group_id`
-        ids = [names for group, names in groups.items() if group == group_id][0]
-
-        # need to remove the passed in `ifname` from the list
-        ids.remove(ifname)
-
-        # we can have more than one interface in the failover
-        # group so check the state of the interface
-        for i in ids:
-            iface = netif.get_interface(i)
-            for j in iface.vrrp_config:
-                if j['state'] == 'MASTER':
-                    masters.append(i)
+        masters, backups = list(), list()
+        for i in await self.middleware.call('interface.query', [['id', 'in', failover_grp_ifaces]]):
+            # We're checking any other interface that is in the same
+            # failover group as `ifname`. For example, customers often
+            # configure multiple physical interfaces for iSCSI MPIO.
+            # Since they are using MPIO, each interface serves as a
+            # discreet path to their data. However, if 1 of the 4
+            # interfaces go down then we don't need to failover since
+            # 3 other paths are up (That's the point of MPIO). In this
+            # scenario, the customer will have to put all 4 of the
+            # physical interfaces in the _same_ failover group.
+            for vrrp_info in i['state'].get('vrrp_config', []):
+                # `vrrp_config` should never be NoneType here but this
+                # is a critical call path for processing a failover
+                # event so we access it safely. There are other layers
+                # of checks and balances that happen in the failover
+                # event logic.
+                if vrrp_info['state'] == 'MASTER':
+                    masters.append(i['id'])
                 else:
-                    backups.append(i)
+                    backups.append(i['id'])
 
         return masters, backups
 


### PR DESCRIPTION
Fix the following TypeError crash:
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/event.py", line 635, in vrrp_backup
    status = self.run_call(
             ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/event.py", line 145, in run_call
    return self.middleware.call_sync(method, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1420, in call_sync
    return self.run_coroutine(methodobj(*prepared_call.args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1460, in run_coroutine
    return fut.result()
           ^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/virtual_ips.py", line 32, in check_failover_group
    for j in iface.vrrp_config:
TypeError: 'NoneType' object is not iterable
```

This seems to have been broken since it was written back in 2020. The reason why this is broken is because `netif.get_interfaces()` will never populate the `vrrp_config` attribute by itself (it will always be `NoneType`). Calling `interface.query` populates this attribute. The reason why this wasn't caught is because this code-path is only exercised when there is more than 1 interface configured, all of them being marked critical for failover, all of them being in the same failover group. (A common configuration when dealing with iSCSI and MPIO). While I was fixing this issue, I noticed we were blocking the main event loop by calling `netif.get_interfaces` in a coroutine.

To summarize, I've fixed the following:
1. fix the `TypeError` crash by safely iterating the `vrrp_config` object
2. stop blocking the main event loop by removing the call to `netif.get_interfaces` and instead call `interface.query`
3. removed 2 list comprehensions since they were superfluous

I've also added more documentation in this area so, in theory, future readers have an idea of what's going on.