### PR TITLE
NAS-128651 / 24.04.1 / Disable nslcd auto-start in Dragonfish

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -47,6 +47,11 @@ systemctl disable nvidia-persistenced
 # NOTE: This should be reviewed on next update where the startup issue is fixed via a new systemd unit file.
 systemctl disable proftpd.socket
 
+# Disable auto-start of nslcd - NAS-128651
+echo "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants"
+rm -f /lib/systemd/system/multi-user.target.wants/nslcd.service
+rm -f /lib/systemd/system/graphical.target.wants/nslcd.service
+
 # Update alternatives
 update-alternatives --install "/usr/sbin/sendmail" sendmail "/etc/find_alias_for_smtplib.sh" "10"
 update-alternatives --install "/usr/bin/vim" vim.tiny "/usr/bin/vim.tiny" "10"

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -38,6 +38,7 @@ systemctl disable wsdd
 systemctl disable walinuxagent
 systemctl disable openipmi
 systemctl disable nfs-server
+systemctl disable nslcd
 
 # nvidia-persistenced is not respecting vendor preset file so we disable it explicitly
 systemctl disable nvidia-persistenced
@@ -46,13 +47,6 @@ systemctl disable nvidia-persistenced
 # proftpd.socket is used in conjunction with xinetd
 # NOTE: This should be reviewed on next update where the startup issue is fixed via a new systemd unit file.
 systemctl disable proftpd.socket
-
-# Disable auto-start of nslcd - NAS-128651
-logger "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants"  # <------------------- DEBUG
-echo "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants" > /dev/console  # <------------------- DEBUG
-systemctl disable nslcd
-rm -f /lib/systemd/system/multi-user.target.wants/nslcd.service
-rm -f /lib/systemd/system/graphical.target.wants/nslcd.service
 
 # Update alternatives
 update-alternatives --install "/usr/sbin/sendmail" sendmail "/etc/find_alias_for_smtplib.sh" "10"

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -48,7 +48,7 @@ systemctl disable nvidia-persistenced
 systemctl disable proftpd.socket
 
 # Disable auto-start of nslcd - NAS-128651
-echo "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants"
+logger "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants"  # <------------------- DEBUG
 rm -f /lib/systemd/system/multi-user.target.wants/nslcd.service
 rm -f /lib/systemd/system/graphical.target.wants/nslcd.service
 

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -49,6 +49,8 @@ systemctl disable proftpd.socket
 
 # Disable auto-start of nslcd - NAS-128651
 logger "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants"  # <------------------- DEBUG
+echo "[MCG DEBUG] postinst: rm nslcd from multi-user.target.wants" > /dev/console  # <------------------- DEBUG
+systemctl disable nslcd
 rm -f /lib/systemd/system/multi-user.target.wants/nslcd.service
 rm -f /lib/systemd/system/graphical.target.wants/nslcd.service
 


### PR DESCRIPTION
Disable auto-start of nslcd in the Dragonfish release.
The LDAP module manages the start and stop of nslcd as necessary.
_This should not be forward ported._