### PR TITLE
NAS-127969 / 13.3 / Fail test run if pool not created

### DIFF
--- a/tests/api2/test_008_pool.py
+++ b/tests/api2/test_008_pool.py
@@ -6,7 +6,7 @@ import os
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import POST, GET, wait_on_job
+from functions import fail, POST, GET, wait_on_job
 from auto_config import pool_name, ha
 
 IMAGES = {}
@@ -59,10 +59,14 @@ def test_04_creating_a_pool(pool_data):
         }
     }
     results = POST("/pool/", payload)
-    assert results.status_code == 200, results.text
+    if results.status_code != 200:
+        fail(f'Failed to start job to create first pool: {results.text}')
+
     job_id = results.json()
     job_status = wait_on_job(job_id, 180)
-    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+    if job_status['state'] != 'SUCCESS':
+        fail(f'Failed to create first pool: {job_status["results"]}')
+
     pool_data['id'] = job_status['results']['result']['id']
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from functions import failed
+
+
+@pytest.fixture(autouse=True)
+def fail_fixture():
+    if failed[0] is not None:
+        pytest.exit(failed[0], 1)

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -26,6 +26,8 @@ header = {'Content-Type': 'application/json', 'Vary': 'accept'}
 global authentication
 authentication = (user, password)
 
+failed = [None]
+
 
 def GET(testpath, payload=None, controller_a=False, **optional):
     data = {} if payload is None else payload
@@ -314,3 +316,13 @@ def make_ws_request(ip, payload):
     payload.update({'id': id})
     ws.send(json.dumps(payload))
     return json.loads(ws.recv())
+
+
+def fail(reason):
+    """
+    Prematurely abort the whole test suite execution, failing the test where this function is called
+    (as opposed to just using `pytest.exit` which will not fail the test, and, if no previous tests failed, junit
+    Jenkins plugin will display the test suite as green)
+    """
+    failed[0] = reason
+    assert False, reason


### PR DESCRIPTION
There's not really any point to proceeding with tests if our attempt to create a pool fails.