### PR TITLE
NAS-127970 / Fix user + group choices share ACL

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory_/cache.py
+++ b/src/middlewared/middlewared/plugins/activedirectory_/cache.py
@@ -136,6 +136,7 @@ class ActiveDirectoryService(Service):
                 'local': False,
                 'id_type_both': u['domain_info']['idmap_backend'] in id_type_both_backends,
                 'nt_name': user_data.pw_name,
+                'smb': True,
                 'sid': u['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
@@ -157,6 +158,7 @@ class ActiveDirectoryService(Service):
                 'local': False,
                 'id_type_both': g['domain_info']['idmap_backend'] in id_type_both_backends,
                 'nt_name': group_data.gr_name,
+                'smb': True,
                 'sid': g['sid'],
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1202,6 +1202,7 @@ class IdmapDomainService(CRUDService):
             'sshpubkey': None,
             'local': False,
             'id_type_both': idmap_info[1],
+            'smb': True,
             'sid': sid
         }
 
@@ -1225,6 +1226,7 @@ class IdmapDomainService(CRUDService):
             'users': [],
             'local': False,
             'id_type_both': idmap_info[1],
+            'smb': True,
             'sid': sid
         }
 

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -1084,6 +1084,7 @@ class LDAPService(ConfigService):
                 'local': False,
                 'id_type_both': False,
                 'nt_name': None,
+                'smb': True,
                 'sid': None,
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'USER', entry)
@@ -1102,6 +1103,7 @@ class LDAPService(ConfigService):
                 'local': False,
                 'id_type_both': False,
                 'nt_name': None,
+                'smb': True,
                 'sid': None,
             }
             self.middleware.call_sync('dscache.insert', self._config.namespace.upper(), 'GROUP', entry)


### PR DESCRIPTION
Refactoring work related to choices for SMB share ACL users and groups revealed a long-standing bug whereby `smb` key was omitted from objects from directory services.