### PR TITLE
NAS-127032 / 24.04-RC.1 / Make sure console keymap changes persist (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -217,14 +217,18 @@ class BootService(Service):
         else:
             yield
 
+    @accepts(
+        Bool('force', default=False)
+    )
     @private
-    async def update_initramfs(self):
+    async def update_initramfs(self, force):
         """
         Returns true if initramfs was updated and false otherwise.
         """
         async with self.__toggle_rootfs_readwrite():
             cp = await run(
-                '/usr/local/bin/truenas-initrd.py', '/', encoding='utf8', errors='ignore', check=False
+                '/usr/local/bin/truenas-initrd.py', *['/', '--force'] if force else '/',
+                encoding='utf8', errors='ignore', check=False
             )
             if cp.returncode > 1:
                 raise CallError(f'Failed to update initramfs: {cp.stderr}')

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -293,7 +293,7 @@ class SystemGeneralService(ConfigService):
     async def set_kbdlayout(self, kbdmap='us'):
         await self.middleware.call('etc.generate', 'keyboard')
         await run(['setupcon'], check=False)
-        await run(['localectl', 'set-keymap', kbdmap], check=False)
+        await self.middleware.call('boot.update_initramfs', True)
 
     @accepts()
     @returns(Int('remaining_seconds', null=True))


### PR DESCRIPTION
## Problem
When the console keymap is updated in the UI, it updates successfully, but the change does not persist across reboots.

## Solution
Update the initramfs to ensure the console keymap change persists across reboots.

## Reference
https://superuser.com/questions/646425/permanently-change-default-language-and-keyboard-settings-what-am-i-missing

Original PR: https://github.com/truenas/middleware/pull/13220
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127032