### PR TITLE
NAS-128466 / 24.10 / Make robustize_clean_type_and_path more tolerant

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -327,7 +327,7 @@ class iSCSITargetExtentService(SharingService):
                 verrors.add(f'{schema_name}.disk', 'Disk name must start with "zvol/"')
                 raise verrors
 
-            device = os.path.join('/dev', disk)
+            device = os.path.join('/dev', disk.replace(" ", "+"))
 
             zvol_name = zvol_path_to_name(device)
             if not os.path.exists(device):

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -8,7 +8,7 @@ import uuid
 import middlewared.sqlalchemy as sa
 
 from middlewared.async_validators import check_path_resides_within_volume
-from middlewared.plugins.zfs_.utils import zvol_path_to_name
+from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.schema import accepts, Bool, Dict, Int, Patch, Str
 from middlewared.service import CallError, private, SharingService, ValidationErrors
 from middlewared.utils.size import format_size
@@ -327,7 +327,8 @@ class iSCSITargetExtentService(SharingService):
                 verrors.add(f'{schema_name}.disk', 'Disk name must start with "zvol/"')
                 raise verrors
 
-            device = os.path.join('/dev', disk.replace(" ", "+"))
+            # When providing a parameter here, skip past the 'zvol/'
+            device = zvol_name_to_path(disk[5:])
 
             zvol_name = zvol_path_to_name(device)
             if not os.path.exists(device):


### PR DESCRIPTION
A recent change to `iscsi_extent_locked` in PR #13572 wrt space handling meant `clean_type_and_path` could return an error.  Rectify.

Note:
- Currently the WebUI does **_not_** do this, so at the moment the space breakage only impacts CI tests.
- There is **another** issue with this test, that will probably be handled by a zfs change.  (TBD.)