### PR TITLE
NAS-128301 / 24.10 / Fix forced initrd update (by themylogin)

### DIFF
--- a/src/freenas/usr/local/bin/truenas-initrd.py
+++ b/src/freenas/usr/local/bin/truenas-initrd.py
@@ -249,12 +249,12 @@ if __name__ == "__main__":
 
         database = args.database or os.path.join(root, FREENAS_DATABASE[1:])
 
-        if update_required := (
-            args.force |
-            update_zfs_default(root) |
-            update_pci_initramfs_config(root, database) |
-            update_zfs_module_config(root, database)
-        ):
+        if update_required := any((
+            args.force,
+            update_zfs_default(root),
+            update_pci_initramfs_config(root, database),
+            update_zfs_module_config(root, database),
+        )):
             set_readonly(root, False)
             subprocess.run(["chroot", root, "update-initramfs", "-k", "all", "-u"], check=True)
             set_readonly(root, True)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 06264d5b34d5b4ffd6dce38415208a1fd21b3262

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 1d23c7162538a9feebc0ddef4ec0c109583538fe



Original PR: https://github.com/truenas/middleware/pull/13539
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128301