### PR TITLE
NAS-126988 / 24.10 / Fix edge case in container pruning test

### DIFF
--- a/tests/api2/test_023_kubernetes.py
+++ b/tests/api2/test_023_kubernetes.py
@@ -4,7 +4,7 @@ import time
 from pytest_dependency import depends
 from functions import GET, PUT, wait_on_job
 from auto_config import ha, pool_name, interface, ip
-from middlewared.test.integration.utils import call, fail
+from middlewared.test.integration.utils import call
 
 
 # Read all the test below only on non-HA
@@ -82,7 +82,7 @@ if not ha:
                     break
 
             if timeout <= 0:
-                fail('Time to setup kubernetes exceeded 150 seconds')
+                pytest.fail('Time to setup kubernetes exceeded 150 seconds')
 
             timeout -= 5
 


### PR DESCRIPTION
## Problem
In the test `test_pruning_for_deleted_chart_release_images`, an assertion error still occurs sometimes even after waiting for a container to stop using its ID. After investigation, it appears that if a container of a different ID from the same image is still running, it can also cause this test to fail. This can happen if the container is still running from a previous test.

## Solution
Wait for the container to terminate in the previous test `test_pruning_for_deleted_chart_release_images`.