### PR TITLE
NAS-128058 / 13.3 / Set low winbind request timeout for standalone severs

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -271,6 +271,7 @@
             elif db['role'] == "standalone":
                 pc.update({'server role': 'standalone'})
                 pc.update({'workgroup': db['cifs']['workgroup'].upper()})
+                pc.update({'winbind request timeout': '2'})
 
             return pc
 


### PR DESCRIPTION
Standalone servers should never have winbindd hang for a significant length of time. Aggressively time out winbind ops in case for some reason nsswitch has winbind in it.

This backports change from SCALE.