### PR TITLE
NAS-128373 / 13.3 / Update ZFS plugin for py-libzfs changes

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -23,7 +23,7 @@ class ScanWatch(object):
     def run(self):
         while not self._cancel.wait(2):
             with libzfs.ZFS() as zfs:
-                scan = zfs.get(self.pool).scrub.__getstate__()
+                scan = zfs.get(self.pool).scrub.asdict()
             if scan['state'] == 'SCANNING':
                 self.send_scan(scan)
             elif scan['state'] == 'FINISHED':
@@ -34,7 +34,7 @@ class ScanWatch(object):
     def send_scan(self, scan=None):
         if not scan:
             with libzfs.ZFS() as zfs:
-                scan = zfs.get(self.pool).scrub.__getstate__()
+                scan = zfs.get(self.pool).scrub.asdict()
         self.middleware.send_event('zfs.pool.scan', 'CHANGED', fields={
             'scan': scan,
             'name': self.pool,


### PR DESCRIPTION
* We deprecated and removed an unused private API parameter in SCALE. Said parameter is also unused in 13.3 by both middleware and webui, and since it is a private API there is no guarantee of stability between versions.

* Recent versions of python-libzfs removed __getstate__() methods for python 3.10 compatibilty and replaced with asdict().