### PR TITLE
NAS-128161 / 24.10 / Get all interface names for reporting

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -189,6 +189,7 @@ class InterfaceService(CRUDService):
         """
         Query Interfaces with `query-filters` and `query-options`
         """
+        retrieve_names_only = options.get('extra', {}).get('retrieve_names_only')
         data = {}
         configs = {
             i['int_interface']: i
@@ -214,6 +215,12 @@ class InterfaceService(CRUDService):
                 # interface so users can't configure it
                 continue
 
+            if retrieve_names_only:
+                data[name] = {
+                    'name': name,
+                }
+                continue
+
             iface_extend_kwargs = {}
             if ha_hardware:
                 vrrp_config = self.middleware.call_sync('interfaces.vrrp_config', name)
@@ -223,28 +230,33 @@ class InterfaceService(CRUDService):
             except OSError:
                 self.logger.warn('Failed to get interface state for %s', name, exc_info=True)
         for name, config in filter(lambda x: x[0] not in data, configs.items()):
-            data[name] = self.iface_extend({
-                'name': config['int_interface'],
-                'orig_name': config['int_interface'],
-                'description': config['int_name'],
-                'aliases': [],
-                'link_address': '',
-                'permanent_link_address': None,
-                'hardware_link_address': '',
-                'cloned': True,
-                'mtu': 1500,
-                'flags': [],
-                'nd6_flags': [],
-                'capabilities': [],
-                'link_state': '',
-                'media_type': '',
-                'media_subtype': '',
-                'active_media_type': '',
-                'active_media_subtype': '',
-                'supported_media': [],
-                'media_options': [],
-                'vrrp_config': [],
-            }, configs, ha_hardware, fake=True)
+            if retrieve_names_only:
+                data[name] = {
+                    'name': name,
+                }
+            else:
+                data[name] = self.iface_extend({
+                    'name': config['int_interface'],
+                    'orig_name': config['int_interface'],
+                    'description': config['int_name'],
+                    'aliases': [],
+                    'link_address': '',
+                    'permanent_link_address': None,
+                    'hardware_link_address': '',
+                    'cloned': True,
+                    'mtu': 1500,
+                    'flags': [],
+                    'nd6_flags': [],
+                    'capabilities': [],
+                    'link_state': '',
+                    'media_type': '',
+                    'media_subtype': '',
+                    'active_media_type': '',
+                    'active_media_subtype': '',
+                    'supported_media': [],
+                    'media_options': [],
+                    'vrrp_config': [],
+                }, configs, ha_hardware, fake=True)
         return filter_list(list(data.values()), filters, options)
 
     @private

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -86,7 +86,11 @@ class RealtimeEventSource(EventSource):
                     'cpu': get_cpu_stats(netdata_metrics, cores),
                     'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
                     'interfaces': get_interface_stats(
-                        netdata_metrics, self.middleware.call_sync('interface.query_names_only')
+                        netdata_metrics, [
+                            iface['name'] for iface in self.middleware.call_sync(
+                                'interface.query', [], {'extra': {'retrieve_names_only': True}}
+                            )
+                        ]
                     ),
                     'failed_to_connect': False,
                 }


### PR DESCRIPTION
## Problem
In a fresh install, physical interfaces are not stored in the database. When the `reporting.realtime` event tries to retrieve the interface names from the database, it returns an empty list, resulting in network stats not being displayed.

## Solution

Retrieve all interface names from `interface.query` for reporting events, which obtains interface information directly from the system if interfaces are not stored in the database.