### PR TITLE
NAS-127269 / 24.10 / Handle missing k3s network stats in k3s netdata plugin

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/k3s_stats.chart.py
@@ -45,7 +45,7 @@ class Service(SimpleService):
         pod_name = pod_stats['podRef']['name']
         data[self.get_dimension_name(pod_name, StatsTypes.CPU.value)] = int(pod_stats['cpu']['usageNanoCores'])
         data[self.get_dimension_name(pod_name, StatsTypes.MEMORY.value)] = int(pod_stats['memory']['rssBytes'])
-        for interface in pod_stats['network']['interfaces']:
+        for interface in pod_stats.get('network', {'interfaces': []})['interfaces']:
             data[f'{self.get_dimension_name(pod_name, StatsTypes.NETWORK.value)}.incoming'] += int(interface['rxBytes'])
             data[f'{self.get_dimension_name(pod_name, StatsTypes.NETWORK.value)}.outgoing'] += int(interface['txBytes'])
 


### PR DESCRIPTION
## Problem
Some k3s pods don't use the network at all, and as a result, their network stats don't appear in the k3s stats summary. This can cause a network key error in the netdata k3s_stats plugin, leading to an abnormal exit of the plugin. Consequently, netdata is unable to report stats for any pods.

## Solution
Handle the 'networks' key appropriately to prevent key errors in such cases.