### PR TITLE
NAS-128787 / 24.10 / Fix catalog.query

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/update.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/update.py
@@ -70,7 +70,9 @@ class CatalogService(CRUDService):
     @private
     async def catalog_extend_context(self, rows, extra):
         if await self.dataset_mounted():
-            catalogs_dir = (await self.middleware.call('kubernetes.config'))['dataset']
+            catalogs_dir = os.path.join(
+                '/mnt', (await self.middleware.call('kubernetes.config'))['dataset'], 'catalogs'
+            )
         else:
             # FIXME: TMP_IX_APPS_DIR is in tmpfs (RAM)....a large catalog
             # will eat a large amount of RAM....


### PR DESCRIPTION
This commit fixes an issue where we were not retrieving the correct catalog dir which resulted in catalog related operations to fail.