### PR TITLE
NAS-127058 / 24.04-RC.1 / add READONLY_ADMIN to system.debug (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/debug.py
+++ b/src/middlewared/middlewared/plugins/system/debug.py
@@ -62,7 +62,7 @@ class SystemService(Service):
         except Exception as e:
             raise CallError(f'Failed to generate debug: {e!r}')
 
-    @accepts()
+    @accepts(roles=['READONLY_ADMIN'])
     @returns()
     @job(lock='system.debug', pipes=['output'])
     def debug(self, job):


### PR DESCRIPTION
This is required by UI team to allow readonly user to generate a debug.

Original PR: https://github.com/truenas/middleware/pull/13025
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127058