### PR TITLE
NAS-128835 / 24.10 / Add framework to have etc.generate return list of changes

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -200,3 +200,11 @@ def test__write_file_wrong_open_type_value_error(create_etc_dir):
 ])
 def test__write_file_dump_changes(mask, expected_dump):
     assert FileChanges.dump(mask) == expected_dump
+
+
+
+def test__write_file_dump_changes_validation():
+    with pytest.raises(ValueError) as exc:
+        FileChanges.dump(16)
+
+    assert 'unsupported flags in mask' in str(exc.value)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -141,7 +141,6 @@ def test__write_file_exceptions(create_etc_dir):
 
 
 @pytest.mark.parametrize("params,expected_text", [
-    # ataprint.cpp
     ({'uid': -1}, f'uid must be between 0 and {ID_MAX}'),
     ({'gid': -1}, f'gid must be between 0 and {ID_MAX}'),
     ({'uid': 'bob'}, 'uid must be an integer'),
@@ -189,3 +188,15 @@ def test__write_file_wrong_open_type_value_error(create_etc_dir):
         assert 'dirfd must be opened' in str(exc.value)
 
     os.unlink(os.path.join(create_etc_dir, 'testfile10'))
+
+@pyetst.mark.parametrize("mask,expected_dump", [
+    (FileChanges.CONTENTS, ['CONTENTS']),
+    (FileChanges.UID, ['UID']),
+    (FileChanges.GID, ['GID']),
+    (FileChanges.PERMS, ['PERMS']),
+    (FileChanges.CONTENTS | FileChanges.UID | FileChanges.GID | FileChanges.PERMS, [
+        'CONTENTS', 'UID', 'GID', 'PERMS'
+    ])
+])
+def test__write_file_dump_changes(mask, expected_dump):
+    assert FileChanges.dump(mask) == expected_dump

--- a/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_write_if_changed.py
@@ -189,7 +189,7 @@ def test__write_file_wrong_open_type_value_error(create_etc_dir):
 
     os.unlink(os.path.join(create_etc_dir, 'testfile10'))
 
-@pyetst.mark.parametrize("mask,expected_dump", [
+@pytest.mark.parametrize("mask,expected_dump", [
     (FileChanges.CONTENTS, ['CONTENTS']),
     (FileChanges.UID, ['UID']),
     (FileChanges.GID, ['GID']),

--- a/src/middlewared/middlewared/utils/io.py
+++ b/src/middlewared/middlewared/utils/io.py
@@ -18,7 +18,7 @@ class FileChanges(enum.IntFlag):
     PERMS = enum.auto()
 
     def dump(mask):
-        if unmapped := mask & ~(FileChanges.CONTENTS | FileChanges.UID | FileChanges.GID | FileChanges.PERMS):
+        if unmapped := mask & ~int(FileChanges.CONTENTS | FileChanges.UID | FileChanges.GID | FileChanges.PERMS):
             raise ValueError(f'{unmapped}: unsupported flags in mask')
 
         return [


### PR DESCRIPTION
This is beginning of plumbing for better tracking of configuration file changes that are made by middlewared.

```
root@truenas[~/middleware/src/middlewared]# midclt call etc.generate smb
[]
root@truenas[~/middleware/src/middlewared]# chmod 700 /etc/smb4.conf 
root@truenas[~/middleware/src/middlewared]# midclt call etc.generate smb
[{"path": "/etc/smb4.conf", "status": "CHANGED", "changes": ["PERMS"]}]
```