### PR TITLE
NAS-127223 / 24.04-BETA.1 / Prevent users from editing roles for builtin privileges (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -124,7 +124,7 @@ class PrivilegeService(CRUDService):
         verrors = ValidationErrors()
 
         if new["builtin_name"]:
-            for k in ["name", "allowlist"]:
+            for k in ["name", "allowlist", "roles"]:
                 if new[k] != old[k]:
                     verrors.add(f"privilege_update.{k}", "This field is read-only for built-in privileges")
 

--- a/tests/api2/test_account_privilege.py
+++ b/tests/api2/test_account_privilege.py
@@ -24,6 +24,13 @@ def test_change_local_administrator_allowlist():
     assert ve.value.errors[0].attribute == "privilege_update.allowlist"
 
 
+def test_change_local_administrator_roles():
+    with pytest.raises(ValidationErrors) as ve:
+        call("privilege.update", 1, {"roles": ['READONLY_ADMIN']})
+
+    assert ve.value.errors[0].attribute == "privilege_update.roles"
+
+
 def test_delete_local_administrator():
     with pytest.raises(CallError) as ve:
         call("privilege.delete", 1)


### PR DESCRIPTION
This was an oversight when we added roles to privileges framework.
Allowlists are readonly for builtin privileges. In keeping with same
design, we should also prevent changing roles

Original PR: https://github.com/truenas/middleware/pull/13088
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127223