### PR TITLE
NAS-128300 / 24.10 / Fix typo in stat_x call

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -581,7 +581,7 @@ class FilesystemService(Service):
             fd = os.open(path, os.O_PATH)
             try:
                 st = os.fstatvfs(fd)
-                mntid = stat_x.statx('', {'dirfd': fd, 'flags':  stat_x.ATFlags.EMPTY_PATH}).stx_mnt_id
+                mntid = stat_x.statx('', {'dir_fd': fd, 'flags':  stat_x.ATFlags.EMPTY_PATH}).stx_mnt_id
             finally:
                 os.close(fd)
 

--- a/src/middlewared/middlewared/plugins/filesystem_/stat_x.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/stat_x.py
@@ -103,6 +103,9 @@ def statx(path, options=None):
     mask = Mask.BASIC_STATS | Mask.BTIME
     path = path.encode() if isinstance(path, str) else path
 
+    if flags & ATFlags.EMPTY_PATH and dirfd == AT_FDCWD:
+        raise ValueError('dir_fd key is required when using AT_EMPTY_PATH')
+
     invalid_flags = flags & ~ATFlags.VALID_FLAGS
     if invalid_flags:
         raise ValueError(f'{hex(invalid_flags)}: unsupported statx flags')


### PR DESCRIPTION
Typo specifying dirfd instead of dir_fd caused AT_FDCWD to be used instead of the desired O_PATH fd.