### PR TITLE
NAS-127251 / 24.10 / Add pytest markers for more intelligent runs

### DIFF
--- a/tests/api2/pytest.ini
+++ b/tests/api2/pytest.ini
@@ -1,0 +1,23 @@
+[pytest]
+markers =
+    slow: mark test as slow
+    base: mark a test or module as requried for all runs
+    boot: include boot-volume-related tests
+    accounts: include account (user / group) tests
+    alerts: include alerts tests
+    audit: include audit tests
+    apps: include apps tests
+    certs: include cert-related tests
+    cloudsync: include cloudsync tests
+    core: include core plugin tests
+    cron: include cron-related tests
+    disk: include disk / storage-related tests
+    ds: include tests for directory services
+    fs: include filesystem plugin tests
+    ftp: include FTP tests
+    iscsi: include iSCSI tests
+    nfs: include NFS tests
+    rbac: include privilege / role tests
+    smb: include SMB tests
+    vm: include VM tests
+    zfs: include extra ZFS-related tests

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -10,6 +10,8 @@ from auto_config import ip, sshKey, user, password
 from middlewared.test.integration.utils import call, fail
 from middlewared.test.integration.utils.client import client
 
+pytestmark = pytest.mark.base
+
 
 @pytest.fixture(scope='module')
 def ip_to_use():

--- a/tests/api2/test_003_network_global.py
+++ b/tests/api2/test_003_network_global.py
@@ -9,6 +9,8 @@ from pytest_dependency import depends
 from auto_config import ha, interface, hostname, domain, ip
 from middlewared.test.integration.utils.client import client
 
+pytestmark = pytest.mark.base
+
 
 @pytest.fixture(scope='module')
 def ip_to_use():

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -9,6 +9,8 @@ import pytest
 from auto_config import ip, interface, ha
 from middlewared.test.integration.utils.client import client
 
+pytestmark = pytest.mark.base
+
 
 @pytest.fixture(scope='module')
 def ip_to_use():

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -12,6 +12,8 @@ from middlewared.test.integration.assets.directory_service import active_directo
 from middlewared.test.integration.utils import fail
 from middlewared.test.integration.utils.client import client
 
+pytestmark = pytest.mark.base
+
 
 @pytest.fixture(scope='module')
 def ws_client():

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,10 +1,12 @@
+import pytest
+
 from middlewared.test.integration.utils import call
 
 # this is found in middlewared.plugins.sysctl.sysctl_info
 # but the client running the tests isn't guaranteed to have
 # the middlewared application installed locally
 DEFAULT_ARC_MAX_FILE = '/var/run/middleware/default_arc_max'
-
+pytestmark = pytest.mark.base
 
 def test_sysctl_arc_max_is_set():
     """Middleware should have created this file and written a number

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -20,6 +20,8 @@ from middlewared.test.integration.assets.account import user as user_asset
 from middlewared.test.integration.assets.pool import dataset as dataset_asset
 from middlewared.test.integration.utils import call, ssh
 
+pytestmark = pytest.mark.accounts
+
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import POST, GET, DELETE, PUT, SSH_TEST, wait_on_job

--- a/tests/api2/test_012_directory_service_ssh.py
+++ b/tests/api2/test_012_directory_service_ssh.py
@@ -11,6 +11,8 @@ from auto_config import hostname, ip
 from middlewared.test.integration.assets.directory_service import active_directory, ldap
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.ds
+
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME
 except ImportError:

--- a/tests/api2/test_020_account.py
+++ b/tests/api2/test_020_account.py
@@ -4,11 +4,14 @@
 # License: BSD
 # Location for tests into REST API of FreeNAS
 
+import pytest
 import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST
+
+pytest.mark.accounts
 
 
 def delete_group_delete_users(delete_users):

--- a/tests/api2/test_023_kubernetes.py
+++ b/tests/api2/test_023_kubernetes.py
@@ -6,6 +6,7 @@ from functions import GET, PUT, wait_on_job
 from auto_config import ha, pool_name, interface, ip
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.apps
 
 # Read all the test below only on non-HA
 if not ha:

--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     skip_container_image = pytest.mark.skipif(True, reason=container_reason)
 
+pytestmark = pytest.mark.apps
 
 # Read all the test below only on non-HA
 if not ha:

--- a/tests/api2/test_026_kubernetes_backup_chart_releases.py
+++ b/tests/api2/test_026_kubernetes_backup_chart_releases.py
@@ -15,7 +15,7 @@ from middlewared.test.integration.assets.catalog import catalog
 from middlewared.test.integration.assets.kubernetes import backup
 from middlewared.test.integration.utils import file_exists_and_perms_check
 
-
+pytestmark = [pytest.mark.apps, pytest.mark.slow]
 backup_release_name = 'backupsyncthing'
 
 # Read all the test below only on non-HA

--- a/tests/api2/test_027_kubernetes_logs.py
+++ b/tests/api2/test_027_kubernetes_logs.py
@@ -5,6 +5,7 @@ from middlewared.test.integration.utils import call, ssh
 from pytest_dependency import depends
 from time import sleep
 
+pytestmark = pytest.mark.apps
 
 @contextlib.contextmanager
 def official_chart_release(chart_name, release_name):

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -29,10 +29,10 @@ else:
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME
     AD_USER = fr"AD02\{ADUSERNAME.lower()}"
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)
-
 
 SMB_NAME = "TestADShare"
 

--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -20,6 +20,7 @@ from middlewared.test.integration.assets.directory_service import active_directo
 
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -26,6 +26,7 @@ try:
         LDAPBINDPASSWORD,
         LDAPHOSTNAME
     )
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -16,6 +16,7 @@ from middlewared.test.integration.utils import call
 
 try:
     from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer, AD_COMPUTER_OU
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
     pytestmark = pytest.mark.skip(reason=Reason)

--- a/tests/api2/test_050_alert.py
+++ b/tests/api2/test_050_alert.py
@@ -11,6 +11,7 @@ from functions import GET, POST, SSH_TEST
 from auto_config import ip, password, user, pool_name
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.alerts
 
 
 def test_01_get_alert_list():

--- a/tests/api2/test_070_alertservice.py
+++ b/tests/api2/test_070_alertservice.py
@@ -7,6 +7,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, PUT, DELETE
 
+pytestmark = pytest.mark.alerts
+
 
 def test_01_get_alertservice():
     results = GET("/alertservice/")

--- a/tests/api2/test_090_boot.py
+++ b/tests/api2/test_090_boot.py
@@ -12,6 +12,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET
 
+pytestmark = pytest.mark.boot
+
 
 @pytest.mark.dependency(name='BOOT_DISKS')
 def test_01_get_boot_disks():

--- a/tests/api2/test_100_bootenv.py
+++ b/tests/api2/test_100_bootenv.py
@@ -12,6 +12,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import POST, DELETE, GET, PUT, wait_on_job
 
+pytestmark = pytest.mark.boot
+
 
 def test_01_get_the_activated_bootenv():
     global active_be_id

--- a/tests/api2/test_110_certificate.py
+++ b/tests/api2/test_110_certificate.py
@@ -20,6 +20,7 @@ try:
         LDAPBINDPASSWORD,
         LDAPHOSTNAME,
     )
+    pytestmark = pytest.mark.certs
 except ImportError:
     Reason = 'LDAP* variable are not setup in config.py'
     # comment pytestmark for development testing with --dev-test

--- a/tests/api2/test_120_certificateauthority.py
+++ b/tests/api2/test_120_certificateauthority.py
@@ -10,6 +10,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET
 
+pytestmark = pytest.mark.certs
+
 
 def test_01_get_certificateauthority_query():
     results = GET('/certificateauthority/')

--- a/tests/api2/test_130_cloudsync.py
+++ b/tests/api2/test_130_cloudsync.py
@@ -20,6 +20,7 @@ try:
         AWS_SECRET_ACCESS_KEY,
         AWS_BUCKET
     )
+    pytestmark = pytest.mark.cloudsync
 except ImportError:
     Reason = 'AWS credential are missing in config.py'
     pytestmark = pytest.mark.skip(reason=Reason)

--- a/tests/api2/test_150_cronjob.py
+++ b/tests/api2/test_150_cronjob.py
@@ -12,6 +12,7 @@ from functions import POST, PUT, SSH_TEST, GET, DELETE
 from auto_config import user, password, ip
 
 TESTFILE = '/tmp/.testFileCreatedViaCronjob'
+pytestmark = pytest.mark.cron
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_160_device.py
+++ b/tests/api2/test_160_device.py
@@ -12,6 +12,8 @@ from functions import POST
 from auto_config import ha
 global all_results
 all_results = {}
+pytestmark = pytest.mark.disk
+
 disk_list = list(POST('/device/get_info/', 'DISK', controller_a=ha).json().keys())
 
 

--- a/tests/api2/test_170_disk.py
+++ b/tests/api2/test_170_disk.py
@@ -13,6 +13,7 @@ from auto_config import ha
 RunTest = True
 TestName = "get disk information"
 DISK_ID = None
+pytestmark = pytest.mark.disk
 
 disk_list = list(POST('/device/get_info/', 'DISK', controller_a=ha).json().keys())
 

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -24,6 +24,7 @@ group = 'root'
 path = '/etc'
 path_list = ['default', 'kernel', 'zfs', 'ssh']
 random_path = ['/boot/grub', '/root', '/bin', '/usr/bin']
+pytestmark = pytest.mark.fs
 
 
 def test_01_get_filesystem_listdir():

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -33,6 +33,8 @@ if ha and "virtual_ip" in os.environ:
 else:
     from auto_config import ip
 
+pytestmark = pytest.mark.ftp
+
 FTP_DEFAULT = {}
 DB_DFLT = {}
 INIT_DIRS_AND_FILES = {

--- a/tests/api2/test_210_group.py
+++ b/tests/api2/test_210_group.py
@@ -15,6 +15,7 @@ from auto_config import user, password, ip
 from middlewared.test.integration.utils import call
 from pytest_dependency import depends
 GroupIdFile = "/tmp/.ixbuild_test_groupid"
+pytestmark = pytest.mark.accounts
 
 
 def test_01_get_next_gid():

--- a/tests/api2/test_230_idmap.py
+++ b/tests/api2/test_230_idmap.py
@@ -15,6 +15,7 @@ try:
         LDAPBINDPASSWORD,
         LDAPHOSTNAME,
     )
+    pytestmark = pytest.mark.certs
 except ImportError:
     Reason = 'LDAP* variable are not setup in config.py'
     # comment pytestmark for development testing with --dev-test

--- a/tests/api2/test_25_kubernetes_passthrough_test.py
+++ b/tests/api2/test_25_kubernetes_passthrough_test.py
@@ -15,6 +15,7 @@ import pytest
 
 
 APP_NAME = 'syncthing'
+pytestmark = pytest.mark.apps
 
 
 @pytest.mark.dependency(name='default_kubernetes_cluster')

--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -30,6 +30,7 @@ basename = "iqn.2005-10.org.freenas.ctl"
 zvol_name = f"ds{digit}"
 zvol = f'{pool_name}/{zvol_name}'
 zvol_url = zvol.replace('/', '%2F')
+pytestmark = pytest.mark.iscsi
 
 
 def waiting_for_iscsi_to_disconnect(base_target, wait):

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -26,6 +26,8 @@ from functions import DELETE, GET, POST, PUT, SSH_TEST
 from protocols import (initiator_name_supported, iscsi_scsi_connection,
                        isns_connection)
 
+pytestmark = pytest.mark.iscsi
+
 if ha and "virtual_ip" in os.environ:
     from auto_config import password, user
     ip = os.environ["virtual_ip"]

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -28,6 +28,7 @@ try:
         LDAPUSER,
         LDAPPASSWORD
     )
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'LDAP* variable are not setup in config.py'
     pytestmark = pytest.mark.skipif(True, reason=Reason)

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -24,6 +24,7 @@ try:
         FREEIPA_BINDPW,
         FREEIPA_HOSTNAME,
     )
+    pytestmark = pytest.mark.ds
 except ImportError:
     Reason = 'FREEIPA* variable are not setup in config.py'
     pytestmark = pytest.mark.skipif(True, reason=Reason)

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -29,6 +29,8 @@ if ha and "virtual_ip" in os.environ:
     ip = os.environ["virtual_ip"]
 else:
     from auto_config import ip
+
+pytestmark = pytest.mark.nfs
 MOUNTPOINT = f"/tmp/nfs-{hostname}"
 dataset = f"{pool_name}/nfs"
 dataset_url = dataset.replace('/', '%2F')

--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -12,6 +12,8 @@ from auto_config import ip, user, password, pool_name
 test1_dataset = f'{pool_name}/test1'
 dataset_url = test1_dataset.replace("/", "%2F")
 
+pytestmark = pytest.mark.zfs
+
 
 def test_01_verify_default_acltype_from_pool_dataset_with_api(request):
     results = GET(f'/pool/dataset/id/{pool_name}/')

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -15,6 +15,7 @@ from middlewared.client import ClientException
 from middlewared.test.integration.assets.pool import dataset as dataset_asset
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.zfs
 dataset = f'{pool_name}/dataset1'
 dataset_url = dataset.replace('/', '%2F')
 zvol = f'{pool_name}/zvol1'

--- a/tests/api2/test_341_pool_dataset_encryption.py
+++ b/tests/api2/test_341_pool_dataset_encryption.py
@@ -22,6 +22,7 @@ dataset = f'{encrypted_pool_name}/encrypted'
 dataset_url = dataset.replace('/', '%2F')
 child_dataset = f'{dataset}/child'
 child_dataset_url = child_dataset.replace('/', '%2F')
+pytestmark = pytest.mark.zfs
 
 
 @pytest.mark.dependency(name="CREATED_POOL")

--- a/tests/api2/test_344_acl_templates.py
+++ b/tests/api2/test_344_acl_templates.py
@@ -9,6 +9,7 @@ sys.path.append(apifolder)
 from functions import POST, GET, PUT, DELETE
 from auto_config import pool_name
 
+pytestmark = pytest.mark.fs
 
 @pytest.mark.dependency(name="ACLTEMPLATE_DATASETS_CREATED")
 @pytest.mark.parametrize('acltype', ['NFSV4', 'POSIX'])

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -32,6 +32,7 @@ group0 = "root"
 
 ACL_USER = 'acluser'
 ACL_PWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+pytestmark = [pytest.mark.fs, pytest.mark.slow]
 
 base_permset = {
     "READ_DATA": False,

--- a/tests/api2/test_347_posix_mode.py
+++ b/tests/api2/test_347_posix_mode.py
@@ -12,6 +12,7 @@ from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
 from auto_config import ip, pool_name, user, password
 from pytest_dependency import depends
 
+pytestmark = [pytest.mark.fs, pytest.mark.slow]
 MODE_DATASET = f'{pool_name}/modetest'
 dataset_url = MODE_DATASET.replace('/', '%2F')
 

--- a/tests/api2/test_348_posix_acl.py
+++ b/tests/api2/test_348_posix_acl.py
@@ -12,7 +12,7 @@ from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
 from auto_config import ip, pool_name, user, password
 from pytest_dependency import depends
 
-
+pytestmark = [pytest.mark.fs, pytest.mark.slow]
 ACLTEST_DATASET = f'{pool_name}/posixacltest'
 DATASET_URL = ACLTEST_DATASET.replace('/', '%2F')
 

--- a/tests/api2/test_350_pool_dataset_quota_alert.py
+++ b/tests/api2/test_350_pool_dataset_quota_alert.py
@@ -13,6 +13,7 @@ from functions import DELETE, GET, POST, SSH_TEST
 from auto_config import ip, pool_name, user, password
 
 G = 1024 * 1024 * 1024
+pytestmark = pytest.mark.zfs
 
 
 @pytest.mark.parametrize("datasets,expected_alerts", [

--- a/tests/api2/test_360_pool_scrub.py
+++ b/tests/api2/test_360_pool_scrub.py
@@ -9,6 +9,8 @@ sys.path.append(apifolder)
 from functions import GET, PUT, POST, DELETE
 from auto_config import pool_name
 
+pytestmark = pytest.mark.zfs
+
 
 def test_01_create_scrub_for_same_pool(request):
     global pool_id

--- a/tests/api2/test_410_smart.py
+++ b/tests/api2/test_410_smart.py
@@ -11,6 +11,7 @@ from functions import DELETE, POST, PUT, GET
 from auto_config import interface
 
 Reason = "VM detected no real ATA disk"
+pytestmark = pytest.mark.disk
 
 not_real = (
     interface == "vtnet0"

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -21,6 +21,7 @@ AUDIT_WAIT = 10
 SMB_NAME = "TestCifsSMB"
 SHAREUSER = 'smbuser420'
 PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+pytestmark = pytest.mark.smb
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -29,6 +29,7 @@ SMB_NAME = "SMBPROTO"
 SMB_USER = "smbuser"
 SMB_PWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
 TEST_DATA = {}
+pytestmark = pytest.mark.smb
 
 
 class DOSmode(enum.Enum):

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -25,6 +25,7 @@ from utils import create_dataset
 SMB_USER = "smbacluser"
 SMB_PWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
 TEST_DATA = {}
+pytestmark = pytest.mark.smb
 
 
 permset = {

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -18,6 +18,7 @@ from protocols import MS_RPC
 SMB_USER = "smbrpcuser"
 SMB_PWD = "smb1234#!@"
 INVALID_SHARE_NAME_CHARACTERS = {'%', '<', '>', '*', '?', '|', '/', '\\', '+', '=', ';', ':', '"', ',', '[', ']'}
+pytestmark = pytest.mark.smb
 
 @pytest.fixture(scope="module")
 def setup_smb_share(request):

--- a/tests/api2/test_430_smb_sharesec.py
+++ b/tests/api2/test_430_smb_sharesec.py
@@ -27,6 +27,7 @@ Users = {
     "name": "Users",
     "sidtype": "ALIAS"
 }
+pytestmark = pytest.mark.smb
 
 
 @pytest.fixture(scope="module")

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -17,6 +17,7 @@ PRESETS = [
     "WORM_DROPBOX"
 ]
 DETECTED_PRESETS = None
+pytestmark = pytest.mark.smb
 
 """
 Note: following sample auxiliary parameters and comments were

--- a/tests/api2/test_438_snapshots.py
+++ b/tests/api2/test_438_snapshots.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import pytest
 import sys
 
 from middlewared.test.integration.assets.pool import dataset, snapshot
@@ -8,6 +9,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import hostname, ip, pool_name
 from functions import DELETE, GET, POST, PUT, wait_on_job
+
+pytestmark = pytest.mark.zfs
 
 
 def _verify_snapshot_keys_present(snap, expected, unexpected):

--- a/tests/api2/test_540_vm.py
+++ b/tests/api2/test_540_vm.py
@@ -14,6 +14,7 @@ from functions import GET, POST, PUT, DELETE, wait_on_job
 from auto_config import ha
 
 support_virtualization = GET('/vm/supports_virtualization/', controller_a=ha).json()
+pytestmark = pytest.mark.vm
 
 bootloader = {'UEFI': 'UEFI', 'UEFI_CSM': 'Legacy BIOS'}
 

--- a/tests/api2/test_543_vm_device.py
+++ b/tests/api2/test_543_vm_device.py
@@ -21,6 +21,7 @@ CDROM_DATASET = f'{pool_name}/cdrom'
 CDROM_DATASET_URL = CDROM_DATASET.replace('/', '%2F')
 CDROM_DATASET_PATH = f'/mnt/{CDROM_DATASET}'
 DEVICE = {'disk_id': 'DISK', 'display_id': 'DISPLAY', 'cdrom_id': 'CDROM'}
+pytestmark = pytest.mark.vm
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_810_delete_user.py
+++ b/tests/api2/test_810_delete_user.py
@@ -12,6 +12,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, DELETE
 
+pytestmark = pytest.mark.accounts
+
 
 def test_01_deleting_user_shareuser(request):
     depends(request, ["shareuser"], scope="session")

--- a/tests/api2/test_999_pool_dataset_unlock.py
+++ b/tests/api2/test_999_pool_dataset_unlock.py
@@ -14,6 +14,7 @@ from auto_config import ip, pool_name, password, user
 from functions import POST, DELETE, SSH_TEST, wait_on_job
 from protocols import SMB
 
+pytestmark = pytest.mark.zfs
 
 
 def passphrase_encryption():

--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -11,6 +11,8 @@ from middlewared.test.integration.utils.audit import expect_audit_method_calls
 sys.path.append(os.getcwd())
 from functions import PUT
 
+pytestmark = pytest.mark.audit
+
 
 @pytest.mark.parametrize("api", ["ws", "rest"])
 def test_update_account_audit(api):

--- a/tests/api2/test_account_idmap.py
+++ b/tests/api2/test_account_idmap.py
@@ -8,6 +8,7 @@ from middlewared.test.integration.utils import call, client
 
 LOCAL_USER_SID_PREFIX = 'S-1-22-1-'
 LOCAL_GROUP_SID_PREFIX = 'S-1-22-2-'
+pytestmark = pytest.mark.accounts
 
 def test_uid_idmapping():
     with user({

--- a/tests/api2/test_account_privilege.py
+++ b/tests/api2/test_account_privilege.py
@@ -7,6 +7,8 @@ from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.test.integration.assets.account import group, root_with_password_disabled
 from middlewared.test.integration.utils import call, client, mock
 
+pytestmark = pytest.mark.rbac
+
 
 def test_change_local_administrator_groups_to_invalid():
     operator = call("group.query", [["group", "=", "operator"]], {"get": True})

--- a/tests/api2/test_account_privilege_authentication.py
+++ b/tests/api2/test_account_privilege_authentication.py
@@ -12,6 +12,7 @@ from middlewared.test.integration.utils import call, client, ssh, websocket_url
 from middlewared.test.integration.utils.shell import assert_shell_works
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.rbac
 
 
 @pytest.fixture(scope="module")

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -10,6 +10,7 @@ from middlewared.test.integration.utils import client
 from time import sleep
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.rbac
 
 
 @pytest.mark.parametrize("role", ["SNAPSHOT_READ", "SNAPSHOT_WRITE"])

--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -12,6 +12,7 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, client, mock
 
 REDACTED = "********"
+pytestmark = pytest.mark.rbac
 
 
 @pytest.fixture(scope="module")

--- a/tests/api2/test_account_query_roles.py
+++ b/tests/api2/test_account_query_roles.py
@@ -2,7 +2,10 @@ import pytest
 
 from middlewared.test.integration.assets.account import unprivileged_user_client
 
+pytestmark = pytest.mark.accounts
 
+
+@pytest.mark.rbac
 @pytest.mark.parametrize("role", ["READONLY_ADMIN", "FULL_ADMIN"])
 def test_user_role_in_account(role):
     with unprivileged_user_client(roles=[role]) as c:
@@ -11,6 +14,7 @@ def test_user_role_in_account(role):
         assert this_user['roles'] == [role]
 
 
+@pytest.mark.rbac
 def test_user_role_full_admin_map():
     with unprivileged_user_client(allowlist=[{"method": "*", "resource": "*"}]) as c:
         this_user = c.call("user.query", [["username", "=", c.username]], {"get": True})

--- a/tests/api2/test_apps_roles.py
+++ b/tests/api2/test_apps_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.slow, pytest.mark.apps]
+
 
 def test_app_readonly_role():
     common_checks('app.categories', 'READONLY_ADMIN', True, valid_role_exception=False)

--- a/tests/api2/test_attachment_querying.py
+++ b/tests/api2/test_attachment_querying.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import pytest
 import sys
 from pytest_dependency import depends
 
@@ -13,6 +14,7 @@ from middlewared.test.integration.utils import call, client
 
 PARENT_DATASET = 'test_parent'
 CHILD_DATASET = f'{PARENT_DATASET}/child_dataset'
+pytestmark = pytest.mark.zfs
 
 
 def test_attachment_with_child_path(request):

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -16,6 +16,7 @@ import string
 
 SMBUSER = 'audit-smb-user'
 PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+pytestmark = pytest.mark.audit
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_audit_rest.py
+++ b/tests/api2/test_audit_rest.py
@@ -2,6 +2,7 @@
 import io
 import json
 import os
+import pytest
 import sys
 from unittest.mock import ANY
 
@@ -13,6 +14,7 @@ from middlewared.test.integration.utils.audit import expect_audit_log
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.audit
 from functions import POST
 
 

--- a/tests/api2/test_audit_websocket.py
+++ b/tests/api2/test_audit_websocket.py
@@ -10,6 +10,8 @@ from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.utils import call, client, ssh
 from middlewared.test.integration.utils.audit import expect_audit_log
 
+pytestmark = pytest.mark.audit
+
 
 def test_unauthenticated_call():
     with client(auth=None) as c:

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -5,6 +5,8 @@ from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.utils import call, client
 
+pytestmark = pytest.mark.rbac
+
 
 def test_works():
     user = call("auth.me")

--- a/tests/api2/test_boot_attach_replace_detach.py
+++ b/tests/api2/test_boot_attach_replace_detach.py
@@ -3,6 +3,9 @@ import pytest
 from middlewared.test.integration.utils import call
 from auto_config import ha
 
+pytestmark = pytest.mark.boot
+
+
 if not ha:
     # the HA VMs only have 1 extra disk at time
     # of writing this. QE is aware and is working

--- a/tests/api2/test_boot_format.py
+++ b/tests/api2/test_boot_format.py
@@ -1,4 +1,7 @@
+import pytest
 from middlewared.test.integration.utils import call
+
+pytestmark = pytest.mark.boot
 
 
 def test_optimal_disk_usage():

--- a/tests/api2/test_can_access_as_user.py
+++ b/tests/api2/test_can_access_as_user.py
@@ -8,6 +8,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.rbac
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -12,6 +12,7 @@ MIDDLEWARE_RUN_DIR = '/var/run/middleware'
 TEST_CATALOG_NAME = 'TEST_CATALOG'
 TEST_SECOND_CATALOG_NAME = 'TEST_SECOND_CATALOG'
 CATALOG_SYNC_TMP_PATH = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-applications', 'catalogs')
+pytestmark = pytest.mark.apps
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = pytest.mark.rbac
+
 
 @pytest.mark.parametrize('method, role, valid_role', (
     ('certificate.profiles', 'CERTIFICATE_READ', True),

--- a/tests/api2/test_certs.py
+++ b/tests/api2/test_certs.py
@@ -11,6 +11,7 @@ import textwrap
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = [pytest.mark.certs, pytest.mark.slow]
 
 
 # We would like to test the following cases

--- a/tests/api2/test_chart_release_acl_apply.py
+++ b/tests/api2/test_chart_release_acl_apply.py
@@ -12,6 +12,7 @@ from middlewared.test.integration.assets.catalog import catalog
 
 USER_ID = 568
 TEST_DIR = 'test_dir_for_acl'
+pytestmark = pytest.mark.apps
 
 
 def path_exists(path: str) -> bool:

--- a/tests/api2/test_charts_schema.py
+++ b/tests/api2/test_charts_schema.py
@@ -8,6 +8,8 @@ from middlewared.client.client import ValidationErrors
 from middlewared.test.integration.assets.apps import chart_release
 from middlewared.test.integration.assets.catalog import catalog
 
+pytestmark = pytest.mark.apps
+
 
 def test_text_schema(request):
     depends(request, ['setup_kubernetes'], scope='session')

--- a/tests/api2/test_cloud_backup.py
+++ b/tests/api2/test_cloud_backup.py
@@ -16,6 +16,7 @@ try:
         AWS_SECRET_ACCESS_KEY,
         AWS_BUCKET,
     )
+    pytestmark = pytest.mark.cloudsync
 except ImportError:
     pytestmark = pytest.mark.skip(reason="AWS credential are missing in config.py")
 

--- a/tests/api2/test_cloud_sync.py
+++ b/tests/api2/test_cloud_sync.py
@@ -13,6 +13,7 @@ import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import ha
+pytestmark = pytest.mark.cloudsync
 
 
 def test_include(request):

--- a/tests/api2/test_cloud_sync_config.py
+++ b/tests/api2/test_cloud_sync_config.py
@@ -11,6 +11,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.cloudsync
 
 
 def test_rclone_config_writer_bool(request):

--- a/tests/api2/test_cloud_sync_custom_s3.py
+++ b/tests/api2/test_cloud_sync_custom_s3.py
@@ -11,6 +11,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.cloudsync
 
 
 @pytest.mark.parametrize("credential_attributes,result", [

--- a/tests/api2/test_cloudsync_storj.py
+++ b/tests/api2/test_cloudsync_storj.py
@@ -11,6 +11,7 @@ from middlewared.test.integration.assets.pool import dataset
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.cloudsync
 
 try:
     from config import (

--- a/tests/api2/test_dataset_encryption_keys_in_replication.py
+++ b/tests/api2/test_dataset_encryption_keys_in_replication.py
@@ -5,6 +5,7 @@ from middlewared.test.integration.assets.replication import replication_task
 from middlewared.test.integration.utils import call
 
 
+pytestmark = pytest.mark.zfs
 BASE_REPLICATION = {
     'direction': 'PUSH',
     'transport': 'LOCAL',

--- a/tests/api2/test_dataset_mount.py
+++ b/tests/api2/test_dataset_mount.py
@@ -1,5 +1,8 @@
+import pytest
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, ssh
+
+pytestmark = pytest.mark.zfs
 
 
 def test_dataset_mount_on_readonly_dataset():

--- a/tests/api2/test_dataset_unlock_validation.py
+++ b/tests/api2/test_dataset_unlock_validation.py
@@ -7,6 +7,7 @@ from middlewared.client.client import ValidationErrors
 
 
 PASSPHRASE = '12345678'
+pytestmark = pytest.mark.zfs
 
 
 def encryption_props():

--- a/tests/api2/test_device_get_disk_names.py
+++ b/tests/api2/test_device_get_disk_names.py
@@ -1,4 +1,7 @@
+import pytest
 from middlewared.test.integration.utils import call
+
+pytestmark = pytest.mark.disk
 
 
 def test_device_get_disk_names():

--- a/tests/api2/test_device_get_disks_size.py
+++ b/tests/api2/test_device_get_disks_size.py
@@ -1,4 +1,7 @@
+import pytest
 from middlewared.test.integration.utils import call, ssh
+
+pytestmark = pytest.mark.disk
 
 
 def test_device_get_disks_size():

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -3,6 +3,8 @@ import pytest
 from middlewared.service_exception import CallError
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.disk
+
 
 def test_disk_format_without_size_without_swap():
     disk = call('disk.get_unused')[0]

--- a/tests/api2/test_disk_get_dev_size.py
+++ b/tests/api2/test_disk_get_dev_size.py
@@ -4,6 +4,8 @@ import pytest
 
 from middlewared.test.integration.utils import call, ssh
 
+pytestmark = pytest.mark.disk
+
 
 @pytest.fixture(scope="session")
 def blockdevices():

--- a/tests/api2/test_disk_temperature.py
+++ b/tests/api2/test_disk_temperature.py
@@ -5,6 +5,7 @@ import pytest
 
 from middlewared.test.integration.utils import call, mock
 
+pytestmark = pytest.mark.disk
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -5,6 +5,8 @@ import pytest
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.pool import another_pool
 
+pytestmark = pytest.mark.disk
+
 
 def test_disk_wipe_exported_zpool_in_disk_get_unused():
     with another_pool() as tmp_pool:

--- a/tests/api2/test_disk_zfs_guid.py
+++ b/tests/api2/test_disk_zfs_guid.py
@@ -1,3 +1,4 @@
+import pytest
 from datetime import datetime
 
 from middlewared.test.integration.utils import call
@@ -29,6 +30,7 @@ DISK_TEMPLATE = {
     "disk_zfs_guid": None,
     "disk_bus": "ATA"
 }
+pytestmark = pytest.mark.disk
 
 
 def test_does_not_set_zfs_guid_for_expired_disk():

--- a/tests/api2/test_draid.py
+++ b/tests/api2/test_draid.py
@@ -6,6 +6,7 @@ from middlewared.test.integration.utils import call
 
 
 POOL_NAME = 'test_draid_pool'
+pytestmark = pytest.mark.zfs
 
 
 @pytest.mark.parametrize(

--- a/tests/api2/test_draid_record_and_block_size.py
+++ b/tests/api2/test_draid_record_and_block_size.py
@@ -9,6 +9,7 @@ from auto_config import ha
 
 pytestmark = [
     pytest.mark.skipif(ha, reason='Skipping for HA testing due to less disks'),
+    pytest.mark.zfs
 ]
 
 

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -11,6 +11,7 @@ sys.path.append(os.getcwd())
 
 
 PASSPHRASE = 'testing123'
+pytestmark = pytest.mark.zfs
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_filesystem__file_tail_follow.py
+++ b/tests/api2/test_filesystem__file_tail_follow.py
@@ -8,6 +8,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+pytestmark = pytest.mark.fs
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=5)

--- a/tests/api2/test_filesystem__put.py
+++ b/tests/api2/test_filesystem__put.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pytest
 import sys
 import tempfile
 
@@ -8,6 +9,7 @@ sys.path.append(apifolder)
 from functions import wait_on_job, POST
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
+pytestmark = pytest.mark.fs
 
 
 def upload_file(file_path, file_path_on_tn):

--- a/tests/api2/test_group_utils.py
+++ b/tests/api2/test_group_utils.py
@@ -1,5 +1,8 @@
+import pytest
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.assets.account import group, user
+
+pytestmark = pytest.mark.accounts
 
 
 def test_root_password_disabled():

--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -5,6 +5,8 @@ from middlewared.test.integration.assets.iscsi import iscsi_extent
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.iscsi
+
 
 def test__iscsi_extent__disk_choices(request):
     with dataset("test zvol", {"type": "VOLUME", "volsize": 1048576}) as ds:

--- a/tests/api2/test_iscsi_auth_crud_roles.py
+++ b/tests/api2/test_iscsi_auth_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -14,6 +14,8 @@ from middlewared.test.integration.utils import call, ssh
 import contextlib
 from auto_config import ip
 
+pytestmark = pytest.mark.iscsi
+
 
 def my_ip4(ipaddr=ip, port=80):
     """See which of my IP addresses will be used to connect."""

--- a/tests/api2/test_iscsi_extent_crud_roles.py
+++ b/tests/api2/test_iscsi_extent_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_EXTENT_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_global_crud_roles.py
+++ b/tests/api2/test_iscsi_global_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_host_crud_roles.py
+++ b/tests/api2/test_iscsi_host_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_initiator_crud_roles.py
+++ b/tests/api2/test_iscsi_initiator_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_portal_crud_roles.py
+++ b/tests/api2/test_iscsi_portal_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_PORTAL_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_target_crud_roles.py
+++ b/tests/api2/test_iscsi_target_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_iscsi_targetextent_crud_roles.py
+++ b/tests/api2/test_iscsi_targetextent_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.iscsi, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_kubernetes_delegate_validation.py
+++ b/tests/api2/test_kubernetes_delegate_validation.py
@@ -8,6 +8,7 @@ from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call, ssh, mock
 
 SMB_SHARE_NAME = 'test_share'
+pytestmark = pytest.mark.apps
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.nfs, pytest.mark.rbac]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -3,6 +3,8 @@ import pytest
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.zfs
+
 
 @pytest.mark.parametrize("child", ["a/b", "a/b/c"])
 def test_pool_dataset_create_ancestors(child):

--- a/tests/api2/test_pool_dataset_details.py
+++ b/tests/api2/test_pool_dataset_details.py
@@ -4,6 +4,8 @@ from middlewared.test.integration.assets.cloud_sync import local_ftp_task
 from middlewared.test.integration.assets.pool import dataset, pool
 from middlewared.test.integration.utils import call, ssh
 
+pytestmark = pytest.mark.zfs
+
 
 @pytest.fixture(scope="module")
 def cloud_sync_fixture():

--- a/tests/api2/test_pool_dataset_encrypted.py
+++ b/tests/api2/test_pool_dataset_encrypted.py
@@ -8,6 +8,7 @@ from middlewared.test.integration.utils import call
 
 
 PASSPHRASE = "12345678"
+pytestmark = pytest.mark.zfs
 
 
 def encryption_props():

--- a/tests/api2/test_pool_dataset_info.py
+++ b/tests/api2/test_pool_dataset_info.py
@@ -1,5 +1,8 @@
+import pytest
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.assets.pool import pool
+
+pytestmark = pytest.mark.zfs
 
 
 def test_recommended_zvol_blocksize():

--- a/tests/api2/test_pool_dataset_processes.py
+++ b/tests/api2/test_pool_dataset_processes.py
@@ -7,6 +7,8 @@ import os
 import sys
 sys.path.append(os.getcwd())
 
+pytestmark = pytest.mark.zfs
+
 
 def test_empty_for_locked_root_dataset():
     with another_pool({"encryption": True, "encryption_options": {"passphrase": "passphrase"}}):

--- a/tests/api2/test_pool_dataset_set_quota.py
+++ b/tests/api2/test_pool_dataset_set_quota.py
@@ -8,6 +8,8 @@ import os
 import sys
 sys.path.append(os.getcwd())
 
+pytestmark = pytest.mark.zfs
+
 
 @pytest.mark.parametrize("id", ["0", "root"])
 @pytest.mark.parametrize("quota_type,error", [

--- a/tests/api2/test_pool_dataset_snapshot_count.py
+++ b/tests/api2/test_pool_dataset_snapshot_count.py
@@ -9,6 +9,8 @@ import os
 import sys
 sys.path.append(os.getcwd())
 
+pytestmark = pytest.mark.zfs
+
 
 def test_empty_for_locked_root_dataset():
     with dataset("test_pool_dataset_snapshot_count") as ds:

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -10,6 +10,8 @@ import os
 import sys
 sys.path.append(os.getcwd())
 
+pytestmark = pytest.mark.zfs
+
 
 @pytest.mark.parametrize("datasets,file_open_path,arg_path", [
     # A file on a dataset

--- a/tests/api2/test_pool_dataset_unlock_lock_immutable_flags.py
+++ b/tests/api2/test_pool_dataset_unlock_lock_immutable_flags.py
@@ -10,6 +10,7 @@ sys.path.append(apifolder)
 
 
 PASSPHRASE = '12345678'
+pytestmark = pytest.mark.zfs
 
 
 def encryption_props():

--- a/tests/api2/test_pool_dataset_unlock_recursive.py
+++ b/tests/api2/test_pool_dataset_unlock_recursive.py
@@ -1,5 +1,9 @@
+import pytest
+
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.pool import pool
+
+pytestmark = pytest.mark.zfs
 
 
 def test_pool_dataset_unlock_recursive():

--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -5,6 +5,7 @@ from middlewared.test.integration.utils import call, mock, ssh
 
 
 PASSPHRASE = "12345678"
+pytestmark = [pytest.mark.vm, pytest.mark.zfs]
 
 
 def encryption_props():

--- a/tests/api2/test_pool_expand.py
+++ b/tests/api2/test_pool_expand.py
@@ -1,5 +1,9 @@
+import pytest
+
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, ssh
+
+pytestmark = pytest.mark.zfs
 
 
 def test_expand_pool():

--- a/tests/api2/test_pool_export.py
+++ b/tests/api2/test_pool_export.py
@@ -12,6 +12,8 @@ sys.path.append(apifolder)
 from functions import PUT
 from auto_config import pool_name, ha
 
+pytestmark = pytest.mark.zfs
+
 
 def test_systemdataset_migrate_error(request):
     """

--- a/tests/api2/test_pool_is_upgraded.py
+++ b/tests/api2/test_pool_is_upgraded.py
@@ -3,6 +3,8 @@ import pytest
 from middlewared.test.integration.assets.pool import another_pool, pool
 from middlewared.test.integration.utils import call, ssh
 
+pytestmark = pytest.mark.zfs
+
 
 @pytest.fixture(scope="module")
 def outdated_pool():

--- a/tests/api2/test_pool_is_upgraded_alert_removal.py
+++ b/tests/api2/test_pool_is_upgraded_alert_removal.py
@@ -1,8 +1,11 @@
 import contextlib
+import pytest
 import time
 
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, ssh
+
+pytestmark = [pytest.mark.alerts, pytest.mark.zfs]
 
 
 def assert_has_outdated_pool_alert(pool_name, has):

--- a/tests/api2/test_pool_remove_disk.py
+++ b/tests/api2/test_pool_remove_disk.py
@@ -6,6 +6,8 @@ from middlewared.test.integration.utils import call, ssh
 from auto_config import ha
 pytestmark = [
     pytest.mark.skipif(ha, reason='Skipping for HA testing'),
+    pytest.mark.disk,
+    pytest.mark.zfs,
 ]
 
 

--- a/tests/api2/test_pool_replace_disk.py
+++ b/tests/api2/test_pool_replace_disk.py
@@ -6,6 +6,8 @@ from middlewared.test.integration.utils import call
 from auto_config import ha
 pytestmark = [
     pytest.mark.skipif(ha, reason='Skipping for HA testing'),
+    pytest.mark.disk,
+    pytest.mark.zfs
 ]
 
 

--- a/tests/api2/test_pool_resilver.py
+++ b/tests/api2/test_pool_resilver.py
@@ -1,4 +1,7 @@
+import pytest
 from middlewared.test.integration.utils import call
+
+pytestmark = pytest.mark.zfs
 
 
 def test_pool_resilver_update():

--- a/tests/api2/test_pool_spare.py
+++ b/tests/api2/test_pool_spare.py
@@ -8,6 +8,7 @@ from middlewared.test.integration.utils import call
 from auto_config import ha
 pytestmark = [
     pytest.mark.skipif(ha, reason='Skipping for HA testing'),
+    pytest.mark.zfs
 ]
 
 

--- a/tests/api2/test_sharing_service_encrypted_dataset_info.py
+++ b/tests/api2/test_sharing_service_encrypted_dataset_info.py
@@ -15,6 +15,7 @@ ENCRYPTION_PARAMETERS = {
     },
     'inherit_encryption': False,
 }
+pytestmark = pytest.mark.vm
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_simple_share.py
+++ b/tests/api2/test_simple_share.py
@@ -13,6 +13,7 @@ from middlewared.test.integration.utils import call
 PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
 
 
+@pytest.mark.smb
 def test__smb_simple_share_validation():
     assert call('user.query', [['smb', '=', True]], {'count': True}) == 0
 

--- a/tests/api2/test_smart_test_crud.py
+++ b/tests/api2/test_smart_test_crud.py
@@ -6,6 +6,8 @@ import pytest
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import call
 
+pytestmark = pytest.mark.disk
+
 
 @contextlib.contextmanager
 def smart_test(data):

--- a/tests/api2/test_smart_test_run.py
+++ b/tests/api2/test_smart_test_run.py
@@ -6,6 +6,7 @@ import pytest
 
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import call, client, mock
+pytestmark = pytest.mark.disk
 
 
 @pytest.fixture(scope="function")

--- a/tests/api2/test_smb_client.py
+++ b/tests/api2/test_smb_client.py
@@ -43,6 +43,7 @@ PERSISTENT_ACL = [
 ]
 
 TMP_SMB_USER_PASSWORD = 'Abcd1234$'
+pytestmark = pytest.mark.smb
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.rbac, pytest.mark.smb]
+
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_SMB_READ"])
 def test_read_role_can_read(role):

--- a/tests/api2/test_snapshot_count_alert.py
+++ b/tests/api2/test_snapshot_count_alert.py
@@ -4,6 +4,7 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, mock
 from time import sleep
 
+pytestmark = [pytest.mark.alerts, pytest.mark.zfs]
 
 def test_snapshot_total_count_alert(request):
     with dataset("snapshot_count") as ds:

--- a/tests/api2/test_swap_creation_on_ha.py
+++ b/tests/api2/test_swap_creation_on_ha.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import pytest
 import os
 import sys
 
@@ -12,6 +12,7 @@ from auto_config import ha
 
 
 if ha:
+    @pytest.mark.disk
     def test_swap_creation_on_ha(request):
         with another_pool():
             swap_disks = [

--- a/tests/api2/test_twofactor_auth.py
+++ b/tests/api2/test_twofactor_auth.py
@@ -25,6 +25,7 @@ USERS_2FA_CONF = {
     TEST_USERNAME: {'interval': 30, 'otp_digits': 6},
     TEST_USERNAME_2: {'interval': 40, 'otp_digits': 7}
 }
+pytestmark = pytest.mark.accounts
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_unsupported_md_devices.py
+++ b/tests/api2/test_unsupported_md_devices.py
@@ -12,6 +12,7 @@ from middlewared.test.integration.utils import call, ssh
 
 MD_DEVICE_NAME = 'mddevicetest'
 MD_DEVICE_MIRROR_LENGTH = 2
+pytestmark = pytest.mark.disk
 
 if not ha:
     # HA vms don't have enough disks for this so skip

--- a/tests/api2/test_user_admin.py
+++ b/tests/api2/test_user_admin.py
@@ -11,6 +11,8 @@ from middlewared.test.integration.assets.account import root_with_password_disab
 from middlewared.test.integration.assets.keychain import ssh_keypair
 from middlewared.test.integration.utils import call, client, host, mock, url
 
+pytestmark = pytest.mark.accounts
+
 
 @pytest.fixture(scope="module")
 def admin():

--- a/tests/api2/test_user_ssh_password.py
+++ b/tests/api2/test_user_ssh_password.py
@@ -3,6 +3,8 @@ import pytest
 from middlewared.test.integration.assets.account import user, group
 from middlewared.test.integration.utils import call, ssh
 
+pytestmark = pytest.mark.accounts
+
 
 @pytest.mark.parametrize("ssh_password_enabled", [True, False])
 def test_user_ssh_password_enabled(ssh_password_enabled):

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -2,6 +2,8 @@ import pytest
 
 from middlewared.test.integration.assets.roles import common_checks
 
+pytestmark = [pytest.mark.vm, pytest.mark.slow]
+
 
 @pytest.mark.parametrize('method, expected_error', [
     ('vm.virtualization_details', False),

--- a/tests/api2/test_zfs_snapshot_events.py
+++ b/tests/api2/test_zfs_snapshot_events.py
@@ -8,6 +8,8 @@ from middlewared.service_exception import InstanceNotFound, ValidationErrors, Va
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import client
 
+pytestmark = pytest.mark.zfs
+
 
 def test_create():
     with dataset("test_snapshot_events_create") as ds:

--- a/tests/api2/test_zfs_snapshot_hold.py
+++ b/tests/api2/test_zfs_snapshot_hold.py
@@ -1,7 +1,10 @@
+import pytest
 from unittest.mock import ANY
 
 from middlewared.test.integration.assets.pool import dataset, snapshot
 from middlewared.test.integration.utils import call
+
+pytestmark = pytest.mark.zfs
 
 
 def test_normal_snapshot():

--- a/tests/api2/test_zpool_capacity_alert.py
+++ b/tests/api2/test_zpool_capacity_alert.py
@@ -3,6 +3,7 @@ from pytest_dependency import depends
 from middlewared.service_exception import CallError
 from middlewared.test.integration.utils import call, mock, pool
 
+pytestmark = [pytest.mark.alerts, pytest.mark.zfs]
 
 
 def test__does_not_emit_alert(request):

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -37,6 +37,7 @@ Mandatory option
     --interface <interface>     - The interface that TrueNAS is run one
 
 Optional option
+    --markers "smb or nfs"      - Markers to run
     --test <test name>          - Test name (Network, ALL)
     --tests <test1>[,test2,...] - List of tests to be supplied to pytest
     --vm-name <VM_NAME>         - Name the the Bhyve VM
@@ -66,6 +67,7 @@ option_list = [
     "isns_ip=",
     "pool=",
     "tests=",
+    "markers=",
 ]
 
 # look if all the argument are there.
@@ -85,6 +87,7 @@ debug_mode = False
 verbose = 0
 exitfirst = ''
 returncode = False
+markers = []
 callargs = []
 tests = []
 for output, arg in myopts:
@@ -123,6 +126,8 @@ for output, arg in myopts:
         callargs.append('-s')
     elif output == '--tests':
         tests.extend(arg.split(','))
+    elif output == '--markers':
+        markers.extend(['-m', f'base or {arg}'])
 
 if 'ip' not in locals() and 'passwd' not in locals() and 'interface' not in locals():
     print("Mandatory option missing!\n")
@@ -194,7 +199,7 @@ pytest_command = [
     sys.executable,
     '-m',
     'pytest'
-] + callargs + [
+] + callargs + markers + [
     "-o", "junit_family=xunit2",
     '--timeout=300',
     "--junitxml",


### PR DESCRIPTION
This commit adds basic framework for setting custom markers in our API tests. They can either be set globally for the module via
`pytestmark = pytest.mark.smb`

and multiple for module
`pytestmark = [pytest.mark.fs, pytest.mark.slow]`

or via test-specific decorator
`@pytest.mark.smb`

Long-running tests (more than a couple of minutes) should be marked as `slow` so that they can be skipped in incremental builds.

New markers can be added to the pytest.ini file. If someone feels particularly ambitious they can enhance in the future by adding a parser to assign markers based on test file names.