### PR TITLE
Relax recent restriction on supplied ip parameter

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -8,6 +8,7 @@ from subprocess import call
 from sys import argv, exit
 import os
 import getopt
+import socket
 import sys
 import secrets
 import string
@@ -141,7 +142,7 @@ if not os.path.exists(artifacts):
 os.environ["MIDDLEWARE_TEST_IP"] = ip
 os.environ["MIDDLEWARE_TEST_PASSWORD"] = passwd
 
-interface = ws_call('interface.query', [['state.aliases.*.address', '=', ip]], {'get': True})['id']
+interface = ws_call('interface.query', [['state.aliases.*.address', '=', socket.gethostbyname(ip)]], {'get': True})['id']
 
 cfg_content = f"""#!{sys.executable}
 


### PR DESCRIPTION
A recent change (dade5605b9) disallowed a hostname from being supplied as the `ip` parameter to `runtest.py`.  Work around this new restriction. (Only useful in limited circumstances e.g. running tests locally.  There _may_ be tests that _require_ an IP address, but I use `runtest.py` to run a subset that do not.)

----
`socket.gethostbyname` of an IP address, just returns the IP address - so this change should be non-destructive
```
>>> socket.gethostbyname('1.2.3.4')
'1.2.3.4'
>>> socket.gethostbyname('scale3')
'192.168.56.115'
>>>
```
