### PR TITLE
NAS-128546 / 24.10 / Improvements requested by UI team for new enclosure.dashboard

### DIFF
--- a/src/middlewared/middlewared/plugins/webui/enclosure.py
+++ b/src/middlewared/middlewared/plugins/webui/enclosure.py
@@ -49,7 +49,7 @@ class WebUIEnclosureService(Service):
                         slot_info.pop(to_pop)
 
                     pool_info = None
-                    slot_info.update(self.disk_detail_dict())
+                    slot_info.update({'drive_bay_number': int(disk_slot), **self.disk_detail_dict()})
                     if slot_info['dev']:
                         # map disk details
                         # NOTE: some of these fields need to be removed


### PR DESCRIPTION
The UI team is currently implementing the changes required to consume `webui.enclosure.dashboard` but they're missing some key items that make it awkward to deal with on their side. This does 3 primary things:

1. add `drive_bay_number` key to `webui.enclosure.dashboard`
2. add `drive_bay_number` and `id` keys to `disk.get_unused`
3. use `device.get_disks` in `disk.get_unused` instead of querying the disk table. The reason why we don't query the database table is because we have seen various edge-cases where disks are updated in kernel but our database doesn't get updated. This is hard to predict and is even harder to properly handle. The kernel already "caches" the disk info that we need so `device.get_disks` goes directly to the source of truth. This method has been optimized tremendously and has been proven to perform tolerably compared to querying the db.