### PR TITLE
NAS-127336 / 24.04-RC.1 /  Fix TypeError on lookup failure for DS users (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -193,7 +193,9 @@ class DSCache(Service):
             entry['sid'] = None
             entry['nt_name'] = None
 
-        entry['roles'] = []
+        if entry is not None:
+            entry['roles'] = []
+
         return entry
 
     @accepts(


### PR DESCRIPTION
entry may be None type if user has queried a non-existent user directly via filters (for example ['name', '=', 'bob']).

Original PR: https://github.com/truenas/middleware/pull/13130
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127336