### PR TITLE
NAS-127772 / 24.10 / Remove reference to AD kerberos principal

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -950,11 +950,17 @@ class KerberosKeytabService(CRUDService):
         """
         kt = await self.get_instance(id_)
         if kt['name'] == 'AD_MACHINE_ACCOUNT':
-            if (await self.middleware.call('activedirectory.get_state')) != 'DISABLED':
+            ad_config = await self.middleware.call('activedirectory.config')
+            if ad_config['enable']:
                 raise CallError(
                     'Active Directory machine account keytab may not be deleted while '
                     'the Active Directory service is enabled.'
                 )
+
+            await self.middleware.call(
+                'datastore.update', 'directoryservice.activedirectory',
+                ad_config['id'], {'kerberos_principal': ''}, {'prefix': 'ad_'}
+            )
 
         await self.middleware.call('datastore.delete', self._config.datastore, id_)
         await self.middleware.call('etc.generate', 'kerberos')


### PR DESCRIPTION
If the Active Directory service is deleted and user decides to actually delete the existing AD machine account keytab, we should make sure that potential references to it are removed from the AD form.