### PR TITLE
NAS-127770 / 24.10 / Add auditing of NFS and FTP

### DIFF
--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -1,5 +1,5 @@
 from middlewared.async_validators import check_path_resides_within_volume, resolve_hostname, validate_port
-from middlewared.schema import Bool, Dict, Dir, Int, Str
+from middlewared.schema import accepts, Bool, Dict, Dir, Int, Patch, Str
 from middlewared.validators import Exact, Match, Or, Range
 from middlewared.service import private, SystemServiceService, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -62,6 +62,7 @@ class FTPService(SystemServiceService):
 
     ENTRY = Dict(
         'ftp_entry',
+        Int('id', required=True),
         Int('port', validators=[Range(min_=1, max_=65535)], required=True),
         Int('clients', validators=[Range(min_=1, max_=10000)], required=True),
         Int('ipconnections', validators=[Range(min_=0, max_=1000)], required=True),
@@ -104,7 +105,6 @@ class FTPService(SystemServiceService):
         Bool('tls_opt_ip_address_required', required=True),
         Int('ssltls_certificate', null=True, required=True),
         Str('options', max_length=None, required=True),
-        Int('id', required=True),
     )
 
     @private
@@ -113,6 +113,14 @@ class FTPService(SystemServiceService):
             data['ssltls_certificate'] = data['ssltls_certificate']['id']
         return data
 
+    @accepts(
+        Patch(
+            'ftp_entry', 'ftp_update',
+            ('rm', {'name': 'id'}),
+            ('attr', {'update': True}),
+        ),
+        audit='Update FTP configuration',
+    )
     async def do_update(self, data):
         """
         Update ftp service configuration.

--- a/src/middlewared/middlewared/plugins/nfs_/krb5.py
+++ b/src/middlewared/middlewared/plugins/nfs_/krb5.py
@@ -71,7 +71,11 @@ class NFSService(Service):
         raise CallError('This feature has not yet been implemented for '
                         'the LDAP directory service.', errno=errno.ENOSYS)
 
-    @accepts(Ref('kerberos_username_password'), roles=['SHARING_NFS_WRITE'])
+    @accepts(
+        Ref('kerberos_username_password'),
+        roles=['SHARING_NFS_WRITE'],
+        audit='Add NFS principal', audit_extended=lambda data: data["username"]
+    )
     @returns(Bool('principal_add_status'))
     async def add_principal(self, data):
         """

--- a/tests/api2/test_audit_ftp.py
+++ b/tests/api2/test_audit_ftp.py
@@ -48,7 +48,7 @@ def test_ftp_config_audit(api):
         # Restore initial state
         restore_payload = {
             'clients': initial_ftp_config['clients'],
-            'onlyanonymous': initial_ftp_config['onlyanonymous'],
+            'rootlogin': initial_ftp_config['rootlogin'],
             'banner': initial_ftp_config['banner']
         }
         if api == 'ws':

--- a/tests/api2/test_audit_ftp.py
+++ b/tests/api2/test_audit_ftp.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+import pytest
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.audit import expect_audit_method_calls
+
+sys.path.append(os.getcwd())
+from functions import PUT
+
+
+@pytest.fixture(scope='module')
+def nfs_audit_dataset(request):
+    with dataset('audit-test-nfs') as ds:
+        try:
+            yield ds
+        finally:
+            pass
+
+
+@pytest.mark.parametrize('api', ['ws', 'rest'])
+def test_ftp_config_audit(api):
+    '''
+    Test the auditing of FTP configuration changes
+    '''
+    initial_ftp_config = call('ftp.config')
+    try:
+        # UPDATE
+        payload = {
+            'clients': 1000,
+            'rootlogin': True,
+            'banner': "Hello, from New York"
+        }
+        with expect_audit_method_calls([{
+            'method': 'ftp.update',
+            'params': [payload],
+            'description': 'Update FTP configuration',
+        }]):
+            if api == 'ws':
+                call('ftp.update', payload)
+            elif api == 'rest':
+                result = PUT('/ftp/', payload)
+                assert result.status_code == 200, result.text
+            else:
+                raise ValueError(api)
+    finally:
+        # Restore initial state
+        restore_payload = {
+            'clients': initial_ftp_config['clients'],
+            'onlyanonymous': initial_ftp_config['onlyanonymous'],
+            'banner': initial_ftp_config['banner']
+        }
+        if api == 'ws':
+            call('ftp.update', restore_payload)
+        elif api == 'rest':
+            result = PUT('/ftp/', restore_payload)
+            assert result.status_code == 200, result.text
+        else:
+            raise ValueError(api)

--- a/tests/api2/test_audit_nfs.py
+++ b/tests/api2/test_audit_nfs.py
@@ -1,0 +1,153 @@
+import os
+import sys
+
+import pytest
+from middlewared.service_exception import CallError
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.audit import expect_audit_method_calls
+
+sys.path.append(os.getcwd())
+from functions import DELETE, POST, PUT
+
+REDACTED_SECRET = '********'
+
+
+@pytest.fixture(scope='module')
+def nfs_audit_dataset(request):
+    with dataset('audit-test-nfs') as ds:
+        try:
+            yield ds
+        finally:
+            pass
+
+
+@pytest.mark.parametrize('api', ['ws', 'rest'])
+def test_nfs_config_audit(api):
+    '''
+    Test the auditing of NFS configuration changes
+    '''
+    bogus_user = 'bogus_user'
+    bogus_password = 'boguspassword123'
+    initial_nfs_config = call('nfs.config')
+    try:
+        # CREATE
+        with expect_audit_method_calls([{
+            'method': 'nfs.add_principal',
+            'params': [
+                {
+                    'username': bogus_user,
+                    'password': REDACTED_SECRET,
+                }
+            ],
+            'description': f'Add NFS principal {bogus_user}',
+        }]):
+            payload = {
+                'username': bogus_user,
+                'password': bogus_password,
+            }
+            # The 'add' will fail, but the audit check should pass
+            if api == 'ws':
+                with pytest.raises(CallError):
+                    call('nfs.add_principal', payload)
+            elif api == 'rest':
+                result = POST('/nfs/add_principal/', payload)
+                assert result.status_code != 200, result.text
+            else:
+                raise ValueError(api)
+        # UPDATE
+        payload = {
+            'mountd_log': not initial_nfs_config['mountd_log'],
+            'mountd_port': 618,
+            'protocols': ["NFSV4"]
+        }
+        with expect_audit_method_calls([{
+            'method': 'nfs.update',
+            'params': [payload],
+            'description': 'Update NFS configuration',
+        }]):
+            if api == 'ws':
+                call('nfs.update', payload)
+            elif api == 'rest':
+                result = PUT('/nfs/', payload)
+                assert result.status_code == 200, result.text
+            else:
+                raise ValueError(api)
+    finally:
+        # Restore initial state
+        restore_payload = {
+            'mountd_log': initial_nfs_config['mountd_log'],
+            'mountd_port': initial_nfs_config['mountd_port'],
+            'protocols': initial_nfs_config['protocols']
+        }
+        if api == 'ws':
+            call('nfs.update', restore_payload)
+        elif api == 'rest':
+            result = PUT('/nfs/', restore_payload)
+            assert result.status_code == 200, result.text
+        else:
+            raise ValueError(api)
+
+
+@pytest.mark.parametrize('api', ['ws', 'rest'])
+def test_nfs_share_audit(api, nfs_audit_dataset):
+    '''
+    Test the auditing of NFS share operations
+    '''
+    nfs_export_path = f"/mnt/{nfs_audit_dataset}"
+    try:
+        # CREATE
+        payload = {
+            "comment": "My Test Share",
+            "path": nfs_export_path,
+            "security": ["SYS"]
+        }
+        with expect_audit_method_calls([{
+            'method': 'sharing.nfs.create',
+            'params': [payload],
+            'description': f'NFS share create {nfs_export_path}',
+        }]):
+            if api == 'ws':
+                share_config = call('sharing.nfs.create', payload)
+            elif api == 'rest':
+                results = POST("/sharing/nfs/", payload)
+                assert results.status_code == 200, results.text
+                share_config = results.json()
+            else:
+                raise ValueError(api)
+        # UPDATE
+        payload = {
+            "security": []
+        }
+        with expect_audit_method_calls([{
+            'method': 'sharing.nfs.update',
+            'params': [
+                share_config['id'],
+                payload,
+            ],
+            'description': f'NFS share update {nfs_export_path}',
+        }]):
+            if api == 'ws':
+                share_config = call('sharing.nfs.update', share_config['id'], payload)
+            elif api == 'rest':
+                results = PUT(f"/sharing/nfs/id/{share_config['id']}/", payload)
+                assert results.status_code == 200, results.text
+                share_config = results.json()
+            else:
+                raise ValueError(api)
+    finally:
+        if share_config is not None:
+            # DELETE
+            id_ = share_config['id']
+            with expect_audit_method_calls([{
+                'method': 'sharing.nfs.delete',
+                'params': [id_],
+                'description': f'NFS share delete {nfs_export_path}',
+            }]):
+                if api == 'ws':
+                    call('sharing.nfs.delete', id_)
+                elif api == 'rest':
+                    result = DELETE(f'/sharing/nfs/id/{id_}')
+                    assert result.status_code == 200, result.text
+                else:
+                    raise ValueError(api)


### PR DESCRIPTION
Add auditing of NFS and FTP.

NFS auditing includes configuration and share create, update and delete.
FTP auditing includes configuration only.