### PR TITLE
NAS-127006 / 24.10 / Add a text field schema in catalog format for UI

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -14,6 +14,8 @@ mapping = {
     'int': Int,
     'boolean': Bool,
     'path': Path,
+    # to support large text / toml data of upto 1MiB
+    'text': lambda *args, **kwargs: Str(*args, **kwargs, max_length=1024 * 1024),
     'hostpath': HostPath,
     'hostpathdirectory': Dir,
     'hostpathfile': File,

--- a/tests/api2/test_charts_schema.py
+++ b/tests/api2/test_charts_schema.py
@@ -1,0 +1,53 @@
+import pytest
+import secrets
+import time
+
+from pytest_dependency import depends
+
+from middlewared.client.client import ValidationErrors
+from middlewared.test.integration.assets.apps import chart_release
+from middlewared.test.integration.assets.catalog import catalog
+
+
+def test_text_schema(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    with catalog({
+        'force': True,
+        'preferred_trains': ['charts'],
+        'label': 'TESTTEXT',
+        'repository': 'https://github.com/truenas/charts.git',
+        'branch': 'ix-text-schema-test'
+    }) as catalog_obj:
+        with chart_release({
+            'catalog': catalog_obj['label'],
+            'item': 'plex',
+            'release_name': 'plex',
+            'train': 'charts',
+            'version': '1.7.59',
+            'values': {'testtext': 'random-text'},
+        }) as chart_release_obj:
+            time.sleep(5)
+            assert chart_release_obj['config']['testtext'] == 'random-text'
+
+
+def test_text_schema_max_length(request):
+    depends(request, ['setup_kubernetes'], scope='session')
+    with catalog({
+        'force': True,
+        'preferred_trains': ['charts'],
+        'label': 'TESTTEXT',
+        'repository': 'https://github.com/truenas/charts.git',
+        'branch': 'ix-text-schema-test'
+    }) as catalog_obj:
+        with pytest.raises(ValidationErrors) as ve:
+            with chart_release({
+                'catalog': catalog_obj['label'],
+                'item': 'plex',
+                'release_name': 'plex',
+                'train': 'charts',
+                'version': '1.7.59',
+                'values': {'testtext': secrets.token_hex(2 * 1024 * 1024 // 2)},
+            }):
+                assert ve.value.errors[0].errmsg == (
+                    'values.testtext: Value greater than 1048576 not allowed'
+                )


### PR DESCRIPTION
## Context

PR adds support for charts to specify and use large text data (json, yaml, toml etc) inputs of upto 1 MiB using `text type` in questions.yaml, the idea to allow up to 1 MiB after discussion with Stavros is specifically to make sure this is not abused but still be large enough to accommodate configmap/secret(s) contents.