### PR TITLE
NAS-127766 / 24.04.0 / Add roles for system.* services (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -56,6 +56,7 @@ class SystemAdvancedService(ConfigService):
         datastore_extend = 'system.advanced.system_advanced_extend'
         namespace = 'system.advanced'
         cli_namespace = 'system.advanced'
+        role_prefix = 'SYSTEM_ADVANCED'
 
     ENTRY = Dict(
         'system_advanced_entry',
@@ -298,14 +299,14 @@ class SystemAdvancedService(ConfigService):
 
         return await self.config()
 
-    @accepts(roles=['READONLY_ADMIN'])
+    @accepts(roles=['SYSTEM_ADVANCED_READ'])
     @returns(Bool('sed_global_password_is_set'))
     async def sed_global_password_is_set(self):
         """Returns a boolean identifying whether or not a global
         SED password has been set"""
         return bool(await self.sed_global_password())
 
-    @accepts()
+    @accepts(roles=['SYSTEM_ADVANCED_READ'])
     @returns(Password('sed_global_password'))
     async def sed_global_password(self):
         """Returns configured global SED password in clear-text if one

--- a/src/middlewared/middlewared/plugins/system_advanced/gpu.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/gpu.py
@@ -8,7 +8,7 @@ class SystemAdvancedService(Service):
         namespace = 'system.advanced'
         cli_namespace = 'system.advanced'
 
-    @accepts(List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True))
+    @accepts(List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True), roles=['SYSTEM_ADVANCED_WRITE'])
     @returns()
     async def update_gpu_pci_ids(self, isolated_gpu_pci_ids):
         """

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -65,7 +65,7 @@ class SystemGeneralService(Service):
         }
 
     @rest_api_metadata(extra_methods=['GET'])
-    @accepts(Int('delay', default=3, validators=[Range(min_=0)]))
+    @accepts(Int('delay', default=3, validators=[Range(min_=0)]), roles=['SYSTEM_GENERAL_WRITE'])
     async def ui_restart(self, delay):
         """
         Restart HTTP server to use latest UI settings.
@@ -75,7 +75,7 @@ class SystemGeneralService(Service):
         event_loop = asyncio.get_event_loop()
         event_loop.call_later(delay, lambda: self.middleware.create_task(self.middleware.call('service.restart', 'http')))
 
-    @accepts()
+    @accepts(roles=['SYSTEM_GENERAL_READ'])
     @returns(Str('local_url'))
     async def local_url(self):
         """

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -43,6 +43,7 @@ class SystemGeneralService(ConfigService):
         datastore_prefix = 'stg_'
         datastore_extend = 'system.general.general_system_extend'
         cli_namespace = 'system.general'
+        role_prefix = 'SYSTEM_GENERAL'
 
     ENTRY = Dict(
         'system_general_entry',

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -177,6 +177,13 @@ ROLES = {
     'KUBERNETES_WRITE': Role(includes=['CONTAINER_WRITE', 'KUBERNETES_READ']),
     'APPS_READ': Role(includes=['CATALOG_READ', 'CONTAINER_READ']),
     'APPS_WRITE': Role(includes=['CATALOG_WRITE', 'APPS_READ', 'CONTAINER_WRITE']),
+
+    # System settings
+    'SYSTEM_GENERAL_READ': Role(),
+    'SYSTEM_GENERAL_WRITE': Role(includes=['SYSTEM_GENERAL_READ']),
+
+    'SYSTEM_ADVANCED_READ': Role(),
+    'SYSTEM_ADVANCED_WRITE': Role(includes=['SYSTEM_ADVANCED_READ'])
 }
 ROLES['READONLY_ADMIN'] = Role(includes=[role for role in ROLES if role.endswith('_READ')], builtin=False)
 

--- a/tests/api2/test_system_settings_roles.py
+++ b/tests/api2/test_system_settings_roles.py
@@ -1,0 +1,28 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+@pytest.mark.parametrize('role,endpoint,payload,should_work,valid_role_exception,is_return_type_none', [
+    ('APPS_READ', 'system.general.config', [], False, False, False),
+    ('SYSTEM_GENERAL_READ', 'system.general.config', [], True, False, False),
+    ('READONLY_ADMIN', 'system.general.update', [{}], False, False, False),
+    ('SYSTEM_GENERAL_WRITE', 'system.general.update', [{}], True, False, False),
+    ('APPS_READ', 'system.advanced.config', [], False, False, False),
+    ('SYSTEM_ADVANCED_READ', 'system.advanced.config', [], True, False, False),
+    ('READONLY_ADMIN', 'system.advanced.update', [{}], False, False, False),
+    ('SYSTEM_ADVANCED_WRITE', 'system.advanced.update', [{}], True, False, False),
+    ('SYSTEM_ADVANCED_READ', 'system.advanced.sed_global_password', [], True, False, False),
+    ('APPS_READ', 'system.advanced.sed_global_password', [], False, False, False),
+    ('READONLY_ADMIN', 'system.advanced.update_gpu_pci_ids', [[]], False, False, False),
+    ('SYSTEM_ADVANCED_WRITE', 'system.advanced.update_gpu_pci_ids', [], True, False, True),
+    ('APPS_READ', 'system.general.local_url', [], False, False, False),
+    ('SYSTEM_GENERAL_READ', 'system.general.local_url', [], True, False, False),
+])
+def test_catalog_read_and_write_role(
+    role, endpoint, payload, should_work, valid_role_exception, is_return_type_none
+):
+    common_checks(
+        endpoint, role, should_work, is_return_type_none=is_return_type_none,
+        valid_role_exception=valid_role_exception, method_args=payload
+    )


### PR DESCRIPTION
## Problem
Roles were not assigned to general or advanced system settings which essentially meant that only users with administrator privileges would have been able to modify it. In the UI this meant that we have a lock icon next to update buttons for relevant forms etc.

## Solution
Assign relevant roles to system settings and add additional integration tests to verify role-related changes.

Original PR: https://github.com/truenas/middleware/pull/13301
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127766