### PR TITLE
NAS-127317 / 24.10 / fix output of zpool.status when dev is removed

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -19,7 +19,16 @@ class ZPoolService(Service):
 
         try:
             dev = Path(path).resolve().name
-            return Path(f'/sys/class/block/{dev}').resolve().parent.name
+            resolved = Path(f'/sys/class/block/{dev}').resolve().parent.name
+            if resolved == 'block':
+                # example zpool status
+                # NAME                                        STATE     READ WRITE CKSUM
+                # tank                                        DEGRADED     0     0     0
+	            #   mirror-0                                  DEGRADED     0     0     0
+	            #       sdrh1                                 ONLINE       0     0     0
+	            #       7008beaf-4fa3-4c43-ba15-f3d5bea3fe0c  REMOVED      0     0     0
+	            #       sda1                                  ONLINE       0     0     0
+                return dev
         except Exception:
             return path
 


### PR DESCRIPTION
When a device is removed from the system, zpool status output would show the guid partition label and show `REMOVED` in the state column. We weren't showing that properly in this endpoint. It was being resolved to `block` because sysfs `/sys/class/block/<gptid>` didn't exist. This changes the endpoint to catch this type of scenario.