### PR TITLE
NAS-127378 / 24.10 / Update k8s to 1.29

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
+++ b/src/middlewared/middlewared/etc_files/rancher/k3s/flags.py
@@ -30,7 +30,6 @@ def render(service, middleware):
         'audit-log-maxbackup=10',
         'audit-log-maxsize=100',
         'service-account-lookup=true',
-        'feature-gates=MixedProtocolLBService=true',
     ]
     kubelet_args = [
         f'config={KUBELET_CONFIG_PATH}',


### PR DESCRIPTION
In 1.29, `MixedProtocolLBService` feature is available and an additional flag is not required to enable this anymore. Changes have been made to make sure middleware is up to date with the update in k8s version.