### PR TITLE
NAS-127852 / 24.04-RC.1 / fix license alert for ES12 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -157,7 +157,7 @@ class Enclosure:
                 # R50
                 self.model = dmi_model.value
                 self.controller = True
-            case 'CELESTIC_X2012':
+            case 'CELESTIC_X2012' | 'CELESTIC_X2012-MT':
                 self.model = JbodModels.ES12.value
                 self.controller = False
             case 'ECStream_4024J' | 'iX_4024J':


### PR DESCRIPTION
Customer upgraded to 23.10.2 and received a false alert for the ES12. This fixes it.

Original PR: https://github.com/truenas/middleware/pull/13343
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127852