### PR TITLE
NAS-128518 / 24.04.1 / Strip whitespace from smb_options before registry insertion

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry_global.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry_global.py
@@ -150,7 +150,7 @@ class SMBService(Service):
             kv = i.split("=", 1)
             if len(kv) != 2:
                 continue
-            to_set.update({kv[0]: {"parsed": kv[1], "raw": kv[1]}})
+            to_set.update({kv[0]: {"parsed": kv[1].strip(), "raw": kv[1].strip()}})
 
         return to_set
 


### PR DESCRIPTION
This was an oversight in angelfish when we first switched to using registry for global parameters. Will not be backported to EE because we are removing this portion of SMB configuration from registry in that release.