### PR TITLE
NAS-127074 / 24.04-RC.1 / Fix permissions check for services plugin using api key (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -19,6 +19,9 @@ def app_has_write_privilege_for_service(
     if app.authenticated_credentials is None:
         return False
 
+    if not app.authenticated_credentials.is_user_session:
+        return True
+
     if credential_has_full_admin(app.authenticated_credentials):
         return True
 

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -39,6 +39,17 @@ def test_root_api_key_websocket(request):
         assert results['result'] is True, f'out: {results["output"]}, err: {results["stderr"]}'
         assert 'uptime' in str(results['stdout'])
 
+        with client(auth=None) as c:
+            assert c.call("auth.login_with_api_key", key)
+
+            # root-level API key should be able to start / stop services
+            c.call("service.start", "cifs")
+            c.call("service.stop", "cifs")
+
+            # root-level API key should be able to enable / disable services
+            c.call("service.update", "cifs", {"enable": True})
+            c.call("service.update", "cifs", {"enable": False})
+
 
 def test_allowed_api_key_websocket(request):
     """We should be able to call a method with API key that allows that call using Websocket."""
@@ -75,6 +86,12 @@ def test_denied_api_key_noauthz(request):
             with pytest.raises(Exception):
                 c.call("system.version")
 
+            with pytest.raises(Exception):
+                c.call("service.start", "cifs")
+
+            with pytest.raises(Exception):
+                c.call("service.update", "cifs", {"enable": True})
+
             auth_token = c.call("auth.generate_token")
 
         with client(auth=None) as c:
@@ -85,6 +102,12 @@ def test_denied_api_key_noauthz(request):
 
             with pytest.raises(Exception):
                 c.call("system.version")
+
+            with pytest.raises(Exception):
+                c.call("service.start", "cifs")
+
+            with pytest.raises(Exception):
+                c.call("service.update", "cifs", {"enable": True})
 
 
 def test_api_key_auth_session_list_terminate():


### PR DESCRIPTION
Allow API keys to toggle services. We only need to check whether this is a user session since API keys don't support roles. This means that once an API key is within the permissions check function we already know that it has been explicitly granted access to this endpoint via its allowlist.

Original PR: https://github.com/truenas/middleware/pull/13213
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127074