### PR TITLE
Add integration test for validating system dataset spec

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -400,7 +400,6 @@ class SystemDatasetService(ConfigService):
 
         corepath = f'{SYSDATASET_PATH}/cores'
         if os.path.exists(corepath):
-            os.chmod(corepath, 0o775)
 
             if self.middleware.call_sync('keyvalue.get', 'run_migration', False):
                 try:
@@ -699,6 +698,10 @@ class SystemDatasetService(ConfigService):
                 restart.reverse()
                 for i in restart:
                     self.middleware.call_sync('service.start', i)
+
+    @private
+    def get_system_dataset_spec(self, pool, uid):
+        return get_system_dataset_spec(pool, uid)
 
 
 async def pool_post_create(middleware, pool):

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -89,7 +89,7 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
             'chown_config': {
                 'uid': 0,
                 'gid': 0,
-                'mode': 0o755,
+                'mode': 0o775,
             },
         },
         {


### PR DESCRIPTION
## Problem
Changes to netdata mount points were introduced in the system dataset, but corresponding integration tests were not added. Additionally, some additional adjustments are needed to ensure the success of these tests. This is because the system dataset also undergoes a chown process during the setup, overwriting the chown operation performed during the mount. Consequently, this causes a failure in the test where dataset mount point ownership is asserted.

## Solution
Add integration tests for the system dataset mount points to validate the changes. Make necessary adjustments to ensure the success of these tests.

## Reference
[Pull Request #13149](https://github.com/truenas/middleware/pull/13149)