### PR TITLE
NAS-126080 / 13.1 / Fix pagination parameters (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -27,6 +27,7 @@ from middlewared.utils.type import copy_function_metadata
 from middlewared.async_validators import check_path_resides_within_volume
 from middlewared.validators import Range, IpAddress
 
+PAGINATION_OPTS = ('count', 'get', 'limit', 'offset')
 PeriodicTaskDescriptor = namedtuple("PeriodicTaskDescriptor", ["interval", "run_on_start"])
 get_or_insert_lock = asyncio.Lock()
 LOCKS = defaultdict(asyncio.Lock)
@@ -478,8 +479,8 @@ class CRUDService(ServiceChangeMixin, Service):
         # for filters for performance reasons.
         if not options['force_sql_filters'] and options['extend']:
             datastore_options = options.copy()
-            datastore_options.pop('count', None)
-            datastore_options.pop('get', None)
+            for option in PAGINATION_OPTS:
+                datastore_options.pop(option, None)
             result = await self.middleware.call(
                 'datastore.query', self._config.datastore, [], datastore_options
             )


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 760bda0a21146c28e019c807ae8fbe5de47d8193
    git cherry-pick -x b8d927cf869db72199c314967072917ca934c955

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 89e2d4bca9646fc8b3366fd277f16746d982cdf1

## Problem

`offset` and `limit` parameters were being applied twice, one at the sql level and the then again at middleware level.

## Fix

PR fixes the problem by making sure this is not done at database level keeping in line with some other parameters we remove as well already.

Original PR: https://github.com/truenas/middleware/pull/12970
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126080