### PR TITLE
NAS-125640 / 24.04-RC.1 / Improve checking if containerd socket is available (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/containerd_utils.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/containerd_utils.py
@@ -4,6 +4,8 @@ from .client import ContainerdClient
 
 
 def check_containerd_connection() -> bool:
+    # Just to clarify that this does not make any internet requests but rather just checks if the socket is available
+    # and if we can connect to it. The image check returns nothing if the image is not present.
     with contextlib.suppress(Exception):
         with ContainerdClient('image') as client:
             client.get_image('alpine')

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/containerd_utils.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/containerd_utils.py
@@ -1,0 +1,11 @@
+import contextlib
+
+from .client import ContainerdClient
+
+
+def check_containerd_connection() -> bool:
+    with contextlib.suppress(Exception):
+        with ContainerdClient('image') as client:
+            client.get_image('alpine')
+            return True
+    return False

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/utils.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/utils.py
@@ -1,9 +1,13 @@
+import contextlib
 import re
+
 from collections import defaultdict
 from typing import Dict, List, Union
 
-import aiohttp
 from middlewared.service import CallError
+
+from .client import ContainerdClient
+
 
 # Default values
 DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
@@ -101,3 +105,11 @@ def normalize_docker_limits_header(headers: dict) -> dict:
         'remaining_time_limit_in_secs': int(remaining_time_limit),
         'error': None,
     }
+
+
+def check_containerd_connection() -> bool:
+    with contextlib.suppress(Exception):
+        with ContainerdClient('image') as client:
+            client.get_image('alpine')
+            return True
+    return False

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/utils.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/utils.py
@@ -1,12 +1,9 @@
-import contextlib
 import re
 
 from collections import defaultdict
 from typing import Dict, List, Union
 
 from middlewared.service import CallError
-
-from .client import ContainerdClient
 
 
 # Default values
@@ -105,11 +102,3 @@ def normalize_docker_limits_header(headers: dict) -> dict:
         'remaining_time_limit_in_secs': int(remaining_time_limit),
         'error': None,
     }
-
-
-def check_containerd_connection() -> bool:
-    with contextlib.suppress(Exception):
-        with ContainerdClient('image') as client:
-            client.get_image('alpine')
-            return True
-    return False

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import yaml
 
-from middlewared.plugins.container_runtime_interface.utils import check_containerd_connection
+from middlewared.plugins.container_runtime_interface.containerd_utils import check_containerd_connection
 from middlewared.schema import Dict, List, Str
 from middlewared.service import accepts, ConfigService
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -2,10 +2,9 @@ import asyncio
 import contextlib
 import yaml
 
-from middlewared.plugins.container_runtime_interface.client import CONTAINERD_SOCKET_PATH
+from middlewared.plugins.container_runtime_interface.utils import check_containerd_connection
 from middlewared.schema import Dict, List, Str
 from middlewared.service import accepts, ConfigService
-from middlewared.utils.socket import is_socket_available
 
 from .k8s import Node
 from .utils import KUBECONFIG_FILE, KUBERNETES_WORKER_NODE_PASSWORD, NODE_NAME
@@ -19,9 +18,7 @@ class KubernetesNodeService(ConfigService):
 
     async def config(self):
         try:
-            containerd_socket_available = await self.middleware.run_in_thread(
-                is_socket_available, CONTAINERD_SOCKET_PATH
-            )
+            containerd_socket_available = await self.middleware.run_in_thread(check_containerd_connection)
             return {
                 'node_configured': True and containerd_socket_available,
                 'events': await self.middleware.call('k8s.event.query', [], {


### PR DESCRIPTION
This PR adds changes to consume containerd socket instead of just connecting to the socket to see if it is available. Problem we see is that sometimes it is possible the socket can be connected to but containerd is still initiating itself which leads to calls failing which involve containerd.

Original PR: https://github.com/truenas/middleware/pull/13093
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125640