### PR TITLE
NAS-127856 / 24.10 / Detect and save mgmt_ip2 if not supplied during jbof.create

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -176,20 +176,11 @@ class JBOFService(CRUDService):
         # If the caller just supplied mgmt_ip1, let's fetch mgmt_ip2 to store in the DB
         if data.get('mgmt_ip2') in ['', None]:
             try:
-                # Grab the IOM redfish IPs
-                redfish = RedfishClient.cache_get(mgmt_ip)
-                mgmt_ips = filter(lambda x: x != mgmt_ip, await self.middleware.run_in_thread(redfish.mgmt_ips))
-                # Connectivity check - pick one we can talk to
-                for ip in mgmt_ips:
-                    if await self.middleware.run_in_thread(RedfishClient.is_redfish, ip):
-                        data['mgmt_ip2'] = ip
-                        self.logger.info('Detected additional JBOF mgmt IP %r', ip)
-                        break
-                # If unable to talk to one, pick the first one.  Maybe connectivity will
-                # be restored later.
-                if data.get('mgmt_ip2') in ['', None] and len(mgmt_ips):
-                    data['mgmt_ip2'] = mgmt_ips[0]
-                    self.logger.info('Added additional JBOF mgmt IP %r without connectivity', mgmt_ips[0])
+                if ip := await self.middleware.call('jbof.alt_mgmt_ip', mgmt_ip):
+                    data['mgmt_ip2'] = ip
+                    self.logger.info('Detected additional JBOF mgmt IP %r', ip)
+                else:
+                    self.logger.warning('Unable to determine additional JBOF mgmt IP')
             except Exception:
                 self.logger.warning('Unable to detect additional JBOF mgmt IP', exc_info=True)
 
@@ -258,6 +249,21 @@ class JBOFService(CRUDService):
         # Now delete the entry
         response = await self.middleware.call('datastore.delete', self._config.datastore, id_)
         return response
+
+    @private
+    def get_mgmt_ips(self, mgmt_ip):
+        redfish = RedfishClient.cache_get(mgmt_ip)
+        return redfish.mgmt_ips()
+
+    @private
+    def alt_mgmt_ip(self, mgmt_ip):
+        other_mgmt_ips = filter(lambda x: x != mgmt_ip, self.get_mgmt_ips(mgmt_ip))
+        for ip in other_mgmt_ips:
+            if RedfishClient.is_redfish(ip):
+                return ip
+        # If unable to talk to one, pick the first one.  Maybe connectivity will be restored later.
+        if len(other_mgmt_ips):
+            self.logger.info('Unable to validate connectivity to alternate JBOF mgmt IP %r', other_mgmt_ips[0])
 
     @private
     def ensure_redfish_client_cached(self, data):

--- a/src/middlewared/middlewared/plugins/jbof/redfish/client.py
+++ b/src/middlewared/middlewared/plugins/jbof/redfish/client.py
@@ -144,6 +144,18 @@ class RedfishClient:
         uri = f'{self.managers()[iom]}/EthernetInterfaces'
         return self._cached_fetch(f'{iom}/mgmt_ethernet_interfaces', uri, use_cached)
 
+    def mgmt_ips(self):
+        result = []
+        for iom in self.managers():
+            for eth_uri in self.mgmt_ethernet_interfaces(iom).values():
+                # Do not want any cached value.  IPs can change.
+                data = self.get_uri(eth_uri, False)
+                for ipv4_address in data.get('IPv4Addresses', []):
+                    addr = ipv4_address.get('Address')
+                    if addr:
+                        result.append(addr)
+        return result
+
     def network_device_functions(self, iom, use_cached=True):
         return self._cached_fetch(
             f'{iom}/network_device_functions',


### PR DESCRIPTION
We want to save the `mgmt_ip2` in the database (even if not supplied during the create), so that we can add robustness later.  (Splitting this functionality out to backport to 24.04, but won't avail of it until 24.10)