### PR TITLE
NAS-127406 / 24.04-RC.1 / Remove restriction on registering global addresses (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -305,14 +305,6 @@ class ActiveDirectoryService(ConfigService):
                         'configure DNS A and AAAA records as needed for their domain.'
                     )
 
-                if addr.is_global:
-                    verrors.add(
-                        'activedirectory_update.allow_dns_updates',
-                        f'{addr}: automatic DNS update would result in registering a global '
-                        'IP address. Users may disable automatic DNS updates and manually '
-                        'configure DNS A and AAAA records as needed for their domain.'
-                    )
-
                 if addr.is_loopback:
                     verrors.add(
                         'activedirectory_update.allow_dns_updates',


### PR DESCRIPTION
This validation is perhaps overly restrictive as it prevents us from automatically registering IPv6 and public IPv4 addresses in Active Directory.

Original PR: https://github.com/truenas/middleware/pull/13206
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127406