### PR TITLE
NAS-126698 / 23.10.1.1 / fix logic in failover.events.fenced_start_loop (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -303,22 +303,27 @@ class FailoverEventsService(Service):
         elif event == 'BACKUP':
             return self.run_call('failover.events.vrrp_backup', fobj, ifname, event)
 
-    def fenced_start_loop(self, force=False, timeout=10):
-
+    def fenced_start_loop(self, max_retries=3):
         # When active node is rebooted administratively from shell, the
         # fenced process will continue running on the node until systemd
         # finishes terminating services and actually reboots. Hence, we may
-        # need towait a little while for fenced on other node to go away.
-        # fenced_err == 2 means that remote fenced is still running
-        while timeout:
-            fenced_error = self.run_call('failover.fenced.start', force)
+        # need to retry a few times before fenced goes away on the remote
+        # node. NOTE: fenced waits for ~11 or so seconds to see if the
+        # reservation keys change.
+        total_time_waited = 0
+        for i in range(1, max_retries + 1):
+            start = time.time()
+            fenced_error = self.run_call('failover.fenced.start')
             if fenced_error != 2:
                 break
-
-            logger.warning('Fenced is running on remote node waiting %d more seconds.',
-                           timeout)
-            timeout -= 1
-            sleep(1)
+            else:
+                total_time_waited += int(time.time() - start)
+                retrying = ', retrying.' if i < max_retries else ''
+                logger.warning(
+                    'Fenced is running on remote node after waiting %d seconds%s',
+                    total_time_waited,
+                    retrying
+                )
 
         return fenced_error
 
@@ -342,7 +347,7 @@ class FailoverEventsService(Service):
             self.run_call('failover.fenced.stop')
 
             logger.warning('Forcefully starting fenced')
-            fenced_error = self.fenced_start_loop(force=True)
+            fenced_error = self.run_call('failover.fenced.start', True)
         else:
             # if we're here then we need to check a couple things before we start fenced
             # and start the process of becoming master


### PR DESCRIPTION
The `failover.events.fenced_start_loop` method assumes that `failover.fenced.start` takes 1 second to return. This is not the case since the `fenced` daemon has functionality built-in to wait around 10 or so seconds to see if the reservations on the disk change. If the reservation keys change, then fenced assumes that the other node's fenced daemon is running and so backs off. This is by design and has been this way since the beginning.

This fixes the `fenced_start_loop` to take into account for this wait time and logs accurate messages in logs files. Before these changes, we're populating the log files with messages like these (notice timestamp)
```
[2024/01/08 12:37:35] (WARNING) failover.vrrp_master():376 - Entering MASTER on "eno1".
[2024/01/08 12:37:35] (WARNING) failover.vrrp_master():381 - Starting fenced
[2024/01/08 12:37:47] (WARNING) failover.fenced_start_loop():318 - Fenced is running on remote node waiting 10 more seconds.
[2024/01/08 12:38:00] (WARNING) failover.fenced_start_loop():318 - Fenced is running on remote node waiting 9 more seconds.
[2024/01/08 12:38:13] (WARNING) failover.fenced_start_loop():318 - Fenced is running on remote node waiting 8 more seconds.
```

Finally, the fenced_start_loop had a `force` option which would be passed along to `fenced.failover.start`. The `force` flag (when set to True) ignores whether or not the reservation keys change on the disk and `force`fully updates the disks with reservation keys owned by this host. This means we do not need to call `fenced_start_loop` with `force=True` which allows us to simplify this method further.

Original PR: https://github.com/truenas/middleware/pull/12863
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126698