### PR TITLE
NAS-127956 / 24.10 / Silence some syslog DEBUG spam from passlib.utils.compat

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -20,6 +20,7 @@ logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 # registered 'pbkdf2_sha256' handler: <class 'passlib.handlers.pbkdf2.pbkdf2_sha256'>
 logging.getLogger('passlib.registry').setLevel(logging.INFO)
 logging.getLogger('passlib.handlers').setLevel(logging.INFO)
+logging.getLogger('passlib.utils.compat').setLevel(logging.INFO)
 # pyroute2.ndb is chatty....only log errors
 logging.getLogger('pyroute2.ndb').setLevel(logging.CRITICAL)
 logging.getLogger('pyroute2.netlink').setLevel(logging.CRITICAL)


### PR DESCRIPTION
Avoid some log spam.

Found the following was occurring in syslog on DF and EE
```
Mar 21 18:07:06 truenas middlewared[14820]: [2024/03/21 18:07:06] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'SafeConfigParser': <class 'configparser.ConfigParser'>
Mar 21 18:07:06 truenas middlewared[14820]: [2024/03/21 18:07:06] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'NativeStringIO': <class '_io.StringIO'>
Mar 21 18:07:06 truenas middlewared[14820]: [2024/03/21 18:07:06] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'BytesIO': <class '_io.BytesIO'>
Mar 21 18:07:07 truenas middlewared[14855]: [2024/03/21 18:07:07] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'SafeConfigParser': <class 'configparser.ConfigParser'>
Mar 21 18:07:07 truenas middlewared[14855]: [2024/03/21 18:07:07] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'NativeStringIO': <class '_io.StringIO'>
Mar 21 18:07:07 truenas middlewared[14855]: [2024/03/21 18:07:07] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'BytesIO': <class '_io.BytesIO'>
Mar 21 18:08:17 truenas middlewared[16727]: [2024/03/21 18:08:17] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'SafeConfigParser': <class 'configparser.ConfigParser'>
Mar 21 18:08:17 truenas middlewared[16727]: [2024/03/21 18:08:17] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'NativeStringIO': <class '_io.StringIO'>
Mar 21 18:08:17 truenas middlewared[16727]: [2024/03/21 18:08:17] (DEBUG) passlib.utils.compat.__getattr__():449 - loaded lazy attr 'BytesIO': <class '_io.BytesIO'>
```

Whoever reviews, please let me know if you disagree with the backport.