### PR TITLE
NAS-128374 / 24.04.1 / Add options to failover.send_file (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -750,7 +750,8 @@ class FailoverService(ConfigService):
                     'failover.send_file',
                     token,
                     os.path.join(local_path, effective_updatefile_name),
-                    os.path.join(remote_path, effective_updatefile_name)
+                    os.path.join(remote_path, effective_updatefile_name),
+                    {'mode': 0o600}
                 )
 
             local_version = self.middleware.call_sync('system.version')

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -85,7 +85,7 @@ class FailoverDatastoreService(Service):
 
     def send(self):
         token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
-        self.middleware.call_sync('failover.send_file', token, FREENAS_DATABASE, FREENAS_DATABASE_REPLICATED, {'mode': 0o600})
+        self.middleware.call_sync('failover.send_file', token, FREENAS_DATABASE, FREENAS_DATABASE_REPLICATED, {'mode': db_utils.FREENAS_DATABASE_MODE})
         self.middleware.call_sync('failover.call_remote', 'failover.datastore.receive')
 
         self.failure = False

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -85,7 +85,7 @@ class FailoverDatastoreService(Service):
 
     def send(self):
         token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
-        self.middleware.call_sync('failover.send_file', token, FREENAS_DATABASE, FREENAS_DATABASE_REPLICATED)
+        self.middleware.call_sync('failover.send_file', token, FREENAS_DATABASE, FREENAS_DATABASE_REPLICATED, {'mode': 0o600})
         self.middleware.call_sync('failover.call_remote', 'failover.datastore.receive')
 
         self.failure = False

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -161,12 +161,13 @@ class RemoteClient:
             except Exception:
                 logger.warning('Failed to run callback for %s', name, exc_info=True)
 
-    def send_file(self, token, local_path, remote_path, options={}):
+    def send_file(self, token, local_path, remote_path, options=None):
         # No reason to honor proxy settings in this
         # method since we're sending across the
         # heartbeat interface which is point-to-point
         proxies = {'http': '', 'https': ''}
 
+        options = options or {}
         r = requests.post(
             f'http://{self.remote_ip}:6000/_upload/',
             proxies=proxies,
@@ -298,7 +299,7 @@ class FailoverService(Service):
             return self.CLIENT.get_remote_os_version()
 
     @private
-    def send_file(self, token, src, dst, options={}):
+    def send_file(self, token, src, dst, options=None):
         self.CLIENT.send_file(token, src, dst, options)
 
     @private

--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -161,7 +161,7 @@ class RemoteClient:
             except Exception:
                 logger.warning('Failed to run callback for %s', name, exc_info=True)
 
-    def send_file(self, token, local_path, remote_path):
+    def send_file(self, token, local_path, remote_path, options={}):
         # No reason to honor proxy settings in this
         # method since we're sending across the
         # heartbeat interface which is point-to-point
@@ -173,7 +173,7 @@ class RemoteClient:
             files=[
                 ('data', json.dumps({
                     'method': 'filesystem.put',
-                    'params': [remote_path],
+                    'params': [remote_path, options],
                 })),
                 ('file', open(local_path, 'rb')),
             ],
@@ -298,8 +298,8 @@ class FailoverService(Service):
             return self.CLIENT.get_remote_os_version()
 
     @private
-    def send_file(self, token, src, dst):
-        self.CLIENT.send_file(token, src, dst)
+    def send_file(self, token, src, dst, options={}):
+        self.CLIENT.send_file(token, src, dst, options)
 
     @private
     async def ensure_remote_client(self):

--- a/src/middlewared/middlewared/utils/db.py
+++ b/src/middlewared/middlewared/utils/db.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 FREENAS_DATABASE = '/data/freenas-v1.db'
+FREENAS_DATABASE_MODE = 0o600
 
 
 def dict_factory(cursor, row):

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,9 +1,3 @@
-import sys
-from os import getcwd
-
-apifolder = getcwd()
-sys.path.append(apifolder)
-
 from auto_config import ha
 from middlewared.test.integration.utils import call
 

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,3 +1,10 @@
+import sys
+from os import getcwd
+
+apifolder = getcwd()
+sys.path.append(apifolder)
+
+from auto_config import ha
 from middlewared.test.integration.utils import call
 
 # this is found in middlewared.plugins.sysctl.sysctl_info
@@ -11,3 +18,15 @@ def test_sysctl_arc_max_is_set():
     to it early in the boot process. That's why we check it here in
     this test so early"""
     assert call('filesystem.stat', DEFAULT_ARC_MAX_FILE)['size']
+
+
+def test_database_mode():
+    """Test the mode of the database file."""
+    db_name = "/data/freenas-v1.db"
+    db_mode = 0o600
+    mode = call('filesystem.stat', db_name)['mode']
+    assert mode & 0o777 == db_mode, mode
+    if ha:
+        call('failover.sync_to_peer')
+        mode = call('failover.call_remote', 'filesystem.stat', [db_name])['mode']
+        assert mode & 0o777 == db_mode, mode


### PR DESCRIPTION
Add options to `failover.send_file` and restrict the `mode` when calling.

Original PR: https://github.com/truenas/middleware/pull/13586
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128374