### PR TITLE
NAS-127100 / 23.10.3 / Fix netdata boot order (by Qubad786)

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -1,2 +1,5 @@
+[Unit]
+After=smartmontools.service
+
 [Service]
 Restart=always


### PR DESCRIPTION
## Problem
On the first boot, when netdata is initializing for the first time, if smartd starts after netdata's smart_log plugin has started, it will cause the smart_log plugin's check to fail. This is because smartd is not started yet, and the smart_log plugin requires its CSV files to get disk temperature.

## How to Reproduce
1. First, stop smartd.
2. Delete the smartd `smartmontools` folder.
3. Turn off and on netdata's smart_log plugin, followed by a system restart in each case to emulate the first boot scenario.
4. Reboot the system.
5. Start smartd by creating its folder and starting its service.

Observation: We will observe that netdata will not collect disk temperature until it is restarted.

I was not able to reproduce exactly the reporter's issue because of the system i am testing on is not entirely based off on SATA/SAS drives which is where we observed that check usually fails.

## Solution
Ensure that netdata starts after smartd by overwriting its unit file dependency using the `after` directive. This should ensure that smart starts before netdata and smart directory is setup. I have verified that smart directory is initialized if i nuke it before starting and right after start check it's contents so this case should be catered to without making modifications in the netdata smart log plugin.

Original PR: https://github.com/truenas/middleware/pull/13106
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127100