### PR TITLE
NAS-126825 / 24.04 / Fix regressions caused by SID handling refactor

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -244,7 +244,7 @@ class PrivilegeService(CRUDService):
         """
         result = []
 
-        if (sids_to_check := [entry for entry in ds_groups if wbclient.sid_is_valid(entry)]):
+        if (sids_to_check := [entry for entry in ds_groups if wbclient.sid_is_valid(str(entry))]):
             try:
                 mapped_sids = (await self.middleware.call('idmap.convert_sids', sids_to_check))['mapped']
             except Exception:

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1060,7 +1060,7 @@ class IdmapDomainService(CRUDService):
             }
 
         gid = int(sid[len(SID_LOCAL_GROUP_PREFIX):])
-        g = self.middleware.call('group.get_group_obj', {'gid': gid})
+        g = self.middleware.call_sync('group.get_group_obj', {'gid': gid})
         return {
             'name': f'Unix Group{separator}{g["gr_name"]}',
             'id': gid,


### PR DESCRIPTION
When LDAP users are presented for directory services privileges the sysadmin may specify a GID rather than SID for identifying the group in question. Convert to string before having libwbclient check whether it's a SID to prevent TypeError.

Fix instance where middleware.call is used instead of middleware.call_sync.