### PR TITLE
NAS-126809 / 24.10 / Preserve partition start when expanding a pool

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/resize.py
+++ b/src/middlewared/middlewared/plugins/disk_/resize.py
@@ -60,7 +60,7 @@ class DiskService(Service):
         disks = []
         for disk in data:
             if disk['name'] in disks:
-                verrors.add('disk.resize', 'Disk {disk["name"]!r} specified more than once.')
+                verrors.add('disk.resize', f'Disk {disk["name"]!r} specified more than once.')
             else:
                 disks.append(disk['name'])
 


### PR DESCRIPTION
@yocalebo this is the part that is absolute must even for 23.10.2. Always partitioning the disk to its fullest size even if we do it (I want to run additional tests to ensure that we can do it, that logic is there for a reason) probably should not be in 23.10.2.