### PR TITLE
NAS-127319 / 24.10 / Make sure middleware socket is present

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -27,7 +27,7 @@ PACKAGES=(
 )
 PIP_PACKAGES=()
 
-if [ -f /usr/local/libexec/disable-rootfs-protection ]; then
+if [[ -f /usr/local/libexec/disable-rootfs-protection && -S /var/run/middleware/middlewared.sock ]]; then
     # Running on SCALE
     /usr/local/libexec/disable-rootfs-protection
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This commit fixes an issue where checking file's existence we were running it whereas it required middlewared to be actually running - now this becomes a problem in our unit tests pipeline as middleware is not running in the docker container we create and these changes are not really required either for us torun the unit tests etc.