### PR TITLE
NAS-127385 / 23.10.3 / fix EBADF error in HA logic (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -16,7 +16,7 @@ from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImpo
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
 
 logger = logging.getLogger('failover')
-
+FAILOVER_LOCK_NAME = 'vrrp_event'
 
 # When we get to the point of transitioning to MASTER or BACKUP
 # we wrap the associated methods (`vrrp_master` and `vrrp_backup`)
@@ -345,7 +345,7 @@ class FailoverEventsService(Service):
 
         return fenced_error
 
-    @job(lock='vrrp_master')
+    @job(lock=FAILOVER_LOCK_NAME)
     def vrrp_master(self, job, fobj, ifname, event):
 
         # vrrp does the "election" for us. If we've gotten this far
@@ -662,7 +662,7 @@ class FailoverEventsService(Service):
         )['dataset']:
             self.middleware.create_task(self.middleware.call('kubernetes.start_service'))
 
-    @job(lock='vrrp_backup')
+    @job(lock=FAILOVER_LOCK_NAME)
     def vrrp_backup(self, job, fobj, ifname, event):
 
         # we need to check a couple things before we stop fenced

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -707,7 +707,7 @@ class FailoverEventsService(Service):
         logger.info('Pausing failover event processing')
         self.run_call('vrrpthread.pause_events')
         logger.info('Transitioning all VIPs off this node')
-        self.run_call('service.restart', 'keepalived', self.HA_PROPAGATE)
+        self.run_call('service.stop', 'keepalived', self.HA_PROPAGATE)
 
         # ticket 23361 enabled a feature to send email alerts when an unclean reboot occurrs.
         # TrueNAS HA, by design, has a triggered unclean shutdown.
@@ -807,6 +807,8 @@ class FailoverEventsService(Service):
             logger.warning('Unhandled exception persisting network interface link addresses on MASTER node',
                            exc_info=True)
 
+        logger.info('Starting VRRP daemon')
+        self.run_call('service.start', 'keepalived', self.HA_PROPAGATE)
         logger.info('Unpausing failover event processing')
         self.run_call('vrrpthread.unpause_events')
         logger.info('Successfully became the BACKUP node.')


### PR DESCRIPTION
A race condition exists where a `vrrp_master` job would start and then a `vrrp_backup` would subsequently start and depending on which method was the quickest, they would both interact with `fenced` which ultimately ended up with fenced exiting with EBADF. This is because the 2 methods run in their own native threads. There are 2 subtle issues and that is the controller would become `vrrp_master` and `vrrp_backup` almost simultaneously and then fenced would error with EBADF.

To fix both issues:
1. create a global lock that is shared between vrrp_master/backup methods
2. outright _stop_ the vrrp daemon when we become backup (instead of restarting it)

Original PR: https://github.com/truenas/middleware/pull/13173
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127385