### PR TITLE
NAS-126745 / 24.04 / add new endpoints for UI team

### DIFF
--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -1,9 +1,7 @@
-import os
 from subprocess import run
 
 from middlewared.schema import accepts, returns, Bool
 from middlewared.service import CallError, Service
-from middlewared.plugins.system.product import LICENSE_FILE
 
 
 class SystemSecurityInfoService(Service):
@@ -19,10 +17,7 @@ class SystemSecurityInfoService(Service):
         mode made be toggled on this system"""
         # being able to toggle fips mode is hinged on whether
         # or not this is an iX licensed piece of hardware
-        # we also (at time of writing) don't put a specific
-        # feature flag in the license so we don't need to decode
-        # it, just need to check its existence
-        return os.path.exists(LICENSE_FILE)
+        return bool(self.middleware.call_sync('system.license'))
 
     @accepts(roles=['READONLY'])
     @returns(Bool('fips_available'))

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -19,6 +19,9 @@ class SystemSecurityInfoService(Service):
         mode made be toggled on this system"""
         # being able to toggle fips mode is hinged on whether
         # or not this is an iX licensed piece of hardware
+        # we also (at time of writing) don't put a specific
+        # feature flag in the license so we don't need to decode
+        # it, just need to check its existence
         return os.path.exists(LICENSE_FILE)
 
     @accepts(roles=['READONLY'])

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -14,7 +14,7 @@ class SystemSecurityInfoService(Service):
     @returns(Bool('fips_available'))
     def fips_available(self):
         """Returns a boolean identifying whether or not FIPS
-        mode made be toggled on this system"""
+        mode may be toggled on this system"""
         # being able to toggle fips mode is hinged on whether
         # or not this is an iX licensed piece of hardware
         return bool(self.middleware.call_sync('system.license'))

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -1,0 +1,33 @@
+import os
+from subprocess import run
+
+from middlewared.schema import accepts, returns, Bool
+from middlewared.service import CallError, Service
+from middlewared.plugins.system.product import LICENSE_FILE
+
+
+class SystemSecurityInfoService(Service):
+
+    class Config:
+        namespace = 'system.security.info'
+        cli_namespace = 'system.security.info'
+
+    @accepts(roles=['READONLY'])
+    @returns(Bool('fips_available'))
+    def fips_available(self):
+        """Returns a boolean identifying whether or not FIPS
+        mode made be toggled on this system"""
+        # being able to toggle fips mode is hinged on whether
+        # or not this is an iX licensed piece of hardware
+        return os.path.exists(LICENSE_FILE)
+
+    @accepts(roles=['READONLY'])
+    @returns(Bool('fips_available'))
+    def fips_enabled(self):
+        """Returns a boolean identifying whether or not FIPS
+        mode has been enabled on this system"""
+        cp = run(['openssl', 'list', '-providers'], capture_output=True)
+        if cp.returncode:
+            raise CallError(f'Failed to determine if fips is enabled: {cp.stderr.decode()}')
+
+        return b'OpenSSL FIPS Provider' in cp.stdout

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -1,7 +1,7 @@
 import middlewared.sqlalchemy as sa
 
 from middlewared.schema import accepts, Bool, Dict, Int, Patch
-from middlewared.service import ConfigService, private, ValidationError
+from middlewared.service import ConfigService, ValidationError
 
 
 class SystemSecurityModel(sa.Model):
@@ -63,8 +63,3 @@ class SystemSecurityService(ConfigService):
             await self.middleware.call('etc.generate', 'fips')
 
         return await self.config()
-
-    @private
-    def fips_enabled(self):
-        # TODO: remove this method from this CRUD file
-        return self.middleware.call_sync('system.security.info.fips_enabled')

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -292,12 +292,18 @@ class SystemAdvancedService(ConfigService):
 
         return await self.config()
 
+    @accepts(roles=['READONLY'])
+    @returns(Bool('sed_global_password_is_set'))
+    async def sed_global_password_is_set(self):
+        """Returns a boolean identifying whether or not a global
+        SED password has been set"""
+        return bool(await self.sed_global_password())
+
     @accepts()
     @returns(Password('sed_global_password'))
     async def sed_global_password(self):
-        """
-        Returns configured global SED password.
-        """
+        """Returns configured global SED password in clear-text if one
+        is configured, otherwise an empty string"""
         passwd = (await self.middleware.call(
             'datastore.config', 'system.advanced', {'prefix': self._config.datastore_prefix}
         ))['sed_passwd']

--- a/tests/api2/test_fips.py
+++ b/tests/api2/test_fips.py
@@ -14,4 +14,4 @@ def test_fips(flag):
         pytest.skip('FIPS test can only be run on licensed hardware')
 
     call('system.security.update', {'enable_fips': flag})
-    assert call('system.security.fips_enabled') is flag
+    assert call('system.security.info.fips_enabled') is flag


### PR DESCRIPTION
This adds 2 new endpoints for the UI team to finalize the Roles work.
1. `system.advanced.sed_global_password_is_set`
2. `system.security.info.fips_available`

Finally, this moves the logic out of the `security/update.py` module to `security/info.py` where it makes sense. There should be no change in functionality.