### PR TITLE
NAS-128140 / 24.04.0 / Account for failover status when reporting backup node as ready

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -273,7 +273,7 @@ class FailoverService(ConfigService):
                     'failover.events.vrrp_master',
                     'failover.events.vrrp_backup'
                 ]),
-                ('state', '=', 'RUNNING'),
+                ('state', 'in', ('RUNNING', 'WAITING')),
             ]
         )
         return bool(event)


### PR DESCRIPTION
This PR fixes 2 bugs:

1) `failover.in_progress` not accounting for a job which might not have had started when it was called but system had registered it.
2) Endpoint we used to determine if remote node is active or not was only accounting for system being ready whereas in case of HA that is incomplete and it should account for remote node actually being available for consumption as failover event on remote can take some time as well.