### PR TITLE
NAS-128310 / 24.04.1 / fix remaining usages of host() in api tests (by yocalebo)

### DIFF
--- a/tests/api2/test_snmp_agent.py
+++ b/tests/api2/test_snmp_agent.py
@@ -24,7 +24,7 @@ def test_truenas_mib_elements(snmpd_running):
         f.flush()
 
         snmp = subprocess.run(
-            f"snmpwalk -v2c -c public -m {f.name} {host()} "
+            f"snmpwalk -v2c -c public -m {f.name} {host().ip} "
             "1.3.6.1.4.1.50536",
             shell=True,
             capture_output=True,

--- a/tests/api2/test_system_general_ui_allowlist.py
+++ b/tests/api2/test_system_general_ui_allowlist.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.utils import call, host, mock, ssh, url, webso
 
 def test_system_general_ui_allowlist():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect((host(), 1))  # connect() for UDP doesn't send packets
+    s.connect((host().ip, 1))  # connect() for UDP doesn't send packets
     local_ip = s.getsockname()[0]
 
     with mock("vm.query", return_value=[

--- a/tests/api2/test_user_admin.py
+++ b/tests/api2/test_user_admin.py
@@ -54,7 +54,7 @@ def test_can_set_admin_authorized_key(admin):
                     "-o", "StrictHostKeyChecking=no",
                     "-o", "UserKnownHostsFile=/dev/null",
                     "-o", "VerifyHostKeyDNS=no",
-                    f"admin@{host()}",
+                    f"admin@{host().ip}",
                     "uptime",
                 ], capture_output=True, check=True, timeout=30)
 


### PR DESCRIPTION
A few tests are failing because the `host()` function was changed during the move to the new jenkins instance. This fixes the remaining usages.

Original PR: https://github.com/truenas/middleware/pull/13536
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128310