### PR TITLE
NAS-127637 / 24.04.0 / Fix disk temperature logs not being retrieved when smartd interval is changed (by Qubad786)

### DIFF
--- a/src/freenas/usr/lib/netdata/conf.d/python.d/smart_log.conf
+++ b/src/freenas/usr/lib/netdata/conf.d/python.d/smart_log.conf
@@ -1,3 +1,0 @@
-debian:
-  name: smart
-  log_path: '/var/lib/smartmontools/'

--- a/src/freenas/usr/lib/netdata/python.d/smart_log.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/smart_log.chart.py
@@ -23,7 +23,6 @@ CSV = '.csv'
 DEF_AGE = 30
 DEF_PATH = '/var/log/smartd'
 DEF_RESCAN_INTERVAL = 60
-UPDATE_INTERVAL = 30
 INCREMENTAL = 'incremental'
 RE_ATA = re.compile(
     r'(\d+);'  # attribute
@@ -284,7 +283,7 @@ class Service(SimpleService):
         self.exclude = configuration.get('exclude_disks', str()).split()
         self.disks = list()
         self.runs = 0
-        self.update_data = UPDATE_INTERVAL
+        self.update_data = self.age
         self.do_force_rescan = False
         # smartd daemon only queries drive temps every 30mins so the files won't be updated
         # but once every 30ish minutes - we should change this if at any point we change smartd interval
@@ -321,14 +320,14 @@ class Service(SimpleService):
                 self.do_force_rescan = True
                 continue
 
-            if self.update_data >= UPDATE_INTERVAL and not disk.populate_attrs():
+            if self.update_data >= self.age and not disk.populate_attrs():
                 disk.alive = False
                 self.do_force_rescan = True
                 continue
 
             data.update(disk.data())
 
-        if not self.do_force_rescan and self.update_data >= UPDATE_INTERVAL:
+        if not self.do_force_rescan and self.update_data >= self.age:
             self.update_data = 0
 
         return data

--- a/src/middlewared/middlewared/etc_files/netdata/python.d/smart_log.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/python.d/smart_log.conf.mako
@@ -1,0 +1,7 @@
+<%
+    smart_config_interval = middleware.call_sync('smart.config')['interval']
+%>\
+debian:
+  name: smart
+  log_path: '/var/lib/smartmontools/'
+  age: ${smart_config_interval}

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -100,6 +100,7 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'netdata/netdata.conf', 'checkpoint': 'pool_import'},
             {'type': 'mako', 'path': 'netdata/charts.d/exclude_netdata.conf', 'checkpoint': 'pool_import'},
             {'type': 'mako', 'path': 'netdata/exporting.conf'},
+            {'type': 'mako', 'path': 'netdata/python.d/smart_log.conf'},
         ],
         'fstab': [
             {'type': 'mako', 'path': 'fstab'},

--- a/src/middlewared/middlewared/plugins/service_/services/smartd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/smartd.py
@@ -13,3 +13,6 @@ class SMARTDService(SimpleService):
 
     systemd_unit = "smartmontools"
     systemd_async_start = True
+
+    async def after_start(self):
+        await self.middleware.call('service.restart', 'netdata')


### PR DESCRIPTION
## Problem
The smartd interval is hard-coded in the Netdata smart_log plugin. When users change the smartd time interval to a value greater than the hard-coded interval in the plugin, the Netdata plugin's check fails. This happens because smartd does not update its CSV file according to the hard-coded value in the Netdata plugin.

## Solution
Create a configuration file for the Netdata smart_log plugin. Update this configuration file whenever the smartd interval changes. Additionally, synchronize the Netdata smart plugin cache update interval to comply with configured smartd interval.

Original PR: https://github.com/truenas/middleware/pull/13278
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127637