### PR TITLE
NAS-126925 / 24.04-RC.1 / Mark app's config as private (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -33,7 +33,7 @@ class ChartReleaseService(CRUDService):
         'chart_release_entry',
         Str('name', required=True),
         Dict('info', additional_attrs=True),
-        Dict('config', additional_attrs=True),
+        Dict('config', additional_attrs=True, private=True),
         List('hooks'),
         Int('version', required=True, description='Version of chart release'),
         Str('namespace', required=True),


### PR DESCRIPTION
This commit adds changes marking app's config as private as it can contain potentially passwords/secrets of user's app configuration.

Original PR: https://github.com/truenas/middleware/pull/13105
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126925