### PR TITLE
NAS-128333 / 24.04.1 / Improve role checking logic to reduce tests execution tim (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -1,8 +1,30 @@
+import contextlib
 import errno
+import random
 import pytest
+import string
 
 from middlewared.client.client import ClientException
-from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.account import (
+    unprivileged_user,
+    unprivileged_user_client as unprivileged_user_client_main,
+)
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(scope='session')
+def unprivileged_user_fixture(request):
+    suffix = ''.join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
+    group_name = f'unprivileged_users_fixture_{suffix}'
+    with unprivileged_user(
+        username=f'unprivileged_fixture_{suffix}',
+        group_name=group_name,
+        privilege_name=f'Unprivileged users fixture ({suffix})',
+        allowlist=[],
+        roles=[],
+        web_shell=False,
+    ) as t:
+        yield t, group_name
 
 
 def common_checks(
@@ -10,7 +32,7 @@ def common_checks(
 ):
     method_args = method_args or []
     method_kwargs = method_kwargs or {}
-    with unprivileged_user_client(roles=[role]) as client:
+    with unprivileged_user_client_main(roles=[role]) as client:
         if valid_role:
             if valid_role_exception:
                 with pytest.raises(Exception) as exc_info:

--- a/tests/api2/test_apps_roles.py
+++ b/tests/api2/test_apps_roles.py
@@ -18,7 +18,7 @@ def test_app_readonly_role():
     ('CATALOG_WRITE', 'app.similar', [], False, True, True, False),
     ('CATALOG_READ', 'catalog.sync_all', [], True, False, False, True),
     ('CATALOG_READ', 'catalog.sync', [], True, False, True, True),
-    ('CATALOG_READ', 'catalog.validate', [], True, True, True, False),
+    ('CATALOG_READ', 'catalog.validate', [], True, False, True, False),
     ('CATALOG_WRITE', 'catalog.sync_all', [], True, True, False, True),
     ('CATALOG_WRITE', 'catalog.sync', [], True, True, True, True),
     ('CATALOG_WRITE', 'catalog.validate', [], True, True, True, False),
@@ -43,7 +43,7 @@ def test_catalog_read_and_write_role(
     ('APPS_WRITE', 'container.prune', True, True),
 ])
 def test_apps_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, method_kwargs={'job': job})
+    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})
 
 
 @pytest.mark.parametrize('role,endpoint,job,should_work', [
@@ -70,4 +70,4 @@ def test_apps_read_and_write_roles_with_params(role, endpoint, job, should_work)
     ('KUBERNETES_WRITE', 'kubernetes.events', False, True),
 ])
 def test_kubernetes_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, method_kwargs={'job': job})
+    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})

--- a/tests/api2/test_apps_roles.py
+++ b/tests/api2/test_apps_roles.py
@@ -3,8 +3,8 @@ import pytest
 from middlewared.test.integration.assets.roles import common_checks
 
 
-def test_app_readonly_role():
-    common_checks('app.categories', 'READONLY_ADMIN', True, valid_role_exception=False)
+def test_app_readonly_role(unprivileged_user_fixture):
+    common_checks(unprivileged_user_fixture, 'app.categories', 'READONLY_ADMIN', True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role,endpoint,payload,job,should_work,valid_role_exception,is_return_type_none', [
@@ -27,10 +27,10 @@ def test_app_readonly_role():
     ('CATALOG_WRITE', 'catalog.items', [], False, True, True, False),
 ])
 def test_catalog_read_and_write_role(
-    role, endpoint, payload, job, should_work, valid_role_exception, is_return_type_none
+    unprivileged_user_fixture, role, endpoint, payload, job, should_work, valid_role_exception, is_return_type_none
 ):
     common_checks(
-        endpoint, role, should_work, is_return_type_none=is_return_type_none,
+        unprivileged_user_fixture, endpoint, role, should_work, is_return_type_none=is_return_type_none,
         valid_role_exception=valid_role_exception, method_args=payload, method_kwargs={'job': job}
     )
 
@@ -42,8 +42,10 @@ def test_catalog_read_and_write_role(
     ('APPS_READ', 'container.prune', True, False),
     ('APPS_WRITE', 'container.prune', True, True),
 ])
-def test_apps_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})
+def test_apps_read_and_write_roles(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job}
+    )
 
 
 @pytest.mark.parametrize('role,endpoint,job,should_work', [
@@ -55,8 +57,8 @@ def test_apps_read_and_write_roles(role, endpoint, job, should_work):
     ('APPS_READ', 'chart.release.upgrade', True, False),
     ('APPS_WRITE', 'chart.release.upgrade', True, True),
 ])
-def test_apps_read_and_write_roles_with_params(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, method_kwargs={'job': job})
+def test_apps_read_and_write_roles_with_params(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(unprivileged_user_fixture, endpoint, role, should_work, method_kwargs={'job': job})
 
 
 @pytest.mark.parametrize('role,endpoint,job,should_work', [
@@ -69,5 +71,7 @@ def test_apps_read_and_write_roles_with_params(role, endpoint, job, should_work)
     ('KUBERNETES_READ', 'kubernetes.events', False, True),
     ('KUBERNETES_WRITE', 'kubernetes.events', False, True),
 ])
-def test_kubernetes_read_and_write_roles(role, endpoint, job, should_work):
-    common_checks(endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job})
+def test_kubernetes_read_and_write_roles(unprivileged_user_fixture, role, endpoint, job, should_work):
+    common_checks(
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=False, method_kwargs={'job': job}
+    )

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -26,7 +26,7 @@ def test_certificate_authority_create_role(role, valid_role):
     ('CERTIFICATE_READ', False),
 ))
 def test_certificate_create_role(role, valid_role):
-    common_checks('certificate.create', role, valid_role, method_args=[{}], method_kwargs={'job': True})
+    common_checks('certificate.create', role, valid_role, method_args=[], method_kwargs={'job': True})
 
 
 @pytest.mark.parametrize('role, valid_role', (

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -9,32 +9,32 @@ from middlewared.test.integration.assets.roles import common_checks
     ('certificate.profiles', 'CERTIFICATE_AUTHORITY_READ', False),
     ('certificateauthority.profiles', 'CERTIFICATE_READ', False),
 ))
-def test_profiles_read_roles(method, role, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def test_profiles_read_roles(unprivileged_user_fixture, method, role, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_AUTHORITY_WRITE', True),
     ('CERTIFICATE_AUTHORITY_READ', False),
 ))
-def test_certificate_authority_create_role(role, valid_role):
-    common_checks('certificateauthority.create', role, valid_role, method_args=[{}])
+def test_certificate_authority_create_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificateauthority.create', role, valid_role, method_args=[{}])
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_WRITE', True),
     ('CERTIFICATE_READ', False),
 ))
-def test_certificate_create_role(role, valid_role):
-    common_checks('certificate.create', role, valid_role, method_args=[], method_kwargs={'job': True})
+def test_certificate_create_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificate.create', role, valid_role, method_args=[], method_kwargs={'job': True})
 
 
 @pytest.mark.parametrize('role, valid_role', (
     ('CERTIFICATE_AUTHORITY_WRITE', True),
     ('CERTIFICATE_AUTHORITY_READ', False),
 ))
-def test_signing_csr_role(role, valid_role):
-    common_checks('certificateauthority.ca_sign_csr', role, valid_role, method_args=[{
+def test_signing_csr_role(unprivileged_user_fixture, role, valid_role):
+    common_checks(unprivileged_user_fixture, 'certificateauthority.ca_sign_csr', role, valid_role, method_args=[{
         'ca_id': 1,
         'csr_cert_id': 1,
         'name': 'test_csr_signing_role',

--- a/tests/api2/test_certificate_roles.py
+++ b/tests/api2/test_certificate_roles.py
@@ -1,26 +1,6 @@
-import errno
 import pytest
 
-from middlewared.client.client import ClientException, ValidationErrors
-from middlewared.service_exception import ValidationErrors as ValidationErrorsServiceException
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-def common_checks(method, role, valid_role, valid_role_exception=True, method_args=None, method_kwargs=None):
-    method_args = method_args or []
-    method_kwargs = method_kwargs or {}
-    with unprivileged_user_client(roles=[role]) as client:
-        if valid_role:
-            if valid_role_exception:
-                with pytest.raises((ValidationErrors, ValidationErrorsServiceException)):
-                    client.call(method, *method_args, **method_kwargs)
-            else:
-                assert client.call(method, *method_args, **method_kwargs) is not None
-        else:
-            with pytest.raises(ClientException) as ve:
-                client.call(method, *method_args, **method_kwargs)
-            assert ve.value.errno == errno.EACCES
-            assert ve.value.error == 'Not authorized'
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize('method, role, valid_role', (

--- a/tests/api2/test_iscsi_auth_crud_roles.py
+++ b/tests/api2/test_iscsi_auth_crud_roles.py
@@ -1,53 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_auth
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def auth():
-    with iscsi_auth({"tag": "42", "user": "dummyuser", "secret": "dummysecret1234"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.auth.query")
+    common_checks("iscsi.auth.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_cant_write(auth, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.create", {
-                "tag": "1",
-                "user": "someusername",
-                "secret": "password1234",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.update", auth['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.delete", auth['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.auth.create", role, False)
+    common_checks("iscsi.auth.update", role, False)
+    common_checks("iscsi.auth.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_AUTH_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.auth.create", {
-            "tag": "1",
-            "user": "someusername",
-            "secret": "password1234",
-        })
-
-        c.call("iscsi.auth.update", item["id"], {})
-
-        c.call("iscsi.auth.delete", item["id"])
+    common_checks("iscsi.auth.create", role, True)
+    common_checks("iscsi.auth.update", role, True)
+    common_checks("iscsi.auth.delete", role, True)

--- a/tests/api2/test_iscsi_auth_crud_roles.py
+++ b/tests/api2/test_iscsi_auth_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.auth.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_AUTH_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.auth.create", role, False)
-    common_checks("iscsi.auth.update", role, False)
-    common_checks("iscsi.auth.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_AUTH_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.auth.create", role, True)
-    common_checks("iscsi.auth.update", role, True)
-    common_checks("iscsi.auth.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.auth.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.auth.delete", role, True)

--- a/tests/api2/test_iscsi_extent_crud_roles.py
+++ b/tests/api2/test_iscsi_extent_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_EXTENT_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.extent.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_EXTENT_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.extent.create", role, False)
-    common_checks("iscsi.extent.update", role, False)
-    common_checks("iscsi.extent.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_EXTENT_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.extent.create", role, True)
-    common_checks("iscsi.extent.update", role, True)
-    common_checks("iscsi.extent.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.extent.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.extent.delete", role, True)

--- a/tests/api2/test_iscsi_global_crud_roles.py
+++ b/tests/api2/test_iscsi_global_crud_roles.py
@@ -4,18 +4,18 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.global.config", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.sessions", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.client_count", role, True, valid_role_exception=False)
-    common_checks("iscsi.global.alua_enabled", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.config", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.sessions", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.client_count", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.global.alua_enabled", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.global.update", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.update", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_GLOBAL_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.global.update", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.global.update", role, True)

--- a/tests/api2/test_iscsi_global_crud_roles.py
+++ b/tests/api2/test_iscsi_global_crud_roles.py
@@ -1,29 +1,21 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.account import unprivileged_user_client
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.global.config")
-        c.call("iscsi.global.sessions")
-        c.call("iscsi.global.client_count")
-        c.call("iscsi.global.alua_enabled")
+    common_checks("iscsi.global.config", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.sessions", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.client_count", role, True, valid_role_exception=False)
+    common_checks("iscsi.global.alua_enabled", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_GLOBAL_READ"])
 def test_read_role_cant_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.global.update", {})
-        assert ve.value.errno == errno.EACCES
+    common_checks("iscsi.global.update", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_GLOBAL_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.global.update", {})
+    common_checks("iscsi.global.update", role, True)

--- a/tests/api2/test_iscsi_host_crud_roles.py
+++ b/tests/api2/test_iscsi_host_crud_roles.py
@@ -4,23 +4,23 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.host.query", role, True, valid_role_exception=False)
-    common_checks("iscsi.host.get_initiators", role, True)
-    common_checks("iscsi.host.get_targets", role, True)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.query", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.get_initiators", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.get_targets", role, True)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.host.create", role, False)
-    common_checks("iscsi.host.update", role, False)
-    common_checks("iscsi.host.delete", role, False)
-    common_checks("iscsi.host.set_initiators", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.delete", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.host.set_initiators", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_HOST_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.host.create", role, True)
-    common_checks("iscsi.host.update", role, True)
-    common_checks("iscsi.host.delete", role, True)
-    common_checks("iscsi.host.set_initiators", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.host.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.delete", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.host.set_initiators", role, True)

--- a/tests/api2/test_iscsi_host_crud_roles.py
+++ b/tests/api2/test_iscsi_host_crud_roles.py
@@ -1,63 +1,26 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_host
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def host():
-    with iscsi_host({"ip": "1.1.2.8", "description": "Target to test targetextent"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_can_read(host, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.host.query")
-        c.call("iscsi.host.get_initiators", host["id"])
-        c.call("iscsi.host.get_targets", host["id"])
+def test_read_role_can_read(role):
+    common_checks("iscsi.host.query", role, True, valid_role_exception=False)
+    common_checks("iscsi.host.get_initiators", role, True)
+    common_checks("iscsi.host.get_targets", role, True)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_HOST_READ"])
-def test_read_role_cant_write(host, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.create", {
-                "ip": "1.2.3.4",
-                "description": "test host for CRUD role",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.update", host["id"], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.set_initiators", host["id"], [])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.delete", host["id"])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.host.set_initiators", host["id"], [])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.host.create", role, False)
+    common_checks("iscsi.host.update", role, False)
+    common_checks("iscsi.host.delete", role, False)
+    common_checks("iscsi.host.set_initiators", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_HOST_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.host.create", {
-            "ip": "1.2.3.4",
-            "description": "test host for CRUD role",
-        })
-        try:
-            c.call("iscsi.host.update", item["id"], {})
-            c.call("iscsi.host.set_initiators", item["id"], [])
-            c.call("iscsi.host.set_targets", item["id"], [])
-        finally:
-            c.call("iscsi.host.delete", item["id"])
+    common_checks("iscsi.host.create", role, True)
+    common_checks("iscsi.host.update", role, True)
+    common_checks("iscsi.host.delete", role, True)
+    common_checks("iscsi.host.set_initiators", role, True)

--- a/tests/api2/test_iscsi_initiator_crud_roles.py
+++ b/tests/api2/test_iscsi_initiator_crud_roles.py
@@ -1,51 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_initiator
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def initiator():
-    with iscsi_initiator({"initiators": ["host1", "host2"], "comment": "Dummy entry"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.initiator.query")
+    common_checks("iscsi.initiator.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_cant_write(initiator, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.initiator.create", {
-                "initiators": ["hostnameAAA", "hostnameBBB"],
-                "comment": "Not going to work",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.update", initiator['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.auth.delete", initiator['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.initiator.create", role, False)
+    common_checks("iscsi.initiator.update", role, False)
+    common_checks("iscsi.initiator.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_INITIATOR_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.initiator.create", {
-            "initiators": ["hostnameA", "hostnameB"],
-            "comment": "Some very interesting comment",
-        })
-        try:
-            c.call("iscsi.initiator.update", item["id"], {})
-        finally:
-            c.call("iscsi.initiator.delete", item["id"])
+    common_checks("iscsi.initiator.create", role, True)
+    common_checks("iscsi.initiator.update", role, True)
+    common_checks("iscsi.initiator.delete", role, True)

--- a/tests/api2/test_iscsi_initiator_crud_roles.py
+++ b/tests/api2/test_iscsi_initiator_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.initiator.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_INITIATOR_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.initiator.create", role, False)
-    common_checks("iscsi.initiator.update", role, False)
-    common_checks("iscsi.initiator.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_INITIATOR_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.initiator.create", role, True)
-    common_checks("iscsi.initiator.update", role, True)
-    common_checks("iscsi.initiator.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.initiator.delete", role, True)

--- a/tests/api2/test_iscsi_portal_crud_roles.py
+++ b/tests/api2/test_iscsi_portal_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_PORTAL_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.portal.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_PORTAL_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.portal.create", role, False)
-    common_checks("iscsi.portal.update", role, False)
-    common_checks("iscsi.portal.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_PORTAL_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.portal.create", role, True)
-    common_checks("iscsi.portal.update", role, True)
-    common_checks("iscsi.portal.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.portal.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.portal.delete", role, True)

--- a/tests/api2/test_iscsi_target_crud_roles.py
+++ b/tests/api2/test_iscsi_target_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.target.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.target.create", role, False)
-    common_checks("iscsi.target.update", role, False)
-    common_checks("iscsi.target.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.target.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.target.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGET_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.target.create", role, True)
-    common_checks("iscsi.target.update", role, True)
-    common_checks("iscsi.target.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.target.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.target.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.target.delete", role, True)

--- a/tests/api2/test_iscsi_target_crud_roles.py
+++ b/tests/api2/test_iscsi_target_crud_roles.py
@@ -1,55 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_target
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def target():
-    with iscsi_target({"name": "dummytarget1", "alias": "Just for rigging purposes"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.target.query")
+    common_checks("iscsi.target.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGET_READ"])
-def test_read_role_cant_write(target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.create", {
-                "name": "test1",
-            })
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.validate_name", "newname1")
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.update", target['id'], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.target.delete", target['id'])
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.target.create", role, False)
+    common_checks("iscsi.target.update", role, False)
+    common_checks("iscsi.target.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGET_WRITE"])
 def test_write_role_can_write(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        # Just do a minimal create here (lower cost)
-        item = c.call("iscsi.target.create", {
-            "name": "test1",
-        })
-        try:
-            c.call("iscsi.target.validate_name", "newname1")
-            c.call("iscsi.target.update", item["id"], {})
-        finally:
-            c.call("iscsi.target.delete", item["id"])
+    common_checks("iscsi.target.create", role, True)
+    common_checks("iscsi.target.update", role, True)
+    common_checks("iscsi.target.delete", role, True)

--- a/tests/api2/test_iscsi_targetextent_crud_roles.py
+++ b/tests/api2/test_iscsi_targetextent_crud_roles.py
@@ -4,19 +4,19 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_can_read(role):
-    common_checks("iscsi.targetextent.query", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_cant_write(role):
-    common_checks("iscsi.targetextent.create", role, False)
-    common_checks("iscsi.targetextent.update", role, False)
-    common_checks("iscsi.targetextent.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.create", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.update", role, False)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGETEXTENT_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("iscsi.targetextent.create", role, True)
-    common_checks("iscsi.targetextent.update", role, True)
-    common_checks("iscsi.targetextent.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.create", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.update", role, True)
+    common_checks(unprivileged_user_fixture, "iscsi.targetextent.delete", role, True)

--- a/tests/api2/test_iscsi_targetextent_crud_roles.py
+++ b/tests/api2/test_iscsi_targetextent_crud_roles.py
@@ -1,72 +1,22 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.iscsi import iscsi_extent, iscsi_target
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-
-@pytest.fixture(scope="module")
-def ds():
-    with dataset("test", {"type": "VOLUME", "volsize": 1048576}) as ds:
-        yield ds
-
-
-@pytest.fixture(scope="module")
-def share():
-    with dataset("test2", {"type": "VOLUME", "volsize": 1048576}) as ds:
-        with iscsi_extent({
-            "name": "test_extent",
-            "type": "DISK",
-            "disk": f"zvol/{ds}",
-        }) as share:
-            yield share
-
-
-@pytest.fixture(scope="module")
-def target():
-    with iscsi_target({"name": "test1", "alias": "Target to test targetextent"}) as result:
-        yield result
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("iscsi.targetextent.query")
+    common_checks("iscsi.targetextent.query", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_ISCSI_READ", "SHARING_ISCSI_TARGETEXTENT_READ"])
-def test_read_role_cant_write(ds, share, target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.create", {
-                "target": target["id"],
-                "lunid": 0,
-                "extent": share["id"],
-            })
-        assert ve.value.errno == errno.EACCES
-
-        dummyID = 0x845fed
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.update", dummyID, {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("iscsi.targetextent.delete", dummyID)
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("iscsi.targetextent.create", role, False)
+    common_checks("iscsi.targetextent.update", role, False)
+    common_checks("iscsi.targetextent.delete", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_ISCSI_WRITE", "SHARING_ISCSI_TARGETEXTENT_WRITE"])
-def test_write_role_can_write(ds, share, target, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        item = c.call("iscsi.targetextent.create", {
-            "target": target["id"],
-            "lunid": 0,
-            "extent": share["id"],
-        })
-        try:
-            c.call("iscsi.targetextent.update", item["id"], {})
-        finally:
-            c.call("iscsi.targetextent.delete", item["id"])
+def test_write_role_can_write(role):
+    common_checks("iscsi.targetextent.create", role, True)
+    common_checks("iscsi.targetextent.update", role, True)
+    common_checks("iscsi.targetextent.delete", role, True)

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -4,33 +4,41 @@ from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_can_read(role):
-    common_checks("sharing.nfs.query", role, True, valid_role_exception=False)
-    common_checks("nfs.client_count", role, True, valid_role_exception=False)
+def test_read_role_can_read(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.query", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.client_count", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_cant_write(role):
-    common_checks("sharing.nfs.create", role, False)
-    common_checks("sharing.nfs.update", role, False)
-    common_checks("sharing.nfs.delete", role, False)
+def test_read_role_cant_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.create", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.update", role, False)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.delete", role, False)
 
-    common_checks("nfs.get_nfs3_clients", role, False)
-    common_checks("nfs.get_nfs4_clients", role, False)
-    common_checks("nfs.add_principal", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs3_clients", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs4_clients", role, False)
+    common_checks(unprivileged_user_fixture, "nfs.add_principal", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_NFS_WRITE"])
-def test_write_role_can_write(role):
-    common_checks("sharing.nfs.create", role, True)
-    common_checks("sharing.nfs.update", role, True)
-    common_checks("sharing.nfs.delete", role, True)
+def test_write_role_can_write(unprivileged_user_fixture, role):
+    common_checks(unprivileged_user_fixture, "sharing.nfs.create", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.update", role, True)
+    common_checks(unprivileged_user_fixture, "sharing.nfs.delete", role, True)
 
-    common_checks("nfs.get_nfs3_clients", role, True, valid_role_exception=False)
-    common_checks("nfs.get_nfs4_clients", role, True, valid_role_exception=False)
-    common_checks("nfs.add_principal", role, True)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs3_clients", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.get_nfs4_clients", role, True, valid_role_exception=False)
+    common_checks(unprivileged_user_fixture, "nfs.add_principal", role, True)
 
-    common_checks("service.start", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.restart", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.reload", role, True, method_args=["nfs"], valid_role_exception=False)
-    common_checks("service.stop", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks(
+        unprivileged_user_fixture, "service.start", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.restart", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.reload", role, True, method_args=["nfs"], valid_role_exception=False
+    )
+    common_checks(
+        unprivileged_user_fixture, "service.stop", role, True, method_args=["nfs"], valid_role_exception=False
+    )

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -1,81 +1,36 @@
-import errno
-
 import pytest
 
-from middlewared.client import ClientException
-from middlewared.test.integration.assets.nfs import nfs_share
-from middlewared.test.integration.assets.pool import dataset
-from middlewared.test.integration.assets.account import unprivileged_user_client
-
-try:
-    from config import ADPASSWORD, ADUSERNAME
-except ImportError:
-    Reason = 'ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
-    pytestmark = pytest.mark.skip(reason=Reason)
-
-
-@pytest.fixture(scope="module")
-def ds():
-    with dataset("nfs_crud_test1") as ds:
-        yield ds
-
-
-@pytest.fixture(scope="module")
-def share():
-    with dataset("nfs_crud_test2") as ds:
-        with nfs_share(ds) as share:
-            yield share
+from middlewared.test.integration.assets.roles import common_checks
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
 def test_read_role_can_read(role):
-    with unprivileged_user_client(roles=[role]) as c:
-        c.call("sharing.nfs.query")
-        c.call("nfs.client_count")
+    common_checks("sharing.nfs.query", role, True, valid_role_exception=False)
+    common_checks("nfs.client_count", role, True, valid_role_exception=False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_READ", "SHARING_NFS_READ"])
-def test_read_role_cant_write(ds, share, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.create", {"path": f"/mnt/{ds}"})
-        assert ve.value.errno == errno.EACCES
+def test_read_role_cant_write(role):
+    common_checks("sharing.nfs.create", role, False)
+    common_checks("sharing.nfs.update", role, False)
+    common_checks("sharing.nfs.delete", role, False)
 
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.update", share["id"], {})
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("sharing.nfs.delete", share["id"])
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.get_nfs3_clients")
-        assert ve.value.errno == errno.EACCES
-
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.get_nfs4_clients")
-        assert ve.value.errno == errno.EACCES
-
-        # This should be blocked before needing to mock any configuration
-        with pytest.raises(ClientException) as ve:
-            c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
-        assert ve.value.errno == errno.EACCES
+    common_checks("nfs.get_nfs3_clients", role, False)
+    common_checks("nfs.get_nfs4_clients", role, False)
+    common_checks("nfs.add_principal", role, False)
 
 
 @pytest.mark.parametrize("role", ["SHARING_WRITE", "SHARING_NFS_WRITE"])
-def test_write_role_can_write(ds, role):
-    with unprivileged_user_client(roles=[role]) as c:
-        share = c.call("sharing.nfs.create", {"path": f"/mnt/{ds}"})
+def test_write_role_can_write(role):
+    common_checks("sharing.nfs.create", role, True)
+    common_checks("sharing.nfs.update", role, True)
+    common_checks("sharing.nfs.delete", role, True)
 
-        c.call("sharing.nfs.update", share["id"], {})
-        c.call("sharing.nfs.delete", share["id"])
-        c.call("nfs.get_nfs3_clients")
-        c.call("nfs.get_nfs4_clients")
-        # Multiple layers of dependencies to mock up this as a successful write
-        # c.call("nfs.add_principal", {"username": ADUSERNAME, "password": ADPASSWORD})
+    common_checks("nfs.get_nfs3_clients", role, True, valid_role_exception=False)
+    common_checks("nfs.get_nfs4_clients", role, True, valid_role_exception=False)
+    common_checks("nfs.add_principal", role, True)
 
-        c.call("service.start", "nfs")
-        c.call("service.restart", "nfs")
-        c.call("service.reload", "nfs")
-        c.call("service.stop", "nfs")
+    common_checks("service.start", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.restart", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.reload", role, True, method_args=["nfs"], valid_role_exception=False)
+    common_checks("service.stop", role, True, method_args=["nfs"], valid_role_exception=False)

--- a/tests/api2/test_system_settings_roles.py
+++ b/tests/api2/test_system_settings_roles.py
@@ -20,9 +20,9 @@ from middlewared.test.integration.assets.roles import common_checks
     ('SYSTEM_GENERAL_READ', 'system.general.local_url', [], True, False, False),
 ])
 def test_catalog_read_and_write_role(
-    role, endpoint, payload, should_work, valid_role_exception, is_return_type_none
+    unprivileged_user_fixture, role, endpoint, payload, should_work, valid_role_exception, is_return_type_none
 ):
     common_checks(
-        endpoint, role, should_work, is_return_type_none=is_return_type_none,
+        unprivileged_user_fixture, endpoint, role, should_work, is_return_type_none=is_return_type_none,
         valid_role_exception=valid_role_exception, method_args=payload
     )

--- a/tests/api2/test_truecommand_roles.py
+++ b/tests/api2/test_truecommand_roles.py
@@ -3,9 +3,9 @@ import pytest
 from middlewared.test.integration.assets.roles import common_checks
 
 
-def test_truecommand_readonly_role():
+def test_truecommand_readonly_role(unprivileged_user_fixture):
     common_checks(
-        'truecommand.connected', 'READONLY_ADMIN', True, valid_role_exception=False
+        unprivileged_user_fixture, 'truecommand.connected', 'READONLY_ADMIN', True, valid_role_exception=False
     )
 
 
@@ -17,7 +17,7 @@ def test_truecommand_readonly_role():
     ('truecommand.update', 'TRUECOMMAND_READ', False, True),
     ('truecommand.update', 'TRUECOMMAND_WRITE', True, True),
 ])
-def test_truecommand_read_and_write_role(endpoint, role, should_work, valid_role_exception):
+def test_truecommand_read_and_write_role(unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception):
     common_checks(
-        endpoint, role, should_work, valid_role_exception=valid_role_exception
+        unprivileged_user_fixture, endpoint, role, should_work, valid_role_exception=valid_role_exception
     )

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -63,7 +63,7 @@ def test_vm_read_write_roles_requiring_virtualization(unprivileged_user_fixture,
     ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
     ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
 ])
-def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+def test_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
     common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
@@ -71,5 +71,5 @@ def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, va
     ('VM_DEVICE_READ', 'vm.device.passthrough_device', True),
     ('VM_DEVICE_WRITE', 'vm.device.passthrough_device', True),
 ])
-def atest_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+def test_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
     common_checks(unprivileged_user_fixture, method, role, valid_role)

--- a/tests/api2/test_vm_roles.py
+++ b/tests/api2/test_vm_roles.py
@@ -11,8 +11,8 @@ from middlewared.test.integration.assets.roles import common_checks
     ('vm.get_available_memory', False),
     ('vm.bootloader_options', False),
 ])
-def test_vm_readonly_role(method, expected_error):
-    common_checks(method, 'READONLY_ADMIN', True, valid_role_exception=expected_error)
+def test_vm_readonly_role(unprivileged_user_fixture, method, expected_error):
+    common_checks(unprivileged_user_fixture, method, 'READONLY_ADMIN', True, valid_role_exception=expected_error)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -29,8 +29,8 @@ def test_vm_readonly_role(method, expected_error):
     ('VM_READ', 'vm.port_wizard', True),
     ('VM_READ', 'vm.bootloader_options', True),
 ])
-def test_vm_read_write_roles(role, method, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def test_vm_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -52,8 +52,8 @@ def test_vm_read_write_roles(role, method, valid_role):
     ('VM_READ', 'vm.status', True),
     ('VM_READ', 'vm.log_file_path', True),
 ])
-def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
-    common_checks(method, role, valid_role)
+def test_vm_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
@@ -63,13 +63,13 @@ def test_vm_read_write_roles_requiring_virtualization(role, method, valid_role):
     ('VM_DEVICE_READ', 'vm.device.usb_passthrough_choices', True),
     ('VM_READ', 'vm.guest_architecture_and_machine_choices', True),
 ])
-def test_vm_device_read_write_roles(role, method, valid_role):
-    common_checks(method, role, valid_role, valid_role_exception=False)
+def atest_vm_device_read_write_roles(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=False)
 
 
 @pytest.mark.parametrize('role, method, valid_role', [
     ('VM_DEVICE_READ', 'vm.device.passthrough_device', True),
     ('VM_DEVICE_WRITE', 'vm.device.passthrough_device', True),
 ])
-def test_vm_device_read_write_roles_requiring_virtualization(role, method, valid_role):
-    common_checks(method, role, valid_role)
+def atest_vm_device_read_write_roles_requiring_virtualization(unprivileged_user_fixture, role, method, valid_role):
+    common_checks(unprivileged_user_fixture, method, role, valid_role)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.test.integration.assets.roles import unprivileged_user_fixture  # noqa
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils.pytest import failed
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x df62113a7253aca7964a9b0c31f223341baf093c
    git cherry-pick -x a6e58868129c7db1dc8712d8a290d1adcbd88e13
    git cherry-pick -x 2ddb38118188b0a84a6b26f808f0adf387f7e6df
    git cherry-pick -x 66447ef153213768843d1791fb25b576fdfa6c6e
    git cherry-pick -x ed7a494220777387c08c88823d3bf38f7606cbb9
    git cherry-pick -x 48b6dadf7eb19b9ad224d1adff7f13c24f6703dc
    git cherry-pick -x 76d4078d26f88e7dc152d8cb6c72129e0b88355d
    git cherry-pick -x b31c6b95bf8a069ae62b856e904c4c8f0a24d267
    git cherry-pick -x dc384a70a4e2199d183b46d272e520456992ee8f
    git cherry-pick -x 98ca6b5d25562ee727813ee1842d39bb145a2f3a
    git cherry-pick -x 5694e1c1a200ad6d8d61d4935243b867eac37873
    git cherry-pick -x 0001b83a2a02a0af0b8968fd508d5f2335f4f7b4
    git cherry-pick -x c1470b2df68ee33fd9d1f4ede2130659405cbece
    git cherry-pick -x 83a91324e9015e5a97461b93172b7ce8f0ffd378
    git cherry-pick -x 4a254027bb62dce0e6b459f3b8c8d8f3d7e0297e
    git cherry-pick -x 6a6af47f7a173dd328999d01f10ac78df1247a47

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~4
    git cherry-pick -x dcd79528b8f1657bfc14e6d30630c2f8f9833017

This PR adds changes to improve implementation of `common_checks` to reduce the time it took to execute tests which were consuming this. Essentially what was happening was that we were creating a user on each run of that function which also meant that we were creating a dataset where both are costly operations. So now we use a fixture to cache these for the entire run of the test suite but make sure specific roles are updated to account for it.

Original PR: https://github.com/truenas/middleware/pull/13568
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128333