### PR TITLE
NAS-128716 / 24.04.1 / Only have one yield in fixture (by bmeagherix)

### DIFF
--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -118,8 +118,9 @@ def set_product_type(request):
     if ha:
         # HA product is already enterprise-licensed
         yield
-    with product_type():
-        yield
+    else:
+        with product_type():
+            yield
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Noticed the following error being raised in CI tests
```
ERROR api2/test_030_activedirectory.py::test_10_account_privilege_authentication - Failed: fixture function has more than one 'yield':

    @pytest.fixture(scope="function")
    def set_product_type(request):
        if ha:
            # HA product is already enterprise-licensed
            yield
        with product_type():
            yield
/home/jenkins/scale_build/master/api_tests/224/middleware/tests/api2/test_030_activedirectory.py:118
```

Introduced by PR #13236, so just give a minor tweak to keep that fix without introducing the above error.

Original PR: https://github.com/truenas/middleware/pull/13646
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128716