### PR TITLE
NAS-127850 / 24.04.0 / Check for properly setup system dataset before SMB configure (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1173,6 +1173,9 @@ class ActiveDirectoryService(ConfigService):
         used to perform the actual removal from the domain.
         """
         ad = await self.config()
+        if not ad['domainname']:
+            raise CallError('Active Directory domain name present in configuration.')
+
         smb_ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
 
         ad['bindname'] = data.get("username", "")

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -601,6 +601,9 @@ class SMBService(ConfigService):
         if in_progress:
             return False
 
+        if not await self.middleware.call('systemdataset.sysdataset_path'):
+            return False
+
         self.logger.warning(
             "SMB service was not properly initialized. "
             "Attempting to configure SMB service."


### PR DESCRIPTION
This commit reduces potential for API consumer actions during system dataset move to cause umount failures. Many operations during smb.configure will touch the system dataset via commands run in subprocesses.

Original PR: https://github.com/truenas/middleware/pull/13332
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127850