### PR TITLE
NAS-128378 / 24.10 / Fix recent breakage in update_initramfs

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -230,9 +230,9 @@ class BootService(Service):
         async with self.__toggle_rootfs_readwrite():
             args = ['/']
             if options['database']:
-                args.append(['-d', options['database']])
+                args.extend(['-d', options['database']])
             if options['force']:
-                args.append(['-f'])
+                args.extend(['-f'])
 
             cp = await run(
                 '/usr/local/bin/truenas-initrd.py', *args,


### PR DESCRIPTION
Noticed breakage on HA STANDBY node (from PR #13280).

Repro'd from command line:
```
root@truenas-b[~]# midclt call boot.update_initramfs '{"database": "/data/freenas-v1.db"}'
expected str, bytes or os.PathLike object, not list
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 198, in call_method
    result = await self.middleware.call_with_audit(message['method'], serviceobj, methodobj, params, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1467, in call_with_audit
    result = await self._call(method, serviceobj, methodobj, params, app=app,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1418, in _call
    return await methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 187, in nf
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/boot.py", line 238, in update_initramfs
    cp = await run(
         ^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/__init__.py", line 81, in run
    return await loop.run_in_executor(io_thread_pool_executor, functools.partial(subprocess.run, args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1834, in _execute_child
    self.pid = _fork_exec(
               ^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not list

root@truenas-b[~]#
```