### PR TITLE
NAS-128884 / 24.10 / Fix home shares connectivity when AD enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -417,7 +417,7 @@ class IdmapDomainService(CRUDService):
 
         await self.middleware.call('service.start', 'idmap')
         if smb_started:
-            await self.middleware.call('service.start', 'cifs')
+            await self.middleware.call('service.restart', 'cifs')
 
     @private
     async def may_enable_trusted_domains(self):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -872,6 +872,7 @@ class SharingSMBService(SharingService):
         if do_global_reload:
             if (await self.middleware.call('activedirectory.get_state')) == 'HEALTHY':
                 if data['home']:
+                    await self.middleware.call('etc.generate', 'smb')
                     await self.middleware.call('idmap.clear_idmap_cache')
 
             await self._service_change('cifs', 'restart')


### PR DESCRIPTION
Recent refactoring of SMB plugin overly reduced places where we regenerate the smb.conf file and restart SMB. When create a homes share we need to rewrite winbindd's template homedir parameter in the smb configuration before clearing caches and restarting winbindd.

Otherwise, the NSS plugin doesn't pick up the home directory changes and attempts to access home dir fails with ENOENT.