### PR TITLE
NAS-128277 / 24.04.0 / Restart winbindd while initializing directory services (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -482,6 +482,8 @@ class DirectoryServices(Service):
         except Exception:
             self.logger.warning('Cache flush failed', exc_info=True)
 
+        await self.middleware.call('service.restart', 'idmap')
+
         if is_kerberized:
             await self.__kerberos_start_retry()
 
@@ -529,6 +531,8 @@ class DirectoryServices(Service):
             self.middleware.call_sync('activedirectory.started')
         else:
             self.middleware.call_sync('ldap.started')
+
+        await self.middleware.call('service.restart', 'idmap')
 
         job.set_progress(10, 'Refreshing cache'),
         cache_refresh = self.middleware.call_sync('dscache.refresh')


### PR DESCRIPTION
During QE testing it was observed that in-memory idmap backend settings of the idmap worker process was stale after reboot.

SIGHUP was insufficient to prompt reload and so this adds a winbind restart to ensure we always have correct configuration loaded.

Original PR: https://github.com/truenas/middleware/pull/13506
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128277