### PR TITLE
NAS-127600 / 24.04-RC.1 / add ES24N enclosure to legacy enclosure code

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -126,6 +126,7 @@ class EnclosureService(CRUDService):
                 enclosures.append(enclosure)
 
         enclosures.extend(self.middleware.call_sync("enclosure.map_nvme"))
+        enclosures.extend(self.middleware.call_sync("enclosure.map_jbof"))
         enclosures = self.middleware.call_sync("enclosure.map_enclosures", enclosures)
 
         for number, enclosure in enumerate(enclosures):


### PR DESCRIPTION
This adds ES24N support to our legacy enclosure code. I use the logic from the previous PR: https://github.com/truenas/middleware/pull/13256 and just massage the data into the structured object that our legacy code expects.

NOTE: this is a DF only change which is why it's targeted to this branch only.