### PR TITLE
NAS-129269 / 24.10 / Make rsyslog support IPv6 destinations

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -136,13 +136,13 @@ class SystemAdvancedService(ConfigService):
 
         syslog_server = data.get('syslogserver')
         if syslog_server:
-            match = re.match(r"^[\w\.\-]+(\:\d+)?$", syslog_server)
+            match = re.match(r"^\[?[\w\.\-\:\%]+\]?(\:\d+)?$", syslog_server)
             if not match:
                 verrors.add(
                     f'{schema}.syslogserver',
                     'Invalid syslog server format'
                 )
-            elif ':' in syslog_server:
+            elif ']:' in syslog_server or (':' in syslog_server and not ']' in syslog_server):
                 port = int(syslog_server.split(':')[-1])
                 if port < 0 or port > 65535:
                     verrors.add(


### PR DESCRIPTION
I noticed that the current rsyslog-ng implementation was buggy and didn't support IPv6 destinations. 

Entering an IPv6 IP as the syslog server failed due to input validation (both with the [] around the IP and without), and entering a hostname still only made it connect using IPv4. 

This PR should fix that issue. 

The regex for the input validation in the syslog server textbox has been changed to allow colons, percent signs and brackets [] as well which are needed for IPv6 adresses, and the template that creates the syslog-ng config has been modified to add the "ip-protocol(6) parameter. 

According to the documentation this parameter defaults to "4" making it only send data to IPv4 destinations, but setting it to "6" makes it support both IPv4 and IPv6 destinations, under the condition that the OS kernel supports IPv6 (i.e., a "ping6 ::1" must work, which is probably the case for all Truenas installations). 

My tests seem to confirm that, so with that change syslog-ng can send to both IPv4 and IPv6 destinations (both using a direct IP or using a hostname).