### PR TITLE
NAS-127366 / 23.10.2 / fix failover group logic (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/etc_files/keepalived.conf.mako
+++ b/src/middlewared/middlewared/etc_files/keepalived.conf.mako
@@ -11,6 +11,7 @@
     elif not licensed:
 	return
 
+    prio = middleware.call_sync('failover.vrrp.get_priority')
     config = middleware.call_sync('failover.config')
 
     advert_int = .68 # default 2 second timeout
@@ -60,9 +61,9 @@ vrrp_instance ${i['name']} {
     interface ${i['name'].split('_')[0]}
     state BACKUP
     advert_int ${advert_int}
-    nopreempt
+    preempt
     virtual_router_id 20
-    priority 254
+    priority ${prio}
     version 3
     unicast_peer {
     % for j in i['failover_aliases'] if node == 'A' else i['aliases']:

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -102,7 +102,12 @@ class FailoverEventsService(Service):
             to_restart = [i for i in to_restart if i not in self.CRITICAL_SERVICES]
 
         exceptions = await asyncio.gather(
-            *[self.become_active_service(svc, data['timeout']) if svc in self.BECOME_ACTIVE_SERVICES else self.restart_service(svc, data['timeout']) for svc in to_restart],
+            *[
+                self.become_active_service(svc, data['timeout'])
+                if svc in self.BECOME_ACTIVE_SERVICES
+                else self.restart_service(svc, data['timeout'])
+                for svc in to_restart
+            ],
             return_exceptions=True
         )
         for svc, exc in zip(to_restart, exceptions):

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -415,6 +415,20 @@ class FailoverEventsService(Service):
 
         # fenced is now running, so we *are* the ACTIVE/MASTER node
 
+        # if 2x interfaces are in the same failover group and 1 of them goes
+        # down, the VIP will float to the other controller. However, a failover
+        # won't happen because the other interface is still UP on the master.
+        # If the down'ed interface comes back online, the VIP needs to float
+        # back to the original master controller. Reloading keepalived service
+        # re-generates the configuration file which ensures the config has the
+        # right priority set.
+        logger.info('Pausing failover event processing')
+        self.run_call('vrrpthread.pause_events')
+        logger.info('Taking ownership of all VIPs')
+        self.run_call('service.reload', 'keepalived', self.HA_PROPAGATE)
+        logger.info('Unpausing failover event processing')
+        self.run_call('vrrpthread.unpause_events')
+
         # Kick off a job to clean up any left-over ALUA state from when we were STANDBY/BACKUP.
         if self.run_call('service.started_or_enabled', 'iscsitarget'):
             handle_alua = self.run_call('iscsi.global.alua_enabled')

--- a/src/middlewared/middlewared/plugins/failover_/vrrp.py
+++ b/src/middlewared/middlewared/plugins/failover_/vrrp.py
@@ -1,0 +1,30 @@
+# Copyright (c) - iXsystems Inc.
+#
+# Licensed under the terms of the TrueNAS Enterprise License Agreement
+# See the file LICENSE.IX for complete terms and conditions
+
+from middlewared.service import Service
+
+MASTER_PRIO = 254
+BACKUP_PRIO = 200
+
+
+class FailoverVrrpService(Service):
+    class Config:
+        private = True
+        cli_private = True
+        namespace = 'failover.vrrp'
+
+    def get_priority(self):
+        """Return the VRRP priority value that should be set
+        based on whether or not this controller is the MASTER
+        or BACKUP system"""
+        master_event = self.middleware.call_sync('core.get_jobs', [
+            ('method', '=', 'failover.events.vrrp_master')
+            ('state', '=', 'RUNNING'),
+        ])
+        fenced = self.middleware.call_sync('failover.fenced.run_info')
+        if master_event and fenced['running']:
+            # a master event is taking place and it started fenced
+            return MASTER_PRIO
+        return BACKUP_PRIO

--- a/src/middlewared/middlewared/plugins/failover_/vrrp.py
+++ b/src/middlewared/middlewared/plugins/failover_/vrrp.py
@@ -23,7 +23,7 @@ class FailoverVrrpService(Service):
             return MASTER_PRIO
 
         master_event = self.middleware.call_sync('core.get_jobs', [
-            ('method', '=', 'failover.events.vrrp_master')
+            ('method', '=', 'failover.events.vrrp_master'),
             ('state', '=', 'RUNNING'),
         ])
         fenced = self.middleware.call_sync('failover.fenced.run_info')

--- a/src/middlewared/middlewared/plugins/failover_/vrrp.py
+++ b/src/middlewared/middlewared/plugins/failover_/vrrp.py
@@ -19,6 +19,9 @@ class FailoverVrrpService(Service):
         """Return the VRRP priority value that should be set
         based on whether or not this controller is the MASTER
         or BACKUP system"""
+        if self.middleware.call_sync('failover.status') == 'MASTER':
+            return MASTER_PRIO
+
         master_event = self.middleware.call_sync('core.get_jobs', [
             ('method', '=', 'failover.events.vrrp_master')
             ('state', '=', 'RUNNING'),
@@ -27,4 +30,5 @@ class FailoverVrrpService(Service):
         if master_event and fenced['running']:
             # a master event is taking place and it started fenced
             return MASTER_PRIO
+
         return BACKUP_PRIO


### PR DESCRIPTION
if 2x interfaces are in the same failover group and 1 of them goes
down, the VIP will float to the other controller. However, a failover
won't happen because the other interface is still UP on the master.
If the down'ed interface comes back online, the VIP needs to float
back to the original master controller. Reloading keepalived service
re-generates the configuration file which ensures the config has the
right priority set.

To ensure the VIP floats back to the original master, this does 2 primary things:
1. set priority property on the master/backup controllers appropriately (higher priority wins)
2. enable preemption

Original PR: https://github.com/truenas/middleware/pull/13155
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127366