### PR TITLE
NAS-128259 / 24.04.0 / Fix pool import normalization (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -131,7 +131,8 @@ class PoolService(Service):
         )
         if ds['acltype']['value'] == 'NFSV4':
             opts = {'properties': {
-                'aclinherit': {'value': 'passthrough'}
+                'aclinherit': {'value': 'passthrough'},
+                'aclmode': {'value': 'passthrough'},
             }}
         else:
             opts = {'properties': {
@@ -248,7 +249,8 @@ class PoolService(Service):
 
         if ds['acltype']['value'] == 'NFSV4':
             opts = {'properties': {
-                'aclinherit': {'value': 'passthrough'}
+                'aclinherit': {'value': 'passthrough'},
+                'aclmode': {'value': 'passthrough'},
             }}
         else:
             opts = {'properties': {


### PR DESCRIPTION
In some cases users may have root dataset with NFSv4 acltype and an improper aclmode setting. This commit defaults to PASSTHROUGH aclmode in this case (which allows chmod to succeed if for some reason a non-trivial ACL is present).

Original PR: https://github.com/truenas/middleware/pull/13492
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128259