### PR TITLE
NAS-126939 / 24.04-RC.1 / Add earlier validation to prevent enabling AD without pool (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -245,6 +245,11 @@ class ActiveDirectoryService(ConfigService):
         if not new["enable"]:
             return
 
+        if not await self.middleware.call('pool.query', [], {'count': True}):
+            verrors.add(
+                "activedirectory_update.enable",
+                "Active Directory service may not be enabled before data pool is created."
+            )
         ldap_enabled = (await self.middleware.call('ldap.config'))['enable']
         if ldap_enabled:
             verrors.add(

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -7,6 +7,8 @@ import pytest
 from pytest_dependency import depends
 
 from auto_config import ha, ip, pool_name
+from middlewared.client.client import ValidationErrors
+from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import fail
 from middlewared.test.integration.utils.client import client
 
@@ -39,6 +41,15 @@ def test_001_check_sysdataset_exists_on_boot_pool(ws_client):
     sysds = ws_client.call('systemdataset.config')
     assert bp_name == sysds['pool']
     assert bp_basename == sysds['basename']
+
+
+def test_activedirectory_requires_pool(request):
+    depends(request, ['SYSDS'])
+    with pytest.raises(ValidationErrors) as ve:
+        with active_directory():
+            pass
+
+    assert ve.value.errors[0].errmsg.startswith('Active Directory service may not be enabled before data pool is created')
 
 
 def test_002_create_permanent_zpool(request, ws_client):


### PR DESCRIPTION
This mirrors validation that already takes place when attempting to move the system dataset while AD is enabled.

Original PR: https://github.com/truenas/middleware/pull/13043
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126939