### PR TITLE
NAS-125728 / 24.04 / handle NetlinkDumpInterrupted in list_interfaces()

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -1,5 +1,5 @@
 import logging
-from pyroute2 import IPRoute
+from pyroute2 import IPRoute, NetlinkDumpInterrupted
 
 from .bridge import create_bridge
 from .interface import Interface, CLONED_PREFIXES
@@ -38,5 +38,21 @@ def get_interface(name, safe_retrieval=False):
 
 
 def list_interfaces():
-    with IPRoute() as ipr:
-        return {dev.get_attr('IFLA_IFNAME'): Interface(dev) for dev in ipr.get_links()}
+    max_retries = 3
+    for attempt in range(1, max_retries + 1):
+        try:
+            with IPRoute() as ipr:
+                return {dev.get_attr('IFLA_IFNAME'): Interface(dev) for dev in ipr.get_links()}
+        except NetlinkDumpInterrupted:
+            if attempt < max_retries:
+                # When the kernel is producing a dump of a kernel structure
+                # over multiple netlink messages, and the structure changes
+                # mid-way, NLM_F_DUMP_INTR is added to the header flags.
+                # This an indication that the requested dump contains
+                # inconsistent data and must be re-requested. See function
+                # nl_dump_check_consistent() in include/net/netlink.h. The
+                # pyroute2 library raises this specific exception for this
+                # scenario so we'll try again (up to a max of 3 times).
+                continue
+            else:
+                raise


### PR DESCRIPTION
On HA systems, the UI is immediately showing the login page on a failover event. This means they're making a bunch of API calls related to networking. This is happening too soon (before failover is actually complete) and so various places in middleware are crashing because `netif.list_interfaces()` is crashing.

The exception being raised is actually expected in these circumstances and so we need retry to grab the information when this specific exception is raised.