### PR TITLE
NAS-128224 / 24.04.1 / Add USE_VIP to allow tests when HA/VIP already configured (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -45,7 +45,10 @@ def host():
 
     # Some older test runners have old python
     if truenas_server.server_type == 'ENTERPRISE_HA':
-        truenas_server.ip = os.environ["controller1_ip"]
+        if "USE_VIP" in os.environ and os.environ["USE_VIP"] == "yes":
+            truenas_server.ip = os.environ["virtual_ip"]
+        else:
+            truenas_server.ip = os.environ["controller1_ip"]
         truenas_server.nodea_ip = os.environ["controller1_ip"]
         truenas_server.nodeb_ip = os.environ["controller2_ip"]
     else:


### PR DESCRIPTION
If using `runtest.py` against a **previously configured** HA system, and we are skipping `test_001_configure_interface`, then we may want to force the `truenas_server.ip` to the VIP.

Original PR: https://github.com/truenas/middleware/pull/13486
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128224