### PR TITLE
NAS-127350 / 24.10 / Add ability to filter by keys in list objects

### DIFF
--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -143,14 +143,13 @@ Javascript:
       ["local_groups.0.name", "=", "myuser"],
     ]
 
-Alternatively, the index may be omitted, which will result in the result returning if any array member has a key matching the
-value.
+Alternatively, an asterisk (`*`) may be substituted for the array index, which match any entry where an array member has a key matching the value. for example, the following query-filters if passed to the `privilege.query` endpoint will return entries where any member of the local groups array has a `name` key with the value of `myuser`.
 
 Javascript:
 
     :::javascript
     [
-      ["local_groups.name", "=", "myuser"],
+      ["local_groups.*.name", "=", "myuser"],
     ]
 
 

--- a/src/middlewared/middlewared/apidocs/templates/websocket/query.md
+++ b/src/middlewared/middlewared/apidocs/templates/websocket/query.md
@@ -132,6 +132,28 @@ Javascript:
     ]
 
 
+When the path to the key contains an array, an array index may be manually specified. For example, the following query-filters
+if passed to the `privilege.query` endpoint will return entries where the first element of the local groups array has a name
+of "myuser".
+
+Javascript:
+
+    :::javascript
+    [
+      ["local_groups.0.name", "=", "myuser"],
+    ]
+
+Alternatively, the index may be omitted, which will result in the result returning if any array member has a key matching the
+value.
+
+Javascript:
+
+    :::javascript
+    [
+      ["local_groups.name", "=", "myuser"],
+    ]
+
+
 ${'####'} Datetime information
 
 Some query results may include datetime information encoded in JSON object via

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -120,7 +120,7 @@ class ChartReleaseService(Service):
         if tag == '$node_ip':
             return node_ip
         elif tag.startswith('$variable-'):
-            return get(release_data['config'], tag[len('$variable-'):])
+            return get(release_data['config'], tag[len('$variable-'):]).result
 
         return tag
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/portals.py
@@ -120,7 +120,7 @@ class ChartReleaseService(Service):
         if tag == '$node_ip':
             return node_ip
         elif tag.startswith('$variable-'):
-            return get(release_data['config'], tag[len('$variable-'):]).result
+            return get(release_data['config'], tag[len('$variable-'):])
 
         return tag
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -523,4 +523,4 @@ def test__filter_list_timestamp():
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '<', '2023-12-18T16:15:35Z']])) == 2
 
 def test__filter_list_nested_object_in_list():
-    assert len(filter_list(DATA_WITH_LISTODICTS, [['list.number', '=', 3]])) == 2
+    assert len(filter_list(DATA_WITH_LISTODICTS, [['list.*.number', '=', 3]])) == 2

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -86,6 +86,40 @@ DATA_WITH_LISTODICTS = [
     }
 ]
 
+DATA_WITH_LISTODICTS_INCONSISTENT = [
+    {
+        'foo': 'foo',
+        'list': [{'number': 1}, 'canary'],
+    },
+    {
+        'foo': 'Foo',
+        'list': [1, {'number': 3}],
+    },
+    {
+        'foo': 'foO_',
+        'list': [{'number': 3}, ('bob', 1)],
+    },
+    {
+        'foo': 'bar',
+        'list': [{'number': 0}],
+    },
+    {
+        'foo': 'bar',
+        'list': 'whointheirrightmindwoulddothis'
+    },
+    {
+        'foo': 'bar',
+    },
+    {
+        'foo': 'bar',
+        'list': None,
+    },
+    {
+        'foo': 'bar',
+        'list': 42,
+    },
+]
+
 DATA_SELECT_COMPLEX = [
     {
         'foo': 'foo',
@@ -523,4 +557,7 @@ def test__filter_list_timestamp():
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '<', '2023-12-18T16:15:35Z']])) == 2
 
 def test__filter_list_nested_object_in_list():
+    assert len(filter_list(DATA_WITH_LISTODICTS, [['list.*.number', '=', 3]])) == 2
+
+def test__filter_list_inconsistent_nested_object_in_list():
     assert len(filter_list(DATA_WITH_LISTODICTS, [['list.*.number', '=', 3]])) == 2

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -67,6 +67,25 @@ DATA_WITH_CASE = [
     },
 ]
 
+DATA_WITH_LISTODICTS = [
+    {
+        'foo': 'foo',
+        'list': [{'number': 1}, {'number': 2}],
+    },
+    {
+        'foo': 'Foo',
+        'list': [{'number': 2}, {'number': 3}],
+    },
+    {
+        'foo': 'foO_',
+        'list': [{'number': 3}],
+    },
+    {
+        'foo': 'bar',
+        'list': [{'number': 0}],
+    }
+]
+
 DATA_SELECT_COMPLEX = [
     {
         'foo': 'foo',
@@ -502,3 +521,6 @@ def test__filter_list_timestamp():
 
     # Check that zulu abbreviation is evaluated properly
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '<', '2023-12-18T16:15:35Z']])) == 2
+
+def test__filter_list_nested_object_in_list():
+    assert len(filter_list(DATA_WITH_LISTODICTS, [['list.number', '=', 3]])) == 2

--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -118,6 +118,18 @@ DATA_WITH_LISTODICTS_INCONSISTENT = [
         'foo': 'bar',
         'list': 42,
     },
+    'canary'
+]
+
+DATA_WITH_DEEP_LISTS = [
+    {
+        'foo': 'foo',
+        'list': [{'list2': [{'number': 1}, 'canary']}, {'list2': [{'number': 2}, 'canary']}],
+    },
+    {
+        'foo': 'Foo',
+        'list': [{'list2': [{'number': 3}, 'canary']}, {'list2': [{'number': 2}, 'canary']}],
+    }
 ]
 
 DATA_SELECT_COMPLEX = [
@@ -556,8 +568,14 @@ def test__filter_list_timestamp():
     # Check that zulu abbreviation is evaluated properly
     assert len(filter_list(SAMPLE_AUDIT, [['timestamp.$date', '<', '2023-12-18T16:15:35Z']])) == 2
 
+
 def test__filter_list_nested_object_in_list():
     assert len(filter_list(DATA_WITH_LISTODICTS, [['list.*.number', '=', 3]])) == 2
 
+
 def test__filter_list_inconsistent_nested_object_in_list():
-    assert len(filter_list(DATA_WITH_LISTODICTS, [['list.*.number', '=', 3]])) == 2
+    assert len(filter_list(DATA_WITH_LISTODICTS_INCONSISTENT, [['list.*.number', '=', 3]])) == 2
+
+
+def test__filter_list_deeply_nested_lists():
+    assert len(filter_list(DATA_WITH_DEEP_LISTS, [['list.*.list2.*.number', '=', 2]])) == 2

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import time
 import json
-from dataclasses import dataclass
+from collections import namedtuple
 from datetime import datetime
 
 from middlewared.service_exception import MatchNotFound
@@ -34,11 +34,7 @@ class UnexpectedFailure(Exception):
     pass
 
 
-@dataclass
-class FilterGetResult:
-    result: object
-    key: str = None
-    done: bool = True
+FilterGetResult = namedtuple('FilterGetResult', 'result,key,done', defaults=(None, True))
 
 
 def bisect(condition, iterable):
@@ -441,7 +437,6 @@ class filters(object):
             operand_2 = the_filter[2]
 
         return self.filterop(list_item, (operand_1, the_filter[1], operand_2), getter)
-
 
     def do_filters(self, _list, filters, select, shortcircuit, value_maps):
         rv = []

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -100,19 +100,7 @@ def partition(s):
             return rv + left, right
 
 
-def get(obj, path):
-    """
-    Get a path in obj using dot notation. In case of nested list or tuple, item may be specified by
-    numeric index, otherwise the contents of the array are returned along with the unresolved path
-    component. Returns FilterGetResult type.
-
-    e.g.
-        obj = {'foo': {'bar': '1'}, 'foo.bar': '2', 'foobar': ['first', 'second', 'third']}
-
-        path = 'foo.bar' returns '1'
-        path = 'foo\\.bar' returns '2'
-        path = 'foobar.0' returns 'first'
-    """
+def get_impl(obj, path):
     right = path
     cur = obj
     while right:
@@ -139,6 +127,22 @@ def get_attr(obj, path):
     types.
     """
     return FilterGetResult(getattr(obj, path))
+
+
+def get(obj, path):
+    """
+    Get a path in obj using dot notation. In case of nested list or tuple, item may be specified by
+    numeric index, otherwise the contents of the array are returned along with the unresolved path
+    component.
+
+    e.g.
+        obj = {'foo': {'bar': '1'}, 'foo.bar': '2', 'foobar': ['first', 'second', 'third']}
+
+        path = 'foo.bar' returns '1'
+        path = 'foo\\.bar' returns '2'
+        path = 'foobar.0' returns 'first'
+    """
+    return get_impl(obj, path).result
 
 
 def select_path(obj, path):
@@ -383,7 +387,7 @@ class filters(object):
             return None
 
         if isinstance(_list[0], dict):
-            return get
+            return get_impl
 
         return get_attr
 

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -515,7 +515,7 @@ class filters(object):
             else:
                 non_nulls.append(entry)
 
-        non_nulls = sorted(non_nulls, key=lambda x: get(x, order).result, reverse=reverse)
+        non_nulls = sorted(non_nulls, key=lambda x: get(x, order), reverse=reverse)
         return (nulls, non_nulls)
 
     def order_no_null(self, _list, order):
@@ -525,7 +525,7 @@ class filters(object):
         else:
             reverse = False
 
-        return sorted(_list, key=lambda x: get(x, order).result, reverse=reverse)
+        return sorted(_list, key=lambda x: get(x, order), reverse=reverse)
 
     def do_order(self, rv, order_by):
         for o in order_by:

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -126,7 +126,10 @@ def get(obj, path):
         elif isinstance(cur, (list, tuple)):
             if not left.isdigit():
                 # return all members and the remaining portion of path
-                return FilterGetResult(result=cur, key=left, done=False)
+                if left == '*':
+                    return FilterGetResult(result=cur, key=right, done=False)
+
+                raise ValueError(f'{left}: must be array index or wildcard character')
 
             left = int(left)
             cur = cur[left] if left < len(cur) else None


### PR DESCRIPTION
There are some cases where API user may wish to query an endpoint based on nested values within a list. For example

[["local_groups.*.name", "=", "bad"]] passed to privilege.query to return all privileges where the group "bad" is present in the list of local groups to which the privilege applies.