### PR TITLE
Add test to ensure we don't regress on invalid key handling

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -587,3 +587,7 @@ def test__filter_list_deeply_nested_lists():
 
 def test__filter_list_undefined():
     assert len(filter_list(DATA_WITH_NULL, [['foo', '=', None]])) == 1
+
+
+def test__filter_list_invalid_key():
+    assert len(filter_list(DATA_WITH_NULL, [['canary', 'in', 'canary2']])) == 0


### PR DESCRIPTION
Earlier versions of filter_list would crash on handling None type with `in` filter when an invalid key was specified for the filter. Since fix in NAS-127480 we short-circuit when specified key doesn't exist. This commit adds an additional test for this specific situation.