### PR TITLE
NAS-128330 / 24.04.1 / fix vm role tests (by yocalebo)

### DIFF
--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -53,7 +53,6 @@ def test_vm_read_write_roles(role, method, valid_role):
     ('VM_WRITE', 'vm.clone', True),
     ('VM_READ', 'vm.get_memory_usage', True),
     ('VM_WRITE', 'vm.get_memory_usage', True),
-    ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
     ('VM_READ', 'vm.start', False),
     ('VM_WRITE', 'vm.start', True),
     ('VM_READ', 'vm.stop', False),
@@ -86,6 +85,8 @@ def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
     ('VM_DEVICE_READ', 'vm.device.iommu_enabled', True),
     ('VM_DEVICE_READ', 'vm.device.passthrough_device_choices', True),
     ('VM_DEVICE_READ', 'vm.device.nic_attach_choices', True),
+    ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
+    ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
 ])
 def test_vm_device_read_write_roles(role, method, valid_role):
     with unprivileged_user_client(roles=[role]) as c:
@@ -101,7 +102,6 @@ def test_vm_device_read_write_roles(role, method, valid_role):
 @pytest.mark.parametrize('role, method, valid_role', [
     ('VM_DEVICE_READ', 'vm.device.passthrough_device', True),
     ('VM_DEVICE_WRITE', 'vm.device.passthrough_device', True),
-    ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
 ])
 def test_vm_device_read_write_roles_requiring_virtualization(role, method, valid_role):
     with unprivileged_user_client(roles=[role]) as c:


### PR DESCRIPTION
It's hard to really tell what's going on here because the `common_checks` function isn't documented but these 2 endpoints are not raising exceptions when using an "unprivileged" user account. However, they're not raising an exception because they're able to make the call to the endpoint. The issue is that `valid_role_exception` is set to True by default in `common_checks`. This fixes the tests.

Original PR: https://github.com/truenas/middleware/pull/13549
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128330