### PR TITLE
NAS-126813 / 24.04 / Fix regressions in CI tests

### DIFF
--- a/tests/api2/test_account_privilege.py
+++ b/tests/api2/test_account_privilege.py
@@ -75,7 +75,7 @@ def privilege_with_orphan_local_group():
         })
         call("datastore.delete", "account.bsdgroups", g["id"])
         call("etc.generate", "user")
-        call("idmap.flush_gencache")
+        call("idmap.gencache.flush")
 
     yield types.SimpleNamespace(gid=gid, privilege=privilege)
 

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -183,5 +183,5 @@ def test_can_not_subscribe_to_event():
 
 
 def test_can_subscribe_to_event():
-    with unprivileged_user_client(["READONLY"]) as unprivileged:
+    with unprivileged_user_client(["READONLY_ADMIN"]) as unprivileged:
         unprivileged.subscribe("alert.list", lambda *args, **kwargs: None)


### PR DESCRIPTION
This commit fixes two account-related regressions in CI tests
* idmap.flush_gencache is now idmap.gencache.flush
* READONLY role was renamed