### PR TITLE
NAS-127967 / 13.3 / Adjust ix.rc.d scripts for new rc.subr

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-bsdloader
+++ b/src/freenas/etc/ix.rc.d/ix-bsdloader
@@ -54,7 +54,7 @@ q
 EOF
 }
 
-name="ix-bsdloader"
+name="ix_bsdloader"
 start_cmd='migrate_bsd_loader'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-chelsio
+++ b/src/freenas/etc/ix.rc.d/ix-chelsio
@@ -18,7 +18,7 @@ if sysctl dev.cxl > /dev/null 2>&1 ; then
 fi
 }
 
-name="ix-chelsio"
+name="ix_chelsio"
 start_cmd='set_sysctl'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -44,7 +44,7 @@ generate_etc()
 	killall -ALRM sh
 }
 
-name="ix-etc"
+name="ix_etc"
 start_cmd='generate_etc'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-kinit
+++ b/src/freenas/etc/ix.rc.d/ix-kinit
@@ -30,7 +30,7 @@ kerberos_renew()
 	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call kerberos.renew > /dev/null
 }
 
-name="ix-kinit"
+name="ix_kinit"
 start_cmd='kerberos_start'
 status_cmd='kerberos_status'
 stop_cmd='kerberos_stop'

--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -236,7 +236,7 @@ netif_start()
 	fi
 }
 
-name="ix-netif"
+name="ix_netif"
 start_cmd='netif_start'
 stop_cmd=':'
 status_cmd=':'

--- a/src/freenas/etc/ix.rc.d/ix-nfsbind
+++ b/src/freenas/etc/ix.rc.d/ix-nfsbind
@@ -16,7 +16,7 @@ nfs_bindip() {
 	/usr/local/bin/midclt call etc.generate rc > /dev/null
 }
 
-name="ix-nfsbind"
+name="ix_nfsbind"
 start_cmd='nfs_bindip'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-nsswitch
+++ b/src/freenas/etc/ix.rc.d/ix-nsswitch
@@ -20,7 +20,7 @@ generate_nsswitch_stop()
 	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate nss > /dev/null
 }
 
-name="ix-nsswitch"
+name="ix_nsswitch"
 start_cmd='generate_nsswitch_start'
 stop_cmd='generate_nsswitch_stop'
 

--- a/src/freenas/etc/ix.rc.d/ix-preinit
+++ b/src/freenas/etc/ix.rc.d/ix-preinit
@@ -14,7 +14,7 @@ do_preinit()
 	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks PREINIT > /dev/null 2>&1
 }
 
-name="ix-preinit"
+name="ix_preinit"
 start_cmd='do_preinit'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-savehostid
+++ b/src/freenas/etc/ix.rc.d/ix-savehostid
@@ -24,7 +24,7 @@ ix_save_hostid()
 	fi
 }
 
-name="ix-savehostid"
+name="ix_savehostid"
 start_cmd='ix_save_hostid'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-sed
+++ b/src/freenas/etc/ix.rc.d/ix-sed
@@ -20,7 +20,7 @@ unlock_drives()
 	fi
 }
 
-name="ix-sed"
+name="ix_sed"
 start_cmd='unlock_drives'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -16,7 +16,7 @@ do_shutdown()
 	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks SHUTDOWN > /dev/null 2>&1
 }
 
-name="ix-shutdown"
+name="ix_shutdown"
 start_cmd=':'
 stop_cmd='do_shutdown'
 

--- a/src/freenas/etc/ix.rc.d/ix-syncdisks
+++ b/src/freenas/etc/ix.rc.d/ix-syncdisks
@@ -15,7 +15,7 @@ syncdisks()
 	/usr/local/bin/midclt call --job true --job-print description disk.sync_all > /dev/null
 }
 
-name="ix-syncdisks"
+name="ix_syncdisks"
 start_cmd='syncdisks'
 stop_cmd=''
 

--- a/src/freenas/etc/ix.rc.d/ix-syncmultipaths
+++ b/src/freenas/etc/ix.rc.d/ix-syncmultipaths
@@ -17,7 +17,7 @@ syncmultipaths()
 	fi
 }
 
-name="ix-syncmultipaths"
+name="ix_syncmultipaths"
 start_cmd='syncmultipaths'
 stop_cmd=''
 

--- a/src/freenas/etc/ix.rc.d/ix-update
+++ b/src/freenas/etc/ix.rc.d/ix-update
@@ -163,7 +163,7 @@ db_update()
 	reboot
 }
 
-name="ix-update"
+name="ix_update"
 start_cmd='db_update'
 stop_cmd=':'
 

--- a/src/freenas/etc/ix.rc.d/ix-zfs
+++ b/src/freenas/etc/ix.rc.d/ix-zfs
@@ -14,7 +14,7 @@ import_zpools()
 	/usr/local/bin/midclt call -job --job-print description pool.import_on_boot > /dev/null
 }
 
-name="ix-zfs"
+name="ix_zfs"
 start_cmd='import_zpools'
 stop_cmd=':'
 


### PR DESCRIPTION
Upstream FreeBSD changes to rc.subr break parsing of rc scripts that have name variable containing a minus sign `-` in subtle ways.