### PR TITLE
Fix regression in validation for dataset parameters

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -309,7 +309,7 @@ class PoolDatasetService(CRUDService):
                     case 'INHERIT':
                         to_check[key] = parent[key]['value']
                     case 'NFSV4' | 'POSIX' | 'OFF' | 'PASSTHROUGH' | 'RESTRICTED' | 'DISCARD':
-                        to_check[key] = data[key]
+                        to_check[key] = val
                     case _:
                         raise CallError(f'{val}: unexpected value for {key}')
 

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -46,7 +46,8 @@ def test_02_create_dataset(request):
     result = POST(
         '/pool/dataset/', {
             'name': dataset,
-            "acltype": "NFSV4"
+            "acltype": "NFSV4",
+            "aclmode": "PASSTHROUGH"
         }
     )
     assert result.status_code == 200, result.text

--- a/tests/api2/test_344_acl_templates.py
+++ b/tests/api2/test_344_acl_templates.py
@@ -21,7 +21,8 @@ def test_01_create_test_datasets(request, acltype):
     result = POST(
         '/pool/dataset/', {
             'name': f'{pool_name}/acltemplate_{acltype.lower()}',
-            'acltype': acltype
+            'acltype': acltype,
+            'aclmode': 'DISCARD' if acltype == 'POSIX' else 'PASSTHROUGH'
         }
     )
 


### PR DESCRIPTION
This commit fixes a KeyError that may be raised when dataset update payload does not contain the acltype or aclmode keys.