### PR TITLE
NAS-127467 / 24.10 / add disk details to webui.enclosure.dashboard

### DIFF
--- a/src/middlewared/middlewared/plugins/webui/enclosure.py
+++ b/src/middlewared/middlewared/plugins/webui/enclosure.py
@@ -9,31 +9,61 @@ class WebUIEnclosureService(Service):
         cli_private = True
         role_prefix = 'ENCLOSURE'
 
+    def disk_detail_dict(self):
+        return {
+            'name': None,
+            'size': None,
+            'model': None,
+            'serial': None,
+            'advpowermgmt': None,
+            'togglesmart': None,
+            'smartoptions': None,
+            'transfermode': None,
+            'hddstandby': None,
+            'description': None,
+            'rotationrate': None,
+        }
+
+    def map_disk_details(self, slot_info, disks_in_db):
+        for key in self.disk_detail_dict():
+            slot_info[key] = disks_in_db.get(slot_info['dev'], {}).get(key)
+
+    def map_zpool_info(self, enc_id, disk_slot, dev, pool_info):
+        info = {'enclosure_id': enc_id, 'slot': int(disk_slot), 'dev': dev}
+        try:
+            index = pool_info['vdev_disks'].index(dev)
+            pool_info['vdev_disks'][index] = info
+        except ValueError:
+            # it means the disk's status in zfs land != ONLINE
+            # (i.e. it could be OFFLINE) and so it won't show
+            # up in the `vdev_disks` key, so it's best to catch
+            # this error and still append the disk to the list
+            # The `pool_info['disk_status']` key will be added
+            # which will give more insight into what's going on
+            pool_info['vdev_disks'].append(info)
+
     def dashboard_impl(self):
         disks_to_pools = dict()
         enclosures = self.middleware.call_sync('enclosure2.query')
         if enclosures:
+            disks_in_db = {i['name']: i for i in self.middleware.call_sync('disk.query')}
             disks_to_pools = self.middleware.call_sync('zpool.status', {'real_paths': True})
             for enc in enclosures:
                 for disk_slot, slot_info in enc['elements']['Array Device Slot'].items():
-                    # remove some values that webUI doesn't use
-                    slot_info.pop('original')
-                    slot_info.pop('value')
-                    slot_info.pop('value_raw')
+                    for to_pop in ('original', 'value', 'value_raw'):
+                        # remove some values that webUI doesn't use
+                        slot_info.pop(to_pop)
+
                     pool_info = None
+                    slot_info.update(self.disk_detail_dict())
                     if slot_info['dev'] and (pool_info := disks_to_pools['disks'].get(slot_info['dev'])):
-                        info = {'enclosure_id': enc['id'], 'slot': int(disk_slot), 'dev': slot_info['dev']}
-                        try:
-                            index = pool_info['vdev_disks'].index(slot_info['dev'])
-                            pool_info['vdev_disks'][index] = info
-                        except ValueError:
-                            # it means the disk's status in zfs land != ONLINE
-                            # (i.e. it could be OFFLINE) and so it won't show
-                            # up in the `vdev_disks` key, so it's best to catch
-                            # this error and still append the disk to the list
-                            # The `pool_info['disk_status']` key will be added
-                            # which will give more insight into what's going on
-                            pool_info['vdev_disks'].append(info)
+                        # map zpool info first
+                        self.map_zpool_info(enc['id'], disk_slot, slot_info['dev'], pool_info)
+
+                        # now map disk details
+                        # NOTE: some of these fields need to be removed
+                        # work with UI to remove unnecessary ones
+                        self.map_disk_details(slot_info, disks_in_db)
 
                     slot_info.update({'pool_info': pool_info})
 
@@ -46,65 +76,67 @@ class WebUIEnclosureService(Service):
 
         An example of what this returns looks like the following:
             (NOTE: some redundant information cut out for brevity)
-                [{
-                    "id": "f60_nvme_enclosure",
-                    "dmi": "f60_nvme_enclosure",
-                    "model": "F60",
-                    "sg": null,
-                    "bsg": null,
-                    "name": "F60 NVMe Enclosure",
-                    "controller": true,
-                    "status": [
-                      "OK"
-                    ],
-                    "elements": {
-                      "Array Device Slot": {
-                        "1": {
-                          "descriptor": "Disk #1",
-                          "status": "OK",
-                          "dev": "nvme3n1",
-                          "pool_info": {
-                            "pool_name": "sanity",
+        [{
+            "name": "iX 4024Sp c205",
+            "model": "M40",
+            "controller": true,
+            "dmi": "TRUENAS-M40-HA",
+            "status": ["OK"],
+            "id": "5b0bd6d1a30714bf",
+            "vendor": "iX",
+            "product": "4024Sp",
+            "revision": "c205",
+            "bsg": "/dev/bsg/0:0:23:0",
+            "sg": "/dev/sg25",
+            "pci": "0:0:23:0",
+            "rackmount": true,
+            "top_loaded": false,
+            "front_slots": 24,
+            "rear_slots": 0,
+            "internal_slots": 0,
+            "elements": {
+                "Array Device Slot": {
+                    "1": {
+                        "descriptor": "slot00",
+                        "status": "OK",
+                        "dev": "sda",
+                        "name": "sda",
+                        "size": 12000138625024,
+                        "model": "HUH721212AL4200",
+                        "serial": "XXXXX",
+                        "advpowermgmt": "DISABLED",
+                        "togglesmart": true,
+                        "smartoptions": "",
+                        "transfermode": "Auto",
+                        "hddstandby": "ALWAYS ON",
+                        "description": "",
+                        "rotationrate": 7200,
+                        "pool_info": {
+                            "pool_name": "test",
                             "disk_status": "ONLINE",
                             "vdev_name": "mirror-0",
                             "vdev_type": "data",
                             "vdev_disks": [
-                              {
-                                "enclosure_id": "f60_nvme_enclosure",
-                                "slot": 1,
-                                "dev": "nvme3n1"
-                              },
-                              {
-                                "enclosure_id": "f60_nvme_enclosure",
-                                "slot": 2,
-                                "dev": "nvme1n1"
-                              }
+                                {
+                                    "enclosure_id": "5b0bd6d1a30714bf",
+                                    "slot": 1,
+                                    "dev": "sda"
+                                },
+                                {
+                                    "enclosure_id": "5b0bd6d1a30714bf",
+                                    "slot": 2,
+                                    "dev": "sdb"
+                                },
+                                {
+                                    "enclosure_id": "5b0bd6d1a30714bf",
+                                    "slot": 3,
+                                    "dev": "sdc"
+                                }
                             ]
-                          }
-                        },
-                        "2": {
-                          "descriptor": "Disk #2",
-                          "status": "OK",
-                          "dev": "nvme1n1",
-                          "pool_info": {
-                            "pool_name": "sanity",
-                            "disk_status": "OFFLINE",
-                            "vdev_name": "mirror-0",
-                            "vdev_type": "data",
-                            "vdev_disks": [
-                              {
-                                "enclosure_id": "f60_nvme_enclosure",
-                                "slot": 1,
-                                "dev": "nvme3n1"
-                              },
-                              {
-                                "enclosure_id": "f60_nvme_enclosure",
-                                "slot": 2,
-                                "dev": "nvme1n1"
-                              }
-                            ]
-                          }
-                        },
-                    }]
+                        }
+                    }
+                }
+            }
+        }]
         """
         return self.dashboard_impl()


### PR DESCRIPTION
To allow UI team to start using this new endpoint, we needed to add some of the disk details from `disk.query` to the returned object. Most of the changes here are associated to the docstring being updated to reflect reality.