### PR TITLE
Allow configuring ha_propagate default per-service

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/base_interface.py
+++ b/src/middlewared/middlewared/plugins/service_/services/base_interface.py
@@ -5,6 +5,7 @@ class ServiceInterface:
     restartable = False  # Implements `restart` method instead of `stop` + `start`
     reloadable = False  # Implements `reload` method
     deprecated = False  # Alert if service is running
+    default_ha_propagate = True # If HA propagate service changes to other node
 
     def __init__(self, middleware):
         self.middleware = middleware

--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -7,6 +7,7 @@ from middlewared.service_exception import CallError
 class CIFSService(SimpleService):
     name = "cifs"
     reloadable = True
+    default_ha_propagate = False
 
     etc = ["smb"]
 

--- a/src/middlewared/middlewared/plugins/service_/services/idmap.py
+++ b/src/middlewared/middlewared/plugins/service_/services/idmap.py
@@ -5,6 +5,7 @@ class IdmapService(SimpleService):
     name = "idmap"
     reloadable = True
     restartable = True
+    default_ha_propagate = False
 
     systemd_unit = "winbind"
 

--- a/src/middlewared/middlewared/plugins/service_/services/mdns.py
+++ b/src/middlewared/middlewared/plugins/service_/services/mdns.py
@@ -4,6 +4,7 @@ from .base import SimpleService
 class MDNSService(SimpleService):
     name = "mdns"
     reloadable = True
+    default_ha_propagate = False
 
     etc = ["mdns"]
 

--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -6,6 +6,7 @@ from .base import SimpleService
 class NFSService(SimpleService):
     name = "nfs"
     reloadable = True
+    default_ha_propagate = False
 
     etc = ["nfsd"]
 

--- a/src/middlewared/middlewared/plugins/service_/services/nslcd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nslcd.py
@@ -3,5 +3,6 @@ from .base import SimpleService
 
 class NSSPamLdapdService(SimpleService):
     name = "nslcd"
+    default_ha_propagate = False
 
     systemd_unit = "nslcd"

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -199,6 +199,7 @@ class TimeservicesService(PseudoServiceBase):
 
 class DSCacheService(PseudoServiceBase):
     name = "dscache"
+    default_ha_propagate = False
 
     async def start(self):
         await self.middleware.call('dscache.refresh')

--- a/src/middlewared/middlewared/plugins/service_/services/wsd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/wsd.py
@@ -3,6 +3,7 @@ from .base import SimpleService
 
 class WSDService(SimpleService):
     name = "wsdd"
+    default_ha_propagate = False
 
     etc = ["wsd"]
 


### PR DESCRIPTION
There are many services on TrueNAS for which we should not propogate service changes to standby controller. Historically the default has been to always propagate these changes to the standby controller. This commit allows changing the default on a per-service basis, which reduces risk of introducing issues by forgetting to specify not to propagate to other controller.