### PR TITLE
NAS-127970 / 24.04.0 / Fix directory services initialization

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/cache.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/cache.py
@@ -136,6 +136,7 @@ class ActiveDirectoryService(Service):
                 'local': False,
                 'id_type_both': u['domain_info']['idmap_backend'] in id_type_both_backends,
                 'nt_name': user_data.pw_name,
+                'smb': True,
                 'sid': u['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
@@ -157,6 +158,7 @@ class ActiveDirectoryService(Service):
                 'local': False,
                 'id_type_both': g['domain_info']['idmap_backend'] in id_type_both_backends,
                 'nt_name': group_data.gr_name,
+                'smb': True,
                 'sid': g['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -359,6 +359,7 @@ class DirectoryServices(Service):
         on it. It's better to just do a quick lookup of the
         single value.
         """
+        ha_mode = self.middleware.call_sync('smb.get_smb_ha_mode')
         with DirectorySecrets(logger=self.logger, ha_mode=ha_mode) as s:
             rv = s.has_domain(domain)
 

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1200,6 +1200,7 @@ class IdmapDomainService(CRUDService):
             'sshpubkey': None,
             'local': False,
             'id_type_both': idmap_info[1],
+            'smb': True,
             'sid': sid
         }
 
@@ -1223,6 +1224,7 @@ class IdmapDomainService(CRUDService):
             'users': [],
             'local': False,
             'id_type_both': idmap_info[1],
+            'smb': True,
             'sid': sid
         }
 

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1098,6 +1098,7 @@ class LDAPService(ConfigService):
                 'local': False,
                 'id_type_both': False,
                 'nt_name': None,
+                'smb': True,
                 'sid': None,
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
@@ -1116,6 +1117,7 @@ class LDAPService(ConfigService):
                 'local': False,
                 'id_type_both': False,
                 'nt_name': None,
+                'smb': True,
                 'sid': None,
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)

--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -272,7 +272,6 @@ class ShareSec(CRUDService):
                 continue
 
             if share_acl[0] != s['share_acl']:
-                self.logger.debug('Updating stored copy of SMB share ACL on %s', share_name)
                 await self.middleware.call(
                     'datastore.update',
                     'sharing.cifs_share',

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -280,6 +280,8 @@ def test_07_enable_leave_activedirectory(request):
         assert res['result'][0]['ds_groups'][0]['sid'].endswith('512')
         assert res['result'][0]['allowlist'][0] == {'method': '*', 'resource': '*'}
 
+        assert call('directoryservices.secrets_has_domain', 'AD02')
+
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'DISABLED', results.text
@@ -299,6 +301,8 @@ def test_07_enable_leave_activedirectory(request):
     error = res.get('error')
     assert error is None, str(error)
     assert len(res['result']) == 0, str(res['result'])
+
+    assert call('directoryservices.secrets_has_domain', 'AD02') is False
 
 
 def test_08_activedirectory_smb_ops(request):


### PR DESCRIPTION
This method was broken during removal of clustering from product, which was followed by significant refactor of directoryservices plugin for ElectricEel and so regression wasn't caught. Fix bug and add test.