### PR TITLE
NAS-127150 / 24.10 / Add new endpoint to retrieve truecommand status

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -52,7 +52,7 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if middleware.call_sync('truecommand.connected')['connected'] and wg_config['wg_address']:
+    if middleware.call_sync('truecommand.info')['connected'] and wg_config['wg_address']:
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -1,21 +1,16 @@
 import asyncio
 import re
-import subprocess
 import time
 
 from middlewared.schema import Bool, Dict, IPAddr, returns, Str
-from middlewared.service import accepts, CallError, no_auth_required, periodic, pass_app, private, Service, throttle
-from middlewared.utils import Popen, run
+from middlewared.service import accepts, CallError, periodic, private, Service
+from middlewared.utils import run
 
 from .enums import Status
 from .utils import WIREGUARD_INTERFACE_NAME
 
 HEALTH_CHECK_SECONDS = 1800
 WIREGUARD_HEALTH_RE = re.compile(r'=\s*(.*)')
-
-
-def throttle_condition(middleware, app, *args, **kwargs):
-    return app is None or (app and app.authenticated), None
 
 
 class TruecommandService(Service):
@@ -99,8 +94,6 @@ class TruecommandService(Service):
                         health_error = True
         return not health_error
 
-    @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(Dict(
         'truecommand_connected',
@@ -110,8 +103,7 @@ class TruecommandService(Service):
         Str('status', required=True),
         Str('status_reason', required=True),
     ))
-    @pass_app()
-    async def connected(self, app):
+    async def info(self):
         """
         Returns information which shows if system has an authenticated api key
         and has initiated a VPN connection with TrueCommand.

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -94,7 +94,7 @@ class TruecommandService(Service):
                         health_error = True
         return not health_error
 
-    @accepts()
+    @accepts(roles=['TRUECOMMAND_READ'])
     @returns(Dict(
         'truecommand_connected',
         Bool('connected', required=True),

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -7,7 +7,7 @@ from ixhardware import TRUENAS_UNKNOWN, get_chassis_hardware
 
 from middlewared.plugins.truecommand.enums import Status as TrueCommandStatus
 from middlewared.schema import accepts, Bool, Dict, Patch, returns, Str
-from middlewared.service import cli_private, job, no_auth_required, pass_app, private, Service, throttle
+from middlewared.service import cli_private, job, no_auth_required, private, Service
 from middlewared.utils.functools_ import cache
 import middlewared.sqlalchemy as sa
 
@@ -29,10 +29,6 @@ user_attrs = [
 ]
 
 
-def throttle_condition(middleware, app, *args, **kwargs):
-    return app is None or (app and app.authenticated), None
-
-
 class TruenasCustomerInformationModel(sa.Model):
     __tablename__ = 'truenas_customerinformation'
 
@@ -49,11 +45,9 @@ class TrueNASService(Service):
         cli_namespace = 'system.truenas'
 
     @no_auth_required
-    @throttle(seconds=2, condition=throttle_condition)
     @accepts()
     @returns(Bool())
-    @pass_app()
-    async def managed_by_truecommand(self, app):
+    async def managed_by_truecommand(self):
         """
         Returns whether TrueNAS is being managed by TrueCommand or not.
 

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -53,7 +53,7 @@ class TrueNASService(Service):
     @accepts()
     @returns(Bool())
     @pass_app()
-    async def managed_by_truecommand(self):
+    async def managed_by_truecommand(self, app):
         """
         Returns whether TrueNAS is being managed by TrueCommand or not.
 

--- a/tests/api2/test_truecommand_roles.py
+++ b/tests/api2/test_truecommand_roles.py
@@ -5,15 +5,15 @@ from middlewared.test.integration.assets.roles import common_checks
 
 def test_truecommand_readonly_role():
     common_checks(
-        'truecommand.connected', 'READONLY_ADMIN', True, valid_role_exception=False
+        'truenas.managed_by_truecommand', 'READONLY_ADMIN', True, valid_role_exception=False
     )
 
 
 @pytest.mark.parametrize('endpoint,role,should_work,valid_role_exception', [
     ('truecommand.config', 'TRUECOMMAND_READ', True, False),
     ('truecommand.config', 'TRUECOMMAND_WRITE', True, False),
-    ('truecommand.connected', 'TRUECOMMAND_READ', True, False),
-    ('truecommand.connected', 'TRUECOMMAND_WRITE', True, False),
+    ('truecommand.info', 'TRUECOMMAND_READ', True, False),
+    ('truecommand.info', 'TRUECOMMAND_WRITE', True, False),
     ('truecommand.update', 'TRUECOMMAND_READ', False, True),
     ('truecommand.update', 'TRUECOMMAND_WRITE', True, True),
 ])


### PR DESCRIPTION
This PR adds changes to add a new endpoint which can be used to retrieve if system is being managed by Truecommand.