### PR TITLE
NAS-126940 / 24.10 / Undo some breakage wrt iscsi incremental tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/iscsi.py
+++ b/src/middlewared/middlewared/test/integration/assets/iscsi.py
@@ -1,6 +1,15 @@
 import contextlib
+import json
+import platform
+import time
 
 from middlewared.test.integration.utils import call, run_on_runner, RunOnRunnerException
+
+# We could be running these tests on a Linux or FreeBSD test-runner, so the commands
+# used by a client can be different depending on the platform of the test runner
+# (i.e. NOT related to CORE vs SCALE).
+SYSTEM = platform.system().upper()
+IS_LINUX = SYSTEM == "LINUX"
 
 
 @contextlib.contextmanager
@@ -64,10 +73,13 @@ def iscsi_target(data):
 
 
 def target_login_test(portal_ip, target_name):
-    return target_login_test_generic(portal_ip, target_name)
+    if IS_LINUX:
+        return target_login_test_linux(portal_ip, target_name)
+    else:
+        return target_login_test_freebsd(portal_ip, target_name)
 
 
-def target_login_test_generic(portal_ip, target_name):
+def target_login_test_linux(portal_ip, target_name):
     try:
         run_on_runner(['iscsiadm', '-m', 'discovery', '-t', 'sendtargets', '--portal', portal_ip])
         run_on_runner(['iscsiadm', '-m', 'node', '--targetname', target_name, '--portal', portal_ip, '--login'])
@@ -76,3 +88,48 @@ def target_login_test_generic(portal_ip, target_name):
     else:
         run_on_runner(['iscsiadm', '-m', 'node', '--targetname', target_name, '--portal', portal_ip, '--logout'])
         return True
+
+
+@contextlib.contextmanager
+def iscsi_client_freebsd():
+    started = run_on_runner(['service', 'iscsid', 'onestatus'], check=False).returncode == 0
+    if started:
+        yield
+    else:
+        run_on_runner(['service', 'iscsid', 'onestart'])
+        try:
+            yield
+        finally:
+            run_on_runner(['service', 'iscsid', 'onestop'])
+
+
+def target_login_impl_freebsd(portal_ip, target_name):
+    run_on_runner(['iscsictl', '-A', '-p', portal_ip, '-t', target_name], check=False)
+    retries = 5
+    connected = False
+    connected_clients = None
+    # Unfortunately iscsictl can take some time to show the client as actually connected so adding a few retries here
+    # to handle that case
+    while retries > 0 and not connected:
+        time.sleep(3)
+        cp = run_on_runner(['iscsictl', '-L', '--libxo', 'json'])
+        connected_clients = json.loads(cp.stdout)
+        connected = any(
+            session.get('state') == 'Connected' for session in connected_clients.get('iscsictl', {}).get('session', [])
+            if session.get('name') == target_name
+        )
+        retries -= 1
+
+    assert connected is True, connected_clients
+
+
+def target_login_test_freebsd(portal_ip, target_name):
+    with iscsi_client_freebsd():
+        try:
+            target_login_impl_freebsd(portal_ip, target_name)
+        except AssertionError:
+            return False
+        else:
+            return True
+        finally:
+            run_on_runner(['iscsictl', '-R', '-t', target_name], check=False)


### PR DESCRIPTION
A recent PR (#12927) was over-zealous in removing some code, which meant that some iSCSI tests were broken.  Restore the code (with minor tweaks to account for the code elsewhere **not** being restored).
