### PR TITLE
NAS-128851 / 24.10 / Enhance permissions check on data directory

### DIFF
--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,3 +1,5 @@
+import stat
+
 from auto_config import ha
 from middlewared.test.integration.utils import call
 
@@ -14,13 +16,41 @@ def test_sysctl_arc_max_is_set():
     assert call('filesystem.stat', DEFAULT_ARC_MAX_FILE)['size']
 
 
-def test_database_mode():
-    """Test the mode of the database file."""
-    db_name = "/data/freenas-v1.db"
-    db_mode = 0o600
-    mode = call('filesystem.stat', db_name)['mode']
-    assert mode & 0o777 == db_mode, mode
-    if ha:
-        call('failover.sync_to_peer')
-        mode = call('failover.call_remote', 'filesystem.stat', [db_name])['mode']
-        assert mode & 0o777 == db_mode, mode
+def test_data_dir_perms():
+    default_dir_mode = 0o700
+    default_file_mode = 0o600
+    data_subsystems_mode = 0o755
+
+    def check_permissions(directory):
+        contents = call('filesystem.listdir', directory)
+        for i in contents:
+            i_path = i['path']
+            i_mode = stat.S_IMODE(i['mode'])
+            if i['type'] == 'DIRECTORY':
+                assert i_mode == data_subsystems_mode, \
+                    f'Incorrect permissions for {i_path}, should be {stat.S_IMODE(data_subsystems_mode):#o}'
+                check_permissions(i_path)
+
+    # Check perms of `/data`
+    data_dir_mode = call('filesystem.stat', '/data')['mode']
+    assert stat.S_IMODE(data_dir_mode) == data_subsystems_mode, \
+        f'Incorrect permissions for /data, should be {stat.S_IMODE(data_subsystems_mode):#o}'
+
+    # Check perms of contents `/data`
+    data_contents = call('filesystem.listdir', '/data')
+    for item in data_contents:
+        item_path = item['path']
+        if item_path == '/data/subsystems':
+            continue
+        item_mode = stat.S_IMODE(item['mode'])
+        desired_mode = default_dir_mode if item['type'] == 'DIRECTORY' else default_file_mode
+        assert item_mode == desired_mode, \
+            f'Incorrect permissions for {item_path}, should be {stat.S_IMODE(desired_mode):#o}'
+
+    # Check perms of `/data/subsystems`
+    ss_dir_mode = stat.S_IMODE(call('filesystem.stat', '/data/subsystems')['mode'])
+    assert ss_dir_mode == data_subsystems_mode, \
+        f'Incorrect permissions for /data/subsystems, should be {stat.S_IMODE(data_subsystems_mode):#o}'
+
+    # Check perms of contents of `/data/subsystems` recursively
+    check_permissions('/data/subsystems')


### PR DESCRIPTION
### Context

Newly added integration test checks the permission of `/data` dir and its contents to ensure that perms are like below: 

1. `u=rwX,g=,o=` on `/data` recursively ensuring every dir inside has `0o700` perms and every file has `0o600`
2. `0o755` on just `/data` itself
3. `0o755` recursively on `/data/subsystems`

Scale build change was added in the [PR](https://github.com/truenas/scale-build/pull/635).