### PR TITLE
NAS-127636 / 24.10 / Expose API arguments to device.get_info

### DIFF
--- a/src/middlewared/middlewared/plugins/device.py
+++ b/src/middlewared/middlewared/plugins/device.py
@@ -7,7 +7,14 @@ class DeviceService(Service):
     class Config:
         cli_namespace = 'system.device'
 
-    @accepts(Str('type', enum=['SERIAL', 'DISK', 'GPU']), roles=['READONLY_ADMIN'])
+    @accepts(
+        Dict(
+            Str('type', enum=['SERIAL', 'DISK', 'GPU'], required=True),
+            Bool('get_partitions', required=False, default=False),
+            Bool('serials_only', required=False, default=False),
+        ),
+        roles=['READONLY_ADMIN']
+    )
     @returns(OROperator(
         List('serial_info', items=[Dict(
             'serial_info',
@@ -42,8 +49,18 @@ class DeviceService(Service):
         Dict('disk_info', additional_attrs=True),
         name='device_info',
     ))
-    async def get_info(self, _type):
+    async def get_info(self, data):
         """
-        Get info for SERIAL/DISK/GPU device types.
+        Get info for `data['type']` device.
+
+        If `type` is "DISK":
+            `get_partitions`: boolean, when set to True will query partition
+                information for the disks. NOTE: this can be expensive on
+                systems with a large number of disks present.
+            `serials_only`: boolean, when set to True will query serial information
+                _ONLY_ for the disks.
         """
-        return await self.middleware.call(f'device.get_{_type.lower()}s')
+        method = f'device.get_{data["type"].lower()}'
+        if method == 'device.get_disk':
+            return await self.middleware.call(method, data['get_partitions'], data['serials_only'])
+        return await self.middleware.call(method)

--- a/src/middlewared/middlewared/plugins/device.py
+++ b/src/middlewared/middlewared/plugins/device.py
@@ -9,6 +9,7 @@ class DeviceService(Service):
 
     @accepts(
         Dict(
+            'data',
             Str('type', enum=['SERIAL', 'DISK', 'GPU'], required=True),
             Bool('get_partitions', required=False, default=False),
             Bool('serials_only', required=False, default=False),
@@ -60,7 +61,7 @@ class DeviceService(Service):
             `serials_only`: boolean, when set to True will query serial information
                 _ONLY_ for the disks.
         """
-        method = f'device.get_{data["type"].lower()}'
-        if method == 'device.get_disk':
+        method = f'device.get_{data["type"].lower()}s'
+        if method == 'device.get_disks':
             return await self.middleware.call(method, data['get_partitions'], data['serials_only'])
         return await self.middleware.call(method)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/gpu.py
@@ -186,7 +186,7 @@ class KubernetesGPUService(Service):
             self.logger.error('Unable to configure GPU for node: %s', e, exc_info=True)
 
     async def get_system_gpus(self):
-        gpus = await self.middleware.call('device.get_info', 'GPU')
+        gpus = await self.middleware.call('device.get_info', {'type': 'GPU'})
         supported_gpus = {'NVIDIA', 'INTEL', 'AMD'}
         return supported_gpus.intersection(set([gpu['vendor'] for gpu in gpus if gpu['available_to_host']]))
 

--- a/src/middlewared/middlewared/plugins/system_advanced/serial.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/serial.py
@@ -15,7 +15,7 @@ class SystemAdvancedService(Service):
         """
         Get available choices for `serialport`.
         """
-        ports = {e['name']: e['name'] for e in await self.middleware.call('device.get_info', 'SERIAL')}
+        ports = {e['name']: e['name'] for e in await self.middleware.call('device.get_info', {'type': 'SERIAL'})}
         if not ports or (await self.middleware.call('system.advanced.config'))['serialport'] == 'ttyS0':
             # We should always add ttyS0 if ports is false or current value is the default one in db
             # i.e ttyS0


### PR DESCRIPTION
We need the ability for this endpoint to return the disk partition information if the `type` is `DISK`. The logic that implements this functionality has existed in our product for quite awhile now but it is behind a private endpoint.

Changes made are:
1. Convert the positional argument of a string and change it to accepting a dictionary object
2. add the 2 new boolean arguments that will be passed along as-is
3. Add a more details docstring (explaining the arguments that apply to the "DISK" type)
4. update the callers of this endpoint since the API has changed