### PR TITLE
Dynamically configure nsswitch.conf based on DS

### DIFF
--- a/src/freenas/etc/nsswitch.conf
+++ b/src/freenas/etc/nsswitch.conf
@@ -2,13 +2,13 @@
 # nsswitch.conf(5) - name service switch configuration file
 #
 
-group: files winbind sss
+group: files
 hosts: files dns
 networks: files
-passwd: files winbind sss
+passwd: files
 shells: files
 services: files
 protocols: files
 rpc: files
 sudoers: files
-netgroup: files sss
+netgroup: files

--- a/src/middlewared/middlewared/etc_files/nsswitch.conf
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf
@@ -1,0 +1,43 @@
+<%
+    from middlewared.utils.nss.nss_common import NssModule
+    from middlewared.plugins.directoryservices import DSType, DSStatus
+
+    ds_status = middleware.call_sync('directoryservices.status')
+    netgroup = ''
+    ds = ''
+
+    # An unhealthy directory service cause significant server-wide
+    # issues when it is present in the nsswitch in some edge cases.
+
+    # It should only be added if we are reasonably sure we're healthy
+    match ds_status['directory_service']:
+        case DSType.LDAP.value:
+            if ds_status['state'] in (DSStatus.HEALTHY.value, DSStatus.JOINING.value):
+                ds = NssModule.SSS.name.lower()
+                netgroup = NssModule.SSS.name.lower()
+        case DSType.AD.value:
+            if ds_status['state'] in (DSStatus.HEALTHY.value, DSStatus.JOINING.value):
+                ds = NssModule.WINBIND.name.lower()
+        case None:
+            pass
+        case _:
+            # This should never happen and indicates a bug
+            middleware.logger.error(
+                '%s: unknown directory service. Please file a bug report.'
+                ds_status['directory_service']
+            )
+%>\
+#
+# nsswitch.conf(5) - name service switch configuration file
+#
+
+group: files ${ds}
+hosts: files dns
+networks: files
+passwd: files ${ds}
+shells: files
+services: files
+protocols: files
+rpc: files
+sudoers: files
+netgroup: files ${netgroup}

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -922,6 +922,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('service.stop', 'cifs')
         job.set_progress(40, 'Reconfiguring pam and nss.')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'].name)
         job.set_progress(60, 'clearing caches.')
         await self.middleware.call('service.stop', 'dscache')
@@ -1262,6 +1263,7 @@ class ActiveDirectoryService(ConfigService):
 
         job.set_progress(60, 'Regenerating configuration.')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
         await self.synchronize()
         await self.middleware.call('idmap.synchronize')
 

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -216,6 +216,9 @@ class EtcService(Service):
         'nscd': [
             {'type': 'mako', 'path': 'nscd.conf'},
         ],
+        'nss': [
+            {'type': 'mako', 'path': 'nsswitch.conf'},
+        ],
         'wsd': [
             {'type': 'mako', 'path': 'local/wsdd.conf', 'checkpoint': 'post_init'},
         ],


### PR DESCRIPTION
Since middleware is now able to query NSS modules directly for users and groups we can dynamically generate the nsswitch.conf to improve application stability when directory services are unhealthy. In case of misconfigured or unhealthy directory services we remove them from the nsswitch until we're able to re-establish that they're healthy.