### PR TITLE
NAS-126722 / 23.10.2 / handle iface fault events on SCALE HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/vrrp_events.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events.py
@@ -74,8 +74,12 @@ class VrrpEventThread(Thread):
             LOGGER.error('Failed parsing vrrp message', exc_info=True)
             return
         else:
-            if event not in ('MASTER', 'BACKUP'):
+            if event not in ('MASTER', 'BACKUP', 'FAULT'):
                 return
+
+            if event == 'FAULT':
+                # when a FAULT message is sent when iface goes down
+                event = 'BACKUP'
 
         return {'ifname': ifname, 'event': event, 'time': msg['time']}
 


### PR DESCRIPTION
On SCALE HA systems, our support team often administratively down interfaces during a support session. When this happens, HA isn't completing and fails (by design). The reason why this fails is because of the following:
1. on A node, run `ip link set <iface> down`
2. on A node _NO_ event is generated via the vrrp daemon
3. `fenced` continues to run on A node
4. at same time, VIP floats to B node and receives a MASTER event
5. B node begins to takeover as MASTER and starts `fenced`
6. `fenced` fails on B node because the A node's `fenced` daemon is still running

The failover _failure_ condition is understood and by design (i.e. we fail "safely" because we detected the reservation keys on the disk weren't owned by us and they changed).

The failover _not completing_ is unexpected and is resolved in this PR. When an interface is down'ed, a `FAULT` message will be generated. In this instance, we'll treat a `FAULT` event as a `BACKUP` event and send it down the pipe.

Original PR: https://github.com/truenas/middleware/pull/12880
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126722