### PR TITLE
NAS-127132 / 24.04-RC.1 / Add roles to subscriptions for CRUD services (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -122,11 +122,17 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
     def __init__(self, middleware):
         super().__init__(middleware)
         if self._config.event_register:
+            if self._config.role_prefix:
+                roles = [f'{self._config.role_prefix}_READ']
+            else:
+                roles = None
+
             self.middleware.event_register(
                 f'{self._config.namespace}.query',
                 f'Sent on {self._config.namespace} changes.',
                 private=self._config.private,
                 returns=Ref(self.ENTRY.name),
+                roles=roles,
             )
 
     @private


### PR DESCRIPTION
If role prefix is defined, allow corresponding READ role to subscribe to events by default.

Original PR: https://github.com/truenas/middleware/pull/13058
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127132