### PR TITLE
NAS-127942 / 13.3 / Update wsdd configuration for version in Samba 4.19

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/wsdd.conf
+++ b/src/middlewared/middlewared/etc_files/local/wsdd.conf
@@ -1,11 +1,26 @@
 <%
     import json
+    import os
+
+    enabled = middleware.call_sync('network.configuration.config')['service_announcement']['wsd']
+    smb_config = middleware.call_sync('smb.config')
+
+    # We use bindip_choices because this is cluster-aware and will give ctdb public IPs
+    interfaces = smb_config['bindip'] or list(middleware.call_sync('smb.bindip_choices').values())
 
     conf = {
-        "realm": middleware.call_sync('smb.getparm', 'realm', 'GLOBAL'),
-        "netbios_name": middleware.call_sync('smb.getparm', 'netbios name', 'GLOBAL'),
-        "workgroup": middleware.call_sync('smb.getparm', 'workgroup', 'GLOBAL'),
-        "enabled": middleware.call_sync('network.configuration.config')['service_announcement']['wsd']
+        'realm': middleware.call_sync('smb.getparm', 'realm', 'GLOBAL'),
+        'netbios_name': smb_config['netbiosname_local'],
+        'workgroup': smb_config['workgroup'],
+        'interfaces': interfaces,
+        'enabled': middleware.call_sync('network.configuration.config')['service_announcement']['wsd']
     }
+
+    try:
+        os.chown('/var/log/wsdd.log', 1, 1)
+    except FileNotFoundError:
+        with open('/var/log/wsdd.log', 'w') as f:
+            os.fchown(f.fileno(), 1, 1)
+
 %>
 ${json.dumps(conf)}


### PR DESCRIPTION
wsdd fails to start in TrueNAS 13.3 due to configuration file differences.