### PR TITLE
NAS-126734 / 24.04 / Add delay to allow syslog flush

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1544,6 +1544,7 @@ def test_52_manage_gids(request, state, expected):
     with nfs_config():
 
         if state is not None:
+            sleep(3)  # In Cobia: Prevent restarting NFS too quickly.
             call("nfs.update", {"userd_manage_gids": state})
 
         s = parse_server_config()


### PR DESCRIPTION
This same fix was added to the Cobia branch.