### PR TITLE
NAS-127771 / 24.04.0 / Fix `KeyError` in `rdma.get_link_choices` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -78,7 +78,8 @@ class RDMAService(Service):
 
         result = []
         for link in json.loads(ret.stdout.decode()):
-            result.append({'rdma': link['ifname'], 'netdev': link['netdev']})
+            if 'netdev' in link:
+                result.append({'rdma': link['ifname'], 'netdev': link['netdev']})
         return result
 
     @accepts()


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/rdma/rdma.py", line 69, in get_link_choices
    result.append({'rdma': link['ifname'], 'netdev': link['netdev']})
                                                     ~~~~^^^^^^^^^^
KeyError: 'netdev'
```

Original PR: https://github.com/truenas/middleware/pull/13342
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127771