### PR TITLE
VMs: Consider ::1 a localhost IP as well

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1901,6 +1901,7 @@ class InterfaceService(CRUDService):
         if choices['loopback']:
             ignore_nics.remove('lo')
             static_ips['127.0.0.1'] = '127.0.0.1'
+            static_ips['::1'] = '::1'
 
         ignore_nics = tuple(ignore_nics)
         for iface in filter(lambda x: not x.orig_name.startswith(ignore_nics), list(netif.list_interfaces().values())):


### PR DESCRIPTION
Currently, the dropdown for the VMs Display bind address allows you to choose between 0.0.0.0 (all IPv4), :: (all IPv6) and 127.0.0.1 (localhost IPv4). ::1 (localhost IPv6) is not an option, so it's not possible to have a VM whose display is reachable over IPv6 but only from the local machine. 

This PR changes that, by making the code add "::1" to the list of loopback IPs in network.py as well, instead of just 127.0.0.1. 

Related to #13439 