### PR TITLE
NAS-128164 / 24.04.0 / remove notify_test* calls on HA (by yocalebo)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,6 @@ def log_test_name_to_middlewared_log(request):
 
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_start", test_name)
-        if ha:
-            c.call("failover.call_remote", "test.notify_test_start", [test_name])
 
     yield
 
@@ -39,8 +37,3 @@ def log_test_name_to_middlewared_log(request):
     # fixtures setup code.
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_end", test_name)
-        if ha:
-            # the CI suite does all kinds of things to the standby controller
-            # on HA systems, so we need to suppress connection errors here
-            with contextlib.suppress(Exception):
-                c.call("failover.call_remote", "test.notify_test_end", [test_name])


### PR DESCRIPTION
This is breaking all of the CI tests and I'm tired of dealing with it. It doesn't provide any benefit to log the test name to the remote controller. Especially since the remote controller doesn't even run the test. If we were to maintain this functionality, it means we're going to have to figure out which exact tests expect a failure here and which ones do not. That's too much maintenance overhead and doesn't provide any benefit.

NOTE: this still means we log this functionality on HA systems, it just means we log it on the controller that's actually running the test.

Original PR: https://github.com/truenas/middleware/pull/13453
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128164