### PR TITLE
NAS-126875 / 23.10.2 / Fail earlier in directoryservices.setup (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -521,6 +521,16 @@ class DirectoryServices(Service):
             wait_id = self.middleware.call_sync('core.job_wait', config_in_progress[0]['id'])
             wait_id.wait_sync()
 
+        if not self.middleware.call_sync('smb.is_configured'):
+            raise CallError('Skipping directory service setup due to SMB service being unconfigured')
+
+
+        failover_status = self.middleware.call_sync('failover.status')
+        if failover_status not in ('SINGLE', 'MASTER'):
+            self.logger.debug('%s: skipping directory service setup due to failover status', failover_status)
+            job.set_progress(100, f'{failover_status}: skipping directory service setup due to failover status')
+            return
+
         ldap_enabled = self.middleware.call_sync('ldap.config')['enable']
         ad_enabled = self.middleware.call_sync('activedirectory.config')['enable']
         if not ldap_enabled and not ad_enabled:


### PR DESCRIPTION
We don't want to run though this method if controller is not MASTER. Additionally, we should fail early if SMB has not been properly configured (otherwise we will failure with unrelated errors later in this method).

Original PR: https://github.com/truenas/middleware/pull/12930
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126875