### PR TITLE
NAS-128802 / 24.10 / Improve configuration file generation

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -6,10 +6,11 @@ import stat
 
 from mako import exceptions
 from middlewared.service import CallError, Service
-from middlewared.utils.io import write_if_changed
+from middlewared.utils.io import write_if_changed, UnexpectedFileChange
 from middlewared.utils.mako import get_template
 
 DEFAULT_ETC_PERMS = 0o644
+DEFAULT_ETC_XID = 0
 
 
 class FileShouldNotExist(Exception):
@@ -325,36 +326,15 @@ class EtcService(Service):
 
         return rv
 
-    def set_etc_file_perms(self, fd, entry):
-        perm_changed = False
+    def get_perms_and_ownership(self, entry):
         user_name = entry.get('owner')
         group_name = entry.get('group')
         mode = entry.get('mode', DEFAULT_ETC_PERMS)
 
-        if all(i is None for i in (user_name, group_name, mode)):
-            return perm_changed
+        uid = self.middleware.call_sync('user.get_builtin_user_id', user_name) if user_name else DEFAULT_ETC_XID
+        gid = self.middleware.call_sync('group.get_builtin_group_id', group_name) if group_name else DEFAULT_ETC_XID
 
-        uid = self.middleware.call_sync('user.get_builtin_user_id', user_name) if user_name else -1
-        gid = self.middleware.call_sync('group.get_builtin_group_id', group_name) if group_name else -1
-        st = os.fstat(fd)
-        uid_to_set = -1
-        gid_to_set = -1
-
-        if uid != -1 and st.st_uid != uid:
-            uid_to_set = uid
-
-        if gid != -1 and st.st_gid != gid:
-            gid_to_set = gid
-
-        if gid_to_set != -1 or uid_to_set != -1:
-            os.fchown(fd, uid_to_set, gid_to_set)
-            perm_changed = True
-
-        if mode and stat.S_IMODE(st.st_mode) != mode:
-            os.fchmod(fd, mode)
-            perm_changed = True
-
-        return perm_changed
+        return {'uid': uid, 'gid': gid, 'perms': mode}
 
     def make_changes(self, full_path, entry, rendered):
         mode = entry.get('mode', DEFAULT_ETC_PERMS)
@@ -366,11 +346,14 @@ class EtcService(Service):
         if outfile_dirname != '/etc':
             os.makedirs(outfile_dirname, exist_ok=True)
 
-        with open(full_path, "w", opener=opener) as f:
-            perms_changed = self.set_etc_file_perms(f.fileno(), entry)
-            contents_changed = write_if_changed(f.fileno(), rendered)
+        payload = self.get_perms_and_ownership(entry)
+        try:
+            changes = write_if_changed(full_path, rendered, raise_error=True, **payload)
+        except UnexpectedFileChange as e:
+            self.logger.error(str(e))
+            changes = e.changes
 
-        return perms_changed or contents_changed
+        return changes
 
     async def generate(self, name, checkpoint=None):
         group = self.GROUPS.get(name)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -348,7 +348,7 @@ class EtcService(Service):
 
         payload = self.get_perms_and_ownership(entry)
         try:
-            changes = write_if_changed(full_path, rendered, raise_error=True, **payload)
+            changes = write_if_changed(full_path, rendered, **payload)
         except Exception:
             changes = 0
             self.logger.warning('%s: failed to write changes to configuration file', full_path, exc_info=True)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -350,8 +350,14 @@ class EtcService(Service):
         try:
             changes = write_if_changed(full_path, rendered, raise_error=True, **payload)
         except UnexpectedFileChange as e:
-            self.logger.error(str(e))
+            self.logger.error(
+                '%s: unexpected changes were made to configuration file that may '
+                'allow unauthorized user to alter service behavior', full_path, exc_info=True
+            )
             changes = e.changes
+        except Exception:
+            changes = 0
+            self.logger.warning('%s: failed to write changes to configuration file', full_path, exc_info=True)
 
         return changes
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -1,0 +1,161 @@
+import os
+import pytest
+import shutil
+
+from middlewared.utils.io import (
+     FileChanges,
+     ID_MAX,
+     UnexpectedFileChange,
+     write_if_changed
+)
+
+
+ETC_DIR = 'test-etc'
+
+
+@pytest.fixture(scope='module')
+def create_etc_dir(request):
+    os.mkdir(ETC_DIR)
+
+    try:
+        yield os.path.realpath(ETC_DIR)
+    finally:
+        shutil.rmtree(ETC_DIR)
+
+
+def test__write_file_content_basic(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile1')
+    changes = write_if_changed(target, "canary")
+    assert changes == FileChanges.CONTENTS
+
+    changes = write_if_changed(target, b"canary2")
+    assert changes == FileChanges.CONTENTS
+
+    # basic smoketest that we're actually writing contents
+    with open(target, 'r') as f:
+        assert f.read() == 'canary2'
+
+    os.unlink(target)
+
+
+def test__write_file_content_basic_dirfd(create_etc_dir):
+    dirfd = os.open(create_etc_dir, os.O_DIRECTORY)
+    try:
+        changes = write_if_changed('testfile2', "canary", dirfd=dirfd)
+        assert changes == FileChanges.CONTENTS
+
+        changes = write_if_changed('testfile2', b"canary2", dirfd=dirfd)
+        assert changes == FileChanges.CONTENTS
+        os.remove('testfile2', dir_fd=dirfd)
+    finally:
+        os.close(dirfd)
+
+
+def test__write_file_perms(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile3')
+
+    # file doesn't exist and so we only expect contents change
+    changes = write_if_changed(target, "canary", perms=0o777)
+    assert changes == FileChanges.CONTENTS
+
+    # changing content and perms
+    changes = write_if_changed(target, b"canary2", perms=0o755)
+    assert changes == FileChanges.CONTENTS | FileChanges.PERMS
+
+    # changing only perms
+    changes = write_if_changed(target, b"canary2", perms=0o700)
+    assert changes == FileChanges.PERMS
+
+    # changing nothing
+    changes = write_if_changed(target, b"canary2", perms=0o700)
+    assert changes == 0
+
+    assert os.stat(target).st_mode & 0o777 == 0o700
+    os.unlink(target)
+
+
+def test__write_file_uid(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile4')
+
+    # file doesn't exist and so we only expect contents change
+    changes = write_if_changed(target, "canary", uid=1000)
+    assert changes == FileChanges.CONTENTS
+
+    # changing content and uid
+    changes = write_if_changed(target, b"canary2", uid=1001)
+    assert changes == FileChanges.CONTENTS | FileChanges.UID
+
+    # changing uid only
+    changes = write_if_changed(target, b"canary2", uid=1002)
+    assert changes == FileChanges.UID
+
+    # changing nothing
+    changes = write_if_changed(target, b"canary2", uid=1002)
+    assert changes == 0
+
+    assert os.stat(target).st_uid  == 1002
+    os.unlink(target)
+
+
+def test__write_file_gid(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile5')
+
+    # file doesn't exist and so we only expect contents change
+    changes = write_if_changed(target, "canary", gid=1000)
+    assert changes == FileChanges.CONTENTS
+
+    # changing content and gid
+    changes = write_if_changed(target, b"canary2", gid=1001)
+    assert changes == FileChanges.CONTENTS | FileChanges.GID
+
+    # changing gid only
+    changes = write_if_changed(target, b"canary2", gid=1002)
+    assert changes == FileChanges.GID
+
+    # changing nothing
+    changes = write_if_changed(target, b"canary2", gid=1002)
+    assert changes == 0
+
+    assert os.stat(target).st_gid  == 1002
+    os.unlink(target)
+
+
+def test__write_file_exceptions(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile6')
+
+    changes = write_if_changed(target, "canary")
+    assert changes == FileChanges.CONTENTS
+
+
+    with pytest.raises(UnexpectedFileChange) as exc:
+        changes = write_if_changed(target, "canary", uid=1000, gid=1001, perms=0o700, raise_error=True)
+
+    assert exc.value.changes == FileChanges.UID | FileChanges.GID | FileChanges.PERMS
+    assert exc.value.path == target
+
+    # Make sure changes were still written
+    st = os.stat(target)
+    assert st.st_uid == 1000
+    assert st.st_gid == 1001
+    assert st.st_mode & 0o700 == 0o700
+    os.unlink(target)
+
+
+@pytest.mark.parametrize("params,expected_text", [
+    # ataprint.cpp
+    ({'uid': -1}, f'uid must be between 0 and {ID_MAX}'),
+    ({'gid': -1}, f'gid must be between 0 and {ID_MAX}'),
+    ({'uid': 'bob'}, 'uid must be an integer'),
+    ({'gid': 'bob'}, 'gid must be an integer'),
+    ({'perms': 'bob'}, 'perms must be an integer'),
+    ({'perms': 0o4777}, '2559: invalid mode'),
+    ({'dirfd': 'home'}, 'dirfd must be a valid file descriptor'),
+    ({'dirfd': -1}, '-1: file descriptor not found'),
+])
+def test__write_file_value_errors(create_etc_dir, params, expected_text):
+    target = os.path.join(create_etc_dir, 'testfile7')
+
+    with pytest.raises(ValueError) as exc:
+        write_if_changed(target, "canary", **params)
+
+    assert expected_text in str(exc.value)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -159,3 +159,34 @@ def test__write_file_value_errors(create_etc_dir, params, expected_text):
         write_if_changed(target, "canary", **params)
 
     assert expected_text in str(exc.value)
+
+
+def test__write_file_path_absolute_dirfd_value_error(create_etc_dir):
+    target = os.path.join(create_etc_dir, 'testfile8')
+
+    dirfd = os.open(create_etc_dir, os.O_DIRECTORY)
+    try:
+        with pytest.raises(ValueError) as exc:
+            write_if_changed(target, "canary", dirfd=dirfd)
+    finally:
+        os.close(dirfd)
+
+    assert 'absolute paths may not be used' in str(exc.value)
+
+
+def test__write_file_path_relative_no_dirfd_value_error(create_etc_dir):
+    with pytest.raises(ValueError) as exc:
+        write_if_changed('testfile9', "canary")
+
+    assert 'relative paths may not be used' in str(exc.value)
+
+
+def test__write_file_wrong_open_type_value_error(create_etc_dir):
+    # create a test file
+    with open(os.path.join(create_etc_dir, 'testfile10'), 'w') as f:
+        with pytest.raises(ValueError) as exc:
+            write_if_changed('willnotexist', "canary", dirfd=f.fileno())
+
+        assert 'dirfd must be opened' in str(exc.value)
+
+    os.unlink(os.path.join(create_etc_dir, 'testfile10'))

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -148,7 +148,7 @@ def test__write_file_exceptions(create_etc_dir):
     ({'uid': 'bob'}, 'uid must be an integer'),
     ({'gid': 'bob'}, 'gid must be an integer'),
     ({'perms': 'bob'}, 'perms must be an integer'),
-    ({'perms': 0o4777}, '2559: invalid mode'),
+    ({'perms': 0o4777}, '2559: invalid mode. Supported bits are RWX for UGO.'),
     ({'dirfd': 'home'}, 'dirfd must be a valid file descriptor'),
     ({'dirfd': -1}, '-1: file descriptor not found'),
 ])

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -126,7 +126,6 @@ def test__write_file_exceptions(create_etc_dir):
     changes = write_if_changed(target, "canary")
     assert changes == FileChanges.CONTENTS
 
-
     with pytest.raises(UnexpectedFileChange) as exc:
         changes = write_if_changed(target, "canary", uid=1000, gid=1001, perms=0o700, raise_error=True)
 

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -41,8 +41,8 @@ def write_if_changed(path, data, uid=0, gid=0, perms=0o755, dirfd=None, raise_er
     `dirfd` - optional open file descriptor (may be O_PATH or O_DIRECTORY) if `path` is
     relative.
 
-    `raise_error` - raise an exception if file ownership or permissions have unexpectedly
-    changed.
+    `raise_error` - raise an UnexpectedFileChange exception if file ownership or
+    permissions have unexpectedly changed.
     """
 
     if isinstance(data, str):

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -48,7 +48,7 @@ def write_if_changed(path, data, uid=0, gid=0, perms=0o755, dirfd=None, raise_er
         raise ValueError('perms must be an integer')
 
     if perms & ~(stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO):
-        raise ValueError(f'{perms}: invalid mode')
+        raise ValueError(f'{perms}: invalid mode. Supported bits are RWX for UGO.')
 
     for xid in ((uid, 'uid'), (gid, 'gid')):
         value, name = xid

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -37,6 +37,9 @@ def write_if_changed(path, data, uid=0, gid=0, perms=0o755, dirfd=None, raise_er
 
     `perms` - numeric permissions that file should have
 
+    `dirfd` - optional open file descriptor (may be O_PATH or O_DIRECTORY) if `path` is
+    relative.
+
     `raise_error` - raise an exception if file ownership or permissions have unexpectedly
     changed.
     """

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -1,24 +1,124 @@
 import os
+import enum
+import stat
+from tempfile import NamedTemporaryFile
 
 
-def write_if_changed(path, data):
+ID_MAX = 2 ** 32 - 2
+
+
+class FileChanges(enum.IntFlag):
+    CONTENTS = enum.auto()
+    UID = enum.auto()
+    GID = enum.auto()
+    PERMS = enum.auto()
+
+
+class UnexpectedFileChange(Exception):
+    def __init__(self, path, changes):
+        self.changes = changes
+        self.path = path
+        self.changes_str = ', '.join([x.name for x in FileChanges if self.changes & x])
+
+    def __str__(self):
+        return f'{self.path}: unexpected change in the following file attributes: {self.changes_str}'
+
+
+def write_if_changed(path, data, uid=0, gid=0, perms=0o755, dirfd=None, raise_error=False):
+    """
+    Commit changes to a configuration file.
+    `path` - path to configuration file. May be relative to a specified `dirfd`
+
+    `data` - expected file contents. May be bytes or string
+
+    `uid` - expected numeric UID for file
+
+    `gid` - expected numeric GID for file
+
+    `perms` - numeric permissions that file should have
+
+    `raise_error` - raise an exception if file ownership or permissions have unexpectedly
+    changed.
+    """
 
     if isinstance(data, str):
         data = data.encode()
 
-    if isinstance(path, int):
-        path = f'/proc/self/fd/{path}'
+    if not isinstance(perms, int):
+        raise ValueError('perms must be an integer')
 
-    changed = False
+    if perms & ~(stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO):
+        raise ValueError(f'{perms}: invalid mode')
 
-    with open(os.open(path, os.O_CREAT | os.O_RDWR), 'wb+') as f:
-        f.seek(0)
-        current = f.read()
-        if current != data:
-            changed = True
-            f.seek(0)
-            f.write(data)
-            f.truncate()
-        os.fsync(f)
+    for xid in ((uid, 'uid'), (gid, 'gid')):
+        value, name = xid
+        if not isinstance(value, int):
+            raise ValueError(f'{name} must be an integer')
 
-    return changed
+        if value < 0 or value > ID_MAX:
+            raise ValueError(f'{name} must be between 0 and {ID_MAX}')
+
+    if dirfd is not None:
+        if not isinstance(dirfd, int):
+            raise ValueError('dirfd must be a valid file descriptor')
+
+        if not os.path.exists(f'/proc/self/fd/{dirfd}'):
+            raise ValueError(f'{dirfd}: file descriptor not found')
+
+    if dirfd is not None:
+        # tempfile API does not permit using a file descriptor
+        parent_dir = os.readlink(f'/proc/self/fd/{dirfd}')
+    else:
+        parent_dir = os.path.dirname(path)
+
+    changes = 0
+
+    try:
+        with open(os.open(path, os.O_RDONLY, dir_fd=dirfd), 'rb+') as f:
+            current = f.read()
+            if current != data:
+                changes |= FileChanges.CONTENTS
+
+            # The following cannot be skipped if we're changing file contents
+            # because we want accurate list of what has changed in file.
+
+            st = os.fstat(f.fileno())
+            if stat.S_IMODE(st.st_mode) != perms:
+                changes |= FileChanges.PERMS
+
+            if st.st_uid != uid:
+                changes |= FileChanges.UID
+
+            if st.st_gid != gid:
+                changes |= FileChanges.GID
+
+            if changes & (FileChanges.UID | FileChanges.GID):
+                os.fchown(f.fileno(), uid, gid)
+
+            if changes & FileChanges.PERMS:
+                os.fchmod(f.fileno(), perms)
+
+    except FileNotFoundError:
+        # Do not specify we're changing permissions on file
+        # because we're creating it new
+        changes = FileChanges.CONTENTS
+
+    if changes & FileChanges.CONTENTS:
+        with NamedTemporaryFile(mode='wb+', dir=parent_dir, delete=False) as tmp:
+            tmp.file.write(data)
+            tmp.file.flush()
+            os.fsync(tmp.file.fileno())
+            os.fchmod(tmp.file.fileno(), perms)
+            os.fchown(tmp.file.fileno(), uid, gid)
+            source_path = tmp.name
+
+        if dirfd is not None:
+            os.rename(source_path, path, src_dir_fd=dirfd, dst_dir_fd=dirfd)
+
+        else:
+            os.rename(source_path, path)
+
+    elif changes != 0 and raise_error:
+        raise UnexpectedFileChange(path, changes)
+
+    return changes


### PR DESCRIPTION
1. use os.rename to overwrite config files. Avoid possibility of having applications read partially written configuration files by first writing the changed config to a temporary file, then renaming over existing file.

2. have write_if_changed allow specifying the desired permissions and ownership of the file. This allows us to ensure that ownership and permissions changes happen before we close and rename the file.

3. alter return value for write_if_changed from boolean indicating whether changes were written to a bitmask of changes made. This allows us to flag when permissions and ownership had to be altered (logging potentially unexpected CLI changes).

4. add optional non-default parameter to raise an exception if we had to change ownership and permissions. This exception can be used in future to generate audit messages / alerts if we had unexpected config file changes.

5. add tests for functionality