### PR TITLE
NAS-127405 / 24.04-RC.1 / Safely validate GPU related config in system.advanced namespace

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -168,7 +168,7 @@ class SystemAdvancedService(ConfigService):
                     f'{schema}.syslog_tls_certificate', False
                 ))
 
-        if data['isolated_gpu_pci_ids']:
+        if data.get('isolated_gpu_pci_ids'):
             verrors = await self.middleware.call(
                 'system.advanced.validate_gpu_pci_ids', data['isolated_gpu_pci_ids'], verrors, schema
             )
@@ -222,6 +222,9 @@ class SystemAdvancedService(ConfigService):
         config_data.pop('consolemsg')
         original_data = deepcopy(config_data)
         config_data.update(data)
+
+        if 'isolated_gpu_pci_ids' not in data:
+            config_data.pop('isolated_gpu_pci_ids')
 
         verrors, config_data = await self.__validate_fields('advanced_settings_update', config_data)
         verrors.check()
@@ -279,7 +282,10 @@ class SystemAdvancedService(ConfigService):
                 await self.middleware.call('etc.generate', 'kdump')
                 generate_grub = True
 
-            if original_data['isolated_gpu_pci_ids'] != config_data['isolated_gpu_pci_ids']:
+            if (
+                'isolated_gpu_pci_ids' in config_data and
+                original_data['isolated_gpu_pci_ids'] != config_data['isolated_gpu_pci_ids']
+            ):
                 await self.middleware.call('boot.update_initramfs')
 
             if original_data['debugkernel'] != config_data['debugkernel']:


### PR DESCRIPTION
### Context

Previously values from old config were also sent for validation hence making update problematic for users in case there is some issue in old config wrt GPU configuration.

PR makes the change to safely validate only the changed fields for `system.advanced.update`. Essentially motivation is that in the UI where user changes system advanced settings, GPU settings are not listed and it is very awkward to see a GPU error when you are changing system advanced settings in the UI where there is no GPU attr (which has it's own dedicated tab/section in the UI).