### PR TITLE
Backport sysdataset fixes

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -535,7 +535,7 @@ class SystemDatasetService(ConfigService):
 
         return mounted
 
-    def __umount(self, pool, uuid):
+    def __umount(self, pool, uuid, retry=True):
         """
         Umount the group of datasets associated with the system dataset.
         When migrating between system datasets, `pool` will be filesystem
@@ -555,7 +555,13 @@ class SystemDatasetService(ConfigService):
             return
 
         mp = mntinfo[0]['mountpoint']
-        flags = '-f' if not self.middleware.call_sync('failover.licensed') else '-l'
+        if retry:
+            flags = '-f' if not self.middleware.call_sync('failover.licensed') else '-l'
+        else:
+            # We're doing a retry and have logged a warning message pointing fingers
+            # at offending processes so that a dev can hopefully fix it later on.
+            flags = '-lf'
+
         try:
             subprocess.run(['umount', flags, '--recursive', mp], check=True, capture_output=True)
         except subprocess.CalledProcessError as e:
@@ -570,6 +576,12 @@ class SystemDatasetService(ConfigService):
             # error message is of format "umount: <mountpoint>: target is busy"
             ds_mp = stderr.split(':')[1].strip()
             processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [ds_mp], True, True)
+
+            if retry:
+                self.logger.warning("The following processes are using %s: %s",
+                                    ds_mp, json.dumps(processes, indent=2))
+                return self.__umount(pool, uuid, False)
+
             error += f'\nThe following processes are using {ds_mp!r}: ' + json.dumps(processes, indent=2)
 
         raise CallError(error) from None

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -567,8 +567,10 @@ class SystemDatasetService(ConfigService):
 
         error = f'Unable to umount {mp}: {stderr}'
         if 'target is busy' in stderr:
-            processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [mp], True)
-            error += f'\nThe following processes are using {mp!r}: ' + json.dumps(processes, indent=2)
+            # error message is of format "umount: <mountpoint>: target is busy"
+            ds_mp = stderr.split(':')[1].strip()
+            processes = self.middleware.call_sync('pool.dataset.processes_using_paths', [ds_mp], True, True)
+            error += f'\nThe following processes are using {ds_mp!r}: ' + json.dumps(processes, indent=2)
 
         raise CallError(error) from None
 

--- a/tests/api2/test_pool_dataset_track_processes.py
+++ b/tests/api2/test_pool_dataset_track_processes.py
@@ -67,6 +67,17 @@ def test__open_path_and_check_proc(request, datasets, file_open_path, arg_path):
             result = res[0]
             assert result['pid'] == open_pid, f'{result["pid"]!r} does not match {open_pid!r}'
             assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert 'paths' not in result
+
+            res = call('pool.dataset.processes_using_paths', [arg_path(ssh)], True)
+            assert len(res) == 1
+            result = res[0]
+            assert result['pid'] == open_pid, f'{result["pid"]!r} does not match {open_pid!r}'
+            assert result['cmdline'] == cmdline, f'{result["cmdline"]!r} does not match {cmdline!r}'
+            assert 'paths' in result
+            assert len(result['paths']) == 1
+            assert result['paths'][0] == test_file if test_file.startswith('/mnt') else '/dev/zd0'
+
         finally:
             if opened:
                 ssh(f'kill -9 {open_pid}', check=False)


### PR DESCRIPTION
Per request from automation team, backport fixes for:
NAS-127724 - If for some reason a process has an open handle on our old system dataset, log an error message and proceed with a lazy umount to avoid leaving system in broken state.

NAS-127671 - Fix error message for errors umounting sysdataset