### PR TITLE
NAS-127095 / 13.1 / fix KeyError crash in pool.py

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1062,7 +1062,7 @@ class PoolService(CRUDService):
                                 devname = d['name']
                             disk_path = os.path.join('/dev', devname)
                             if await self.middleware.run_in_thread(os.path.exists, disk_path):
-                                yield d['devname']
+                                yield devname
 
     @item_method
     @accepts(Int('id'), Dict(


### PR DESCRIPTION
The original commit didn't remove all the references to the `devname` key (https://github.com/truenas/middleware/pull/11612)