### PR TITLE
NAS-128692 / 24.04.1 / Skip `Update Available` errors (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -19,13 +19,16 @@ class UpdateFailedAlertClass(AlertClass):
     text = f"Update failed. See {UPDATE_FAILED_SENTINEL} for details."
 
 
-class HadUpdateAlertSource(AlertSource):
+class HasUpdateAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(hours=1))
     run_on_backup_node = False
 
     async def check(self):
-        if (await self.middleware.call("update.check_available"))["status"] == "AVAILABLE":
-            return Alert(HasUpdateAlertClass)
+        try:
+            if (await self.middleware.call("update.check_available"))["status"] == "AVAILABLE":
+                return Alert(HasUpdateAlertClass)
+        except Exception:
+            pass
 
 
 class UpdateFailedAlertSource(FilePresenceAlertSource):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e3dca01c5f2dd80641992386f518787201751c2d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8ca93f139a9092a4e525b013b14e54305883fd3e

There is no reason to have this alert if TrueNAS does not have an internet connection.

Original PR: https://github.com/truenas/middleware/pull/13653
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128692