### PR TITLE
NAS-127488 / 24.10 / Add lightweight replacement for disk.list_partitions

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -9,6 +9,8 @@ from middlewared.service import job, Service, private
 
 
 CHUNK = 1048576  # 1MB binary
+# Maximum number of attempts to request partition table update
+MAX_NUM_PARTITION_UPDATE_RETRIES = 4
 
 
 class DiskService(Service):
@@ -111,7 +113,7 @@ class DiskService(Service):
 
         # The call to update_partition_table_quick can require retries
         error = {}
-        retries = 4
+        retries = MAX_NUM_PARTITION_UPDATE_RETRIES
         # Unfortunately, without a small initial sleep, the following
         # retry loop will almost certainly require two iterations.
         sleep(0.1)


### PR DESCRIPTION
Recent changes to `disk.wipe` added a call to `disk.list_partitions`.  It was later determined `disk.list_partitions` might cause excessive delay when used in wipe on large systems.  This PR adds a lightweight alternative and eliminates the call to `disk.list_partitions`.  The new routine is called `get_partitions_quick`.

Also, during testing it was discovered we are failing to update the kernel partition table after a `disk.wipe` call.  This behavior was introduced in Electric Eel.  The fix is to use the block ioctl `BLKRRPATH`.  This was already conveniently implemented in `retaste.py` and only required a simple wrapper and small bug fix.

Finally, added a CI test to `test_disk_wipe.py` to detect regression of the kernel partition table updates.