### PR TITLE
NAS-126691 / 24.04 / fix TypeError crash in failover.vip.check_failover_group (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
+++ b/src/middlewared/middlewared/plugins/failover_/virtual_ips.py
@@ -21,7 +21,7 @@ class DetectVirtualIpStates(Service):
             if ifname in names:
                 # get the list of interfaces that are in the same
                 # failover group as `ifname`.
-                failover_grp_ifaces = names
+                failover_grp_ifaces = names[:]
 
                 # we remove `ifname` since we only care about the other
                 # interfaces in this failover group


### PR DESCRIPTION
Fix the following TypeError crash:
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/event.py", line 635, in vrrp_backup
    status = self.run_call(
             ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/event.py", line 145, in run_call
    return self.middleware.call_sync(method, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1420, in call_sync
    return self.run_coroutine(methodobj(*prepared_call.args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1460, in run_coroutine
    return fut.result()
           ^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/virtual_ips.py", line 32, in check_failover_group
    for j in iface.vrrp_config:
TypeError: 'NoneType' object is not iterable
```

This seems to have been broken since it was written back in 2020. The reason why this is broken is because `netif.get_interfaces()` will never populate the `vrrp_config` attribute by itself (it will always be `NoneType`). Calling `interface.query` populates this attribute. The reason why this wasn't caught is because this code-path is only exercised when there is more than 1 interface configured, all of them being marked critical for failover, all of them being in the same failover group. (A common configuration when dealing with iSCSI and MPIO). While I was fixing this issue, I noticed we were blocking the main event loop by calling `netif.get_interfaces` in a coroutine.

To summarize, I've fixed the following:
1. fix the `TypeError` crash by safely iterating the `vrrp_config` object
2. stop blocking the main event loop by removing the call to `netif.get_interfaces` and instead call `interface.query`
3. removed 2 list comprehensions since they were superfluous

I've also added more documentation in this area so, in theory, future readers have an idea of what's going on.

Original PR: https://github.com/truenas/middleware/pull/12860
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126691