### PR TITLE
NAS-125859 / 24.04-RC.1 / Allow multiple NVIDIA gpus to be shared to a single app (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -142,7 +142,7 @@ GPU_CONFIGMAPS = {
 sharing:
   timeSlicing:
     renameByDefault: false
-    failRequestsGreaterThanOne: true
+    failRequestsGreaterThanOne: false
     resources:
     - name: nvidia.com/gpu
       replicas: 5


### PR DESCRIPTION
## Problem
Currently, we only allow one Nvidia GPU to be shared for use by an app in the Nvidia GPU configuration. However, AMD and Intel configurations allow multiple GPUs to be allocated to a single app.

## Solution
Modify the configuration to allow apps to use more than one Nvidia GPU shared in the Nvidia GPU configuration.

Original PR: https://github.com/truenas/middleware/pull/12969
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125859