### PR TITLE
NAS-123721 / 24.10 / make runtest.py work with new jenkins

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -10,6 +10,7 @@ from middlewared.client import Client
 from middlewared.client.utils import undefined
 
 __all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url"]
+IS_HA = os.environ.get('SERVER_TYPE') == 'ENTERPRISE_HA'
 
 
 @contextlib.contextmanager
@@ -17,20 +18,31 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
     if auth is undefined:
         auth = ("root", password())
 
+    uri = host_websocket_uri(host_ip)
     try:
-        with Client(host_websocket_uri(host_ip), py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+        with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
             if auth is not None:
                 logged_in = c.call("auth.login", *auth)
                 if auth_required:
                     assert logged_in
             yield c
-    except socket.timeout:
-        fail('socket timeout')
+    except socket.timeout as e:
+        if IS_HA:
+            # don't fail the entire run on HA systems since
+            # we perform failovers to and from each controller
+            # so timeouts could happen (which are expected)
+            raise e from None
+        else:
+            fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
 
 
 def host():
     if "NODE_A_IP" in os.environ:
+        # this is not to be confused with HA systems
+        # as it should only be set on NON-HA environments
         return os.environ["NODE_A_IP"]
+    elif IS_HA:
+        return os.environ["virtual_ip"]
     else:
         return os.environ["MIDDLEWARE_TEST_IP"]
 

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -27,13 +27,7 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
                     assert logged_in
             yield c
     except socket.timeout as e:
-        if IS_HA:
-            # don't fail the entire run on HA systems since
-            # we perform failovers to and from each controller
-            # so timeouts could happen (which are expected)
-            raise e from None
-        else:
-            fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
+        fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
 
 
 def host():

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -13,17 +13,8 @@ from middlewared.test.integration.utils.client import client
 
 
 @pytest.fixture(scope='module')
-def ip_to_use():
-    ip_to_use = ip
-    if (ctrl1_ip := os.environ.get('controller1_ip')) is not None:
-        ip_to_use = ctrl1_ip
-
-    return ip_to_use
-
-
-@pytest.fixture(scope='module')
-def ws_client(ip_to_use):
-    with client(host_ip=ip_to_use) as c:
+def ws_client():
+    with client(host_ip=ip) as c:
         yield c
 
 
@@ -90,16 +81,16 @@ def test_004_enable_and_start_ssh(ws_client):
     assert ws_client.call('service.query', [['service', '=', 'ssh']], options)['state'] == 'RUNNING'
 
 
-def test_005_ssh_using_root_password(ip_to_use):
-    results = SSH_TEST('ls -la', user, password, ip_to_use)
+def test_005_ssh_using_root_password():
+    results = SSH_TEST('ls -la', user, password, ip)
     if not results['result']:
         fail(f"SSH is not usable: {results['output']}. Aborting tests.")
 
 
-def test_006_setup_and_login_using_root_ssh_key(ip_to_use):
+def test_006_setup_and_login_using_root_ssh_key():
     assert os.environ.get('SSH_AUTH_SOCK') is not None
     assert if_key_listed() is True  # horrible function name
-    results = SSH_TEST('ls -la', user, None, ip_to_use)
+    results = SSH_TEST('ls -la', user, None, ip)
     assert results['result'] is True, results['output']
 
 
@@ -119,8 +110,8 @@ def test_007_check_local_accounts(ws_client, account):
         fail(f'Group has unexpected name: {account["name"]} -> {entry["group"]}')
 
 
-def test_008_check_root_dataset_settings(ws_client, ip_to_use):
-    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password, ip_to_use)
+def test_008_check_root_dataset_settings(ws_client):
+    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password, ip)
     if not data['result']:
         fail(f'Unable to get dataset schema: {data["output"]}')
 
@@ -129,7 +120,7 @@ def test_008_check_root_dataset_settings(ws_client, ip_to_use):
     except Exception as e:
         fail(f'Unable to load dataset schema: {e}')
 
-    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password, ip_to_use)
+    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password, ip)
     if not data['result']:
         fail('Failed to determine whether developer mode enabled')
 

--- a/tests/api2/test_002_system_license.py
+++ b/tests/api2/test_002_system_license.py
@@ -2,31 +2,36 @@ import os
 import sys
 import time
 sys.path.append(os.getcwd())
-from auto_config import ha
+from auto_config import ip, ha, ha_license
 
 from middlewared.test.integration.utils import client
 
 # Only read the test on HA
 if ha:
     def test_apply_and_verify_license():
-        with client(host_ip=os.environ.get('controller1_ip', None)) as c:
-            with open(os.environ.get('license_file', '/root/license.txt')) as f:
-                # apply license
-                c.call('system.license_update', f.read())
+        with client(host_ip=ip) as c:
+            if ha_license:
+                _license_string = ha_license
+            else:
+                with open(os.environ.get('license_file', '/root/license.txt')) as f:
+                    _license_string = f.read()
 
-                # verify license is applied
-                assert c.call('failover.licensed') is True
+            # apply license
+            c.call('system.license_update', _license_string)
 
-                retries = 30
-                sleep_time = 1
-                for i in range(retries):
-                    if c.call('failover.call_remote', 'failover.licensed') is False:
-                        # we call a hook that runs in a background task
-                        # so give it a bit to propagate to other controller
-                        # furthermore, our VMs are...well...inconsistent to say the least
-                        # so sometimes this is almost instant while others I've 10+ secs
-                        time.sleep(sleep_time)
-                    else:
-                        break
+            # verify license is applied
+            assert c.call('failover.licensed') is True
+
+            retries = 30
+            sleep_time = 1
+            for i in range(retries):
+                if c.call('failover.call_remote', 'failover.licensed') is False:
+                    # we call a hook that runs in a background task
+                    # so give it a bit to propagate to other controller
+                    # furthermore, our VMs are...well...inconsistent to say the least
+                    # so sometimes this is almost instant while others I've 10+ secs
+                    time.sleep(sleep_time)
                 else:
-                    assert False, f'Timed out after {sleep_time * retries}s waiting on license to sync to standby'
+                    break
+            else:
+                assert False, f'Timed out after {sleep_time * retries}s waiting on license to sync to standby'

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -7,7 +7,7 @@ sys.path.append(apifolder)
 import pytest
 from pytest_dependency import depends
 
-from auto_config import ha, ip, pool_name
+from auto_config import ha, ip, vip, pool_name
 from middlewared.client.client import ValidationErrors
 from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import fail
@@ -55,7 +55,7 @@ def ws_client():
     # by the time this test is called in the pipeline,
     # the HA VM should have networking configured so
     # we can use the VIP
-    with client(host_ip=os.environ['virtual_ip'] if ha else ip) as c:
+    with client(host_ip=vip if ha else ip) as c:
         yield c
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,11 @@ import os
 
 import pytest
 
-pytest.register_assert_rewrite("middlewared.test")
-
-from middlewared.test.integration.utils import call
+from auto_config import ha, ip, vip
+from middlewared.test.integration.utils.client import client
 from middlewared.test.integration.utils.pytest import failed
+
+pytest.register_assert_rewrite("middlewared.test")
 
 
 @pytest.fixture(autouse=True)
@@ -17,20 +18,40 @@ def fail_fixture():
 
 @pytest.fixture(autouse=True)
 def log_test_name_to_middlewared_log(request):
-    client_kwargs_list = [dict(host_ip=os.environ.get('controller1_ip', None))]
-    if 'controller2_ip' in os.environ:
-        client_kwargs_list.append(dict(host_ip=os.environ['controller2_ip']))
+    # Beware that this is executed after session/package/module/class fixtures
+    # are applied so the logs will still not be exactly precise.
+    test_name = request.node.name
+    ip_to_use = ip
+    if ha and os.environ['USE_VIP'] == 'YES':
+        # this is set after the first few tests run that
+        # "setup" the prereqs for an HA system
+        ip_to_use = vip
 
-    for client_kwargs in client_kwargs_list:
-        # Beware that this is executed after session/package/module/class fixtures are applied so the logs will still
-        # not be exactly precise.
-        with contextlib.suppress(Exception):
-            call("test.notify_test_start", request.node.name, client_kwargs=client_kwargs)
+    with client(host_ip=ip_to_use) as c:
+        c.call("test.notify_test_start", test_name)
+        if ha:
+            # the CI suite does all kinds of things to the standby controller
+            # on HA systems, so we need to suppress connection errors here
+            with contextlib.suppress(Exception):
+                c.call(
+                    "failover.call_remote",
+                    "test.notify_test_start",
+                    [test_name],
+                )
 
     yield
 
-    for client_kwargs in client_kwargs_list:
-        # That's why we also notify test ends. What happens between a test end and the next test start is caused by
-        # session/package/module/class fixtures setup code.
-        with contextlib.suppress(Exception):
-            call("test.notify_test_end", request.node.name, client_kwargs=client_kwargs)
+    # That's why we also notify test ends. What happens between a test end
+    # and the next test start is caused by session/package/module/class
+    # fixtures setup code.
+    with client(host_ip=ip_to_use) as c:
+        c.call("test.notify_test_end", test_name)
+        if ha:
+            # the CI suite does all kinds of things to the standby controller
+            # on HA systems, so we need to suppress connection errors here
+            with contextlib.suppress(Exception):
+                c.call(
+                    "failover.call_remote",
+                    "test.notify_test_end",
+                    [test_name],
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,7 @@ def log_test_name_to_middlewared_log(request):
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_start", test_name)
         if ha:
-            # the CI suite does all kinds of things to the standby controller
-            # on HA systems, so we need to suppress connection errors here
-            with contextlib.suppress(Exception):
-                c.call(
-                    "failover.call_remote",
-                    "test.notify_test_start",
-                    [test_name],
-                )
+            c.call("failover.call_remote", "test.notify_test_start", [test_name])
 
     yield
 
@@ -50,8 +43,4 @@ def log_test_name_to_middlewared_log(request):
             # the CI suite does all kinds of things to the standby controller
             # on HA systems, so we need to suppress connection errors here
             with contextlib.suppress(Exception):
-                c.call(
-                    "failover.call_remote",
-                    "test.notify_test_end",
-                    [test_name],
-                )
+                c.call("failover.call_remote", "test.notify_test_end", [test_name])

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -189,9 +189,8 @@ def get_ipinfo(ip_to_use):
                     iface = i['id']
                     net = j['netmask']
                     for k in c.call('route.system_routes'):
-                        if k.get('network') == '0.0.0.0' and k.get('interface') == i['id']:
-                            if k['gateway']:
-                                return iface, net, k['gateway'], ns1, ns2
+                        if k.get('network') == '0.0.0.0' and k.get('gateway'):
+                            return iface, net, k['gateway'], ns1, ns2
 
     return iface, net, gate, ns1, ns2
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -4,7 +4,8 @@
 # License: BSD
 
 from middlewared.test.integration.utils import client
-from subprocess import call
+from ipaddress import ip_interface
+from subprocess import run, call
 from sys import argv, exit
 import os
 import getopt
@@ -39,10 +40,13 @@ Mandatory option
     --interface <interface>     - The interface that TrueNAS is run one
 
 Optional option
+    --ip2                       - B controller IPv4 of TrueNAS HA machine
+    --vip                       - VIP (ipv4) of TrueNAS HA machine
     --test <test name>          - Test name (Network, ALL)
     --tests <test1>[,test2,...] - List of tests to be supplied to pytest
     --vm-name <VM_NAME>         - Name the the Bhyve VM
     --ha                        - Run test for HA
+    --ha_license                - The base64 encoded string of an HA license
     --debug-mode                - Start API tests with middleware debug mode
     --isns_ip <###.###.###.###> - IP of the iSNS server (default: {isns_ip})
     --pool <POOL_NAME>          - Name of the ZFS pool (default: {pool_name})
@@ -55,6 +59,8 @@ if len(argv) == 1:
 
 option_list = [
     "ip=",
+    "ip2=",
+    "vip=",
     "password=",
     "interface=",
     'test=',
@@ -68,6 +74,9 @@ option_list = [
     "isns_ip=",
     "pool=",
     "tests=",
+    "ha_license=",
+    "hostname=",
+    "show_locals"
 ]
 
 # look if all the argument are there.
@@ -89,9 +98,19 @@ exitfirst = ''
 returncode = False
 callargs = []
 tests = []
+ip2 = vip = ''
+netmask = None
+gateway = None
+ha_license = ''
+hostname = None
+show_locals = False
 for output, arg in myopts:
     if output in ('-i', '--ip'):
         ip = arg
+    elif output == '--ip2':
+        ip2 = arg
+    elif output == '--vip':
+        vip = arg
     elif output in ('-p', '--password'):
         passwd = arg
     elif output in ('-I', '--interface'):
@@ -104,6 +123,8 @@ for output, arg in myopts:
         vm_name = f"'{arg}'"
     elif output == '--ha':
         ha = True
+    elif output == '--hostname':
+        hostname = arg
     elif output == '--update':
         update = True
     elif output == '--debug-mode':
@@ -125,6 +146,10 @@ for output, arg in myopts:
         callargs.append('-s')
     elif output == '--tests':
         tests.extend(arg.split(','))
+    elif output == '--ha_license':
+        ha_license = arg
+    elif output == '--show_locals':
+        show_locals = True
 
 if 'ip' not in locals() and 'passwd' not in locals() and 'interface' not in locals():
     print("Mandatory option missing!\n")
@@ -133,8 +158,9 @@ if 'ip' not in locals() and 'passwd' not in locals() and 'interface' not in loca
 
 # create random hostname and random fake domain
 digit = ''.join(secrets.choice((string.ascii_uppercase + string.digits)) for i in range(10))
-hostname = f'test{digit}'
-domain = f'test{digit}.nb.ixsystems.com'
+if not hostname:
+    hostname = f'test{digit}'
+domain = f'{hostname}.nb.ixsystems.com'
 artifacts = f"{workdir}/artifacts/"
 if not os.path.exists(artifacts):
     os.makedirs(artifacts)
@@ -143,20 +169,81 @@ os.environ["MIDDLEWARE_TEST_IP"] = ip
 os.environ["MIDDLEWARE_TEST_PASSWORD"] = passwd
 os.environ["SERVER_TYPE"] = "ENTERPRISE_HA" if ha else "STANDARD"
 
-ip_to_use = ip if not ha else os.environ['controller1_ip']
+ip_to_use = ip
+if ha and ip2:
+    domain = 'tn.ixsystems.com'
+    os.environ['controller1_ip'] = ip
+    os.environ['controller2_ip'] = ip2
 
-with client(host_ip=ip_to_use) as c:
-    interface = c.call(
-        'interface.query',
-        [['state.aliases.*.address', '=', socket.gethostbyname(ip_to_use)]],
-        {'get': True}
-    )['id']
+
+def get_ipinfo(ip_to_use):
+    iface = net = gate = ns1 = ns2 = None
+    with client(host_ip=ip_to_use) as c:
+        net_config = c.call('network.configuration.config')
+        ns1 = net_config.get('nameserver1')
+        ns2 = net_config.get('nameserver2')
+        _ip_to_use = socket.gethostbyname(ip_to_use)
+        for i in c.call('interface.query'):
+            for j in i['state']['aliases']:
+                if j.get('address') == _ip_to_use:
+                    iface = i['id']
+                    net = j['netmask']
+                    for k in c.call('route.system_routes'):
+                        if k.get('network') == '0.0.0.0' and k.get('interface') == i['id']:
+                            if k['gateway']:
+                                return iface, net, k['gateway'], ns1, ns2
+
+    return iface, net, gate, ns1, ns2
+
+interface, netmask, gateway, ns1, ns2 = get_ipinfo(ip_to_use)
+if not all((interface, netmask, gateway)):
+    print(f'Unable to determine interface ({interface!r}), netmask ({netmask!r}) and gateway ({gateway!r}) for {ip_to_use!r}')
+    exit()
+
+os.environ['USE_VIP'] = 'NO'
+if ha:
+    if vip:
+        os.environ['virtual_ip'] = vip
+    elif os.environ.get('virtual_ip'):
+        vip = os.environ['virtual_ip']
+    else:
+        for i in ip_interface(f'{ip}/{netmask}').network:
+            last_octet = int(i.compressed.split('.')[-1])
+            if last_octet < 15 or last_octet >= 250:
+                # addresses like *.255, *.0 and any of them that
+                # are < *.15 we'll ignore. Those are typically
+                # reserved for routing/switch devices anyways
+                continue
+            elif run(['ping', '-c', '2', '-w', '4', i.compressed]).returncode != 0:
+                # sent 2 packets to the address and got no response so assume
+                # it's safe to use
+                os.environ['virtual_ip'] = i.compressed
+                vip = i.compressed
+                break
+
+    # Set various env variables for HA, if not already set
+    if not os.environ.get('domain'):
+        os.environ['domain'] = domain
+    if not os.environ.get('hostname_virtual'):
+        os.environ['hostname_virtual'] = hostname
+    if not os.environ.get('hostname'):
+        os.environ['hostname'] = f'{hostname}-nodea'
+    if not os.environ.get('hostname_b'):
+        os.environ['hostname_b'] = f'{hostname}-nodeb'
+    if not os.environ.get('primary_dns'):
+        os.environ['primary_dns'] = ns1 or '10.230.0.10'
+    if not os.environ.get('secondary_dns'):
+        os.environ['secondary_dns'] = ns2 or '10.230.0.11'
 
 cfg_content = f"""#!{sys.executable}
 
 user = "root"
 password = "{passwd}"
 ip = "{ip}"
+ip2 = "{ip2}"
+netmask = "{netmask}"
+gateway = "{gateway}"
+vip = "{vip}"
 vm_name = {vm_name}
 hostname = "{hostname}"
 domain = "{domain}"
@@ -168,6 +255,7 @@ keyPath = "{keyPath}"
 pool_name = "{pool_name}"
 ha_pool_name = "ha"
 ha = {ha}
+ha_license = "{ha_license}"
 update = {update}
 debug_mode = {debug_mode}
 artifacts = "{artifacts}"
@@ -199,6 +287,9 @@ if verbose:
     callargs.append("-" + "v" * verbose)
 if exitfirst:
     callargs.append("-x")
+
+if show_locals:
+    callargs.append('--showlocals')
 
 # Use the right python version to start pytest with sys.executable
 # So that we can support virtualenv python pytest.


### PR DESCRIPTION
This makes the necessary changes to allow the `runtest.py` script work on our new jenkins infrastructure. There were an innumerable amount of issues (I'm exaggerating obviously) that were found while testing these changes so I'll list the most important ones:
1. our websocket client function `call` was never using the VIP on an HA system
2. because of this fact, the `log_test_name_to_middlewared_log` was causing the entire HA CI run to fail on the iSCSI tests. The reason why this was failing is because there is a test that fails over from the A to B node. This function was making a direct connection to the B node as well as the A node and so the connection was raising socket.timeout errors (as expected). This resolves that underlying issue by using the VIP (when appropriate)
3. The entirety of our REST helper functions (POST, GET, PUT, DELETE, etc) DO NOT use the VIP at all. To make matters worse, if a test fails over from the A to B nodes, the REST functions just don't even work. This is _NOT_ fixed in this PR and will be done so in another, however, we do fix the websocket issues
4. Add the bare minimum amount of new arguments to `runtest.py` so it can be called against an HA "pair" so that it can further configure the HA system and run tests
5. Simplify the logic in some of the early tests so that it's very clear what IP address(es) are being used

There are more issues to resolve but this needs to be merged as it is so that the PR doesn't grow too unwieldy.