### PR TITLE
NAS-128021 / 13.3 / Fix collectd-daemon RC script

### DIFF
--- a/src/freenas/usr/local/etc/rc.d/collectd-daemon
+++ b/src/freenas/usr/local/etc/rc.d/collectd-daemon
@@ -27,8 +27,7 @@ pidfile=${collectd_daemon_pidfile:="/var/run/collectd-daemon.pid"}
 command="/usr/sbin/daemon"
 
 start_cmd=collectd_daemon_start
-stop_precmd=collectd_daemon_pre_stop
-stop_postcmd=collectd_daemon_post_stop
+stop_cmd=collectd_daemon_stop
 
 collectd_daemon_start()
 {
@@ -36,20 +35,43 @@ collectd_daemon_start()
 	$command -f -p /var/run/collectd.pid -P /var/run/collectd-daemon.pid -r -R 60 /usr/local/sbin/collectd -f
 }
 
-collectd_daemon_pre_stop()
+collectd_daemon_stop()
 {
-    collectd_pid=$(cat /var/run/collectd.pid 2> /dev/null)
-    return 0
-}
+    local collectd_pid d_pid
 
-collectd_daemon_post_stop()
-{
-    if [ -z "$collectd_pid"  ]; then
-        return 0
+    collectd_pid="$(check_pidfile "/var/run/collectd.pid" "/usr/local/sbin/collectd")"
+    d_pid="$(check_pidfile ${pidfile} ${command})"
+
+    debug "collectd pid: ${collectd_pid}"
+    debug "collectd-daemon pid: ${d_pid}"
+
+    echo "stopping collectd-daemon pids: ${d_pid} ${collectd_pid}"
+    if [ -n "$collectd_pid" ]; then
+        if [ -n "${d_pid}" ]; then
+            # This is the normal situation both processes are running
+	    # and we can kill send SIGTERM to the daemon process and it
+	    # will pass along to the collectd process
+            debug "killing daemon process: ${d_pid}"
+            kill -TERM "${d_pid}"
+	else
+	    # We have a collectd process, but no associated collectd-daemon
+	    # process. Stop it.
+            echo "killing orphaned collectd process ${collectd_pid}"
+	    kill -TERM "${collectd_pid}"
+	fi
+    elif [ -n "${d_pid}" ]; then
+	# We have a daemon process, but the process its monitoring has already died
+	# Send SIGKILL to prevent it from waiting long enough to try to restart the
+	# collectd process (in the best situation) or hanging forever (in worst case).
+        debug "killing: ${d_pid}"
+        kill -KILL "${d_pid}"
+    else
+	echo "collectd-daemon is already stopped"
+	return 0
     fi
 
-    echo "Waiting for collectd to terminate."
-    wait_for_pids "$collectd_pid"
+    wait_for_pids "$collectd_pid" "$d_pid"
+    return $?
 }
 
 run_rc_command "$1"

--- a/src/freenas/usr/local/etc/rc.d/collectd-daemon
+++ b/src/freenas/usr/local/etc/rc.d/collectd-daemon
@@ -66,7 +66,7 @@ collectd_daemon_stop()
         debug "killing: ${d_pid}"
         kill -KILL "${d_pid}"
     else
-	echo "collectd-daemon is already stopped"
+	debug "collectd-daemon is already stopped"
 	return 0
     fi
 

--- a/tests/api2/test_007_systemdataset.py
+++ b/tests/api2/test_007_systemdataset.py
@@ -121,7 +121,7 @@ def test_05_verify_the_first_pool_created_become_sysds(request, pool_data):
     assert results.status_code == 200, results.text
     job_id = results.json()
     job_status = wait_on_job(job_id, 180)
-    if job_status['state'] != SUCCESS:
+    if job_status['state'] != 'SUCCESS':
         fail(f'Failed to create first pool: {job_status["state"]}: {job_status["results"]}')
 
     pool_data['first_pool'] = job_status['results']['result']


### PR DESCRIPTION
There are various combinations of running state for the daemon
process monitoring the collectd process and the process that it
is monitoring. In some pathological cases the original script
could hang for up to 60 seconds on 13.0 and indefinitely in 13.3

This commit addresses the problem by doing the following:

* consolidates the pre-stop and post-stop functions into a single
  stop function

* convert the rc script to use standard rc.subr functions to get pids

* validate that have pids we're trying to wait for

* Send a SIGKILL instead of SIGTERM to daemon process if the monitored
  process has gone away.