### PR TITLE
NAS-127947 / 24.04.0 / Handle misconfigured AD idmap backends better in acltemplate (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -217,11 +217,11 @@ class ACLTemplateService(CRUDService):
         ])
         has_bu = bool([x['id'] for x in data['acl'] if x['id'] == bu_id])
         if has_bu:
-            du = idmaps['mapped'][domain_users_sid]
+            du = idmaps['mapped'].get(domain_users_sid)
         else:
             du = {'id': -1}
 
-        da = idmaps['mapped'][domain_admins_sid]
+        da = idmaps['mapped'].get(domain_admins_sid)
         if du is None:
             self.logger.warning(
                 "Failed to resolve the Domain Users group to a Unix ID. This most likely "


### PR DESCRIPTION
When we generate template ACLs for users, we have option to include domain users and domain admins groups into the template return.

If idmap settings are misconfigured or someone has removed mappings for these default AD groups, then we need to warn but not crash.

Original PR: https://github.com/truenas/middleware/pull/13393
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127947