### PR TITLE
NAS-128339 / 24.10 / account for disk['State'] == 'Absent' on ES24N

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -101,8 +101,22 @@ def map_es24n(model, rclient, uri):
     }
     mapped = dict()
     for disk in all_disks['Members']:
-        slot = int(disk['Id'])
-        if found := mounted_disks.get(disk['SerialNumber']):
+        if disk['State'] == 'Absent':
+            mapped[slot] = None
+            continue
+
+        sn = disk.get('SerialNumber')
+        if not sn:
+            mapped[slot] = None
+            continue
+
+        slot = disk.get('Id', '')
+        if not slot or not slot.isdigit():
+            # shouldn't happen but need to catch edge-case
+            mapped[slot] = None
+
+        slot = int(slot)
+        if found := mounted_disks.get(sn):
             try:
                 # we expect namespace 1 for the device (i.e. nvme1n1)
                 idx = found[1]['namespaces'].index(f'{found[0]}n1')

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -114,6 +114,7 @@ def map_es24n(model, rclient, uri):
         if not slot or not slot.isdigit():
             # shouldn't happen but need to catch edge-case
             mapped[slot] = None
+            continue
 
         slot = int(slot)
         if found := mounted_disks.get(sn):

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -105,14 +105,14 @@ def map_es24n(model, rclient, uri):
             mapped[slot] = None
             continue
 
-        sn = disk.get('SerialNumber')
-        if not sn:
+        slot = dis.get('Id', '')
+        if not slot or not slot.isdigit():
+            # shouldn't happen but need to catch edge-case
             mapped[slot] = None
             continue
 
-        slot = disk.get('Id', '')
-        if not slot or not slot.isdigit():
-            # shouldn't happen but need to catch edge-case
+        sn = disk.get('SerialNumber')
+        if not sn:
             mapped[slot] = None
             continue
 

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -101,13 +101,14 @@ def map_es24n(model, rclient, uri):
     }
     mapped = dict()
     for disk in all_disks['Members']:
-        if disk['State'] == 'Absent':
-            mapped[slot] = None
-            continue
-
         slot = dis.get('Id', '')
         if not slot or not slot.isdigit():
             # shouldn't happen but need to catch edge-case
+            continue
+        else:
+            slot = int(slot)
+
+        if disk['State'] == 'Absent':
             mapped[slot] = None
             continue
 
@@ -116,7 +117,6 @@ def map_es24n(model, rclient, uri):
             mapped[slot] = None
             continue
 
-        slot = int(slot)
         if found := mounted_disks.get(sn):
             try:
                 # we expect namespace 1 for the device (i.e. nvme1n1)


### PR DESCRIPTION
When a disk is removed from ES24N, the REST API doesn't report a `SerialNumber` key. The fix is to check for the `State` key as being `Absent`. This fixes this particular issue but also adds a bit more guard-rails when mapping the disks for this platform. If we crash inside this function, the entirety of the enclosure section in the UI ceases to function which isn't desirable.