### PR TITLE
NAS-127553 / 24.10 / Fix test for local accounts on HA platform

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -109,8 +109,8 @@ def test_006_setup_and_login_using_root_ssh_key(ip_to_use):
     {'type': 'GROUP', 'gid': 951, 'name': 'truenas_readonly_administrators'},
     {'type': 'GROUP', 'gid': 952, 'name': 'truenas_sharing_administrators'},
 ])
-def test_007_check_local_accounts(account):
-    entry = call('group.query', [['gid', '=', account['gid']]])
+def test_007_check_local_accounts(ws_client, account):
+    entry = ws_client.call('group.query', [['gid', '=', account['gid']]])
     if not entry:
         fail(f'{account["gid"]}: entry does not exist in db')
 


### PR DESCRIPTION
This API call needs to be made via the ws_client fixture rather than normal middleware call test asset.