### PR TITLE
NAS-127367 / 24.10 / Changed set_ldap_secret call to set_ldap_idmap_secret

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -817,7 +817,7 @@ class IdmapDomainService(CRUDService):
             secret = data['options'].pop('ldap_user_dn_password')
 
             await self.middleware.call(
-                'directoryservices.secrets.set_ldap_secret',
+                'directoryservices.secrets.set_ldap_idmap_secret',
                 domain, data['options']['ldap_user_dn'], secret
             )
             await self.middleware.call('directoryservices.secrets.backup')


### PR DESCRIPTION
In a previous refactor ([PR #13001](https://github.com/truenas/middleware/pull/13001)) `directoryservices.set_ldap_secret` was changed to `directoryservices.secrets.set_ldap_idmap_secret`, but one call was incorrectly updated.