### PR TITLE
NAS-127880 / 24.10 / Make sure netdata state persists across upgrades

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -7,7 +7,6 @@ Restart=always
 ReadWriteDirectories=
 ReadWriteDirectories=/dev
 ReadWriteDirectories=/proc/self
-ReadWriteDirectories=/var/lib/netdata
 ReadWriteDirectories=/var/log
 ReadWriteDirectories=/var/spool
 ReadWriteDirectories=/run

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -2,6 +2,7 @@
     from middlewared.plugins.reporting.netdata.utils import NETDATA_PORT, NETDATA_UPDATE_EVERY
 
     netdata_cache_dataset = middleware.call_sync('reporting.netdata_storage_location')
+    netdata_state_location =  middleware.call_sync('reporting.netdata_state_location')
     if not netdata_cache_dataset:
         # Let's exit if netdata storage is not in place
         middleware.logger.error('Netdata configuration file could not be generated')
@@ -26,6 +27,7 @@
 [directories]
     cache = ${netdata_cache_dataset}
     home = ${netdata_cache_dataset}
+    lib = ${netdata_state_location}
 
 [plugins]
 	proc = yes

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import subprocess
 
 from middlewared.service import private, Service
@@ -32,3 +32,6 @@ class ReportingService(Service):
         )
         if cp.returncode != 0:
             self.logger.error('Failed to copy netdata state over from /var/lib/netdata: %r', cp.stderr.decode())
+            # We want to make sure this path exists always regardless of an error so that
+            # at least netdata can start itself gracefully
+            os.makedirs(get_netdata_state_path(), exist_ok=True)

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -1,6 +1,9 @@
 import collections
 import contextlib
+import os.path
 import typing
+
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 
 from .netdata.graph_base import GraphBase
 
@@ -40,6 +43,10 @@ async def fetch_data_from_graph_plugins(
         await graph_plugin.build_context()
         with contextlib.suppress(Exception):
             yield await graph_plugin.export_multiple_identifiers(query_params, identifiers, aggregate=aggregate)
+
+
+def get_netdata_state_path() -> str:
+    return os.path.join(SYSDATASET_PATH, 'netdata/ix_state')
 
 
 def get_metrics_approximation(disk_count: int, core_count: int, interface_count: int, pool_count: int) -> dict:

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -556,12 +556,27 @@ class SystemDatasetService(ConfigService):
                 os.chmod(mountpoint, mode_perms)
 
             mounted = True
+            self.__post_mount_actions(ds_config['name'], ds_config.get('post_mount_actions', []))
 
         if mounted and path == SYSDATASET_PATH:
             fsid = os.statvfs(SYSDATASET_PATH).f_fsid
             self.middleware.call_sync('cache.put', 'SYSDATASET_PATH', {'dataset': f'{path}/.system', 'fsid': fsid})
 
         return mounted
+
+    def __post_mount_actions(self, ds_name, actions):
+        for action in actions:
+            try:
+                self.middleware.call_sync(action['method'], *action.get('args', []))
+            except Exception:
+                self.logger.error(
+                    'Failed to run post mount action %r endpoint for %r dataset',
+                    action['method'], ds_name, exc_info=True,
+                )
+            else:
+                self.logger.info(
+                    'Successfully ran post mount action %r endpoint for %r dataset', action['method'], ds_name
+                )
 
     def __umount(self, pool, uuid, retry=True):
         """

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -55,7 +55,21 @@ SYSTEM_DATASET_JSON_SCHEMA = {
                     },
                     'required': ['path', 'uid', 'gid']
                 }
-            }
+            },
+            'post_mount_actions': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'method': {'type': 'string'},
+                        'args': {
+                            'type': 'array',
+                            'items': {'type': 'string'},
+                        },
+                    },
+                    'required': ['method']
+                }
+            },
         },
         'required': ['name', 'props', 'chown_config'],
         'additionalProperties': False,
@@ -135,5 +149,11 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
             'create_paths': [
                 {'path': '/var/log/netdata', 'uid': 999, 'gid': 997},
             ],
+            'post_mount_actions': [
+                {
+                    'method': 'reporting.post_dataset_mount_action',
+                    'args': [],
+                }
+            ]
         },
     ]


### PR DESCRIPTION
## Problem

Netdata assigns itself a UUID which it stores in `/var/lib/netdata` and on upgrade we lose this which results in older reporting history not being available in the new BE.

## Solution

Carry forward `/var/lib/netdata` to new BE and persist this state in system dataset like we are doing for the reporting data. Carrying forward state from older BE to new BE is being done in scale build repo (https://github.com/truenas/scale-build/pull/609).