### PR TITLE
Implement temporary cache or audit query results

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -222,7 +222,7 @@ class AuditService(ConfigService):
 
         verrors.check()
 
-        if (existing_results := data.get('query-result')):
+        if (existing_results := data.get('result-id')):
             results = await self.middleware.call('audit.cache.fetch', existing_results)
         else:
             results = []

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -243,7 +243,7 @@ class AuditService(ConfigService):
 
             if data['cache-results']:
                 entry_uuid = await self.middleware.call('audit.cache.store', results)
-                return {'count': len(results), 'results-id': entry_uuid}
+                return {'count': len(results), 'result-id': entry_uuid}
 
         return filter_list(results, data.get('query-filters', []), data.get('query-options', {}))
 

--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -251,3 +251,11 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
                 'Cleanup of auditing report directory failed',
                 exc_info=True
             )
+
+        try:
+            self.middleware.call_sync('audit.cache.cleanup')
+        except Exception:
+            self.logger.warning(
+                'Cleanup of auditing report cache failed',
+                exc_info=True
+            )

--- a/src/middlewared/middlewared/plugins/audit/cache.py
+++ b/src/middlewared/middlewared/plugins/audit/cache.py
@@ -47,7 +47,7 @@ class AuditCacheService(Service):
         now = time.time()
         if now > ts['timeout']:
             try:
-                await self.remove(uuid)
+                await self.remove(entry_uuid)
             except Exception:
                 self.logger.error('%s: failed to remove expired entry', uuid, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/audit/cache.py
+++ b/src/middlewared/middlewared/plugins/audit/cache.py
@@ -1,0 +1,89 @@
+import time
+import uuid
+
+from .utils import AUDIT_CACHE_FILE
+from middlewared.service import Service
+from middlewared.service_exception import MatchNotFound
+
+CACHE_DATA_SUFFIX = '_data'
+CACHE_TIMESTAMP_SUFFIX = '_ts'
+
+
+class AuditCacheService(Service):
+    class Config:
+        private = True
+        namespace = 'audit.cache'
+
+    tdb_options = {
+        'backend': 'CUSTOM',
+        'data_type': 'JSON'
+    }
+
+    async def store(self, data, ttl=360):
+        """
+        Write timestamp and data entries for UUID under a transaction
+        lock in the cache file in /audit directory. Since cache is persistent
+        the timeout is based on realtime clock.
+        """
+        entry_uuid = str(uuid.uuid4())
+        timeout = time.time() + ttl
+        await self.middleware.call('tdb.batch_ops', {
+            'name': AUDIT_CACHE_FILE,
+            'ops': [
+                {'action': 'SET', 'key': f'{entry_uuid}{CACHE_DATA_SUFFIX}', 'val': data},
+                {'action': 'SET', 'key': f'{entry_uuid}{CACHE_TIMESTAMP_SUFFIX}', 'val': {'timeout': timeout}},
+            ],
+            'tdb-options': self.tdb_options
+        })
+        return entry_uuid
+
+    async def fetch(self, entry_uuid):
+        ts = await self.middleware.call('tdb.fetch', {
+            'name': AUDIT_CACHE_FILE,
+            'key': f'{entry_uuid}{CACHE_TIMESTAMP_SUFFIX}',
+            'tdb-options': self.tdb_options
+        })
+
+        now = time.time()
+        if now > ts['timeout']:
+            try:
+                await self.remove(uuid)
+            except Exception:
+                self.logger.error('%s: failed to remove expired entry', uuid, exc_info=True)
+
+            raise MatchNotFound
+
+        return await self.middleware.call('tdb.fetch', {
+            'name': AUDIT_CACHE_FILE,
+            'key': f'{entry_uuid}{CACHE_DATA_SUFFIX}',
+            'tdb-options': self.tdb_options
+        })
+
+    async def remove(self, entry_uuid):
+        """
+        Remove entries for UUID under a transaction lock
+        """
+        await self.middleware.call('tdb.batch_ops', {
+            'name': AUDIT_CACHE_FILE,
+            'ops': [
+                {'action': 'DEL', 'key': f'{entry_uuid}{CACHE_DATA_SUFFIX}'},
+                {'action': 'DEL', 'key': f'{entry_uuid}{CACHE_TIMESTAMP_SUFFIX}'},
+            ],
+            'tdb-options': self.tdb_options
+        })
+
+    async def cleanup(self):
+        try:
+            entries = await self.middleware.call('tdb.entries', {
+                'name': AUDIT_CACHE_FILE,
+                'query-filters': [['key', '$', CACHE_TIMESTAMP_SUFFIX]],
+                'tdb-options': self.tdb_options
+            })
+        except FileNotFoundError:
+            entries = []
+
+        now = time.time()
+
+        for entry in entries:
+            if now > entry['val']['timeout']:
+                await self.remove(entry['key'].strip(CACHE_TIMESTAMP_SUFFIX))

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -13,6 +13,7 @@ AUDIT_DEFAULT_QUOTA = 0
 AUDIT_DEFAULT_FILL_CRITICAL = 95
 AUDIT_DEFAULT_FILL_WARNING = 80
 AUDIT_REPORTS_DIR = os.path.join(AUDIT_DATASET_PATH, 'reports')
+AUDIT_CACHE_FILE = os.path.join(AUDIT_DATASET_PATH, 'results_cache.tdb')
 
 AuditBase = declarative_base()
 

--- a/src/middlewared/middlewared/plugins/tdb/wrapper.py
+++ b/src/middlewared/middlewared/plugins/tdb/wrapper.py
@@ -2,9 +2,9 @@ import os
 import tdb
 import ctdb
 import enum
-import json
 import copy
 from subprocess import run
+from middlewared.client import ejson as json
 from middlewared.service_exception import CallError
 
 FD_CLOSED = -1

--- a/src/middlewared/middlewared/schema/adaptable_schemas.py
+++ b/src/middlewared/middlewared/schema/adaptable_schemas.py
@@ -125,6 +125,7 @@ class OROperator:
             'anyOf': [i.to_json_schema() for i in self.schemas],
             'nullable': False,
             '_name_': self.name,
+            'title': self.title,
             'description': self.description,
             '_required_': self.required,
         }


### PR DESCRIPTION
The UI team currently performs two audit.query calls for every search in the webui form (first to get count and second to perform pagination). Pagination is achieved by submitting audit.query with query-options, which can suffer from TOCTOU issues on a busy server. This is to provide consistent pagination for audit query results from the webui.

This commit adds a new parameter that can optionally be passed to audit.query `cache-results`. If this is specified, then we return dict with keys `count` (so consumer knows total results) and a `results-id` UUID that can be used to retrieve cached prior results.

The same `results-id` can be used generate reports in order to provide end-user with exact results that were displayed in UI.

The results are temporarily stored on-disk in the /audit dataset.