### PR TITLE
NAS-128283 / 24.04.1 / Fix regression in middleware startup

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -532,7 +532,7 @@ class DirectoryServices(Service):
         else:
             self.middleware.call_sync('ldap.started')
 
-        await self.middleware.call('service.restart', 'idmap')
+        self.middleware.call_sync('service.restart', 'idmap')
 
         job.set_progress(10, 'Refreshing cache'),
         cache_refresh = self.middleware.call_sync('dscache.refresh')


### PR DESCRIPTION
This fixes a regression caused by a typo in a change to directory services startup.