### PR TITLE
NAS-128102 / 24.04.1 / NAS-128102 / Fix IPv6 bind for VM display (by Leseratte10)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -189,7 +189,11 @@ http {
 
 % for device in display_devices:
         location ${display_device_path}/${device['id']} {
+    % if ":" in device['attributes']['bind']:
+            proxy_pass http://[${device['attributes']['bind']}]:${device['attributes']['web_port']}/;
+    % else:
             proxy_pass http://${device['attributes']['bind']}:${device['attributes']['web_port']}/;
+    % endif
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Real-Remote-Port $remote_port;


### PR DESCRIPTION
I've found a bug in TrueNAS Scale 24.04-RC.1 which I reported here: https://ixsystems.atlassian.net/browse/NAS-128102

When a VM's display is bound to an IPv6 address like "::" using the "Bind" setting in the GUI, the resulting Nginx config is corrupt and Nginx refuses to start. This is because IPv6 addresses need to be surrounded by [] which is currently not the case. 

This bug has been introduced by [#12049](https://github.com/truenas/middleware/pull/12049). 

This PR fixes this by checking if the IP contains a colon, and if so, it adds the brackets to the address in the nginx config.

Original PR: https://github.com/truenas/middleware/pull/13439
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128102