### PR TITLE
NAS-128469 / 24.04.1 / Revert "fix iscsi_extent_locked test (#13572)" (by bmeagherix)

### DIFF
--- a/tests/api2/test_iscsi.py
+++ b/tests/api2/test_iscsi.py
@@ -60,7 +60,7 @@ def test__iscsi_extent__locked(request):
         with iscsi_extent({
             "name": "test_extent",
             "type": "DISK",
-            "disk": f"zvol/{ds}",
+            "disk": f"zvol/{ds.replace(' ', '+')}",
         }) as extent:
             assert not extent["locked"]
 


### PR DESCRIPTION
This reverts commit 355fb38154cdaf062da8e682bb2f70a98bb951e8.

Underlying issue with this test being addressed in PR #[230 ](https://github.com/truenas/zfs/pull/230)

Original PR: https://github.com/truenas/middleware/pull/13611
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128469