### PR TITLE
NAS-126877 / 24.10 / Bump AMD k8s device plugin image tag

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -110,7 +110,7 @@ GPU_CONFIG = {
                         {'key': 'CriticalAddonsOnly', 'operator': 'Exists'},
                     ],
                     'containers': [{
-                        'image': 'rocm/k8s-device-plugin:1.18.0',
+                        'image': 'rocm/k8s-device-plugin:1.25.2.7',
                         'name': 'amdgpu-dp-cntr',
                         'securityContext': {'allowPrivilegeEscalation': False, 'capabilities': {'drop': ['ALL']}},
                         'volumeMounts': [


### PR DESCRIPTION
This commit updates AMD k8s device plugin image tag as we have a user whose gpu is not being recognized by the tag we had earlier. However there is still breakage expected for other users as we had bumped this earlier as well but we had quite a few users for whom AMD gpu was not being recognized anymore and hence we went back to the older version in https://github.com/truenas/middleware/pull/10312. Idea is to see that if things have improved as it's been a while since we reverted back and based on feedback we can re-evaluate.