### PR TITLE
NAS-128333 / 24.10 / Improve role checking logic to reduce tests execution tim

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -1,8 +1,30 @@
+import contextlib
 import errno
+import random
 import pytest
+import string
 
 from middlewared.client.client import ClientException
-from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.account import (
+    unprivileged_user,
+    unprivileged_user_client as unprivileged_user_client_main,
+)
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(scope='session')
+def unprivileged_user_fixture(request):
+    suffix = ''.join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
+    group_name = f'unprivileged_users_fixture_{suffix}'
+    with unprivileged_user(
+        username=f'unprivileged_fixture_{suffix}',
+        group_name=group_name,
+        privilege_name=f'Unprivileged users fixture ({suffix})',
+        allowlist=[],
+        roles=[],
+        web_shell=False,
+    ) as t:
+        yield t, group_name
 
 
 def common_checks(
@@ -10,7 +32,7 @@ def common_checks(
 ):
     method_args = method_args or []
     method_kwargs = method_kwargs or {}
-    with unprivileged_user_client(roles=[role]) as client:
+    with unprivileged_user_client_main(roles=[role]) as client:
         if valid_role:
             if valid_role_exception:
                 with pytest.raises(Exception) as exc_info:

--- a/tests/api2/test_apps_roles.py
+++ b/tests/api2/test_apps_roles.py
@@ -3,8 +3,8 @@ import pytest
 from middlewared.test.integration.assets.roles import common_checks
 
 
-def test_app_readonly_role():
-    common_checks('app.categories', 'READONLY_ADMIN', True, valid_role_exception=False)
+def test_app_readonly_role(unprivileged_user_fixture):
+    common_checks(unprivileged_user_fixture, 'app.categories', 'READONLY_ADMIN', True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role,endpoint,payload,job,should_work,valid_role_exception,is_return_type_none', [
@@ -27,10 +27,10 @@ def test_app_readonly_role():
     ('CATALOG_WRITE', 'catalog.items', [], False, True, True, False),
 ])
 def test_catalog_read_and_write_role(
-    role, endpoint, payload, job, should_work, valid_role_exception, is_return_type_none
+    unprivileged_user_fixture, role, endpoint, payload, job, should_work, valid_role_exception, is_return_type_none
 ):
     common_checks(
-        endpoint, role, should_work, is_return_type_none=is_return_type_none,
+        unprivileged_user_fixture, endpoint, role, should_work, is_return_type_none=is_return_type_none,
         valid_role_exception=valid_role_exception, method_args=payload, method_kwargs={'job': job}
     )
 
@@ -42,8 +42,10 @@ def test_catalog_read_and_write_role(
     ('APPS_READ', 'container.prune', True, False),
     ('APPS_WRITE', 'container.prune', True, True),
 ])
-def test_apps_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})
+def test_apps_read_and_write_roles(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job}
+    )
 
 
 @pytest.mark.parametrize('role,endpoint,job,should_work', [
@@ -55,8 +57,8 @@ def test_apps_read_and_write_roles(role, endpoint, job, should_work):
     ('APPS_READ', 'chart.release.upgrade', True, False),
     ('APPS_WRITE', 'chart.release.upgrade', True, True),
 ])
-def test_apps_read_and_write_roles_with_params(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, method_kwargs={'job': job})
+def test_apps_read_and_write_roles_with_params(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(unprivileged_user_fixture, endpoint, role, should_work, method_kwargs={'job': job})
 
 
 @pytest.mark.parametrize('role,endpoint,job,should_work', [
@@ -69,5 +71,7 @@ def test_apps_read_and_write_roles_with_params(role, endpoint, job, should_work)
     ('KUBERNETES_READ', 'kubernetes.events', False, True),
     ('KUBERNETES_WRITE', 'kubernetes.events', False, True),
 ])
-def test_kubernetes_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})
+def test_kubernetes_read_and_write_roles(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job}
+    )

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -9,32 +9,32 @@ from middlewared.test.integration.assets.roles import common_checks
     ('certificate.profiles', 'CERTIFICATE_AUTHORITY_READ', False),
     ('certificateauthority.profiles', 'CERTIFICATE_READ', False),
 ))
-def test_profiles_read_roles(method, role, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def test_profiles_read_roles(unprivileged_user_fixture, method, role, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_AUTHORITY_WRITE', True),
     ('CERTIFICATE_AUTHORITY_READ', False),
 ))
-def test_certificate_authority_create_role(role, valid_role):
-    common_checks('certificateauthority.create', role, valid_role, method_args=[{}])
+def test_certificate_authority_create_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificateauthority.create', role, valid_role, method_args=[{}])
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_WRITE', True),
     ('CERTIFICATE_READ', False),
 ))
-def test_certificate_create_role(role, valid_role):
-    common_checks('certificate.create', role, valid_role, method_args=[], method_kwargs={'job': True})
+def test_certificate_create_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificate.create', role, valid_role, method_args=[], method_kwargs={'job': True})
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_AUTHORITY_WRITE', True),
     ('CERTIFICATE_AUTHORITY_READ', False),
 ))
-def test_signing_csr_role(role, valid_role):
-    common_checks('certificateauthority.ca_sign_csr', role, valid_role, method_args=[{
+def test_signing_csr_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificateauthority.ca_sign_csr', role, valid_role, method_args=[{
         'ca_id': 1,
         'csr_cert_id': 1,
         'name': 'test_csr_signing_role',

--- a/tests/api2/test_iscsi_auth_crud_roles.py
+++ b/tests/api2/test_iscsi_auth_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.auth.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.auth.create", role, False)
-    common_checks("iscsi.auth.update", role, False)
-    common_checks("iscsi.auth.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_AUTH_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.auth.create", role, True)
-    common_checks("iscsi.auth.update", role, True)
-    common_checks("iscsi.auth.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.delete", role, True)

--- a/tests/api2/test_iscsi_extent_crud_roles.py
+++ b/tests/api2/test_iscsi_extent_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_EXTENT_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.extent.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_EXTENT_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.extent.create", role, False)
-    common_checks("iscsi.extent.update", role, False)
-    common_checks("iscsi.extent.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_EXTENT_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.extent.create", role, True)
-    common_checks("iscsi.extent.update", role, True)
-    common_checks("iscsi.extent.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.delete", role, True)

--- a/tests/api2/test_iscsi_global_crud_roles.py
+++ b/tests/api2/test_iscsi_global_crud_roles.py
@@ -4,18 +4,18 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.global.config", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.sessions", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.client_count", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.alua_enabled", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.config", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.sessions", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.client_count", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.alua_enabled", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.global.update", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.update", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_GLOBAL_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.global.update", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.update", role, True)

--- a/tests/api2/test_iscsi_host_crud_roles.py
+++ b/tests/api2/test_iscsi_host_crud_roles.py
@@ -4,23 +4,23 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.host.query", role, True, valid_role_exception=False)
-    common_checks("iscsi.host.get_initiators", role, True)
-    common_checks("iscsi.host.get_targets", role, True)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.query", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.get_initiators", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.get_targets", role, True)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.host.create", role, False)
-    common_checks("iscsi.host.update", role, False)
-    common_checks("iscsi.host.delete", role, False)
-    common_checks("iscsi.host.set_initiators", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.delete", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.set_initiators", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_HOST_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.host.create", role, True)
-    common_checks("iscsi.host.update", role, True)
-    common_checks("iscsi.host.delete", role, True)
-    common_checks("iscsi.host.set_initiators", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.delete", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.set_initiators", role, True)

--- a/tests/api2/test_iscsi_initiator_crud_roles.py
+++ b/tests/api2/test_iscsi_initiator_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.initiator.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.initiator.create", role, False)
-    common_checks("iscsi.initiator.update", role, False)
-    common_checks("iscsi.initiator.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_INITIATOR_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.initiator.create", role, True)
-    common_checks("iscsi.initiator.update", role, True)
-    common_checks("iscsi.initiator.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.delete", role, True)

--- a/tests/api2/test_iscsi_portal_crud_roles.py
+++ b/tests/api2/test_iscsi_portal_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_PORTAL_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.portal.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_PORTAL_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.portal.create", role, False)
-    common_checks("iscsi.portal.update", role, False)
-    common_checks("iscsi.portal.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_PORTAL_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.portal.create", role, True)
-    common_checks("iscsi.portal.update", role, True)
-    common_checks("iscsi.portal.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.delete", role, True)

--- a/tests/api2/test_iscsi_target_crud_roles.py
+++ b/tests/api2/test_iscsi_target_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.target.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.target.create", role, False)
-    common_checks("iscsi.target.update", role, False)
-    common_checks("iscsi.target.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.target.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.target.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGET_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.target.create", role, True)
-    common_checks("iscsi.target.update", role, True)
-    common_checks("iscsi.target.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.target.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.target.delete", role, True)

--- a/tests/api2/test_iscsi_targetextent_crud_roles.py
+++ b/tests/api2/test_iscsi_targetextent_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.targetextent.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.targetextent.create", role, False)
-    common_checks("iscsi.targetextent.update", role, False)
-    common_checks("iscsi.targetextent.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGETEXTENT_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.targetextent.create", role, True)
-    common_checks("iscsi.targetextent.update", role, True)
-    common_checks("iscsi.targetextent.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.delete", role, True)

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -4,33 +4,41 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_can_read(role):
-    common_checks("sharing.nfs.query", role, True, valid_role_exception=False)
-    common_checks("nfs.client_count", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.query", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.client_count", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_cant_write(role):
-    common_checks("sharing.nfs.create", role, False)
-    common_checks("sharing.nfs.update", role, False)
-    common_checks("sharing.nfs.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.create", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.update", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.delete", role, False)
 
-    common_checks("nfs.get_nfs3_clients", role, False)
-    common_checks("nfs.get_nfs4_clients", role, False)
-    common_checks("nfs.add_principal", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs3_clients", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs4_clients", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.add_principal", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_NFS_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("sharing.nfs.create", role, True)
-    common_checks("sharing.nfs.update", role, True)
-    common_checks("sharing.nfs.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.create", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.update", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.delete", role, True)
 
-    common_checks("nfs.get_nfs3_clients", role, True, valid_role_exception=False)
-    common_checks("nfs.get_nfs4_clients", role, True, valid_role_exception=False)
-    common_checks("nfs.add_principal", role, True)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs3_clients", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs4_clients", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.add_principal", role, True)
 
-    common_checks("service.start", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.restart", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.reload", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.stop", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks(
+        unprivileged_user_fixture, "service.start", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.restart", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.reload", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.stop", role, True, method_args=["nfs"], valid_role_exception=False
+    )

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -15,35 +15,43 @@ def create_dataset():
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_SMB_READ"])
-def test_read_role_can_read(role):
-    common_checks("sharing.smb.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.smb.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_SMB_READ"])
-def test_read_role_cant_write(role):
-    common_checks("sharing.smb.create", role, False)
-    common_checks("sharing.smb.update", role, False)
-    common_checks("sharing.smb.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.smb.create", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.smb.update", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.smb.delete", role, False)
 
-    common_checks("sharing.smb.getacl", role, True)
-    common_checks("sharing.smb.setacl", role, False)
-    common_checks("smb.status", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.smb.getacl", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.smb.setacl", role, False)
+    common_checks(unprivileged_user_fixture, "smb.status", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("sharing.smb.create", role, True)
-    common_checks("sharing.smb.update", role, True)
-    common_checks("sharing.smb.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.smb.create", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.smb.update", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.smb.delete", role, True)
 
-    common_checks("sharing.smb.getacl", role, True)
-    common_checks("sharing.smb.setacl", role, True)
-    common_checks("smb.status", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "sharing.smb.getacl", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.smb.setacl", role, True)
+    common_checks(unprivileged_user_fixture, "smb.status", role, True, valid_role_exception=False)
 
-    common_checks("service.start", role, True, method_args=["cifs"], valid_role_exception=False)
-    common_checks("service.restart", role, True, method_args=["cifs"], valid_role_exception=False)
-    common_checks("service.reload", role, True, method_args=["cifs"], valid_role_exception=False)
-    common_checks("service.stop", role, True, method_args=["cifs"], valid_role_exception=False)
+    common_checks(
+        unprivileged_user_fixture, "service.start", role, True, method_args=["cifs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.restart", role, True, method_args=["cifs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.reload", role, True, method_args=["cifs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.stop", role, True, method_args=["cifs"], valid_role_exception=False
+    )
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_SMB_WRITE"])

--- a/tests/api2/test_system_settings_roles.py
+++ b/tests/api2/test_system_settings_roles.py
@@ -20,9 +20,9 @@ from middlewared.test.integration.assets.roles import common_checks
     ('SYSTEM_GENERAL_READ', 'system.general.local_url', [], True, False, False),
 ])
 def test_catalog_read_and_write_role(
-    role, endpoint, payload, should_work, valid_role_exception, is_return_type_none
+    unprivileged_user_fixture, role, endpoint, payload, should_work, valid_role_exception, is_return_type_none
 ):
     common_checks(
-        endpoint, role, should_work, is_return_type_none=is_return_type_none,
+        unprivileged_user_fixture, endpoint, role, should_work, is_return_type_none=is_return_type_none,
         valid_role_exception=valid_role_exception, method_args=payload
     )

--- a/tests/api2/test_truecommand_roles.py
+++ b/tests/api2/test_truecommand_roles.py
@@ -3,9 +3,9 @@ import pytest
 from middlewared.test.integration.assets.roles import common_checks
 
 
-def test_truecommand_readonly_role():
+def test_truecommand_readonly_role(unprivileged_user_fixture):
     common_checks(
-        'truenas.managed_by_truecommand', 'READONLY_ADMIN', True, valid_role_exception=False
+        unprivileged_user_fixture, 'truenas.managed_by_truecommand', 'READONLY_ADMIN', True, valid_role_exception=False
     )
 
 
@@ -17,7 +17,7 @@ def test_truecommand_readonly_role():
     ('truecommand.update', 'TRUECOMMAND_READ', False, True),
     ('truecommand.update', 'TRUECOMMAND_WRITE', True, True),
 ])
-def test_truecommand_read_and_write_role(endpoint, role, should_work, valid_role_exception):
+def test_truecommand_read_and_write_role(unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception):
     common_checks(
-        endpoint, role, should_work, valid_role_exception=valid_role_exception
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=valid_role_exception
     )

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -63,7 +63,7 @@ def test_vm_read_write_roles_requiring_virtualization(unprivileged_user_fixture,
     ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
     ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
 ])
-def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+def test_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
     common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
@@ -71,5 +71,5 @@ def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, va
     ('VM_DEVICE_READ', 'vm.device.passthrough_device', True),
     ('VM_DEVICE_WRITE', 'vm.device.passthrough_device', True),
 ])
-def atest_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+def test_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
     common_checks(unprivileged_user_fixture, method, role, valid_role)

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -11,8 +11,8 @@ from middlewared.test.integration.assets.roles import common_checks
     ('vm.get_available_memory', False),
     ('vm.bootloader_options', False),
 ])
-def test_vm_readonly_role(method, expected_error):
-    common_checks(method, 'READONLY_ADMIN', True, valid_role_exception=expected_error)
+def test_vm_readonly_role(unprivileged_user_fixture, method, expected_error):
+    common_checks(unprivileged_user_fixture, method, 'READONLY_ADMIN', True, valid_role_exception=expected_error)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -29,8 +29,8 @@ def test_vm_readonly_role(method, expected_error):
     ('VM_READ', 'vm.port_wizard', True),
     ('VM_READ', 'vm.bootloader_options', True),
 ])
-def test_vm_read_write_roles(role, method, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def test_vm_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -52,8 +52,8 @@ def test_vm_read_write_roles(role, method, valid_role):
     ('VM_READ', 'vm.status', True),
     ('VM_READ', 'vm.log_file_path', True),
 ])
-def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
-    common_checks(method, role, valid_role)
+def test_vm_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -63,13 +63,13 @@ def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
     ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
     ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
 ])
-def test_vm_device_read_write_roles(role, method, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
     ('VM_DEVICE_READ', 'vm.device.passthrough_device', True),
     ('VM_DEVICE_WRITE', 'vm.device.passthrough_device', True),
 ])
-def test_vm_device_read_write_roles_requiring_virtualization(role, method, valid_role):
-    common_checks(method, role, valid_role)
+def atest_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils.pytest import failed
 


### PR DESCRIPTION
This PR adds changes to improve implementation of `common_checks` to reduce the time it took to execute tests which were consuming this. Essentially what was happening was that we were creating a user on each run of that function which also meant that we were creating a dataset where both are costly operations. So now we use a fixture to cache these for the entire run of the test suite but make sure specific roles are updated to account for it.