### PR TITLE
NAS-125859 / 24.10 / Allow multiple NVIDIA gpus to be shared to a single app

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -142,7 +142,7 @@ GPU_CONFIGMAPS = {
 sharing:
   timeSlicing:
     renameByDefault: false
-    failRequestsGreaterThanOne: true
+    failRequestsGreaterThanOne: false
     resources:
     - name: nvidia.com/gpu
       replicas: 5


### PR DESCRIPTION
## Problem
Currently, we only allow one Nvidia GPU to be shared for use by an app in the Nvidia GPU configuration. However, AMD and Intel configurations allow multiple GPUs to be allocated to a single app.

## Solution
Modify the configuration to allow apps to use more than one Nvidia GPU shared in the Nvidia GPU configuration.