### PR TITLE
NAS-127341 / 24.10 / idmap: add validation to prevent duplicate DNS names

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -512,6 +512,9 @@ class IdmapDomainService(CRUDService):
             if i['name'] == data['name']:
                 verrors.add(f'{schema_name}.name', 'Name must be unique.')
 
+            if data.get('dns_domain_name') and data['dns_domain_name'] == i['dns_domain_name']:
+                verrors.add(f'{schema_name}.dns_domain_name', 'Name must be unique.')
+
             # Do not generate validation errors for overlapping with a disabled DS.
             if not ldap_enabled and i['name'] == 'DS_TYPE_LDAP':
                 continue


### PR DESCRIPTION
We should raise a ValidationError on duplicate DNS names because there shouldn't be multiple idmap backends configured for a single domain.