### PR TITLE
NAS-128388 / 24.04.1 / fix typo in failover_/event.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -660,10 +660,10 @@ class FailoverEventsService(Service):
         self.run_call('interface.persist_link_addresses')
 
         try:
-            logger.info('Updating HA boot status')
-            self.run_call('failover.reboot.check_reboot_required')
+            logger.info('Updating HA reboot info')
+            self.run_call('failover.reboot.info')
         except Exception:
-            logger.error('Failed to check if reboot is required after failover event', exc_info=True)
+            logger.warning('Failed to update reboot info', exc_info=True)
 
         logger.info('Failover event complete.')
 


### PR DESCRIPTION
Discovered by QE during testing. This is a typo, no functional change.

Original PR: https://github.com/truenas/middleware/pull/13588
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128388