### PR TITLE
NAS-126802 / 24.04 / Fix app available schema

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/apps.py
@@ -44,7 +44,7 @@ class AppService(Service):
         Str('latest_version', required=True),
         Str('latest_app_version', required=True),
         Str('latest_human_version', required=True),
-        Str('icon_url', required=True),
+        Str('icon_url', null=True, required=True),
         Str('train', required=True),
         Str('catalog', required=True),
         register=True


### PR DESCRIPTION
## Problem

We have failing integration tests for app based roles because when using a non admin ROLE values are dumped through return schema and if it is invalid - an exception is raised.

## Solution

Make sure schema is properly reflected so that `app.available` based integration tests work as desired and a user consuming it through appropriate ROLE has no issue either.