### PR TITLE
NAS-127452 / 24.10 / Retry starting kerberos during DS initialization

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -282,6 +282,11 @@ class ActiveDirectoryService(ConfigService):
 
         if new['allow_dns_updates']:
             ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
+
+            if ha_mode == 'UNIFIED':
+                if await self.middleware.call('failover.status') != 'MASTER':
+                    return
+
             smb = await self.middleware.call('smb.config')
             addresses = await self.middleware.call(
                 'activedirectory.get_ipaddresses', new, smb, ha_mode

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -563,10 +563,11 @@ class SMBService(ConfigService):
         if they are missing from the current running configuration.
         """
         job.set_progress(65, 'Initializing directory services')
-        await self.middleware.call(
+        ds_job = await self.middleware.call(
             "directoryservices.initialize",
             {"activedirectory": ad_enabled, "ldap": ldap_enabled}
         )
+        await ds_job.wait()
 
         job.set_progress(70, 'Checking SMB server status.')
         if await self.middleware.call("service.started_or_enabled", "cifs"):


### PR DESCRIPTION
If networking is not fully configured, kinit attempt may fail with EAGAIN. Retry several times before giving up. Since the actual kinit has a timeout set for 30 seconds, this loop may end up being quite long-running and so convert directoryservices.initialize into a middleware job. The only direct caller for this private endpoint is smb.configure which is itself a job and so we don't have to worry about any potential timeouts here.