### PR TITLE
NAS-127946 / 24.10 / Improve validation of docker returned response when retrieving image manifests

### DIFF
--- a/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
@@ -139,6 +139,11 @@ class CRIClientMixin:
                 # 3) Redo the manifest call with updated token
                 response = await self._api_call(manifest_url, headers=headers, mode=mode)
 
+        try:
+            json_schema_validate(response['response'], DIGEST_JSON_SCHEMA)
+        except JsonValidationError as e:
+            response['error'] = f'Invalid response schema: {e}'
+
         if raise_error and response['error']:
             raise CallError(f"Unable to retrieve latest image digest for registry={registry} "
                             f"image={image} tag={tag}: {response['error']}")

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/client.py
@@ -8,12 +8,14 @@ import urllib
 from cri_api.channel import Channel
 from cri_api.containers import Containers
 from cri_api.images import Images
+from jsonschema import validate as json_schema_validate, ValidationError as JsonValidationError
 
 from middlewared.service import CallError, private
 
 from .utils import DEFAULT_DOCKER_REGISTRY, DOCKER_CONTENT_DIGEST_HEADER
 
 
+CONTAINERD_SOCKET_PATH = '/run/k3s/containerd/containerd.sock'
 DOCKER_AUTH_HEADER = 'WWW-Authenticate'
 DOCKER_AUTH_URL = 'https://auth.docker.io/token'
 DOCKER_AUTH_SERVICE = 'registry.docker.io'
@@ -21,7 +23,21 @@ DOCKER_MANIFEST_SCHEMA_V1 = 'application/vnd.docker.distribution.manifest.v1+jso
 DOCKER_MANIFEST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.v2+json'
 DOCKER_MANIFEST_LIST_SCHEMA_V2 = 'application/vnd.docker.distribution.manifest.list.v2+json'
 DOCKER_RATELIMIT_URL = 'https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest'
-CONTAINERD_SOCKET_PATH = '/run/k3s/containerd/containerd.sock'
+DIGEST_JSON_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'mediaType': {
+            'type': 'string',
+        },
+        'config': {
+            'type': 'object',
+        },
+        'manifests': {
+            'type': 'array',
+        },
+    },
+    'required': ['mediaType'],
+}
 
 
 def parse_digest_from_schema(response):


### PR DESCRIPTION
This PR adds changes to better validate the response a docker registry sends for image digests as we have seen a rare case where the response was malformed which resulted in a `KeyError` whereas it should have been properly raised instead.