### PR TITLE
NAS-127158 / 13.1 / change format of rsync push in module mode (by stavros-k)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -659,7 +659,7 @@ class RsyncTaskService(TaskPathService):
             remote = f'"{rsync["user"]}"@{rsync["remotehost"]}'
 
         if rsync['mode'] == 'MODULE':
-            module_args = [path, f'{remote}::"{rsync["remotemodule"]}"']
+            module_args = [path, f'rsync://{remote}/"{rsync["remotemodule"]}"']
             if rsync['direction'] != 'PUSH':
                 module_args.reverse()
             line += module_args


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e1e982771889424b803b4ed7720e4af64d035d4a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b7b7e0b9c3e5083b6ce6e67df91bb7e088a21100

Changes the format of rsync push in module mode.
While the current format is valid based on the man pages (https://rsync.samba.org/ftp/rsync/rsync.html), it prompts for password, but the new proposed format does not.

Modified this on a test **Core** system and
![image](https://github.com/truenas/middleware/assets/47820033/67935dc1-c2fa-4621-97fd-32839ecb5e7a)

And Rsync task worked, while previously it was failing with auth error (publickey,password).

Original PR: https://github.com/truenas/middleware/pull/13094
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127158