### PR TITLE
NAS-128723 / 24.10 / Enable cgroups plugin

### DIFF
--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -38,7 +38,7 @@
 [plugins]
 	proc = yes
 	diskspace = no
-	cgroups = no
+	cgroups = yes # Useful stats (CPU, MEM, DISK) for VMs and systemd services
 	tc = no
 	idlejitter = no
 	perf = no

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -151,4 +151,4 @@
 	# performance metrics for disks with major 230 = no
 
 [plugin:cgroups]
-        enable by default cgroups names matching = *qemu* /system
+        enable by default cgroups names matching = !*udev* *

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -38,7 +38,7 @@
 [plugins]
 	proc = yes
 	diskspace = no
-	cgroups = yes # Useful stats (CPU, MEM, DISK) for VMs and systemd services
+	cgroups = yes
 	tc = no
 	idlejitter = no
 	perf = no
@@ -149,3 +149,6 @@
 	# performance metrics for disks with major 9 = no
 	# performance metrics for disks with major 253 = no
 	# performance metrics for disks with major 230 = no
+
+[plugin:cgroups]
+        enable by default cgroups names matching = *qemu* /system

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -1,3 +1,4 @@
+import glob
 import logging
 
 from middlewared.service import accepts, Service
@@ -52,6 +53,8 @@ class NetdataService(Service):
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
             self.middleware.call_sync('zfs.pool.query', [], {'count': True}),
+            self.middleware.call_sync('vm.query', [], {'count': True}),
+            len(glob.glob('/sys/fs/cgroup/**/*.service')),
         )
 
     def get_disk_space_for_tier0(self):

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -54,7 +54,9 @@ def get_netdata_state_path() -> str:
     return os.path.join(SYSDATASET_PATH, 'netdata/ix_state')
 
 
-def get_metrics_approximation(disk_count: int, core_count: int, interface_count: int, pool_count: int) -> dict:
+def get_metrics_approximation(
+    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int, systemd_service_count: int,
+) -> dict:
     data = {
         1: {
             'system.cpu': 10,
@@ -160,6 +162,38 @@ def get_metrics_approximation(disk_count: int, core_count: int, interface_count:
             'nut_ups.load': 1,
             'nut_ups.temp': 1,
             'netdata.plugin_chartsd_nut': 1,
+
+            # cgroups
+            'services.io_ops_write': systemd_service_count,
+            'services.io_ops_read': systemd_service_count,
+            'services.io_write': systemd_service_count,
+            'services.io_read': systemd_service_count,
+            'services.mem_usage': systemd_service_count,
+            'services.cpu': systemd_service_count,
+            'cgroup_qemu_vm.cpu_limit': vms_count,
+            'cgroup_qemu_vm.cpu': 2 * vms_count,
+            'cgroup_qemu_vm.throttled': vms_count,
+            'cgroup_qemu_vm.throttled_duration': vms_count,
+            'cgroup_qemu_vm.mem': 6 * vms_count,
+            'cgroup_qemu_vm.writeback': 2 * vms_count,
+            'cgroup_qemu_vm.pgfaults': 2 * vms_count,
+            'cgroup_qemu_vm.mem_usage': 2 * vms_count,
+            'cgroup_qemu_vm.mem_usage_limit': 2 * vms_count,
+            'cgroup_qemu_vm.mem_utilization': vms_count,
+            'cgroup_qemu_vm.io': 2 * vms_count,
+            'cgroup_qemu_vm.serviced_ops': 2 * vms_count,
+            'cgroup_qemu_vm.cpu_some_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.cpu_some_pressure_stall_time': vms_count,
+            'cgroup_qemu_vm.cpu_full_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.cpu_full_pressure_stall_time': vms_count,
+            'cgroup_qemu_vm.mem_some_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.memory_some_pressure_stall_time': vms_count,
+            'cgroup_qemu_vm.mem_full_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.memory_full_pressure_stall_time': vms_count,
+            'cgroup_qemu_vm.io_some_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.io_some_pressure_stall_time': vms_count,
+            'cgroup_qemu_vm.io_full_pressure': 3 * vms_count,
+            'cgroup_qemu_vm.io_full_pressure_stall_time': vms_count,
         },
         60: {  # smartd_logs
             'smart_log.temperature_celsius': disk_count}

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -55,7 +55,8 @@ def get_netdata_state_path() -> str:
 
 
 def get_metrics_approximation(
-    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int, systemd_service_count: int,
+    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int,
+    systemd_service_count: int, containers_count: typing.Optional[int] = 10,
 ) -> dict:
     data = {
         1: {
@@ -194,6 +195,29 @@ def get_metrics_approximation(
             'cgroup_qemu_vm.io_some_pressure_stall_time': vms_count,
             'cgroup_qemu_vm.io_full_pressure': 3 * vms_count,
             'cgroup_qemu_vm.io_full_pressure_stall_time': vms_count,
+
+            'cgroup_hash.cpu_limit': containers_count,
+            'cgroup_hash.cpu': 2 * containers_count,
+            'cgroup_hash.throttled': containers_count,
+            'cgroup_hash.throttled_duration': containers_count,
+            'cgroup_hash.mem': 6 * containers_count,
+            'cgroup_hash.writeback': 2 * containers_count,
+            'cgroup_hash.pgfaults': 2 * containers_count,
+            'cgroup_hash.mem_usage': 2 * containers_count,
+            'cgroup_hash.mem_usage_limit': 2 * containers_count,
+            'cgroup_hash.mem_utilization': containers_count,
+            'cgroup_hash.cpu_some_pressure': 3 * containers_count,
+            'cgroup_hash.cpu_some_pressure_stall_time': containers_count,
+            'cgroup_hash.cpu_full_pressure': 3 * containers_count,
+            'cgroup_hash.cpu_full_pressure_stall_time': containers_count,
+            'cgroup_hash.mem_some_pressure': 3 * containers_count,
+            'cgroup_hash.memory_some_pressure_stall_time': containers_count,
+            'cgroup_hash.mem_full_pressure': 3 * containers_count,
+            'cgroup_hash.memory_full_pressure_stall_time': containers_count,
+            'cgroup_hash.io_some_pressure': 3 * containers_count,
+            'cgroup_hash.io_some_pressure_stall_time': containers_count,
+            'cgroup_hash.io_full_pressure': 3 * containers_count,
+            'cgroup_hash.io_full_pressure_stall_time': containers_count,
         },
         60: {  # smartd_logs
             'smart_log.temperature_celsius': disk_count}

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -3,51 +3,59 @@ import pytest
 from middlewared.plugins.reporting.utils import get_metrics_approximation, calculate_disk_space_for_netdata
 
 
-@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,expected_output', [
-    (4, 2, 1, 2, {1: 370, 60: 4}),
-    (1600, 32, 4, 4, {1: 44017, 60: 1600}),
-    (10, 16, 2, 2, {1: 777, 60: 10}),
+@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
+    (4, 2, 1, 2, 10, 2, {1: 526, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 44125, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 993, 60: 10}),
 ])
-def test_netdata_metrics_count_approximation(disk_count, core_count, interface_count, pool_count, expected_output):
-    assert get_metrics_approximation(disk_count, core_count, interface_count, pool_count) == expected_output
+def test_netdata_metrics_count_approximation(
+    disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
+):
+    assert get_metrics_approximation(
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+    ) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,pool_count,days,bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 7, 1, 1, 213),
-        (4, 2, 1, 2, 7, 4, 60, 14),
-        (1600, 32, 4, 4, 4, 1, 1, 14516),
-        (1600, 32, 4, 4, 4, 4, 900, 64),
-        (10, 16, 2, 2, 3, 1, 1, 192),
-        (10, 16, 2, 2, 3, 4, 60, 12),
-        (1600, 32, 4, 4, 18, 1, 1, 65323),
-        (1600, 32, 4, 4, 18, 4, 900, 290),
+    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
+    'bytes_per_point,tier_interval,expected_output', [
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 303),
+        (4, 2, 1, 2, 10, 1, 7, 4, 60, 18),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 14599),
+        (1600, 32, 4, 10, 1, 4, 4, 4, 900, 64),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 221),
+        (10, 16, 2, 2, 10, 3, 3, 4, 60, 16),
+        (1600, 32, 4, 4, 12, 3,  18, 1, 1, 65643),
+        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 291),
     ],
 )
 def test_netdata_disk_space_approximation(
-    disk_count, core_count, interface_count, pool_count, days, bytes_per_point, tier_interval, expected_output
+    disk_count, core_count, interface_count, pool_count, services_count,
+    vms_count, days, bytes_per_point, tier_interval, expected_output
 ):
     assert calculate_disk_space_for_netdata(get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
     ), days, bytes_per_point, tier_interval) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,pool_count,days,bytes_per_point,tier_interval', [
-        (4, 2, 1, 2, 7, 1, 1),
-        (4, 2, 1, 2, 7, 4, 60),
-        (1600, 32, 4, 4, 4, 1, 1),
-        (1600, 32, 4, 4, 4, 4, 900),
-        (10, 16, 2, 2, 3, 1, 1),
-        (10, 16, 2, 2, 3, 4, 60),
-        (1600, 32, 4, 4, 18, 1, 1),
-        (1600, 32, 4, 4, 18, 4, 900),
+    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,bytes_per_point,tier_interval', [
+        (4, 2, 1, 2, 10, 2, 7, 1, 1),
+        (4, 2, 1, 2, 12, 2, 7, 4, 60),
+        (1600, 32, 4, 4, 10, 3, 4, 1, 1),
+        (1600, 32, 4, 4, 12, 3, 4, 4, 900),
+        (10, 16, 2, 2, 10, 4, 3, 1, 1),
+        (10, 16, 2, 2, 12, 4, 3, 4, 60),
+        (1600, 32, 4, 4, 10, 5, 18, 1, 1),
+        (1600, 32, 4, 4, 12, 5, 18, 4, 900),
     ],
 )
 def test_netdata_days_approximation(
-    disk_count, core_count, interface_count, pool_count, days, bytes_per_point, tier_interval
+    disk_count, core_count, interface_count, pool_count, services_count, vms_count, days, bytes_per_point, tier_interval
 ):
-    metric_intervals = get_metrics_approximation(disk_count, core_count, interface_count, pool_count)
+    metric_intervals = get_metrics_approximation(
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+    )
     disk_size = calculate_disk_space_for_netdata(metric_intervals, days, bytes_per_point, tier_interval)
     total_metrics = metric_intervals[1] + (metric_intervals[60] / 60)
     assert round((disk_size * 1024 * 1024) / (bytes_per_point * total_metrics * (86400 / tier_interval))) == days

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 526, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 44125, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 993, 60: 10}),
+    (4, 2, 1, 2, 10, 2, {1: 966, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 44565, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 1433, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
@@ -19,14 +19,14 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 303),
-        (4, 2, 1, 2, 10, 1, 7, 4, 60, 18),
-        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 14599),
-        (1600, 32, 4, 10, 1, 4, 4, 4, 900, 64),
-        (10, 16, 2, 2, 12, 1, 3, 1, 1, 221),
-        (10, 16, 2, 2, 10, 3, 3, 4, 60, 16),
-        (1600, 32, 4, 4, 12, 3,  18, 1, 1, 65643),
-        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 291),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 557),
+        (4, 2, 1, 2, 10, 1, 7, 4, 60, 35),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 14744),
+        (1600, 32, 4, 10, 1, 4, 4, 4, 900, 65),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 330),
+        (10, 16, 2, 2, 10, 3, 3, 4, 60, 23),
+        (1600, 32, 4, 4, 12, 3,  18, 1, 1, 66296),
+        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 294),
     ],
 )
 def test_netdata_disk_space_approximation(


### PR DESCRIPTION
cgroups plugin enabled useful stats (CPU, Memory and Disk activity) for systemd services and VMs.

Overhead of this plugin seems to be minimal to always enable it.

In the future we might consider making the plugins configurable.

This plugin was research as part of SOLN-230.