### PR TITLE
NAS-128161 / 24.04.1 / Get all interface names for reporting (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -86,7 +86,11 @@ class RealtimeEventSource(EventSource):
                     'cpu': get_cpu_stats(netdata_metrics, cores),
                     'disks': get_disk_stats(netdata_metrics, self.middleware.call_sync('device.get_disk_names')),
                     'interfaces': get_interface_stats(
-                        netdata_metrics, self.middleware.call_sync('interface.query_names_only')
+                        netdata_metrics, [
+                            iface['name'] for iface in self.middleware.call_sync(
+                                'interface.query', [], {'extra': {'retrieve_names_only': True}}
+                            )
+                        ]
                     ),
                     'failed_to_connect': False,
                 }


### PR DESCRIPTION
## Problem
In a fresh install, physical interfaces are not stored in the database. When the `reporting.realtime` event tries to retrieve the interface names from the database, it returns an empty list, resulting in network stats not being displayed.

## Solution

Retrieve all interface names from `interface.query` for reporting events, which obtains interface information directly from the system if interfaces are not stored in the database.

Original PR: https://github.com/truenas/middleware/pull/13577
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128161