### PR TITLE
NAS-126959 / 24.04-RC.1 / add truenas.is_ix_hardware for UI team (RBAC required changes) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/ipmi_sel.py
+++ b/src/middlewared/middlewared/alert/source/ipmi_sel.py
@@ -157,7 +157,7 @@ class IPMISELAlertSource(AlertSource):
         return alert
 
     async def check(self):
-        if not await self.middleware.call("system.is_ix_hardware"):
+        if not await self.middleware.call("truenas.is_ix_hardware"):
             return
 
         alerts = []

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -90,7 +90,7 @@ async def render(service, middleware):
         Cron.convert_db_format_to_schedule(disk, "smarttest_schedule", "smarttest_")
 
     devices = await middleware.call("device.get_disks")
-    hardware = await middleware.call("system.is_enterprise_ix_hardware")
+    hardware = await middleware.call("truenas.is_ix_hardware")
     context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
     annotated = dict(filter(None, await asyncio_map(
         lambda disk: annotate_disk_for_smart(context, disk["disk_name"], disk["disk_smartoptions"]),

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -140,7 +140,7 @@ class DiskService(CRUDService):
 
         disk['supports_smart'] = None
         if context['supports_smart']:
-            if await self.middleware.call('system.is_enterprise_ix_hardware'):
+            if await self.middleware.call('truenas.is_ix_hardware'):
                 disk['supports_smart'] = True
             else:
                 disk['supports_smart'] = disk['name'].startswith('nvme') or bool(RE_SMART_AVAILABLE.search(

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -20,8 +20,8 @@ class DiskService(Service):
                 disks = await self.middleware.call("disk.query", [["name", "!=", None]])
 
                 devices = await self.middleware.call("device.get_disks")
-                is_ix_hardware = await self.middleware.call("truenas.is_ix_hardware")
-                context = SMARTCTX(devices=devices, enterprise_hardware=is_ix_hardware)
+                hardware = await self.middleware.call("truenas.is_ix_hardware")
+                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
                 self.smartctl_args_for_disk = dict(zip(
                     [disk["name"] for disk in disks],
                     await asyncio_map(
@@ -56,8 +56,8 @@ class DiskService(Service):
                 smartctl_args = await self.middleware.call('disk.smartctl_args', disk)
             else:
                 devices = await self.middleware.call('device.get_disks')
-                is_ix_hardware = await self.middleware.call('truenas.is_ix_hardware')
-                context = SMARTCTX(devices=devices, enterprise_hardware=is_ix_hardware)
+                hardware = await self.middleware.call('truenas.is_ix_hardware')
+                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
                 if disks := await self.middleware.call('disk.query', [['name', '=', disk]]):
                     smartoptions = disks[0]['smartoptions']
                 else:

--- a/src/middlewared/middlewared/plugins/disk_/smartctl.py
+++ b/src/middlewared/middlewared/plugins/disk_/smartctl.py
@@ -20,8 +20,8 @@ class DiskService(Service):
                 disks = await self.middleware.call("disk.query", [["name", "!=", None]])
 
                 devices = await self.middleware.call("device.get_disks")
-                hardware = await self.middleware.call("system.is_enterprise_ix_hardware")
-                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
+                is_ix_hardware = await self.middleware.call("truenas.is_ix_hardware")
+                context = SMARTCTX(devices=devices, enterprise_hardware=is_ix_hardware)
                 self.smartctl_args_for_disk = dict(zip(
                     [disk["name"] for disk in disks],
                     await asyncio_map(
@@ -56,8 +56,8 @@ class DiskService(Service):
                 smartctl_args = await self.middleware.call('disk.smartctl_args', disk)
             else:
                 devices = await self.middleware.call('device.get_disks')
-                hardware = await self.middleware.call('system.is_enterprise_ix_hardware')
-                context = SMARTCTX(devices=devices, enterprise_hardware=hardware)
+                is_ix_hardware = await self.middleware.call('truenas.is_ix_hardware')
+                context = SMARTCTX(devices=devices, enterprise_hardware=is_ix_hardware)
                 if disks := await self.middleware.call('disk.query', [['name', '=', disk]]):
                     smartoptions = disks[0]['smartoptions']
                 else:

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -70,7 +70,7 @@ class EnclosureService(CRUDService):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if self.middleware.call_sync('truenas.get_chassis_hardware') == 'TRUENAS-UNKNOWN':
+        if not self.middleware.call_sync('truenas.is_ix_hardware'):
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -14,6 +14,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list
 from middlewared.plugins.enclosure_.r30_drive_identify import set_slot_status as r30_set_slot_status
 from middlewared.plugins.enclosure_.fseries_drive_identify import set_slot_status as fseries_set_slot_status
+from middlewared.plugins.truenas import TRUENAS_UNKNOWN
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class EnclosureService(CRUDService):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if not self.middleware.call_sync('truenas.is_ix_hardware'):
+        if self.middleware.call_sync('truenas.get_chassis_hardware') == TRUENAS_UNKNOWN:
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -122,7 +122,7 @@ class Enclosure2Service(Service):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if self.middleware.call_sync('truenas.get_chassis_hardware') == 'TRUENAS-UNKNOWN':
+        if not self.middleware.call_sync('truenas.is_ix_hardware'):
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -8,6 +8,7 @@ from middlewared.schema import accepts, Dict, Str, Int
 from middlewared.service import Service, filterable
 from middlewared.service_exception import MatchNotFound, ValidationError
 from middlewared.utils import filter_list
+from middlewared.plugins.truenas import TRUENAS_UNKNOWN
 
 from .map2 import combine_enclosures
 from .nvme2 import map_nvme
@@ -122,7 +123,7 @@ class Enclosure2Service(Service):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if not self.middleware.call_sync('truenas.is_ix_hardware'):
+        if self.middleware.call_sync('truenas.get_chassis_hardware') == TRUENAS_UNKNOWN:
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1269,7 +1269,7 @@ class InterfaceService(CRUDService):
 
             if iface['type'] == 'PHYSICAL':
                 link_address_update = {'link_address': iface['state']['hardware_link_address']}
-                if await self.middleware.call('system.is_enterprise_ix_hardware'):
+                if await self.middleware.call('truenas.is_ix_hardware'):
                     if await self.middleware.call('failover.node') == 'B':
                         link_address_update = {'link_address_b': iface['state']['hardware_link_address']}
                 link_address_row = await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -18,10 +18,6 @@ from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 LICENSE_FILE = '/data/license'
 
 
-def is_enterprise_ix_hardware(chassis_hardware):
-    return chassis_hardware != 'TRUENAS-UNKNOWN'
-
-
 class SystemService(Service):
 
     PRODUCT_TYPE = None
@@ -248,10 +244,6 @@ class SystemService(Service):
     async def is_ix_hardware(self):
         product = (await self.middleware.call('system.dmidecode_info'))['system-product-name']
         return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))
-
-    @private
-    async def is_enterprise_ix_hardware(self):
-        return is_enterprise_ix_hardware(await self.middleware.call('truenas.get_chassis_hardware'))
 
 
 async def hook_license_update(middleware, prev_product_type, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -240,11 +240,6 @@ class SystemService(Service):
             return True
         return False
 
-    @private
-    async def is_ix_hardware(self):
-        product = (await self.middleware.call('system.dmidecode_info'))['system-product-name']
-        return product is not None and product.startswith(('FREENAS-', 'TRUENAS-'))
-
 
 async def hook_license_update(middleware, prev_product_type, *args, **kwargs):
     if prev_product_type != 'ENTERPRISE' and await middleware.call('system.product_type') == 'ENTERPRISE':

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -10,7 +10,6 @@ import middlewared.sqlalchemy as sa
 
 EULA_FILE = '/usr/local/share/truenas/eula.html'
 EULA_PENDING_PATH = "/data/truenas-eula-pending"
-
 user_attrs = [
     Str('first_name'),
     Str('last_name'),
@@ -39,6 +38,7 @@ PLATFORM_PREFIXES = (
     'TRUENAS-R',  # freenas certified replacement
     'FREENAS-MINI',  # minis tagged with legacy information
 )
+TRUENAS_UNKNOWN = 'TRUENAS-UNKNOWN'
 
 
 def get_chassis_hardware(dmi):
@@ -51,7 +51,7 @@ def get_chassis_hardware(dmi):
         # last resort
         return 'TRUENAS-X'
 
-    return 'TRUENAS-UNKNOWN'
+    return TRUENAS_UNKNOWN
 
 
 class TruenasCustomerInformationModel(sa.Model):
@@ -79,6 +79,13 @@ class TrueNASService(Service):
         """
         dmi = await self.middleware.call('system.dmidecode_info')
         return get_chassis_hardware(dmi)
+
+    @accepts(roles=['READONLY_ADMIN'])
+    @returns(Bool('is_ix_hardware'))
+    async def is_ix_hardware(self):
+        """Return a boolean value on whether or not this is hardware
+        that iXsystems sells."""
+        return await self.get_chassis_hardware() != TRUENAS_UNKNOWN
 
     @accepts(roles=['READONLY_ADMIN'])
     @returns(Str('eula', max_length=None, null=True))


### PR DESCRIPTION
UI was calling `system.is_ix_hardware` for various reasons which was marked as a `private` endpoint. Instead of making changes to that endpoint, I've added a new endpoint called `truenas.is_ix_hardware` which uses the proper logic.

I've also removed the `is_enterprise_ix_hardware` function as that was removed in 8528961fdc2 but the surrounding code was never cleaned up. This unifies all `system.is_ix_hardware` and/or `system.is_enterprise_ix_hardware` to use `truenas.is_ix_hardware`.

I also removed a bunch of references to `TRUENAS-UNKNOWN` strings since that is prone to breakage.

Original PR: https://github.com/truenas/middleware/pull/12968
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126959