### PR TITLE
NAS-127267 / 24.04-RC.1 / Fix webui access flag in auth.me for custom privileges (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -22,7 +22,7 @@ def privilege_has_webui_access(privilege: dict) -> bool:
 
     Returns True if privilege grants webui access and False if it does not.
     """
-    return not any(ROLES[role].builtin for role in privilege['roles'])
+    return any(ROLES[role].builtin is False for role in privilege['roles'])
 
 
 def credential_has_full_admin(credential: object) -> bool:

--- a/tests/api2/test_auth_me.py
+++ b/tests/api2/test_auth_me.py
@@ -1,6 +1,7 @@
 import pytest
 
 from middlewared.service_exception import CallError
+from middlewared.test.integration.assets.account import unprivileged_user_client
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.utils import call, client
@@ -91,3 +92,15 @@ def test_distinguishes_attributes():
             assert me['privilege']['webui_access']
 
     assert not call("datastore.query", "account.bsdusers_webui_attribute", [["uid", "=", admin["uid"]]])
+
+
+@pytest.mark.parametrize("role,expected",  [
+    (["READONLY_ADMIN", "FILESYSTEM_ATTRS_WRITE"], True),
+    (["READONLY_ADMIN"], True),
+    (["SHARING_ADMIN"], True),
+    (["FILESYSTEM_ATTRS_WRITE"], False)
+])
+def test_webui_access(role, expected):
+    with unprivileged_user_client(roles=role) as c:
+        me = c.call('auth.me')
+        assert me['privilege']['webui_access'] == expected


### PR DESCRIPTION
We need to allow webui access if at least one of user roles grant webui access.

Original PR: https://github.com/truenas/middleware/pull/13117
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127267