### PR TITLE
NAS-127453 / 24.10 / fix regression in pool_status.py

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -29,6 +29,7 @@ class ZPoolService(Service):
 	            #       7008beaf-4fa3-4c43-ba15-f3d5bea3fe0c  REMOVED      0     0     0
 	            #       sda1                                  ONLINE       0     0     0
                 return dev
+            return resolved
         except Exception:
             return path
 


### PR DESCRIPTION
I fixed an error in 88ebd737e30 but caused a regression whereby I omitted returning the resolved disk.