### PR TITLE
NAS-127627 / 24.10 / Try to use sql filters in audit.query calls

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -133,33 +133,45 @@ def parse_query_filters(
     return (services_to_check, filters_out)
 
 
-def may_use_sql_filters(
+def requires_python_filtering(
     services: list,
     filters_in: list,
     filters_for_sql: list,
     options: dict
 ) -> bool:
+    """
+    There are situations where we have to perform additional audit filtering
+    in python via `filter_list`.
+
+    1. Not all user specified filters could be converted directly into an SQL
+       statement for auditbackend.query.
+
+    2. We are selecting a subkey within a JSON object.
+
+    3. Multiple services are being queried and pagination options are being used
+       or a specific ordering is specified.
+    """
     if filters_in != filters_for_sql:
         # We will need to do additional filtering after retrieval
-        return False
+        return True
 
     if (to_investigate := set(options.get('select', [])) - set(SQL_SAFE_FIELDS)):
         # Field is being selected that may not be safe for SQL select
         for entry in to_investigate:
             # Selecting subkey in entry is not currently supported
             if '.' in entry or isiinstance(entry, tuple):
-                return False
+                return True
 
     if len(services) > 1:
         # When we have more than one database being queried we
         # often need to pass the aggregated results to filter_list
         if options.get('offset') or options.get('limit'):
             # We need to do pagination on total results.
-            return False
+            return True
         if options.get('order_by'):
-            return False
+            return True
 
-    return True
+    return False
 
 
 AUDIT_TABLES = {svc[0]: generate_audit_table(*svc) for svc in AUDITED_SERVICES}

--- a/src/middlewared/middlewared/pytest/unit/plugins/audit/test_audit_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/audit/test_audit_utils.py
@@ -1,0 +1,106 @@
+import pytest
+
+from middlewared.utils import filter_list
+from middlewared.plugins.audit.utils import (
+    AUDITED_SERVICES,
+    may_use_sql_filters,
+    parse_query_filters,
+    SQL_SAFE_FIELDS,
+)
+
+def test_service_filter_equal():
+    services = [s[0] for s in AUDITED_SERVICES]
+    to_check, filters = parse_query_filters(services, [['service', '=', 'SMB']], True)
+    assert len(to_check) == 1
+    assert to_check == {'SMB'}
+
+
+def test_service_filter_in():
+    services = [s[0] for s in AUDITED_SERVICES]
+    to_check, filters = parse_query_filters(services, [['service', 'in', ['SMB']]], True)
+    assert len(to_check) == 1
+    assert to_check == {'SMB'}
+
+
+def test_service_filter_not_equal():
+    """ Test that direct match properly excludes service """
+    services = [s[0] for s in AUDITED_SERVICES]
+    to_check, filters = parse_query_filters(services, [['service', '!=', 'SMB']], True)
+
+    assert len(to_check) == len(services) - 1
+    assert 'SMB' not in to_check
+
+
+def test_service_filter_not_in():
+    """ Test that not-in filter properly excludes service """
+    services = [s[0] for s in AUDITED_SERVICES]
+    to_check, filters = parse_query_filters(services, [['service', 'nin', ['SMB']]], True)
+
+    assert len(to_check) == len(services) - 1
+    assert 'SMB' not in to_check
+
+
+def test_no_services():
+    """ Test that all services being excluded results in empty `to_check` """
+    services = [s[0] for s in AUDITED_SERVICES]
+    to_check, filters = parse_query_filters(services, [['service', 'nin', services]], True)
+    assert len(to_check) == 0
+
+
+def test_query_filters_supported():
+    """ Test that large filters containing only supported keys will get passed to SQL """
+    services = [s[0] for s in AUDITED_SERVICES]
+    filters = [[key, "=", services] for key in SQL_SAFE_FIELDS]
+    to_check, filters_out = parse_query_filters(services, filters, False)
+
+    assert len(to_check) == len(services)
+    assert len(filters_out) == len(filters)
+
+
+def test_query_filters_disjunction():
+    """ Test that filters involing disjunction won't be passed to SQL """
+    services = [s[0] for s in AUDITED_SERVICES]
+    bad_filter = ['OR', ['username', '=', 'Bob'], ['username', '=', 'mary']]
+    good_filter = ['event', '=', 'CONNECT']
+    to_check, filters_out = parse_query_filters(services, [bad_filter, good_filter], False)
+
+    # verify OR is excluded
+    assert len(filters_out) == 1
+    assert filters_out == [good_filter]
+
+
+def test_query_filters_json():
+    """ Test that excluded fields won't be passed to SQL """
+    services = [s[0] for s in AUDITED_SERVICES]
+    bad_filter = ['event_data', '=', {'result': 'canary'}]
+    good_filter = ['event', '=', 'CONNECT']
+    to_check, filters_out = parse_query_filters(services, [bad_filter, good_filter], False)
+
+    assert len(filters_out) == 1
+    assert filters_out == [good_filter]
+
+
+def test_may_use_sql_filters_filter_mismatch():
+    """ test that mismatch between filtersets results in rejection """
+    services = [s[0] for s in AUDITED_SERVICES]
+    result = may_use_sql_filters(services, [['event_data.result', '=', 'canary']], [], {})
+    assert result is False
+
+
+def test_may_use_sql_filters_select_subkey():
+    """ test that selecting for subkey in JSON object results in rejection """
+    services = [s[0] for s in AUDITED_SERVICES]
+    result = may_use_sql_filters(services, [], [], {'select': ['event_data.result']})
+    assert result is False
+
+
+@pytest.mark.parametrize('services,options,expected', [
+    ([s[0] for s in AUDITED_SERVICES], {'offset': 1}, False),
+    ([s[0] for s in AUDITED_SERVICES], {'limit': 1}, False),
+    (['SMB'], {'offset': 1}, True),
+    (['SMB'], {'limit': 1}, True),
+])
+def test_may_use_sql_filters_options(services, options, expected):
+    """ test that selecting for subkey in JSON object results in rejection """
+    result = may_use_sql_filters(services, [], [], options)
+    assert result is expected

--- a/src/middlewared/middlewared/pytest/unit/plugins/audit/test_audit_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/audit/test_audit_utils.py
@@ -3,8 +3,8 @@ import pytest
 from middlewared.utils import filter_list
 from middlewared.plugins.audit.utils import (
     AUDITED_SERVICES,
-    may_use_sql_filters,
     parse_query_filters,
+    requires_python_filtering,
     SQL_SAFE_FIELDS,
 )
 
@@ -80,27 +80,27 @@ def test_query_filters_json():
     assert filters_out == [good_filter]
 
 
-def test_may_use_sql_filters_filter_mismatch():
+def test_requires_python_filtering_filter_mismatch():
     """ test that mismatch between filtersets results in rejection """
     services = [s[0] for s in AUDITED_SERVICES]
-    result = may_use_sql_filters(services, [['event_data.result', '=', 'canary']], [], {})
-    assert result is False
+    result = requires_python_filtering(services, [['event_data.result', '=', 'canary']], [], {})
+    assert result is True
 
 
-def test_may_use_sql_filters_select_subkey():
+def test_requires_python_filtering_select_subkey():
     """ test that selecting for subkey in JSON object results in rejection """
     services = [s[0] for s in AUDITED_SERVICES]
-    result = may_use_sql_filters(services, [], [], {'select': ['event_data.result']})
-    assert result is False
+    result = requires_python_filtering(services, [], [], {'select': ['event_data.result']})
+    assert result is True
 
 
 @pytest.mark.parametrize('services,options,expected', [
-    ([s[0] for s in AUDITED_SERVICES], {'offset': 1}, False),
-    ([s[0] for s in AUDITED_SERVICES], {'limit': 1}, False),
-    (['SMB'], {'offset': 1}, True),
-    (['SMB'], {'limit': 1}, True),
+    ([s[0] for s in AUDITED_SERVICES], {'offset': 1}, True),
+    ([s[0] for s in AUDITED_SERVICES], {'limit': 1}, True),
+    (['SMB'], {'offset': 1}, False),
+    (['SMB'], {'limit': 1}, False),
 ])
-def test_may_use_sql_filters_options(services, options, expected):
+def test_requires_python_filtering_options(services, options, expected):
     """ test that selecting for subkey in JSON object results in rejection """
-    result = may_use_sql_filters(services, [], [], options)
+    result = requires_python_filtering(services, [], [], options)
     assert result is expected

--- a/src/middlewared/middlewared/sqlalchemy.py
+++ b/src/middlewared/middlewared/sqlalchemy.py
@@ -5,7 +5,7 @@ from sqlalchemy import (
     Table, Column as _Column, ForeignKey, Index,
     Boolean, CHAR, DateTime, Integer, SmallInteger, String, Text, UniqueConstraint
 )  # noqa
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship  # noqa
 from sqlalchemy.types import UserDefinedType
 


### PR DESCRIPTION
Most queries to this endpoint can be passed directly to sqlalchemy which provides a very large performance boost.

Additionally, users may specify filters that can be used to exclude some of our audit databases from the query results.
This commit makes us more intelligent about how we handle this situation (avoiding unnecessarily querying
databases).