### PR TITLE
Fix test 056 netbios name change check sid

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1,12 +1,10 @@
 import asyncio
 import codecs
-import enum
 import errno
 import middlewared.sqlalchemy as sa
 import os
 import re
 from pathlib import Path
-import stat
 import uuid
 import unicodedata
 
@@ -20,7 +18,7 @@ from middlewared.schema import Path as SchemaPath
 # defaults for ignore_list or watch_list from overrwriting previous value
 from middlewared.schema.utils import NOT_PROVIDED
 from middlewared.service import accepts, job, pass_app, private, SharingService
-from middlewared.service import ConfigService, ValidationError, ValidationErrors, filterable
+from middlewared.service import ConfigService, ValidationError, ValidationErrors
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.plugins.smb_.constants import (
     NETIF_COMPLETE_SENTINEL,
@@ -31,7 +29,6 @@ from middlewared.plugins.smb_.constants import (
     RESERVED_SHARE_NAMES,
     SMBHAMODE,
     SMBCmd,
-    SMBBuiltin,
     SMBPath,
     SMBSharePreset
 )
@@ -117,9 +114,9 @@ class SMBService(ConfigService):
         ds_state = self.middleware.call_sync('directoryservices.get_state')
         ds_config = None
         for svc, state in ds_state.items():
-           if state != 'DISABLED':
-               ds_config = self.middleware.call_sync(f'{svc}.config')
-               break
+            if state != 'DISABLED':
+                ds_config = self.middleware.call_sync(f'{svc}.config')
+                break
 
         idmap_config = self.middleware.call_sync('idmap.query')
         smb_config = self.middleware.call_sync('smb.config')
@@ -127,7 +124,7 @@ class SMBService(ConfigService):
         bind_ip_choices = self.middleware.call_sync('smb.bindip_choices')
 
         return generate_smb_conf_dict(
-                ds_state, ds_config, smb_config, smb_shares, bind_ip_choices, idmap_config
+            ds_state, ds_config, smb_config, smb_shares, bind_ip_choices, idmap_config
         )
 
     @private
@@ -1358,7 +1355,6 @@ class SharingSMBService(SharingService):
             verrors.add(
                 f'{schema_name}.name', 'Share with this name already exists.', errno.EEXIST
             )
-
 
     @private
     async def validate(self, data, schema_name, verrors, old=None):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -328,7 +328,6 @@ class SMBService(ConfigService):
         do not exist or have incorrect permissions.
         """
         data = await self.config()
-        ha_mode = SMBHAMODE[(await self.middleware.call('smb.get_smb_ha_mode'))]
         job.set_progress(0, 'Setting up SMB directories.')
         if create_paths:
             await self.setup_directories()
@@ -829,7 +828,6 @@ class SharingSMBService(SharingService):
 
         `auxsmbconf` is a string of additional smb4.conf parameters not covered by the system's API.
         """
-        ha_mode = SMBHAMODE[(await self.middleware.call('smb.get_smb_ha_mode'))]
         audit_info = deepcopy(SMB_AUDIT_DEFAULTS) | data.get('audit')
         data['audit'] = audit_info
 
@@ -921,7 +919,6 @@ class SharingSMBService(SharingService):
             Since the old share was not in our running configuration, we need
             to add it.
             """
-            check_mdns = True
             await self.toggle_share(newname, True)
 
         elif not old_is_locked and new_is_locked:
@@ -1326,7 +1323,6 @@ class SharingSMBService(SharingService):
     async def validate_share_name(self, name, schema_name, verrors, exist_ok=True):
         # Standards for SMB share name are defined in MS-FSCC 2.1.6
         # We are slighly more strict in that blacklist all unicode control characters
-        has_control_characters = False
         if name.lower() in RESERVED_SHARE_NAMES:
             verrors.add(
                 f'{schema_name}.name',

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -672,6 +672,7 @@ class SMBService(ConfigService):
             new['id'], new, {'prefix': 'cifs_srv_'}
         )
 
+        await self.middleware.call('etc.generate', 'smb')
         new_config = await self.config()
         await self.reset_smb_ha_mode()
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -32,6 +32,7 @@ from middlewared.plugins.smb_.constants import (
     SMBPath,
     SMBSharePreset
 )
+from middlewared.plugins.smb_.constants import SMBBuiltin  # noqa (imported so may be imported from here)
 from middlewared.plugins.smb_.util_param import smbconf_getparm, lpctx_validate_global_parm
 from middlewared.plugins.smb_.util_net_conf import reg_delshare, reg_listshares, reg_setparm
 from middlewared.plugins.smb_.util_smbconf import generate_smb_conf_dict


### PR DESCRIPTION
Test `test_056_netbios_name_change_check_sid` was failing because the _smb4.conf_ file was not being rewritten (with the new `netbiosname`).  Rectify.

Also `flake8` fixes.