### PR TITLE
NAS-126859 / 24.04-RC.1 / fix typo in log message (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -365,7 +365,7 @@ class FailoverEventsService(Service):
             #   TODO: Not sure how keepalived and laggs operate so need to test this
             #           (maybe the event only gets triggered if the lagg goes down)
             #
-            status = self.run_call(
+            _, backups = self.run_call(
                 'failover.vip.check_failover_group', ifname, fobj['groups']
             )
 
@@ -373,11 +373,11 @@ class FailoverEventsService(Service):
             # in a failover group. And in that failover group, there were other
             # interfaces that were still in the BACKUP state which means the
             # other node has them as MASTER so ignore the event.
-            if len(status[1]):
+            if backups:
                 logger.warning(
                     'Received MASTER event for "%s", but other '
-                    'interfaces "%r" are still working on the '
-                    'MASTER node. Ignoring event.', ifname, status[0],
+                    'interfaces %s are still working on the '
+                    'MASTER node. Ignoring event.', ifname, ', '.join(backups),
                 )
 
                 job.set_progress(None, description='IGNORED')


### PR DESCRIPTION
Noticed on a customer's system running Cobia.
```
[2024/01/17 13:18:48] (WARNING) failover.vrrp_master():372 - Received MASTER event for "enp193s0f0np0", but other interfaces "[]" are still working on the MASTER node. Ignoring event.
```

Original PR: https://github.com/truenas/middleware/pull/12919
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126859