### PR TITLE
NAS-128839 / 24.10 / Fix modernize ad tests

### DIFF
--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -13,12 +13,12 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.privilege import privilege
 from middlewared.test.integration.assets.product import product_type
 from middlewared.test.integration.utils import call, client, ssh
+from middlewared.test.integration.utils.client import truenas_server
 from pytest_dependency import depends
 
-from auto_config import ha, ip, vip
+from auto_config import ha
 from protocols import smb_connection, smb_share
 
-public_ip = vip if ha else ip
 if ha and "hostname_virtual" in os.environ:
     hostname = os.environ["hostname_virtual"]
 else:
@@ -199,7 +199,7 @@ def test_07_enable_leave_activedirectory(request):
         assert len(result) != 0
 
         addresses = [x['address'] for x in result]
-        assert public_ip in addresses
+        assert truenas_server.ip in addresses
 
         res = call('privilege.query', [['name', 'C=', AD_DOMAIN]], {'get': True})
         assert res['ds_groups'][0]['name'].endswith('domain admins')
@@ -246,7 +246,7 @@ def test_08_activedirectory_smb_ops(request):
 
             with smb_share(f'/mnt/{ds}', {'name': SMB_NAME}):
                 with smb_connection(
-                    host=public_ip,
+                    host=truenas_server.ip,
                     share=SMB_NAME,
                     username=ADUSERNAME,
                     domain='AD02',
@@ -285,7 +285,7 @@ def test_08_activedirectory_smb_ops(request):
                 'path_suffix': '%D/%U'
             }):
                 with smb_connection(
-                    host=public_ip,
+                    host=truenas_server.ip,
                     share='DATASETS',
                     username=ADUSERNAME,
                     domain='AD02',
@@ -322,7 +322,7 @@ def test_08_activedirectory_smb_ops(request):
                 sleep(10 if ha else 5)
 
                 with smb_connection(
-                    host=public_ip,
+                    host=truenas_server.ip,
                     share='HOMES',
                     username=ADUSERNAME,
                     domain='AD02',

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -309,7 +309,6 @@ def test_08_activedirectory_smb_ops(request):
                 'type': 'ALLOW'
             }]
         ) as ds:
-            call('service.restart', 'cifs')
 
             with smb_share(f'/mnt/{ds}', {
                 'name': 'TEST_HOME',

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -319,7 +319,7 @@ def test_08_activedirectory_smb_ops(request):
                 # must refresh idmap cache to get new homedir from NSS
                 # this means we may need a few seconds for winbindd
                 # service to settle down on slow systems (like our CI VMs)
-                sleep(5)
+                sleep(10 if ha else 5)
 
                 with smb_connection(
                     host=public_ip,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+dnspython
 pytest
 pytest-dependency
 pytest-rerunfailures


### PR DESCRIPTION
CI test runs against HA were failing some tests in _test_030_activedirectory.py_ (e.g. `test_07_enable_leave_activedirectory`).  Modernize and tweak so that they work against both single-node and HA.

Note: had to add `dnspython` to the test requirements.txt in order to be able to trap `dns.resolver.NXDOMAIN` exceptions.