### PR TITLE
NAS-128145 / 24.04.0 / Fix ups service not starting properly (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -17,8 +17,8 @@ class UPSService(SimpleService):
 
     async def start(self):
         if (await self.middleware.call("ups.config"))["mode"] == "MASTER":
-            await self._systemd_unit("nut-driver-enumerator", "start")
             await self._systemd_unit("nut-server", "start")
+            await self._systemd_unit("nut-driver-enumerator", "start")
         await self._unit_action("Start")
 
     async def before_stop(self):


### PR DESCRIPTION
This PR introduces changes to fix failing ups integration tests and fix the order in which UPS services should start.

Original PR: https://github.com/truenas/middleware/pull/13447
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128145