### PR TITLE
NAS-126860 / 24.04-RC.1 / Fix `NOT NULL constraint failed: network_lagginterfacemembers.lagg_or… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/lag.py
+++ b/src/middlewared/middlewared/plugins/interface/lag.py
@@ -34,7 +34,7 @@ class InterfaceService(Service):
             info['protocol'] = protocol
 
         if protocol.name == 'FAILOVER':
-            db_primary = [i['lagg_physnic'] for i in members if i['lagg_ordernum'] == 0][0]
+            db_primary = [i['lagg_physnic'] for i in members][0]
             curr_primary = iface.primary_interface
             if curr_primary != db_primary:
                 info['primary_interface'] = db_primary

--- a/src/middlewared/middlewared/plugins/interface/link_address.py
+++ b/src/middlewared/middlewared/plugins/interface/link_address.py
@@ -41,14 +41,15 @@ class InterfaceService(Service):
 
             for real_interface in real_interfaces:
                 name = real_interfaces.get_name(real_interface)
-                await self.__handle_interface(db_interfaces, name, local_key, real_interface["state"]["link_address"])
+                await self.__handle_interface(db_interfaces, name, local_key,
+                                              real_interface["state"]["hardware_link_address"])
                 if real_interfaces_remote is not None:
                     real_interface_remote = real_interfaces_remote.by_name.get(name)
                     if real_interface_remote is None:
                         self.middleware.logger.warning(f"Interface {name!r} is only present on the local system")
                     else:
                         await self.__handle_interface(db_interfaces, name, remote_key,
-                                                      real_interface_remote["state"]["link_address"])
+                                                      real_interface_remote["state"]["hardware_link_address"])
         except Exception:
             self.middleware.logger.error("Unhandled exception while persisting network interfaces link addresses",
                                          exc_info=True)
@@ -97,7 +98,7 @@ class DatabaseInterfaceCollection(InterfaceCollection):
 class RealInterfaceCollection(InterfaceCollection):
     @property
     def by_link_address(self):
-        return {i["state"]["link_address"]: i for i in self.interfaces}
+        return {i["state"]["hardware_link_address"]: i for i in self.interfaces}
 
     def get_name(self, i):
         return i["name"]

--- a/src/middlewared/middlewared/plugins/interface/link_address.py
+++ b/src/middlewared/middlewared/plugins/interface/link_address.py
@@ -187,11 +187,12 @@ class InterfaceRenamer:
                 await self.middleware.call(
                     "datastore.delete", "network.lagginterfacemembers", lagg_member["id"],
                 )
-            for lagg_member in lagg_members:
+            for order, lagg_member in enumerate(lagg_members):
                 if "delete" not in lagg_member:
                     await self.middleware.call("datastore.insert", "network.lagginterfacemembers", {
                         "interfacegroup": lagg_member["interfacegroup"]["id"],
                         "physnic": lagg_member["physnic"],
+                        "ordernum": order,
                     }, {"prefix": "lagg_"})
 
 

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/interface.py
@@ -12,7 +12,7 @@ from .ethernet_settings import EthernetHardwareSettings
 __all__ = ["Interface", "CLONED_PREFIXES"]
 
 # Keep this as an immutable type since this
-# is used all over the place and we don't want
+# is used all over the place, and we don't want
 # the contents to change
 CLONED_PREFIXES = ("br", "vlan", "bond")
 
@@ -25,6 +25,7 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         self._nd6_flags = dev.get_attr('IFLA_AF_SPEC').get_attr('AF_INET6').get_attr('IFLA_INET6_FLAGS') or 0
         self._link_state = f'LINK_STATE_{dev.get_attr("IFLA_OPERSTATE")}'
         self._link_address = dev.get_attr('IFLA_ADDRESS')
+        self._permanent_link_address = dev.get_attr('IFLA_PERM_ADDRESS')
         self._cloned = any((
             (self.name.startswith(CLONED_PREFIXES)),
             (self.name.startswith(INTERNAL_INTERFACES))
@@ -95,6 +96,10 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
         return self._link_address
 
     @property
+    def permanent_link_address(self):
+        return self._permanent_link_address
+
+    @property
     def rx_queues(self):
         return self._rxq
 
@@ -120,6 +125,8 @@ class Interface(AddressMixin, BridgeMixin, LaggMixin, VlanMixin, VrrpMixin):
             'supported_media': [],
             'media_options': None,
             'link_address': self.link_address or '',
+            'permanent_link_address': self.permanent_link_address,
+            'hardware_link_address': self.permanent_link_address or self.link_address or '',
             'aliases': [i.asdict(stats=address_stats) for i in self.addresses],
             'vrrp_config': vrrp_config,
             'rx_queues': self.rx_queues,

--- a/src/middlewared/middlewared/plugins/interface/netif_linux/vrrp.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/vrrp.py
@@ -4,9 +4,6 @@ __all__ = ['VrrpMixin']
 
 class VrrpMixin:
 
-    def __init__(self):
-        self.data = None
-
     @property
     def vrrp_config(self):
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -132,6 +132,8 @@ class InterfaceService(CRUDService):
             List('supported_media', required=True),
             List('media_options', required=True, null=True),
             Str('link_address', required=True),
+            Str('permanent_link_address', required=True, null=True),
+            Str('hardware_link_address', required=True),
             Int('rx_queues', required=True),
             Int('tx_queues', required=True),
             List('aliases', required=True, items=[Dict(
@@ -225,6 +227,8 @@ class InterfaceService(CRUDService):
                 'description': config['int_name'],
                 'aliases': [],
                 'link_address': '',
+                'permanent_link_address': None,
+                'hardware_link_address': '',
                 'cloned': True,
                 'mtu': 1500,
                 'flags': [],
@@ -1264,10 +1268,10 @@ class InterfaceService(CRUDService):
                     )
 
             if iface['type'] == 'PHYSICAL':
-                link_address_update = {'link_address': iface['state']['link_address']}
+                link_address_update = {'link_address': iface['state']['hardware_link_address']}
                 if await self.middleware.call('system.is_enterprise_ix_hardware'):
                     if await self.middleware.call('failover.node') == 'B':
-                        link_address_update = {'link_address_b': iface['state']['link_address']}
+                        link_address_update = {'link_address_b': iface['state']['hardware_link_address']}
                 link_address_row = await self.middleware.call(
                     'datastore.query', 'network.interface_link_address', [['interface', '=', new['name']]],
                 )

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_interface_link_address.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_interface_link_address.py
@@ -196,7 +196,7 @@ async def test__interface_link_address_setup(before, after):
             {
                 "name": name,
                 "state": {
-                    "link_address": link_address,
+                    "hardware_link_address": link_address,
                 }
             }
             for name, link_address in (


### PR DESCRIPTION
Two issues are being fixed here:
* `ordernum` field missing from the DB update request when upgrading Link Aggregation interface members if any of them is renamed in the kernel. That leads to removing all the members of one Link Aggregation interface on first boot after the upgrade.
* Effective interface link address being used to match real and database network interfaces on boot (interface names can change, for example, on TrueNAS kernel upgrade). If Link Aggregation is configured on interfaces then their effective link addresses will be changed to the one of the Link Aggregation and we will have duplicate entries in the database, yielding incorrect interface matching results. Instead, persistent interface link address should be used for this purpose.


Original PR: https://github.com/truenas/middleware/pull/12948
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126860