### PR TITLE
Add separate logfile for netdata

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -35,13 +35,13 @@ logging.getLogger('acme.client').setLevel(logging.WARNING)
 logging.getLogger('certbot_dns_cloudflare._internal.dns_cloudflare').setLevel(logging.WARNING)
 # "Encoding detection: ascii is most likely the one."
 logging.getLogger('charset_normalizer').setLevel(logging.INFO)
+logging.TRACE = 6
 
-
-LOGFILE = '/var/log/middlewared.log'
-ZETTAREPL_LOGFILE = '/var/log/zettarepl.log'
 FAILOVER_LOGFILE = '/var/log/failover.log'
 K8S_API_LOGFILE = '/var/log/k8s_api.log'
-logging.TRACE = 6
+LOGFILE = '/var/log/middlewared.log'
+NETDATA_API_LOGFILE = '/var/log/netdata_api.log'
+ZETTAREPL_LOGFILE = '/var/log/zettarepl.log'
 
 
 def trace(self, message, *args, **kws):
@@ -82,6 +82,7 @@ class Logger:
                 (None, LOGFILE, self.log_format),
                 ('failover', FAILOVER_LOGFILE, self.log_format),
                 ('k8s_api', K8S_API_LOGFILE, self.log_format),
+                ('netdata_api', NETDATA_API_LOGFILE, self.log_format),
                 ('zettarepl', ZETTAREPL_LOGFILE,
                  '[%(asctime)s] %(levelname)-8s [%(threadName)s] [%(name)s] %(message)s'),
             ]:

--- a/src/middlewared/middlewared/plugins/reporting/netdata/client.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/client.py
@@ -11,7 +11,7 @@ from .exceptions import ApiException, ClientConnectError
 from .utils import NETDATA_URI, NETDATA_REQUEST_TIMEOUT
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('netdata_api')
 
 
 class ClientMixin:

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -1,9 +1,14 @@
+import logging
+
 from middlewared.service import accepts, Service
 from middlewared.schema import Str, Dict, Int
 from middlewared.utils.cpu import cpu_info
 
 from .netdata import ClientConnectError, Netdata
 from .utils import calculate_disk_space_for_netdata, get_metrics_approximation, TIER_0_POINT_SIZE, TIER_1_POINT_SIZE
+
+
+logger = logging.getLogger('netdata_api')
 
 
 class NetdataService(Service):
@@ -38,7 +43,7 @@ class NetdataService(Service):
         try:
             return await Netdata.get_all_metrics()
         except ClientConnectError:
-            self.logger.debug('Failed to connect to netdata when retrieving all metrics')
+            logger.debug('Failed to connect to netdata when retrieving all metrics')
             return {}
 
     def calculated_metrics_count(self):


### PR DESCRIPTION
## Problem
When Netdata is stopped for any reason, the middleware logs become flooded with connection errors, making it challenging to debug the actual issue.

## Solution
Create a new Netdata log file to capture all Netdata-related logs. This will prevent the middleware logs from being filled with Netdata logs and help in more efficient debugging.