### PR TITLE
NAS-127134 / 24.10 / Add roles for directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -92,6 +92,7 @@ class ActiveDirectoryService(ConfigService):
         datastore_extend = "activedirectory.ad_extend"
         datastore_prefix = "ad_"
         cli_namespace = "directory_service.activedirectory"
+        role_prefix = "DIRECTORY_SERVICE"
 
     ENTRY = Dict(
         'activedirectory_update',
@@ -642,7 +643,7 @@ class ActiveDirectoryService(ConfigService):
     async def set_state(self, state):
         return await self.middleware.call('directoryservices.set_state', {'activedirectory': state})
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(Str('directoryservice_state', enum=[x.name for x in DSStatus], register=True))
     async def get_state(self):
         """
@@ -1051,7 +1052,7 @@ class ActiveDirectoryService(ConfigService):
 
         return True
 
-    @accepts(Str('domain', default=''))
+    @accepts(Str('domain', default=''), roles=['DIRECTORY_SERVICE_READ'])
     @returns(Dict(
         IPAddr('LDAP server'),
         Str('LDAP server name'),
@@ -1155,7 +1156,7 @@ class ActiveDirectoryService(ConfigService):
         out = json.loads(lookup.stdout.decode())
         return out
 
-    @accepts(Ref('kerberos_username_password'))
+    @accepts(Ref('kerberos_username_password'), roles=['DIRECTORY_SERVICE_WRITE'])
     @returns()
     @job(lock="AD_start_stop")
     async def leave(self, job, data):

--- a/src/middlewared/middlewared/plugins/activedirectory_/health.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/health.py
@@ -148,7 +148,7 @@ class ActiveDirectoryService(Service):
         # TODO: evaluate  UAC to determine account status
         self.machine_account_status(dc)
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(Bool('started'))
     async def started(self):
         """

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -198,7 +198,7 @@ class DirectoryServices(Service):
             self.logger.trace("No previous DS_STATE exists. Lazy initializing for %s", new)
 
         ds_state.update(new)
-        self.middleware.send_event('directoryservices.status', 'CHANGED', fields=ds_state)
+        self.middleware.send_event('directoryservices.status', 'CHANGED', fields=ds_state, roles=['DIRECTORY_SERVICE_READ'])
         return await self.middleware.call('cache.put', 'DS_STATE', ds_state)
 
     @accepts()

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -229,6 +229,7 @@ class IdmapDomainService(CRUDService):
         namespace = 'idmap'
         datastore_extend = 'idmap.idmap_extend'
         cli_namespace = 'directory_service.idmap'
+        role_prefix = 'DIRECTORY_SERVICE'
 
 
     def __wbclient_ctx(self, retry=True):
@@ -409,7 +410,7 @@ class IdmapDomainService(CRUDService):
 
         return (hash_ % max_slices) * range_size + range_size
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_WRITE'])
     @job(lock='clear_idmap_cache', lock_queue_size=1)
     async def clear_idmap_cache(self, job):
         """
@@ -447,7 +448,7 @@ class IdmapDomainService(CRUDService):
 
         return False
 
-    @accepts(roles=['READONLY_ADMIN'])
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     async def backend_options(self):
         """
         This returns full information about idmap backend options. Not all
@@ -457,6 +458,7 @@ class IdmapDomainService(CRUDService):
 
     @accepts(
         Str('idmap_backend', enum=[x.name for x in IdmapBackend]),
+        roles=['DIRECTORY_SERVICE_READ']
     )
     async def options_choices(self, backend):
         """
@@ -464,7 +466,7 @@ class IdmapDomainService(CRUDService):
         """
         return IdmapBackend[backend].supported_keys()
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     async def backend_choices(self):
         """
         Returns array of valid idmap backend choices per directory service.

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -130,6 +130,7 @@ class KerberosService(ConfigService):
         datastore = 'directoryservice.kerberossettings'
         datastore_prefix = "ks_"
         cli_namespace = "directory_service.kerberos.settings"
+        role_prefix = 'DIRECTORY_SERVICE'
 
     @accepts(Dict(
         'kerberos_settings_update',
@@ -755,6 +756,7 @@ class KerberosRealmService(CRUDService):
         datastore_extend = 'kerberos.realm.kerberos_extend'
         namespace = 'kerberos.realm'
         cli_namespace = 'directory_service.kerberos.realm'
+        role_prefix = 'DIRECTORY_SERVICE'
 
     @private
     async def kerberos_extend(self, data):
@@ -872,6 +874,7 @@ class KerberosKeytabService(CRUDService):
         datastore_prefix = 'keytab_'
         namespace = 'kerberos.keytab'
         cli_namespace = 'directory_service.kerberos.keytab'
+        role_prefix = 'DIRECTORY_SERVICE'
 
     ENTRY = Patch(
         'kerberos_keytab_create', 'kerberos_keytab_entry',
@@ -1061,7 +1064,7 @@ class KerberosKeytabService(CRUDService):
 
         return keytab_entries
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(List(
         'system-keytab',
         items=[

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -260,6 +260,7 @@ class LDAPService(ConfigService):
         datastore_extend = "ldap.ldap_extend"
         datastore_prefix = "ldap_"
         cli_namespace = "directory_service.ldap"
+        role_prefix = "DIRECTORY_SERVICE"
 
     ENTRY = Dict(
         'ldap_update',
@@ -432,7 +433,7 @@ class LDAPService(ConfigService):
 
         return data
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(List('schema_choices', items=[Ref('nss_info_ldap')]))
     async def schema_choices(self):
         """
@@ -440,7 +441,7 @@ class LDAPService(ConfigService):
         """
         return await self.middleware.call('directoryservices.nss_info_choices', 'LDAP')
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(List('ssl_choices', items=[Ref('ldap_ssl_choice', 'ssl')]))
     async def ssl_choices(self):
         """
@@ -955,7 +956,7 @@ class LDAPService(ConfigService):
     async def set_state(self, state):
         return await self.middleware.call('directoryservices.set_state', {'ldap': state.name})
 
-    @accepts()
+    @accepts(roles=['DIRECTORY_SERVICE_READ'])
     @returns(Ref('directoryservice_state'))
     async def get_state(self):
         """

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -26,6 +26,9 @@ ROLES = {
     'AUTH_SESSIONS_READ': Role(),
     'AUTH_SESSIONS_WRITE': Role(includes=['AUTH_SESSIONS_READ']),
 
+    'DIRECTORY_SERVICE_READ': Role(),
+    'DIRECTORY_SERVICE_WRITE': Role(includes=['DIRECTORY_SERVICE_READ']),
+
     'KMIP_READ': Role(),
     'KMIP_WRITE': Role(includes=['KMIP_READ']),
 


### PR DESCRIPTION
This commit adds read and write roles for endpoints related to directory services LDAP, Active Directory, and Kerberos. Since the functionality is all inter-connected, we use single set of roles for all of these plugins.