### PR TITLE
NAS-128631 / 24.04.1 / Make sure we redirect logs to relevant log files instead of copying them (by Qubad786)

### DIFF
--- a/src/freenas/etc/logrotate.d/netdata_override
+++ b/src/freenas/etc/logrotate.d/netdata_override
@@ -1,0 +1,8 @@
+/var/log/netdata/*.log {
+    size 10M
+    rotate 7
+    compress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -113,6 +113,32 @@ source tn_remote_src_files {
 #######################
 # Log paths
 ########################
+log {
+  source(s_src);
+  filter(f_k3s);
+  destination { file("/var/log/k3s_daemon.log"); };
+  flags(final);
+};
+
+log {
+  source(s_src);
+  filter(f_containerd);
+  destination { file("/var/log/containerd.log"); };
+  flags(final);
+};
+log {
+  source(s_src);
+  filter(f_kube_router);
+  destination { file("/var/log/kube_router.log"); };
+  flags(final);
+};
+log {
+  source(s_src);
+  filter(f_app_mounts);
+  destination { file("/var/log/app_mounts.log"); };
+  flags(final);
+};
+
 log { source(s_src); filter(f_auth); destination(d_auth); };
 log { source(s_src); filter(f_cron); destination(d_cron); };
 log { source(s_src); filter(f_daemon); destination(d_daemon); };
@@ -126,27 +152,6 @@ log { source(s_src); filter(f_error); destination(d_error); };
 log { source(s_src); filter(f_messages); destination(d_messages); };
 log { source(s_src); filter(f_console); destination(d_console_all); destination(d_xconsole); };
 log { source(s_src); filter(f_crit); destination(d_console); };
-
-log {
-  source(s_src);
-  filter(f_k3s);
-  destination { file("/var/log/k3s_daemon.log"); };
-};
-log {
-  source(s_src);
-  filter(f_containerd);
-  destination { file("/var/log/containerd.log"); };
-};
-log {
-  source(s_src);
-  filter(f_kube_router);
-  destination { file("/var/log/kube_router.log"); };
-};
-log {
-  source(s_src);
-  filter(f_app_mounts);
-  destination { file("/var/log/app_mounts.log"); };
-};
 
 % if render_ctx['system.advanced.config']['syslogserver']:
 ${generate_syslog_remote_destination(render_ctx['system.advanced.config'])}


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a056d0faef2c8ad3fbcae3b7b7a3b2c848b9f230
    git cherry-pick -x 463f87b4593024afa88a0a675bd60b39154f6ace

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 0b48ec03e43c026e3b7b526b3230346a568c42d7

## Problem

We have different log filters specified where we want to make sure that different sources i.e k3s/scst etc do not pollute other log files with their messages but unfortunately what in reality is happening is that we have their logs being logged to separate files but they are still getting logged in other log files i.e daemon.log etc which indicates that logs are being copied rather then redirected completely.

## Solution

Add changes to make sure we don't process other log filters if we have a match for a filter earlier and once we have gone through our custom log file solutions we can finally have rest of the filters for other log files being processed.

Original PR: https://github.com/truenas/middleware/pull/13649
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128631