### PR TITLE
NAS-127524 / 23.10.3 / Remove old hddstandby usages (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -23,8 +23,6 @@ class DiskService(Service):
                 [
                     ['name', '!=', None],
                     ['togglesmart', '=', True],
-                    # Polling for disk temperature does not allow them to go to sleep automatically
-                    ['hddstandby', '=', 'ALWAYS ON'],
                 ]
             )
         ]

--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -56,7 +56,7 @@ def parse_smartctl_for_temperature_output(stdout: str) -> Optional[int]:
 def get_disks_for_temperature_reading() -> Dict[str, Disk]:
     disks = {}
     for disk in query_table('storage_disk', prefix='disk_'):
-        if disk['serial'] != '' and bool(disk['togglesmart']) and disk['hddstandby'] == 'Always On':
+        if disk['serial'] != '' and bool(disk['togglesmart']):
             disks[disk['serial']] = Disk(id=disk['name'], serial=disk['serial'])
 
     return disks


### PR DESCRIPTION
## Problem
Users are unable to retrieve the disk temperature of certain disks because their `hddstandby` value is set to something other then `ALWAYS ON`.

## Solution
In TrueNAS CORE, we supported HDD standby functionality, which was due to the reason as in reporting it could lead to inconsistencies, as some disks might not report temperature when in standby mode. However, TrueNAS SCALE should effectively not be supporting HDD standby feature now. To address this, we are removing the usage of HDD standby attr in reporting because disks will always remain active in SCALE, ensuring data consistency and allowing users to retrieve disk temperatures reliably.

Original PR: https://github.com/truenas/middleware/pull/13240
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127524