### PR TITLE
NAS-127576 / 24.04-RC.1 / Fix failing AD test related to ds_auth for middleware (by anodos325)

### DIFF
--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -115,6 +115,9 @@ def cleanup_reverse_zone():
 
 @pytest.fixture(scope="function")
 def set_product_type(request):
+    if ha:
+        # HA product is already enterprise-licensed
+        yield
     with product_type():
         yield
 
@@ -195,9 +198,10 @@ def test_06_get_activedirectory_started_before_starting_activedirectory(request)
 def test_07_enable_leave_activedirectory(request):
     global domain_users_id
 
-    with pytest.raises(ValidationErrors):
-        # At this point we are not enterprise licensed
-        call("system.general.update", {"ds_auth": True})
+    if not ha:
+        with pytest.raises(ValidationErrors):
+            # At this point we are not enterprise licensed
+            call("system.general.update", {"ds_auth": True})
 
     with active_directory(AD_DOMAIN, ADUSERNAME, ADPASSWORD,
         netbiosname=hostname,


### PR DESCRIPTION
Our HA vms are always enterprise-licensed and so we should bypass tests related to license in the AD plugin.

Original PR: https://github.com/truenas/middleware/pull/13236
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127576