### PR TITLE
NAS-126823 / 23.10.2 / Fix cluster_mode_targets (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -597,7 +597,7 @@ class iSCSITargetService(CRUDService):
         Returns a list of target names that are currently in cluster_mode on this controller.
         """
         targets = await self.middleware.call('iscsi.target.query')
-        extents = await self.middleware.call('iscsi.extent.query', [['enabled', '=', True]])
+        extents = {extent['id']: extent for extent in await self.middleware.call('iscsi.extent.query', [['enabled', '=', True]])}
         assoc = await self.middleware.call('iscsi.targetextent.query')
 
         # Generate a dict, keyed by target ID whose value is a set of associated extent names


### PR DESCRIPTION
Logic (data struct type error) introduced when some code was replicated here.  `extents` needs to be a dict keyed by extent id in order for the loop that generates `target_extents` to work properly.  Currently it was yielding the empty set which is **always** a subset of `cl_extents`.

Original PR: https://github.com/truenas/middleware/pull/12909
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126823