### PR TITLE
NAS-126724 / 24.04 / NFS syslog filter test:  Add samples and widen search to eliminate false failures

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1372,7 +1372,7 @@ def test_48_syslog_filters(request):
         # Confirm default setting: mountd logging enabled
         call("nfs.update", {"mountd_log": True})
         with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
-            num_tries = 5
+            num_tries = 10
             found = False
             res = ""
             while not found and num_tries > 0:

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1371,17 +1371,22 @@ def test_48_syslog_filters(request):
 
         # Confirm default setting: mountd logging enabled
         call("nfs.update", {"mountd_log": True})
+
+        # Add dummy entries to avoid false positives
+        for i in range(10):
+            ssh(f'logger "====== {i}: NFS test_48_syslog_filters (with) ======"')
         with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
             num_tries = 10
             found = False
             res = ""
             while not found and num_tries > 0:
-                res = ssh("tail -5 /var/log/syslog")
+                numlines = 3 * (10 - num_tries) + 5
+                res = ssh(f"tail -{numlines} /var/log/syslog")
                 if "rpc.mountd" in res:
                     found = True
                     break
                 num_tries -= 1
-                sleep(1)
+                sleep(10 - num_tries)
 
             assert found, f"Expected to find 'rpc.mountd' in the output but found:\n{res}"
 
@@ -1389,15 +1394,19 @@ def test_48_syslog_filters(request):
 
         # Disable mountd logging
         call("nfs.update", {"mountd_log": False})
+
+        # Add dummy entries to avoid false positives
+        for i in range(10):
+            ssh(f'logger "====== {i}: NFS test_48_syslog_filters (without) ======"')
         with SSH_NFS(ip, NFS_PATH, vers=4, user=user, password=password, ip=ip):
             # wait a few seconds to make sure syslog has a chance to flush log messages
-            sleep(3)
-            res = ssh("tail -5 /var/log/syslog")
+            sleep(4)
+            res = ssh("tail -10 /var/log/syslog")
             assert "rpc.mountd" not in res, f"Did not expect to find 'rpc.mountd' in the output but found:\n{res}"
 
         # Get a second chance to catch mountd messages on the umount.  They should not be present.
-        sleep(3)
-        res = ssh("tail -5 /var/log/syslog")
+        sleep(4)
+        res = ssh("tail -10 /var/log/syslog")
         assert "rpc.mountd" not in res, f"Did not expect to find 'rpc.mountd' in the output but found:\n{res}"
 
 


### PR DESCRIPTION
Analysis of the logs from tests where `test_48_syslog_filters` failed found the time to complete the NFS restart was much longer than expected.  In some circumstances it was nearly twice as long and with more unrelated entries.

Fix:  Increase the number of samples taken to allow for slow restarts and widen the syslog search to account for the additional unrelated entries.   The test will exit on the first sample that passes the criteria.