### PR TITLE
NAS-127109 / 24.04-RC.1 / fix TypeError crash in ipmi.lan.update (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -26,7 +26,7 @@ def lan_channels():
 
 
 def apply_config(channel, data):
-    base_cmd = ['ipmitool', 'lan', 'set', channel]
+    base_cmd = ['ipmitool', 'lan', 'set', str(channel)]
 
     rc = 0
     options = {'stdout': DEVNULL, 'stderr': DEVNULL}


### PR DESCRIPTION
The `channel` argument is an integer but must be converted to a string since we're calling `subprocess.run`

Original PR: https://github.com/truenas/middleware/pull/13045
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127109