### PR TITLE
NAS-127213 / 23.10.3 / Do not use ix temp dir when creating catalogs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -264,9 +264,12 @@ class CatalogService(CRUDService):
         if not data.pop('force'):
             job.set_progress(40, f'Validating {data["label"]!r} catalog')
             # We will validate the catalog now to ensure it's valid wrt contents / format
+            k8s_dataset = (await self.middleware.call('kubernetes.config'))['dataset']
             path = os.path.join(
-                TMP_IX_APPS_DIR, 'validate_catalogs', convert_repository_to_path(data['repository'], data['branch'])
+                '/mnt', k8s_dataset, 'catalogs/validate_catalogs',
+                convert_repository_to_path(data['repository'], data['branch'])
             )
+            await self.middleware.run_in_thread(shutil.rmtree, path, ignore_errors=True)
             try:
                 await self.middleware.call('catalog.update_git_repository', {**data, 'location': path})
                 await self.middleware.call('catalog.validate_catalog_from_path', path)


### PR DESCRIPTION
This PR fixes a problem where we were still using temp dir when a new catalog was being added so we could validate it before adding it to the system. With the changes, now we use the apps dataset to hold the catalog and validate it for any issues.

Original PR: https://github.com/truenas/middleware/pull/13100
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127213