### PR TITLE
NAS-127579 / 24.10 / Skip catalog tests on HA platform

### DIFF
--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -13,6 +13,8 @@ TEST_CATALOG_NAME = 'TEST_CATALOG'
 TEST_SECOND_CATALOG_NAME = 'TEST_SECOND_CATALOG'
 CATALOG_SYNC_TMP_PATH = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-applications', 'catalogs')
 
+pytestmark = pytest.mark.skipif(os.environ['SERVER_TYPE'] == 'ENTERPRISE_HA', reason='test disabled for HA platform')
+
 
 @contextlib.contextmanager
 def unconfigured_kubernetes():

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -141,7 +141,7 @@ if not os.path.exists(artifacts):
 
 os.environ["MIDDLEWARE_TEST_IP"] = ip
 os.environ["MIDDLEWARE_TEST_PASSWORD"] = passwd
-os.environ["SERVER_TYPE"] = 'ENTERPRISE_HA' if ha else 'STANDARD'
+os.environ["SERVER_TYPE"] = "ENTERPRISE_HA" if ha else "STANDARD"
 
 ip_to_use = ip if not ha else os.environ['controller1_ip']
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -141,6 +141,7 @@ if not os.path.exists(artifacts):
 
 os.environ["MIDDLEWARE_TEST_IP"] = ip
 os.environ["MIDDLEWARE_TEST_PASSWORD"] = passwd
+os.environ["SERVER_TYPE"] = 'ENTERPRISE_HA' if ha else 'STANDARD'
 
 ip_to_use = ip if not ha else os.environ['controller1_ip']
 


### PR DESCRIPTION
These tests fail because we are enterprise-licensed.