### PR TITLE
NAS-128174 / 24.04.0 / Make REST functions in CI use proper IP addresses on HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -2,6 +2,7 @@
 import contextlib
 import os
 import socket
+import types
 
 import requests
 
@@ -10,7 +11,12 @@ from middlewared.client import Client
 from middlewared.client.utils import undefined
 
 __all__ = ["client", "host", "host_websocket_uri", "password", "session", "url", "websocket_url"]
-IS_HA = os.environ.get('SERVER_TYPE') == 'ENTERPRISE_HA'
+"""
+truenas_server object is used by both websocket client and REST client for determining which
+server to access for API calls. For HA, the `ip` attribute should be set to the virtual IP
+of the truenas server.
+"""
+truenas_server = types.SimpleNamespace(ip=None, nodea_ip=None, nodeb_ip=None, server_type=None)
 
 
 @contextlib.contextmanager
@@ -31,18 +37,24 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
 
 
 def host():
-    if "NODE_A_IP" in os.environ:
-        # this is not to be confused with HA systems
-        # as it should only be set on NON-HA environments
-        return os.environ["NODE_A_IP"]
-    elif IS_HA:
-        return os.environ["virtual_ip"]
-    else:
-        return os.environ["MIDDLEWARE_TEST_IP"]
+    if truenas_server.ip:
+        return truenas_server
+
+    # Initialize our settings. At this point on HA servers, the VIP is not available
+    truenas_server.server_type = os.environ['SERVER_TYPE']
+    match truenas_server.server_type:
+        case 'ENTERPRISE_HA':
+            truenas_server.ip = os.environ["controller1_ip"]
+            truenas_server.nodea_ip = os.environ["controller1_ip"]
+            truenas_server.nodeb_ip = os.environ["controller2_ip"]
+        case _:
+            truenas_server.ip = os.environ["MIDDLEWARE_TEST_IP"]
+
+    return truenas_server
 
 
 def host_websocket_uri(host_ip=None):
-    return f"ws://{host_ip or host()}/websocket"
+    return f"ws://{host_ip or host().ip}/websocket"
 
 
 def password():

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -42,13 +42,14 @@ def host():
 
     # Initialize our settings. At this point on HA servers, the VIP is not available
     truenas_server.server_type = os.environ['SERVER_TYPE']
-    match truenas_server.server_type:
-        case 'ENTERPRISE_HA':
-            truenas_server.ip = os.environ["controller1_ip"]
-            truenas_server.nodea_ip = os.environ["controller1_ip"]
-            truenas_server.nodeb_ip = os.environ["controller2_ip"]
-        case _:
-            truenas_server.ip = os.environ["MIDDLEWARE_TEST_IP"]
+
+    # Some older test runners have old python
+    if truenas_server.server_type == 'ENTERPRISE_HA':
+        truenas_server.ip = os.environ["controller1_ip"]
+        truenas_server.nodea_ip = os.environ["controller1_ip"]
+        truenas_server.nodeb_ip = os.environ["controller2_ip"]
+    else:
+        truenas_server.ip = os.environ["MIDDLEWARE_TEST_IP"]
 
     return truenas_server
 

--- a/src/middlewared/middlewared/test/integration/utils/ssh.py
+++ b/src/middlewared/middlewared/test/integration/utils/ssh.py
@@ -4,7 +4,7 @@ import sys
 try:
     apifolder = os.getcwd()
     sys.path.append(apifolder)
-    from auto_config import user as default_user, password as default_password, ip as default_ip
+    from auto_config import user as default_user, password as default_password
     from functions import SSH_TEST
 except ImportError:
     default_user = None
@@ -14,7 +14,7 @@ except ImportError:
 __all__ = ["ssh"]
 
 
-def ssh(command, check=True, complete_response=False, *, user=default_user, password=default_password, ip=default_ip):
+def ssh(command, check=True, complete_response=False, *, user=default_user, password=default_password, ip=None):
     result = SSH_TEST(command, user, password, ip)
     if check:
         assert result["result"], result["output"]

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -6,13 +6,13 @@ sys.path.append(apifolder)
 
 import pytest
 
-from auto_config import ip, interface, ha, netmask
-from middlewared.test.integration.utils.client import client
+from auto_config import interface, ha, netmask
+from middlewared.test.integration.utils.client import client, host
 
 
 @pytest.fixture(scope='module')
 def ws_client():
-    with client(host_ip=ip) as c:
+    with client(host_ip=host().ip) as c:
         yield c
 
 
@@ -51,6 +51,7 @@ def get_payload(ws_client):
         ans = ws_client.call('interface.query', [['name', '=', interface]], {'get': True})
         payload = {'ipv4_dhcp': False, 'aliases': []}
         to_validate = []
+        ip = host().ip
         for info in filter(lambda x: x['address'] == ip, ans['state']['aliases']):
             payload['aliases'].append({'address': ip, 'netmask': info['netmask']})
             to_validate.append(ip)
@@ -99,6 +100,6 @@ def test_001_configure_interface(request, ws_client, get_payload):
             assert c.call('failover.call_remote', 'core.ping') == 'pong'
 
         # it's very important to set this because the `tests/conftest.py` config
-        # (that pytest uses globally for the entirety of CI runs) will check this
-        # value and use the proper IP address (the VIP) on HA systems
-        os.environ['USE_VIP'] = 'YES'
+        # (that pytest uses globally for the entirety of CI runs) uses this IP
+        # address and so we need to make sure it uses the VIP on HA systems
+        host().ip = os.environ['virtual_ip']

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -7,12 +7,12 @@ sys.path.append(apifolder)
 import pytest
 
 from auto_config import interface, ha, netmask
-from middlewared.test.integration.utils.client import client, host
+from middlewared.test.integration.utils.client import client, truenas_server
 
 
 @pytest.fixture(scope='module')
 def ws_client():
-    with client(host_ip=host().ip) as c:
+    with client(host_ip=truenas_server.ip) as c:
         yield c
 
 
@@ -51,7 +51,7 @@ def get_payload(ws_client):
         ans = ws_client.call('interface.query', [['name', '=', interface]], {'get': True})
         payload = {'ipv4_dhcp': False, 'aliases': []}
         to_validate = []
-        ip = host().ip
+        ip = truenas_server.ip
         for info in filter(lambda x: x['address'] == ip, ans['state']['aliases']):
             payload['aliases'].append({'address': ip, 'netmask': info['netmask']})
             to_validate.append(ip)
@@ -102,4 +102,7 @@ def test_001_configure_interface(request, ws_client, get_payload):
         # it's very important to set this because the `tests/conftest.py` config
         # (that pytest uses globally for the entirety of CI runs) uses this IP
         # address and so we need to make sure it uses the VIP on HA systems
-        host().ip = os.environ['virtual_ip']
+        truenas_server.ip = os.environ['virtual_ip']
+        truenas_server.nodea_ip = os.environ['controller1_ip']
+        truenas_server.nodeb_ip = os.environ['controller2_ip']
+        truenas_server.server_type = os.environ['SERVER_TYPE']

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -42,10 +42,6 @@ def test_001_check_sysdataset_exists_on_boot_pool(ws_client):
     assert bp_name == sysds['pool']
     assert bp_basename == sysds['basename']
 
-    # If we are here on HA system, then VIP is working.
-    if ha:
-        host().ip = os.environ['virtual_ip']
-
 
 """
 # TODO: refactor and backport the active_directory test asset

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -10,7 +10,7 @@ from auto_config import ha, ip, vip, pool_name
 from middlewared.client.client import ValidationErrors
 # from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import fail
-from middlewared.test.integration.utils.client import client
+from middlewared.test.integration.utils.client import client, host
 
 
 @pytest.fixture(scope='module')
@@ -41,6 +41,10 @@ def test_001_check_sysdataset_exists_on_boot_pool(ws_client):
     sysds = ws_client.call('systemdataset.config')
     assert bp_name == sysds['pool']
     assert bp_basename == sysds['basename']
+
+    # If we are here on HA system, then VIP is working.
+    if ha:
+        host().ip = os.environ['virtual_ip']
 
 
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from middlewared.test.integration.utils.client import client, host
+from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils.pytest import failed
 
 pytest.register_assert_rewrite("middlewared.test")
@@ -17,7 +17,7 @@ def log_test_name_to_middlewared_log(request):
     # Beware that this is executed after session/package/module/class fixtures
     # are applied so the logs will still not be exactly precise.
     test_name = request.node.name
-    ip_to_use = host().ip
+    ip_to_use = truenas_server.ip
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_start", test_name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,6 @@
-import contextlib
-import os
-
 import pytest
 
-from auto_config import ha, ip, vip
-from middlewared.test.integration.utils.client import client
+from middlewared.test.integration.utils.client import client, host
 from middlewared.test.integration.utils.pytest import failed
 
 pytest.register_assert_rewrite("middlewared.test")
@@ -21,12 +17,7 @@ def log_test_name_to_middlewared_log(request):
     # Beware that this is executed after session/package/module/class fixtures
     # are applied so the logs will still not be exactly precise.
     test_name = request.node.name
-    ip_to_use = ip
-    if ha and os.environ['USE_VIP'] == 'YES':
-        # this is set after the first few tests run that
-        # "setup" the prereqs for an HA system
-        ip_to_use = vip
-
+    ip_to_use = host().ip
     with client(host_ip=ip_to_use) as c:
         c.call("test.notify_test_start", test_name)
 

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 import requests
 import websocket
 
-from auto_config import api_url, password, user
+from auto_config import password, user
 from middlewared.test.integration.utils import host
 
 
@@ -24,6 +24,7 @@ header = {'Content-Type': 'application/json', 'Vary': 'accept'}
 global authentication
 authentication = (user, password)
 RE_HTTPS = re.compile(r'^http(:.*)')
+
 
 class SRVTarget(enum.Enum):
     DEFAULT = enum.auto()

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -33,13 +33,12 @@ class SRVTarget(enum.Enum):
 
 def get_host_ip(target):
     server = host()
-
     if target is SRVTarget.DEFAULT:
-        return host().ip
+        return server.ip
     elif target is SRVTarget.NODEA:
-        return host().nodea_ip
+        return server.nodea_ip
     elif target is SRVTarget.NODEB:
-        return host().nodeb_ip
+        return server.nodeb_ip
 
     raise ValueError(f'{target}: unexpected target')
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -193,12 +193,12 @@ def get_ipinfo(ip_to_use):
 
     return iface, net, gate, ns1, ns2
 
+
 interface, netmask, gateway, ns1, ns2 = get_ipinfo(ip_to_use)
 if not all((interface, netmask, gateway)):
     print(f'Unable to determine interface ({interface!r}), netmask ({netmask!r}) and gateway ({gateway!r}) for {ip_to_use!r}')
     exit()
 
-os.environ['USE_VIP'] = 'NO'
 if ha:
     if vip:
         os.environ['virtual_ip'] = vip


### PR DESCRIPTION
As mentioned in https://github.com/truenas/middleware/pull/13450, this fixes the other issue whereby the REST related functions do not use the proper IP address on HA systems. This takes the work that @anodos325 pushed in https://github.com/truenas/middleware/pull/13438 but fixes a couple issues and tidies it up. This has been tested on new and old jenkins.

Original PR: https://github.com/truenas/middleware/pull/13454
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128174