### PR TITLE
NAS-126829 / 24.10 / Improve invalid AD config alert verbosity

### DIFF
--- a/src/middlewared/middlewared/alert/source/active_directory.py
+++ b/src/middlewared/middlewared/alert/source/active_directory.py
@@ -12,7 +12,7 @@ class ActiveDirectoryDomainBindAlertClass(AlertClass):
     category = AlertCategory.DIRECTORY_SERVICE
     level = AlertLevel.WARNING
     title = "Active Directory Bind Is Not Healthy"
-    text = "Attempt to connect to netlogon share failed with error: %(wberr)s."
+    text = "Attempt to connect to domain controller failed: %(wberr)s."
 
 
 class ActiveDirectoryDomainHealthAlertClass(AlertClass):
@@ -57,11 +57,26 @@ class ActiveDirectoryDomainBindAlertSource(AlertSource):
     run_on_backup_node = False
 
     async def check(self):
-        if (await self.middleware.call('activedirectory.get_state')) == 'DISABLED':
+        if not (await self.middleware.call('activedirectory.config'))['enable']:
             return
 
         try:
             await self.middleware.call("activedirectory.started")
+        except CallError as e:
+            if e.errno == errno.EINVAL:
+                new_status = DSStatus.DISABLED
+                # ValidationErrors text is crammed into e.extra
+                errmsg = f'Configuration validation failed: {e.extra}'
+            else:
+                new_status = DSStatus.FAULTED
+                errmsg = str(e.errmsg)
+
+            await self.middleware.call("activedirectory.set_state", new_status.name)
+            return Alert(
+                ActiveDirectoryDomainBindAlertClass,
+                {'wberr': errmsg},
+                key=None
+            )
         except Exception as e:
             await self.middleware.call("activedirectory.set_state", DSStatus['FAULTED'].name)
             return Alert(

--- a/src/middlewared/middlewared/plugins/activedirectory_/health.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/health.py
@@ -16,6 +16,7 @@ class ActiveDirectoryService(Service):
 
     class Config:
         service = "activedirectory"
+        datastore = "directoryservice.activedirectory"
 
     @private
     def winbind_status(self, check_trust=False):
@@ -173,13 +174,13 @@ class ActiveDirectoryService(Service):
 
         try:
             verrors.check()
-        except ValidationErrors:
+        except ValidationErrors as ve:
             await self.middleware.call(
-                'datstore.update', self._config.datastore, config['id'],
+                'datastore.update', self._config.datastore, config['id'],
                 {"enable": False}, {'prefix': 'ad_'}
             )
-            raise CallError('Automatically disabling ActiveDirectory service due to invalid configuration.',
-                            errno.EINVAL)
+            raise CallError('Automatically disabling ActiveDirectory service due to invalid configuration',
+                            errno.EINVAL, ', '.join([err[1] for err in ve]))
 
         """
         Verify winbindd netlogon connection.


### PR DESCRIPTION
Include text of ValidationErrors in alert so that it's easier for users and support team to diagnose problems.