### PR TITLE
NAS-128613 / 24.10 / Do not start netdata on boot in HA

### DIFF
--- a/debian/debian/ix-reporting.service
+++ b/debian/debian/ix-reporting.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Setup TrueNAS Reporting
+DefaultDependencies=no
+
+# The after here reflects the after of netdata.service
+After=middlewared.service network-online.target httpd.service squid.service nfs-server.service mysqld.service named.service postfix.service smartmontools.service nut.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=midclt -t 120 call reporting.start_service
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -16,6 +16,7 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-netif
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-postinit
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-preinit
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-reporting
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-shutdown
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-ssh-keys
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-syncdisks

--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -19,6 +19,7 @@ disable avahi-daemon.service
 disable nmbd.service
 disable nfs*
 disable rsync.service
+disable netdata.service
 disable nscd.service
 disable snmpd.service
 disable snmp-agent.service

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -723,6 +723,11 @@ class FailoverEventsService(Service):
 
         logger.warning('Entering BACKUP on "%s".', ifname)
 
+        # We stop netdata before exporting pools because otherwise we might have erroneous stuff
+        # getting logged and causing spam
+        logger.info('Stopping reporting metrics')
+        self.run_call('service.stop', 'netdata', self.HA_PROPAGATE)
+
         logger.info('Blocking network traffic.')
         fw_drop_job = self.run_call('failover.firewall.drop_all')
         fw_drop_job.wait_sync()
@@ -803,9 +808,6 @@ class FailoverEventsService(Service):
 
         logger.info('Regenerating cron')
         self.run_call('etc.generate', 'cron')
-
-        logger.info('Stopping reporting metrics')
-        self.run_call('service.stop', 'netdata', self.HA_PROPAGATE)
 
         self.run_call('truecommand.stop_truecommand_service')
 

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -35,3 +35,10 @@ class ReportingService(Service):
             # We want to make sure this path exists always regardless of an error so that
             # at least netdata can start itself gracefully
             os.makedirs(get_netdata_state_path(), exist_ok=True)
+
+    @private
+    async def start_service(self):
+        if await self.middleware.call('failover.licensed'):
+            return
+
+        await self.middleware.call('service.start', 'netdata')


### PR DESCRIPTION
## Problem

We don't have netdata running on standby node but when passive boots there is a brief window when netdata starts because by default it is enabled to do so and then it leaves a spam in systemd logs.

## Solution

Make sure netdata does not run on passive node and it only runs on the active node.