### PR TITLE
NAS-128290 / 24.04.1 / Add some (disabled by default) logging wrt redfish client (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/redfish/client.py
+++ b/src/middlewared/middlewared/plugins/jbof/redfish/client.py
@@ -43,6 +43,7 @@ class RedfishClient:
         verify=False,
         timeout=DEFAULT_REDFISH_TIMEOUT_SECS
     ):
+        self.log_requests = False
         self.base_url = base_url.rstrip('/')
         self.username = username
         self.password = password
@@ -289,6 +290,9 @@ class RedfishClient:
         timeout = kwargs.get('timeout', self.timeout)
         payload = kwargs.get('data', {})
         headers = kwargs.get('headers', {})
+
+        if self.log_requests:
+            LOGGER.debug('%r %r %r', method.upper(), url, payload)
 
         if payload:
             if isinstance(payload, dict) or isinstance(payload, list):


### PR DESCRIPTION
Nice to be able to capture redfish traffic if necessary (was requested).

Original PR: https://github.com/truenas/middleware/pull/13523
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128290