### PR TITLE
NAS-126975 / 24.10 / Update NUT driver systemctl stop function.

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -28,3 +28,4 @@ class UPSService(SimpleService):
         await self._unit_action("Stop")
         await self._systemd_unit("nut-driver-enumerator", "stop")
         await self._systemd_unit("nut-server", "stop")
+        await self._systemd_unit("nut-driver.target", "stop")

--- a/tests/api2/test_015_services.py
+++ b/tests/api2/test_015_services.py
@@ -75,3 +75,6 @@ def test_non_silent_service_start_failure():
     # the error messages will differ slightly (different PID for upsmon) but the number
     # of lines should be the same
     assert len_lines1 == len_lines2
+
+    # Stop the service to avoid syslog spam
+    call('service.stop', 'ups')


### PR DESCRIPTION
### The Problem
After calling `service.stop ups` the NUT driver continues to record attempts to restart:
`Jan 23 17:49:35 tnee-A systemd[1]: nut-driver@ups.service: Scheduled restart job, restart counter is at 349.
Jan 23 17:49:35 tnee-A systemd[1]: Stopped nut-driver@ups.service - Network UPS Tools - device driver for ups.
Jan 23 17:49:35 tnee-A systemd[1]: Starting nut-driver@ups.service - Network UPS Tools - device driver for ups...
Jan 23 17:49:35 tnee-A nut-driver@ups[34624]: Can't start /lib/nut/(null): No such file or directory
Jan 23 17:49:35 tnee-A nut-driver@ups[34624]: Network UPS Tools - UPS driver controller 2.8.0
Jan 23 17:49:35 tnee-A systemd[1]: nut-driver@ups.service: Control process exited, code=exited, status=1/FAILURE
Jan 23 17:49:35 tnee-A systemd[1]: nut-driver@ups.service: Failed with result 'exit-code'.
Jan 23 17:49:35 tnee-A systemd[1]: Failed to start nut-driver@ups.service - Network UPS Tools - device driver for ups.`

This blob of messages are output about every 10 seconds.

### The Fix
Adding a systemctl stop of `nut-driver.target` stops the start attempts and the associated syslog messages.
