### PR TITLE
NAS-126960 / 24.10 / fix interface.lag_ports_choices and API

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1595,6 +1595,7 @@ class InterfaceService(CRUDService):
         """
         exclude = {}
         include = {}
+        configured_ifaces = await self.middleware.call('interface.query_names_only')
         for interface in await self.middleware.call('interface.query'):
             if interface['type'] == 'LINK_AGGREGATION':
                 if id_ and id_ == interface['id']:
@@ -1616,6 +1617,12 @@ class InterfaceService(CRUDService):
                 exclude.update({interface['id']: interface['id']})
                 # exclude interfaces that are already part of a bridge interface
                 exclude.update({i: i for i in interface['bridge_members']})
+            elif interface['id'] in configured_ifaces:
+                # only remaining type of interface is PHYSICAL but if this is
+                # an interface that has already been configured then we obviously
+                # don't want to allow it to be added to a bond (user will need
+                # to wipe the config of said interface before it can be added)
+                exclude.update({interface['id']: interface['id']})
 
             # add the interface to inclusion list and it will be discarded
             # if it was also added to the exclusion list

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -938,6 +938,7 @@ class InterfaceService(CRUDService):
             lag_ports = data.get('lag_ports')
             if not lag_ports:
                 verrors.add(f'{schema_name}.lag_ports', 'This field cannot be empty.')
+            ds_ifaces_set = {i['int_interface'] for i in ds_ifaces}
             for i, member in enumerate(lag_ports):
                 _schema = f'{schema_name}.lag_ports.{i}'
                 if member not in ifaces:
@@ -948,6 +949,8 @@ class InterfaceService(CRUDService):
                     verrors.add(_schema, f'Interface {member} is currently in use by {bridge_used[member]}.')
                 elif member in vlan_used:
                     verrors.add(_schema, f'Interface {member} is currently in use by {vlan_used[member]}.')
+                elif member in ds_ifaces:
+                    verrors.add(_schema, f'Interface {member} is currently in use')
         elif itype == 'VLAN':
             if 'name' in data:
                 try:


### PR DESCRIPTION
Before these changes, the user is presented a list of interfaces that are available to be added to a `bond` type interface regardless of whether or not that interface has an associated config tied to it. This means, a user could have configured a physical interface and marked it critical for failover but then added it to the `bond`. This wiped the config on the physical interface silently without any warning to the end-user.

The changes implemented here skips interfaces in the `interface.lag_ports_choices` endpoint to exclude any interface that has an associated config to it. This also prevents the same configuration error from occurring in the `do_create` or `do_update` methods.