### PR TITLE
NAS-127850 / 24.10 / Check for properly setup system dataset before SMB configure

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1172,6 +1172,9 @@ class ActiveDirectoryService(ConfigService):
         used to perform the actual removal from the domain.
         """
         ad = await self.config()
+        if not ad['domainname']:
+            raise CallError('Active Directory domain name present in configuration.')
+
         smb_ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
 
         ad['bindname'] = data.get("username", "")

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -596,6 +596,9 @@ class SMBService(ConfigService):
         if in_progress:
             return False
 
+        if not await self.middleware.call('systemdataset.sysdataset_path'):
+            return False
+
         self.logger.warning(
             "SMB service was not properly initialized. "
             "Attempting to configure SMB service."


### PR DESCRIPTION
This commit reduces potential for API consumer actions during system dataset move to cause umount failures. Many operations during smb.configure will touch the system dataset via commands run in subprocesses.