### PR TITLE
NAS-128717 / 24.10 / Add missing level to MemorySizeMismatchAlertClass

### DIFF
--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -19,6 +19,7 @@ class MemoryErrorsAlertClass(AlertClass):
 
 class MemorySizeMismatchAlertClass(AlertClass):
     category = AlertCategory.HARDWARE
+    level = AlertLevel.WARNING
     title = 'Memory Size Mismatch Detected'
     text = 'Memory size on this controller %(r1)s doesn\'t match other controller %(r2)s'
     products = ('SCALE_ENTERPRISE',)


### PR DESCRIPTION
Class was created in PR #13285, but no level was set.

This caused the following error in CI tests:
```
FAILED api2/test_050_alert.py::test_02_get_alert_list_categories - AssertionError: {
   "message": "'NotImplementedType' object has no attribute 'name'",
   "traceback": "Traceback (most recent call last):\n  File \"/usr/lib/python3/dist-packages/middlewared/restful.py\", line 849, in do\n    result = await self.middleware.call_with_audit(methodname, serviceobj, methodobj, method_args,\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/main.py\", line 1477, in call_with_audit\n    result = await self._call(method, serviceobj, methodobj, params, app=app,\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/main.py\", line 1428, in _call\n    return await methodobj(*prepared_call.args)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/schema/processor.py\", line 187, in nf\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/schema/processor.py\", line 47, in nf\n    res = await f(*args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3/dist-packages/middlewared/plugins/alert.py\", line 312, in list_categories\n    return [\n           ^\n  File \"/usr/lib/python3/dist-packages/middlewared/plugins/alert.py\", line 317, in <listcomp>\n    [\n  File \"/usr/lib/python3/dist-packages/middlewared/plugins/alert.py\", line 321, in <listcomp>\n    \"level\": alert_class.level.name,\n             ^^^^^^^^^^^^^^^^^^^^^^\nAttributeError: 'NotImplementedType' object has no attribute 'name'\n"
```
(then iterated over the `AlertClass.classes` to find the culprit.)