### PR TITLE
NAS-128362 / 24.04.1 / fix iscsi_extent_locked test (by yocalebo)

### DIFF
--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -60,7 +60,7 @@ def test__iscsi_extent__locked(request):
         with iscsi_extent({
             "name": "test_extent",
             "type": "DISK",
-            "disk": f"zvol/{ds.replace(' ', '+')}",
+            "disk": f"zvol/{ds}",
         }) as extent:
             assert not extent["locked"]
 


### PR DESCRIPTION
No need to replace whitespace with plus signs. ZFS will recognize and handle the space in the zvol name without issue. This is done in other tests in this file but seems to have been omitted from this particular test.

Original PR: https://github.com/truenas/middleware/pull/13572
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128362