### PR TITLE
NAS-128141 / 24.04.1 / Fix some test breakage from recent refactor (by bmeagherix)

### DIFF
--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -706,7 +706,6 @@ def test_176_check_dataset_auto_create(request):
 
 
 def test_180_create_share_multiple_dirs_deep(request):
-    depends(request, ["SMB_SHARE_CREATED"])
     with dataset('nested_dirs', data={'share_type': 'SMB'}) as ds:
         dirs_path = os.path.join('/mnt', ds, 'd1/d2/d3')
         ssh(f'mkdir -p {dirs_path}')
@@ -727,7 +726,6 @@ def test_180_create_share_multiple_dirs_deep(request):
 
 
 def test_181_create_and_disable_share(request):
-    depends(request, ["SMB_SHARE_CREATED"])
     with dataset('smb_disabled', data={'share_type': 'SMB'}) as ds:
         with smb_share(os.path.join('/mnt', ds), 'TO_DISABLE') as tmp_share:
             with smb_connection(

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -706,6 +706,7 @@ def test_176_check_dataset_auto_create(request):
 
 
 def test_180_create_share_multiple_dirs_deep(request):
+    depends(request, ["SMB_SHARE_CREATED"])
     with dataset('nested_dirs', data={'share_type': 'SMB'}) as ds:
         dirs_path = os.path.join('/mnt', ds, 'd1/d2/d3')
         ssh(f'mkdir -p {dirs_path}')
@@ -726,6 +727,7 @@ def test_180_create_share_multiple_dirs_deep(request):
 
 
 def test_181_create_and_disable_share(request):
+    depends(request, ["SMB_SHARE_CREATED"])
     with dataset('smb_disabled', data={'share_type': 'SMB'}) as ds:
         with smb_share(os.path.join('/mnt', ds), 'TO_DISABLE') as tmp_share:
             with smb_connection(


### PR DESCRIPTION
During a recent test refactor (PR #12298), some breakage was introduced:

- Definition of `SMB_USER_CREATED` was removed, but some tests still depend upon it.
- Attempted to turn off `aapl_extensions` while `afp` enabled share still existed.


Original PR: https://github.com/truenas/middleware/pull/13445
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128141