### PR TITLE
NAS-128399 / 24.10 / More nfs failover fixes

### DIFF
--- a/src/freenas/etc/systemd/system/nfsdcld.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/nfsdcld.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+BindTo=nfs-server.service
+

--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -1,8 +1,8 @@
 <%
-    from middlewared.plugins.nfs import NFSPath
-    state_path = NFSPath.STATEDIR.path()
-    cld_storedir = NFSPath.CLDDIR.path()
-    cltrack_storedir = NFSPath.CLDTRKDIR.path()
+    from middlewared.plugins.nfs import NFSServicePathInfo
+    state_path = NFSServicePathInfo.STATEDIR.path()
+    cld_storedir = NFSServicePathInfo.CLDDIR.path()
+    cltrack_storedir = NFSServicePathInfo.CLDTRKDIR.path()
     config = render_ctx["nfs.config"]
 
     # Fail-safe setting is two nfsd

--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -1,8 +1,8 @@
 <%
     from middlewared.plugins.nfs import NFSPath
-    state_path = NFSPath.STATEDIR.platform()
-    cld_storedir = NFSPath.CLDDIR.platform()
-    cltrack_storedir = NFSPath.CLDTRKDIR.platform()
+    state_path = NFSPath.STATEDIR.path()
+    cld_storedir = NFSPath.CLDDIR.path()
+    cltrack_storedir = NFSPath.CLDTRKDIR.path()
     config = render_ctx["nfs.config"]
 
     # Fail-safe setting is two nfsd

--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -1,4 +1,8 @@
 <%
+    from middlewared.plugins.nfs import NFSPath
+    state_path = NFSPath.STATEDIR.platform()
+    cld_storedir = NFSPath.CLDDIR.platform()
+    cltrack_storedir = NFSPath.CLDTRKDIR.platform()
     config = render_ctx["nfs.config"]
 
     # Fail-safe setting is two nfsd
@@ -28,7 +32,15 @@ vers4 = n
 host = ${','.join(config['bindip'])}
 % endif
 
+[exportd]
+state-directory-path = ${state_path}
+[nfsdcld]
+storagedir = ${cld_storedir}
+[nfsdcltrack]
+storagedir = ${cltrack_storedir}
+
 [mountd]
+state-directory-path = ${state_path}
 threads = ${num_mountd}
 % if config['mountd_port']:
 port = ${config['mountd_port']}
@@ -36,6 +48,7 @@ port = ${config['mountd_port']}
 manage-gids = ${manage_gids}
 
 [statd]
+state-directory-path = ${state_path}
 % if config['rpcstatd_port']:
 port = ${config['rpcstatd_port']}
 % endif

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -160,7 +160,7 @@ class NFSService(SystemServiceService):
         try:
             with open(procfs_path, 'r+') as fp:
                 fp.write(f'{NFSPath.V4RECOVERYDIR.path()}\n')
-        except FileNotFoundError:
+        except Exception:
             self.logger.error("Unexpected failure updating %r", procfs_path, exc_info=True)
 
     @private

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -103,7 +103,7 @@ class NFSService(SystemServiceService):
     )
 
     @private
-    def name_to_id_converstion(self, name, name_type='user'):
+    def name_to_id_conversion(self, name, name_type='user'):
         ''' Convert built-in user or group name to associated UID or GID '''
         if any((not isinstance(name, str), isinstance(name, int))):
             # it's not a string (NoneType, float, w/e) or it's an int

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -156,12 +156,12 @@ class NFSService(SystemServiceService):
                     os.mkdir(path, p.mode())
                     os.chown(path, usrgrp[0], usrgrp[1])
 
-        if os.path.exists('/proc/fs/nfsd/nfsv4recoverydir'):
-            try:
-                with open('/proc/fs/nfsd/nfsv4recoverydir', 'r+') as fp:
-                    fp.write(NFSPath.V4RECOVERYDIR.platform() + '\n')
-            except Exception as e:
-                self.logger.error("Failed to update nfsv4recoverydir: %r", str(e))
+        procfs_path = '/proc/fs/nfsd/nfsv4recoverydir'
+        try:
+            with open(procfs_path, 'r+') as fp:
+                fp.write(f'{NFSPath.V4RECOVERYDIR.platform()}\n')
+        except FileNotFoundError:
+            self.logger.error("Unexpected failure updating %r", procfs_path, exec_info=True)
 
     @private
     async def nfs_extend(self, nfs):

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -154,7 +154,7 @@ class NFSService(SystemServiceService):
                 with open('/proc/fs/nfsd/nfsv4recoverydir', 'r+') as fp:
                     fp.write(NFSPath.V4RECOVERYDIR.platform() + '\n')
             except Exception as e:
-                self.logger.error(f"Failed to update nfsv4recoverydir: %r", str(e))
+                self.logger.error("Failed to update nfsv4recoverydir: %r", str(e))
 
     @private
     async def nfs_extend(self, nfs):

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -160,6 +160,9 @@ class NFSService(SystemServiceService):
         try:
             with open(procfs_path, 'r+') as fp:
                 fp.write(f'{NFSPath.V4RECOVERYDIR.path()}\n')
+        except FileNotFoundError:
+            # When this is removed from the kernel we will have a gentle reminder
+            self.logger.info("%r: Proc file has been removed", procfs_path)
         except Exception:
             self.logger.error("Unexpected failure updating %r", procfs_path, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -155,27 +155,11 @@ class NFSService(SystemServiceService):
             gid = self.name_to_id_conversion(i.owner()['gid'], name_type='group')
             path = i.path()
             if i.is_dir():
-                open_flags = os.O_RDWR | os.O_DIRECTORY
                 os.makedirs(path, exist_ok=True)
-            else:
-                open_flags = os.O_RDWR
 
             try:
-                with open(os.open(path, flags=open_flags)) as f:
-                    os.fchmod(f.fileno(), i.mode())
-                    os.fchown(f.fileno(), uid, gid)
-            except IsADirectoryError:
-                if not i.is_dir():
-                    # the path is expected to be a file but it's a directory
-                    self.logger.error('Expected %r to be a file but instead found a directory', path)
-                else:
-                    self.logger.error('Unexpected failure updating file %r', path, exc_info=True)
-            except NotADirectoryError:
-                if i.is_dir():
-                    # the path is expected to be a directory but it's a file
-                    self.logger.error('Expected %r to be a directory but instead found a file', path)
-                else:
-                    self.logger.error('Unexpected failure updating directory %r', path, exc_info=True)
+                os.chmod(path, i.mode())
+                os.chown(path, uid, gid)
             except Exception:
                 self.logger.error('Unexpected failure initializing %r', path, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -140,7 +140,7 @@ class NFSService(SystemServiceService):
         '''
 
         # Initialize the system dataset NFS state directory
-        state_dir = NFSServicePathInfo().STATEDIR.path()
+        state_dir = NFSServicePathInfo.STATEDIR.path()
         try:
             shutil.copytree('/var/lib/nfs', state_dir)
         except FileExistsError:

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -130,14 +130,16 @@ class NFSService(SystemServiceService):
         # Initialize the system dataset NFS state directory
         try:
             if not any(os.scandir(NFSPath.STATEDIR.path())):
-                # System db is empty, populate it with contents of /var/lib/nfs
-                # Going forward, the system dataset should hold the NFS state data
-                if not os.path.isdir('/var/lib/nfs'):
-                    try:
-                        shutil.copytree('/var/lib/nfs', NFSPath.STATEDIR.path())
-                    except Exception as e:
-                        self.logger.error('Failed to initialize NFS state from /var/lib/nfs: %r', e)
-                    # Continue anyway.
+                # System db is empty, populate it with contents of /var/lib/nfs.
+                # This should be a one-time operation.
+                # Going forward, the system dataset will hold the NFS state data.
+                try:
+                    shutil.copytree('/var/lib/nfs', NFSPath.STATEDIR.path())
+                except FileExistsError:
+                    pass
+                except Exception as e:
+                    self.logger.error('Failed to initialize NFS state from /var/lib/nfs: %r', e)
+                # Continue anyway.
         except Exception as e:
             self.logger.error("Could not find required path: %r", e)
 

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -19,7 +19,7 @@ class NFSService(Service):
         """
         entries = []
         with suppress(FileNotFoundError):
-            with open(os.path.join(NFSPath.STATEDIR.platform(), "rmtab"), "r") as f:
+            with open(os.path.join(NFSPath.STATEDIR.path(), "rmtab"), "r") as f:
                 for line in f:
                     ip, data = line.split(":", 1)
                     export, refcnt = line.rsplit(":", 1)

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.nfs import NFSPath
 from middlewared.schema import accepts, Int, returns, Str, Dict
 from middlewared.service import Service, private, filterable, filterable_returns
 from middlewared.utils import filter_list
@@ -18,7 +19,7 @@ class NFSService(Service):
         """
         entries = []
         with suppress(FileNotFoundError):
-            with open("/var/lib/nfs/rmtab", "r") as f:
+            with open(os.path.join(NFSPath.STATEDIR.platform(), "rmtab"), "r") as f:
                 for line in f:
                     ip, data = line.split(":", 1)
                     export, refcnt = line.rsplit(":", 1)

--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -1,4 +1,4 @@
-from middlewared.plugins.nfs import NFSPath
+from middlewared.plugins.nfs import NFSServicePathInfo
 from middlewared.schema import accepts, Int, returns, Str, Dict
 from middlewared.service import Service, private, filterable, filterable_returns
 from middlewared.utils import filter_list
@@ -19,7 +19,7 @@ class NFSService(Service):
         """
         entries = []
         with suppress(FileNotFoundError):
-            with open(os.path.join(NFSPath.STATEDIR.path(), "rmtab"), "r") as f:
+            with open(os.path.join(NFSServicePathInfo.STATEDIR.path(), "rmtab"), "r") as f:
                 for line in f:
                     ip, data = line.split(":", 1)
                     export, refcnt = line.rsplit(":", 1)

--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -6,6 +6,7 @@ from .base import SimpleService
 class NFSService(SimpleService):
     name = "nfs"
     reloadable = True
+    systemd_unit_timeout = 10
 
     etc = ["nfsd"]
 

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -107,6 +107,25 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
             },
         },
         {
+            'name': os.path.join(pool_name, '.system/nfs'),
+            'props': {
+                'mountpoint': 'legacy',
+                'readonly': 'off',
+                'snapdir': 'hidden',
+            },
+            'chown_config': {
+                'uid': 0,
+                'gid': 0,
+                'mode': 0o755,
+            },
+            'post_mount_actions': [
+                {
+                    'method': 'nfs.setup_directories',
+                    'args': [],
+                }
+            ]
+        },
+        {
             'name': os.path.join(pool_name, '.system/samba4'),
             'props': {
                 'mountpoint': 'legacy',

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -8,7 +8,7 @@ import pytest
 
 from functions import if_key_listed, SSH_TEST
 from auto_config import ip, sshKey, user, password
-from middlewared.test.integration.utils import call, fail
+from middlewared.test.integration.utils import fail
 from middlewared.test.integration.utils.client import client
 
 
@@ -34,6 +34,7 @@ def test_002_firstboot_checks(ws_client):
     expected_ds = [
         'boot-pool/.system',
         'boot-pool/.system/cores',
+        'boot-pool/.system/nfs',
         'boot-pool/.system/samba4',
         'boot-pool/grub'
     ]
@@ -50,8 +51,8 @@ def test_002_firstboot_checks(ws_client):
     # always start in all circumstances (even if there is an invalid (or empty) config)
     ignore = ('smartd',)
     for srv in filter(lambda x: x['service'] not in ignore, ws_client.call('service.query')):
-        assert srv['enable'] is False
-        assert srv['state'] == 'STOPPED'
+        assert srv['enable'] is False, f"service {srv['service']} is unexpectedly enabled"
+        assert srv['state'] == 'STOPPED', f"service {srv['service']} expected STOPPED, but found {srv['state']}"
 
     # verify posix mode, uid and gid for standard users
     stat_info = {

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -51,8 +51,8 @@ def test_002_firstboot_checks(ws_client):
     # always start in all circumstances (even if there is an invalid (or empty) config)
     ignore = ('smartd',)
     for srv in filter(lambda x: x['service'] not in ignore, ws_client.call('service.query')):
-        assert srv['enable'] is False, f"service {srv['service']} is unexpectedly enabled"
-        assert srv['state'] == 'STOPPED', f"service {srv['service']} expected STOPPED, but found {srv['state']}"
+        assert srv['enable'] is False, f"{srv['service']} service is unexpectedly enabled"
+        assert srv['state'] == 'STOPPED', f"{srv['service']} service expected STOPPED, but found {srv['state']}"
 
     # verify posix mode, uid and gid for standard users
     stat_info = {


### PR DESCRIPTION
### Problem
NFS was not configured to properly support HA function.  NFS holds client state information in a database that, by default, is located at /var/lib/nfs.  To properly support failover we need that to be a shared directory.  For TrueNAS that is the system dataset.

### Fix
Create and NFS entry in the system dataset.  Generate the necessary directory structure and to support upgrade we also initialize it with data from /var/lib/nfs.
In systemd we bind the NFS client tracking daemon to nfs-server to allow the transfer of the client tracking database.
Update the nfs configuration file with the path to the nfs data on the system dataset: `/var/db/system/nfs`

### Other related items in the PR

1. Updated the CI tests
2. Minor flake8 cleanup and refactoring