### PR TITLE
NAS-128838 / 24.10 / Use proper util for writing kerberos keytab

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -106,7 +106,7 @@ class EtcService(Service):
         ],
         'kerberos': [
             {'type': 'mako', 'path': 'krb5.conf'},
-            {'type': 'py', 'path': 'krb5.keytab'},
+            {'type': 'py', 'path': 'krb5.keytab', 'mode': 0o600},
         ],
         'cron': [
             {'type': 'mako', 'path': 'cron.d/middlewared', 'checkpoint': 'pool_import'},


### PR DESCRIPTION
We should use standard etc plugin methods to write kerberos keytab. This allows monitoring unexpected changes to permissions, owner, etc.