### PR TITLE
NAS-123721 / 24.04.0 / make runtest.py work with new jenkins (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -10,6 +10,7 @@ from middlewared.client import Client
 from middlewared.client.utils import undefined
 
 __all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url"]
+IS_HA = os.environ.get('SERVER_TYPE') == 'ENTERPRISE_HA'
 
 
 @contextlib.contextmanager
@@ -17,20 +18,31 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
     if auth is undefined:
         auth = ("root", password())
 
+    uri = host_websocket_uri(host_ip)
     try:
-        with Client(host_websocket_uri(host_ip), py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+        with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
             if auth is not None:
                 logged_in = c.call("auth.login", *auth)
                 if auth_required:
                     assert logged_in
             yield c
-    except socket.timeout:
-        fail('socket timeout')
+    except socket.timeout as e:
+        if IS_HA:
+            # don't fail the entire run on HA systems since
+            # we perform failovers to and from each controller
+            # so timeouts could happen (which are expected)
+            raise e from None
+        else:
+            fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
 
 
 def host():
     if "NODE_A_IP" in os.environ:
+        # this is not to be confused with HA systems
+        # as it should only be set on NON-HA environments
         return os.environ["NODE_A_IP"]
+    elif IS_HA:
+        return os.environ["virtual_ip"]
     else:
         return os.environ["MIDDLEWARE_TEST_IP"]
 

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -27,13 +27,7 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
                     assert logged_in
             yield c
     except socket.timeout as e:
-        if IS_HA:
-            # don't fail the entire run on HA systems since
-            # we perform failovers to and from each controller
-            # so timeouts could happen (which are expected)
-            raise e from None
-        else:
-            fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
+        fail(f'socket timeout on URI: {uri!r} HOST_IP: {host_ip!r}')
 
 
 def host():

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -13,17 +13,8 @@ from middlewared.test.integration.utils.client import client
 
 
 @pytest.fixture(scope='module')
-def ip_to_use():
-    ip_to_use = ip
-    if (ctrl1_ip := os.environ.get('controller1_ip')) is not None:
-        ip_to_use = ctrl1_ip
-
-    return ip_to_use
-
-
-@pytest.fixture(scope='module')
-def ws_client(ip_to_use):
-    with client(host_ip=ip_to_use) as c:
+def ws_client():
+    with client(host_ip=ip) as c:
         yield c
 
 
@@ -91,16 +82,16 @@ def test_004_enable_and_start_ssh(ws_client):
     assert ws_client.call('service.query', [['service', '=', 'ssh']], options)['state'] == 'RUNNING'
 
 
-def test_005_ssh_using_root_password(ip_to_use):
-    results = SSH_TEST('ls -la', user, password, ip_to_use)
+def test_005_ssh_using_root_password():
+    results = SSH_TEST('ls -la', user, password, ip)
     if not results['result']:
         fail(f"SSH is not usable: {results['output']}. Aborting tests.")
 
 
-def test_006_setup_and_login_using_root_ssh_key(ip_to_use):
+def test_006_setup_and_login_using_root_ssh_key():
     assert os.environ.get('SSH_AUTH_SOCK') is not None
     assert if_key_listed() is True  # horrible function name
-    results = SSH_TEST('ls -la', user, None, ip_to_use)
+    results = SSH_TEST('ls -la', user, None, ip)
     assert results['result'] is True, results['output']
 
 
@@ -120,8 +111,8 @@ def test_007_check_local_accounts(ws_client, account):
         fail(f'Group has unexpected name: {account["name"]} -> {entry["group"]}')
 
 
-def test_008_check_root_dataset_settings(ws_client, ip_to_use):
-    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password, ip_to_use)
+def test_008_check_root_dataset_settings(ws_client):
+    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password, ip)
     if not data['result']:
         fail(f'Unable to get dataset schema: {data["output"]}')
 
@@ -130,7 +121,7 @@ def test_008_check_root_dataset_settings(ws_client, ip_to_use):
     except Exception as e:
         fail(f'Unable to load dataset schema: {e}')
 
-    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password, ip_to_use)
+    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password, ip)
     if not data['result']:
         fail('Failed to determine whether developer mode enabled')
 

--- a/tests/api2/test_002_system_license.py
+++ b/tests/api2/test_002_system_license.py
@@ -2,31 +2,36 @@ import os
 import sys
 import time
 sys.path.append(os.getcwd())
-from auto_config import ha
+from auto_config import ip, ha, ha_license
 
 from middlewared.test.integration.utils import client
 
 # Only read the test on HA
 if ha:
     def test_apply_and_verify_license():
-        with client(host_ip=os.environ.get('controller1_ip', None)) as c:
-            with open(os.environ.get('license_file', '/root/license.txt')) as f:
-                # apply license
-                c.call('system.license_update', f.read())
+        with client(host_ip=ip) as c:
+            if ha_license:
+                _license_string = ha_license
+            else:
+                with open(os.environ.get('license_file', '/root/license.txt')) as f:
+                    _license_string = f.read()
 
-                # verify license is applied
-                assert c.call('failover.licensed') is True
+            # apply license
+            c.call('system.license_update', _license_string)
 
-                retries = 30
-                sleep_time = 1
-                for i in range(retries):
-                    if c.call('failover.call_remote', 'failover.licensed') is False:
-                        # we call a hook that runs in a background task
-                        # so give it a bit to propagate to other controller
-                        # furthermore, our VMs are...well...inconsistent to say the least
-                        # so sometimes this is almost instant while others I've 10+ secs
-                        time.sleep(sleep_time)
-                    else:
-                        break
+            # verify license is applied
+            assert c.call('failover.licensed') is True
+
+            retries = 30
+            sleep_time = 1
+            for i in range(retries):
+                if c.call('failover.call_remote', 'failover.licensed') is False:
+                    # we call a hook that runs in a background task
+                    # so give it a bit to propagate to other controller
+                    # furthermore, our VMs are...well...inconsistent to say the least
+                    # so sometimes this is almost instant while others I've 10+ secs
+                    time.sleep(sleep_time)
                 else:
-                    assert False, f'Timed out after {sleep_time * retries}s waiting on license to sync to standby'
+                    break
+            else:
+                assert False, f'Timed out after {sleep_time * retries}s waiting on license to sync to standby'

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -6,7 +6,7 @@ sys.path.append(apifolder)
 import pytest
 from pytest_dependency import depends
 
-from auto_config import ha, ip, pool_name
+from auto_config import ha, ip, vip, pool_name
 from middlewared.client.client import ValidationErrors
 # from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import fail
@@ -18,7 +18,7 @@ def ws_client():
     # by the time this test is called in the pipeline,
     # the HA VM should have networking configured so
     # we can use the VIP
-    with client(host_ip=os.environ['virtual_ip'] if ha else ip) as c:
+    with client(host_ip=vip if ha else ip) as c:
         yield c
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,11 @@ import os
 
 import pytest
 
-pytest.register_assert_rewrite("middlewared.test")
-
-from middlewared.test.integration.utils import call
+from auto_config import ha, ip, vip
+from middlewared.test.integration.utils.client import client
 from middlewared.test.integration.utils.pytest import failed
+
+pytest.register_assert_rewrite("middlewared.test")
 
 
 @pytest.fixture(autouse=True)
@@ -17,20 +18,40 @@ def fail_fixture():
 
 @pytest.fixture(autouse=True)
 def log_test_name_to_middlewared_log(request):
-    client_kwargs_list = [dict(host_ip=os.environ.get('controller1_ip', None))]
-    if 'controller2_ip' in os.environ:
-        client_kwargs_list.append(dict(host_ip=os.environ['controller2_ip']))
+    # Beware that this is executed after session/package/module/class fixtures
+    # are applied so the logs will still not be exactly precise.
+    test_name = request.node.name
+    ip_to_use = ip
+    if ha and os.environ['USE_VIP'] == 'YES':
+        # this is set after the first few tests run that
+        # "setup" the prereqs for an HA system
+        ip_to_use = vip
 
-    for client_kwargs in client_kwargs_list:
-        # Beware that this is executed after session/package/module/class fixtures are applied so the logs will still
-        # not be exactly precise.
-        with contextlib.suppress(Exception):
-            call("test.notify_test_start", request.node.name, client_kwargs=client_kwargs)
+    with client(host_ip=ip_to_use) as c:
+        c.call("test.notify_test_start", test_name)
+        if ha:
+            # the CI suite does all kinds of things to the standby controller
+            # on HA systems, so we need to suppress connection errors here
+            with contextlib.suppress(Exception):
+                c.call(
+                    "failover.call_remote",
+                    "test.notify_test_start",
+                    [test_name],
+                )
 
     yield
 
-    for client_kwargs in client_kwargs_list:
-        # That's why we also notify test ends. What happens between a test end and the next test start is caused by
-        # session/package/module/class fixtures setup code.
-        with contextlib.suppress(Exception):
-            call("test.notify_test_end", request.node.name, client_kwargs=client_kwargs)
+    # That's why we also notify test ends. What happens between a test end
+    # and the next test start is caused by session/package/module/class
+    # fixtures setup code.
+    with client(host_ip=ip_to_use) as c:
+        c.call("test.notify_test_end", test_name)
+        if ha:
+            # the CI suite does all kinds of things to the standby controller
+            # on HA systems, so we need to suppress connection errors here
+            with contextlib.suppress(Exception):
+                c.call(
+                    "failover.call_remote",
+                    "test.notify_test_end",
+                    [test_name],
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,14 +30,7 @@ def log_test_name_to_middlewared_log(request):
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_start", test_name)
         if ha:
-            # the CI suite does all kinds of things to the standby controller
-            # on HA systems, so we need to suppress connection errors here
-            with contextlib.suppress(Exception):
-                c.call(
-                    "failover.call_remote",
-                    "test.notify_test_start",
-                    [test_name],
-                )
+            c.call("failover.call_remote", "test.notify_test_start", [test_name])
 
     yield
 
@@ -50,8 +43,4 @@ def log_test_name_to_middlewared_log(request):
             # the CI suite does all kinds of things to the standby controller
             # on HA systems, so we need to suppress connection errors here
             with contextlib.suppress(Exception):
-                c.call(
-                    "failover.call_remote",
-                    "test.notify_test_end",
-                    [test_name],
-                )
+                c.call("failover.call_remote", "test.notify_test_end", [test_name])

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -188,9 +188,8 @@ def get_ipinfo(ip_to_use):
                     iface = i['id']
                     net = j['netmask']
                     for k in c.call('route.system_routes'):
-                        if k.get('network') == '0.0.0.0' and k.get('interface') == i['id']:
-                            if k['gateway']:
-                                return iface, net, k['gateway'], ns1, ns2
+                        if k.get('network') == '0.0.0.0' and k.get('gateway'):
+                            return iface, net, k['gateway'], ns1, ns2
 
     return iface, net, gate, ns1, ns2
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ddb18da19386bd6c9d89c03446a76dcac2ee978a
    git cherry-pick -x 79dcc1550ac3f52aca5ef6c041126e8c953c4532
    git cherry-pick -x 50ee263efffd182b20e44d84268ef41ad4aa2550
    git cherry-pick -x 78f128703dc20124f8adff821219b8d65b2390a9
    git cherry-pick -x cc85d0cb5e23b90e1be79be676c74d6006ea5cc5
    git cherry-pick -x 6c6cc0727ba8b62a5df4e94cddf7e6ed3cb9b95c
    git cherry-pick -x ccd7302aec21d319add9fa0e348c67316cf5e1e8
    git cherry-pick -x 06840691c587acc7415aae88694f3f19b19b24ed
    git cherry-pick -x 8f8b402c939f661f5cc8b8b62ad62c08eb481c2a
    git cherry-pick -x 25fece64a87f8eac5001c4c3af172edfa7cb06d7

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3a09b47a515f31dc09cac0308b664a50f50ca090

This makes the necessary changes to allow the `runtest.py` script work on our new jenkins infrastructure. There were an innumerable amount of issues (I'm exaggerating obviously) that were found while testing these changes so I'll list the most important ones:
1. our websocket client function `call` was never using the VIP on an HA system
2. because of this fact, the `log_test_name_to_middlewared_log` was causing the entire HA CI run to fail on the iSCSI tests. The reason why this was failing is because there is a test that fails over from the A to B node. This function was making a direct connection to the B node as well as the A node and so the connection was raising socket.timeout errors (as expected). This resolves that underlying issue by using the VIP (when appropriate)
3. The entirety of our REST helper functions (POST, GET, PUT, DELETE, etc) DO NOT use the VIP at all. To make matters worse, if a test fails over from the A to B nodes, the REST functions just don't even work. This is _NOT_ fixed in this PR and will be done so in another, however, we do fix the websocket issues
4. Add the bare minimum amount of new arguments to `runtest.py` so it can be called against an HA "pair" so that it can further configure the HA system and run tests
5. Simplify the logic in some of the early tests so that it's very clear what IP address(es) are being used

There are more issues to resolve but this needs to be merged as it is so that the PR doesn't grow too unwieldy.

Original PR: https://github.com/truenas/middleware/pull/13450
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123721