### PR TITLE
NAS-127079 / 24.10 / Optimize role based integration tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -13,8 +13,11 @@ def common_checks(
     with unprivileged_user_client(roles=[role]) as client:
         if valid_role:
             if valid_role_exception:
-                with pytest.raises(Exception):
+                with pytest.raises(Exception) as exc_info:
                     client.call(method, *method_args, **method_kwargs)
+
+                assert not isinstance(exc_info.value, ClientException)
+
             elif is_return_type_none:
                 assert client.call(method, *method_args, **method_kwargs) is None
             else:

--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -1,5 +1,5 @@
-import pytest
 import errno
+import pytest
 
 from middlewared.client.client import ClientException
 from middlewared.test.integration.assets.account import unprivileged_user_client

--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -1,0 +1,26 @@
+import pytest
+import errno
+
+from middlewared.client.client import ClientException
+from middlewared.test.integration.assets.account import unprivileged_user_client
+
+
+def common_checks(
+    method, role, valid_role, valid_role_exception=True, method_args=None, method_kwargs=None, is_return_type_none=False
+):
+    method_args = method_args or []
+    method_kwargs = method_kwargs or {}
+    with unprivileged_user_client(roles=[role]) as client:
+        if valid_role:
+            if valid_role_exception:
+                with pytest.raises(Exception):
+                    client.call(method, *method_args, **method_kwargs)
+            elif is_return_type_none:
+                assert client.call(method, *method_args, **method_kwargs) is None
+            else:
+                assert client.call(method, *method_args, **method_kwargs) is not None
+        else:
+            with pytest.raises(ClientException) as ve:
+                client.call(method, *method_args, **method_kwargs)
+            assert ve.value.errno == errno.EACCES
+            assert ve.value.error == 'Not authorized'

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -1,26 +1,6 @@
-import errno
 import pytest
 
-from middlewared.client.client import ClientException, ValidationErrors
-from middlewared.service_exception import ValidationErrors as ValidationErrorsServiceException
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-def common_checks(method, role, valid_role, valid_role_exception=True, method_args=None, method_kwargs=None):
-    method_args = method_args or []
-    method_kwargs = method_kwargs or {}
-    with unprivileged_user_client(roles=[role]) as client:
-        if valid_role:
-            if valid_role_exception:
-                with pytest.raises((ValidationErrors, ValidationErrorsServiceException)):
-                    client.call(method, *method_args, **method_kwargs)
-            else:
-                assert client.call(method, *method_args, **method_kwargs) is not None
-        else:
-            with pytest.raises(ClientException) as ve:
-                client.call(method, *method_args, **method_kwargs)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize('method, role, valid_role', (

--- a/tests/api2/test_iscsi_auth_crud_roles.py
+++ b/tests/api2/test_iscsi_auth_crud_roles.py
@@ -1,53 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_auth
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def auth():
-    with iscsi_auth({"tag": "42", "user": "dummyuser", "secret": "dummysecret1234"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.auth.query")
+    common_checks("iscsi.auth.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_cant_write(auth, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.create", {
-                "tag": "1",
-                "user": "someusername",
-                "secret": "password1234",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.update", auth['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.delete", auth['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.auth.create", role, False)
+    common_checks("iscsi.auth.update", role, False)
+    common_checks("iscsi.auth.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_AUTH_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.auth.create", {
-            "tag": "1",
-            "user": "someusername",
-            "secret": "password1234",
-        })
-
-        c.call("iscsi.auth.update", item["id"], {})
-
-        c.call("iscsi.auth.delete", item["id"])
+    common_checks("iscsi.auth.create", role, True)
+    common_checks("iscsi.auth.update", role, True)
+    common_checks("iscsi.auth.delete", role, True)

--- a/tests/api2/test_iscsi_global_crud_roles.py
+++ b/tests/api2/test_iscsi_global_crud_roles.py
@@ -1,29 +1,21 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.global.config")
-        c.call("iscsi.global.sessions")
-        c.call("iscsi.global.client_count")
-        c.call("iscsi.global.alua_enabled")
+    common_checks("iscsi.global.config", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.sessions", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.client_count", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.alua_enabled", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
 def test_read_role_cant_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.global.update", {})
-        assert ve.value.errno == errno.EACCES
+    common_checks("iscsi.global.update", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_GLOBAL_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.global.update", {})
+    common_checks("iscsi.global.update", role, True)

--- a/tests/api2/test_iscsi_host_crud_roles.py
+++ b/tests/api2/test_iscsi_host_crud_roles.py
@@ -1,63 +1,26 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_host
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def host():
-    with iscsi_host({"ip": "1.1.2.8", "description": "Target to test targetextent"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_can_read(host, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.host.query")
-        c.call("iscsi.host.get_initiators", host["id"])
-        c.call("iscsi.host.get_targets", host["id"])
+def test_read_role_can_read(role):
+    common_checks("iscsi.host.query", role, True, valid_role_exception=False)
+    common_checks("iscsi.host.get_initiators", role, True)
+    common_checks("iscsi.host.get_targets", role, True)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_cant_write(host, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.create", {
-                "ip": "1.2.3.4",
-                "description": "test host for CRUD role",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.update", host["id"], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.set_initiators", host["id"], [])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.delete", host["id"])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.set_initiators", host["id"], [])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.host.create", role, False)
+    common_checks("iscsi.host.update", role, False)
+    common_checks("iscsi.host.delete", role, False)
+    common_checks("iscsi.host.set_initiators", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_HOST_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.host.create", {
-            "ip": "1.2.3.4",
-            "description": "test host for CRUD role",
-        })
-        try:
-            c.call("iscsi.host.update", item["id"], {})
-            c.call("iscsi.host.set_initiators", item["id"], [])
-            c.call("iscsi.host.set_targets", item["id"], [])
-        finally:
-            c.call("iscsi.host.delete", item["id"])
+    common_checks("iscsi.host.create", role, True)
+    common_checks("iscsi.host.update", role, True)
+    common_checks("iscsi.host.delete", role, True)
+    common_checks("iscsi.host.set_initiators", role, True)

--- a/tests/api2/test_iscsi_initiator_crud_roles.py
+++ b/tests/api2/test_iscsi_initiator_crud_roles.py
@@ -1,51 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_initiator
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def initiator():
-    with iscsi_initiator({"initiators": ["host1", "host2"], "comment": "Dummy entry"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.initiator.query")
+    common_checks("iscsi.initiator.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_cant_write(initiator, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.initiator.create", {
-                "initiators": ["hostnameAAA", "hostnameBBB"],
-                "comment": "Not going to work",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.update", initiator['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.delete", initiator['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.initiator.create", role, False)
+    common_checks("iscsi.initiator.update", role, False)
+    common_checks("iscsi.initiator.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_INITIATOR_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.initiator.create", {
-            "initiators": ["hostnameA", "hostnameB"],
-            "comment": "Some very interesting comment",
-        })
-        try:
-            c.call("iscsi.initiator.update", item["id"], {})
-        finally:
-            c.call("iscsi.initiator.delete", item["id"])
+    common_checks("iscsi.initiator.create", role, True)
+    common_checks("iscsi.initiator.update", role, True)
+    common_checks("iscsi.initiator.delete", role, True)

--- a/tests/api2/test_iscsi_target_crud_roles.py
+++ b/tests/api2/test_iscsi_target_crud_roles.py
@@ -1,55 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_target
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def target():
-    with iscsi_target({"name": "dummytarget1", "alias": "Just for rigging purposes"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.target.query")
+    common_checks("iscsi.target.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_cant_write(target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.create", {
-                "name": "test1",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.validate_name", "newname1")
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.update", target['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.delete", target['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.target.create", role, False)
+    common_checks("iscsi.target.update", role, False)
+    common_checks("iscsi.target.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGET_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        # Just do a minimal create here (lower cost)
-        item = c.call("iscsi.target.create", {
-            "name": "test1",
-        })
-        try:
-            c.call("iscsi.target.validate_name", "newname1")
-            c.call("iscsi.target.update", item["id"], {})
-        finally:
-            c.call("iscsi.target.delete", item["id"])
+    common_checks("iscsi.target.create", role, True)
+    common_checks("iscsi.target.update", role, True)
+    common_checks("iscsi.target.delete", role, True)

--- a/tests/api2/test_iscsi_targetextent_crud_roles.py
+++ b/tests/api2/test_iscsi_targetextent_crud_roles.py
@@ -1,72 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_extent, iscsi_target
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def ds():
-    with dataset("test", {"type": "VOLUME", "volsize": 1048576}) as ds:
-        yield ds
-
-
-@pytest.fixture(scope="module")
-def share():
-    with dataset("test2", {"type": "VOLUME", "volsize": 1048576}) as ds:
-        with iscsi_extent({
-            "name": "test_extent",
-            "type": "DISK",
-            "disk": f"zvol/{ds}",
-        }) as share:
-            yield share
-
-
-@pytest.fixture(scope="module")
-def target():
-    with iscsi_target({"name": "test1", "alias": "Target to test targetextent"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.targetextent.query")
+    common_checks("iscsi.targetextent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_cant_write(ds, share, target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.create", {
-                "target": target["id"],
-                "lunid": 0,
-                "extent": share["id"],
-            })
-        assert ve.value.errno == errno.EACCES
-
-        dummyID = 0x845fed
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.update", dummyID, {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.delete", dummyID)
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.targetextent.create", role, False)
+    common_checks("iscsi.targetextent.update", role, False)
+    common_checks("iscsi.targetextent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGETEXTENT_WRITE"])
-def test_write_role_can_write(ds, share, target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.targetextent.create", {
-            "target": target["id"],
-            "lunid": 0,
-            "extent": share["id"],
-        })
-        try:
-            c.call("iscsi.targetextent.update", item["id"], {})
-        finally:
-            c.call("iscsi.targetextent.delete", item["id"])
+def test_write_role_can_write(role):
+    common_checks("iscsi.targetextent.create", role, True)
+    common_checks("iscsi.targetextent.update", role, True)
+    common_checks("iscsi.targetextent.delete", role, True)

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -1,81 +1,36 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.nfs import nfs_share
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-try:
-    from config import ADPASSWORD, ADUSERNAME
-except ImportError:
-    Reason = 'ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
-    pytestmark = pytest.mark.skip(reason=Reason)
-
-
-@pytest.fixture(scope="module")
-def ds():
-    with dataset("nfs_crud_test1") as ds:
-        yield ds
-
-
-@pytest.fixture(scope="module")
-def share():
-    with dataset("nfs_crud_test2") as ds:
-        with nfs_share(ds) as share:
-            yield share
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("sharing.nfs.query")
-        c.call("nfs.client_count")
+    common_checks("sharing.nfs.query", role, True, valid_role_exception=False)
+    common_checks("nfs.client_count", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_cant_write(ds, share, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.create", {"path": f"/mnt/{ds}"})
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("sharing.nfs.create", role, False)
+    common_checks("sharing.nfs.update", role, False)
+    common_checks("sharing.nfs.delete", role, False)
 
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.update", share["id"], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.delete", share["id"])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.get_nfs3_clients")
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.get_nfs4_clients")
-        assert ve.value.errno == errno.EACCES
-
-        # This should be blocked before needing to mock any configuration
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
-        assert ve.value.errno == errno.EACCES
+    common_checks("nfs.get_nfs3_clients", role, False)
+    common_checks("nfs.get_nfs4_clients", role, False)
+    common_checks("nfs.add_principal", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_NFS_WRITE"])
-def test_write_role_can_write(ds, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        share = c.call("sharing.nfs.create", {"path": f"/mnt/{ds}"})
+def test_write_role_can_write(role):
+    common_checks("sharing.nfs.create", role, True)
+    common_checks("sharing.nfs.update", role, True)
+    common_checks("sharing.nfs.delete", role, True)
 
-        c.call("sharing.nfs.update", share["id"], {})
-        c.call("sharing.nfs.delete", share["id"])
-        c.call("nfs.get_nfs3_clients")
-        c.call("nfs.get_nfs4_clients")
-        # Multiple layers of dependencies to mock up this as a successful write
-        # c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
+    common_checks("nfs.get_nfs3_clients", role, True, valid_role_exception=False)
+    common_checks("nfs.get_nfs4_clients", role, True, valid_role_exception=False)
+    common_checks("nfs.add_principal", role, True)
 
-        c.call("service.start", "nfs")
-        c.call("service.restart", "nfs")
-        c.call("service.reload", "nfs")
-        c.call("service.stop", "nfs")
+    common_checks("service.start", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.restart", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.reload", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.stop", role, True, method_args=["nfs"], valid_role_exception=False)

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -1,9 +1,6 @@
-import errno
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.service_exception import ValidationErrors
-from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize('method, expected_error', [
@@ -15,13 +12,7 @@ from middlewared.test.integration.assets.account import unprivileged_user_client
     ('vm.bootloader_options', False),
 ])
 def test_vm_readonly_role(method, expected_error):
-    with unprivileged_user_client(roles=['READONLY_ADMIN']) as c:
-        if expected_error:
-            with pytest.raises(Exception) as ve:
-                c.call(method)
-            assert isinstance(ve.value, ValidationErrors) or ve.value.errno != errno.EACCES
-        else:
-            assert c.call(method) is not None
+    common_checks(method, 'READONLY_ADMIN', True, valid_role_exception=expected_error)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -39,14 +30,7 @@ def test_vm_readonly_role(method, expected_error):
     ('VM_READ', 'vm.bootloader_options', True),
 ])
 def test_vm_read_write_roles(role, method, valid_role):
-    with unprivileged_user_client(roles=[role]) as c:
-        if valid_role:
-            assert c.call(method) is not None
-        else:
-            with pytest.raises(ClientException) as ve:
-                c.call(method)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+    common_checks(method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -70,16 +54,7 @@ def test_vm_read_write_roles(role, method, valid_role):
     ('VM_READ', 'vm.log_file_path', True),
 ])
 def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
-    with unprivileged_user_client(roles=[role]) as c:
-        if valid_role:
-            with pytest.raises(Exception) as ve:
-                c.call(method)
-            assert isinstance(ve.value, (ValidationErrors, IndexError)) or ve.value.errno != errno.EACCES
-        else:
-            with pytest.raises(ClientException) as ve:
-                c.call(method)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+    common_checks(method, role, valid_role)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -88,14 +63,7 @@ def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
     ('VM_DEVICE_READ', 'vm.device.nic_attach_choices', True),
 ])
 def test_vm_device_read_write_roles(role, method, valid_role):
-    with unprivileged_user_client(roles=[role]) as c:
-        if valid_role:
-            assert c.call(method) is not None
-        else:
-            with pytest.raises(ClientException) as ve:
-                c.call(method)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+    common_checks(method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -104,13 +72,4 @@ def test_vm_device_read_write_roles(role, method, valid_role):
     ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
 ])
 def test_vm_device_read_write_roles_requiring_virtualization(role, method, valid_role):
-    with unprivileged_user_client(roles=[role]) as c:
-        if valid_role:
-            with pytest.raises(Exception) as ve:
-                c.call(method)
-            assert isinstance(ve.value, ValidationErrors) or ve.value.errno != errno.EACCES
-        else:
-            with pytest.raises(ClientException) as ve:
-                c.call(method)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+    common_checks(method, role, valid_role)


### PR DESCRIPTION
This PR adds changes optimizing role based integration tests removing subsystem specific logic where we setup relevant resources needed for the subsystem calls to work. However earlier what we were missing was the fact that we don't really need to make sure those calls actually succeed, what we are testing is that does the consumer has relevant role to make that call in the first place - so just checking that the consumer can/cannot make the call is enough. This saves time/resources optimizing the integration tests for the specific case they are written for.