### PR TITLE
NAS-127812 / 24.04.0 / Fix es24n disk mapping (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -103,7 +103,12 @@ def map_es24n(model, rclient, uri):
     for disk in all_disks['Members']:
         slot = int(disk['Id'])
         if found := mounted_disks.get(disk['SerialNumber']):
-            mapped[slot] = found[0]
+            try:
+                # we expect namespace 1 for the device (i.e. nvme1n1)
+                idx = found[1]['namespaces'].index(f'{found[0]}n1')
+                mapped[slot] = found[1]['namespaces'][idx]
+            except ValueError:
+                mapped[slot] = None
         else:
             mapped[slot] = None
 


### PR DESCRIPTION
UI team was implementing the ES24N for DF and found that `disk.query` enclosure key was always null for drives in the ES24N. Closer inspection shows that I was mapping the nvme character device (i.e. `/dev/nvme2`) instead of the namespace block device (i.e. /dev/nvme2n1). This adds `namespaces` and `partitions` to `get_sys_class_nvme` and then fixes the disk mapping in `jbof_enclosures.py`

Original PR: https://github.com/truenas/middleware/pull/13321
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127812