### PR TITLE
NAS-127302 / 24.10 / Fix app authentication error

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1465,7 +1465,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                                       audit_callback=audit_callback_messages.append, **kwargs)
             success = True
 
-            if app.authenticated_credentials:
+            if app and app.authenticated_credentials:
                 if app.authenticated_credentials.is_user_session and not (
                     credential_has_full_admin(app.authenticated_credentials) or
                     (


### PR DESCRIPTION
## Problem
The test `test_chart_release_acl_apply.py` is failing because it uses acl normalization of paths, and acl normalization uses the core.bulk API to apply acl on multiple paths at once. The bug exists in the core.bulk API because it expects the `@pass_app` parameter, and we are not providing it in acl normalization. This is causing a `NoneType` error when it tries to authenticate credentials while calling the `call_with_audit` API.

## Solution
Authenticate app's credentials only when the app object is present.

## Reference
- [core_service.py](https://github.com/truenas/middleware/blob/8eb4000954f60818e64f625da2ab9137984e9722/src/middlewared/middlewared/service/core_service.py#L763)
- [acl.py](https://github.com/truenas/middleware/blob/8eb4000954f60818e64f625da2ab9137984e9722/src/middlewared/middlewared/plugins/chart_releases_linux/acl.py#L11)
- [main.py](https://github.com/truenas/middleware/blob/8eb4000954f60818e64f625da2ab9137984e9722/src/middlewared/middlewared/main.py#L1462)