### PR TITLE
NAS-126857 / 24.04-RC.1 / Prevent combination of DISCARD aclmode and NFSv4 acltype (by anodos325)

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -330,7 +330,8 @@ def test_30_creating_home_dataset(request):
     payload = {
         "name": dataset,
         "share_type": "SMB",
-        "acltype": "NFSV4"
+        "acltype": "NFSV4",
+        "aclmode": "RESTRICTED"
     }
     results = POST("/pool/dataset/", payload)
     assert results.status_code == 200, results.text

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -173,7 +173,7 @@ TEST_INFO = {}
 
 @pytest.fixture(scope='module')
 def initialize_for_acl_tests(request):
-    with make_dataset(ACLTEST_DATASET_NAME, data={'acltype': 'NFSV4'}) as ds:
+    with make_dataset(ACLTEST_DATASET_NAME, data={'acltype': 'NFSV4', 'aclmode': 'RESTRICTED'}) as ds:
         with create_user({
             'username': ACL_USER,
             'full_name': ACL_USER,


### PR DESCRIPTION
Setting a DISCARD aclmode when NFSv4 acltype is in use. The DISCARD aclmode causes ZFS to strip ACL whenever chmod is called on a file. This may lead to security incidents if administrator sets the parameter without actually knowing what it does.

Original PR: https://github.com/truenas/middleware/pull/13014
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126857