### PR TITLE
NAS-128574 / 24.10 / Allow HeaderDigest and DataDigest to be configured for iSCSI targets

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-04-25_19-46_iscsi_target_options.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-04-25_19-46_iscsi_target_options.py
@@ -1,0 +1,26 @@
+"""Add iSCSI target options
+
+Revision ID: fc912643baa2
+Revises: 4f11cc19bb9c
+Create Date: 2024-04-25 19:46:37.356476+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fc912643baa2'
+down_revision = '4f11cc19bb9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_iscsitarget', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('iscsi_target_options', sa.TEXT(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('services_iscsitarget', schema=None) as batch_op:
+        batch_op.drop_column('iscsi_target_options')

--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-05-02_19-46_iscsi_target_options.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-05-02_19-46_iscsi_target_options.py
@@ -1,7 +1,7 @@
 """Add iSCSI target options
 
 Revision ID: fc912643baa2
-Revises: 4f11cc19bb9c
+Revises: 135a7e02cbec
 Create Date: 2024-04-25 19:46:37.356476+00:00
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'fc912643baa2'
-down_revision = '4f11cc19bb9c'
+down_revision = '135a7e02cbec'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -212,6 +212,11 @@
             if set(devices).issubset(clustered_extents):
                 return True
         return False
+
+    def option_value(v):
+        if type(v) is bool:
+            return "Yes" if v else "No"
+        return v
 %>\
 ##
 ## If we are on a HA system then write out a cluster name, we'll hard-code
@@ -415,6 +420,12 @@ TARGET_DRIVER iscsi {
 %   if mutual_chap:
         OutgoingUser "${mutual_chap}"
 %   endif
+##
+## Add target options
+##
+% for k,v in target.get('options', {}).items():
+        ${k} ${option_value(v)}
+% endfor
 
         GROUP security_group {
 %   for access_control in initiator_portal_access:

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -103,3 +103,25 @@ class iSCSITargetService(Service):
         else:
             pathlib.Path(SCST_CONTROLLER_A_TARGET_GROUPS_STATE).write_text("nonoptimized\n")
             pathlib.Path(SCST_CONTROLLER_B_TARGET_GROUPS_STATE).write_text("active\n")
+
+    def reset_target_parameter(self, iqn, param):
+        """Reset the specified parameter to its default value."""
+        # Do some sanity checking
+        valid_parm_names = [
+            'DataDigest',
+            'HeaderDigest',
+            'InitialR2T',
+            'ImmediateData',
+            'MaxRecvDataSegmentLength',
+            'MaxXmitDataSegmentLength',
+            'MaxBurstLength',
+            'FirstBurstLength',
+            'MaxOutstandingR2T'
+        ]
+        if param not in valid_parm_names:
+            raise ValueError('Invalid parameter name supplied', param)
+        try:
+            return pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/{param}').write_text(':default:\n')
+        except FileNotFoundError:
+            # If we're not running, that's OK
+            pass


### PR DESCRIPTION
Enhance iSCSI APIs to allow some target options to be specified