### PR TITLE
NAS-127547 / 24.10 / Fix middle partition clean processing

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -91,8 +91,10 @@ class DiskService(Service):
 
                 # The middle partitions often contain old cruft.  Clean those.
                 if len(disk_parts) > 1:
-                    for partnum, sector_start in disk_parts.items():
-                        if partnum == 1:
+                    _30MiB = 30 * CHUNK
+                    for sector_start in disk_parts.values():
+                        # Skip any partitions that start under 30 MiB
+                        if sector_start < _30MiB:
                             continue
 
                         # Start 2 MiB back from the start and 'clean' 2 MiB past, 4 MiB total

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -92,9 +92,10 @@ class DiskService(Service):
                 # The middle partitions often contain old cruft.  Clean those.
                 if len(disk_parts) > 1:
                     _30MiB = 30 * CHUNK
+                    _30MiB_from_end = size - _30MiB
                     for sector_start in disk_parts.values():
-                        # Skip any partitions that start under 30 MiB
-                        if sector_start < _30MiB:
+                        # Skip any that start under 30 MiB or 30MiB from the end
+                        if (sector_start < _30MiB) or (_30MiB_from_end < sector_start):
                             continue
 
                         # Start 2 MiB back from the start and 'clean' 2 MiB past, 4 MiB total


### PR DESCRIPTION
### Problem
Previously, the check was to skip the first partition, which would start at 1MiB and process all others.
This did not account for drives that that had partitions within 1MiB of the start of the drive.
### Fix
Add check for partition start and exclude those that are less than 30MiB