### PR TITLE
NAS-127347 / 24.10 / Add more error handling for filter_list

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -177,6 +177,9 @@ def casefold(obj):
 
 class filters(object):
     def op_in(x, y):
+        if x is None:
+            return False
+
         return operator.contains(y, x)
 
     def op_rin(x, y):


### PR DESCRIPTION
This adds handling for the case where API user specifies a filter that for a non-existent key during `in` operations.