### PR TITLE
NAS-128404 / 24.04.1 / Improve file receive (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -18,9 +18,9 @@ from middlewared.plugins.filesystem_ import chflags, dosmode, stat_x
 from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, returns, Path, Str, UnixPerm
 from middlewared.service import private, CallError, filterable_returns, filterable, Service, job
 from middlewared.utils import filter_list
-from middlewared.utils.mount import getmntinfo
+from middlewared.utils.osc import getmntinfo
 from middlewared.utils.path import FSLocation, path_location, is_child_realpath
-from middlewared.plugins.filesystem_.utils import ACLType
+from middlewared.plugins.filesystem_.acl_base import ACLType
 from middlewared.plugins.zfs_.utils import ZFSCTL
 
 

--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -12,6 +12,7 @@ from middlewared.utils.path import pathref_open
 
 PWENC_BLOCK_SIZE = 32
 PWENC_FILE_SECRET = os.environ.get('FREENAS_PWENC_SECRET', '/data/pwenc_secret')
+PWENC_FILE_SECRET_MODE = 0o600
 PWENC_PADDING = b'{'
 PWENC_CHECK = 'Donuts!'
 
@@ -63,7 +64,7 @@ class PWEncService(Service):
     def _write_secret(self, secret, reset_passwords):
         with open(self.secret_path, 'wb', opener=self._secret_opener) as f:
             with self._lock_secrets(f.fileno()):
-                os.fchmod(f.fileno(), 0o600)
+                os.fchmod(f.fileno(), PWENC_FILE_SECRET_MODE)
                 f.write(secret)
                 f.flush()
                 os.fsync(f.fileno())


### PR DESCRIPTION
`file_receive` was susceptible to the TOCTOU race conditions when checking for a paths existence (or any path component) before opening said path. This should get rid of theoretical conditions and also switches to using the `fchmod`/`fchown` syscalls. I've also fixed a few flake8 issues while I'm here. There should be no functional change.

Original PR: https://github.com/truenas/middleware/pull/13600
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128404