### PR TITLE
NAS-127981 / 24.04.0 / Restrict changes to SMB aux parameters to FULL_ADMIN (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -20,7 +20,7 @@ from middlewared.schema import Path as SchemaPath
 # List schema defaults to [], supplying NOT_PROVIDED avoids having audit update that
 # defaults for ignore_list or watch_list from overrwriting previous value
 from middlewared.schema.utils import NOT_PROVIDED
-from middlewared.service import accepts, job, private, SharingService
+from middlewared.service import accepts, job, pass_app, private, SharingService
 from middlewared.service import ConfigService, ValidationErrors, filterable
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.plugins.smb_.smbconf.reg_global_smb import LOGLEVEL_MAP
@@ -31,6 +31,7 @@ import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list, osc, Popen, run, MIDDLEWARE_RUN_DIR
 from middlewared.utils.osc import getmnttree
 from middlewared.utils.path import FSLocation, path_location, is_child_realpath
+from middlewared.utils.privilege import credential_has_full_admin
 
 NETIF_COMPLETE_SENTINEL = f"{MIDDLEWARE_RUN_DIR}/ix-netif-complete"
 CONFIGURED_SENTINEL = '/var/run/samba/.configured'
@@ -768,7 +769,8 @@ class SMBService(ConfigService):
         Str('smb_options', max_length=None),
         update=True,
     ))
-    async def do_update(self, data):
+    @pass_app(rest=True)
+    async def do_update(self, app, data):
         """
         Update SMB Service Configuration.
 
@@ -816,6 +818,14 @@ class SMBService(ConfigService):
                                 'This parameter may not be changed after joining Active Directory (AD). '
                                 'If it must be changed, the proper procedure is to leave the AD domain '
                                 'and then alter the parameter before re-joining the domain.')
+
+        if app and not credential_has_full_admin(app.authenticated_credentials):
+            if old['smb_options'] != new['smb_options']:
+                verrors.add(
+                    'smb_update.smb_options',
+                    'Changes to auxiliary parameters for the SMB service are restricted '
+                    'to users with full administrative privileges.'
+                )
 
         await self.validate_smb(new, verrors)
         verrors.check()
@@ -950,7 +960,8 @@ class SharingSMBService(SharingService):
             register=True
         )
     )
-    async def do_create(self, data):
+    @pass_app(rest=True)
+    async def do_create(self, app, data):
         """
         Create a SMB Share.
 
@@ -995,6 +1006,14 @@ class SharingSMBService(SharingService):
 
         verrors = ValidationErrors()
 
+        if app and not credential_has_full_admin(app.authenticated_credentials):
+            if data['auxsmbconf']:
+                verrors.add(
+                    'smb_update.auxsmbconf',
+                    'Changes to auxiliary parameters for SMB shares are restricted '
+                    'to users with full administrative privileges.'
+                )
+
         await self.add_path_local(data)
         await self.validate(data, 'sharingsmb_create', verrors)
         await self.apply_presets(data)
@@ -1036,7 +1055,8 @@ class SharingSMBService(SharingService):
             ('attr', {'update': True})
         )
     )
-    async def do_update(self, id_, data):
+    @pass_app(rest=True)
+    async def do_update(self, app, id_, data):
         """
         Update SMB Share of `id`.
         """
@@ -1060,6 +1080,14 @@ class SharingSMBService(SharingService):
         await self.validate(new, 'sharingsmb_update', verrors, old=old)
         await self.legacy_afp_check(new, 'sharingsmb_update', verrors)
         check_mdns = False
+
+        if app and not credential_has_full_admin(app.authenticated_credentials):
+            if old['auxsmbconf'] != new['auxsmbconf']:
+                verrors.add(
+                    'smb_update.auxsmbconf',
+                    'Changes to auxiliary parameters for SMB shares are restricted '
+                    'to users with full administrative privileges.'
+                )
 
         verrors.check()
 


### PR DESCRIPTION
There are various parameters in which the administrator can provide arbitrary commands and scripts to run via auxiliary parameters, some of which may be executed as the root user. This can present a risk of a limited administrator accidentally or intentionally performing actions on the NAS with privileges that are higher than intended.

Original PR: https://github.com/truenas/middleware/pull/13406
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127981