### PR TITLE
NAS-127709 / 24.04.0 / drive ident for legacy enclosure hseries (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -15,7 +15,7 @@ from middlewared.utils import filter_list
 from middlewared.plugins.enclosure_.r30_drive_identify import set_slot_status as r30_set_slot_status
 from middlewared.plugins.enclosure_.fseries_drive_identify import set_slot_status as fseries_set_slot_status
 from middlewared.plugins.truenas import TRUENAS_UNKNOWN
-
+from middlewared.plugins.enclosure_.sysfs_disks import toggle_enclosure_slot_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +238,25 @@ class EnclosureService(CRUDService):
             info = self.middleware.call_sync('enclosure.query', [['id', '=', enclosure_id]])[0]
         except IndexError:
             raise CallError(f'Enclosure with id: {enclosure_id!r} not found', errno.ENOENT)
+
+        if info['model'] == 'H Series':
+            sysfs_to_ui = {
+                1: '8', 2: '9', 3: '10', 4: '11',
+                5: '12', 6: '13', 7: '14', 8: '15',
+                9: '0', 10: '1', 11: '2', 12: '3',
+            }
+            if slot not in sysfs_to_ui:
+                raise CallError(f'Slot: {slot!r} not found', errno.ENOENT)
+
+            addr = info['bsg'].removeprefix('bsg/')
+            sysfs_path = f'/sys/class/enclosure/{addr}'
+            mapped_slot = sysfs_to_ui[slot]
+            try:
+                toggle_enclosure_slot_identifier(sysfs_path, mapped_slot, status, True)
+            except FileNotFoundError:
+                raise CallError(f'Slot: {slot!r} not found', errno.ENOENT)
+
+            return
 
         original = self._get_orig_enclosure_and_disk(enclosure_id, slot, info)
         if original is None:


### PR DESCRIPTION
This adds enclosure slot identification for the H series platform to the legacy enclosure code. It was simply omitted from the original PR adding this platform to our code base.

Original PR: https://github.com/truenas/middleware/pull/13304
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127709