### PR TITLE
NAS-126878 / 24.10 / Forcibly disable AD service if misconfigured

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -857,6 +857,20 @@ class ActiveDirectoryService(ConfigService):
             await self.set_idmap(ad['allow_trusted_doms'], ad['domainname'])
             await self.middleware.call('activedirectory.set_ntp_servers')
             ret = neterr.JOINED
+        elif ret == neterr.JOINED:
+            if not ad['kerberos_principal']:
+                await self.middleware.call(
+                    'datastore.update', self._config.datastore, ad['id'],
+                    {'enable': False},
+                    {'prefix': 'ad_'}
+                )
+                self.logger.warning('Disabling active directory service due to missing kerberos principal.')
+                await self.set_state(DSStatus['DISABLED'].name)
+                raise CallError(
+                    'TrueNAS server is joined to activedirectory (possibly through '
+                    'commands issued outside of public APIs) while lacking a configured kerberos '
+                    'principal, which is required maintain a stable domain connection. Disabling service.'
+                )
 
         await self.middleware.call('idmap.synchronize')
         await self.middleware.call('service.reload', 'idmap')


### PR DESCRIPTION
There are apparent cases of users manually calling the private `activedirectory.start` API via midclt whilst having an incomplete active directory configuration. This may allow winbindd to start and some AD integration to work, but at the cost of having service potentially get disabled during future health checks. This commit adds some rudimentary detection of this situation and will refuse to start the activedirectory service if we're misconfigured. This commit is for backport to Cobia. More recent versions will have more robust fixes.