### PR TITLE
NAS-128040 / 24.04.0 / Fix aux parameter comment parsing in services->SMB (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -24,6 +24,7 @@ from middlewared.service import accepts, job, private, SharingService
 from middlewared.service import ConfigService, ValidationErrors, filterable
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.plugins.smb_.smbconf.reg_global_smb import LOGLEVEL_MAP
+from middlewared.plugins.smb_.utils import smb_strip_comments
 from middlewared.plugins.tdb.utils import TDBError
 from middlewared.plugins.idmap_.utils import IDType, SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX
 import middlewared.sqlalchemy as sa
@@ -828,7 +829,8 @@ class SMBService(ConfigService):
         )
 
         new_config = await self.config()
-        await self.middleware.call('smb.reg_update', new_config)
+        stripped_options = smb_strip_comments(new_config['smb_options'])
+        await self.middleware.call('smb.reg_update', new_config | {'smb_options': stripped_options})
         await self.reset_smb_ha_mode()
 
         """
@@ -911,16 +913,6 @@ class SharingSMBService(SharingService):
         role_prefix = 'SHARING_SMB'
 
     LP_CTX = param.LoadParm(SMBPath.STUBCONF.platform())
-
-    @private
-    async def strip_comments(self, data):
-        parsed_config = ""
-        for entry in data['auxsmbconf'].splitlines():
-            if entry == "" or entry.startswith(('#', ';')):
-                continue
-            parsed_config += entry if len(parsed_config) == 0 else f'\n{entry}'
-
-        data['auxsmbconf'] = parsed_config
 
     @accepts(
         Dict(
@@ -1016,7 +1008,7 @@ class SharingSMBService(SharingService):
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
 
-        await self.strip_comments(data)
+        data['auxsmbconf'] = smb_strip_comments(data['auxsmbconf'])
         await self.middleware.call('sharing.smb.reg_addshare', data)
         do_global_reload = await self.must_reload_globals(data)
 
@@ -1084,7 +1076,7 @@ class SharingSMBService(SharingService):
             'datastore.update', self._config.datastore, id_, new,
             {'prefix': self._config.datastore_prefix})
 
-        await self.strip_comments(new)
+        new['auxsmbconf'] = smb_strip_comments(new['auxsmbconf'])
         if not new_is_locked:
             """
             Enabling AAPL SMB2 extensions globally affects SMB shares. If this

--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -3,6 +3,7 @@ from middlewared.service_exception import CallError
 from middlewared.plugins.smb_.smbconf.reg_global_smb import GlobalSchema
 from middlewared.plugins.activedirectory import AD_SMBCONF_PARAMS
 from middlewared.plugins.ldap import LDAP_SMBCONF_PARAMS
+from .utils import smb_strip_comments
 
 import errno
 
@@ -156,4 +157,5 @@ class SMBService(Service):
     @private
     async def initialize_globals(self):
         data = await self.middleware.call('smb.config')
+        data['smb_options'] = smb_strip_comments(data['smb_options'])
         await self.reg_update(data)

--- a/src/middlewared/middlewared/plugins/smb_/utils.py
+++ b/src/middlewared/middlewared/plugins/smb_/utils.py
@@ -1,0 +1,12 @@
+def smb_strip_comments(auxparam_in):
+    parsed_config = ""
+    for entry in auxparam_in.splitlines():
+        if entry == "" or entry.startswith(('#', ';')):
+            continue
+
+        # For some reason user may have added more comments after the value
+        # For example "socket options = IPTOS_LOWDELAY # I read about this on the internet"
+        entry = entry.split("#")[0].strip()
+        parsed_config += entry if len(parsed_config) == 0 else f'\n{entry}'
+
+    return parsed_config

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -40,6 +40,30 @@ SAMPLE_AUX = [
     'hide dot files = yes',
 ]
 
+SAMPLE_OPTIONS = [
+    'mangled names = no',
+    'dos charset = CP850',
+    'unix charset = UTF-8',
+    'strict sync = no',
+    '',
+    'min protocol = SMB2',
+    'vfs objects = fruit streams_xattr  ',
+    'fruit:model = MacSamba', 'fruit:posix_rename = yes ',
+    'fruit:veto_appledouble = no',
+    'fruit:wipe_intentionally_left_blank_rfork = yes ',
+    'fruit:delete_empty_adfiles = yes ',
+    '',
+    'fruit:locking=none',
+    'fruit:metadata=netatalk',
+    'fruit:resource=file',
+    'streams_xattr:prefix=user.',
+    'streams_xattr:store_stream_type=no',
+    'strict locking=auto',
+    '# oplocks=no  # breaks Time Machine',
+    ' level2 oplocks=no  #  breaks TM?',
+    '# spotlight=yes  # invalid without further config'
+]
+
 
 @contextlib.contextmanager
 def create_smb_share(share_name, mkdir=False, options=None):
@@ -346,3 +370,11 @@ def test_022_registry_rebuild_homes(request):
     call('service.reload', 'cifs')
     reg_shares = call('sharing.smb.reg_listshares')
     assert any(['homes'.casefold() == s.casefold() for s in reg_shares]), str(reg_shares)
+
+
+def test_023_test_smb_options():
+    """
+    Validate that user comments are preserved as-is
+    """
+    new_config = call('smb.update', {'smb_options': '\n'.join(SAMPLE_OPTIONS)})
+    assert new_config['smb_options'].splitlines() == SAMPLE_OPTIONS


### PR DESCRIPTION
Since the initial angelfish release in order to facilitate SMB clustering we have stored Samba's global section (services->SMB) in the samba registry via libsmbconf. 

Libsmbconf is more strict at validation of what gets written in the configuration. Some core users have copious smb_options with many comments in them. This shifts the function that was used for stripping comments from auxiliary parameters from sharing.smb to a utility function for consumption by both sharing.smb and services.smb.

Original PR: https://github.com/truenas/middleware/pull/13420
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128040