### PR TITLE
NAS-128833 / 24.10 / Change the Audit quota and reservation 'disabled' setting from '0' to 'None'

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-05-08_05-23_fixup_audit_storage_config.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-05-08_05-23_fixup_audit_storage_config.py
@@ -1,0 +1,35 @@
+"""
+Allow the system.audit quota and reservation fields to be disabled with a 'None' setting.
+
+Revision ID: d8e7c9bab524
+Revises: 135a7e02cbec
+Create Date: 2024-05-08 05:23:43.195180+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd8e7c9bab524'
+down_revision = '135a7e02cbec'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_audit', schema=None) as batch_op:
+        batch_op.alter_column('reservation',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+        batch_op.alter_column('quota',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+
+    conn = op.get_bind()
+    conn.execute("UPDATE system_audit SET quota = NULL WHERE quota = 0")
+    conn.execute("UPDATE system_audit SET reservation = NULL WHERE reservation = 0")
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -9,8 +9,8 @@ AUDIT_DATASET_PATH = '/audit'
 AUDITED_SERVICES = [('MIDDLEWARE', 0.1), ('SMB', 0.1)]
 AUDIT_TABLE_PREFIX = 'audit_'
 AUDIT_LIFETIME = 7
-AUDIT_DEFAULT_RESERVATION = 0
-AUDIT_DEFAULT_QUOTA = 0
+AUDIT_DEFAULT_RESERVATION = None
+AUDIT_DEFAULT_QUOTA = None
 AUDIT_DEFAULT_FILL_CRITICAL = 95
 AUDIT_DEFAULT_FILL_WARNING = 80
 AUDIT_REPORTS_DIR = os.path.join(AUDIT_DATASET_PATH, 'reports')
@@ -118,7 +118,7 @@ def parse_query_filters(
             if not services_to_check:
                 # These filters are guaranteed to have no results. Bail
                 # early and let caller handle it.
-                break;
+                break
 
         if skip_sql_filters:
             # User has manually specified to pass all these filters to datastore
@@ -159,7 +159,7 @@ def requires_python_filtering(
         # Field is being selected that may not be safe for SQL select
         for entry in to_investigate:
             # Selecting subkey in entry is not currently supported
-            if '.' in entry or isiinstance(entry, tuple):
+            if '.' in entry or isinstance(entry, tuple):
                 return True
 
     if len(services) > 1:


### PR DESCRIPTION
The Audit `quota` and `reservation` settings were using `0` to indicate a `disabled` state.
This PR changes the `disabled` setting from `0` to `None`.

This allows for a more user friendly UI where a disabled quota or reservation field can be displayed as 'None' or an empty field.
This also more closely follows the paradigm used by zfs for these fields.

Also fixed:

- A divide by zero bug
- A typo in runtime code
- flake8 issues