### PR TITLE
NAS-127981 / 24.10 / Restrict changes to SMB aux parameters to FULL_ADMIN

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1012,7 +1012,7 @@ class SharingSMBService(SharingService):
         if app and not credential_has_full_admin(app.authenticated_credentials):
             if data['auxsmbconf']:
                 verrors.add(
-                    'smb_update.smb_options',
+                    'smb_update.auxsmbconf',
                     'Changes to auxiliary parameters for SMB shares are restricted '
                     'to users with full administrative privileges.'
                 )
@@ -1087,7 +1087,7 @@ class SharingSMBService(SharingService):
         if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['auxsmbconf'] != new['auxsmbconf']:
                 verrors.add(
-                    'smb_update.smb_options',
+                    'smb_update.auxsmbconf',
                     'Changes to auxiliary parameters for SMB shares are restricted '
                     'to users with full administrative privileges.'
                 )

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -813,7 +813,7 @@ class SMBService(ConfigService):
                                 'If it must be changed, the proper procedure is to leave the AD domain '
                                 'and then alter the parameter before re-joining the domain.')
 
-        if app and not credential_has_full_admin(app->authenticated_user):
+        if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['smb_options'] != new['smb_options']:
                 verrors.add(
                     'smb_update.smb_options',
@@ -1009,7 +1009,7 @@ class SharingSMBService(SharingService):
 
         verrors = ValidationErrors()
 
-        if app and not credential_has_full_admin(app->authenticated_user):
+        if app and not credential_has_full_admin(app.authenticated_credentials):
             if data['auxsmbconf']:
                 verrors.add(
                     'smb_update.smb_options',
@@ -1084,7 +1084,7 @@ class SharingSMBService(SharingService):
         await self.legacy_afp_check(new, 'sharingsmb_update', verrors)
         check_mdns = False
 
-        if app and not credential_has_full_admin(app->authenticated_user):
+        if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['auxsmbconf'] != new['auxsmbconf']:
                 verrors.add(
                     'smb_update.smb_options',

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -18,7 +18,7 @@ from middlewared.schema import Path as SchemaPath
 # List schema defaults to [], supplying NOT_PROVIDED avoids having audit update that
 # defaults for ignore_list or watch_list from overrwriting previous value
 from middlewared.schema.utils import NOT_PROVIDED
-from middlewared.service import accepts, job, private, SharingService
+from middlewared.service import accepts, job, pass_app, private, SharingService
 from middlewared.service import ConfigService, ValidationErrors, filterable
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.plugins.smb_.smbconf.reg_global_smb import LOGLEVEL_MAP

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -1,6 +1,17 @@
 import pytest
 
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.roles import common_checks
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(scope='module')
+def create_dataset():
+    with dataset('smb_roles_test') as ds:
+        yield ds
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_SMB_READ"])
@@ -33,3 +44,27 @@ def test_write_role_can_write(role):
     common_checks("service.restart", role, True, method_args=["cifs"], valid_role_exception=False)
     common_checks("service.reload", role, True, method_args=["cifs"], valid_role_exception=False)
     common_checks("service.stop", role, True, method_args=["cifs"], valid_role_exception=False)
+
+
+@pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])
+def test_auxsmbconf_rejected_create(create_dataset, role):
+    share = None
+    with unprivileged_user_client(roles=[role]) as c:
+        with pytest.raises(ValidationErrors) as ve:
+            try:
+                share = c.call('sharing.smb.create', {
+                    'name': 'FAIL',
+                    'path': f'/mnt/{create_dataset}',
+                    'auxsmbconf': 'test:param = CANARY'
+                })
+            finally:
+                if share:
+                    call('sharing.smb.delete', share['id'])
+
+
+@pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])
+def test_auxsmbconf_rejected_update(create_dataset, role):
+    with smb_share(f'/mnt/{create_dataset}', 'FAIL') as share:
+        with unprivileged_user_client(roles=[role]) as c:
+            with pytest.raises(ValidationErrors):
+                c.call('sharing.smb.update', share['id'], {'auxsmbconf': 'test:param = Bob'})


### PR DESCRIPTION
There are various parameters in which the administrator can provide arbitrary commands and scripts to run via auxiliary parameters, some of which may be executed as the root user. This can present a risk of a limited administrator accidentally or intentionally performing actions on the NAS with privileges that are higher than intended.