### PR TITLE
NAS-128822 / 24.10 / Log container registry exceptions in separate file

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -37,6 +37,7 @@ logging.getLogger('certbot_dns_cloudflare._internal.dns_cloudflare').setLevel(lo
 logging.getLogger('charset_normalizer').setLevel(logging.INFO)
 logging.TRACE = 6
 
+CONTAINER_IMAGES_LOGFILE = '/var/log/container_images.log'
 FAILOVER_LOGFILE = '/var/log/failover.log'
 K8S_API_LOGFILE = '/var/log/k8s_api.log'
 LOGFILE = '/var/log/middlewared.log'
@@ -80,6 +81,7 @@ class Logger:
         else:
             for name, filename, log_format in [
                 (None, LOGFILE, self.log_format),
+                ('container_images', CONTAINER_IMAGES_LOGFILE, self.log_format),
                 ('failover', FAILOVER_LOGFILE, self.log_format),
                 ('k8s_api', K8S_API_LOGFILE, self.log_format),
                 ('netdata_api', NETDATA_API_LOGFILE, self.log_format),

--- a/src/middlewared/middlewared/plugins/container_runtime_interface/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/container_runtime_interface/update_alerts.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 
 from collections import defaultdict
 from typing import Dict
@@ -7,6 +8,9 @@ from middlewared.service import CallError, private, Service
 
 from .client import CRIClientMixin
 from .utils import normalize_reference
+
+
+logger = logging.getLogger('container_images')
 
 
 class ContainerImagesService(Service, CRIClientMixin):
@@ -33,7 +37,7 @@ class ContainerImagesService(Service, CRIClientMixin):
                 try:
                     await self.check_update_for_image(tag, image)
                 except CallError as e:
-                    self.logger.error(str(e))
+                    logger.error(str(e))
 
     @private
     async def retrieve_image_digest(self, reference: str):


### PR DESCRIPTION
Changes have been made to add image's registry errors to separate file `/var/log/container_images.log` to avoid unnecessary noise in middleware logs.