### PR TITLE
NAS-117880 / 24.10 / Change SCST extent threading for performance

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -299,6 +299,9 @@ HANDLER ${handler} {
 %       if failover_status == "BACKUP" and alua_enabled:
         active 0
 %       endif
+%       if handler == 'vdisk_blockio':
+        threads_num 32
+%       endif
     }
 
 %   endfor

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -552,7 +552,7 @@ class iSCSITargetExtentService(SharingService):
         filters = [['type', '=', 'DISK']]
         options = {'select': ['path']}
         if pool is not None:
-            filters.append(['path', '^', f'zvol/{pool["name"]}'])
+            filters.append(['path', '^', f'zvol/{pool["name"]}/'])
         zvols = [extent['path'][5:] for extent in await self.middleware.call('iscsi.extent.query', filters, options)]
 
         filters = [['name', 'in', zvols], ['properties.volthreading.value', '=', 'on']]


### PR DESCRIPTION
Some performance analysis was done on our ZVOL based iSCSI targets and configuration changes were suggested.

This PR implements those changes:

- Specify `threads_num 32` in for the extents in _scst.conf_
- When creating a new extent turn **off** `volthreading` parameter on the underlying ZVOL.  Likewise revert when deleting an extent.
- When importing a pool, if necessary turn off `volthreading` parameter on any ZVOL underlying an extent (handles upgrade cases).