### PR TITLE
NAS-127112 / 24.10 / Improve netdata setup

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -3,3 +3,12 @@ After=smartmontools.service
 
 [Service]
 Restart=always
+
+ReadWriteDirectories=
+ReadWriteDirectories=/dev
+ReadWriteDirectories=/proc/self
+ReadWriteDirectories=/var/lib/netdata
+ReadWriteDirectories=/var/log
+ReadWriteDirectories=/var/spool
+ReadWriteDirectories=/run
+ReadWriteDirectories=/var/db/system/netdata

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -1,11 +1,13 @@
 <%
     from middlewared.plugins.reporting.netdata.utils import NETDATA_PORT, NETDATA_UPDATE_EVERY
+
     netdata_cache_dataset = middleware.call_sync('reporting.netdata_storage_location')
-    disk_space = middleware.call_sync('netdata.get_disk_space')
     if not netdata_cache_dataset:
         # Let's exit if netdata storage is not in place
         middleware.logger.error('Netdata configuration file could not be generated')
         raise FileShouldNotExist()
+
+    disk_space = middleware.call_sync('netdata.get_disk_space')
 %>\
 [global]
 	run as user = netdata

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -1,13 +1,11 @@
 <%
-	from middlewared.plugins.reporting.netdata.utils import NETDATA_PORT, NETDATA_UPDATE_EVERY
-
-
-	if not middleware.call_sync('reporting.netdata_setup'):
-		# Let's exit if netdata storage is not in place
-		middleware.logger.error('Netdata configuration file could not be generated')
-		raise FileShouldNotExist()
-
-	disk_space = middleware.call_sync('netdata.get_disk_space')
+    from middlewared.plugins.reporting.netdata.utils import NETDATA_PORT, NETDATA_UPDATE_EVERY
+    netdata_cache_dataset = middleware.call_sync('reporting.netdata_storage_location')
+    disk_space = middleware.call_sync('netdata.get_disk_space')
+    if not netdata_cache_dataset:
+        # Let's exit if netdata storage is not in place
+        middleware.logger.error('Netdata configuration file could not be generated')
+        raise FileShouldNotExist()
 %>\
 [global]
 	run as user = netdata
@@ -22,6 +20,10 @@
 	mode = dbengine
 	storage tiers = 1
 	dbengine multihost disk space MB = ${disk_space}
+
+[directories]
+    cache = ${netdata_cache_dataset}
+    home = ${netdata_cache_dataset}
 
 [plugins]
 	proc = yes

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -1,19 +1,7 @@
-import os
-
-from middlewared.service import lock, private, Service
-from middlewared.utils.shutil import rmtree_one_filesystem
+from middlewared.service import private, Service
 
 
 class ReportingService(Service):
-
-    NETDATA_UID = None
-    NETDATA_GID = None
-
-    @private
-    async def cache_netdata_uid_gid(self):
-        user_obj = await self.middleware.call('user.get_user_obj', {'username': 'netdata'})
-        self.NETDATA_UID = user_obj['pw_uid']
-        self.NETDATA_GID = user_obj['pw_gid']
 
     @private
     def netdata_storage_location(self):
@@ -21,44 +9,4 @@ class ReportingService(Service):
         if not systemdataset_config['path']:
             return None
 
-        return f'{systemdataset_config["path"]}/netdata-{systemdataset_config["uuid"]}'
-
-    @private
-    @lock('netdata_configure')
-    def netdata_setup(self):
-        netdata_mount = self.netdata_storage_location() or ''
-        if not os.path.exists(netdata_mount):
-            self.logger.error('%r does not exist or is not a directory', netdata_mount)
-            return False
-
-        # Ensure that netdata working path is a symlink to system dataset
-        pwd = '/var/cache/netdata'
-        if os.path.islink(pwd):
-            if os.path.realpath(pwd) != netdata_mount:
-                os.unlink(pwd)
-        else:
-            if os.path.exists(pwd):
-                rmtree_one_filesystem(pwd)
-
-        if not os.path.exists(pwd):
-            os.symlink(netdata_mount, pwd)
-
-        # We will make sure now that netdata user/group has access to this directory
-        self.middleware.call_sync('filesystem.acltool', pwd, 'chown', self.NETDATA_UID, self.NETDATA_GID, {
-            'recursive': True,
-            'posixacl': True,
-        })
-        os.makedirs('/var/log/netdata', exist_ok=True)
-        self.middleware.call_sync(
-            'filesystem.acltool', '/var/log/netdata', 'chown',
-            self.NETDATA_UID, self.NETDATA_GID, {
-                'recursive': True,
-                'posixacl': True,
-            }
-        )
-
-        return True
-
-
-async def setup(middleware):
-    await middleware.call('reporting.cache_netdata_uid_gid')
+        return f'{systemdataset_config["path"]}/netdata'

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -472,12 +472,13 @@ class SystemDatasetService(ConfigService):
             pool != boot_pool and
             (await self.middleware.call('pool.dataset.get_instance', pool))['key_format']['value'] == 'PASSPHRASE'
         )
-        datasets = [i[0] for i in self.__get_datasets(pool, uuid)]
+        datasets = {i[0]: i[2] for i in self.__get_datasets(pool, uuid)}
         datasets_prop = {
-            i['id']: i['properties'] for i in await self.middleware.call('zfs.dataset.query', [('id', 'in', datasets)])
+            i['id']: i['properties']
+            for i in await self.middleware.call('zfs.dataset.query', [('id', 'in', list(datasets))])
         }
-        for dataset in datasets:
-            props = {'mountpoint': 'legacy', 'readonly': 'off', 'snapdir': 'hidden'}
+        for dataset, config in datasets.items():
+            props = {'mountpoint': 'legacy', 'readonly': 'off', 'snapdir': 'hidden', **config.get('props', {})}
             # Disable encryption for pools with passphrase-encrypted root datasets so that system dataset could be
             # automatically mounted on system boot.
             if root_dataset_is_passphrase_encrypted:
@@ -500,14 +501,30 @@ class SystemDatasetService(ConfigService):
                 except Exception:
                     self.logger.warning("Failed to replace dataset [%s].", dataset, exc_info=True)
             else:
-                update_props_dict = {k: {'value': v} for k, v in props.items()
-                                     if datasets_prop[dataset][k]['value'] != v}
+                update_props_dict = {
+                    k: {'value': v} for k, v in props.items()
+                    if datasets_prop[dataset][k]['value'] != v
+                }
                 if update_props_dict:
                     await self.middleware.call(
                         'zfs.dataset.update',
                         dataset,
                         {'properties': update_props_dict},
                     )
+
+            try:
+                await self.middleware.run_in_thread(self.__create_relevant_paths, config.get('create_paths', []))
+            except Exception:
+                self.logger.error('Failed to create relevant paths for %r', dataset, exc_info=True)
+
+    def __create_relevant_paths(self, create_paths):
+        for create_path_config in create_paths:
+            os.makedirs(create_path_config['path'], exist_ok=True)
+            cpath_stat = os.stat(create_path_config['path'])
+            if all(create_path_config[k] for k in ('uid', 'gid')) and (
+                cpath_stat.st_uid != create_path_config['uid'] or cpath_stat.st_gid != create_path_config['gid']
+            ):
+                os.chown(create_path_config['path'], create_path_config['uid'], create_path_config['gid'])
 
     def __mount(self, pool, uuid, path=SYSDATASET_PATH):
         """
@@ -516,8 +533,10 @@ class SystemDatasetService(ConfigService):
         rundir. The latter occurs when migrating dataset between pools.
         """
         mounted = False
-        for dataset, name in self.__get_datasets(pool, uuid):
-            if name:
+        for dataset, name, creation_config in self.__get_datasets(pool, uuid):
+            if desired_mountpoint := creation_config.get('mountpoint'):
+                mountpoint = desired_mountpoint
+            elif name:
                 mountpoint = f'{path}/{name}'
             else:
                 mountpoint = path
@@ -527,6 +546,12 @@ class SystemDatasetService(ConfigService):
             with suppress(FileExistsError):
                 os.mkdir(mountpoint)
             subprocess.run(['mount', '-t', 'zfs', dataset, mountpoint], check=True)
+
+            if chown_config := creation_config.get('chown_config'):
+                if os.stat(
+                    mountpoint
+                ).st_uid != chown_config['uid'] or os.stat(mountpoint).st_gid != chown_config['gid']:
+                    os.chown(mountpoint, **chown_config)
             mounted = True
 
         if mounted and path == SYSDATASET_PATH:
@@ -573,14 +598,37 @@ class SystemDatasetService(ConfigService):
         raise CallError(error) from None
 
     def __get_datasets(self, pool, uuid):
-        return [(f'{pool}/.system', '')] + [
-            (f'{pool}/.system/{i}', i) for i in [
-                'cores', 'samba4',
-                f'rrd-{uuid}', f'configs-{uuid}',
-                'webui', 'services',
-                f'netdata-{uuid}',
-            ]
-        ]
+        datasets = [(f'{pool}/.system', '', {})]
+        for i in [
+            'cores',
+            'samba4',
+            f'rrd-{uuid}',
+            f'configs-{uuid}',
+            'webui',
+            'services',
+            (
+                f'netdata-{uuid}', {
+                    'chown_config': {'uid': 999, 'gid': 997},
+                    'mountpoint': f'{SYSDATASET_PATH}/netdata',
+                    'props': {'canmount': 'noauto'},
+                    'create_paths': [
+                        {'path': '/var/log/netdata', 'uid': 999, 'gid': 997},
+                    ],
+                }
+            ),
+        ]:
+            if isinstance(i, (tuple, list)):
+                if len(i) > 2:
+                    raise CallError(f'Invalid dataset entry: {i!r}')
+                if len(i) == 2:
+                    name, config = i
+                else:
+                    name, config = i[0], {}
+                datasets.append((f'{pool}/.system/{i[0]}', name, config))
+            else:
+                datasets.append((f'{pool}/.system/{i}', i, {}))
+
+        return datasets
 
     @private
     def migrate(self, _from, _to):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -1,22 +1,23 @@
-from contextlib import contextmanager, suppress
 import errno
 import json
+import middlewared.sqlalchemy as sa
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import threading
 import uuid
 
+from contextlib import contextmanager, suppress
+from pathlib import Path
+
+from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
+from middlewared.plugins.system_dataset.hierarchy import get_system_dataset_spec
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
 from middlewared.service import CallError, ConfigService, ValidationErrors, job, private
 from middlewared.service_exception import InstanceNotFound
-import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.utils.size import format_size
-from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
-
-SYSDATASET_PATH = '/var/db/system'
 
 
 class SystemDatasetModel(sa.Model):
@@ -472,13 +473,13 @@ class SystemDatasetService(ConfigService):
             pool != boot_pool and
             (await self.middleware.call('pool.dataset.get_instance', pool))['key_format']['value'] == 'PASSPHRASE'
         )
-        datasets = {i[0]: i[2] for i in self.__get_datasets(pool, uuid)}
+        datasets = {i['name']: i for i in get_system_dataset_spec(pool, uuid)}
         datasets_prop = {
             i['id']: i['properties']
             for i in await self.middleware.call('zfs.dataset.query', [('id', 'in', list(datasets))])
         }
         for dataset, config in datasets.items():
-            props = {'mountpoint': 'legacy', 'readonly': 'off', 'snapdir': 'hidden', **config.get('props', {})}
+            props = config['props']
             # Disable encryption for pools with passphrase-encrypted root datasets so that system dataset could be
             # automatically mounted on system boot.
             if root_dataset_is_passphrase_encrypted:
@@ -533,8 +534,9 @@ class SystemDatasetService(ConfigService):
         rundir. The latter occurs when migrating dataset between pools.
         """
         mounted = False
-        for dataset, name, creation_config in self.__get_datasets(pool, uuid):
-            if desired_mountpoint := creation_config.get('mountpoint'):
+        for ds_config in get_system_dataset_spec(pool, uuid):
+            dataset, name = ds_config['name'], os.path.basename(ds_config['name'])
+            if desired_mountpoint := ds_config.get('mountpoint'):
                 mountpoint = desired_mountpoint
             elif name:
                 mountpoint = f'{path}/{name}'
@@ -547,7 +549,7 @@ class SystemDatasetService(ConfigService):
                 os.mkdir(mountpoint)
             subprocess.run(['mount', '-t', 'zfs', dataset, mountpoint], check=True)
 
-            if chown_config := creation_config.get('chown_config'):
+            if chown_config := ds_config.get('chown_config'):
                 if os.stat(
                     mountpoint
                 ).st_uid != chown_config['uid'] or os.stat(mountpoint).st_gid != chown_config['gid']:
@@ -596,39 +598,6 @@ class SystemDatasetService(ConfigService):
             error += f'\nThe following processes are using {mp!r}: ' + json.dumps(processes, indent=2)
 
         raise CallError(error) from None
-
-    def __get_datasets(self, pool, uuid):
-        datasets = [(f'{pool}/.system', '', {})]
-        for i in [
-            'cores',
-            'samba4',
-            f'rrd-{uuid}',
-            f'configs-{uuid}',
-            'webui',
-            'services',
-            (
-                f'netdata-{uuid}', {
-                    'chown_config': {'uid': 999, 'gid': 997},
-                    'mountpoint': f'{SYSDATASET_PATH}/netdata',
-                    'props': {'canmount': 'noauto'},
-                    'create_paths': [
-                        {'path': '/var/log/netdata', 'uid': 999, 'gid': 997},
-                    ],
-                }
-            ),
-        ]:
-            if isinstance(i, (tuple, list)):
-                if len(i) > 2:
-                    raise CallError(f'Invalid dataset entry: {i!r}')
-                if len(i) == 2:
-                    name, config = i
-                else:
-                    name, config = i[0], {}
-                datasets.append((f'{pool}/.system/{i[0]}', name, config))
-            else:
-                datasets.append((f'{pool}/.system/{i}', i, {}))
-
-        return datasets
 
     @private
     def migrate(self, _from, _to):

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -36,9 +36,10 @@ SYSTEM_DATASET_JSON_SCHEMA = {
                 'type': 'object',
                 'properties': {
                     'uid': {'type': 'integer'},
-                    'gid': {'type': 'integer'}
+                    'gid': {'type': 'integer'},
+                    'mode': {'type': 'integer'},
                 },
-                'required': ['uid', 'gid']
+                'required': ['uid', 'gid', 'mode'],
             },
             'mountpoint': {
                 'type': 'string'
@@ -56,7 +57,7 @@ SYSTEM_DATASET_JSON_SCHEMA = {
                 }
             }
         },
-        'required': ['name', 'props'],
+        'required': ['name', 'props', 'chown_config'],
         'additionalProperties': False,
     }
 }
@@ -71,6 +72,12 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'readonly': 'off',
                 'snapdir': 'hidden',
             },
+            'mountpoint': SYSDATASET_PATH,
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
+            },
         },
         {
             'name': os.path.join(pool_name, '.system/cores'),
@@ -78,6 +85,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'mountpoint': 'legacy',
                 'readonly': 'off',
                 'snapdir': 'hidden',
+            },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
             },
         },
         {
@@ -87,6 +99,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'readonly': 'off',
                 'snapdir': 'hidden',
             },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
+            },
         },
         {
             'name': os.path.join(pool_name, f'.system/rrd-{uuid}'),
@@ -94,6 +111,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'mountpoint': 'legacy',
                 'readonly': 'off',
                 'snapdir': 'hidden',
+            },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
             },
         },
         {
@@ -103,6 +125,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'readonly': 'off',
                 'snapdir': 'hidden',
             },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
+            },
         },
         {
             'name': os.path.join(pool_name, '.system/webui'),
@@ -111,6 +138,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'readonly': 'off',
                 'snapdir': 'hidden',
             },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
+            },
         },
         {
             'name': os.path.join(pool_name, '.system/services'),
@@ -118,6 +150,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'mountpoint': 'legacy',
                 'readonly': 'off',
                 'snapdir': 'hidden',
+            },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
             },
         },
         {
@@ -131,6 +168,7 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
             'chown_config': {
                 'uid': 999,
                 'gid': 997,
+                'mode': 0o755,
             },
             'mountpoint': os.path.join(SYSDATASET_PATH, 'netdata'),
             'create_paths': [

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -1,0 +1,140 @@
+import os
+
+from .utils import SYSDATASET_PATH
+
+
+SYSTEM_DATASET_JSON_SCHEMA = {
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    'description': 'Schema for the output of get_system_dataset_spec function',
+    'type': 'array',
+    'items': {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string'
+            },
+            'props': {
+                'type': 'object',
+                'properties': {
+                    'mountpoint': {
+                        'type': 'string',
+                        'const': 'legacy'
+                    },
+                    'readonly': {
+                        'type': 'string',
+                        'const': 'off'
+                    },
+                    'snapdir': {
+                        'type': 'string',
+                        'const': 'hidden'
+                    },
+                    'canmount': {'type': 'string'},
+                },
+                'required': ['mountpoint', 'readonly', 'snapdir'],
+            },
+            'chown_config': {
+                'type': 'object',
+                'properties': {
+                    'uid': {'type': 'integer'},
+                    'gid': {'type': 'integer'}
+                },
+                'required': ['uid', 'gid']
+            },
+            'mountpoint': {
+                'type': 'string'
+            },
+            'create_paths': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'path': {'type': 'string'},
+                        'uid': {'type': 'integer'},
+                        'gid': {'type': 'integer'}
+                    },
+                    'required': ['path', 'uid', 'gid']
+                }
+            }
+        },
+        'required': ['name', 'props'],
+        'additionalProperties': False,
+    }
+}
+
+
+def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
+    return [
+        {
+            'name': os.path.join(pool_name, '.system'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, '.system/cores'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, '.system/samba4'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, f'.system/rrd-{uuid}'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, f'.system/configs-{uuid}'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, '.system/webui'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, '.system/services'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+        },
+        {
+            'name': os.path.join(pool_name, f'.system/netdata-{uuid}'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+                'canmount': 'noauto',
+            },
+            'chown_config': {
+                'uid': 999,
+                'gid': 997,
+            },
+            'mountpoint': os.path.join(SYSDATASET_PATH, 'netdata'),
+            'create_paths': [
+                {'path': '/var/log/netdata', 'uid': 999, 'gid': 997},
+            ],
+        },
+    ]

--- a/src/middlewared/middlewared/plugins/system_dataset/utils.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/utils.py
@@ -1,0 +1,1 @@
+SYSDATASET_PATH = '/var/db/system'

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_system_dataset.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_system_dataset.py
@@ -1,0 +1,13 @@
+import jsonschema
+import pytest
+
+from middlewared.plugins.system_dataset.hierarchy import get_system_dataset_spec, SYSTEM_DATASET_JSON_SCHEMA
+
+
+@pytest.mark.parametrize('pool_name,uuid', [
+    ('test', '12345678'),
+    ('test2', '12345679'),
+])
+@pytest.mark.asyncio
+async def test_system_dataset_spec(pool_name, uuid):
+    jsonschema.validate(get_system_dataset_spec(pool_name, uuid), SYSTEM_DATASET_JSON_SCHEMA)


### PR DESCRIPTION
## Problem
The default path for Netdata database storage exists at `/var/cache/netdata`, but its data is stored in the system dataset. Symlinks were used to bind that dataset with the Netdata storage directory. However, the `netdata_setup` function, responsible for this process, runs on every netdata restart, although it should only be required once or when the system dataset is migrated.

## Solution
Simplify the Netdata setup logic by changing the Netdata database storage directory to `/var/db/system/netdata` and mounting the Netdata system dataset in that same directory. Other tasks performed by the `netdata_setup` function will also be handled in the system dataset in a clean/centric way.