### PR TITLE
NAS-126697 / 24.04 / fix AttributeError crash in vrrp event thread (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/vrrp_events.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events.py
@@ -272,9 +272,7 @@ async def _start_stop_vrrp_threads(middleware):
             await middleware.run_in_thread(VrrpObjs.event_thread.shutdown)
             VrrpObjs.event_thread = None
 
-        if VrrpObjs.event_queue is not None:
-            VrrpObjs.event_queue.clear()
-            VrrpObjs.event_queue = None
+        VrrpObjs.event_queue.clear()
     else:
         # if this is a system that is being licensed for HA for the
         # first time (without being rebooted) then we need to make


### PR DESCRIPTION
`VrrpObjs.event_queue` should never be `None`. If this was written in C, this would be a null pointer deference 😄 Instead, we're crashing with `AttributeError` as seen below:
```
[2024/01/08 07:40:30] (WARNING) failover.run():249 - vrrp fifo connection not established, retrying every 2 seconds
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/vrrp_events.py", line 246, in run
    self.event_queue.append({'event': event, 'time': time()})
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'append'
```

This error condition should only ever be hit when an HA license is being applied (or removed) but the failure condition is that we miss a failover event which is a much larger issue. This just clears the `deque` object instead of setting it to `None`

Original PR: https://github.com/truenas/middleware/pull/12864
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126697