### PR TITLE
NAS-127157 / 24.10 / Mark HA nodes as active/standby in debug

### DIFF
--- a/src/middlewared/middlewared/plugins/system/debug.py
+++ b/src/middlewared/middlewared/plugins/system/debug.py
@@ -122,6 +122,7 @@ class SystemService(Service):
             node = self.middleware.call_sync('failover.node')
 
             tario = io.BytesIO()
+            host_status = self.middleware.call_sync('failover.status')
             with tarfile.open(fileobj=tario, mode='w') as tar:
 
                 if node == 'A':
@@ -131,7 +132,7 @@ class SystemService(Service):
                     my_hostname = network['hostname_b']
                     remote_hostname = network['hostname']
 
-                tar.add(debug_job.result, f'{my_hostname}.txz')
+                tar.add(debug_job.result, f'{my_hostname}{"_active" if host_status == "MASTER" else ""}.txz')
 
                 tarinfo = tarfile.TarInfo(f'{remote_hostname}.txz')
                 tarinfo.size = standby_debug.tell()


### PR DESCRIPTION
## Context

There is no way currently to determine that which compressed file belongs to active or which belongs to standby when a debug for a HA system is taken. The changes made label the compressed folder to represent that they belong to active/standby appropriately.