### PR TITLE
NAS-127460 / 24.10 / Improve disk partitioning

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -41,6 +41,11 @@ class DiskService(Service):
 
         # Get drive specs and size in sectors
         device = parted.getDevice(f'/dev/{disk}')
+
+        # We rely on a valid 'grainSize', let's make sure before we proceed.
+        if device.optimumAlignment.grainSize <= 0:
+            raise CallError(f'Unable to format {disk!r}: grainSize = {device.optimumAlignment.grainSize}')
+
         drive_size_s = parted.sizeToSectors(dd['size'], 'B', device.sectorSize)
 
         # Allocate space for the requested swap size

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -37,10 +37,8 @@ class DiskService(Service):
             if len(disk_parts) > 1:
                 for partition in disk_parts[1:]:
                     # Start 2 MiB back from the start and 'clean' 2 MiB past, 4 MiB total
-                    self.logger.info(f"process partition {partition['name']}")  # <---------------- DEBUG
                     os.lseek(f.fileno(), partition['start'] - (2 * CHUNK), os.SEEK_SET)
                     for i in range(4):
-                        self.logger.info(f"    clean 1MiB at {f.tell()}")  # <--------------------- DEBUG
                         os.write(f.fileno(), to_write)
                         if event.is_set():
                             return

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -23,7 +23,8 @@ class PoolService(Service):
             swap_size = 0
             if config['create_swap'] and create_swap_partition:
                 swap_size = swapgb
-            await self.middleware.call('disk.format', disk, config.get('size'), swap_size)
+            # Drives are partitioned to maximize the data partition
+            await self.middleware.call('disk.format', disk, swap_size)
             formatted += 1
             job.set_progress(15, f'Formatting disks ({formatted}/{len_disks})')
 

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -38,9 +38,9 @@ disk = call('disk.get_unused')[0]
 dd = call('device.get_disk', disk['name'])
 
 # Calculate expected values using the 'heuristic'
-alignment_offset = int(ssh('cat /sys/block/sdb/alignment_offset'))
-optimal_io_size = int(ssh('cat /sys/block/sdb/queue/optimal_io_size'))
-minimum_io_size = int(ssh('cat /sys/block/sdb/queue/minimum_io_size'))
+alignment_offset = int(ssh(f"cat /sys/block/{disk['name']}/alignment_offset"))
+optimal_io_size = int(ssh(f"cat /sys/block/{disk['name']}/queue/optimal_io_size"))
+minimum_io_size = int(ssh(f"cat /sys/block/{disk['name']}/queue/minimum_io_size"))
 
 grain_size = 0
 if 0 == optimal_io_size and 0 == alignment_offset:

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -1,118 +1,150 @@
 import pytest
 
 from middlewared.service_exception import CallError
-from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils import call, ssh
+
+"""
+We use 'parted' to partition disks.
+Verification is based on 'parted' documentation (https://people.redhat.com/msnitzer/docs/io-limits.txt):
+    The heuristic parted uses is:
+    1)  Always use the reported 'alignment_offset' as the offset for the
+        start of the first primary partition.
+    2a) If 'optimal_io_size' is defined (not 0) align all partitions on an
+        'optimal_io_size' boundary.
+    2b) If 'optimal_io_size' is undefined (0) and 'alignment_offset' is 0
+        and 'minimum_io_size' is a power of 2: use a 1MB default alignment.
+        - as you can see this is the catch all for "legacy" devices which
+          don't appear to provide "I/O hints"; so in the default case all
+          partitions will align on a 1MB boundary.
+        - NOTE: we can't distinguish between a "legacy" device and modern
+          device that provides "I/O hints" with alignment_offset=0 and
+          optimal_io_size=0.  Such a device might be a single SAS 4K device.
+          So worst case we lose < 1MB of space at the start of the disk.
+"""
+
+# Some 'constants'
+MBR_SECTOR_GAP = 34
+NO_SWAP = 0
+WITH_2GB_SWAP = 2
+ONE_MB = 1048576
+ONE_GB = (ONE_MB * 1024)
+SWAP_SIZE = (WITH_2GB_SWAP * ONE_GB)
+
+DATA_TYPE_UUID = "6a898cc3-1dd2-11b2-99a6-080020736631"
+SWAP_TYPE_UUID = "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"
+
+# Currently, we use the same 'unused' disk for all tests
+disk = call('disk.get_unused')[0]
+dd = call('device.get_disk', disk['name'])
+
+# Calculate expected values using the 'heuristic'
+alignment_offset = int(ssh('cat /sys/block/sdb/alignment_offset'))
+optimal_io_size = int(ssh('cat /sys/block/sdb/queue/optimal_io_size'))
+minimum_io_size = int(ssh('cat /sys/block/sdb/queue/minimum_io_size'))
+
+grain_size = 0
+if 0 == optimal_io_size and 0 == alignment_offset:
+    if 0 == minimum_io_size % 2:
+        # Alignment value in units of sectors
+        grain_size = ONE_MB / dd['sectorsize']
+
+if 0 != optimal_io_size:
+    grain_size = optimal_io_size
+
+pytestmark = pytest.mark.skipif(grain_size == 0, reason=f"ERROR: Cannot determine alignment value, grain_size={grain_size}")
+
+first_sector = alignment_offset if alignment_offset != 0 else grain_size
 
 
-def test_disk_format_without_size_without_swap():
-    disk = call('disk.get_unused')[0]
-
-    call('disk.format', disk['name'], None, 0)
+def test_disk_format_without_swap():
+    """
+    Generate a single data partition, no swap
+    """
+    call('disk.format', disk['name'], NO_SWAP)
 
     partitions = call('disk.list_partitions', disk['name'])
     assert len(partitions) == 1
+
+    # The first and only partition should be data
+    assert partitions[0]['partition_type'] == DATA_TYPE_UUID
+
+    # Should be a modulo of grain_size
+    assert (partitions[0]['end_sector'] - partitions[0]['start_sector']) % grain_size == 0
+
     # Uses (almost) all the disk
+    assert partitions[0]['start_sector'] == first_sector
+    assert partitions[0]['end_sector'] >= dd['blocks'] - grain_size
+
+    # And does not clobber the MBR data at the end
+    assert partitions[0]['end_sector'] < dd['blocks'] - MBR_SECTOR_GAP
+
+    # Hand-wavy test
     assert partitions[0]['size'] > disk['size'] * 0.99
 
 
-def test_disk_format_without_size_with_swap():
-    disk = call('disk.get_unused')[0]
-
-    call('disk.format', disk['name'], None, 2)
+def test_disk_format_with_swap():
+    """
+    Generate two partitions:
+        1: swap (2 GiB)
+        2: data
+    """
+    call('disk.format', disk['name'], WITH_2GB_SWAP)
 
     partitions = call('disk.list_partitions', disk['name'])
     assert len(partitions) == 2
-    # Swap of the requested size
+
+    # The first partition should be swap
+    assert partitions[0]['partition_type'] == SWAP_TYPE_UUID
+
+    # Swap should start at the specified offset and be the requested size
+    assert partitions[0]['start_sector'] == first_sector
+    num_swap_sectors = partitions[0]['end_sector'] - partitions[0]['start_sector']
+    assert num_swap_sectors == SWAP_SIZE / dd['sectorsize']
+
+    # Should be a modulo of grain_size
+    assert (partitions[0]['end_sector'] - partitions[0]['start_sector']) % grain_size == 0
+
+    # Hand wavey swap size test
     assert int(partitions[0]['size'] / (1024 ** 3) + 0.5) == 2
-    # Uses (almost) all the disk
+
+    # The data partition should start after a 'grain_size' gap
+    assert partitions[1]['start_sector'] == partitions[0]['end_sector'] + grain_size
+
+    # and be a modulo of grain_size
+    assert (partitions[1]['end_sector'] - partitions[1]['start_sector']) % grain_size == 0
+
+    # and be maximal sized
+    assert partitions[1]['end_sector'] >= dd['blocks'] - grain_size
+
+    # And does not clobber the MBR data at the end
+    assert partitions[0]['end_sector'] < dd['blocks'] - MBR_SECTOR_GAP
+
+    # Hand-wavy data size test
     assert partitions[1]['size'] > (disk['size'] - partitions[0]['size']) * 0.99
 
 
-def test_disk_format_without_size_with_swap__too_large_swap():
-    disk = call('disk.get_unused')[0]
-
+@pytest.mark.parametrize("swap_val", [-10, 2.5, 1024])
+def test_disk_format_with_invalid_swap(swap_val):
+    """
+    Confirm we can handle erroneous input
+    """
     with pytest.raises(CallError) as e:
-        call('disk.format', disk['name'], None, 1024)
+        call('disk.format', disk['name'], swap_val)
 
-    assert e.value.errmsg == f'Disk {disk["name"]!r} must be larger than 1024 GiB'
-
-
-def test_disk_format_with_size_without_swap():
-    disk = call('disk.get_unused')[0]
-    disk_size = disk['size']
-    disk = disk['name']
-
-    data_size = 1024 * 1024 * 1024
-    call('disk.format', disk, data_size, 0)
-
-    partitions = call('disk.list_partitions', disk)
-    assert len(partitions) == 1
-    assert partitions[0]['size'] >= disk_size * 0.99
-
-
-def test_disk_format_with_size_without_swap__too_large_size():
-    disk = call('disk.get_unused')[0]['name']
-
-    data_size = 1024 * 1024 * 1024 * 1024
-    with pytest.raises(CallError) as e:
-        call('disk.format', disk, data_size, 0)
-
-    assert e.value.errmsg == f'Disk {disk!r} must be larger than {data_size} bytes'
-
-
-def test_disk_format_with_size_with_swap():
-    disk = call('disk.get_unused')[0]
-    disk_size = disk['size']
-    disk = disk['name']
-
-    data_size = 1024 * 1024 * 1024
-    swap_size_gb = 2
-    call('disk.format', disk, data_size, 2)
-
-    partitions = call('disk.list_partitions', disk)
-    assert len(partitions) == 2
-    # Swap of almost the requested size
-    assert int(partitions[0]['size'] / (1024 ** 3) + 0.5) == 2
-    # Data occupies the rest of the disk
-    assert partitions[1]['size'] >= (disk_size - swap_size_gb * (1024 ** 3)) * 0.99
-
-
-def test_disk_format_with_size_with_swap_overflow():
-    disk = call('disk.get_unused')[0]
-    disk_size = disk['size']
-    disk = disk['name']
-
-    swap_size = 1536 * 1024 * 1024
-
-    data_size = disk_size - swap_size
-    call('disk.format', disk, data_size, 2)
-
-    partitions = call('disk.list_partitions', disk)
-    assert len(partitions) == 2
-    # As much swap as we could afford
-    assert swap_size * 0.9 < partitions[0]['size'] <= swap_size
-    # Data of at least the requested size
-    assert partitions[1]['size'] >= data_size
-
-
-def test_disk_format_with_size_with_swap_overflow_no_swap():
-    disk = call('disk.get_unused')[0]
-    disk_size = disk['size']
-    disk = disk['name']
-
-    swap_size = 512 * 1024 * 1024  # Swaps of less than 1 GiB are not accepted
-
-    data_size = disk_size - swap_size
-    call('disk.format', disk, data_size, 2)
-
-    partitions = call('disk.list_partitions', disk)
-    assert len(partitions) == 1
-    # Data of at least the requested size
-    assert partitions[0]['size'] >= data_size
+    # The error response is input dependent
+    if swap_val > 100:
+        assert e.value.errmsg == (
+            f'Disk {disk["name"]!r} capacity is too small. '
+            'Please use a larger capacity drive or reduce swap.'
+        )
+    else:
+        assert e.value.errmsg == (
+            'Requested swap must be a non-negative integer'
+        )
 
 
 def test_disk_format_removes_existing_partition_table():
     disk = call('disk.get_unused')[0]['name']
 
-    call('disk.format', disk, None, 2)
-    call('disk.format', disk, None, 0)
+    call('disk.format', disk, 2)
+    call('disk.format', disk, 0)

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -116,6 +116,9 @@ def test_disk_format_with_swap(unused_disk):
     # Hand wavey swap size test
     assert int(partitions[0]['size'] / (1024 ** 3) + 0.5) == 2
 
+    # The second partition should be data
+    assert partitions[1]['partition_type'] == DATA_TYPE_UUID
+
     # The data partition should start after a 'grain_size' gap
     assert partitions[1]['start_sector'] == partitions[0]['end_sector'] + grain_size
 
@@ -163,4 +166,11 @@ def test_disk_format_removes_existing_partition_table(unused_disk):
     disk = unused_disk[0]
 
     call('disk.format', disk['name'], 2)
+    # We should now have two partitions: swap and data
+    partitions = call('disk.list_partitions', disk['name'])
+    assert len(partitions) == 2
+
     call('disk.format', disk['name'], 0)
+    # We should now have one partition: data
+    partitions = call('disk.list_partitions', disk['name'])
+    assert len(partitions) == 1

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -96,6 +96,7 @@ def test_disk_format_with_swap(unused_disk):
     """
     disk, dd, grain_size, first_sector = unused_disk
     assert grain_size != 0, 'ERROR: Cannot run this test without a non-zero grain_size'
+
     call('disk.format', disk['name'], WITH_2GB_SWAP)
 
     partitions = call('disk.list_partitions', disk['name'])

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -33,27 +33,31 @@ def test_disk_wipe_partition_clean():
     # Create 1 GiB swap and a data partition
     call('disk.format', disk, 1)
     parts = call('disk.list_partitions', disk)
-    # This 'assumes' 512 byte sectors
     seek_blk = parts[1]['start_sector']
+    blk_size = int(parts[0]['start'] / parts[0]['start_sector'])
 
     # Write some private data into the start of the data partition
     cmd = (
         f"echo '{signal_msg}' > junk;"
-        f"dd if=junk count=1 oseek={seek_blk} of=/dev/{disk};"
+        f"dd if=junk bs={blk_size} count=1 oseek={seek_blk} of=/dev/{disk};"
         "rm -f junk"
     )
     ssh(cmd)
 
     # Confirm presence
-    readback_presence = ssh(f"dd if=/dev/{disk} iseek={seek_blk} count=1").splitlines()[0]
+    readback_presence = ssh(f"dd if=/dev/{disk} bs={blk_size} iseek={seek_blk} count=1").splitlines()[0]
     assert signal_msg in readback_presence
 
     # Clean the drive
     call('disk.wipe', disk, 'QUICK', job=True)
 
     # Confirm it's now clean
-    readback_clean = ssh(f"dd if=/dev/{disk} iseek={seek_blk} count=1").splitlines()[0]
+    readback_clean = ssh(f"dd if=/dev/{disk} bs={blk_size} iseek={seek_blk} count=1").splitlines()[0]
     assert signal_msg not in readback_clean
+
+    # Confirm we have no partitions
+    partitions = call('disk.list_partitions', disk)
+    assert len(partitions) == 0
 
 
 def test_disk_wipe_abort():

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -27,7 +27,6 @@ def test_disk_wipe_partition_clean():
     Confirm we clean up around the middle partitions
     """
     signal_msg = "ix private data"
-    print(f"\nsignal_msg  = '{signal_msg}'")
 
     disk = call("disk.get_unused")[0]["name"]
 
@@ -47,7 +46,6 @@ def test_disk_wipe_partition_clean():
 
     # Confirm presence
     readback_presence = ssh(f"dd if=/dev/{disk} iseek={seek_blk} count=1").splitlines()[0]
-    print(f"start readback  = '{readback_presence}'")
     assert signal_msg in readback_presence
 
     # Clean the drive
@@ -55,7 +53,6 @@ def test_disk_wipe_partition_clean():
 
     # Confirm it's now clean
     readback_clean = ssh(f"dd if=/dev/{disk} iseek={seek_blk} count=1").splitlines()[0]
-    print(f"finish readback = '{readback_clean}'")
     assert signal_msg not in readback_clean
 
 

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -1,7 +1,5 @@
 import time
 
-import pytest
-
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.pool import another_pool
 


### PR DESCRIPTION
This PR does a few things to improve our disk format (partitioning) and clean handling.
### Add partition names/labels
This makes it easier to identify the partition function.   
Example output from `sgdisk -p /dev/sdb`, where `sdb` is a 4 GiB drive with 2 GiB swap partition:
```
Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048         4196352   2.0 GiB     8200  swap
   2         4198400         8386560   2.0 GiB     BF01  data

```
### Clean up inconsistencies
Partitioning a disk without swap would result in a partition shortened by 1MiB
```
	Number  Start (sector)    End (sector)  Size       Code  Name
	   1            4096         4192256   2.0 GiB     BF01
```
The starting sector for that partition should be 2048
### Remove unused parameters
We now _always_ partition disks to the largest possible data partition.  As such, removed the parameter that specifies the size of the data partition. 
### Allow for partitioning smallest possible disk
This is mostly in support of TrueNAS VMs for development testing.  If the default 2 GiB swap partition is used the smallest 'supported' drive is 3 GiB.  If no swap is requested a drive as small as 1 GiB may be used.
### Improve user facing error messages
We provide error messages tailored to the condition
### Improve 'QUICK' disk wipe
The 'QUICK' disk wipe method would clear the MBR/GPT data that gets stored at both ends of the drive.  However,
it did not clean up 'partition' data.  This might, for example, include private data written in partition gaps or private data used by the filesystem.  This additional clean step is enacted when there is more than one partition.
### Improve disk format CI testing
The start, end and size of the partitions are now deterministic.  The CI tests have been improved to take advantage.
### Improve disk wipe CI testing
Add test for the added 'middle' partition cleaning
 