### PR TITLE
NAS-128444 / 13.3 / Add HA KVM detection (IXKVM)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -221,6 +221,7 @@ class FailoverService(ConfigService):
           SBB
           ULTIMATE
           BHYVE
+          IXKVM (HA VMs (on KVM) for CI)
           MANUAL
         """
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/detect_internal_interface_freebsd.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/detect_internal_interface_freebsd.py
@@ -35,6 +35,9 @@ class InternalInterfaceDetectionService(Service):
         if hardware == 'BHYVE':
             return ['vtnet1']
 
+        if hardware == 'IXKVM':
+            return ['vtnet0']
+
         if hardware == 'SBB':
             return ['ix0']
 


### PR DESCRIPTION
Add HA KVM detection to CORE, for use in our new KVM/ixnode/jenkins CI.