### PR TITLE
NAS-128631 / 24.10 / Make sure we redirect logs to relevant log files instead of copying them

### DIFF
--- a/src/freenas/etc/logrotate.d/netdata_override
+++ b/src/freenas/etc/logrotate.d/netdata_override
@@ -1,0 +1,8 @@
+/var/log/netdata/*.log {
+    size 10M
+    rotate 7
+    compress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -113,6 +113,38 @@ source tn_remote_src_files {
 #######################
 # Log paths
 ########################
+log {
+  source(s_src);
+  filter(f_k3s);
+  destination { file("/var/log/k3s_daemon.log"); };
+  flags(final);
+};
+
+log {
+  source(s_src);
+  filter(f_containerd);
+  destination { file("/var/log/containerd.log"); };
+  flags(final);
+};
+log {
+  source(s_src);
+  filter(f_kube_router);
+  destination { file("/var/log/kube_router.log"); };
+  flags(final);
+};
+log {
+  source(s_src);
+  filter(f_app_mounts);
+  destination { file("/var/log/app_mounts.log"); };
+  flags(final);
+};
+log {
+  source(s_src);
+  filter(f_scst);
+  destination { file("/var/log/scst.log"); };
+  flags(final);
+};
+
 log { source(s_src); filter(f_auth); destination(d_auth); };
 log { source(s_src); filter(f_cron); destination(d_cron); };
 log { source(s_src); filter(f_daemon); destination(d_daemon); };
@@ -127,31 +159,6 @@ log { source(s_src); filter(f_messages); destination(d_messages); };
 log { source(s_src); filter(f_console); destination(d_console_all); destination(d_xconsole); };
 log { source(s_src); filter(f_crit); destination(d_console); };
 
-log {
-  source(s_src);
-  filter(f_k3s);
-  destination { file("/var/log/k3s_daemon.log"); };
-};
-log {
-  source(s_src);
-  filter(f_containerd);
-  destination { file("/var/log/containerd.log"); };
-};
-log {
-  source(s_src);
-  filter(f_kube_router);
-  destination { file("/var/log/kube_router.log"); };
-};
-log {
-  source(s_src);
-  filter(f_app_mounts);
-  destination { file("/var/log/app_mounts.log"); };
-};
-log {
-  source(s_src);
-  filter(f_scst);
-  destination { file("/var/log/scst.log"); };
-};
 
 % if render_ctx['system.advanced.config']['syslogserver']:
 ${generate_syslog_remote_destination(render_ctx['system.advanced.config'])}


### PR DESCRIPTION
## Problem

We have different log filters specified where we want to make sure that different sources i.e k3s/scst etc do not pollute other log files with their messages but unfortunately what in reality is happening is that we have their logs being logged to separate files but they are still getting logged in other log files i.e daemon.log etc which indicates that logs are being copied rather then redirected completely.

## Solution

Add changes to make sure we don't process other log filters if we have a match for a filter earlier and once we have gone through our custom log file solutions we can finally have rest of the filters for other log files being processed.