### PR TITLE
Add framework for testing TrueNAS spaces

### DIFF
--- a/spaces-tests/config.py
+++ b/spaces-tests/config.py
@@ -1,0 +1,31 @@
+from os import environ
+from types import SimpleNamespace
+
+
+SPACES_CONFIG = {
+    'NETMASK': int(environ.get('NETMASK')),
+    'INTERFACE': environ.get('INTERFACE'),
+    'DEFGW': environ.get('DEFGW'),
+    'DNS1': environ.get('DNS1'),
+    'ZPOOL_DISK': environ.get('ZPOOL_DISK'),
+}
+
+SPACES_ADS = {
+    'DOMAIN': environ.get('AD_DOMAIN'),
+    'USERNAME': environ.get('AD_USERNAME'),
+    'PASSWORD': environ.get('AD_PASSWORD'),
+}
+
+TIMEOUTS = {
+}
+
+CLEANUP_TEST_DIR = 'tests/cleanup'
+
+SPACES_MEMBERS = [SimpleNamespace(
+    node=x,
+    dns=environ.get(f'NODE_{x}_DNS'),
+    ip=environ.get(f'NODE_{x}_IP'),
+    username=environ.get('APIUSER'),
+    password=environ.get('APIPASS'),
+    zpool=environ.get(f'NODE_{x}_POOL'),
+) for x in ('A', 'B', 'C', 'D')]

--- a/spaces-tests/get_debugs.py
+++ b/spaces-tests/get_debugs.py
@@ -1,0 +1,39 @@
+import requests
+import sys
+from config import SPACES_CONFIG
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from utils import spaces_connections
+
+
+def download_debug(c, member, results_dir):
+    # query for existing zpool (clean CI run creates a zpool)
+    print(f'Checking for existing zpools on {member.ip}')
+    where = None
+    try:
+        where = "generate debug"
+        job_id, path = c.call('core.download', 'system.debug', [], f'debug_node_{member.node}')
+        r = requests.get(f'http://{member.ip}{path}')
+        r.raise_for_status()
+        filename = f'{results_dir}/node_{member.node}.tgz'
+        print(f'Writing debug to {filename}')
+        with open(filename, 'wb') as f:
+            f.write(r.content)
+
+    except Exception as e:
+        return {'error': e, 'where': where, 'node': member.node, 'ip': member.ip}
+
+    return {'result': filename, 'node': member.node, 'ip': member.ip}
+
+
+def init(results_path):
+    with spaces_connections() as connections:
+        with ThreadPoolExecutor() as exc:
+            # First, setup the network
+            futures = [exc.submit(download_debug, *c, results_path) for c in connections]
+            for fut in as_completed(futures):
+                res = fut.result()
+                if res.get('error'):
+                    print(f'Node {res["node"]}, address {res["ip"]}: Failed to generate debug [{res["where"]}]: {res["error"]}')
+                    sys.exit(2)
+                else:
+                    print(f'{res["result"]}: Node {res["node"]}, address {res["ip"]}: debug completed')

--- a/spaces-tests/init_servers.py
+++ b/spaces-tests/init_servers.py
@@ -1,0 +1,128 @@
+import sys
+from config import SPACES_CONFIG
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from middlewared.test.integration.utils import client
+from utils import spaces_connections
+from time import sleep
+
+
+def setup_zpool_and_datasets(c, member):
+    # query for existing zpool (clean CI run creates a zpool)
+    print(f'Checking for existing zpools on {member.ip}')
+    where = None
+    try:
+        where = "export"
+        pool = c.call('pool.query')
+        if pool:
+            c.call('pool.export', pool[0]['id'], job=True)
+
+        where = "wipe"
+        # wipe the disks to clean any remnants of previous zpools
+        print(f'Wiping "{SPACES_CONFIG["ZPOOL_DISK"]}" on {member.ip}')
+        c.call('disk.wipe', SPACES_CONFIG['ZPOOL_DISK'], 'QUICK', job=True)
+
+        # now create the zpool
+        where = "pool create"
+        print(f'Creating zpool "{member.zpool}" on {member.ip}')
+        pool_create = c.call('pool.create', {
+            'name': member.zpool,
+            'encryption': False,
+            'topology': {'data': [{
+                'type': 'STRIPE',
+                'disks': [SPACES_CONFIG['ZPOOL_DISK']]}
+            ]},
+            'allow_duplicate_serials': True,
+        # }, job=True)
+        })
+        while (j := c.call(
+            'core.get_jobs', [['id', '=', pool_create]], {'get': True}
+        ))['state'] == 'RUNNING':
+            sleep(1)
+
+        if j.get('error'):
+            return {'error': j['error'], 'where': where, 'node': member.node, 'ip': member.ip}
+
+    except Exception as e:
+        return {'error': e, 'where': where, 'node': member.node, 'ip': member.ip}
+
+    return {'result': member.zpool, 'node': member.node, 'ip': member.ip}
+
+
+def setup_network(c, member):
+    # the cluster nodes are assigned an IP
+    # address via DHCP reservations, however,
+    # it's a prerequisite that the peers in
+    # the cluster have static IP addresses
+    # setup router/dns/defgw first
+    print(f'Setting up default gateway and dns on {member.ip}')
+    c.call('network.configuration.update', {
+        'ipv4gateway': SPACES_CONFIG['DEFGW'],
+        'nameserver1': SPACES_CONFIG['DNS1']
+    })
+
+    # setup the static IP address
+    print(f'Setting up static ip on {member.ip}')
+    c.call('interface.update', SPACES_CONFIG['INTERFACE'], {
+        'ipv4_dhcp': False,
+        'aliases': [{
+            'address': member.ip,
+            'netmask': SPACES_CONFIG['NETMASK'],
+        }],
+    })
+
+    # commit changes
+    print(f'Commit network changes on {member.ip}')
+    c.call('interface.commit', {
+        'rollback': True, 'checkin_timeout': 5
+    })
+
+    # checkin the changes (finalize them)
+    print(f'Checkin network changes on {member.ip}')
+    c.call('interface.checkin')
+
+    print(f'Allowing root SSH {member.ip}')
+    c.call('user.update', 1, {'ssh_password_enabled': True})
+
+    print(f'Enabling SSH on boot {member.ip}')
+    c.call('service.update', 'ssh', {'enable': True})
+
+    print(f'Starting SSH {member.ip}')
+    c.call('service.start', 'ssh', {'silent': False})
+
+
+def get_os_version(c, member):
+    # the os versions for all peers need to match
+    # or we're going to have a bad time
+
+    print(f'Getting OS version on {member.ip}')
+    return c.call('system.version')
+
+
+def init():
+    with spaces_connections() as connections:
+        with ThreadPoolExecutor() as exc:
+            # First, setup the network
+            futures = [exc.submit(setup_network, *c) for c in connections]
+            for fut in as_completed(futures):
+                res = fut.result()
+
+            # Second, verify the OS versions match
+            futures = [exc.submit(get_os_version, *c) for c in connections]
+            versions = set()
+            for fut in as_completed(futures):
+                versions.add(fut.result())
+
+            if len(set([i[1] for i in versions])) > 1:
+                # means OS versions do not match between all peers
+                print(f'Version of software installed on each peer is not the same: {versions}')
+                sys.exit(2)
+
+            # Finally, setup the zpools and datasets
+            futures = [exc.submit(setup_zpool_and_datasets, *c) for c in connections]
+            for fut in as_completed(futures):
+                res = fut.result()
+                if res.get('error'):
+                    print(f'Node {res["node"]}, address {res["ip"]}: Failed to set up pools [{res["where"]}]: {res["error"]}')
+                    sys.exit(2)
+                else:
+                    print(f'Node {res["node"]}, address {res["ip"]}: pool setup completed')

--- a/spaces-tests/requirements.txt
+++ b/spaces-tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-dependency
+requests
+websocket-client>=1.4.2

--- a/spaces-tests/utils.py
+++ b/spaces-tests/utils.py
@@ -1,0 +1,23 @@
+from config import SPACES_MEMBERS
+from contextlib import contextmanager
+from middlewared.test.integration.utils import host_websocket_uri
+from middlewared.test.integration.utils.client import Client
+
+
+def client_impl(*, auth, py_exceptions=True, log_py_exceptions=True, host_ip=None):
+    c = Client(host_websocket_uri(host_ip), py_exceptions=True, log_py_exceptions=True)
+    logged_in = c.call("auth.login", *auth)
+    assert logged_in
+    return c
+
+
+@contextmanager
+def spaces_connections():
+    c = [(client_impl(auth=(m.username, m.password), host_ip=m.ip), m) for m in SPACES_MEMBERS]
+
+    try:
+        yield c
+    finally:
+        for cl, member in c:
+
+            cl.close()


### PR DESCRIPTION
This commit introduces a basic framework for creating tests for TrueNAS spaces. At present it only configures networking and pools and generates a debug. Cleanup functions still need to be written, but that will be part of overall design process for spaces. The stubs are left commented out as an indicator for where to place the separate cleanup and teardown routines.