### PR TITLE
NAS-125367 / 24.10 / Disable learning of bridge interface members

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-02-12_19-47_add_enable_learning_flag.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-02-12_19-47_add_enable_learning_flag.py
@@ -1,0 +1,24 @@
+"""Add enable learning flag
+
+Revision ID: 7836261b2f64
+Revises: 968d515e63e7
+Create Date: 2024-02-12 19:47:35.379137+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '7836261b2f64'
+down_revision = '968d515e63e7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('network_bridge', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('enable_learning', sa.Boolean(), nullable=False, server_default='1'))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,7 +52,7 @@ class InterfaceService(Service):
 
         for member in db_members:
             parent_interfaces.append(member)
-            iface.disable_learning(member)
+            iface.set_learning(member, False)
 
         if iface.stp != bridge['stp']:
             verb = 'off' if not bridge['stp'] else 'on'

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,6 +52,7 @@ class InterfaceService(Service):
 
         for member in db_members:
             parent_interfaces.append(member)
+            iface.disable_learning(member)
 
         if iface.stp != bridge['stp']:
             verb = 'off' if not bridge['stp'] else 'on'

--- a/src/middlewared/middlewared/plugins/interface/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/bridge.py
@@ -52,7 +52,7 @@ class InterfaceService(Service):
 
         for member in db_members:
             parent_interfaces.append(member)
-            iface.set_learning(member, False)
+            iface.set_learning(member, bridge.get('enable_learning', True))
 
         if iface.stp != bridge['stp']:
             verb = 'off' if not bridge['stp'] else 'on'

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -18,6 +18,9 @@ class BridgeMixin:
     def add_member(self, name):
         run(["ip", "link", "set", name, "master", self.name])
 
+    def disable_learning(self, name):
+        run(["bridge", "link", "set", "dev", name, "learning", "off"])
+
     def delete_member(self, name):
         run(["ip", "link", "set", name, "nomaster"])
 

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -18,8 +18,8 @@ class BridgeMixin:
     def add_member(self, name):
         run(["ip", "link", "set", name, "master", self.name])
 
-    def disable_learning(self, name):
-        run(["bridge", "link", "set", "dev", name, "learning", "off"])
+    def set_learning(self, name, enable):
+        run(["bridge", "link", "set", "dev", name, "learning", "on" if enable else "off"])
 
     def delete_member(self, name):
         run(["ip", "link", "set", name, "nomaster"])

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -35,6 +35,7 @@ class NetworkBridgeModel(sa.Model):
     members = sa.Column(sa.JSON(list), default=[])
     interface_id = sa.Column(sa.ForeignKey('network_interfaces.id', ondelete='CASCADE'))
     stp = sa.Column(sa.Boolean())
+    enable_learning = sa.Column(sa.Boolean(), default=True)
 
 
 class NetworkInterfaceModel(sa.Model):


### PR DESCRIPTION
This commit fixes an issue where on certain hardware, the bridge interface takes some time to set up, causing a delay in network setup and disrupting other services when they attempt to use the network. To address this issue after syncing with Caleb we decided that we will disable learning of all bridge members allowing the bridge to become active without unnecessary delay