### PR TITLE
NAS-126782 / 13.1 / PoolScrubService.__run: reduce memory usage during zpool history (by rkojedzinszky)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 GELI_KEYPATH = '/data/geli'
 
-RE_HISTORY_ZPOOL_SCRUB = re.compile(r'^([0-9\.\:\-]{19})\s+zpool scrub', re.MULTILINE)
+RE_HISTORY_ZPOOL_SCRUB_CREATE = re.compile(r'^([0-9\.\:\-]{19})\s+zpool (scrub|create)', re.MULTILINE)
 ZFS_CHECKSUM_CHOICES = [
     'ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN',
 ]
@@ -4304,18 +4304,13 @@ class PoolScrubService(CRUDService):
         if pool['scan']['state'] == 'SCANNING':
             return False
 
-        last_scrubs = (await run('sh', '-c', f'zpool history {shlex.quote(name)} | grep "zpool scrub"', encoding='utf-8')).stdout
-        for match in reversed(list(RE_HISTORY_ZPOOL_SCRUB.finditer(last_scrubs))):
+        last_scrubs = (await run('sh', '-c', f'zpool history {shlex.quote(name)} | grep -E "zpool (scrub|create)"', encoding='utf-8')).stdout
+        for match in reversed(list(RE_HISTORY_ZPOOL_SCRUB_CREATE.finditer(last_scrubs))):
             last_scrub = datetime.strptime(match.group(1), '%Y-%m-%d.%H:%M:%S')
             break
         else:
-            # creation time of the pool if no scrub was done
-            creation = (await run('zfs', 'get', '-Hpo', 'value', 'creation', name, encoding='utf-8')).stdout
-            try:
-                last_scrub = datetime.fromtimestamp(int(creation))
-            except ValueError:
-                logger.warning("Could not find last scrub of pool %r", name)
-                last_scrub = datetime.min
+            logger.warning("Could not find last scrub of pool %r", name)
+            last_scrub = datetime.min
 
         if (datetime.now() - last_scrub).total_seconds() < (threshold - 1) * 86400:
             logger.debug("Pool %r last scrub %r", name, last_scrub)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -12,6 +12,7 @@ import os
 import psutil
 import re
 import secrets
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -43,7 +44,6 @@ logger = logging.getLogger(__name__)
 GELI_KEYPATH = '/data/geli'
 
 RE_HISTORY_ZPOOL_SCRUB = re.compile(r'^([0-9\.\:\-]{19})\s+zpool scrub', re.MULTILINE)
-RE_HISTORY_ZPOOL_CREATE = re.compile(r'^([0-9\.\:\-]{19})\s+zpool create', re.MULTILINE)
 ZFS_CHECKSUM_CHOICES = [
     'ON', 'OFF', 'FLETCHER2', 'FLETCHER4', 'SHA256', 'SHA512', 'SKEIN',
 ]
@@ -4304,16 +4304,16 @@ class PoolScrubService(CRUDService):
         if pool['scan']['state'] == 'SCANNING':
             return False
 
-        history = (await run('zpool', 'history', name, encoding='utf-8')).stdout
-        for match in reversed(list(RE_HISTORY_ZPOOL_SCRUB.finditer(history))):
+        last_scrubs = (await run('sh', '-c', f'zpool history {shlex.quote(name)} | grep "zpool scrub"', encoding='utf-8')).stdout
+        for match in reversed(list(RE_HISTORY_ZPOOL_SCRUB.finditer(last_scrubs))):
             last_scrub = datetime.strptime(match.group(1), '%Y-%m-%d.%H:%M:%S')
             break
         else:
             # creation time of the pool if no scrub was done
-            for match in RE_HISTORY_ZPOOL_CREATE.finditer(history):
-                last_scrub = datetime.strptime(match.group(1), '%Y-%m-%d.%H:%M:%S')
-                break
-            else:
+            creation = (await run('zfs', 'get', '-Hpo', 'value', 'creation', name, encoding='utf-8')).stdout
+            try:
+                last_scrub = datetime.fromtimestamp(int(creation))
+            except ValueError:
                 logger.warning("Could not find last scrub of pool %r", name)
                 last_scrub = datetime.min
 


### PR DESCRIPTION
This fixes memory fragmentation issues in python process, as it would allocate a big chunk of memory. This amount of memory is rarely allocated, and over time, the previously allocated block might get fragmented again.

Original PR: https://github.com/truenas/middleware/pull/12889
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126782