### PR TITLE
NAS-127788 / 24.10 / Fix netdata boot time order wrt UPS

### DIFF
--- a/src/freenas/etc/systemd/system/netdata.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/netdata.service.d/override.conf
@@ -1,5 +1,5 @@
 [Unit]
-After=smartmontools.service
+After=smartmontools.service nut.target
 
 [Service]
 Restart=always


### PR DESCRIPTION
## Problem
Some users are experiencing issues with Netdata not displaying UPS (Uninterruptible Power Supply) statistics. Upon investigation, it was found that the problem lies in the systemd service boot order. Netdata starts before the nut services, leading to the issue where Netdata attempts to report UPS stats before the UPS service is started during boot time.

## Solution
Adjust the Netdata boot order by adding the nut service as a dependency in the Netdata service configuration.
(This was already fixed when we added `smartmontools.service` dependency but just adding `nut.target` for explicitness now)