### PR TITLE
NAS-126979 / 24.10 / fix SCALE HA failover logic

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/vrrp_events.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events.py
@@ -78,7 +78,7 @@ class VrrpEventThread(Thread):
                 return
 
             if event == 'FAULT':
-                # when a FAULT message is sent when iface goes down
+                # a FAULT message is sent when iface goes down
                 event = 'BACKUP'
 
         return {'ifname': ifname, 'event': event, 'time': msg['time']}
@@ -105,7 +105,7 @@ class VrrpEventThread(Thread):
             if self.pause_event.is_set():
                 # A BACKUP event has to migrate all the VIPs
                 # off of the controller and the only way to
-                # do that is to restart the vrrp service.
+                # (quickly) do that is to restart the vrrp service.
                 # However, restarting the VRRP service triggers
                 # more BACKUP events for the other interfaces
                 # so we will pause this thread while we become
@@ -123,7 +123,7 @@ class VrrpEventThread(Thread):
                 continue
 
             if this_event is None:
-                # an event that we ignore (i.e. STOP/FAULT events)
+                # an event that we ignore
                 self.event_queue.pop()
                 continue
             elif last_event is None:

--- a/src/middlewared/middlewared/plugins/device_/vrrp_events.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events.py
@@ -39,7 +39,7 @@ class VrrpThreadService(Service):
             VrrpObjs.event_thread.unpause()
 
     def set_non_crit_ifaces(self):
-        if VrrpObjs.event_thread is not None and VrrpObjs.event_thread.is_alive():
+        if VrrpObjs.event_thread is not None:
             VrrpObjs.event_thread.non_crit_ifaces = set(
                 i['int_interface'] for i in self.middleware.call_sync(
                     'datastore.query', 'network.interfaces'

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1652,6 +1652,11 @@ class InterfaceService(CRUDService):
         Sync interfaces configured in database to the OS.
         """
         await self.middleware.call_hook('interface.pre_sync')
+        # The VRRP event thread just reads directly from the database
+        # so there is no reason to actually configure the interfaces
+        # on the OS first. We can update the thread since the db has
+        # already been updated by the time this is called.
+        await self.middleware.call('vrrpthread.set_non_crit_ifaces')
 
         interfaces = [i['int_interface'] for i in (await self.middleware.call('datastore.query', 'network.interfaces'))]
         cloned_interfaces = []


### PR DESCRIPTION
Take the following example:
4x total interfaces
2x marked critical for failover in the same failover group
the other 2x interfaces NOT marked critical for failover

take 1x critical interface down, no failover event is generated (by design since another interface in that group is functional)
take the other critical interface down, failover event is generated (by design since all other interfaces in that group are non-functional)

That's 2 out of the 4 interfaces taken down and a failover event is generated, however, the other controller that is becoming master receives 2 more events for the interfaces that are not marked critical for failover. By design, since these interfaces are not marked critical we ignore the failover event. This leaves HA in a broken state.

The changes being done here add filtering at the failover event thread level by simply ignoring interfaces that aren't marked critical for failover. The only events that will be forwarded down into middleware are critical interfaces.