### PR TITLE
NAS-128337 / 24.10 / Speed up ACL execute permissions check

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
@@ -1,11 +1,17 @@
 import errno
+import grp
 import os
 import pathlib
+import pwd
 
 from middlewared.schema import accepts, Bool, Dict, returns, Str
 from middlewared.service import CallError, Service, private
 
-from middlewared.utils.user_context import run_with_user_context
+from middlewared.utils.user_context import run_with_user_context, set_user_context
+
+# This should be a sufficiently high UID to never be used explicitly
+# We need one for doing access checks based on groups
+SYNTHETIC_UID = 2 ** 32 -2
 
 
 def check_access(path: str, check_perms: dict) -> bool:
@@ -21,6 +27,105 @@ def check_access(path: str, check_perms: dict) -> bool:
         flag &= (perm_check if perm else not perm_check)
 
     return flag
+
+
+def get_user_details(id_type: str, xid: int) -> dict:
+    if id_type not in ['USER', 'GROUP']:
+        raise CallError(f'{id_type}: invalid ID type. Must be "USER" or "GROUP"')
+
+    if id_type == 'USER':
+        try:
+            u = pwd.getpwuid(xid)
+            out = {
+                'pw_name': u.pw_name,
+                'pw_uid': u.pw_uid,
+                'pw_gid': u.pw_gid,
+                'pw_gecos': u.pw_gecos,
+                'pw_dir': u.pw_dir,
+                'pw_shell': u.pw_shell,
+            }
+            out['grouplist'] = os.getgrouplist(u.pw_name, u.pw_gid)
+            out['id_name'] = out['pw_name']
+            return out
+        except KeyError:
+            return None
+
+    try:
+        g = grp.getgrgid(xid)
+        grp_obj = {
+            'gr_name': g.gr_name,
+            'gr_gid': g.gr_gid,
+            'gr_mem': g.gr_mem
+        }
+    except KeyError:
+        return None
+
+    return {
+        'pw_name': 'synthetic_user',
+        'pw_uid': SYNTHETIC_UID,
+        'pw_gid': grp_obj['gr_gid'],
+        'pw_gecos': 'synthetic user',
+        'pw_dir': '/var/empty',
+        'pw_shell': '/usr/bin/zsh',
+        'grouplist': [grp_obj['gr_gid']],
+        'id_name': grp_obj['gr_name']
+    }
+
+
+def check_acl_execute_impl(path: str, acl: list, uid: int, gid: int, path_must_exist: bool):
+    """
+    WARNING: The only way this method should be called is within context of `run_with_user_context`
+    """
+    parts = pathlib.Path(path).parts
+
+    for entry in acl:
+        if entry['tag'] in ('everyone@', 'OTHER', 'MASK'):
+            continue
+
+        if entry.get('type', 'ALLOW') != 'ALLOW':
+            continue
+
+        id_info = {'id_type': None, 'xid': entry['id']}
+
+        if entry['tag'] == 'GROUP':
+            id_info['id_type'] = 'GROUP'
+
+        elif entry['tag'] == 'USER':
+            id_info['id_type'] = 'USER'
+
+        elif entry['tag'] in ('owner@', 'USER_OBJ'):
+            id_info['id_type'] = 'USER'
+            id_info['xid'] = uid
+
+        elif entry['tag'] in ('group@', 'GROUP_OBJ'):
+            id_info['id_type'] = 'USER'
+            id_info['xid'] = gid
+
+        if (user_details := get_user_details(**id_info)) is None:
+            # Account does not exist on server. Skip validation
+            continue
+
+        id_type = id_info['id_type']
+
+        for idx, part in enumerate(parts):
+            if idx < 2:
+                continue
+
+            path_to_check = f'/{"/".join(parts[1:idx])}'
+            if not os.path.exists(path_to_check):
+                if path_must_exist:
+                    raise CallError(f'{path_to_check}: path component does not exist.', errno.ENOENT)
+
+                continue
+
+            set_user_context(user_details)
+            if not check_access(path_to_check, {'read': None, 'write': None, 'execute': True}):
+                raise CallError(
+                    f'Filesystem permissions on path {path_to_check} prevent access for '
+                    f'{id_type.lower()} "{user_details["id_name"]}" to the path {path}. '
+                    f'This may be fixed by granting the aforementioned {id_type.lower()} '
+                    f'execute permissions on the path: {path_to_check}.', errno.EPERM
+                )
 
 
 class FilesystemService(Service):
@@ -78,7 +183,7 @@ class FilesystemService(Service):
         }
 
     @private
-    def check_as_user_impl(self, user_details, path, perms):
+    def check_as_user_imp(self, user_details, path, perms):
         return run_with_user_context(check_access, user_details, [path, perms])
 
     @accepts(
@@ -149,27 +254,6 @@ class FilesystemService(Service):
 
     @private
     def check_acl_execute(self, path, acl, uid, gid, path_must_exist=False):
-        for entry in acl:
-            if entry['tag'] in ('everyone@', 'OTHER', 'MASK'):
-                continue
-
-            if entry.get('type', 'ALLOW') != 'ALLOW':
-                continue
-
-            id_info = {'id_type': None, 'xid': entry['id']}
-
-            if entry['tag'] == 'GROUP':
-                id_info['id_type'] = 'GROUP'
-
-            elif entry['tag'] == 'USER':
-                id_info['id_type'] = 'USER'
-
-            elif entry['tag'] in ('owner@', 'USER_OBJ'):
-                id_info['id_type'] = 'USER'
-                id_info['xid'] = uid
-
-            elif entry['tag'] in ('group@', 'GROUP_OBJ'):
-                id_info['id_type'] = 'USER'
-                id_info['xid'] = gid
-
-            self.check_path_execute(path, id_info['id_type'], id_info['xid'], path_must_exist)
+        run_with_user_context(check_acl_execute_impl, {
+            'pw_uid': 0, 'pw_gid': 0, 'pw_dir': '/var/empty', 'pw_name': 'root', 'grouplist': [0, 544]
+        }, [path, acl, uid, gid, path_must_exist])

--- a/src/middlewared/middlewared/utils/user_context.py
+++ b/src/middlewared/middlewared/utils/user_context.py
@@ -12,19 +12,28 @@ __all__ = ["run_command_with_user_context", "run_with_user_context", "set_user_c
 
 
 def set_user_context(user_details: dict) -> None:
-    os.setgroups(user_details['grouplist'])
-    os.setresgid(user_details['pw_gid'], user_details['pw_gid'], user_details['pw_gid'])
-    os.setresuid(user_details['pw_uid'], user_details['pw_uid'], user_details['pw_uid'])
+    if os.geteuid() != 0:
+        # We need to reset to UID 0 before setgroups is called
+        os.seteuid(0)
 
-    if any(
-        c() != v for c, v in (
-            (os.getuid, user_details['pw_uid']),
-            (os.geteuid, user_details['pw_uid']),
-            (os.getgid, user_details['pw_gid']),
-            (os.getegid, user_details['pw_gid']),
-        )
-    ):
-        raise Exception(f'Unable to set user context to {user_details["pw_name"]!r} user')
+    os.setgroups(user_details['grouplist'])
+
+    # We must preserve the saved uid of zero so that we can call this multiple times
+    # in same child process.
+    gids = (user_details['pw_gid'], user_details['pw_gid'], 0)
+    uids = (user_details['pw_uid'], user_details['pw_uid'], 0)
+
+    os.setresgid(*gids)
+    os.setresuid(*uids)
+
+    new_gids = os.getresgid()
+    new_uids = os.getresuid()
+
+    if new_gids != gids:
+        raise Exception(f'{user_details["pw_name"]}: Unable to set gids for user context received {new_gids}, expected {gids}')
+
+    if new_uids != uids:
+        raise Exception(f'{user_details["pw_name"]}: Unable to set uids for user context received {new_uids}, expected {uids}')
 
     try:
         os.chdir(user_details['pw_dir'])


### PR DESCRIPTION
The validation that ACL entries have ability to chdir to specified path had relatively terrible performance because it was forking a worker process for each change_to_user operation. This commit refactors so that we only fork once for validating the entire ACL.

This required refactoring our user context code to leave the saved UID and saved GID in-tact so that we can repeatedly setresuid and setresgid from same child process.