### PR TITLE
NAS-127018 / 23.10.2 / Add test coverage for resolving names in acl templates (by anodos325)

### DIFF
--- a/tests/api2/test_344_acl_templates.py
+++ b/tests/api2/test_344_acl_templates.py
@@ -46,6 +46,20 @@ def test_02_check_builtin_types_by_path(request, acltype):
         assert entry['builtin'], results.text
         assert entry['acltype'] == expected_acltype, results.text
 
+    payload['format-options'] = {
+        'resolve_names': True,
+        'ensure_builtins': True
+    }
+
+    results = POST('/filesystem/acltemplate/by_path', payload)
+    assert results.status_code == 200, results.text
+    for entry in results.json():
+        for ace in entry['acl']:
+            if ace['tag'] not in ('USER_OBJ', 'GROUP_OBJ', 'USER', 'GROUP'):
+                continue
+
+            assert ace.get('who') is not None, results.text
+
 
 @pytest.mark.dependency(name="NEW_ACLTEMPLATES_CREATED")
 @pytest.mark.parametrize('acltype', ['NFS4', 'POSIX'])


### PR DESCRIPTION
This adds coverage for non-default options related to retrieving acl templates by path.

Original PR: https://github.com/truenas/middleware/pull/13005
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127018