### PR TITLE
NAS-126731 / 23.10.3 / Improve failover handling of a large number of targets (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -106,7 +106,7 @@
                     (cluster_mode_targets, cluster_mode_luns) = middleware.call_sync('failover.call_remote', 'iscsi.target.cluster_mode_targets_luns')
                 except CallError as e:
                     if e.errno != CallError.ENOMETHOD:
-                        raise
+                        raise FileShouldNotExist
                     # We may have upgraded one node, but not yet the other
                     middleware.logger.warning('Failed to configure remote cluster_mode_targets_luns')
                 clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -231,11 +231,13 @@ TARGET_DRIVER copy_manager {
 }
 % endif
 ##
-## Do NOT write "HANDLER vdisk_fileio" and "HANDLER vdisk_blockio" sections if
-## we are BACKUP node.
-% if failover_status != "BACKUP":
+
 % for handler in extents_io:
 HANDLER ${handler} {
+## Do NOT write *contents* of "HANDLER vdisk_fileio" and "HANDLER vdisk_blockio" sections if
+## we are BACKUP node.  However, we still want to write the empty sections so that we will
+## load the handlers on scst startup.  This will facilitate a fast BACKUP -> MASTER reload on failover.
+% if failover_status != "BACKUP":
 %   for extent in extents_io[handler]:
     DEVICE ${extent['name']} {
         filename ${extent['extent_path']}
@@ -264,9 +266,9 @@ HANDLER ${handler} {
     }
 
 %   endfor
+% endif
 }
 % endfor
-% endif
 
 TARGET_DRIVER iscsi {
     enabled 1

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -134,7 +134,7 @@
     hosts_iqns = middleware.call_sync('iscsi.host.get_hosts_iqns')
 
     if alua_enabled and failover_status == "BACKUP":
-        cml = calc_copy_manager_luns(list(itertools.chain.from_iterable(logged_in_targets.values())), True)
+        cml = calc_copy_manager_luns(list(itertools.chain.from_iterable([x for x in logged_in_targets.values() if x is not None])), True)
     else:
         cml = calc_copy_manager_luns(all_extent_names)
 %>\

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -71,7 +71,9 @@
     # - Write a DEVICE_GROUP section with two TARGET_GROUPs
     # - TARGET GROUPs and rel_tgt_id are tied to the controller,
     #   *not* to whether it is currently the MASTER or BACKUP
-    #
+    # - clustered_extents is used to prevent cluster_mode from being
+    #   enabled on entents at startup.  We will have to explicitly
+    #   write 1 to cluster_mode elsewhere.
     is_ha = middleware.call_sync('failover.licensed')
     alua_enabled = middleware.call_sync("iscsi.global.alua_enabled")
     failover_status = middleware.call_sync("failover.status")
@@ -86,20 +88,29 @@
 
     cluster_mode_targets = []
     cluster_mode_luns = {}
+    clustered_extents = set()
+    all_cluster_mode = False
     if failover_status == "MASTER":
-        middleware.call_sync("iscsi.target.logout_ha_targets")
         local_ip = middleware.call_sync("failover.local_ip")
         dlm_ready = middleware.call_sync("dlm.node_ready")
+        if alua_enabled:
+            clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
+            cluster_mode_targets = middleware.call_sync("iscsi.target.cluster_mode_targets")
     elif failover_status == "BACKUP":
         if alua_enabled:
-            logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
-            try:
-                (cluster_mode_targets, cluster_mode_luns) = middleware.call_sync('failover.call_remote', 'iscsi.target.cluster_mode_targets_luns')
-            except CallError as e:
-                if e.errno != CallError.ENOMETHOD:
-                    raise
-                # We may have upgraded one node, but not yet the other
-                middleware.logger.warning('Failed to configure remote cluster_mode_targets_luns')
+            if middleware.call_sync("iscsi.alua.standby_write_empty_config"):
+                logged_in_targets = {}
+            else:
+                logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                try:
+                    (cluster_mode_targets, cluster_mode_luns) = middleware.call_sync('failover.call_remote', 'iscsi.target.cluster_mode_targets_luns')
+                except CallError as e:
+                    if e.errno != CallError.ENOMETHOD:
+                        raise
+                    # We may have upgraded one node, but not yet the other
+                    middleware.logger.warning('Failed to configure remote cluster_mode_targets_luns')
+                clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
+                all_cluster_mode = middleware.call_sync("iscsi.alua.all_cluster_mode")
         else:
             middleware.call_sync("iscsi.target.logout_ha_targets")
             targets = []
@@ -130,6 +141,8 @@
             extents_io_key = 'vdisk_fileio'
 
         if not os.path.exists(extent['extent_path']):
+            if alua_enabled and failover_status == "BACKUP":
+                continue
             middleware.logger.debug(
                 'Skipping generation of extent %r as the underlying resource does not exist', extent['name']
             )
@@ -152,6 +165,19 @@
         cml = calc_copy_manager_luns(list(itertools.chain.from_iterable([x for x in logged_in_targets.values() if x is not None])), True)
     else:
         cml = calc_copy_manager_luns(all_extent_names)
+
+    def set_standby_lun_to_cluster_mode(device, targetname):
+        if all_cluster_mode or device in clustered_extents:
+            if targetname in cluster_mode_luns and int(device.split(':')[-1]) in cluster_mode_luns[targetname]:
+                return True
+        return False
+
+    def set_standy_target_to_enabled(targetname):
+        devices = logged_in_targets.get(targetname, [])
+        if devices:
+            if set(devices).issubset(clustered_extents):
+                return True
+        return False
 %>\
 ##
 ## If we are on a HA system then write out a cluster name, we'll hard-code
@@ -173,9 +199,11 @@ HANDLER dev_disk {
 %                 for device in devices:
 
         DEVICE ${device} {
-## Sanity check to ensure the MASTER target LUN is in cluster_mode, if so then so are we
+## We will only enter cluster_mode here if two conditions are satisfied:
+## 1. We are already in cluster_mode or all_cluster_mode is True, AND
+## 2. The corresponding LUN on the MASTER is in cluster_mode
 ## Note we use a similar check to determine whether the target will be enabled.
-%                 if name in cluster_mode_luns and int(device.split(':')[-1]) in cluster_mode_luns[name]:
+%                 if set_standby_lun_to_cluster_mode(device, name):
             cluster_mode 1
 %                 else:
             cluster_mode 0
@@ -227,7 +255,11 @@ HANDLER ${handler} {
         t10_vend_id ${extent['vendor']}
         t10_dev_id ${extent['t10_dev_id']}
 %       if failover_status == "MASTER" and alua_enabled and dlm_ready:
+%       if extent['name'] in clustered_extents:
         cluster_mode 1
+%       else:
+        cluster_mode 0
+%       endif
 %       endif
     }
 
@@ -314,7 +346,7 @@ TARGET_DRIVER iscsi {
 %       if alua_enabled:
 %           if failover_status == "MASTER":
         enabled 1
-%           elif failover_status == "BACKUP" and target['name'] in cluster_mode_targets:
+%           elif failover_status == "BACKUP" and set_standy_target_to_enabled(target['name']):
         enabled 1
 %           else:
         enabled 0

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -101,7 +101,11 @@
             if middleware.call_sync("iscsi.alua.standby_write_empty_config"):
                 logged_in_targets = {}
             else:
-                logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                try:
+                    logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                except Exception:
+                    middleware.logger.warning('Failed to login HA targets', exc_info=True)
+                    logged_in_targets = {}
                 try:
                     _cmt_cml = middleware.call_sync(
                         'failover.call_remote', 'iscsi.target.cluster_mode_targets_luns', [], {'raise_connect_error': False}

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -295,7 +295,8 @@ TARGET_DRIVER iscsi {
 %>\
 %   if target['id'] in associated_targets:
 ##
-## For ALUA rel_tgt_id is tied to controller, if not ALUA don't bother writing it
+## For ALUA rel_tgt_id is tied to controller, if not ALUA write it anyway
+## to avoid it changing when ALUA is toggled.
 ##
 %       if alua_enabled:
 %           if node == "A":
@@ -304,6 +305,8 @@ TARGET_DRIVER iscsi {
 %           if node == "B":
         rel_tgt_id ${idx + 32000}
 %           endif
+%       else:
+        rel_tgt_id ${idx}
 %       endif
 ##
 ## For ALUA target is enabled if MASTER, disabled for BACKUP

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -543,7 +543,7 @@ DEVICE_GROUP targets {
 % endif
 <%
     if standby_node_requires_reload:
-        middleware.call_sync('iscsi.alua.standby_reload')
+        middleware.call_sync('iscsi.alua.standby_delayed_reload')
     elif fix_cluster_mode:
         middleware.call_sync('iscsi.alua.standby_fix_cluster_mode', fix_cluster_mode)
 %>

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -281,22 +281,27 @@ class DistributedLockManagerService(Service):
 
     @private
     async def local_remove_peer(self, lockspace_name):
+        """Remove the peer node from the specified lockspace without communicating with it."""
         await self.middleware.call('dlm.kernel.lockspace_stop', lockspace_name)
         await self.middleware.call('dlm.kernel.lockspace_remove_node', lockspace_name, self.peernodeID)
         await self.middleware.call('dlm.kernel.lockspace_start', lockspace_name)
 
     @private
     async def lockspaces(self):
+        """Return a list of lockspaces to which we are currently joined."""
         await self.middleware.call('dlm.create')
         return list(await self.middleware.call('dlm.kernel.node_lockspaces', self.nodeID))
 
     @private
     async def peer_lockspaces(self):
+        """Return a list of lockspaces to which we are currently joined, and which also
+        contain the PEER node"""
         await self.middleware.call('dlm.create')
         return list(await self.middleware.call('dlm.kernel.node_lockspaces', self.peernodeID))
 
     @private
     async def eject_peer(self):
+        """Locally remove the PEER node from all of the lockspaces to which we are both joined."""
         await self.middleware.call('dlm.create')
         lockspace_names = await self.middleware.call('dlm.peer_lockspaces')
         if lockspace_names:
@@ -305,6 +310,8 @@ class DistributedLockManagerService(Service):
 
     @private
     async def local_reset(self, disable_iscsi=True):
+        """Locally remove the PEER node from all lockspaces and reset cluster_mode to
+        zero, WITHOUT talking to the peer node."""
         # First turn off all access to targets from outside.
         if disable_iscsi:
             await self.middleware.call('iscsi.scst.disable')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -513,6 +513,8 @@ class FailoverEventsService(Service):
                 logger.error(f'Error unlocking ZFS encrypted datasets: {unlock_job.error}')
             elif unlock_job.result['failed']:
                 logger.error('Failed to unlock %s ZFS encrypted dataset(s)', ','.join(unlock_job.result['failed']))
+            else:
+                logger.info('Successfully completed unlock for %r', vol['name'])
 
         # if we fail to import all zpools then alert the user because nothing
         # is going to work at this point

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -14,7 +14,6 @@ from middlewared.schema import Dict, Bool, Int
 # from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
-from time import sleep
 
 logger = logging.getLogger('failover')
 
@@ -403,6 +402,11 @@ class FailoverEventsService(Service):
             job.set_progress(None, description='ERROR')
             raise FencedError()
 
+        # fenced is now running, so we *are* the ACTIVE/MASTER node
+
+        # Kick off a job to clean up any left-over ALUA state from when we were STANDBY/BACKUP.
+        alua_job = self.run_call('iscsi.alua.active_elected')
+
         if not fobj['volumes']:
             # means we received a master event but there are no zpools to import
             # (happens when the box is initially licensed for HA and being setup)
@@ -530,6 +534,28 @@ class FailoverEventsService(Service):
 
         logger.info('Configuring system dataset')
         self.run_call('systemdataset.setup')
+
+        # Before we attempt to restart iSCSI, log if the alua_job is still running
+        try:
+            alua_found = False
+            for alua_status in self.run_call('core.get_jobs'):
+                if alua_status['id'] == alua_job:
+                    alua_progress = alua_status.get('progress')
+                    if alua_progress:
+                        aluap = alua_progress.get("percent", "")
+                        aluad = alua_progress.get("description", "")
+                        logger.warning(f'alua.active_elected job still in progress ({aluap}%): {aluad}')
+                        alua_found = True
+                        break
+            if not alua_found:
+                # This is the normal case.  Transient job has finished.
+                logger.info('alua.active_elected completed')
+        except Exception as e:
+            logger.error('Failed to check alua.active_elected job progress: %r', e, exc_info=True)
+
+        if self.run_call('iscsi.global.alua_enabled'):
+            logger.info('Regenerating iSCSI config for ALUA')
+            self.run_call('etc.generate', 'scst')
 
         # now we restart the services, prioritizing the "critical" services
         logger.info('Restarting critical services.')
@@ -733,13 +759,24 @@ class FailoverEventsService(Service):
             self.run_call('service.restart', 'ssh', self.HA_PROPAGATE)
 
         # If ALUA is configured reload the iscsitarget service (to regen config) and then start SCST
+        # if self.run_call('iscsi.global.alua_enabled'):
+        #    if not self.run_call('service.reload', 'iscsitarget', self.HA_PROPAGATE):
+        #        timeout = 5
+        #        while not self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE) and timeout > 0:
+        #            logger.warning('Waiting one second to allow iscsitarget to start')
+        #            sleep(1)
+        #            timeout -= 1
         if self.run_call('iscsi.global.alua_enabled'):
-            if not self.run_call('service.reload', 'iscsitarget', self.HA_PROPAGATE):
-                timeout = 5
-                while not self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE) and timeout > 0:
-                    logger.warning('Waiting one second to allow iscsitarget to start')
-                    sleep(1)
-                    timeout -= 1
+            logger.info('Starting iSCSI for ALUA')
+            # Rewrite the scst.conf config to a clean slate state
+            self.run_call('iscsi.alua.standby_write_empty_config', True)
+            self.run_call('etc.generate', 'scst')
+
+            # The most likely situation is that scst is not running
+            if self.run_call('iscsi.scst.is_kernel_module_loaded'):
+                self.run_call('service.restart', 'iscsitarget', self.HA_PROPAGATE)
+            else:
+                self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE)
 
         logger.info('Syncing encryption keys from MASTER node (if any)')
         try:

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -51,6 +51,10 @@ class FailoverEventsService(Service):
     # before the other services during a failover event
     CRITICAL_SERVICES = ['iscsitarget', 'cifs', 'nfs']
 
+    # Any members of the FAILOVER_SERVICES set will be have
+    # failover rather than restart called.
+    FAILOVER_SERVICES = ['iscsitarget']
+
     # option to be given when changing the state of a service
     # during a failover event, we do not want to replicate
     # the state of a service to the other controller since
@@ -65,6 +69,13 @@ class FailoverEventsService(Service):
         logger.info('Restarting %s', service)
         return await asyncio.wait_for(
             self.middleware.create_task(self.middleware.call('service.restart', service, self.HA_PROPAGATE)),
+            timeout=timeout,
+        )
+
+    async def failover_service(self, service, timeout):
+        logger.info('Failover %s', service)
+        return await asyncio.wait_for(
+            self.middleware.create_task(self.middleware.call('service.failover', service)),
             timeout=timeout,
         )
 
@@ -91,7 +102,7 @@ class FailoverEventsService(Service):
             to_restart = [i for i in to_restart if i not in self.CRITICAL_SERVICES]
 
         exceptions = await asyncio.gather(
-            *[self.restart_service(svc, data['timeout']) for svc in to_restart],
+            *[self.failover_service(svc, data['timeout']) if svc in self.FAILOVER_SERVICES else self.restart_service(svc, data['timeout']) for svc in to_restart],
             return_exceptions=True
         )
         for svc, exc in zip(to_restart, exceptions):
@@ -405,7 +416,12 @@ class FailoverEventsService(Service):
         # fenced is now running, so we *are* the ACTIVE/MASTER node
 
         # Kick off a job to clean up any left-over ALUA state from when we were STANDBY/BACKUP.
-        alua_job = self.run_call('iscsi.alua.active_elected')
+        if self.run_call('service.started_or_enabled', 'iscsitarget'):
+            handle_alua = self.run_call('iscsi.global.alua_enabled')
+            if handle_alua:
+                self.run_call('iscsi.alua.active_elected')
+        else:
+            handle_alua = False
 
         if not fobj['volumes']:
             # means we received a master event but there are no zpools to import
@@ -524,6 +540,10 @@ class FailoverEventsService(Service):
 
         logger.info('Volume imports complete.')
 
+        # Now that the volumes have been imported, get a head-start on activating extents.
+        if handle_alua:
+            self.run_call('iscsi.alua.activate_extents')
+
         # need to make sure failover status is updated in the middleware cache
         logger.info('Refreshing failover status')
         self.run_call('failover.status_refresh')
@@ -534,28 +554,6 @@ class FailoverEventsService(Service):
 
         logger.info('Configuring system dataset')
         self.run_call('systemdataset.setup')
-
-        # Before we attempt to restart iSCSI, log if the alua_job is still running
-        try:
-            alua_found = False
-            for alua_status in self.run_call('core.get_jobs'):
-                if alua_status['id'] == alua_job:
-                    alua_progress = alua_status.get('progress')
-                    if alua_progress:
-                        aluap = alua_progress.get("percent", "")
-                        aluad = alua_progress.get("description", "")
-                        logger.warning(f'alua.active_elected job still in progress ({aluap}%): {aluad}')
-                        alua_found = True
-                        break
-            if not alua_found:
-                # This is the normal case.  Transient job has finished.
-                logger.info('alua.active_elected completed')
-        except Exception as e:
-            logger.error('Failed to check alua.active_elected job progress: %r', e, exc_info=True)
-
-        if self.run_call('iscsi.global.alua_enabled'):
-            logger.info('Regenerating iSCSI config for ALUA')
-            self.run_call('etc.generate', 'scst')
 
         # now we restart the services, prioritizing the "critical" services
         logger.info('Restarting critical services.')
@@ -758,25 +756,18 @@ class FailoverEventsService(Service):
             logger.info('Restarting SSH')
             self.run_call('service.restart', 'ssh', self.HA_PROPAGATE)
 
-        # If ALUA is configured reload the iscsitarget service (to regen config) and then start SCST
-        # if self.run_call('iscsi.global.alua_enabled'):
-        #    if not self.run_call('service.reload', 'iscsitarget', self.HA_PROPAGATE):
-        #        timeout = 5
-        #        while not self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE) and timeout > 0:
-        #            logger.warning('Waiting one second to allow iscsitarget to start')
-        #            sleep(1)
-        #            timeout -= 1
         if self.run_call('iscsi.global.alua_enabled'):
-            logger.info('Starting iSCSI for ALUA')
-            # Rewrite the scst.conf config to a clean slate state
-            self.run_call('iscsi.alua.standby_write_empty_config', True)
-            self.run_call('etc.generate', 'scst')
+            if self.run_call('service.started_or_enabled', 'iscsitarget'):
+                logger.info('Starting iSCSI for ALUA')
+                # Rewrite the scst.conf config to a clean slate state
+                self.run_call('iscsi.alua.standby_write_empty_config', True)
+                self.run_call('etc.generate', 'scst')
 
-            # The most likely situation is that scst is not running
-            if self.run_call('iscsi.scst.is_kernel_module_loaded'):
-                self.run_call('service.restart', 'iscsitarget', self.HA_PROPAGATE)
-            else:
-                self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE)
+                # The most likely situation is that scst is not running
+                if self.run_call('iscsi.scst.is_kernel_module_loaded'):
+                    self.run_call('service.restart', 'iscsitarget', self.HA_PROPAGATE)
+                else:
+                    self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE)
 
         logger.info('Syncing encryption keys from MASTER node (if any)')
         try:

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -51,9 +51,9 @@ class FailoverEventsService(Service):
     # before the other services during a failover event
     CRITICAL_SERVICES = ['iscsitarget', 'cifs', 'nfs']
 
-    # Any members of the FAILOVER_SERVICES set will be have
-    # failover rather than restart called.
-    FAILOVER_SERVICES = ['iscsitarget']
+    # list of services that use service.become_active instead of
+    # service.restart during a failover on the MASTER node.
+    BECOME_ACTIVE_SERVICES = ['iscsitarget']
 
     # option to be given when changing the state of a service
     # during a failover event, we do not want to replicate
@@ -72,10 +72,10 @@ class FailoverEventsService(Service):
             timeout=timeout,
         )
 
-    async def failover_service(self, service, timeout):
-        logger.info('Failover %s', service)
+    async def become_active_service(self, service, timeout):
+        logger.info('Become active %s', service)
         return await asyncio.wait_for(
-            self.middleware.create_task(self.middleware.call('service.failover', service)),
+            self.middleware.create_task(self.middleware.call('service.become_active', service)),
             timeout=timeout,
         )
 
@@ -102,7 +102,7 @@ class FailoverEventsService(Service):
             to_restart = [i for i in to_restart if i not in self.CRITICAL_SERVICES]
 
         exceptions = await asyncio.gather(
-            *[self.failover_service(svc, data['timeout']) if svc in self.FAILOVER_SERVICES else self.restart_service(svc, data['timeout']) for svc in to_restart],
+            *[self.become_active_service(svc, data['timeout']) if svc in self.BECOME_ACTIVE_SERVICES else self.restart_service(svc, data['timeout']) for svc in to_restart],
             return_exceptions=True
         )
         for svc, exc in zip(to_restart, exceptions):

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -1,0 +1,275 @@
+import asyncio
+import itertools
+
+from middlewared.schema import returns
+from middlewared.service import Service, job
+
+CHUNK_SIZE = 20
+RETRY_SECONDS = 5
+HA_TARGET_SETTLE_SECONDS = 10
+
+
+class iSCSITargetAluaService(Service):
+    """
+    Support iSCSI ALUA configuration.
+
+    The ALUA mechanism is based up DLM support baked into SCST, along with other
+    potions of middleware (dlm, iscsi.targets, etc ) to handle the coordination
+    between the two nodes in a HA pair.  This is performed in response to
+    cluster_mode being set on target extents.
+
+    However, when a LARGE number of extents(/targets) are present it becomes
+    impractical to leave/enter lockspaces on scst startup.
+
+    To avoid this, SCST on the ACTIVE will start without cluster_mode being
+    set on extents.  Likewise on the STANDBY node, so the targets there will be
+    present but disabled.  However, the STANDBY will then initiate a job to
+    (gradually) enable cluster_mode on the ACTIVE and react.
+    """
+    class Config:
+        private = True
+        namespace = 'iscsi.alua'
+
+    # See HA_PROPAGATE in event.py.  Not only required when running command
+    # on MASTER, and don't want it to propagate.
+    HA_PROPAGATE = {'ha_propagate': False}
+
+    def __init__(self, middleware):
+        super().__init__(middleware)
+        self.enabled = set()
+        self.standby_starting = False
+
+        # scst.conf.mako will check the below value to determine whether it
+        # should write cluster_mode = 1, even if then value in /sys is zero
+        # (i.e. extent not listed in iscsi.target.clustered_extents)
+        self._all_cluster_mode = False
+
+        # Likewise
+        self._standby_write_empty_config = True
+
+    async def before_start(self):
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                self._standby_write_empty_config = True
+                await self.middleware.call('etc.generate', 'scst')
+
+    async def after_start(self):
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                await self.middleware.call('iscsi.alua.standby_after_start')
+
+    async def before_stop(self):
+        self._all_cluster_mode = False
+        self.standby_starting = False
+
+    async def standby_enable_devices(self, devices):
+        await self.middleware.call('iscsi.target.login_ha_targets')
+        extents = await self.middleware.call('iscsi.extent.logged_in_extents')
+        asked = set(devices)
+        if extents and devices and asked.issubset(set(extents)):
+            tochange = [extents[name] for name in devices]
+            await self.middleware.call('iscsi.scst.set_devices_cluster_mode', tochange, 1)
+            # We could expose the targets as we go along, but will just wait until the end.
+            # await self.middleware.call('service.reload', 'iscsitarget')
+            return True
+        else:
+            return False
+
+    def all_cluster_mode(self):
+        return self._all_cluster_mode
+
+    async def standby_write_empty_config(self, value=None):
+        if value is not None:
+            self._standby_write_empty_config = value
+        return self._standby_write_empty_config
+
+    @returns()
+    @job(lock='active_elected', transient=True, lock_queue_size=1)
+    async def active_elected(self, job):
+        self.standby_starting = False
+        job.set_progress(0, 'Start ACTIVE node ALUA reset on election')
+        self.logger.debug('Start ACTIVE node ALUA reset on election')
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'MASTER':
+                await self.middleware.call('dlm.local_reset', False)
+                job.set_progress(50, 'ACTIVE node ALUA local reset done')
+
+                await self.middleware.call('iscsi.target.logout_ha_targets')
+                job.set_progress(100, 'ACTIVE node ALUA reset completed')
+                self.logger.debug('ACTIVE node ALUA reset completed')
+                return
+        job.set_progress(100, 'ACTIVE node ALUA reset NOOP')
+        self.logger.debug('ACTIVE node ALUA reset NOOP')
+
+    @returns()
+    @job(lock='standby_after_start', transient=True, lock_queue_size=1)
+    async def standby_after_start(self, job):
+        job.set_progress(0, 'ALUA starting on STANDBY')
+        self.logger.debug('ALUA starting on STANDBY')
+        self.standby_starting = True
+        self.enabled = set()
+        self._standby_write_empty_config = False
+
+        # First we ensure we're not joined to any lockspaces.  Zero things
+        await self.middleware.call('dlm.local_reset')
+        job.set_progress(5, 'Cleaned local lockspaces')
+
+        # Next ensure the ACTIVE lockspaces are reset
+        # It's OK if we wait here more or less indefinitely.
+        while self.standby_starting:
+            try:
+                await self.middleware.call('failover.call_remote', 'dlm.local_reset', [False])
+                break
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(10, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(10, 'Asked to reset remote lockspaces')
+
+        max_retries = 120
+        while self.standby_starting and max_retries:
+            try:
+                if len(await self.middleware.call('failover.call_remote', 'dlm.lockspaces')) == 0:
+                    break
+                await asyncio.sleep(1)
+                max_retries -= 1
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(15, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(15, 'Reset remote lockspaces')
+
+        # We are the STANDBY node.  Tell the ACTIVE it can logout any HA targets it had left over
+        # We set a low number of retries as it doesn't really matter if these are in place.  This is
+        # just tidy up.
+        max_retries = 5
+        while self.standby_starting and max_retries:
+            try:
+                max_retries -= 1
+                iqns = await self.middleware.call('failover.call_remote', 'iscsi.target.logged_in_iqns')
+                if not iqns:
+                    break
+                await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_targets')
+                await asyncio.sleep(1)
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(20, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(20, 'Logged out HA targets (remote node)')
+
+        # We may want to ensure that the iSCSI service on the remote node is fully
+        # up.  Since we have switched it systemd_async_start asking get_state
+
+        # Next login the HA targets.
+        while self.standby_starting:
+            try:
+                while self.standby_starting:
+                    try:
+                        before_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
+                        await self.middleware.call('iscsi.target.login_ha_targets')
+                        after_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
+                        if before_iqns != after_iqns:
+                            await asyncio.sleep(HA_TARGET_SETTLE_SECONDS)
+                        break
+                    except Exception:
+                        await asyncio.sleep(RETRY_SECONDS)
+                if not self.standby_starting:
+                    job.set_progress(25, 'Abandoned job.')
+                    return
+                else:
+                    job.set_progress(25, 'Logged in HA targets')
+
+                # Now that we've logged in the HA targets, regenerate the config so that the
+                # dev_disk DEVICEs are present (we cleared _standby_write_empty_config above).
+                # We will need these, so that then we can switch them to cluster_mode
+                await self.middleware.call('service.reload', 'iscsitarget')
+                job.set_progress(30, 'Non cluster_mode config written')
+
+                # Sanity check that all the targets surfaced up thru SCST okay.
+                devices = list(itertools.chain.from_iterable([x for x in after_iqns.values() if x is not None]))
+                if await self.middleware.call('iscsi.scst.check_cluster_mode_paths_present', devices):
+                    break
+
+                self.logger.debug('Detected missing cluster_mode.  Retrying.')
+                await self.middleware.call('iscsi.target.logout_ha_targets')
+                await self.middleware.call('service.reload', 'iscsitarget')
+                job.set_progress(20, 'Logged out HA targets (local node)')
+            except Exception as e:
+                self.logger.warning('Failed to login and surface HA targets: %r', e, exc_info=True)
+
+        # Now that the ground is cleared, start enabling cluster_mode on extents
+        local_requires_reload = False
+        remote_requires_reload = False
+        while self.standby_starting:
+            try:
+                # We'll refetch the extents each time round the loop in case more have been added
+                extents = set(extent['name'] for extent in await self.middleware.call('iscsi.extent.query', [], {'select': ['name']}))
+
+                # Choose the next batch of extents to enable.
+                to_enable = set(itertools.islice(extents - self.enabled, CHUNK_SIZE))
+
+                if to_enable:
+
+                    # First we will ensure they are in cluster_mode on the ACTIVE
+                    while self.standby_starting:
+                        try:
+                            remote_clustered_extents = set(await self.middleware.call('failover.call_remote', 'iscsi.target.clustered_extents'))
+                            todo_remote = to_enable - remote_clustered_extents
+                            if todo_remote:
+                                remote_requires_reload = True
+                                await self.middleware.call('failover.call_remote', 'iscsi.scst.set_devices_cluster_mode', [list(todo_remote), 1])
+                            else:
+                                break
+                        except Exception:
+                            await asyncio.sleep(RETRY_SECONDS)
+
+                    # Enable on STANDBY.  If we fail here, we'll still go back around the main loop.
+                    ok = False
+                    enable_retries = 10
+                    while not ok and enable_retries:
+                        ok = await self.middleware.call('iscsi.alua.standby_enable_devices', list(to_enable))
+                        if not ok:
+                            await asyncio.sleep(1)
+                        enable_retries -= 1
+                    if not ok:
+                        self.logger.error('Failed to enable cluster mode on devices: %r', to_enable)
+                    else:
+                        local_requires_reload = True
+
+                    # Update progress
+                    self.enabled.update(to_enable)
+                    progress = 20 + (80 * (len(self.enabled) / len(extents)))
+                    job.set_progress(progress, f'Enabled {len(self.enabled)} extents')
+                    self.logger.info('Set cluster_mode on for %r extents', len(self.enabled))
+                else:
+                    break
+            except Exception as e:
+                # This is a fail-safe exception catch.  Should never occur.
+                self.logger.warning('standby_start job: %r', e, exc_info=True)
+                await asyncio.sleep(RETRY_SECONDS)
+
+        if not self.standby_starting:
+            job.set_progress(100, 'Abandoned job.')
+            return
+
+        if remote_requires_reload:
+            try:
+                if local_requires_reload:
+                    await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+                else:
+                    await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget', self.HA_PROPAGATE])
+            except Exception as e:
+                self.logger.warning('Failed to reload iscsitarget: %r', e, exc_info=True)
+        elif local_requires_reload:
+            await self.middleware.call('service.reload', 'iscsitarget')
+
+        job.set_progress(100, 'All targets in cluster_mode')
+        self.standby_starting = False
+        self._all_cluster_mode = True
+        self.logger.debug('ALUA started on STANDBY')

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -427,6 +427,9 @@ class iSCSITargetAluaService(Service):
 
     @job(lock='standby_fix_cluster_mode', transient=True)
     async def standby_fix_cluster_mode(self, job, devices):
+        if self._standby_write_empty_config is not False:
+            self.logger.debug('Skipping standby_fix_cluster_mode')
+            return
         job.set_progress(0, 'Fixing cluster_mode')
         logged_in_extents = await self.middleware.call('iscsi.extent.logged_in_extents')
         device_to_srcextent = {v: k for k, v in logged_in_extents.items()}

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -146,13 +146,13 @@ class iSCSITargetAluaService(Service):
         job.set_progress(20, 'Read to activate')
 
         if todo:
-            self.logger.debug('Activating extents')
+            self.logger.debug(f'Activating {len(todo)} extents')
             retries = 10
             while todo and retries:
                 do_again = []
                 for item in todo:
                     # Mark them active
-                    if not self.middleware.call('iscsi.scst.activate_extent', *item):
+                    if not await self.middleware.call('iscsi.scst.activate_extent', *item):
                         self.logger.debug(f'Cannot Activate extent {item}')
                         do_again.append(item)
                 if not do_again:

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -408,13 +408,13 @@ class iSCSITargetAluaService(Service):
         self.standby_starting = False
         self.logger.debug('ALUA started on STANDBY')
 
-    @job(lock='standby_reload', transient=True)
-    async def standby_reload(self, job):
+    @job(lock='standby_delayed_reload', transient=True)
+    async def standby_delayed_reload(self, job):
         await asyncio.sleep(30)
         # Verify again that we are ALUA STANDBY
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('failover.status') == 'BACKUP':
-                await self.middleware.call('service.reload', 'iscsitarget')
+                await self.middleware.call('service.reload', 'iscsitarget', {'ha_propagate': False})
 
     @job(lock='standby_fix_cluster_mode', transient=True)
     async def standby_fix_cluster_mode(self, job, devices):
@@ -547,7 +547,7 @@ class iSCSITargetAluaService(Service):
                     'iscsi.alua.active_elected',
                     'iscsi.alua.activate_extents',
                     'iscsi.alua.standby_after_start',
-                    'iscsi.alua.standby_reload',
+                    'iscsi.alua.standby_delayed_reload',
                     'iscsi.alua.standby_fix_cluster_mode',
                 ]),
                 ('state', '=', 'RUNNING'),

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -13,6 +13,7 @@ from middlewared.schema import accepts, Bool, Dict, Int, Patch, Str
 from middlewared.service import CallError, private, SharingService, ValidationErrors
 from middlewared.utils.size import format_size
 from middlewared.validators import Range
+from collections import defaultdict
 
 from .utils import MAX_EXTENT_NAME_LEN
 
@@ -458,3 +459,47 @@ class iSCSITargetExtentService(SharingService):
                 return e
 
         return True
+
+    @private
+    async def logged_in_extents(self):
+        """
+        Obtain the unsurfaced disk names for all extents currently logged into on
+        a HA STANDBY controller.
+
+        :return: dict keyed by extent name, with unsurfaced disk name as the value
+        """
+        result = {}
+
+        # First check if *anything* is logged in.
+        iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
+        if not iqns:
+            return result
+
+        target_to_id = {t['name']: t['id'] for t in await self.middleware.call('iscsi.target.query', [], {'select': ['id', 'name']})}
+        extents = {e['id']: e for e in await self.middleware.call('iscsi.extent.query', [], {'select': ['id', 'name', 'locked']})}
+        assoc = await self.middleware.call('iscsi.targetextent.query')
+        # Generate a dict, keyed by target ID whose value is a set of (lunID, extent name) tuples
+        target_luns = defaultdict(set)
+        for a_tgt in filter(
+            lambda a: a['extent'] in extents and not extents[a['extent']]['locked'],
+            assoc
+        ):
+            target_id = a_tgt['target']
+            extent_name = extents[a_tgt['extent']]['name']
+            target_luns[target_id].add((a_tgt['lunid'], extent_name))
+
+        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
+        ha_basename = f'{global_basename}:HA:'
+
+        for iqn in iqns:
+            if not iqn.startswith(ha_basename):
+                continue
+            target_name = iqn.split(':')[-1]
+            target_id = target_to_id[target_name]
+            for ctl in iqns[iqn]:
+                lun = int(ctl.split(':')[-1])
+                for (l, extent_name) in target_luns[target_id]:
+                    if l == lun:
+                        result[extent_name] = ctl
+                        break
+        return result

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -491,9 +491,7 @@ class iSCSITargetExtentService(SharingService):
         global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
         ha_basename = f'{global_basename}:HA:'
 
-        for iqn in iqns:
-            if not iqn.startswith(ha_basename):
-                continue
+        for iqn in filter(lambda x: x.startswith(ha_basename), iqns):
             target_name = iqn.split(':')[-1]
             target_id = target_to_id[target_name]
             for ctl in iqns[iqn]:

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -501,3 +501,18 @@ class iSCSITargetExtentService(SharingService):
                         result[extent_name] = ctl
                         break
         return result
+
+    @private
+    async def active_extents(self):
+        """
+        Returns the names of all extents who are neither disabled nor locked, and which are
+        associated with a target.
+        """
+        filters = [['enabled', '=', True], ['locked', '=', False]]
+        extents = await self.middleware.call('iscsi.extent.query', filters, {'select': ['id', 'name']})
+        assoc = [a_tgt['extent'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')]
+        result = []
+        for extent in extents:
+            if extent['id'] in assoc:
+                result.append(extent['name'])
+        return result

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -7,6 +7,8 @@ SCST_BASE = '/sys/kernel/scst_tgt'
 SCST_TARGETS_ISCSI_ENABLED_PATH = '/sys/kernel/scst_tgt/targets/iscsi/enabled'
 SCST_DEVICES = '/sys/kernel/scst_tgt/devices'
 SCST_SUSPEND = '/sys/kernel/scst_tgt/suspend'
+SCST_CONTROLLER_A_TARGET_GROUPS_STATE = '/sys/kernel/scst_tgt/device_groups/targets/target_groups/controller_A/state'
+SCST_CONTROLLER_B_TARGET_GROUPS_STATE = '/sys/kernel/scst_tgt/device_groups/targets/target_groups/controller_B/state'
 
 
 class iSCSITargetService(Service):
@@ -83,3 +85,12 @@ class iSCSITargetService(Service):
 
     def replace_lun(self, iqn, extent, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'replace {extent} {lun}\n')
+
+    def set_node_optimized(self, node):
+        """Update which node is reported as being the active/optimized path."""
+        if node == 'A':
+            pathlib.Path(SCST_CONTROLLER_B_TARGET_GROUPS_STATE).write_text("nonoptimized\n")
+            pathlib.Path(SCST_CONTROLLER_A_TARGET_GROUPS_STATE).write_text("active\n")
+        else:
+            pathlib.Path(SCST_CONTROLLER_A_TARGET_GROUPS_STATE).write_text("nonoptimized\n")
+            pathlib.Path(SCST_CONTROLLER_B_TARGET_GROUPS_STATE).write_text("active\n")

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -1,0 +1,95 @@
+import asyncio
+import pathlib
+
+from middlewared.service import Service
+
+SCST_BASE = '/sys/kernel/scst_tgt'
+SCST_TARGETS_ISCSI_ENABLED_PATH = '/sys/kernel/scst_tgt/targets/iscsi/enabled'
+SCST_DEVICES = '/sys/kernel/scst_tgt/devices'
+SCST_SUSPEND = '/sys/kernel/scst_tgt/suspend'
+
+
+class iSCSITargetService(Service):
+
+    class Config:
+        namespace = 'iscsi.scst'
+        private = True
+
+    def path_write(self, path, text):
+        p = pathlib.Path(path)
+        realpath = str(p.resolve())
+        if realpath.startswith(SCST_BASE) and p.exists():
+            p.write_text(text)
+        else:
+            raise ValueError(f'Unexpected path "{realpath}"')
+
+    async def set_all_cluster_mode(self, value):
+        text = f'{int(value)}\n'
+        paths = await self.middleware.call('iscsi.scst.cluster_mode_paths')
+        if paths:
+            await asyncio.gather(*[self.middleware.call('iscsi.scst.path_write', path, text) for path in paths])
+
+    def cluster_mode_paths(self):
+        scst_tgt_devices = pathlib.Path(SCST_DEVICES)
+        if scst_tgt_devices.exists():
+            return [str(p) for p in scst_tgt_devices.glob('*/cluster_mode')]
+        else:
+            return []
+
+    def check_cluster_mode_paths_present(self, devices):
+        for device in devices:
+            if not pathlib.Path(f'{SCST_DEVICES}/{device}/cluster_mode').exists():
+                return False
+        return True
+
+    async def set_devices_cluster_mode(self, devices, value):
+        text = f'{int(value)}\n'
+        paths = [f'{SCST_DEVICES}/{device}/cluster_mode' for device in devices]
+        if paths:
+            await asyncio.gather(*[self.middleware.call('iscsi.scst.path_write', path, text) for path in paths])
+
+    def disable(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        p.write_text('0\n')
+
+    def enable(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        p.write_text('1\n')
+
+    def suspend(self, value):
+        p = pathlib.Path(SCST_SUSPEND)
+        p.write_text(f'{value}\n')
+
+    def enabled(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        try:
+            return p.read_text().strip() == '1'
+        except FileNotFoundError:
+            return False
+
+    def is_kernel_module_loaded(self):
+        return pathlib.Path(SCST_BASE).exists()
+
+    def activate_extent(self, extent_name, extenttype, path):
+        p = pathlib.Path(path)
+        if p.exists():
+            if extenttype == 'DISK':
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_blockio/{extent_name}/active')
+            else:
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_fileio/{extent_name}/active')
+            p.write_text('1\n')
+            return True
+        else:
+            return False
+
+    def activate_extents(self, extents):
+        for extent in extents:
+            if extent['type'] == 'DISK':
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_blockio/{extent["name"]}/active')
+            else:
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_fileio/{extent["name"]}/active')
+            p.write_text('1\n')
+
+    def replace_lun(self, iqn, extent, lun):
+        p = pathlib.Path(f'/sys/kernel/scst_tgt/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt')
+        p.write_text(f'replace {extent} {lun}\n')

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -44,6 +44,12 @@ class iSCSITargetService(Service):
                 return False
         return True
 
+    def get_cluster_mode(self, device):
+        try:
+            return pathlib.Path(f'{SCST_DEVICES}/{device}/cluster_mode').read_text().splitlines()[0]
+        except Exception:
+            return "UNKNOWN"
+
     async def set_devices_cluster_mode(self, devices, value):
         text = f'{int(value)}\n'
         paths = [f'{SCST_DEVICES}/{device}/cluster_mode' for device in devices]

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -82,10 +82,10 @@ class iSCSITargetService(Service):
                 p = pathlib.Path(f'{SCST_BASE}/handlers/vdisk_fileio/{extent_name}/active')
             try:
                 p.write_text('1\n')
-            except FileNotFoundError:
-                return False
-            else:
                 return True
+            except Exception:
+                # Return False on ANY exception
+                return False
         else:
             return False
 

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -89,6 +89,9 @@ class iSCSITargetService(Service):
         else:
             return False
 
+    def delete_lun(self, iqn, lun):
+        pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'del {lun}\n')
+
     def replace_lun(self, iqn, extent, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'replace {extent} {lun}\n')
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -56,6 +56,7 @@ class iSCSITargetToExtentService(CRUDService):
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return await self.get_instance(data['id'])
 
@@ -117,6 +118,7 @@ class iSCSITargetToExtentService(CRUDService):
         await self._service_change('iscsitarget', 'reload')
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('iscsi.alua.removed_target_extent', associated_target['target'], associated_target['extent'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -122,8 +122,14 @@ class iSCSITargetToExtentService(CRUDService):
             extent_name = (await self.middleware.call('iscsi.extent.query',
                                                       [['id', '=', associated_target['extent']]],
                                                       {'select': ['name'], 'get': True}))['name']
-            # iscsi.alua.removed_target_extent includes a local service reload
-            await self.middleware.call('failover.call_remote', 'iscsi.alua.removed_target_extent', [target_name, associated_target['lunid'], extent_name])
+            try:
+                # iscsi.alua.removed_target_extent includes a local service reload
+                await self.middleware.call('failover.call_remote', 'iscsi.alua.removed_target_extent', [target_name, associated_target['lunid'], extent_name])
+            except CallError as e:
+                if e.errno != CallError.ENOMETHOD:
+                    self.logger.warning('Failed up update STANDBY node', exc_info=True)
+                    # Better to continue than to raise the exception
+                await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -55,6 +55,7 @@ class iSCSITargetToExtentService(CRUDService):
         await self._service_change('iscsitarget', 'reload')
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
 
         return await self.get_instance(data['id'])
 
@@ -114,6 +115,8 @@ class iSCSITargetToExtentService(CRUDService):
         )
 
         await self._service_change('iscsitarget', 'reload')
+        if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
+            await self.middleware.call('iscsi.alua.removed_target_extent', associated_target['target'], associated_target['extent'])
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -619,3 +619,59 @@ class iSCSITargetService(CRUDService):
                 result.append(target['name'])
 
         return result
+
+    @private
+    async def cluster_mode_targets_luns(self):
+        """
+        Returns a tuple containing:
+        - list of target names that are currently in cluster_mode on this controller.
+        - dict keyed by target name, where the value is a list of luns that are currently in cluster_mode on this controller.
+        """
+        targets = await self.middleware.call('iscsi.target.query')
+        extents = {extent['id']: extent for extent in await self.middleware.call('iscsi.extent.query', [['enabled', '=', True]])}
+        assoc = await self.middleware.call('iscsi.targetextent.query')
+
+        # Generate a dict, keyed by target ID whose value is a set of associated extent names
+        target_extents = defaultdict(set)
+        # Also Generate a dict, keyed by target ID whose value is a set of (lunID, extent name) tuples
+        target_luns = defaultdict(set)
+        for a_tgt in filter(
+            lambda a: a['extent'] in extents and not extents[a['extent']]['locked'],
+            assoc
+        ):
+            target_id = a_tgt['target']
+            extent_name = extents[a_tgt['extent']]['name']
+            target_extents[target_id].add(extent_name)
+            target_luns[target_id].add((a_tgt['lunid'], extent_name))
+
+        # Check sysfs to see what extents are in cluster mode
+        cl_extents = set(await self.middleware.call('iscsi.target.clustered_extents'))
+
+        cluster_mode_targets = []
+        cluster_mode_luns = defaultdict(list)
+
+        for target in targets:
+            # Find targets whose extents are all in cluster mode
+            if target_extents[target['id']].issubset(cl_extents):
+                cluster_mode_targets.append(target['name'])
+
+            for (lunid, extent_name) in target_luns.get(target['id'], {}):
+                if extent_name in cl_extents:
+                    cluster_mode_luns[target['name']].append(lunid)
+
+        return (cluster_mode_targets, cluster_mode_luns)
+
+    @private
+    async def active_targets(self):
+        """
+        Returns the names of all targets whose extents are neither disabled nor locked.
+        """
+        bad_extents = [extent['id'] for extent in await self.middleware.call('iscsi.extent.query',
+                                                                             [['OR',
+                                                                               [['enabled', '=', False],
+                                                                                ['locked', '=', True]]]])]
+        targets = {t['id']: t['name'] for t in await self.middleware.call('iscsi.target.query', [], {'select': ['id', 'name']})}
+        assoc = {a_tgt['extent']: a_tgt['target'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')}
+        for bad_extent in bad_extents:
+            del targets[assoc[bad_extent]]
+        return list(targets.values())

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -523,6 +523,12 @@ class iSCSITargetService(CRUDService):
             # Regen existing as it should have now changed
             existing = await self.middleware.call('iscsi.target.logged_in_iqns')
 
+            # This below one does NOT have the desired impact, despite the output from 'iscsiadm -m node -o show'
+            # cmd = ['iscsiadm', '-m', 'node', '-o', 'update', '-n', 'node.session.timeo.replacement_timeout', '-v', '10']
+            # await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8')
+            # So instead do this.
+            await self.middleware.call('iscsi.target.set_ha_targets_sys', f'{global_basename}:HA:', 'recovery_tmo', '10\n')
+
         # Now calculate the result to hand back.
         result = {}
         for name, iqn in iqns.items():
@@ -675,3 +681,10 @@ class iSCSITargetService(CRUDService):
         for bad_extent in bad_extents:
             del targets[assoc[bad_extent]]
         return list(targets.values())
+
+    @private
+    def set_ha_targets_sys(self, iqn_prefix, param, text):
+        sys_platform = pathlib.Path('/sys/devices/platform')
+        for targetname in sys_platform.glob('host*/session*/iscsi_session/session*/targetname'):
+            if targetname.read_text().startswith(iqn_prefix):
+                targetname.parent.joinpath(param).write_text(text)

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -477,13 +477,8 @@ class iSCSITargetService(CRUDService):
 
         :return: dict keyed by target name, with list of the unsurfaced disk names or None as the value
         """
-        targets = await self.middleware.call('iscsi.target.query')
+        iqns = await self.middleware.call('iscsi.target.active_ha_iqns')
         global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
-
-        iqns = {}
-        for target in targets:
-            name = target['name']
-            iqns[name] = f'{global_basename}:HA:{name}'
 
         # Check what's already logged in
         existing = await self.middleware.call('iscsi.target.logged_in_iqns')
@@ -551,13 +546,7 @@ class iSCSITargetService(CRUDService):
         When called on a HA BACKUP node will attempt to login to all internal HA targets,
         used in ALUA.
         """
-        targets = await self.middleware.call('iscsi.target.query')
-        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
-
-        iqns = {}
-        for target in targets:
-            name = target['name']
-            iqns[name] = f'{global_basename}:HA:{name}'
+        iqns = await self.middleware.call('iscsi.target.active_ha_iqns')
 
         # Check what's already logged in
         existing = await self.middleware.call('iscsi.target.logged_in_iqns')
@@ -670,7 +659,8 @@ class iSCSITargetService(CRUDService):
     @private
     async def active_targets(self):
         """
-        Returns the names of all targets whose extents are neither disabled nor locked.
+        Returns the names of all targets whose extents are neither disabled nor locked,
+        and which have at least one extent configured.
         """
         filters = [['OR', [['enabled', '=', False], ['locked', '=', True]]]]
         bad_extents = []
@@ -681,7 +671,28 @@ class iSCSITargetService(CRUDService):
         assoc = {a_tgt['extent']: a_tgt['target'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')}
         for bad_extent in bad_extents:
             del targets[assoc[bad_extent]]
+
+        # Also discount targets that do not have any extents
+        targets_with_extents = assoc.values()
+        for target_id in list(targets.keys()):
+            if target_id not in targets_with_extents:
+                del targets[target_id]
+
         return list(targets.values())
+
+    @private
+    async def active_ha_iqns(self):
+        """Return a dict keyed by target name with a value of the corresponding HA IQN for all
+        targets that are deemed to be active_targets (i.e. no disabled of locked extents, and
+        at least one extent configured)."""
+        targets = await self.middleware.call('iscsi.target.active_targets')
+        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
+
+        iqns = {}
+        for name in targets:
+            iqns[name] = f'{global_basename}:HA:{name}'
+
+        return iqns
 
     @private
     def set_ha_targets_sys(self, iqn_prefix, param, text):

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -129,6 +129,7 @@ class iSCSITargetService(CRUDService):
         # Then process the remote (BACKUP) config if we are HA and ALUA is enabled.
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return await self.get_instance(pk)
 
@@ -344,6 +345,7 @@ class iSCSITargetService(CRUDService):
             await self.middleware.call('failover.call_remote', 'iscsi.target.remove_target', [target["name"]])
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_target', [target["name"]])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         await self.middleware.call('iscsi.target.remove_target', target["name"])
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -672,10 +672,11 @@ class iSCSITargetService(CRUDService):
         """
         Returns the names of all targets whose extents are neither disabled nor locked.
         """
-        bad_extents = [extent['id'] for extent in await self.middleware.call('iscsi.extent.query',
-                                                                             [['OR',
-                                                                               [['enabled', '=', False],
-                                                                                ['locked', '=', True]]]])]
+        filters = [['OR', [['enabled', '=', False], ['locked', '=', True]]]]
+        bad_extents = []
+        for extent in await self.middleware.call('iscsi.extent.query', filters):
+            bad_extents.append(extent['id'])
+
         targets = {t['id']: t['name'] for t in await self.middleware.call('iscsi.target.query', [], {'select': ['id', 'name']})}
         assoc = {a_tgt['extent']: a_tgt['target'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')}
         for bad_extent in bad_extents:

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -607,10 +607,10 @@ class iSCSITargetService(CRUDService):
         cl_extents = set(await self.middleware.call('iscsi.target.clustered_extents'))
 
         # Now iterate over all the targets and return a list of those whose extents are all
-        # in cluster mode.
+        # in cluster mode.  Exclude targets with no extents.
         result = []
         for target in targets:
-            if target_extents[target['id']].issubset(cl_extents):
+            if target_extents[target['id']] and target_extents[target['id']].issubset(cl_extents):
                 result.append(target['name'])
 
         return result
@@ -646,8 +646,8 @@ class iSCSITargetService(CRUDService):
         cluster_mode_luns = defaultdict(list)
 
         for target in targets:
-            # Find targets whose extents are all in cluster mode
-            if target_extents[target['id']].issubset(cl_extents):
+            # Find targets whose extents are all in cluster mode.  Exclude targets with no extents.
+            if target_extents[target['id']] and target_extents[target['id']].issubset(cl_extents):
                 cluster_mode_targets.append(target['name'])
 
             for (lunid, extent_name) in target_luns.get(target['id'], {}):

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -382,9 +382,18 @@ class ServiceService(CRUDService):
         return await service_object.get_unit_state()
 
     @private
-    async def failover(self, service):
+    async def become_active(self, service):
+        """During a HA failover event certain services may support this method being called
+        when the node is becoming the new ACTIVE node"""
         service_object = await self.middleware.call('service.object', service)
-        return await service_object.failover()
+        return await service_object.become_active()
+
+    @private
+    async def become_standby(self, service):
+        """During a HA failover event certain services may support this method being called
+        when the node is becoming the new STANDBY node"""
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.become_standby()
 
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -381,6 +381,11 @@ class ServiceService(CRUDService):
         service_object = await self.middleware.call('service.object', service)
         return await service_object.get_unit_state()
 
+    @private
+    async def failover(self, service):
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.failover()
+
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(
         "process_terminated_nicely",

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -376,6 +376,11 @@ class ServiceService(CRUDService):
                 if await service.identify(procname):
                     return service_name
 
+    @private
+    async def get_unit_state(self, service):
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.get_unit_state()
+
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(
         "process_terminated_nicely",

--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -46,6 +46,14 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
         else:
             return ServiceState(False, [])
 
+    async def get_unit_state(self):
+        return await self.middleware.run_in_thread(self._get_unit_state_sync)
+
+    def _get_unit_state_sync(self):
+        unit = self._get_systemd_unit()
+        state = unit.Unit.ActiveState
+        return state.decode("utf-8")
+
     async def start(self):
         await self._unit_action("Start")
 

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -12,6 +12,9 @@ class ServiceInterface:
     async def get_state(self):
         raise NotImplementedError
 
+    async def get_unit_state(self):
+        raise NotImplementedError
+
     async def check_configuration(self):
         pass
 

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -15,7 +15,10 @@ class ServiceInterface:
     async def get_unit_state(self):
         raise NotImplementedError
 
-    async def failover(self):
+    async def become_active(self):
+        raise NotImplementedError
+
+    async def become_standby(self):
         raise NotImplementedError
 
     async def check_configuration(self):

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -15,6 +15,9 @@ class ServiceInterface:
     async def get_unit_state(self):
         raise NotImplementedError
 
+    async def failover(self):
+        raise NotImplementedError
+
     async def check_configuration(self):
         pass
 

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -6,16 +6,21 @@ from .base import SimpleService
 class ISCSITargetService(SimpleService):
     name = "iscsitarget"
     reloadable = True
-    systemd_unit_timeout = 30
+    systemd_async_start = True
 
     etc = ["scst", "scst_targets"]
 
     systemd_unit = "scst"
 
+    async def before_start(self):
+        await self.middleware.call("iscsi.alua.before_start")
+
     async def after_start(self):
         await self.middleware.call("iscsi.host.injection.start")
+        await self.middleware.call("iscsi.alua.after_start")
 
     async def before_stop(self):
+        await self.middleware.call("iscsi.alua.before_stop")
         await self.middleware.call("iscsi.host.injection.stop")
 
     async def reload(self):

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from middlewared.utils import run
 
 from .base import SimpleService
@@ -12,8 +14,28 @@ class ISCSITargetService(SimpleService):
 
     systemd_unit = "scst"
 
+    async def _wait_to_avoid_states(self, states, retries=10):
+        initial_retries = retries
+        while retries > 0:
+            curstate = await self.middleware.call("service.get_unit_state", self.name)
+            if curstate not in states:
+                break
+            retries -= 1
+            await asyncio.sleep(1)
+        if retries != initial_retries:
+            if curstate in states:
+                self.middleware.logger.debug(f'Waited unsucessfully for {self.name} to enter {curstate} state')
+            else:
+                self.middleware.logger.debug(f'Waited sucessfully for {self.name} to enter {curstate} state')
+
     async def before_start(self):
         await self.middleware.call("iscsi.alua.before_start")
+        # Because we are a systemd_async_start service, it is possible that
+        # a start could be requested while a stop is still in progress.
+        if await self.middleware.call("failover.in_progress"):
+            await self._wait_to_avoid_states(['deactivating'], 5)
+        else:
+            await self._wait_to_avoid_states(['deactivating'])
 
     async def after_start(self):
         await self.middleware.call("iscsi.host.injection.start")

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -57,7 +57,7 @@ class ISCSITargetService(SimpleService):
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('iscsi.scst.is_kernel_module_loaded'):
                 try:
-                    return await self.middleware.call("iscsi.alua.failover_to_master")
+                    return await self.middleware.call("iscsi.alua.become_active")
                 except Exception:
                     self.logger.warning('Failover exception', exc_info=True)
                     # Fall through

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -311,6 +311,7 @@ def zvol_extent(zvol, extent_name='zvol_extent'):
 
 @contextlib.contextmanager
 def target_extent_associate(target_id, extent_id, lun_id=0):
+    alua_enabled = call('iscsi.global.alua_enabled')
     payload = {
         'target': target_id,
         'lunid': lun_id,
@@ -320,6 +321,9 @@ def target_extent_associate(target_id, extent_id, lun_id=0):
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict), results.text
     associate_config = results.json()
+    if alua_enabled:
+        # Give a little time for the STANDBY target to surface
+        sleep(2)
 
     try:
         yield associate_config
@@ -327,6 +331,8 @@ def target_extent_associate(target_id, extent_id, lun_id=0):
         results = DELETE(f"/iscsi/targetextent/id/{associate_config['id']}/", True)
         assert results.status_code == 200, results.text
         assert results.json(), results.text
+    if alua_enabled:
+        sleep(2)
 
 
 @contextlib.contextmanager
@@ -447,7 +453,7 @@ def isns_enabled(delay=5):
 
 
 @contextlib.contextmanager
-def alua_enabled(delay=3):
+def alua_enabled(delay=10):
     payload = {'alua': True}
     results = PUT("/iscsi/global", payload)
     assert results.status_code == 200, results.text
@@ -1988,7 +1994,7 @@ def _ha_reboot_master(delay=900):
     if not new_backup:
         raise RuntimeError('Backup controller did not surface.')
 
-    # Finally ensure that a failover is still not in progress
+    # Ensure that a failover is still not in progress
     in_progress = True
     while in_progress:
         try:
@@ -2004,6 +2010,17 @@ def _ha_reboot_master(delay=900):
 
     if in_progress:
         raise RuntimeError('Failover never completed.')
+
+    # Finally check the ALUA status
+    print("Checking ALUA status...")
+    retries = 12
+    while retries:
+        if call('iscsi.alua.settled'):
+            print("ALUA is settled")
+            break
+        retries -= 1
+        print("Waiting for ALUA to settle")
+        sleep(5)
 
 
 @pytest.mark.dependency(name="iscsi_alua_config")


### PR DESCRIPTION
### Background
SCST uses a script `scstadmin` to load the config file into the kernel.  This done serially, so when large configurations are present it can be slow.

Further, iSCSI ALUA targets use the linux kernel `dlm` (distributed lock manager).  Configuration requires the interaction of the kernel and middleware on both nodes.  This can be slow, especially when many targets are present. 

### Overview
A couple of changes to SCST have been made to improve configuration/lifecycle performance (PRs #[19](https://github.com/truenas/scst/pull/19) and #[23](https://github.com/truenas/scst/pull/23)).  Also allowed `vdisk_fileio` to use the same active parameter as `vdisk_blockio` (PR #[26](https://github.com/truenas/scst/pull/26)) - more below.

This PR contains substantial changes being made to middleware to further improve configuration/lifecycle performance:

- On boot do **not** start with `cluster_mode` enabled on target extents.
- When the STANDBY node boots, it will initiate a job that resettles the DLM (on both nodes) and then steps thru the extents (20 at a time), configuring `cluster_mode`
- Define the fileio/blockio based extents in _/etc/scst.conf_ for BOTH nodes - albeit with `active 0` parameter set on the STANDBY node.
- On failover on the ACTIVE node, _become_active_ iscsitarget rather than _restart_ it.  This avoids running `scstadmin`, instead will make _precise_ changes to the scst /sys interface.  We only do the bare minimum that we need (makes extents active, and replace the HA target based LUNs with real extent based ones).
- On failover on the STANDBY node, start iscsitarget but with minimal config.  This will be corrected by the `iscsi.alua.standby_after_start` job.
- For inter-node HA targets tweak the `recovery_tmo` parameter to 10 seconds.  Otherwise we can expect stalls on a newly elected ACTIVE node, before it logs out the HA targets it needed when it was STANDBY.

We can't achieve everything instantly, so the above is an attempt to get the targets on the ACTIVE node available ASAP, with the STANDBY node to follow.

On the newly elected ACTIVE node we split activities into three stages, as certain aspects can be kicked off early/in parallel with other activities:
1. `iscsi.alua.active_elected` job will run as soon as we know we've won the election (i.e. have started fenced)
2. `iscsi.alua.activate_extents` job will run once we have imported the pool and mounted volumes, etc.
3. `service.become_active iscsitarget` will run instead of a `service.restart`

Original PR: https://github.com/truenas/middleware/pull/12967
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126731