### PR TITLE
NAS-126990 / 24.10 / Fix typo

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -321,7 +321,7 @@ class ACLTemplateService(CRUDService):
                 await self.append_builtins(t)
 
             if data['format-options']['resolve_names']:
-                st = await self.middleware.run_in_thread(os.stat, path)
+                st = await self.middleware.run_in_thread(os.stat, data['path'])
                 await self.resolve_names(st.st_uid, st.st_gid, t)
 
             if data['format-options']['canonicalize'] and t['acltype'] == ACLType.NFS4.name:


### PR DESCRIPTION
Fix a typo that generated an exception when on the share page in the UI and selecting the `Edit FilesystemACL` for an SMB share.