### PR TITLE
NAS-125816 / 24.10 / Properly save nvram file for UEFI based guests

### DIFF
--- a/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
+++ b/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+
+from middlewared.plugins.vm.utils import SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name
+
+
+DEFAULT_NVRAM_FOLDER_PATH = '/var/lib/libvirt/qemu/nvram'
+LIBVIRT_QEMU_UID = 64055
+LIBVIRT_QEMU_GID = 64055
+
+
+def migrate(middleware):
+    os.makedirs(SYSTEM_NVRAM_FOLDER_PATH, exist_ok=True)
+    os.chown(SYSTEM_NVRAM_FOLDER_PATH, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+
+    if middleware.call_sync('system.is_ha_capable'):
+        middleware.logger.debug('Skipping nvram migration as system is HA capable')
+        return
+
+    for vm in middleware.call_sync('vm.query', [['bootloader', '=', 'UEFI']]):
+        try:
+            migrate_vm_nvram_file(middleware, vm)
+        except Exception:
+            middleware.logger.error('Failed to migrate nvram file for VM %r(%r)', vm['name'], vm['id'], exc_info=True)
+
+
+def migrate_vm_nvram_file(middleware, vm):
+    file_name = get_vm_nvram_file_name(vm)
+    new_path = os.path.join(SYSTEM_NVRAM_FOLDER_PATH, file_name)
+    to_copy_path = os.path.join(DEFAULT_NVRAM_FOLDER_PATH, file_name)
+    if os.path.exists(to_copy_path):
+        shutil.copy2(to_copy_path, new_path)
+        os.chown(new_path, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+    else:
+        # File does not exist for us to copy, so we need to just log it
+        middleware.logger.debug(
+            'No nvram file found for VM %r(%r), hence setting it up with %r', vm['name'], vm['id'], new_path
+        )

--- a/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
@@ -1,7 +1,9 @@
+import os
 import shlex
 
 from middlewared.plugins.vm.devices import CDROM, DISK, PCI, RAW, DISPLAY, USB
 from middlewared.plugins.vm.numeric_set import parse_numeric_set
+from middlewared.plugins.vm.utils import SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name
 from middlewared.utils import Nid
 
 from .utils import create_element
@@ -256,10 +258,14 @@ def os_xml(vm_data):
         }
     )]
     if vm_data['bootloader'] == 'UEFI':
-        children.append(
+        children.extend([
             create_element(
                 'loader', attribute_dict={'text': f'/usr/share/OVMF/{vm_data["bootloader_ovmf"]}'},
                 readonly='yes', type='pflash',
-            )
-        )
+            ),
+            create_element('nvram', attribute_dict={
+                'text': os.path.join(SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name(vm_data)),
+            })
+        ])
+
     return create_element('os', attribute_dict={'children': children})

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree as etree
 
 
 ACTIVE_STATES = ['RUNNING', 'SUSPENDED']
+SYSTEM_NVRAM_FOLDER_PATH = '/data/subsystems/vm/nvram'
 LIBVIRT_URI = 'qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock'
 LIBVIRT_USER = 'libvirt-qemu'
 NGINX_PREFIX = '/vm/display'
@@ -33,3 +34,7 @@ def get_pci_device_class(pci_path: str) -> str:
             return r.read().strip()
 
     return ''
+
+
+def get_vm_nvram_file_name(vm_data: dict) -> str:
+    return f'{vm_data["id"]}_{vm_data["name"]}_VARS.fd'


### PR DESCRIPTION
### Problem
During installation, some operating systems like Debian modify the nvram file, enabling the VM to boot up. However, when we upgrade the host system, this file is removed. QEMU then recreates the file, restoring it to the default value. Consequently, after the upgrade, the VM is unable to boot up again.
### Solution
Ensure the persistence of nvram fd files after an upgrade by saving the under discussion files at `/data/subsystems/vm/nvram` and using them later after upgrade from the dir.