### PR TITLE
NAS-126984 / 24.10 / Update the error message with a helpful hint.

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -228,7 +228,8 @@ class ActiveDirectoryService(Service):
                     raise CallError(
                         f'{name}: Nameserver {entry["nameserver"]} failed to resolve SRV '
                         f'record for domain {domain}. This may indicate a DNS misconfiguration '
-                        'on the TrueNAS server.',
+                        'on the TrueNAS server. NOTE: When configuring with Active Directory, all '
+                        'registered nameservers must be part of the Active Directory.',
                         errno.EINVAL
                     )
                 except Exception as e:

--- a/src/middlewared/middlewared/plugins/activedirectory_/dns.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/dns.py
@@ -229,7 +229,7 @@ class ActiveDirectoryService(Service):
                         f'{name}: Nameserver {entry["nameserver"]} failed to resolve SRV '
                         f'record for domain {domain}. This may indicate a DNS misconfiguration '
                         'on the TrueNAS server. NOTE: When configuring with Active Directory, all '
-                        'registered nameservers must be part of the Active Directory.',
+                        'registered nameservers must be nameservers for the Active Directory domain.',
                         errno.EINVAL
                     )
                 except Exception as e:


### PR DESCRIPTION
When adding the server to Active Directory, all registered nameservers must also be part of the Active Directory.  This change adds this hint to the error message.