### PR TITLE
NAS-128295 / 24.04.0 / Let kernel choose `fs.inotify.max_user_watches` automatically (by themylogin)

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -1,4 +1,3 @@
-fs.inotify.max_user_watches = 8192
 kernel.panic = 10
 kernel.panic_on_oops = 1
 kernel.panic_on_io_nmi = 1


### PR DESCRIPTION
The root cause of the issue was determined at
```
[2024/04/11 00:53:20] (ERROR) middlewared.settle_udev_events():16 - Failed to settle udev events: Failed to add inotify watch for /run/udev: Too many open files
```

not allowing middleware to correctly wait for the recently formatted partition to appear.

https://github.com/torvalds/linux/commit/92890123749bafc317bbfacbe0a62ce08d78efb7

Original PR: https://github.com/truenas/middleware/pull/13528
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128295