### PR TITLE
NAS-127220 / 24.04-RC.1 / Fix logic error in NFS share validation. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -716,7 +716,7 @@ class SharingNFSService(SharingService):
             if host in used_hosts:
                 verrors.add(
                     f"{schema_name}.hosts",
-                    f"ERROR - Another NFS share already exports {data['path']} for {host}"
+                    f"ERROR - Another NFS share already exports {data['path']} for {str(host)}"
                 )
                 continue
 
@@ -811,7 +811,8 @@ class SharingNFSService(SharingService):
                     elif commonNetworks:
                         desc = other_share_desc
                         reason = str(commonNetworks)
-                    elif this_share_everybody:
+                    elif this_share_everybody and not other_share_everybody:
+                        # Already trapped the 'everyone' exact match condition in the host check
                         desc = this_share_desc
                         all_hosts = set(datahosts) | set(sharehosts)
                         all_networks = set(data["networks"]) | set(share["networks"])


### PR DESCRIPTION
The NFS share validator had logic that allowed a secondary check

NFS share has more than one layer of validation.  There was a logic flaw in a secondary validator that over rode an earlier check.
The error text associated with the earlier check is a better match for _that_ error.   The secondary check traps similar, but different enough to error condition to warrant a different error message.

The fix was to correct the logic to exclude the secondary check from trapping the error.

Enhance NFS CI testing around NFS share validation.

Original PR: https://github.com/truenas/middleware/pull/13092
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127220