### PR TITLE
NAS-126731 / 24.04-RC.1 / Improve failover handling of a large number of targets (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -296,7 +296,8 @@ TARGET_DRIVER iscsi {
 %>\
 %   if target['id'] in associated_targets:
 ##
-## For ALUA rel_tgt_id is tied to controller, if not ALUA don't bother writing it
+## For ALUA rel_tgt_id is tied to controller, if not ALUA write it anyway
+## to avoid it changing when ALUA is toggled.
 ##
 %       if alua_enabled:
 %           if node == "A":
@@ -305,6 +306,8 @@ TARGET_DRIVER iscsi {
 %           if node == "B":
         rel_tgt_id ${idx + 32000}
 %           endif
+%       else:
+        rel_tgt_id ${idx}
 %       endif
 ##
 ## For ALUA target is enabled if MASTER, disabled for BACKUP

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -106,7 +106,7 @@
                     (cluster_mode_targets, cluster_mode_luns) = middleware.call_sync('failover.call_remote', 'iscsi.target.cluster_mode_targets_luns')
                 except CallError as e:
                     if e.errno != CallError.ENOMETHOD:
-                        raise
+                        raise FileShouldNotExist
                     # We may have upgraded one node, but not yet the other
                     middleware.logger.warning('Failed to configure remote cluster_mode_targets_luns')
                 clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -231,11 +231,13 @@ TARGET_DRIVER copy_manager {
 }
 % endif
 ##
-## Do NOT write "HANDLER vdisk_fileio" and "HANDLER vdisk_blockio" sections if
-## we are BACKUP node.
-% if failover_status != "BACKUP":
+
 % for handler in extents_io:
 HANDLER ${handler} {
+## Do NOT write *contents* of "HANDLER vdisk_fileio" and "HANDLER vdisk_blockio" sections if
+## we are BACKUP node.  However, we still want to write the empty sections so that we will
+## load the handlers on scst startup.  This will facilitate a fast BACKUP -> MASTER reload on failover.
+% if failover_status != "BACKUP":
 %   for extent in extents_io[handler]:
     DEVICE ${extent['name']} {
         filename ${extent['extent_path']}
@@ -264,9 +266,9 @@ HANDLER ${handler} {
     }
 
 %   endfor
+% endif
 }
 % endfor
-% endif
 
 TARGET_DRIVER iscsi {
     enabled 1

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -134,7 +134,7 @@
     hosts_iqns = middleware.call_sync('iscsi.host.get_hosts_iqns')
 
     if alua_enabled and failover_status == "BACKUP":
-        cml = calc_copy_manager_luns(list(itertools.chain.from_iterable(logged_in_targets.values())), True)
+        cml = calc_copy_manager_luns(list(itertools.chain.from_iterable([x for x in logged_in_targets.values() if x is not None])), True)
     else:
         cml = calc_copy_manager_luns(all_extent_names)
 %>\

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -550,7 +550,7 @@ DEVICE_GROUP targets {
 % endif
 <%
     if standby_node_requires_reload:
-        middleware.call_sync('iscsi.alua.standby_reload')
+        middleware.call_sync('iscsi.alua.standby_delayed_reload')
     elif fix_cluster_mode:
         middleware.call_sync('iscsi.alua.standby_fix_cluster_mode', fix_cluster_mode)
 %>

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -47,13 +47,6 @@
     for auth in middleware.call_sync('iscsi.auth.query'):
         authenticators[auth['tag']].append(auth)
 
-    associated_targets = defaultdict(list)
-    for a_tgt in filter(
-        lambda a: a['extent'] in extents and not extents[a['extent']]['locked'],
-        middleware.call_sync('iscsi.targetextent.query')
-    ):
-        associated_targets[a_tgt['target']].append(a_tgt)
-
     # There are several changes that must occur if ALUA is enabled,
     # and these are different depending on whether this is the
     # MASTER node, or BACKUP node.
@@ -133,13 +126,13 @@
             extents = {}
             portals = {}
             initiators = {}
-            associated_targets = defaultdict(list)
 
     nodes = {"A" : {"other" : "B", "group_id" : 101},
              "B" : {"other" : "A", "group_id" : 102}}
 
     # Let's map extents to respective ios
     all_extent_names = []
+    missing_extents = []
     extents_io = {'vdisk_fileio': [], 'vdisk_blockio': []}
     for extent in extents.values():
         if extent['locked']:
@@ -156,11 +149,14 @@
             extent['extent_path'] = extent['path']
             extents_io_key = 'vdisk_fileio'
 
-        if not alua_enabled and not os.path.exists(extent['extent_path']):
-            middleware.logger.debug(
-                'Skipping generation of extent %r as the underlying resource does not exist', extent['name']
-            )
-            continue
+        if not os.path.exists(extent['extent_path']):
+            # We're going to permit the extent if ALUA is enabled and we're the BACKUP node
+            if not alua_enabled or failover_status != "BACKUP":
+                middleware.logger.debug(
+                    'Skipping generation of extent %r as the underlying resource does not exist', extent['name']
+                )
+                missing_extents.append(extent['id'])
+                continue
 
         extent['name'] = extent['name'].replace('.', '_')  # CORE ctl device names are incompatible with SCALE SCST
         extents_io[extents_io_key].append(extent)
@@ -169,6 +165,23 @@
         extent['t10_dev_id'] = extent['serial']
         if not extent['xen']:
             extent['t10_dev_id'] = extent['serial'].ljust(31 - len(extent['serial']), ' ')
+
+    associated_targets = defaultdict(list)
+    # On ALUA BACKUP node (only) we will include associated_targets even if underlying device is missing
+    if failover_status == 'BACKUP':
+        if alua_enabled:
+            for a_tgt in filter(
+                lambda a: a['extent'] in extents and not extents[a['extent']]['locked'],
+                middleware.call_sync('iscsi.targetextent.query')
+            ):
+                associated_targets[a_tgt['target']].append(a_tgt)
+        # If ALUA not enabled then keep associated_targets as empty
+    else:
+        for a_tgt in filter(
+            lambda a: a['extent'] in extents and not extents[a['extent']]['locked'] and a['extent'] not in missing_extents,
+            middleware.call_sync('iscsi.targetextent.query')
+        ):
+            associated_targets[a_tgt['target']].append(a_tgt)
 
     # FIXME: SSD is not being reflected in the initiator, please look into it
 
@@ -540,4 +553,4 @@ DEVICE_GROUP targets {
         middleware.call_sync('iscsi.alua.standby_reload')
     elif fix_cluster_mode:
         middleware.call_sync('iscsi.alua.standby_fix_cluster_mode', fix_cluster_mode)
-%>\
+%>

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -101,7 +101,11 @@
             if middleware.call_sync("iscsi.alua.standby_write_empty_config"):
                 logged_in_targets = {}
             else:
-                logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                try:
+                    logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                except Exception:
+                    middleware.logger.warning('Failed to login HA targets', exc_info=True)
+                    logged_in_targets = {}
                 try:
                     _cmt_cml = middleware.call_sync(
                         'failover.call_remote', 'iscsi.target.cluster_mode_targets_luns', [], {'raise_connect_error': False}

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -1,6 +1,7 @@
 <%
     import itertools
     import os
+    import time
 
     from collections import defaultdict
     from pathlib import Path
@@ -86,14 +87,17 @@
                 if 'address' in addr:
                     failover_virtual_aliases.append(addr['address'])
 
+    standby_node_requires_reload = False
+    fix_cluster_mode = []
     cluster_mode_targets = []
     cluster_mode_luns = {}
     clustered_extents = set()
-    all_cluster_mode = False
+    active_extents = []
     if failover_status == "MASTER":
         local_ip = middleware.call_sync("failover.local_ip")
         dlm_ready = middleware.call_sync("dlm.node_ready")
         if alua_enabled:
+            active_extents = middleware.call_sync("iscsi.extent.active_extents")
             clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
             cluster_mode_targets = middleware.call_sync("iscsi.target.cluster_mode_targets")
     elif failover_status == "BACKUP":
@@ -102,21 +106,27 @@
                 logged_in_targets = {}
             else:
                 try:
-                    logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                    try:
+                        logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
+                    except Exception:
+                        # We might just experience a race, so attempt a quick retry
+                        time.sleep(1)
+                        logged_in_targets = middleware.call_sync("iscsi.target.login_ha_targets")
                 except Exception:
                     middleware.logger.warning('Failed to login HA targets', exc_info=True)
                     logged_in_targets = {}
+                    standby_node_requires_reload = True
                 try:
                     _cmt_cml = middleware.call_sync(
                         'failover.call_remote', 'iscsi.target.cluster_mode_targets_luns', [], {'raise_connect_error': False}
                     )
                 except Exception:
                     middleware.logger.warning('Unhandled error contacting remote node', exc_info=True)
+                    standby_node_requires_reload = True
                 else:
                     if _cmt_cml is not None:
                         cluster_mode_targets, cluster_mode_luns = _cmt_cml
                 clustered_extents = set(middleware.call_sync("iscsi.target.clustered_extents"))
-                all_cluster_mode = middleware.call_sync("iscsi.alua.all_cluster_mode")
         else:
             middleware.call_sync("iscsi.target.logout_ha_targets")
             targets = []
@@ -170,8 +180,13 @@
     else:
         cml = calc_copy_manager_luns(all_extent_names)
 
+    def set_active_lun_to_cluster_mode(extentname):
+        if extentname in active_extents and extentname in clustered_extents:
+            return True
+        return False
+
     def set_standby_lun_to_cluster_mode(device, targetname):
-        if all_cluster_mode or device in clustered_extents:
+        if device in clustered_extents:
             if targetname in cluster_mode_luns and int(device.split(':')[-1]) in cluster_mode_luns[targetname]:
                 return True
         return False
@@ -204,12 +219,15 @@ HANDLER dev_disk {
 
         DEVICE ${device} {
 ## We will only enter cluster_mode here if two conditions are satisfied:
-## 1. We are already in cluster_mode or all_cluster_mode is True, AND
+## 1. We are already in cluster_mode, AND
 ## 2. The corresponding LUN on the MASTER is in cluster_mode
 ## Note we use a similar check to determine whether the target will be enabled.
 %                 if set_standby_lun_to_cluster_mode(device, name):
             cluster_mode 1
 %                 else:
+<%
+    fix_cluster_mode.append(device)
+%>\
             cluster_mode 0
 %                 endif
         }
@@ -257,7 +275,7 @@ HANDLER ${handler} {
         t10_vend_id ${extent['vendor']}
         t10_dev_id ${extent['t10_dev_id']}
 %       if failover_status == "MASTER" and alua_enabled and dlm_ready:
-%       if extent['name'] in clustered_extents:
+%       if set_active_lun_to_cluster_mode(extent['name']):
         cluster_mode 1
 %       else:
         cluster_mode 0
@@ -330,7 +348,7 @@ TARGET_DRIVER iscsi {
             for initiator in group_initiators:
                 initiator_portal_access.add(f'{initiator}\#{address}')
 %>\
-%   if target['id'] in associated_targets:
+%   if associated_targets.get(target['id']):
 ##
 ## For ALUA rel_tgt_id is tied to controller, if not ALUA write it anyway
 ## to avoid it changing when ALUA is toggled.
@@ -414,7 +432,12 @@ ${retrieve_luns(target['id'], ' ' * 4)}\
 %       if node == "B":
         rel_tgt_id ${idx}
 %       endif
+## Mimic the enabled behavior of the base target.  Only enable if have associated extents
+%   if associated_targets.get(target['id']):
         enabled 1
+%   else:
+        enabled 0
+%   endif
         forward_dst 1
         aen_disabled 1
         forwarding 1
@@ -512,3 +535,9 @@ DEVICE_GROUP targets {
 }
 %     endif
 % endif
+<%
+    if standby_node_requires_reload:
+        middleware.call_sync('iscsi.alua.standby_reload')
+    elif fix_cluster_mode:
+        middleware.call_sync('iscsi.alua.standby_fix_cluster_mode', fix_cluster_mode)
+%>\

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -281,22 +281,27 @@ class DistributedLockManagerService(Service):
 
     @private
     async def local_remove_peer(self, lockspace_name):
+        """Remove the peer node from the specified lockspace without communicating with it."""
         await self.middleware.call('dlm.kernel.lockspace_stop', lockspace_name)
         await self.middleware.call('dlm.kernel.lockspace_remove_node', lockspace_name, self.peernodeID)
         await self.middleware.call('dlm.kernel.lockspace_start', lockspace_name)
 
     @private
     async def lockspaces(self):
+        """Return a list of lockspaces to which we are currently joined."""
         await self.middleware.call('dlm.create')
         return list(await self.middleware.call('dlm.kernel.node_lockspaces', self.nodeID))
 
     @private
     async def peer_lockspaces(self):
+        """Return a list of lockspaces to which we are currently joined, and which also
+        contain the PEER node"""
         await self.middleware.call('dlm.create')
         return list(await self.middleware.call('dlm.kernel.node_lockspaces', self.peernodeID))
 
     @private
     async def eject_peer(self):
+        """Locally remove the PEER node from all of the lockspaces to which we are both joined."""
         await self.middleware.call('dlm.create')
         lockspace_names = await self.middleware.call('dlm.peer_lockspaces')
         if lockspace_names:
@@ -305,6 +310,8 @@ class DistributedLockManagerService(Service):
 
     @private
     async def local_reset(self, disable_iscsi=True):
+        """Locally remove the PEER node from all lockspaces and reset cluster_mode to
+        zero, WITHOUT talking to the peer node."""
         # First turn off all access to targets from outside.
         if disable_iscsi:
             await self.middleware.call('iscsi.scst.disable')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -518,6 +518,8 @@ class FailoverEventsService(Service):
                 logger.error(f'Error unlocking ZFS encrypted datasets: {unlock_job.error}')
             elif unlock_job.result['failed']:
                 logger.error('Failed to unlock %s ZFS encrypted dataset(s)', ','.join(unlock_job.result['failed']))
+            else:
+                logger.info('Successfully completed unlock for %r', vol['name'])
 
         # if we fail to import all zpools then alert the user because nothing
         # is going to work at this point

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -1,0 +1,275 @@
+import asyncio
+import itertools
+
+from middlewared.schema import returns
+from middlewared.service import Service, job
+
+CHUNK_SIZE = 20
+RETRY_SECONDS = 5
+HA_TARGET_SETTLE_SECONDS = 10
+
+
+class iSCSITargetAluaService(Service):
+    """
+    Support iSCSI ALUA configuration.
+
+    The ALUA mechanism is based up DLM support baked into SCST, along with other
+    potions of middleware (dlm, iscsi.targets, etc ) to handle the coordination
+    between the two nodes in a HA pair.  This is performed in response to
+    cluster_mode being set on target extents.
+
+    However, when a LARGE number of extents(/targets) are present it becomes
+    impractical to leave/enter lockspaces on scst startup.
+
+    To avoid this, SCST on the ACTIVE will start without cluster_mode being
+    set on extents.  Likewise on the STANDBY node, so the targets there will be
+    present but disabled.  However, the STANDBY will then initiate a job to
+    (gradually) enable cluster_mode on the ACTIVE and react.
+    """
+    class Config:
+        private = True
+        namespace = 'iscsi.alua'
+
+    # See HA_PROPAGATE in event.py.  Not only required when running command
+    # on MASTER, and don't want it to propagate.
+    HA_PROPAGATE = {'ha_propagate': False}
+
+    def __init__(self, middleware):
+        super().__init__(middleware)
+        self.enabled = set()
+        self.standby_starting = False
+
+        # scst.conf.mako will check the below value to determine whether it
+        # should write cluster_mode = 1, even if then value in /sys is zero
+        # (i.e. extent not listed in iscsi.target.clustered_extents)
+        self._all_cluster_mode = False
+
+        # Likewise
+        self._standby_write_empty_config = True
+
+    async def before_start(self):
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                self._standby_write_empty_config = True
+                await self.middleware.call('etc.generate', 'scst')
+
+    async def after_start(self):
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'BACKUP':
+                await self.middleware.call('iscsi.alua.standby_after_start')
+
+    async def before_stop(self):
+        self._all_cluster_mode = False
+        self.standby_starting = False
+
+    async def standby_enable_devices(self, devices):
+        await self.middleware.call('iscsi.target.login_ha_targets')
+        extents = await self.middleware.call('iscsi.extent.logged_in_extents')
+        asked = set(devices)
+        if extents and devices and asked.issubset(set(extents)):
+            tochange = [extents[name] for name in devices]
+            await self.middleware.call('iscsi.scst.set_devices_cluster_mode', tochange, 1)
+            # We could expose the targets as we go along, but will just wait until the end.
+            # await self.middleware.call('service.reload', 'iscsitarget')
+            return True
+        else:
+            return False
+
+    def all_cluster_mode(self):
+        return self._all_cluster_mode
+
+    async def standby_write_empty_config(self, value=None):
+        if value is not None:
+            self._standby_write_empty_config = value
+        return self._standby_write_empty_config
+
+    @returns()
+    @job(lock='active_elected', transient=True, lock_queue_size=1)
+    async def active_elected(self, job):
+        self.standby_starting = False
+        job.set_progress(0, 'Start ACTIVE node ALUA reset on election')
+        self.logger.debug('Start ACTIVE node ALUA reset on election')
+        if await self.middleware.call('iscsi.global.alua_enabled'):
+            if await self.middleware.call('failover.status') == 'MASTER':
+                await self.middleware.call('dlm.local_reset', False)
+                job.set_progress(50, 'ACTIVE node ALUA local reset done')
+
+                await self.middleware.call('iscsi.target.logout_ha_targets')
+                job.set_progress(100, 'ACTIVE node ALUA reset completed')
+                self.logger.debug('ACTIVE node ALUA reset completed')
+                return
+        job.set_progress(100, 'ACTIVE node ALUA reset NOOP')
+        self.logger.debug('ACTIVE node ALUA reset NOOP')
+
+    @returns()
+    @job(lock='standby_after_start', transient=True, lock_queue_size=1)
+    async def standby_after_start(self, job):
+        job.set_progress(0, 'ALUA starting on STANDBY')
+        self.logger.debug('ALUA starting on STANDBY')
+        self.standby_starting = True
+        self.enabled = set()
+        self._standby_write_empty_config = False
+
+        # First we ensure we're not joined to any lockspaces.  Zero things
+        await self.middleware.call('dlm.local_reset')
+        job.set_progress(5, 'Cleaned local lockspaces')
+
+        # Next ensure the ACTIVE lockspaces are reset
+        # It's OK if we wait here more or less indefinitely.
+        while self.standby_starting:
+            try:
+                await self.middleware.call('failover.call_remote', 'dlm.local_reset', [False])
+                break
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(10, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(10, 'Asked to reset remote lockspaces')
+
+        max_retries = 120
+        while self.standby_starting and max_retries:
+            try:
+                if len(await self.middleware.call('failover.call_remote', 'dlm.lockspaces')) == 0:
+                    break
+                await asyncio.sleep(1)
+                max_retries -= 1
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(15, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(15, 'Reset remote lockspaces')
+
+        # We are the STANDBY node.  Tell the ACTIVE it can logout any HA targets it had left over
+        # We set a low number of retries as it doesn't really matter if these are in place.  This is
+        # just tidy up.
+        max_retries = 5
+        while self.standby_starting and max_retries:
+            try:
+                max_retries -= 1
+                iqns = await self.middleware.call('failover.call_remote', 'iscsi.target.logged_in_iqns')
+                if not iqns:
+                    break
+                await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_targets')
+                await asyncio.sleep(1)
+            except Exception:
+                await asyncio.sleep(RETRY_SECONDS)
+        if not self.standby_starting:
+            job.set_progress(20, 'Abandoned job.')
+            return
+        else:
+            job.set_progress(20, 'Logged out HA targets (remote node)')
+
+        # We may want to ensure that the iSCSI service on the remote node is fully
+        # up.  Since we have switched it systemd_async_start asking get_state
+
+        # Next login the HA targets.
+        while self.standby_starting:
+            try:
+                while self.standby_starting:
+                    try:
+                        before_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
+                        await self.middleware.call('iscsi.target.login_ha_targets')
+                        after_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
+                        if before_iqns != after_iqns:
+                            await asyncio.sleep(HA_TARGET_SETTLE_SECONDS)
+                        break
+                    except Exception:
+                        await asyncio.sleep(RETRY_SECONDS)
+                if not self.standby_starting:
+                    job.set_progress(25, 'Abandoned job.')
+                    return
+                else:
+                    job.set_progress(25, 'Logged in HA targets')
+
+                # Now that we've logged in the HA targets, regenerate the config so that the
+                # dev_disk DEVICEs are present (we cleared _standby_write_empty_config above).
+                # We will need these, so that then we can switch them to cluster_mode
+                await self.middleware.call('service.reload', 'iscsitarget')
+                job.set_progress(30, 'Non cluster_mode config written')
+
+                # Sanity check that all the targets surfaced up thru SCST okay.
+                devices = list(itertools.chain.from_iterable([x for x in after_iqns.values() if x is not None]))
+                if await self.middleware.call('iscsi.scst.check_cluster_mode_paths_present', devices):
+                    break
+
+                self.logger.debug('Detected missing cluster_mode.  Retrying.')
+                await self.middleware.call('iscsi.target.logout_ha_targets')
+                await self.middleware.call('service.reload', 'iscsitarget')
+                job.set_progress(20, 'Logged out HA targets (local node)')
+            except Exception as e:
+                self.logger.warning('Failed to login and surface HA targets: %r', e, exc_info=True)
+
+        # Now that the ground is cleared, start enabling cluster_mode on extents
+        local_requires_reload = False
+        remote_requires_reload = False
+        while self.standby_starting:
+            try:
+                # We'll refetch the extents each time round the loop in case more have been added
+                extents = set(extent['name'] for extent in await self.middleware.call('iscsi.extent.query', [], {'select': ['name']}))
+
+                # Choose the next batch of extents to enable.
+                to_enable = set(itertools.islice(extents - self.enabled, CHUNK_SIZE))
+
+                if to_enable:
+
+                    # First we will ensure they are in cluster_mode on the ACTIVE
+                    while self.standby_starting:
+                        try:
+                            remote_clustered_extents = set(await self.middleware.call('failover.call_remote', 'iscsi.target.clustered_extents'))
+                            todo_remote = to_enable - remote_clustered_extents
+                            if todo_remote:
+                                remote_requires_reload = True
+                                await self.middleware.call('failover.call_remote', 'iscsi.scst.set_devices_cluster_mode', [list(todo_remote), 1])
+                            else:
+                                break
+                        except Exception:
+                            await asyncio.sleep(RETRY_SECONDS)
+
+                    # Enable on STANDBY.  If we fail here, we'll still go back around the main loop.
+                    ok = False
+                    enable_retries = 10
+                    while not ok and enable_retries:
+                        ok = await self.middleware.call('iscsi.alua.standby_enable_devices', list(to_enable))
+                        if not ok:
+                            await asyncio.sleep(1)
+                        enable_retries -= 1
+                    if not ok:
+                        self.logger.error('Failed to enable cluster mode on devices: %r', to_enable)
+                    else:
+                        local_requires_reload = True
+
+                    # Update progress
+                    self.enabled.update(to_enable)
+                    progress = 20 + (80 * (len(self.enabled) / len(extents)))
+                    job.set_progress(progress, f'Enabled {len(self.enabled)} extents')
+                    self.logger.info('Set cluster_mode on for %r extents', len(self.enabled))
+                else:
+                    break
+            except Exception as e:
+                # This is a fail-safe exception catch.  Should never occur.
+                self.logger.warning('standby_start job: %r', e, exc_info=True)
+                await asyncio.sleep(RETRY_SECONDS)
+
+        if not self.standby_starting:
+            job.set_progress(100, 'Abandoned job.')
+            return
+
+        if remote_requires_reload:
+            try:
+                if local_requires_reload:
+                    await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+                else:
+                    await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget', self.HA_PROPAGATE])
+            except Exception as e:
+                self.logger.warning('Failed to reload iscsitarget: %r', e, exc_info=True)
+        elif local_requires_reload:
+            await self.middleware.call('service.reload', 'iscsitarget')
+
+        job.set_progress(100, 'All targets in cluster_mode')
+        self.standby_starting = False
+        self._all_cluster_mode = True
+        self.logger.debug('ALUA started on STANDBY')

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -427,6 +427,9 @@ class iSCSITargetAluaService(Service):
 
     @job(lock='standby_fix_cluster_mode', transient=True)
     async def standby_fix_cluster_mode(self, job, devices):
+        if self._standby_write_empty_config is not False:
+            self.logger.debug('Skipping standby_fix_cluster_mode')
+            return
         job.set_progress(0, 'Fixing cluster_mode')
         logged_in_extents = await self.middleware.call('iscsi.extent.logged_in_extents')
         device_to_srcextent = {v: k for k, v in logged_in_extents.items()}

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -146,13 +146,13 @@ class iSCSITargetAluaService(Service):
         job.set_progress(20, 'Read to activate')
 
         if todo:
-            self.logger.debug('Activating extents')
+            self.logger.debug(f'Activating {len(todo)} extents')
             retries = 10
             while todo and retries:
                 do_again = []
                 for item in todo:
                     # Mark them active
-                    if not self.middleware.call('iscsi.scst.activate_extent', *item):
+                    if not await self.middleware.call('iscsi.scst.activate_extent', *item):
                         self.logger.debug(f'Cannot Activate extent {item}')
                         do_again.append(item)
                 if not do_again:

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -408,13 +408,13 @@ class iSCSITargetAluaService(Service):
         self.standby_starting = False
         self.logger.debug('ALUA started on STANDBY')
 
-    @job(lock='standby_reload', transient=True)
-    async def standby_reload(self, job):
+    @job(lock='standby_delayed_reload', transient=True)
+    async def standby_delayed_reload(self, job):
         await asyncio.sleep(30)
         # Verify again that we are ALUA STANDBY
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('failover.status') == 'BACKUP':
-                await self.middleware.call('service.reload', 'iscsitarget')
+                await self.middleware.call('service.reload', 'iscsitarget', {'ha_propagate': False})
 
     @job(lock='standby_fix_cluster_mode', transient=True)
     async def standby_fix_cluster_mode(self, job, devices):
@@ -547,7 +547,7 @@ class iSCSITargetAluaService(Service):
                     'iscsi.alua.active_elected',
                     'iscsi.alua.activate_extents',
                     'iscsi.alua.standby_after_start',
-                    'iscsi.alua.standby_reload',
+                    'iscsi.alua.standby_delayed_reload',
                     'iscsi.alua.standby_fix_cluster_mode',
                 ]),
                 ('state', '=', 'RUNNING'),

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -492,9 +492,7 @@ class iSCSITargetExtentService(SharingService):
         global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
         ha_basename = f'{global_basename}:HA:'
 
-        for iqn in iqns:
-            if not iqn.startswith(ha_basename):
-                continue
+        for iqn in filter(lambda x: x.startswith(ha_basename), iqns):
             target_name = iqn.split(':')[-1]
             target_id = target_to_id[target_name]
             for ctl in iqns[iqn]:

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -502,3 +502,18 @@ class iSCSITargetExtentService(SharingService):
                         result[extent_name] = ctl
                         break
         return result
+
+    @private
+    async def active_extents(self):
+        """
+        Returns the names of all extents who are neither disabled nor locked, and which are
+        associated with a target.
+        """
+        filters = [['enabled', '=', True], ['locked', '=', False]]
+        extents = await self.middleware.call('iscsi.extent.query', filters, {'select': ['id', 'name']})
+        assoc = [a_tgt['extent'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')]
+        result = []
+        for extent in extents:
+            if extent['id'] in assoc:
+                result.append(extent['name'])
+        return result

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -197,6 +197,8 @@ class iSCSITargetExtentService(SharingService):
             )
         finally:
             await self._service_change('iscsitarget', 'reload')
+            if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
+                await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
     @private
     def validate(self, data):
@@ -502,6 +504,19 @@ class iSCSITargetExtentService(SharingService):
                         result[extent_name] = ctl
                         break
         return result
+
+    @private
+    async def logged_in_extent(self, iqn, lun):
+        """Return the device name (e.g. 13:0:0:0) of the logged in IQN/lun"""
+        p = pathlib.Path('/sys/devices/platform')
+        for targetname in p.glob('host*/session*/iscsi_session/session*/targetname'):
+            logged_in_iqn = targetname.read_text().strip()
+            if logged_in_iqn == iqn:
+                for disk in targetname.parent.glob('device/target*/*/scsi_disk'):
+                    device = disk.parent.name
+                    if device.split(':')[-1] == str(lun):
+                        return device
+        return None
 
     @private
     async def active_extents(self):

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -7,6 +7,8 @@ SCST_BASE = '/sys/kernel/scst_tgt'
 SCST_TARGETS_ISCSI_ENABLED_PATH = '/sys/kernel/scst_tgt/targets/iscsi/enabled'
 SCST_DEVICES = '/sys/kernel/scst_tgt/devices'
 SCST_SUSPEND = '/sys/kernel/scst_tgt/suspend'
+SCST_CONTROLLER_A_TARGET_GROUPS_STATE = '/sys/kernel/scst_tgt/device_groups/targets/target_groups/controller_A/state'
+SCST_CONTROLLER_B_TARGET_GROUPS_STATE = '/sys/kernel/scst_tgt/device_groups/targets/target_groups/controller_B/state'
 
 
 class iSCSITargetService(Service):
@@ -83,3 +85,12 @@ class iSCSITargetService(Service):
 
     def replace_lun(self, iqn, extent, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'replace {extent} {lun}\n')
+
+    def set_node_optimized(self, node):
+        """Update which node is reported as being the active/optimized path."""
+        if node == 'A':
+            pathlib.Path(SCST_CONTROLLER_B_TARGET_GROUPS_STATE).write_text("nonoptimized\n")
+            pathlib.Path(SCST_CONTROLLER_A_TARGET_GROUPS_STATE).write_text("active\n")
+        else:
+            pathlib.Path(SCST_CONTROLLER_A_TARGET_GROUPS_STATE).write_text("nonoptimized\n")
+            pathlib.Path(SCST_CONTROLLER_B_TARGET_GROUPS_STATE).write_text("active\n")

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -1,0 +1,95 @@
+import asyncio
+import pathlib
+
+from middlewared.service import Service
+
+SCST_BASE = '/sys/kernel/scst_tgt'
+SCST_TARGETS_ISCSI_ENABLED_PATH = '/sys/kernel/scst_tgt/targets/iscsi/enabled'
+SCST_DEVICES = '/sys/kernel/scst_tgt/devices'
+SCST_SUSPEND = '/sys/kernel/scst_tgt/suspend'
+
+
+class iSCSITargetService(Service):
+
+    class Config:
+        namespace = 'iscsi.scst'
+        private = True
+
+    def path_write(self, path, text):
+        p = pathlib.Path(path)
+        realpath = str(p.resolve())
+        if realpath.startswith(SCST_BASE) and p.exists():
+            p.write_text(text)
+        else:
+            raise ValueError(f'Unexpected path "{realpath}"')
+
+    async def set_all_cluster_mode(self, value):
+        text = f'{int(value)}\n'
+        paths = await self.middleware.call('iscsi.scst.cluster_mode_paths')
+        if paths:
+            await asyncio.gather(*[self.middleware.call('iscsi.scst.path_write', path, text) for path in paths])
+
+    def cluster_mode_paths(self):
+        scst_tgt_devices = pathlib.Path(SCST_DEVICES)
+        if scst_tgt_devices.exists():
+            return [str(p) for p in scst_tgt_devices.glob('*/cluster_mode')]
+        else:
+            return []
+
+    def check_cluster_mode_paths_present(self, devices):
+        for device in devices:
+            if not pathlib.Path(f'{SCST_DEVICES}/{device}/cluster_mode').exists():
+                return False
+        return True
+
+    async def set_devices_cluster_mode(self, devices, value):
+        text = f'{int(value)}\n'
+        paths = [f'{SCST_DEVICES}/{device}/cluster_mode' for device in devices]
+        if paths:
+            await asyncio.gather(*[self.middleware.call('iscsi.scst.path_write', path, text) for path in paths])
+
+    def disable(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        p.write_text('0\n')
+
+    def enable(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        p.write_text('1\n')
+
+    def suspend(self, value):
+        p = pathlib.Path(SCST_SUSPEND)
+        p.write_text(f'{value}\n')
+
+    def enabled(self):
+        p = pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH)
+        try:
+            return p.read_text().strip() == '1'
+        except FileNotFoundError:
+            return False
+
+    def is_kernel_module_loaded(self):
+        return pathlib.Path(SCST_BASE).exists()
+
+    def activate_extent(self, extent_name, extenttype, path):
+        p = pathlib.Path(path)
+        if p.exists():
+            if extenttype == 'DISK':
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_blockio/{extent_name}/active')
+            else:
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_fileio/{extent_name}/active')
+            p.write_text('1\n')
+            return True
+        else:
+            return False
+
+    def activate_extents(self, extents):
+        for extent in extents:
+            if extent['type'] == 'DISK':
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_blockio/{extent["name"]}/active')
+            else:
+                p = pathlib.Path(f'/sys/kernel/scst_tgt/handlers/vdisk_fileio/{extent["name"]}/active')
+            p.write_text('1\n')
+
+    def replace_lun(self, iqn, extent, lun):
+        p = pathlib.Path(f'/sys/kernel/scst_tgt/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt')
+        p.write_text(f'replace {extent} {lun}\n')

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -44,6 +44,12 @@ class iSCSITargetService(Service):
                 return False
         return True
 
+    def get_cluster_mode(self, device):
+        try:
+            return pathlib.Path(f'{SCST_DEVICES}/{device}/cluster_mode').read_text().splitlines()[0]
+        except Exception:
+            return "UNKNOWN"
+
     async def set_devices_cluster_mode(self, devices, value):
         text = f'{int(value)}\n'
         paths = [f'{SCST_DEVICES}/{device}/cluster_mode' for device in devices]

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -82,10 +82,10 @@ class iSCSITargetService(Service):
                 p = pathlib.Path(f'{SCST_BASE}/handlers/vdisk_fileio/{extent_name}/active')
             try:
                 p.write_text('1\n')
-            except FileNotFoundError:
-                return False
-            else:
                 return True
+            except Exception:
+                # Return False on ANY exception
+                return False
         else:
             return False
 

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -89,6 +89,9 @@ class iSCSITargetService(Service):
         else:
             return False
 
+    def delete_lun(self, iqn, lun):
+        pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'del {lun}\n')
+
     def replace_lun(self, iqn, extent, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'replace {extent} {lun}\n')
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -56,6 +56,7 @@ class iSCSITargetToExtentService(CRUDService):
         await self._service_change('iscsitarget', 'reload')
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
 
         return await self.get_instance(data['id'])
 
@@ -115,6 +116,8 @@ class iSCSITargetToExtentService(CRUDService):
         )
 
         await self._service_change('iscsitarget', 'reload')
+        if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
+            await self.middleware.call('iscsi.alua.removed_target_extent', associated_target['target'], associated_target['extent'])
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -57,6 +57,7 @@ class iSCSITargetToExtentService(CRUDService):
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return await self.get_instance(data['id'])
 
@@ -118,6 +119,7 @@ class iSCSITargetToExtentService(CRUDService):
         await self._service_change('iscsitarget', 'reload')
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('iscsi.alua.removed_target_extent', associated_target['target'], associated_target['extent'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -53,7 +53,7 @@ class iSCSITargetToExtentService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self._service_change('iscsitarget', 'reload')
+        await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
@@ -116,10 +116,17 @@ class iSCSITargetToExtentService(CRUDService):
             'datastore.delete', self._config.datastore, id_
         )
 
-        await self._service_change('iscsitarget', 'reload')
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
-            await self.middleware.call('iscsi.alua.removed_target_extent', associated_target['target'], associated_target['extent'])
+            target_name = (await self.middleware.call('iscsi.target.query',
+                                                      [['id', '=', associated_target['target']]],
+                                                      {'select': ['name'], 'get': True}))['name']
+            extent_name = (await self.middleware.call('iscsi.extent.query',
+                                                      [['id', '=', associated_target['extent']]],
+                                                      {'select': ['name'], 'get': True}))['name']
+            # iscsi.alua.removed_target_extent includes a local service reload
+            await self.middleware.call('failover.call_remote', 'iscsi.alua.removed_target_extent', [target_name, associated_target['lunid'], extent_name])
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
+        await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -675,10 +675,11 @@ class iSCSITargetService(CRUDService):
         """
         Returns the names of all targets whose extents are neither disabled nor locked.
         """
-        bad_extents = [extent['id'] for extent in await self.middleware.call('iscsi.extent.query',
-                                                                             [['OR',
-                                                                               [['enabled', '=', False],
-                                                                                ['locked', '=', True]]]])]
+        filters = [['OR', [['enabled', '=', False], ['locked', '=', True]]]]
+        bad_extents = []
+        for extent in await self.middleware.call('iscsi.extent.query', filters):
+            bad_extents.append(extent['id'])
+
         targets = {t['id']: t['name'] for t in await self.middleware.call('iscsi.target.query', [], {'select': ['id', 'name']})}
         assoc = {a_tgt['extent']: a_tgt['target'] for a_tgt in await self.middleware.call('iscsi.targetextent.query')}
         for bad_extent in bad_extents:

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -130,6 +130,7 @@ class iSCSITargetService(CRUDService):
         # Then process the remote (BACKUP) config if we are HA and ALUA is enabled.
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return await self.get_instance(pk)
 
@@ -347,6 +348,7 @@ class iSCSITargetService(CRUDService):
             await self.middleware.call('failover.call_remote', 'iscsi.target.remove_target', [target["name"]])
             await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_target', [target["name"]])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         await self.middleware.call('iscsi.target.remove_target', target["name"])
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -610,10 +610,10 @@ class iSCSITargetService(CRUDService):
         cl_extents = set(await self.middleware.call('iscsi.target.clustered_extents'))
 
         # Now iterate over all the targets and return a list of those whose extents are all
-        # in cluster mode.
+        # in cluster mode.  Exclude targets with no extents.
         result = []
         for target in targets:
-            if target_extents[target['id']].issubset(cl_extents):
+            if target_extents[target['id']] and target_extents[target['id']].issubset(cl_extents):
                 result.append(target['name'])
 
         return result
@@ -649,8 +649,8 @@ class iSCSITargetService(CRUDService):
         cluster_mode_luns = defaultdict(list)
 
         for target in targets:
-            # Find targets whose extents are all in cluster mode
-            if target_extents[target['id']].issubset(cl_extents):
+            # Find targets whose extents are all in cluster mode.  Exclude targets with no extents.
+            if target_extents[target['id']] and target_extents[target['id']].issubset(cl_extents):
                 cluster_mode_targets.append(target['name'])
 
             for (lunid, extent_name) in target_luns.get(target['id'], {}):

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -405,6 +405,11 @@ class ServiceService(CRUDService):
                 if await service.identify(procname):
                     return service_name
 
+    @private
+    async def get_unit_state(self, service):
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.get_unit_state()
+
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(
         "process_terminated_nicely",

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -411,9 +411,18 @@ class ServiceService(CRUDService):
         return await service_object.get_unit_state()
 
     @private
-    async def failover(self, service):
+    async def become_active(self, service):
+        """During a HA failover event certain services may support this method being called
+        when the node is becoming the new ACTIVE node"""
         service_object = await self.middleware.call('service.object', service)
-        return await service_object.failover()
+        return await service_object.become_active()
+
+    @private
+    async def become_standby(self, service):
+        """During a HA failover event certain services may support this method being called
+        when the node is becoming the new STANDBY node"""
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.become_standby()
 
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -410,6 +410,11 @@ class ServiceService(CRUDService):
         service_object = await self.middleware.call('service.object', service)
         return await service_object.get_unit_state()
 
+    @private
+    async def failover(self, service):
+        service_object = await self.middleware.call('service.object', service)
+        return await service_object.failover()
+
     @accepts(Int("pid"), Int("timeout", default=10))
     @returns(Bool(
         "process_terminated_nicely",

--- a/src/middlewared/middlewared/plugins/service_/services/base.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base.py
@@ -46,6 +46,14 @@ class SimpleService(ServiceInterface, IdentifiableServiceInterface):
         else:
             return ServiceState(False, [])
 
+    async def get_unit_state(self):
+        return await self.middleware.run_in_thread(self._get_unit_state_sync)
+
+    def _get_unit_state_sync(self):
+        unit = self._get_systemd_unit()
+        state = unit.Unit.ActiveState
+        return state.decode("utf-8")
+
     async def start(self):
         await self._unit_action("Start")
 

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -12,6 +12,9 @@ class ServiceInterface:
     async def get_state(self):
         raise NotImplementedError
 
+    async def get_unit_state(self):
+        raise NotImplementedError
+
     async def check_configuration(self):
         pass
 

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -15,7 +15,10 @@ class ServiceInterface:
     async def get_unit_state(self):
         raise NotImplementedError
 
-    async def failover(self):
+    async def become_active(self):
+        raise NotImplementedError
+
+    async def become_standby(self):
         raise NotImplementedError
 
     async def check_configuration(self):

--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -15,6 +15,9 @@ class ServiceInterface:
     async def get_unit_state(self):
         raise NotImplementedError
 
+    async def failover(self):
+        raise NotImplementedError
+
     async def check_configuration(self):
         pass
 

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -6,16 +6,21 @@ from .base import SimpleService
 class ISCSITargetService(SimpleService):
     name = "iscsitarget"
     reloadable = True
-    systemd_unit_timeout = 30
+    systemd_async_start = True
 
     etc = ["scst", "scst_targets"]
 
     systemd_unit = "scst"
 
+    async def before_start(self):
+        await self.middleware.call("iscsi.alua.before_start")
+
     async def after_start(self):
         await self.middleware.call("iscsi.host.injection.start")
+        await self.middleware.call("iscsi.alua.after_start")
 
     async def before_stop(self):
+        await self.middleware.call("iscsi.alua.before_stop")
         await self.middleware.call("iscsi.host.injection.stop")
 
     async def reload(self):

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from middlewared.utils import run
 
 from .base import SimpleService
@@ -12,8 +14,28 @@ class ISCSITargetService(SimpleService):
 
     systemd_unit = "scst"
 
+    async def _wait_to_avoid_states(self, states, retries=10):
+        initial_retries = retries
+        while retries > 0:
+            curstate = await self.middleware.call("service.get_unit_state", self.name)
+            if curstate not in states:
+                break
+            retries -= 1
+            await asyncio.sleep(1)
+        if retries != initial_retries:
+            if curstate in states:
+                self.middleware.logger.debug(f'Waited unsucessfully for {self.name} to enter {curstate} state')
+            else:
+                self.middleware.logger.debug(f'Waited sucessfully for {self.name} to enter {curstate} state')
+
     async def before_start(self):
         await self.middleware.call("iscsi.alua.before_start")
+        # Because we are a systemd_async_start service, it is possible that
+        # a start could be requested while a stop is still in progress.
+        if await self.middleware.call("failover.in_progress"):
+            await self._wait_to_avoid_states(['deactivating'], 5)
+        else:
+            await self._wait_to_avoid_states(['deactivating'])
 
     async def after_start(self):
         await self.middleware.call("iscsi.host.injection.start")

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -57,7 +57,7 @@ class ISCSITargetService(SimpleService):
         if await self.middleware.call('iscsi.global.alua_enabled'):
             if await self.middleware.call('iscsi.scst.is_kernel_module_loaded'):
                 try:
-                    return await self.middleware.call("iscsi.alua.failover_to_master")
+                    return await self.middleware.call("iscsi.alua.become_active")
                 except Exception:
                     self.logger.warning('Failover exception', exc_info=True)
                     # Fall through


### PR DESCRIPTION
### Background
SCST uses a script `scstadmin` to load the config file into the kernel.  This done serially, so when large configurations are present it can be slow.

Further, iSCSI ALUA targets use the linux kernel `dlm` (distributed lock manager).  Configuration requires the interaction of the kernel and middleware on both nodes.  This can be slow, especially when many targets are present. 

### Overview
A couple of changes to SCST have been made to improve configuration/lifecycle performance (PRs #[19](https://github.com/truenas/scst/pull/19) and #[23](https://github.com/truenas/scst/pull/23)).  Also allowed `vdisk_fileio` to use the same active parameter as `vdisk_blockio` (PR #[26](https://github.com/truenas/scst/pull/26)) - more below.

This PR contains substantial changes being made to middleware to further improve configuration/lifecycle performance:

- On boot do **not** start with `cluster_mode` enabled on target extents.
- When the STANDBY node boots, it will initiate a job that resettles the DLM (on both nodes) and then steps thru the extents (20 at a time), configuring `cluster_mode`
- Define the fileio/blockio based extents in _/etc/scst.conf_ for BOTH nodes - albeit with `active 0` parameter set on the STANDBY node.
- On failover on the ACTIVE node, _become_active_ iscsitarget rather than _restart_ it.  This avoids running `scstadmin`, instead will make _precise_ changes to the scst /sys interface.  We only do the bare minimum that we need (makes extents active, and replace the HA target based LUNs with real extent based ones).
- On failover on the STANDBY node, start iscsitarget but with minimal config.  This will be corrected by the `iscsi.alua.standby_after_start` job.
- For inter-node HA targets tweak the `recovery_tmo` parameter to 10 seconds.  Otherwise we can expect stalls on a newly elected ACTIVE node, before it logs out the HA targets it needed when it was STANDBY.

We can't achieve everything instantly, so the above is an attempt to get the targets on the ACTIVE node available ASAP, with the STANDBY node to follow.

On the newly elected ACTIVE node we split activities into three stages, as certain aspects can be kicked off early/in parallel with other activities:
1. `iscsi.alua.active_elected` job will run as soon as we know we've won the election (i.e. have started fenced)
2. `iscsi.alua.activate_extents` job will run once we have imported the pool and mounted volumes, etc.
3. `service.become_active iscsitarget` will run instead of a `service.restart`

Original PR: https://github.com/truenas/middleware/pull/12967
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126731