### PR TITLE
NAS-127870 / 24.04.1 / fix starting apps with a bridge interface (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -228,7 +228,9 @@ class KubernetesService(Service):
 
         iface_errors = await self.middleware.call('kubernetes.validate_interfaces', config)
         if iface_errors:
-            raise CallError(f'Unable to lookup configured interfaces: {", ".join([v[1] for v in iface_errors])}')
+            iface = iface_errors[1]
+            err_msg = iface_errors[-1]
+            raise CallError(f'Failed to setup {iface!r} with error: {err_msg}')
 
         errors = await self.middleware.call('kubernetes.validate_config')
         if errors:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -14,6 +14,8 @@ from middlewared.utils import filter_list
 
 from .utils import applications_ds_name, Status
 
+IFACE_LINK_STATE_MAX_WAIT = 60
+
 
 class KubernetesModel(sa.Model):
     __tablename__ = 'services_kubernetes'
@@ -373,9 +375,9 @@ class KubernetesService(ConfigService):
 
     @private
     def wait_on_interface_link_state_up(self, interface):
-        max_wait, sleep_time, time_waited = 60, 1, 0
+        sleep_time, time_waited = 1, 0
         is_up, error_msg = False, ''
-        while time_waited < max_wait:
+        while time_waited < IFACE_LINK_STATE_MAX_WAIT:
             time.sleep(sleep_time)
             time_waited += 1
             with contextlib.suppress(Exception):
@@ -384,7 +386,7 @@ class KubernetesService(ConfigService):
                     if is_up:
                         break
         if not is_up:
-            error_msg = f'Timed out waiting {max_wait} seconds for {interface} to come up'
+            error_msg = f'Timed out waiting {IFACE_LINK_STATE_MAX_WAIT} seconds for {interface} to come up'
 
         return is_up, error_msg
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -401,10 +401,10 @@ class KubernetesService(ConfigService):
                     (k, iface, f'{iface!r} is invalid. Valid interfaces are {", ".join([i for i in interfaces])!r}.')
                 )
             else:
-                # means the interface is valid but isn't up so instead of immediately
-                # error'ing, let's play nice and allow the interface to come online.
-                # this is particularly important when the interface that's configured
-                # for apps is a bridge (or lagg) for example
+                # instead of immediately erroring out when the interface isn't up,
+                # let's play nice and allow the interface to come online.
+                # this is particularly important when the interface that's
+                # configured for apps is a bridge (or lagg) for example
                 is_up, err_str = await self.middleware.run_in_thread(
                     self.wait_on_interface_link_state_up, valid_iface
                 )


### PR DESCRIPTION
Since Cobia, users that use apps with a bridge interface have been broken because `kubernetes.validate_interfaces` was too strict on checking whether or not the interface is LINK_STATE_UP. It would only check once and then bail out.

This makes it so that instead of bailing out immediately when the interface isn't up, we actually wait for a bit for it to come online. This was reproduced on a system 100% of the time and after these changes, apps successfully started after a reboot.

I took the liberty to improve this method while we're here because it was calling `interface.query` too many times for no reason.

Finally, and arguably the most frustrating part of this endeavor is that, I fixed the fact that `kubernetes.validate_k8s_fs_setup` was swallowing errors from `validate_interfaces`. It did more than swallow the actual error, it showed a _VERY_ misleading and incorrect error message. I thought, for a long time, that the `br*` interface DIDN'T EXIST by the time this method was started but that's not the case. The issue is that it wasn't up. This makes it so that the caller where this was failing shows the proper error message.

The error message received before these changes was
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/kubernetes_linux/lifecycle.py", line 231, in validate_k8s_fs_setup
    raise CallError(f'Unable to lookup configured interfaces: {", ".join([v[1] for v in iface_errors])}')
middlewared.service_exception.CallError: [EFAULT] Unable to lookup configured interfaces: br0
```
when the ACTUAL error message was
```
[2024/05/08 08:26:12] (DEBUG) KubernetesService.validate_interfaces():392 - errors: [('route_v4_interface', 'br0', "Please specify a valid interface which is active (i.e '').")]
```

NOTE: I don't believe this will solve ALL issues surrounding this area since all hardware/software behaves wildly differently but this is an easy stop-gap solution.

Original PR: https://github.com/truenas/middleware/pull/13680
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127870