### PR TITLE
NAS-126986 / 23.10.2 / Improve logging wrt reestablishment on failover RemoteClient connection (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -32,22 +32,23 @@ class RemoteClient(object):
         self._on_connect_callbacks = []
         self._on_disconnect_callbacks = []
         self._remote_os_version = None
+        self.refused = False
 
     def run(self):
         set_thread_name('ha_connection')
         retry = 5
-        refused = False
+        self.refused = False
         while True:
             try:
                 self.connect_and_wait()
-                refused = False
+                self.refused = False
             except ConnectionRefusedError:
-                if not refused:
+                if not self.refused:
                     logger.error(f'Persistent connection refused, retrying every {retry} seconds')
-                refused = True
+                self.refused = True
             except Exception:
                 logger.error('Remote connection failed', exc_info=True)
-                refused = False
+                self.refused = False
             time.sleep(retry)
 
     def connect_and_wait(self):
@@ -101,6 +102,9 @@ class RemoteClient(object):
                 cb(self.middleware)
             except Exception:
                 logger.error('Failed to run on_connect for remote client', exc_info=True)
+
+        if self.refused:
+            logger.info('Persistent connection reestablished')
 
     def register_disconnect(self, cb):
         """


### PR DESCRIPTION
With this change the `failover.log` will also include an entry when the connection is reestablished.

```
[2024/01/25 07:59:27] (ERROR) failover.remote.run():52 - Persistent connection refused, retrying every 5 seconds
[2024/01/25 08:01:24] (INFO) failover.remote._on_connect():112 - Persistent connection reestablished
```

If `middlewared` is restarted on the other node, then we see a shorter outage:
```
[2024/01/25 08:23:13] (ERROR) failover.remote.run():52 - Persistent connection refused, retrying every 5 seconds
[2024/01/25 08:23:23] (INFO) failover.remote._on_connect():112 - Persistent connection reestablished
```

Original PR: https://github.com/truenas/middleware/pull/12979
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126986