### PR TITLE
NAS-128827 / 24.10 / Re-add recently removed import of pwd, grp

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -17,6 +17,7 @@ from middlewared.schema import accepts, Bool, Dict, Float, Int, List, Ref, retur
 from middlewared.service import private, CallError, filterable_returns, filterable, Service, job
 from middlewared.utils import filter_list
 from middlewared.utils.mount import getmntinfo
+from middlewared.utils.nss import pwd, grp
 from middlewared.utils.path import FSLocation, path_location, is_child_realpath
 from middlewared.plugins.filesystem_.utils import ACLType
 from middlewared.plugins.zfs_.utils import ZFSCTL
@@ -589,7 +590,7 @@ class FilesystemService(Service):
             fd = os.open(path, os.O_PATH)
             try:
                 st = os.fstatvfs(fd)
-                mntid = stat_x.statx('', {'dir_fd': fd, 'flags':  stat_x.ATFlags.EMPTY_PATH}).stx_mnt_id
+                mntid = stat_x.statx('', {'dir_fd': fd, 'flags': stat_x.ATFlags.EMPTY_PATH}).stx_mnt_id
             finally:
                 os.close(fd)
 


### PR DESCRIPTION
Fix problem introduced by #13600 

Also fix a `flake8` complaint.

Fortunately the backport of the above PR (#13671) did **not** introduce the same issue.

----
Can see 
```
middlewared.service_exception.CallError: [EFAULT] name 'pwd' is not defined
```
[here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/271/console)