### PR TITLE
NAS-127900 / 24.10 / Fix CPU temperature unit label

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -347,7 +347,7 @@ class UPSLoadPlugin(UPSBase):
 class UPSTemperaturePlugin(UPSBase):
 
     title = 'UPS Temperature'
-    vertical_label = 'Temperature'
+    vertical_label = 'Celsius'
     skip_zero_values_in_aggregation = True
     uses_identifiers = False
 


### PR DESCRIPTION
## Context
Currently the word `Temperature` exists on the Y axis/label for the UPS Temperature graph. PR adds the change to update label to reflect correct temperature unit i.e Celsius.