### PR TITLE
NAS-127158 / 24.10 / change format of rsync push in module mode

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -580,7 +580,7 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
                     remote = f'"{rsync["user"]}"@{rsync["remotehost"]}'
 
             if rsync['mode'] == 'MODULE':
-                module_args = [path, f'{remote}::"{rsync["remotemodule"]}"']
+                module_args = [path, f'rsync://{remote}/"{rsync["remotemodule"]}"']
                 if rsync['direction'] != 'PUSH':
                     module_args.reverse()
                 line += module_args


### PR DESCRIPTION
Changes the format of rsync push in module mode.
While the current format is valid based on the man pages (https://rsync.samba.org/ftp/rsync/rsync.html), it prompts for password, but the new proposed format does not.

Modified this on a test **Core** system and
![image](https://github.com/truenas/middleware/assets/47820033/67935dc1-c2fa-4621-97fd-32839ecb5e7a)

And Rsync task worked, while previously it was failing with auth error (publickey,password).