### PR TITLE
NAS-128636 / 24.10 / add back identifier key to disk.get_unused

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/info.py
+++ b/src/middlewared/middlewared/plugins/disk_/info.py
@@ -48,7 +48,7 @@ class DiskService(Service):
 
     @private
     async def get_valid_zfs_partition_type_uuids(self):
-        return list(valid_zfs_partition_uuids)
+        return list(valid_zfs_partition_uuids())
 
     @private
     async def get_valid_swap_partition_type_uuids(self):

--- a/src/middlewared/middlewared/plugins/disk_/info.py
+++ b/src/middlewared/middlewared/plugins/disk_/info.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.disk_.utils import valid_zfs_partition_uuids
 from middlewared.schema import accepts, Str
 from middlewared.service import filterable, private, Service
 from middlewared.utils import filter_list
@@ -47,12 +48,7 @@ class DiskService(Service):
 
     @private
     async def get_valid_zfs_partition_type_uuids(self):
-        # https://salsa.debian.org/debian/gdisk/blob/master/parttypes.cc for valid zfs types
-        # 516e7cba was being used by freebsd and 6a898cc3 is being used by linux
-        return [
-            '6a898cc3-1dd2-11b2-99a6-080020736631',
-            '516e7cba-6ecf-11d6-8ff8-00022d09712b',
-        ]
+        return list(valid_zfs_partition_uuids)
 
     @private
     async def get_valid_swap_partition_type_uuids(self):

--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from middlewared.schema import accepts, Bool, Dict, Str
 from middlewared.service import job, private, Service, ServiceChangeMixin
+from middlewared.plugins.disk_.utils import dev_to_ident
 
 RE_IDENT = re.compile(r'^\{(?P<type>.+?)\}(?P<value>.+)$')
 
@@ -98,20 +99,7 @@ class DiskService(Service, ServiceChangeMixin):
 
     @private
     def dev_to_ident(self, name, sys_disks, uuids):
-        if name not in sys_disks:
-            return ''
-        else:
-            dev = sys_disks[name]
-
-        if dev['serial_lunid']:
-            return f'{{serial_lunid}}{dev["serial_lunid"]}'
-        elif dev['serial']:
-            return f'{{serial}}{dev["serial"]}'
-        elif dev['parts']:
-            for part in filter(lambda x: x['partition_type'] in uuids, dev['parts']):
-                return f'{{uuid}}{part["partition_uuid"]}'
-
-        return f'{{devicename}}{name}'
+        return dev_to_ident(name, sys_disks, uuids)
 
     @private
     @accepts(Dict(

--- a/src/middlewared/middlewared/plugins/disk_/utils.py
+++ b/src/middlewared/middlewared/plugins/disk_/utils.py
@@ -1,0 +1,26 @@
+def valid_zfs_partition_uuids():
+    # https://salsa.debian.org/debian/gdisk/blob/master/parttypes.cc for valid zfs types
+    # 516e7cba was being used by freebsd and 6a898cc3 is being used by linux
+    return (
+        '6a898cc3-1dd2-11b2-99a6-080020736631',
+        '516e7cba-6ecf-11d6-8ff8-00022d09712b',
+    )
+
+
+def dev_to_ident(name, sys_disks, uuids):
+    """Map a disk device (i.e. sda5) to its respective "identifier"
+    (i.e. "{serial_lunid}AAAA_012345")"""
+    try:
+        dev = sys_disks[name]
+    except KeyError:
+        return ''
+    else:
+        if dev['serial_lunid']:
+            return f'{{serial_lunid}}{dev["serial_lunid"]}'
+        elif dev['serial']:
+            return f'{{serial}}{dev["serial"]}'
+        elif dev['parts']:
+            for part in filter(lambda x: x['partition_type'] in uuids, dev['parts']):
+                return f'{{uuid}}{part["partition_uuid"]}'
+
+    return f'{{devicename}}{name}'


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/13622 introduced a subtle regression where-by the `identifier` key wasn't included in the response. I noticed that the function that does this can be moved into its own utility function so that I don't have to go through `self.middleware` to get the information. (self.middleware does incur some overhead and we want this endpoint to be as fast as possible)

I did the same for `get_valid_zfs_partition_type_uuids`. 