### PR TITLE
NAS-128762 / 24.10 / bump max_tasks_per_child to 20

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1337,7 +1337,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
     def __init_procpool(self):
         self.__procpool = concurrent.futures.ProcessPoolExecutor(
             max_workers=5,
-            max_tasks_per_child=5,
+            max_tasks_per_child=20,
             initializer=functools.partial(worker_init, self.debug_level, self.log_handler)
         )
 


### PR DESCRIPTION
Back in 23.10 I changed this setting to 5. (c.f. ced399a41ca). This has proven to be fine, however, we have had quite a few users from the community express "higher CPU usage" after upgrading to 24.04.0. (c.f. https://github.com/truenas/middleware/pull/13660 for details).

During the investigation of this problem, I've realized that I can further reduce the CPU usage by bumping this setting a bit. This is not a _solution_ but is a band-aid. There are tradeoffs with changing this. Lowering the value here means, less memory consumption for the total uptime of middlewared but increase CPU usage. Bumping this will lessen the CPU usage, but will increase the memory consumption. This value is based off anecdotal investigation on a dual-core CPU system that reproduced the "higher CPU usage" issue.

Keep in mind, that before this was set to `5`, the process pool grew to very large memory sizes on high uptime systems. This is, what I would consider, "fine tuning" the setting.