### PR TITLE
add MemorySizeMismatch Alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -1,4 +1,5 @@
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
+from middlewared.alert.schedule import CrontabSchedule
 
 
 class MemoryErrorsAlertClass(AlertClass):
@@ -6,6 +7,14 @@ class MemoryErrorsAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'Uncorrected Memory Errors Detected'
     text = '%(count)d total uncorrected errors detected for %(loc)s.'
+    products = ('SCALE_ENTERPRISE',)
+    proactive_support = True
+
+
+class MemorySizeMismatchAlertClass(AlertClass):
+    category = AlertCategory.HARDWARE
+    title = 'Memory Size Mismatch Detected'
+    text = 'Memory size on this controller %(r1)d doesn\'t match other controller %(r2)d'
     products = ('SCALE_ENTERPRISE',)
     proactive_support = True
 
@@ -31,5 +40,33 @@ class MemoryErrorsAlertSource(AlertSource):
                         alerts.append(Alert(
                             MemoryErrorsAlertClass, {'count': val2, 'loc': location + f' on dimm {dimm_key}'}
                         ))
+
+        return alerts
+
+
+class MemorySizeMismatchAlertSource(AlertSource):
+    schedule = CrontabSchedule(hours=1)  # every 24hrs
+    run_on_backup_node = False
+
+    async def check(self):
+        alerts = []
+        if not await self.middleware.call('failover.licensed'):
+            return alerts
+
+        r1 = (await self.middleware.call('system.mem_info'))['physmem_size']
+        if r1 is None:
+            return alerts
+
+        try:
+            r2 = await self.middleware.call(
+                'failover.call_remote', 'system.mem_info', {'raise_connect_error': False}
+            )
+            if r2['physmem_size'] is None:
+                return alerts
+        except Exception:
+            return alerts
+
+        if r1 != r2:
+            alerts.append(Alert(MemorySizeMismatchAlertClass, {'r1': r1, 'r2': r2}))
 
         return alerts

--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -20,6 +20,7 @@ class MemorySizeMismatchAlertClass(AlertClass):
 
 
 class MemoryErrorsAlertSource(AlertSource):
+    schedule = CrontabSchedule(hours=1)  # every 24hrs
 
     async def check(self):
         alerts = []


### PR DESCRIPTION
The performance team had an internal system that had a memory module die. This resulted in a memory size mismatch between the controllers. There was no indication in the UI that this had happened so this adds functionality to check the physical memory size between the controllers on an HA system and ensure they match and raise an alert otherwise.