### PR TITLE
NAS-127362 / 24.10 / Properly reflect bridge members when updating bridge settings

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1301,7 +1301,9 @@ class InterfaceService(CRUDService):
 
             if iface['type'] == 'BRIDGE':
                 options = {}
-                for key in filter(lambda k: k in data, ('bridge_members', 'stp', 'enable_learning')):
+                if 'bridge_members' in data:
+                    options['members'] = data['bridge_members']
+                for key in filter(lambda k: k in data, ('stp', 'enable_learning')):
                     options[key] = data[key]
                 if options:
                     filters = [('interface', '=', config['id'])]


### PR DESCRIPTION
This commit fixes keyerror in `interface.update` as for bridge interface, db column name is `members` and not `bridge_members`.