### PR TITLE
NAS-123519 / 24.10 / Add globally unique system ID

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-03-21_12-15_add_global_system_id.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-03-21_12-15_add_global_system_id.py
@@ -1,0 +1,28 @@
+"""Add global system ID
+
+Revision ID: 14974a858948
+Revises: 7836261b2f64
+Create Date: 2024-03-21 12:15:50.886820+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '14974a858948'
+down_revision = '7836261b2f64'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'system_globalid',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('system_uuid', sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_system_globalid')),
+    )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-04-01_20-15_add_global_system_id.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-04-01_20-15_add_global_system_id.py
@@ -1,8 +1,8 @@
 """Add global system ID
 
 Revision ID: 14974a858948
-Revises: 7836261b2f64
-Create Date: 2024-03-21 12:15:50.886820+00:00
+Revises: 1a6fc6735dc2
+Create Date: 2024-04-01 20:15:50.886820+00:00
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '14974a858948'
-down_revision = '7836261b2f64'
+down_revision = '1a6fc6735dc2'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/migration/0009_system_global_id.py
+++ b/src/middlewared/middlewared/migration/0009_system_global_id.py
@@ -1,0 +1,10 @@
+import uuid
+
+
+async def migrate(middleware):
+    await middleware.call(
+        'datastore.insert',
+        'system.globalid', {
+            'system_uuid': str(uuid.uuid4())
+        }
+    )

--- a/src/middlewared/middlewared/plugins/system/globalid.py
+++ b/src/middlewared/middlewared/plugins/system/globalid.py
@@ -1,0 +1,33 @@
+import middlewared.sqlalchemy as sa
+
+from middlewared.schema import accepts, Dict, Int, returns, Str
+from middlewared.service import Service
+
+
+class SystemGlobalID(sa.Model):
+    __tablename__ = 'system_globalid'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    system_uuid = sa.Column(sa.String(32))
+
+
+class SystemGlobalIDService(Service):
+    class Config:
+        datastore_prefix = 'system_globalid'
+        namespace = 'system.global'
+        cli_namespace = 'system.global'
+
+    ENTRY = Dict(
+        'system_globalid_entry',
+        Int('id'),
+        Str('system_uuid', required=True),
+        register=True
+    )
+
+    @accepts(roles=['READONLY_ADMIN'])
+    @returns(Str('system_uuid'))
+    async def id(self):
+        """
+        Retrieve a 128 bit hexadecimal UUID value unique for each TrueNAS system.
+        """
+        return (await self.middleware.call('datastore.config', 'system.globalid'))['system_uuid']


### PR DESCRIPTION
### Context
We needed a way to uniquely identify ours systems with some IDs generated and store one time in the configuration database

### Solution
Added a new table in database which holds uuid4 value saved in it on initial install of the system or upgrade of the system.