### PR TITLE
NAS-126871 / 24.10 / Fix variable not declared usage

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -568,7 +568,7 @@ class SystemDatasetService(ConfigService):
         error = f'Unable to umount {mp}: {stderr}'
         if 'target is busy' in stderr:
             processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [mp], True)
-            error += f'\nThe following processes are using {mountpoint!r}: ' + json.dumps(processes, indent=2)
+            error += f'\nThe following processes are using {mp!r}: ' + json.dumps(processes, indent=2)
 
         raise CallError(error) from None
 


### PR DESCRIPTION
## Context

`mountpoint` variable was not declared and was being used, so changes have been made to correctly use the relevant variable pointing to the mountpoint.