### PR TITLE
NAS-127902 / 24.04.0 / remove unused system datasets on fresh installs (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -306,11 +306,6 @@ http {
             proxy_set_header X-Real-Remote-Port $remote_port;
         }
 
-        location /images {
-            allow all;
-            alias /var/db/system/webui/images;
-        }
-
         location ~ /netdata/(?<ndpath>.*) {
             auth_basic "Netdata Closed";
             auth_basic_user_file ${netdata_basic_file};

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -590,8 +590,7 @@ class SystemDatasetService(ConfigService):
         return [(f'{pool}/.system', '')] + [
             (f'{pool}/.system/{i}', i) for i in [
                 'cores', 'samba4',
-                f'rrd-{uuid}', f'configs-{uuid}',
-                'webui', 'services',
+                f'configs-{uuid}',
                 f'netdata-{uuid}',
             ]
         ]


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 11aadb93cf4bcc1f6808709f19db23b3ecc98404
    git cherry-pick -x 82176e034a1d5bf2774394427167fe34bb9fd8aa
    git cherry-pick -x 1f882c8e7072fedfb9a771cdb0d1dda4bcb6ce99

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x df43ce08ee6c2a0fab28847e25fcbf607ec1e4ac



Original PR: https://github.com/truenas/middleware/pull/13371
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127902