### PR TITLE
NAS-127357 / 24.04.0 / Retrieve PCI slots in a new endpoint so that they are easily consumed by UI (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/test_pci_ids_for_gpu_isolation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_pci_ids_for_gpu_isolation.py
@@ -1,0 +1,130 @@
+import pytest
+
+from unittest.mock import Mock, patch
+
+from middlewared.pytest.unit.helpers import load_compound_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+SYSTEM_ADVANCED_SERVICE = load_compound_service('system.advanced')
+AVAILABLE_GPU = [
+    {
+        'addr': {
+            'pci_slot': '0000:16:0e.0',
+            'domain': '0000',
+            'bus': '16',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:16:0e.0',
+                'vm_pci_slot': 'pci_0000_16_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:16:0e.2',
+                'vm_pci_slot': 'pci_0000_16_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': False,
+        'available_to_host': True
+    },
+    {
+        'addr': {
+            'pci_slot': '0000:17:0e.0',
+            'domain': '0000',
+            'bus': '17',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:17:0e.0',
+                'vm_pci_slot': 'pci_0000_17_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:17:0e.2',
+                'vm_pci_slot': 'pci_0000_17_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': False,
+        'available_to_host': False
+    },
+    {
+        'addr': {
+            'pci_slot': '0000:18:0e.0',
+            'domain': '0000',
+            'bus': '18',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:18:0e.0',
+                'vm_pci_slot': 'pci_0000_18_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:18:0e.2',
+                'vm_pci_slot': 'pci_0000_18_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': True,
+        'available_to_host': True
+    }
+]
+
+
+@pytest.mark.parametrize('isolated_gpu,keys,values', [
+    (
+        [],
+        {
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:16:0e.0]',
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:17:0e.0]',
+        },
+        {
+            '0000:16:0e.0',
+            '0000:17:0e.0'
+        }
+    ),
+    (
+        ['0000:18:0e.0'],
+        {
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:16:0e.0]',
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:17:0e.0]',
+            'Unknown \'0000:18:0e.0\' slot',
+        },
+        {
+            '0000:16:0e.0',
+            '0000:17:0e.0',
+            '0000:18:0e.0'
+        }
+    ),
+    (
+        ['0000:19:0e.0'],
+        {
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:16:0e.0]',
+            'Red Hat, Inc. Virtio 1.0 GPU [0000:17:0e.0]',
+            'Unknown \'0000:19:0e.0\' slot',
+        },
+        {
+            '0000:16:0e.0',
+            '0000:17:0e.0',
+            '0000:19:0e.0'
+        }
+    ),
+])
+def test_isolate_gpu_choices(isolated_gpu, keys, values):
+    m = Middleware()
+    m['system.advanced.config'] = lambda *args: {'isolated_gpu_pci_ids': isolated_gpu}
+    with patch('middlewared.plugins.system_advanced.gpu.get_gpus', Mock(return_value=AVAILABLE_GPU)):
+        assert set(SYSTEM_ADVANCED_SERVICE(m).get_gpu_pci_choices().keys()) == keys
+        assert set(SYSTEM_ADVANCED_SERVICE(m).get_gpu_pci_choices().values()) == values

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_gpu_pci_choices.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_gpu_pci_choices.py
@@ -1,0 +1,216 @@
+from unittest.mock import Mock, patch
+
+from middlewared.pytest.unit.helpers import load_compound_service
+from middlewared.pytest.unit.middleware import Middleware
+
+
+VMDeviceService = load_compound_service('vm.device')
+
+AVAILABLE_GPUs = [
+    {
+        'addr': {
+            'pci_slot': '0000:16:0e.0',
+            'domain': '0000',
+            'bus': '16',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:16:0e.0',
+                'vm_pci_slot': 'pci_0000_16_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:16:0e.2',
+                'vm_pci_slot': 'pci_0000_16_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': False,
+        'available_to_host': True
+    },
+    {
+        'addr': {
+            'pci_slot': '0000:17:0e.0',
+            'domain': '0000',
+            'bus': '17',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:17:0e.0',
+                'vm_pci_slot': 'pci_0000_17_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:17:0e.2',
+                'vm_pci_slot': 'pci_0000_17_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': False,
+        'available_to_host': False
+    },
+    {
+        'addr': {
+            'pci_slot': '0000:18:0e.0',
+            'domain': '0000',
+            'bus': '18',
+            'slot': '0e'
+        },
+        'description': 'Red Hat, Inc. Virtio 1.0 GPU',
+        'devices': [
+            {
+                'pci_id': '8086:29C0',
+                'pci_slot': '0000:18:0e.0',
+                'vm_pci_slot': 'pci_0000_18_0e_0'
+            },
+            {
+                'pci_id': '1AF4:1050',
+                'pci_slot': '0000:18:0e.2',
+                'vm_pci_slot': 'pci_0000_18_0e_2'
+            },
+        ],
+        'vendor': None,
+        'uses_system_critical_devices': True,
+        'available_to_host': True
+    }
+]
+IOMMU_GROUPS = {
+    '0000:16:0e.2': {
+        'number': 45,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:16:0e.0': {
+        'number': 45,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x16',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:17:0e.2': {
+        'number': 46,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x17',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x17',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:17:0e.0': {
+        'number': 46,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x17',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x17',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:18:0e.2': {
+        'number': 47,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x18',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x18',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:18:0e.0': {
+        'number': 47,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x18',
+                'slot': '0x0e',
+                'function': '0x2'
+            },
+            {
+                'domain': '0x0000',
+                'bus': '0x18',
+                'slot': '0x0e',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:b2:0f.0': {
+        'number': 83,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0xb2',
+                'slot': '0x0f',
+                'function': '0x0'
+            }
+        ]
+    },
+    '0000:00:04.0': {
+        'number': 17,
+        'addresses': [
+            {
+                'domain': '0x0000',
+                'bus': '0x00',
+                'slot': '0x04',
+                'function': '0x0'
+            }
+        ]
+    },
+}
+
+
+def test_get_pci_ids_for_gpu_isolation():
+    with patch('middlewared.plugins.vm.pci.VMDeviceService.get_iommu_groups_info', Mock(return_value=IOMMU_GROUPS)):
+        with patch('middlewared.plugins.vm.pci.get_gpus', Mock(return_value=AVAILABLE_GPUs)):
+            assert set(VMDeviceService(Middleware()).get_pci_ids_for_gpu_isolation('0000:16:0e.0')) == {
+                'pci_0000_16_0e_0', 'pci_0000_16_0e_2'
+            }


### PR DESCRIPTION
## Context

When GPU passthrough is desired, there are essentially 2 steps which need to be done:

1. Add GPU which is to be used for passthrough via `system.advanced` namespace
2. Create PCI devices for the GPU in question based on PCI devices it is consuming and any other which fall in the same iommu group (this happens during VM creation wizard)

For (2), we have an endpoint `vm.device.get_pci_ids_for_gpu_isolation` which UI should be consuming to find out PCI devices which should be created when user says he wants X GPU to be added to a VM.

For (1) however, UI was consuming the same endpoint and passing it's return argument to `system.advanced.update` which was bound to fail.
A new endpoint has been added `system.advanced.get_gpu_pci_choices` which basically does the parsing UI was already doing at the moment and gives values which UI should be passing on for each GPU which is selected to `system.advanced.update_gpu_pci_ids` along with unit tests to ensure consistent behavior.

Original PR: https://github.com/truenas/middleware/pull/13250
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127357