### PR TITLE
NAS-128273 / 13.3 / Ensure samba-dcerpcd process is terminated

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -2,6 +2,10 @@ from middlewared.service_exception import CallError
 
 from .base import SimpleService, ServiceState
 
+import os
+import signal
+import time
+
 
 class CIFSService(SimpleService):
     name = "cifs"
@@ -11,8 +15,55 @@ class CIFSService(SimpleService):
 
     freebsd_rc = "smbd"
     freebsd_pidfile = "/var/run/samba4/smbd.pid"
+    dcerpc_pidfile = "/var/run/samba4/samba-dcerpcd.pid"
 
     systemd_unit = "smbd"
+
+    def get_pid(self):
+        try:
+            with open(self.dcerpc_pidfile, 'r') as f:
+                return int(f.read().strip())
+        except FileNotFoundError:
+            return None
+        except Exception:
+            self.middleware.logger.debug('Failed to open pidfile', exc_info=True)
+
+        return None
+
+    def wait_on_pid(self, pid, timeout=10):
+        while timeout > 0:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+            except Exception:
+                self.middleware.logger.warning('%s: liveness check failed', exc_info=True)
+                break
+
+            time.sleep(1)
+            timeout -= 1
+
+    def terminate_dcerpcd(self):
+        pid = self.get_pid()
+        if pid is None:
+            return
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except Exception:
+            self.middleware.logger.warning('%d: failed to kill samba-dcerpcd', pid, exc_info=True)
+            return
+
+        self.wait_on_pid(pid)
+
+        try:
+            os.unlink(self.dcerpc_pidfile)
+        except Exception:
+            self.middleware.logger.warning('Failed to unlink dcerpcd pidfile', exc_info=True)
+
+        self.middleware.logger.debug('Successfully shut down samba-dcerpcd')
 
     async def _get_state_freebsd(self):
         return ServiceState(
@@ -46,6 +97,7 @@ class CIFSService(SimpleService):
 
     async def after_stop(self):
         await self.middleware.call("service.reload", "mdns")
+        await self.middleware.run_in_thread(self.terminate_dcerpcd)
 
     async def after_reload(self):
         await self.middleware.call("service.reload", "mdns")


### PR DESCRIPTION
When stopping the SMB service via our API we must ensure that the on-demand samba-dcerpcd host process is terminated if it is currently running before returning from `service.stop`. Failure to do this may leave samba-dcerpcd in an inconsistent / unresponsive state.