### PR TITLE
NAS-127851 / 24.10 / Update flush_chain_INPUT to flush both ip4 and ip6 tables

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/nftables.py
+++ b/src/middlewared/middlewared/plugins/failover_/nftables.py
@@ -67,7 +67,9 @@ class NftablesService(Service):
         return True
 
     def flush_chain_INPUT(self):
-        return not bool(run(['nft', 'flush', 'chain', 'filter', 'INPUT']).returncode)
+        ip4_flush = not bool(run(['nft', 'flush', 'chain', 'filter', 'INPUT']).returncode)
+        ip6_flush = not bool(run(['nft', 'flush', 'chain', 'ip6', 'filter', 'INPUT']).returncode)
+        return ip4_flush and ip6_flush
 
     @accepts()
     @job(lock=JOB_LOCK)


### PR DESCRIPTION
It is NOT obvious from the nfs man page, but it appears that if a family is not specified for a flush chain command then it defaults to ip.

(The man page does document similar behavior for TABLES.)

