### PR TITLE
NAS-127432 / 13.1 / fix off-by-1 on R50B nvme drives (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/rseries_nvme.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/rseries_nvme.py
@@ -30,9 +30,9 @@ class EnclosureService(Service):
                 location = sysctl.filter(f'dev.pcib.{m.group(1)}.%location')[0].value
                 if product == 'TRUENAS-R50B':
                     if '_SB_.PC03.BR3A' in location:
-                        slot = 49
-                    elif '_SB_.PC00.RP01' in location:
                         slot = 50
+                    elif '_SB_.PC00.RP01' in location:
+                        slot = 49
                     else:
                         continue
                 elif product == 'TRUENAS-R50':


### PR DESCRIPTION
Pointed out by the platform team. The rear nvme drive bays on the R50B are off by 1.

Original PR: https://github.com/truenas/middleware/pull/13190
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127432