### PR TITLE
NAS-126080 / 24.04-RC.1 / Fix pagination parameters (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -13,6 +13,9 @@ from .service import Service
 from .service_mixin import ServiceChangeMixin
 
 
+PAGINATION_OPTS = ('count', 'get', 'limit', 'offset', 'select')
+
+
 def get_datastore_primary_key_schema(klass):
     return convert_schema({
         'type': klass._config.datastore_primary_key_type,
@@ -152,7 +155,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         # for filters for performance reasons.
         if not options['force_sql_filters'] and options['extend']:
             datastore_options = options.copy()
-            for option in ['count', 'get', 'limit', 'offset', 'select']:
+            for option in PAGINATION_OPTS:
                 datastore_options.pop(option, None)
             result = await self.middleware.call(
                 'datastore.query', self._config.datastore, [], datastore_options

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -152,9 +152,8 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         # for filters for performance reasons.
         if not options['force_sql_filters'] and options['extend']:
             datastore_options = options.copy()
-            datastore_options.pop('count', None)
-            datastore_options.pop('get', None)
-            datastore_options.pop('select', None)
+            for option in ['count', 'get', 'limit', 'offset', 'select']:
+                datastore_options.pop(option, None)
             result = await self.middleware.call(
                 'datastore.query', self._config.datastore, [], datastore_options
             )

--- a/tests/api2/test_crud.py
+++ b/tests/api2/test_crud.py
@@ -1,0 +1,29 @@
+import contextlib
+import pytest
+
+from middlewared.test.integration.assets.privilege import privilege
+from middlewared.test.integration.utils import client
+
+
+@pytest.mark.parametrize('offset,limit', [
+    (0, 4),
+    (1, 4),
+    (2, 4),
+    (3, 4),
+    (2, 5),
+    (3, 5),
+])
+def test_query_filters(offset, limit):
+    with contextlib.ExitStack() as stack:
+        for i in range(5):
+            stack.enter_context(
+                privilege({
+                    'name': f'Test Privilege {i}',
+                    'web_shell': False
+                })
+            )
+        with client() as c:
+            query_results = c.call('privilege.query', [], {'select': ['id']})
+            expected_result = query_results[offset:offset + limit]
+            actual_result = c.call('privilege.query', [], {'offset': offset, 'limit': limit, 'select': ['id']})
+            assert actual_result == expected_result


### PR DESCRIPTION
## Problem

`offset` and `limit` parameters were being applied twice, one at the sql level and the then again at middleware level.

## Fix

PR fixes the problem by making sure this is not done at database level keeping in line with some other parameters we remove as well already.

Original PR: https://github.com/truenas/middleware/pull/12970
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126080