### PR TITLE
NAS-126788 / 24.04 / Fix VM device attributes schema

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/__init__.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/__init__.py
@@ -5,4 +5,11 @@ from .storage_devices import DISK, RAW
 from .display import DISPLAY
 from .usb import USB
 
-__all__ = ['CDROM', 'DISK', 'NIC', 'PCI', 'RAW', 'DISPLAY', 'USB']
+__all__ = ['CDROM', 'DEVICES', 'DISK', 'NIC', 'PCI', 'RAW', 'DISPLAY', 'USB']
+
+
+DEVICES = {
+    device_class.__name__: device_class for device_class in (
+        CDROM, DISK, NIC, PCI, RAW, DISPLAY, USB
+    )
+}

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -3,7 +3,7 @@ import subprocess
 
 from urllib.parse import urlencode, quote_plus
 
-from middlewared.schema import Bool, Dict, Int, Str, ValidationErrors
+from middlewared.schema import Bool, Dict, Int, Password, Str, ValidationErrors
 from middlewared.validators import Range
 
 from .device import Device
@@ -25,7 +25,7 @@ class DISPLAY(Device):
         Int('web_port', default=None, null=True, validators=[Range(min_=5900, max_=65535)]),
         Str('bind', default='127.0.0.1'),
         Bool('wait', default=False),
-        Str('password', private=True, required=True, null=False, empty=False),
+        Password('password', required=True, null=False, empty=False),
         Bool('web', default=True),
         Str('type', default='SPICE', enum=['SPICE']),
     )

--- a/src/middlewared/middlewared/plugins/vm/info.py
+++ b/src/middlewared/middlewared/plugins/vm/info.py
@@ -41,7 +41,7 @@ class VMService(Service, LibvirtConnectionMixin):
 
         return can_run_vms
 
-    @accepts(roles=['READONLY', 'VM_READ'])
+    @accepts(roles=['VM_READ'])
     @returns(Dict(
         Bool('supported', required=True),
         Str('error', null=True, required=True),
@@ -55,7 +55,7 @@ class VMService(Service, LibvirtConnectionMixin):
             'error': None if self._is_kvm_supported() else 'Your CPU does not support KVM extensions',
         }
 
-    @accepts(roles=['READONLY', 'VM_READ'])
+    @accepts(roles=['VM_READ'])
     @returns(Int())
     async def maximum_supported_vcpus(self):
         """

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -48,18 +48,8 @@ class VMService(Service):
         """
         return {r: r for r in DISPLAY.RESOLUTION_ENUM}
 
-    @accepts(Int('id'), roles=['READONLY', 'VM_READ'])
-    @returns(List(
-        'vmdevice', items=[
-        Dict(
-            'vmdevice',
-            Int('id'),
-            Str('dtype'),
-            DISPLAY.schema,
-            Int('order'),
-            Int('vm'),
-        ),
-    ]))
+    @accepts(Int('id'), roles=['VM_READ'])
+    @returns(List(items=[Ref('vm_device_entry')]))
     async def get_display_devices(self, id_):
         """
         Get the display devices from a given guest. If a display device has password configured,
@@ -78,7 +68,7 @@ class VMService(Service):
             'options',
             Str('protocol', default='HTTP', enum=['HTTP', 'HTTPS']),
         ),
-        roles=['READONLY', 'VM_READ']
+        roles=['VM_READ']
     )
     @returns(Dict(
         'display_devices_uri',

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -49,7 +49,17 @@ class VMService(Service):
         return {r: r for r in DISPLAY.RESOLUTION_ENUM}
 
     @accepts(Int('id'), roles=['VM_READ'])
-    @returns(List(items=[Ref('vm_device_entry')]))
+    @returns(List(
+        'vmdevice', items=[
+            Dict(
+                'vmdevice',
+                Int('id'),
+                Str('dtype'),
+                DISPLAY.schema,
+                Int('order'),
+                Int('vm'),
+            ),
+        ]))
     async def get_display_devices(self, id_):
         """
         Get the display devices from a given guest. If a display device has password configured,

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -59,7 +59,8 @@ class VMService(Service):
                 Int('order'),
                 Int('vm'),
             ),
-        ]))
+        ]
+    ))
     async def get_display_devices(self, id_):
         """
         Get the display devices from a given guest. If a display device has password configured,

--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -37,7 +37,7 @@ class VMService(Service):
 
         return memory_allocation
 
-    @accepts(Bool('overcommit', default=False), roles=['READONLY', 'VM_READ'])
+    @accepts(Bool('overcommit', default=False), roles=['VM_READ'])
     @returns(Int('available_memory'))
     async def get_available_memory(self, overcommit):
         """

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -107,7 +107,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             'status': status,
         }
 
-    @accepts(roles=['READONLY', 'VM_READ'])
+    @accepts(roles=['VM_READ'])
     @returns(Dict(
         *[Str(k, enum=[v]) for k, v in BOOT_LOADER_OPTIONS.items()],
     ))

--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -97,6 +97,32 @@ def idmap():
 
 
 @contextlib.contextmanager
+def vm_device():
+    with row(
+        "vm.vm",
+        {
+            "id": 5,
+            "name": "",
+            "memory": 225
+        }):
+        with row(
+            "vm.device",
+            {
+                "id": 7,
+                "dtype": "DISPLAY",
+                "vm": 5,
+                "attributes": {
+                    "bind": "127.0.0.1",
+                    "port": 1,
+                    "web_port": 1,
+                    "password": "pass",
+                }
+            }
+        ) as id:
+            yield id
+
+
+@contextlib.contextmanager
 def iscsi_auth():
     auth = call("iscsi.auth.create", {
         "tag": 1,
@@ -140,6 +166,7 @@ def vmware():
     ("keychaincredential", keychaincredential, {}, ["attributes"]),
     ("user", 1, {}, ["unixhash", "smbhash"]),
     ("vmware", vmware, {}, ["password"]),
+    ("vm.device", vm_device, {}, ["attributes.password"]),
 ))
 def test_crud(readonly_client, how, service, id, options, redacted_fields):
     identifier = "id" if service != "disk" else "identifier"

--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -219,18 +219,6 @@ def test_fields_are_visible_for_api_key():
 
 
 def test_vm_display_device(readonly_client):
-    with mock("vm.device.query", return_value=[
-        {
-            "id": 1,
-            "dtype": "DISPLAY",
-            "vm": 1,
-            "attributes": {
-                "bind": "127.0.0.1",
-                "port": 1,
-                "web_port": 1,
-                "password": "pass",
-            }
-        }
-    ]):
-        result = readonly_client.call("vm.get_display_devices", 1)
+    with vm_device():
+        result = readonly_client.call("vm.get_display_devices", 5)
         assert result[0]["attributes"]["password"] == REDACTED


### PR DESCRIPTION
### Problem

VM device attributes are generic so `private=True` was not working as desired for VM display devices' password making it visible in plain text for READONLY role.

### Fix

PR fixes the problem by using OROperator for dynamic inclusion of VM device attributes.