### PR TITLE
NAS-127452 / 24.04-RC.1 / Retry starting kerberos during DS initialization (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -282,6 +282,11 @@ class ActiveDirectoryService(ConfigService):
 
         if new['allow_dns_updates']:
             ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
+
+            if ha_mode == 'UNIFIED':
+                if await self.middleware.call('failover.status') != 'MASTER':
+                    return
+
             smb = await self.middleware.call('smb.config')
             addresses = await self.middleware.call(
                 'activedirectory.get_ipaddresses', new, smb, ha_mode

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -1,3 +1,4 @@
+import asyncio
 import enum
 import json
 import os
@@ -399,6 +400,21 @@ class DirectoryServices(Service):
 
         return {"dbconfig": stored_ts, "secrets": passwd_ts}
 
+    async def __kerberos_start_retry(self, retries=10):
+        while retries > 0:
+            try:
+                await self.middleware.call('kerberos.start')
+                break
+            except CallError as e:
+                if e.errno == errno.EAGAIN:
+                    self.logger.debug("Failed to start kerberos. Retrying %d more times.",
+                                      retries)
+                else:
+                    self.logger.warning("Failed to start kerberos. Retrying %d more times.",
+                                        retries, exc_info=True)
+            await asyncio.sleep(1)
+            retries -= 1
+
     @private
     def available_secrets(self):
         """
@@ -415,7 +431,8 @@ class DirectoryServices(Service):
         return list(db_secrets.keys())
 
     @private
-    async def initialize(self, data=None):
+    @job()
+    async def initialize(self, job, data=None):
         """
         Ensure that secrets.tdb at a minimum exists. If it doesn't exist, try to restore
         from a backup stored in our config file. If this fails, try to use what
@@ -465,12 +482,7 @@ class DirectoryServices(Service):
             self.logger.warning('Cache flush failed', exc_info=True)
 
         if is_kerberized:
-            try:
-                await self.middleware.call('kerberos.start')
-            except CallError:
-                self.logger.warning("Failed to start kerberos after directory service "
-                                    "initialization. Services dependent on kerberos may"
-                                    "not work correctly.", exc_info=True)
+            await self.__kerberos_start_retry()
 
         await self.middleware.call(health_check)
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -568,10 +568,11 @@ class SMBService(ConfigService):
         if they are missing from the current running configuration.
         """
         job.set_progress(65, 'Initializing directory services')
-        await self.middleware.call(
+        ds_job = await self.middleware.call(
             "directoryservices.initialize",
             {"activedirectory": ad_enabled, "ldap": ldap_enabled}
         )
+        await ds_job.wait()
 
         job.set_progress(70, 'Checking SMB server status.')
         if await self.middleware.call("service.started_or_enabled", "cifs"):


### PR DESCRIPTION
If networking is not fully configured, kinit attempt may fail with EAGAIN. Retry several times before giving up. Since the actual kinit has a timeout set for 30 seconds, this loop may end up being quite long-running and so convert directoryservices.initialize into a middleware job. The only direct caller for this private endpoint is smb.configure which is itself a job and so we don't have to worry about any potential timeouts here.

Original PR: https://github.com/truenas/middleware/pull/13221
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127452