### PR TITLE
NAS-127579 / 24.04-RC.1 / Skip catalog tests on HA platform (by anodos325)

### DIFF
--- a/tests/api2/test_catalog_sync.py
+++ b/tests/api2/test_catalog_sync.py
@@ -13,6 +13,8 @@ TEST_CATALOG_NAME = 'TEST_CATALOG'
 TEST_SECOND_CATALOG_NAME = 'TEST_SECOND_CATALOG'
 CATALOG_SYNC_TMP_PATH = os.path.join(MIDDLEWARE_RUN_DIR, 'ix-applications', 'catalogs')
 
+pytestmark = pytest.mark.skipif(os.environ['SERVER_TYPE'] == 'ENTERPRISE_HA', reason='test disabled for HA platform')
+
 
 @contextlib.contextmanager
 def unconfigured_kubernetes():

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -165,6 +165,7 @@ cfg_file.close()
 
 os.environ["MIDDLEWARE_TEST_IP"] = ip
 os.environ["MIDDLEWARE_TEST_PASSWORD"] = passwd
+os.environ["SERVER_TYPE"] = "ENTERPRISE_HA" if ha else "STANDARD"
 
 from functions import setup_ssh_agent, create_key, add_ssh_key, get_folder
 from functions import SSH_TEST


### PR DESCRIPTION
These tests fail because we are enterprise-licensed.

Original PR: https://github.com/truenas/middleware/pull/13238
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127579