### PR TITLE
NAS-127671 / 24.04.0 / Fix error message for errors umounting sysdataset (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -567,8 +567,10 @@ class SystemDatasetService(ConfigService):
 
         error = f'Unable to umount {mp}: {stderr}'
         if 'target is busy' in stderr:
-            processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [mp], True)
-            error += f'\nThe following processes are using {mp!r}: ' + json.dumps(processes, indent=2)
+            # error message is of format "umount: <mountpoint>: target is busy"
+            ds_mp = stderr.split(':')[1].strip()
+            processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [ds_mp], True, True)
+            error += f'\nThe following processes are using {ds_mp!r}: ' + json.dumps(processes, indent=2)
 
         raise CallError(error) from None
 

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -67,6 +67,17 @@ def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
             result = res[0]
             assert result['pid'] == open_pid, f'{result["pid"]!r} does not match {open_pid!r}'
             assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert 'paths' not in result
+
+            res = call('pool.dataset.processes_using_paths', [arg_path(ssh)], True)
+            assert len(res) == 1
+            result = res[0]
+            assert result['pid'] == open_pid, f'{result["pid"]!r} does not match {open_pid!r}'
+            assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert 'paths' in result
+            assert len(result['paths']) == 1
+            assert result['paths'][0] == test_file if test_file.startswith('/mnt') else '/dev/zd0'
+
         finally:
             if opened:
                 ssh(f'kill -9 {open_pid}', check=False)


### PR DESCRIPTION
This commit does the following:

1. Fixes a bug whereby query for processes owned by paths would not list the paths within the `paths` variable in output
2. Adds ability to pass a parameter to include files opened by the middlewared process in the output to assist in troubleshooting issues where the middlewared process is what is preventing system dataset umount from occurring.
3. Passes new parameter when handling errors during systemdataset setup.
4. Parses the recursive umount error message for the dataset that failed and pass that to the call to look up processes.

Original PR: https://github.com/truenas/middleware/pull/13283
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127671