### PR TITLE
NAS-126741 / 24.04 / Fix catalog sync tests

### DIFF
--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -6,7 +6,7 @@ import time
 from middlewared.client.client import ClientException, ValidationErrors
 from middlewared.test.integration.assets.catalog import catalog
 from middlewared.test.integration.assets.pool import another_pool
-from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils import call, fail, ssh
 
 from auto_config import pool_name
 
@@ -46,8 +46,10 @@ def kubernetes_pool():
                         ['metadata.namespace', '=', 'kube-system']
                     ], {'select': ['metadata.name', 'status.phase']}
                 )
-                if len([pod for pod in kube_system_pods if pod['status']['phase'] == 'Running']) >= 3 or timeout <= 0:
+                if len([pod for pod in kube_system_pods if pod['status']['phase'] == 'Running']) >= 3:
                     break
+                elif timeout <= 0:
+                    fail('Time to setup kubernetes exceeded 150 seconds')
                 timeout -= 5
             try:
                 yield k3s_pool

--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import pytest
+import time
 
 from middlewared.client.client import ClientException, ValidationErrors
 from middlewared.test.integration.assets.catalog import catalog
@@ -37,10 +38,28 @@ def kubernetes_pool():
             'repository': 'https://github.com/truenas/charts.git',
             'branch': 'test'
         }):
+            timeout = 150
+            while True:
+                time.sleep(5)
+                kube_system_pods = call(
+                    'k8s.pod.query', [
+                        ['metadata.namespace', '=', 'kube-system']
+                    ], {'select': ['metadata.name', 'status.phase']}
+                )
+                if len([pod for pod in kube_system_pods if pod['status']['phase'] == 'Running']) >= 3 or timeout <= 0:
+                    break
+                timeout -= 5
             try:
                 yield k3s_pool
             finally:
                 call('kubernetes.update', {'pool': pool_name}, job=True)
+
+
+def test_create_new_catalog_with_configured_pool(kubernetes_pool):
+    assert ssh(
+        f'[ -d /mnt/{kubernetes_pool["name"]}/ix-applications/catalogs/github_com_truenas_charts_git_test ]'
+        f' && echo 0 || echo 1'
+    ).strip() == '0'
 
 
 def test_create_new_catalog_with_unconfigured_pool(kubernetes_pool):
@@ -56,17 +75,6 @@ def test_create_new_catalog_with_unconfigured_pool(kubernetes_pool):
                 pass
         assert ve.value.errors[0].errmsg == 'Catalogs cannot be added until apps pool is configured'
         assert ve.value.errors[0].attribute == 'catalog_create.label'
-
-
-def test_create_new_catalog_with_configured_pool():
-    with catalog({
-        'force': True,
-        'preferred_trains': ['tests'],
-        'label': TEST_CATALOG_NAME,
-        'repository': 'https://github.com/truenas/charts.git',
-        'branch': 'acl-tests'
-    }) as catalog_obj:
-        assert ssh(f'[ -d {catalog_obj["location"]} ] && echo 0 || echo 1').strip() == '0'
 
 
 def test_catalog_sync_with_unconfigured_pool(kubernetes_pool):


### PR DESCRIPTION
Tests in`test_catalog_sync.py` are failing because the k8s cluster starts unconfiguring before it is fully set up. Consequently, the cluster is unable to stop properly, leading to a timeout error.

In this PR we make changes to make sure the k8s cluster is fully set up before initiating the unconfiguration process. This ensures that the cluster stops properly when needed and subsequently the tests run in a neat/clean manner.