### PR TITLE
NAS-128828 / 24.10 / Fix off-by-one in getpwall and getgrall

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -1,0 +1,58 @@
+import pwd as py_pwd
+import grp as py_grp
+
+from middlewared.utils.nss import grp, pwd
+
+
+def test__check_user_count():
+    assert len(pwd.getpwall()['FILES']) == len(py_pwd.getpwall())
+
+
+def test__check_group_count():
+    assert len(grp.getgrall()['FILES']) == len(py_grp.getgrall())
+
+
+def test__check_user_contents():
+    py_users = py_pwd.getpwall()
+    users = pwd.getpwall()['FILES']
+
+    for py_entry, entry in zip(py_users, users):
+        assert py_entry.pw_name == entry.pw_name
+        assert py_entry.pw_uid == entry.pw_uid
+        assert py_entry.pw_gid == entry.pw_gid
+        assert py_entry.pw_gecos == entry.pw_gecos
+        assert py_entry.pw_dir == entry.pw_dir
+        assert py_entry.pw_shell == entry.pw_shell
+
+
+def test__check_group_contents():
+    py_groups = py_grp.getgrall()
+    groups = grp.getgrall()['FILES']
+
+    for py_entry, entry in zip(py_groups, groups):
+        assert py_entry.gr_name == entry.gr_name
+        assert py_entry.gr_gid == entry.gr_gid
+        assert py_entry.gr_mem == entry.gr_mem
+
+
+def test__check_user_dict_conversion():
+    users_normal = pwd.getpwall()['FILES']
+    users_dict = pwd.getpwall(as_dict=True)['FILES']
+
+    for py_entry, entry in zip(users_normal, users_dict):
+        assert py_entry.pw_name == entry['pw_name']
+        assert py_entry.pw_uid == entry['pw_uid']
+        assert py_entry.pw_gid == entry['pw_gid']
+        assert py_entry.pw_gecos == entry['pw_gecos']
+        assert py_entry.pw_dir == entry['pw_dir']
+        assert py_entry.pw_shell == entry['pw_shell']
+
+
+def test__check_group_dict_conversion():
+    py_groups = grp.getgrall()['FILES']
+    groups = grp.getgrall(as_dict=True)['FILES']
+
+    for py_entry, entry in zip(py_groups, groups):
+        assert py_entry.gr_name == entry['gr_name']
+        assert py_entry.gr_gid == entry['gr_gid']
+        assert py_entry.gr_mem == entry['gr_mem']

--- a/src/middlewared/middlewared/utils/nss/grp.py
+++ b/src/middlewared/middlewared/utils/nss/grp.py
@@ -163,10 +163,8 @@ def __getgrall_impl(module, as_dict):
     __setgrent(mod)
     group_list = []
 
-    group = __getgrent_impl(mod, as_dict)
-    while group is not None:
-        if (group := __getgrent_impl(mod, as_dict)):
-            group_list.append(group)
+    while group := __getgrent_impl(mod, as_dict):
+        group_list.append(group)
 
     __endgrent(mod)
     return group_list

--- a/src/middlewared/middlewared/utils/nss/pwd.py
+++ b/src/middlewared/middlewared/utils/nss/pwd.py
@@ -41,7 +41,7 @@ def __parse_nss_result(result, as_dict, module_name):
             'source': module_name
         }
 
-    return pwd_struct(name, result.pw_uid, result.pw_gid, homedir, gecos, shell, module_name)
+    return pwd_struct(name, result.pw_uid, result.pw_gid, gecos, homedir, shell, module_name)
 
 
 def __getpwnam_r(name, result_p, buffer_p, buflen, nss_module):
@@ -165,10 +165,8 @@ def __getpwall_impl(module, as_dict):
     __setpwent(mod)
     pwd_list = []
 
-    user = __getpwent_impl(mod, as_dict)
-    while user is not None:
-        if (user := __getpwent_impl(mod, as_dict)):
-            pwd_list.append(user)
+    while user := __getpwent_impl(mod, as_dict):
+        pwd_list.append(user)
 
     __endpwent(mod)
     return pwd_list


### PR DESCRIPTION
We were omitting first NSS entry. Add basic CI tests to ensure
that our pwd and grp output matches what is expected from base
python module.