### PR TITLE
Fix crash when using SCALE client to talk to 13.0

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -198,7 +198,7 @@ class Job:
                 trace={
                     'class': job['exc_info']['type'],
                     'formatted': job['exception'],
-                    'repr': job['exc_info']['repr'],
+                    'repr': job['exc_info'].get('repr'),
                 },
                 extra=job['exc_info']['extra']
             )


### PR DESCRIPTION
13.0 middleware jobs fail with KeyError. Minimally, we shouldn't crash when trying to initiate jobs there.