### PR TITLE
NAS-128283 / 24.04.0 / Fix regression in middleware startup (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -532,7 +532,7 @@ class DirectoryServices(Service):
         else:
             self.middleware.call_sync('ldap.started')
 
-        await self.middleware.call('service.restart', 'idmap')
+        self.middleware.call_sync('service.restart', 'idmap')
 
         job.set_progress(10, 'Refreshing cache'),
         cache_refresh = self.middleware.call_sync('dscache.refresh')


### PR DESCRIPTION
This fixes a regression caused by a typo in a change to directory services startup.

Original PR: https://github.com/truenas/middleware/pull/13519
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128283