### PR TITLE
NAS-128372 / 24.04.0 / Change permissions on the generated scst.conf (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -187,7 +187,7 @@ class EtcService(Service):
             {'type': 'py', 'path': 'generate_ssl_certs'},
         ],
         'scst': [
-            {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import'},
+            {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import', 'mode': 0o600},
             {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import', 'mode': 0o744},
         ],
         'scst_targets': [


### PR DESCRIPTION
Tweak perms that `etc.py` uses (with `mako`).

Original PR: https://github.com/truenas/middleware/pull/13580
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128372