### PR TITLE
NAS-123833 / 24.04-RC.1 / Rework boot to initiate/wait NVMe/TCP (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -338,21 +338,22 @@ class PoolService(Service):
             # event logic
             return
 
-        # Attach NVMe/RoCE - wait up to 10 seconds
-        self.logger.info('Start bring up of NVMe/RoCE')
-        try:
-            jbof_job = self.middleware.call_sync('jbof.configure_job')
-            jbof_job.wait_sync(timeout=10)
-            if jbof_job.error:
-                self.logger.error(f'Error attaching JBOFs: {jbof_job.error}')
-            elif jbof_job.result['failed']:
-                self.logger.error(f'Failed to attach JBOFs:{jbof_job.result["message"]}')
-            else:
-                self.logger.info(jbof_job.result['message'])
-        except TimeoutError:
-            self.logger.error('Timed out attaching JBOFs - will continue in background')
-        except Exception:
-            self.logger.error('Unexpected error', exc_info=True)
+        if self.middleware.call_sync('truenas.is_ix_hardware'):
+            # Attach NVMe/RoCE - wait up to 10 seconds
+            self.logger.info('Start bring up of NVMe/RoCE')
+            try:
+                jbof_job = self.middleware.call_sync('jbof.configure_job')
+                jbof_job.wait_sync(timeout=10)
+                if jbof_job.error:
+                    self.logger.error(f'Error attaching JBOFs: {jbof_job.error}')
+                elif jbof_job.result['failed']:
+                    self.logger.error(f'Failed to attach JBOFs:{jbof_job.result["message"]}')
+                else:
+                    self.logger.info(jbof_job.result['message'])
+            except TimeoutError:
+                self.logger.error('Timed out attaching JBOFs - will continue in background')
+            except Exception:
+                self.logger.error('Unexpected error', exc_info=True)
 
         set_cachefile_property = True
         dir_name = os.path.dirname(ZPOOL_CACHE_FILE)

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -338,6 +338,22 @@ class PoolService(Service):
             # event logic
             return
 
+        # Attach NVMe/RoCE - wait up to 10 seconds
+        self.logger.info('Start bring up of NVMe/RoCE')
+        try:
+            jbof_job = self.middleware.call_sync('jbof.configure_job')
+            jbof_job.wait_sync(timeout=10)
+            if jbof_job.error:
+                self.logger.error(f'Error attaching JBOFs: {jbof_job.error}')
+            elif jbof_job.result['failed']:
+                self.logger.error(f'Failed to attach JBOFs:{jbof_job.result["message"]}')
+            else:
+                self.logger.info(jbof_job.result['message'])
+        except TimeoutError:
+            self.logger.error('Timed out attaching JBOFs - will continue in background')
+        except Exception:
+            self.logger.error('Unexpected error', exc_info=True)
+
         set_cachefile_property = True
         dir_name = os.path.dirname(ZPOOL_CACHE_FILE)
         try:


### PR DESCRIPTION
Add code to bring up any previously-configure NVMe/RoCE JBOFs on boot.

A new job (`jbof.configure_job`) will bring all configured JBOFs in parallel using `jbof.configure_jbof`.  This configures the necessary RoCE HBA and does a `nvme connect-all`.

In the non-HA case we call `jbof.configure_job` from `pool.import_on_boot` and wait with a 10 second.  Note that if the job takes more than 10 seconds, it will continue to run rather than get aborted after the 10 second timeout.  That said, this should not occur.

For HA we do a similar operation in `failover.vrrp_master`, but also add a parameter to reload fenced if it is running.  We also call `jbof.configure_job` from failover.vrrp_backup, but do not need to wait there as we don't plan on using the drives until the next failover.

Original PR: https://github.com/truenas/middleware/pull/13165
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123833