### PR TITLE
Add a new endpoint to reboot standby controller

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -19,6 +19,7 @@ class FailoverService(Service):
         """
         Reboot the standby node and wait for it to come back online.
         """
+
         job.set_progress(5, 'Rebooting standby controller')
         await self.middleware.call(
             'failover.call_remote', 'system.reboot',
@@ -51,3 +52,7 @@ class FailoverService(Service):
                 f'Timed out waiting {shutdown_timeout} seconds for the standby controller to reboot',
                 errno.ETIMEDOUT
             )
+
+        # Wait for the standby controller to come back online and report as being ready
+        if not await self.middleware.call('failover.upgrade_waitstandby'):
+            raise CallError('Timed out waiting for the standby controller to upgrade', errno.ETIMEDOUT)

--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -54,6 +54,8 @@ class FailoverService(Service):
                 errno.ETIMEDOUT
             )
 
+        job.set_progress(60, 'Waiting for the Standby Controller to come back online')
+
         # Wait for the standby controller to come back online and report as being ready
         if not await self.middleware.call('failover.upgrade_waitstandby'):
             raise CallError('Timed out waiting for the standby controller to upgrade', errno.ETIMEDOUT)
@@ -65,4 +67,5 @@ class FailoverService(Service):
         if remote_boot_id == await self.middleware.call('failover.call_remote', 'system.boot_id'):
             raise CallError('Standby Controller failed to reboot')
 
+        job.set_progress(100, 'Standby Controller has been rebooted successfully')
         return True

--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -1,0 +1,53 @@
+import asyncio
+import errno
+import time
+
+from middlewared.schema import accepts, returns
+from middlewared.service import CallError, job, Service
+
+
+class FailoverService(Service):
+
+    class Config:
+        cli_private = True
+        role_prefix = 'FAILOVER'
+
+    @accepts()
+    @returns()
+    @job(lock='reboot_standby')
+    async def reboot_standby(self, job):
+        """
+        Reboot the standby node and wait for it to come back online.
+        """
+        job.set_progress(5, 'Rebooting standby controller')
+        await self.middleware.call(
+            'failover.call_remote', 'system.reboot',
+            [{'delay': 5}],
+            {'job': True}
+        )
+        # SCALE is using systemd and at the time of writing this, the
+        # DefaultTimeoutStopSec setting hasn't been changed and so
+        # defaults to 90 seconds. This means when the system is sent the
+        # shutdown signal, all the associated user-space programs are
+        # asked to be shutdown. If any of those take longer than 90
+        # seconds to respond to SIGTERM then the program is sent SIGKILL.
+        # Finally, if after 90 seconds the standby controller is still
+        # responding to remote requests then play it safe and assume the
+        # reboot failed (this should be rare but my future self will
+        # appreciate the fact I wrote this out because of the inevitable
+        # complexities of gluster/k8s/vms etc for which I predict
+        # will exhibit this behavior :P )
+        job.set_progress(30, 'Waiting on the Standby Controller to reboot')
+        try:
+            retry_time = time.monotonic()
+            shutdown_timeout = 90  # seconds
+            while time.monotonic() - retry_time < shutdown_timeout:
+                await self.middleware.call('failover.call_remote', 'core.ping', [], {'timeout': 5})
+                await asyncio.sleep(5)
+        except CallError:
+            pass
+        else:
+            raise CallError(
+                f'Timed out waiting {shutdown_timeout} seconds for the standby controller to reboot',
+                errno.ETIMEDOUT
+            )


### PR DESCRIPTION
This PR adds a new endpoint which can be used to reboot standby controller so this can be used in both upgrading HA logic and when FIPS changes are made - both nodes can be rebooted easily.