### PR TITLE
NAS-126842 / 24.10 / Fix UPS reporting plugin

### DIFF
--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -1,4 +1,4 @@
-. /usr/lib/netdata/charts.d/nut.chart.sh
+source /usr/lib/netdata/charts.d/nut.chart.sh
 
 nut_get_all() {
   run -t $nut_timeout upsc -l || echo "ix-dummy-ups"
@@ -54,5 +54,5 @@ nut_ups_update() {
   # remember: KEEP IT SIMPLE AND SHORT
   nut_ups_check
   nut_ups_create
-  nut_update
+  nut_update $@
 }

--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -1,7 +1,7 @@
 . /usr/lib/netdata/charts.d/nut.chart.sh
 
 nut_get_all() {
-  run -t $nut_timeout upsc -l || echo "dummy-ups"
+  run -t $nut_timeout upsc -l || echo "ix-dummy-ups"
 }
 
 nut_ups_check() {

--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -1,0 +1,58 @@
+. /usr/lib/netdata/charts.d/nut.chart.sh
+
+nut_get_all() {
+  run -t $nut_timeout upsc -l || echo "dummy-ups"
+}
+
+nut_ups_check() {
+
+  # this should return:
+  #  - 0 to enable the chart
+  #  - 1 to disable the chart
+
+  local x
+
+  require_cmd upsc || return 1
+
+  nut_ups="$(nut_get_all)"
+  nut_names=()
+  nut_ids=()
+  for x in $nut_ups; do
+    nut_get "$x" > /dev/null
+    # shellcheck disable=SC2181
+    if [ $? -eq 0 ]; then
+      if [ -n "${nut_names[${x}]}" ]; then
+        nut_ids[$x]="$(fixid "${nut_names[${x}]}")"
+      else
+        nut_ids[$x]="$(fixid "$x")"
+      fi
+      continue
+    fi
+    error "cannot get information for NUT UPS '$x'."
+  done
+
+  if [ ${#nut_ids[@]} -eq 0 ]; then
+    # shellcheck disable=SC2154
+    error "Cannot find UPSes - please set nut_ups='ups_name' in $confd/nut.conf"
+    return 1
+  fi
+
+  return 0
+}
+
+nut_ups_create() {
+  # create the charts
+  nut_create
+}
+
+nut_ups_update() {
+  # the first argument to this function is the microseconds since last update
+  # pass this parameter to the BEGIN statement (see below).
+
+  # do all the work to collect / calculate the values
+  # for each dimension
+  # remember: KEEP IT SIMPLE AND SHORT
+  nut_ups_check
+  nut_ups_create
+  nut_update
+}

--- a/src/freenas/usr/lib/netdata/conf.d/charts.d.conf
+++ b/src/freenas/usr/lib/netdata/conf.d/charts.d.conf
@@ -1,2 +1,2 @@
 enable_all_charts=no
-nut=yes
+nut_ups=yes

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graph_base.py
@@ -15,7 +15,7 @@ class GraphMeta(type):
         reg = RE_GRAPH_PLUGIN.search(name)
         if reg and not hasattr(klass, 'plugin'):
             klass.plugin = reg.group('name').lower()
-        elif name != 'GraphBase' and not hasattr(klass, 'plugin'):
+        elif not name.endswith('Base') and not hasattr(klass, 'plugin'):
             raise ValueError(f'Could not determine plugin name for {name!r}')
 
         if reg and not hasattr(klass, 'name'):
@@ -23,7 +23,7 @@ class GraphMeta(type):
             GRAPH_PLUGINS[klass.name] = klass
         elif hasattr(klass, 'name'):
             GRAPH_PLUGINS[klass.name] = klass
-        elif name != 'GraphBase':
+        elif not name.endswith('Base'):
             raise ValueError(f'Could not determine class name for {name!r}')
         return klass
 

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -265,25 +265,40 @@ class DiskTempPlugin(GraphBase):
         return f'smart_log_smart.disktemp.{self.disk_mapping[identifier]}'
 
 
-class UPSChargePlugin(GraphBase):
+class UPSBase(GraphBase):
+
+    UPS_IDENTIFIER = None
+
+    async def export_multiple_identifiers(
+        self, query_params: dict, identifiers: list, aggregate: bool = True
+    ) -> typing.List[dict]:
+        self.UPS_IDENTIFIER = (await self.middleware.call('ups.config'))['identifier']
+        if await self.middleware.call('service.started', 'ups'):
+            return await super().export_multiple_identifiers(query_params, identifiers, aggregate)
+        return []
+
+
+class UPSChargePlugin(UPSBase):
 
     title = 'UPS Charging'
     vertical_label = 'Percentage'
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.charge'
+        return f'nut_{self.UPS_IDENTIFIER}.charge'
 
 
-class UPSRuntimePlugin(GraphBase):
+class UPSRuntimePlugin(UPSBase):
 
     title = 'UPS Runtime'
     vertical_label = 'Seconds'
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.runtime'
+        return f'nut_{self.UPS_IDENTIFIER}.runtime'
 
 
-class UPSVoltagePlugin(GraphBase):
+class UPSVoltagePlugin(UPSBase):
 
     title = 'UPS Voltage'
     vertical_label = 'Volts'
@@ -298,41 +313,45 @@ class UPSVoltagePlugin(GraphBase):
         return list(self.IDENTIFIER_MAPPING.keys())
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return f'nut_ups.{self.IDENTIFIER_MAPPING[identifier]}'
+        return f'nut_{self.UPS_IDENTIFIER}.{self.IDENTIFIER_MAPPING[identifier]}'
 
 
-class UPSCurrentPlugin(GraphBase):
+class UPSCurrentPlugin(UPSBase):
 
     title = 'UPS Input Current'
     vertical_label = 'Ampere'
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.input_current'
+        return f'nut_{self.UPS_IDENTIFIER}.input_current'
 
 
-class UPSFrequencyPlugin(GraphBase):
+class UPSFrequencyPlugin(UPSBase):
 
     title = 'UPS Input Frequency'
     vertical_label = 'Hz'
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.input_frequency'
+        return f'nut_{self.UPS_IDENTIFIER}.input_frequency'
 
 
-class UPSLoadPlugin(GraphBase):
+class UPSLoadPlugin(UPSBase):
 
     title = 'UPS Input Load'
     vertical_label = 'Percentage'
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.load'
+        return f'nut_{self.UPS_IDENTIFIER}.load'
 
 
-class UPSTemperaturePlugin(GraphBase):
+class UPSTemperaturePlugin(UPSBase):
 
     title = 'UPS Temperature'
     vertical_label = 'Temperature'
     skip_zero_values_in_aggregation = True
+    uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'nut_ups.temp'
+        return f'nut_{self.UPS_IDENTIFIER}.temp'

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -273,9 +273,7 @@ class UPSBase(GraphBase):
         self, query_params: dict, identifiers: list, aggregate: bool = True
     ) -> typing.List[dict]:
         self.UPS_IDENTIFIER = (await self.middleware.call('ups.config'))['identifier']
-        if await self.middleware.call('service.started', 'ups'):
-            return await super().export_multiple_identifiers(query_params, identifiers, aggregate)
-        return []
+        return await super().export_multiple_identifiers(query_params, identifiers, aggregate)
 
 
 class UPSChargePlugin(UPSBase):


### PR DESCRIPTION
# Problem
If the UPS service is stopped, Netdata will not start the UPS plugin. Even if the UPS service is restarted, Netdata won't start the plugin until Netdata itself is restarted. Additionally, there are bugs related to UPS identifiers, which can change and affect chart names.

# Solution

Modify the Netdata UPS plugin to send default data if the UPS service is not running. This ensures that Netdata continues to send default stats even when the UPS service is stopped - we handle this gracefully when user tries to retrieve UPS stats when no UPS is running by making sure we are not sharing the default stats. When the UPS service is started, Netdata will begin sending the actual UPS stats. Properly obtain UPS identifiers for use in graphs to ensure the correctness of UPS plugin chart names.