### PR TITLE
NAS-128222 / 24.04.1 / fix alembic crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.04/2024-04-03_14-10_cron.py
+++ b/src/middlewared/middlewared/alembic/versions/24.04/2024-04-03_14-10_cron.py
@@ -31,7 +31,7 @@ def upgrade():
         for row in map(dict, conn.execute(f"SELECT id, {', '.join(fields)} FROM {table}").fetchall()):
             for k in fields:
                 value = row[k]
-                if '/' in value and not re.match(r'^(\*|[0-9]+-[0-9]+)/([0-9]+)$', value):
+                if value is not None and '/' in value and not re.match(r'^(\*|[0-9]+-[0-9]+)/([0-9]+)$', value):
                     if m := re.search(r'/([0-9]+)$', value):
                         value = f'*/{m.group(1)}'
                     else:


### PR DESCRIPTION
```
INFO  [alembic.runtime.migration] Running upgrade 6a7c2281f48e -> ea024b5dff95, Fix cron fields values, follow-up to NAS-125384
Traceback (most recent call last):
  File "/usr/bin/alembic", line 33, in <module>
    sys.exit(load_entry_point('alembic==1.8.1.dev0', 'console_scripts', 'alembic')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/alembic/config.py", line 590, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/usr/lib/python3/dist-packages/alembic/config.py", line 584, in main
    self.run_cmd(cfg, options)
  File "/usr/lib/python3/dist-packages/alembic/config.py", line 561, in run_cmd
    fn(
  File "/usr/lib/python3/dist-packages/alembic/command.py", line 322, in upgrade
    script.run_env()
  File "/usr/lib/python3/dist-packages/alembic/script/base.py", line 569, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/usr/lib/python3/dist-packages/alembic/util/pyfiles.py", line 94, in load_python_file
    module = load_module_py(module_id, path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/alembic/util/pyfiles.py", line 110, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3/dist-packages/middlewared/alembic/env.py", line 173, in <module>
    run_migrations_online()
  File "/usr/lib/python3/dist-packages/middlewared/alembic/env.py", line 167, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/usr/lib/python3/dist-packages/alembic/runtime/environment.py", line 853, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/usr/lib/python3/dist-packages/alembic/runtime/migration.py", line 623, in run_migrations
    step.migration_fn(**kw)
  File "/usr/lib/python3/dist-packages/middlewared/alembic/versions/24.04/2024-04-03_14-10_cron.py", line 34, in upgrade
    if '/' in value and not re.match(r'^(\*|[0-9]+-[0-9]+)/([0-9]+)$', value):
       ^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

Original PR: https://github.com/truenas/middleware/pull/13482
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128222