### PR TITLE
NAS-127498 / 24.04-RC.1 / Fix check for whether a dataset is internal (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -170,7 +170,8 @@ class PoolDatasetService(CRUDService):
 
     @private
     async def is_internal_dataset(self, dataset):
-        return not bool(filter_list([{'id': dataset}], await self.internal_datasets_filters()))
+        pool = dataset.split('/')[0]
+        return not bool(filter_list([{'id': dataset, 'pool': pool}], await self.internal_datasets_filters()))
 
     @filterable
     def query(self, filters, options):


### PR DESCRIPTION
This particular check never quite worked correctly in that our filter for whether the dataset was in boot pool was a de-facto no op (since we were not populating the pool name before filtering).

This issue was not detected due to a compensating bug in filter_list where missing keys were not being handled correctly either.

Original PR: https://github.com/truenas/middleware/pull/13210
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127498