### PR TITLE
NAS-128593 / 24.10 / Fix generating smartd.conf for items that run on Sundays

### DIFF
--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -58,7 +58,7 @@ def get_smartd_config(disk):
 
 def get_smartd_schedule(disk):
     return "/".join([
-        smartd_schedule_piece(disk["smarttest_schedule"][piece.key], piece.min, piece.max, piece.enum)
+        smartd_schedule_piece(disk["smarttest_schedule"][piece.key], piece.min, piece.max, piece.enum, piece.map)
         for piece in SMARTD_SCHEDULE_PIECES
     ])
 

--- a/src/middlewared/middlewared/plugins/smart.py
+++ b/src/middlewared/middlewared/plugins/smart.py
@@ -197,8 +197,8 @@ def smart_test_disks_intersect(existing_test, new_test, disk_choices):
 def smart_test_schedules_intersect_at(a, b):
     intersections = []
     for piece in SMARTD_SCHEDULE_PIECES:
-        a_values = set(smartd_schedule_piece_values(a[piece.key], piece.min, piece.max, piece.enum))
-        b_values = set(smartd_schedule_piece_values(b[piece.key], piece.min, piece.max, piece.enum))
+        a_values = set(smartd_schedule_piece_values(a[piece.key], piece.min, piece.max, piece.enum, piece.map))
+        b_values = set(smartd_schedule_piece_values(b[piece.key], piece.min, piece.max, piece.enum, piece.map))
 
         intersection = a_values & b_values
         if not intersection:

--- a/src/middlewared/middlewared/pytest/unit/etc_files/test_smartd.py
+++ b/src/middlewared/middlewared/pytest/unit/etc_files/test_smartd.py
@@ -75,6 +75,17 @@ def test__get_smartd_schedule__need_mapping():
     }) == "../(01|03)/(2|7)/.."
 
 
+def test__get_smartd_schedule__0_is_sunday():
+    assert get_smartd_schedule({
+        "smarttest_schedule": {
+            "month": "*",
+            "dom": "*",
+            "dow": "0",
+            "hour": "0",
+        }
+    }) == "../../(7)/(00)"
+
+
 def test__get_smartd_config():
     assert get_smartd_config({
         "smartctl_args": ["/dev/ada0", "-d", "sat"],

--- a/src/middlewared/middlewared/pytest/unit/plugins/smart/test_crud.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/smart/test_crud.py
@@ -16,6 +16,8 @@ DEFAULTS = {"hour": "*", "month": "*", "dom": "*", "dow": "*"}
     ({"dom": "1,3,6", "month": "*/2"}, {"dom": "2,4,6", "month": "1"}, None),
     ({"dom": "1,3,6", "month": "*/2"}, {"dom": "2,4,6", "month": "3,8"}, "Aug, 6th, 00:00"),
     ({"hour": "2"}, {"dow": "4", "hour": "2"}, "Thu, 02:00"),
+    ({"dow": "0"}, {"dow": "0"}, "Sun, 00:00"),
+    ({"dow": "0"}, {"dow": "7"}, "Sun, 00:00"),
 ])
 def test__smart_test_schedules_intersect_at(a, b, result):
     assert smart_test_schedules_intersect_at({**DEFAULTS, **a}, {**DEFAULTS, **b}) == result


### PR DESCRIPTION
`0` is a valid reference to Sunday in `crontab`, but is not a valid reference to Sunday in `smartd.conf`