### PR TITLE
NAS-128983 / 24.10 / Fix several API test files for HA

### DIFF
--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -6,11 +6,19 @@ import os
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import POST, GET, PUT, DELETE, SSH_TEST, make_ws_request
-from auto_config import ip, user, password, pool_name
+from functions import POST, GET, PUT, DELETE, SSH_TEST
+from auto_config import user, password, pool_name
+from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.assets.pool import dataset as make_dataset
 
 test1_dataset = f'{pool_name}/test1'
 dataset_url = test1_dataset.replace("/", "%2F")
+
+
+@pytest.fixture(scope='module')
+def create_test_dataset():
+    with make_dataset(test1_dataset) as ds:
+        yield ds
 
 
 def test_01_verify_default_acltype_from_pool_dataset_with_api(request):
@@ -19,88 +27,37 @@ def test_01_verify_default_acltype_from_pool_dataset_with_api(request):
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
-def test_02_verify_default_acltype_from_pool_dataset_with_zfs_get(request):
-    cmd = f"zfs get acltype {pool_name}"
-    results = SSH_TEST(cmd, user, password, ip)
-    assert results['result'] is True, results['output']
-    assert 'posix' in results['output'], results['output']
-
-
-def test_03_create_test1_dataset_to_verify_inherit_parent_acltype(request):
-    result = POST(
-        '/pool/dataset/', {
-            'name': test1_dataset
-        }
-    )
-    assert result.status_code == 200, result.text
-
-
-def test_04_verify_test1_dataset_inherited_parent_acltype_with_api(request):
+def test_04_verify_test1_dataset_inherited_parent_acltype_with_api(create_test_dataset, request):
     results = GET(f'/pool/dataset/id/{dataset_url}/')
     assert results.status_code == 200, results.text
     assert results.json()['acltype']['rawvalue'] == 'posix', results.text
 
 
-def test_05_verify_test1_dataset_inherited_parent_acltype_with_zfs_get(request):
-    cmd = f"zfs get acltype {test1_dataset}"
-    results = SSH_TEST(cmd, user, password, ip)
-    assert results['result'] is True, results['output']
-    assert 'posix' in results['output'], results['output']
+def test_06_change_acltype_to_nfsv4(create_test_dataset, request):
+    call('pool.dataset.update', test1_dataset, {
+        'acltype': 'NFSV4', 'aclmode': 'PASSTHROUGH'
+    })
 
-
-def test_06_change_acltype_to_nfsv4(request):
-    result = PUT(
-        f'/pool/dataset/id/{dataset_url}/', {
-            'acltype': 'NFSV4',
-            'aclmode': 'PASSTHROUGH'
-        }
+    res = call('zfs.dataset.query', [['id', '=', test1_dataset]],
+        {'get': True, 'extra': {'retrieve_children': False}}
     )
-    assert result.status_code == 200, result.text
-
-    payload = {
-        'msg': 'method',
-        'method': 'zfs.dataset.query',
-        'params': [
-            [['id', '=', test1_dataset]],
-            {'get': True, 'extra': {'retrieve_children': False}}
-        ]
-    }
-    res = make_ws_request(ip, payload)
-    assert res.get('error') is None, str(res['error'])
-    props = res['result']['properties']
+    props = res['properties']
 
     assert props['acltype']['value'] == 'nfsv4', str(props)
     assert props['aclmode']['value'] == 'passthrough', str(props)
     assert props['aclinherit']['value'] == 'passthrough', str(props)
 
 
-def test_07_reset_acltype_to_posix(request):
-    result = PUT(
-        f'/pool/dataset/id/{dataset_url}/', {
-            'acltype': 'POSIX',
-            'aclmode': 'DISCARD'
-        }
+def test_07_reset_acltype_to_posix(create_test_dataset, request):
+    call('pool.dataset.update', test1_dataset, {
+        'acltype': 'POSIX', 'aclmode': 'DISCARD'
+    })
+
+    res = call('zfs.dataset.query', [['id', '=', test1_dataset]],
+        {'get': True, 'extra': {'retrieve_children': False}}
     )
-    assert result.status_code == 200, result.text
-
-
-    payload = {
-        'msg': 'method',
-        'method': 'zfs.dataset.query',
-        'params': [
-            [['id', '=', test1_dataset]],
-            {'get': True, 'extra': {'retrieve_children': False}}
-        ]
-    }
-    res = make_ws_request(ip, payload)
-    assert res.get('error') is None, str(res['error'])
-    props = res['result']['properties']
+    props = res['properties']
 
     assert props['acltype']['value'] == 'posix', str(props)
     assert props['aclmode']['value'] == 'discard', str(props)
     assert props['aclinherit']['value'] == 'discard', str(props)
-
-
-def test_08_delete_test1_dataset(request):
-    results = DELETE(f'/pool/dataset/id/{test1_dataset.replace("/", "%2F")}/')
-    assert results.status_code == 200, results.text

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -328,12 +328,12 @@ def test_30_delete_dataset_with_receive_resume_token(request, create_dst):
         result = POST('/pool/dataset/', {'name': f'{pool_name}/dst'})
         assert result.status_code == 200, result.text
 
-    results = SSH_TEST(f'dd if=/dev/urandom of=/mnt/{pool_name}/src/blob bs=1M count=1', user, password, ip)
+    results = SSH_TEST(f'dd if=/dev/urandom of=/mnt/{pool_name}/src/blob bs=1M count=1', user, password)
     assert results['result'] is True, results
-    results = SSH_TEST(f'zfs snapshot {pool_name}/src@snap-1', user, password, ip)
+    results = SSH_TEST(f'zfs snapshot {pool_name}/src@snap-1', user, password)
     assert results['result'] is True, results
-    results = SSH_TEST(f'zfs send {pool_name}/src@snap-1 | head -c 102400 | zfs recv -s -F {pool_name}/dst', user, password, ip)
-    results = SSH_TEST(f'zfs get -H -o value receive_resume_token {pool_name}/dst', user, password, ip)
+    results = SSH_TEST(f'zfs send {pool_name}/src@snap-1 | head -c 102400 | zfs recv -s -F {pool_name}/dst', user, password)
+    results = SSH_TEST(f'zfs get -H -o value receive_resume_token {pool_name}/dst', user, password)
     assert results['result'] is True, results
     assert results['stdout'].strip() != "-", results
 
@@ -437,7 +437,7 @@ def test_33_simplified_charts_api(request):
         # check behavior of using force option.
         # presence of file in path should trigger failure
         # if force is not set
-        results = SSH_TEST(f'touch /mnt/{ds}/canary', user, password, ip)
+        results = SSH_TEST(f'touch /mnt/{ds}/canary', user, password)
         assert results['result'] is True, results
 
         with pytest.raises(ClientException) as ve:

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -486,7 +486,7 @@ def test_23_test_acl_function_deny(perm, request):
         # This should never happen.
         cmd = "touch /var/empty/ERROR"
 
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     """
     Per RFC5661 Section 6.2.1.3.2, deletion is permitted if either
     DELETE_CHILD is permitted on parent, or DELETE is permitted on
@@ -583,7 +583,7 @@ def test_24_test_acl_function_allow(perm, request):
         # This should never happen.
         cmd = "touch /var/empty/ERROR"
 
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
     assert results['result'] is True, errstr
     if perm in ["DELETE", "DELETE_CHILD"]:
@@ -666,7 +666,7 @@ def test_25_test_acl_function_omit(perm, request):
         # This should never happen.
         cmd = "touch /var/empty/ERROR"
 
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
     assert results['result'] is False, errstr
 
@@ -718,13 +718,13 @@ def test_25_test_acl_function_allow_restrict(perm, request):
 
     if "EXECUTE" not in tests_to_skip:
         cmd = f'cd /mnt/{ACLTEST_DATASET}'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "DELETE" not in tests_to_skip:
         cmd = f'rm /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
         if results['result'] is True:
@@ -734,37 +734,37 @@ def test_25_test_acl_function_allow_restrict(perm, request):
 
     if "READ_DATA" not in tests_to_skip:
         cmd = f'cat /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "WRITE_DATA" not in tests_to_skip:
         cmd = f'echo -n "CAT" >> /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "WRITE_ATTRIBUTES" not in tests_to_skip:
         cmd = f'touch -a -m -t 201512180130.09 /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "READ_ACL" not in tests_to_skip:
         cmd = f'{getfaclcmd} /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "WRITE_ACL" not in tests_to_skip:
         cmd = f'{setfaclcmd} -x 0 /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
     if "WRITE_OWNER" not in tests_to_skip:
         cmd = f'chown {ACL_USER} /mnt/{ACLTEST_DATASET}/acltest.txt'
-        results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+        results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
         errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {to_allow}'
         assert results['result'] is False, errstr
 
@@ -802,7 +802,7 @@ def test_26_file_execute_deny(request):
     ssh(f'echo "echo CANARY" > /mnt/{ACLTEST_DATASET}/acltest.txt')
 
     cmd = f'/mnt/{ACLTEST_DATASET}/acltest.txt'
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {payload_acl}'
     assert results['result'] is False, errstr
 
@@ -845,7 +845,7 @@ def test_27_file_execute_allow(request):
     ssh(f'echo "echo CANARY" > /mnt/{ACLTEST_DATASET}/acltest.txt')
 
     cmd = f'/mnt/{ACLTEST_DATASET}/acltest.txt'
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {payload_acl}'
     assert results['result'] is True, errstr
 
@@ -886,7 +886,7 @@ def test_28_file_execute_omit(request):
     ssh(f'echo "echo CANARY" > /mnt/{ACLTEST_DATASET}/acltest.txt')
 
     cmd = f'/mnt/{ACLTEST_DATASET}/acltest.txt'
-    results = SSH_TEST(cmd, ACL_USER, ACL_PWD, ip)
+    results = SSH_TEST(cmd, ACL_USER, ACL_PWD)
     errstr = f'cmd: {cmd}, res: {results["output"]}, to_allow {payload_acl}'
     assert results['result'] is False, errstr
 

--- a/tests/api2/test_347_posix_mode.py
+++ b/tests/api2/test_347_posix_mode.py
@@ -103,11 +103,11 @@ def test_05_prepare_recursive_tests(request):
     assert result.status_code == 200, result.text
 
     cmd = f'mkdir -p /mnt/{MODE_DATASET}/dir1/dir2'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     cmd = f'touch /mnt/{MODE_DATASET}/dir1/dir2/testfile'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     results = POST('/filesystem/stat/', f'/mnt/{MODE_SUBDATASET}')
@@ -241,70 +241,70 @@ Next series of tests are for correct behavior of POSIX permissions
 def dir_mode_check(mode_bit):
     if mode_bit.endswith("READ"):
         cmd = f'ls /mnt/{MODE_DATASET}'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is True, results['output']
 
         cmd = f'touch /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'cd /mnt/{MODE_DATASET}'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
     elif mode_bit.endswith("WRITE"):
         cmd = f'ls /mnt/{MODE_DATASET}'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'touch /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is True, results['output']
 
         cmd = f'rm /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is True, results['output']
 
     elif mode_bit.endswith("EXECUTE"):
         cmd = f'ls /mnt/{MODE_DATASET}'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         # Ensure that file is deleted before trying to create
         cmd = f'rm /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, user, password, ip)
+        results = SSH_TEST(cmd, user, password)
 
         cmd = f'touch /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
 
 def file_mode_check(mode_bit):
     if mode_bit.endswith("READ"):
         cmd = f'cat /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is True, results['output']
         assert results['stdout'].strip() == "echo CANARY", results['output']
 
         cmd = f'echo "FAIL" >> /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'/mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
     elif mode_bit.endswith("WRITE"):
         cmd = f'cat /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'echo "SUCCESS" > /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is True, results['output']
 
         cmd = f'/mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         """
@@ -312,20 +312,20 @@ def file_mode_check(mode_bit):
         means rm should fail even though WRITE is set for user.
         """
         cmd = f'rm /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'echo "echo CANARY" > /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, user, password, ip)
+        results = SSH_TEST(cmd, user, password)
         assert results['result'] is True, results['output']
 
     elif mode_bit.endswith("EXECUTE"):
         cmd = f'cat /mnt/{MODE_DATASET}'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
         cmd = f'echo "FAIL" > /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
 
@@ -336,17 +336,17 @@ def file_mode_check_xor(mode_bit):
     """
     if mode_bit.endswith("READ"):
         cmd = f'cat /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
     elif mode_bit.endswith("WRITE"):
         cmd = f'echo "SUCCESS" > /mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
     elif mode_bit.endswith("EXECUTE"):
         cmd = f'/mnt/{MODE_DATASET}/canary'
-        results = SSH_TEST(cmd, MODE_USER, MODE_PWD, ip)
+        results = SSH_TEST(cmd, MODE_USER, MODE_PWD)
         assert results['result'] is False, results['output']
 
 
@@ -459,7 +459,7 @@ def test_14_setup_file_test(request):
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
     cmd = f'echo "echo CANARY" > /mnt/{MODE_DATASET}/canary'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
 

--- a/tests/api2/test_348_posix_acl.py
+++ b/tests/api2/test_348_posix_acl.py
@@ -362,15 +362,15 @@ def test_12_prepare_recursive_tests(request):
     assert result.status_code == 200, result.text
 
     cmd = f'mkdir -p /mnt/{ACLTEST_DATASET}/dir1/dir2'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     cmd = f'touch /mnt/{ACLTEST_DATASET}/dir1/testfile'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     cmd = f'touch /mnt/{ACLTEST_DATASET}/dir1/dir2/testfile'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
 

--- a/tests/api2/test_350_pool_dataset_quota_alert.py
+++ b/tests/api2/test_350_pool_dataset_quota_alert.py
@@ -69,13 +69,13 @@ def test_dataset_quota_alert(request, datasets, expected_alerts):
 
             if used is not None:
                 results = SSH_TEST(f'dd if=/dev/urandom of=/mnt/{pool_name}/quota_test/{dataset}/blob '
-                                   f'bs=1M count={used}', user, password, ip)
+                                   f'bs=1M count={used}', user, password)
                 assert results['result'] is True, results
 
-        results = SSH_TEST("midclt call alert.initialize", user, password, ip)
+        results = SSH_TEST("midclt call alert.initialize", user, password)
         assert results['result'] is True, results
 
-        results = SSH_TEST("midclt call -job core.bulk alert.process_alerts '[[]]'", user, password, ip)
+        results = SSH_TEST("midclt call -job core.bulk alert.process_alerts '[[]]'", user, password)
         assert results['result'] is True, results
 
         result = GET("/alert/list/")

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -71,7 +71,6 @@ def test_012_test_basic_smb_ops(request, params):
     depends(request, ["smb_initialized"], scope="session")
     proto, runas = params
     with smb_connection(
-        host=ip,
         share=SMB_NAME,
         username=runas,
         password=PASSWD,
@@ -187,7 +186,6 @@ def test_042_recyclebin_functional_test(request):
     depends(request, ["SMB_RECYCLE_CONFIGURED"], scope="session")
     with create_dataset(f'{test_420_ds_name}/subds', {'share_type': 'SMB'}):
         with smb_connection(
-            host=ip,
             share=SMB_NAME,
             username=SHAREUSER,
             password=PASSWD,
@@ -215,7 +213,6 @@ def test_043_recyclebin_functional_test_subdir(request, smb_config):
             'recyclebin': True
         } | smb_config['share']):
             with smb_connection(
-                host=ip,
                 share=tmp_share_name,
                 username=SHAREUSER,
                 password=PASSWD,
@@ -236,7 +233,6 @@ def test_043_recyclebin_functional_test_subdir(request, smb_config):
             'recyclebin': True
         } | smb_config['share']):
             with smb_connection(
-                host=ip,
                 share=tmp_share_name,
                 username=SHAREUSER,
                 password=PASSWD,
@@ -388,7 +384,6 @@ def validate_audit_op(msg, svc):
 
 def do_audit_ops(svc):
     with smb_connection(
-        host=ip,
         share=svc,
         username=SHAREUSER,
         password=PASSWD,

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -125,7 +125,6 @@ def test_001_initialize_smb_servce(initialize_for_smb_tests):
 def test_002_check_client_count(request):
     depends(request, ["SMB_SHARE_CREATED"])
     with smb_connection(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -145,7 +144,7 @@ def test_009_share_is_writable(request):
     """
     depends(request, ["SMB_SHARE_CREATED"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file("testfile", "w")
     c.close(fd, True)
     c.disconnect()
@@ -162,7 +161,7 @@ def test_010_check_dosmode_create(request, dm):
         return
 
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     if dm == DOSmode.READONLY:
         c.create_file(dm.name, "w", "r")
     elif dm == DOSmode.HIDDEN:
@@ -186,7 +185,7 @@ def test_011_check_dos_ro_cred_handling(request):
     """
     depends(request, ["SHARE_IS_WRITABLE"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file("RO_TEST", "w", "r")
     c.write(fd, b"TESTING123\n")
     c.disconnect()
@@ -217,7 +216,7 @@ def test_051_share_is_writable_smb1(request):
     """
     depends(request, ["SMB_SHARE_CREATED"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("testfile", "w")
     c.close(fd, True)
     c.disconnect()
@@ -234,7 +233,7 @@ def test_052_check_dosmode_create_smb1(request, dm):
         return
 
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     if dm == DOSmode.READONLY:
         c.create_file(f'{dm.name}_smb1', "w", "r")
     elif dm == DOSmode.HIDDEN:
@@ -258,7 +257,7 @@ def test_060_create_base_file_for_streams_tests(request):
     """
     depends(request, ["SMB_SHARE_CREATED"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("streamstestfile", "w")
     c.close(fd)
     c.mkdir("streamstestdir")
@@ -273,7 +272,7 @@ def test_061_create_and_write_stream_smb2(request, mount_share):
     """
     depends(request, ["STREAM_TESTFILE_CREATED"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file("streamstestfile:smb2_stream", "w")
     c.write(fd, b'test1', 0)
     c.close(fd)
@@ -310,7 +309,6 @@ def test_062_write_stream_large_offset_smb2(request, mount_share):
     """
     depends(request, ["STREAM_TESTFILE_CREATED"])
     with smb_connection(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -386,7 +384,7 @@ def test_063_stream_delete_on_close_smb2(request):
     """
     depends(request, ["STREAM_WRITTEN_SMB2", "LARGE_STREAM_WRITTEN_SMB2"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file("streamstestfile:smb2_stream", "w")
     c.close(fd, True)
 
@@ -401,7 +399,7 @@ def test_065_create_and_write_stream_smb1(request):
     """
     depends(request, ["STREAM_TESTFILE_CREATED"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("streamstestfile:smb1_stream", "w")
     c.write(fd, b'test1', 0)
     c.close(fd)
@@ -421,7 +419,7 @@ def test_066_write_stream_large_offset_smb1(request):
     """
     depends(request, ["STREAM_WRITTEN_SMB1"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("streamstestfile:smb1_stream", "w")
     c.write(fd, b'test2', 131072)
     c.close(fd)
@@ -443,7 +441,7 @@ def test_067_stream_delete_on_close_smb1(request):
     """
     depends(request, ["STREAM_WRITTEN_SMB1", "LARGE_STREAM_WRITTEN_SMB1"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("streamstestfile:smb1_stream", "w")
     c.close(fd, True)
 
@@ -462,7 +460,7 @@ def test_068_case_insensitive_rename(request):
     """
     depends(request, ["SHARE_IS_WRITABLE"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("to_rename", "w")
     c.close(fd)
     c.rename("to_rename", "To_rename")
@@ -477,7 +475,7 @@ def test_069_normal_rename(request):
     """
     depends(request, ["SHARE_IS_WRITABLE"])
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=True)
     fd = c.create_file("old_file_to_rename", "w")
     c.close(fd)
     c.rename("old_file_to_rename", "renamed_new_file")
@@ -522,7 +520,6 @@ def test_090_test_auto_smb_quota(request, proto):
     depends(request, ["BA_ADDED_TO_USER"])
     c = SMB()
     qt = c.get_quota(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -559,7 +556,6 @@ def test_092_set_smb_quota(request, proto):
     new_quota = 2 * (2**30)
     c = SMB()
     qt = c.set_quota(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -573,7 +569,6 @@ def test_092_set_smb_quota(request, proto):
     assert qt[0]['hard_limit'] == new_quota, qt
 
     qt = c.get_quota(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -585,7 +580,6 @@ def test_092_set_smb_quota(request, proto):
     assert qt[0]['hard_limit'] == new_quota, qt
 
     qt = c.set_quota(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -599,7 +593,6 @@ def test_092_set_smb_quota(request, proto):
     assert qt[0]['hard_limit'] is None, qt
 
     qt = c.get_quota(
-        host=ip,
         share=SMB_NAME,
         username=SMB_USER,
         password=SMB_PWD,
@@ -661,7 +654,7 @@ def test_152_check_xattr_via_smb(request, mount_share, xat):
     afptestfile = f'afp_xattr_testfile:{AFPXattr[xat]["smbname"]}'
     bytes_to_read = AFPXattr[xat]["smb_bytes"] if xat == "org.netatalk.Metadata" else AFPXattr[xat]["bytes"]
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file(afptestfile, "w")
     xat_bytes = c.read(fd, 0, len(bytes_to_read) + 1)
     c.close(fd)
@@ -693,7 +686,7 @@ def test_153_unlink_xattr_via_smb(request, xat):
     depends(request, ["XATTR_CHECK_SMB_READ"])
     afptestfile = f'afp_xattr_testfile:{AFPXattr[xat]["smbname"]}'
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file(afptestfile, "w")
     c.close(fd, True)
     c.disconnect()
@@ -709,7 +702,7 @@ def test_154_write_afp_xattr_via_smb(request, xat):
     afptestfile = f'afp_xattr_testfile:{AFPXattr[xat]["smbname"]}'
     payload = AFPXattr[xat]["smb_bytes"] if xat == "org.netatalk.Metadata" else AFPXattr[xat]["bytes"]
     c = SMB()
-    c.connect(host=ip, share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
+    c.connect(share=SMB_NAME, username=SMB_USER, password=SMB_PWD, smb1=False)
     fd = c.create_file(afptestfile, "w")
     c.write(fd, payload)
     c.close(fd)
@@ -741,7 +734,6 @@ def test_155_ssh_read_afp_xattr(request, xat):
 def test_175_check_external_path(request):
     with smb_share(f'EXTERNAL:{ip}\\{SMB_NAME}', 'EXTERNAL'):
         with smb_connection(
-            host=ip,
             share=SMB_NAME,
             username=SMB_USER,
             password=SMB_PWD,
@@ -765,7 +757,6 @@ def test_176_check_dataset_auto_create(request):
         ds_mp = os.path.join('/mnt', ds)
         with smb_share(ds_mp, 'DATASETS', {'purpose': 'PRIVATE_DATASETS'}):
             with smb_connection(
-                host=ip,
                 share='DATASETS',
                 username=SMB_USER,
                 password=SMB_PWD,
@@ -786,7 +777,6 @@ def test_180_create_share_multiple_dirs_deep(request):
 
         with smb_share(dirs_path, 'DIRS'):
             with smb_connection(
-                host=ip,
                 share='DIRS',
                 username=SMB_USER,
                 password=SMB_PWD,
@@ -803,7 +793,6 @@ def test_181_create_and_disable_share(request):
     with dataset('smb_disabled', data={'share_type': 'SMB'}) as ds:
         with smb_share(os.path.join('/mnt', ds), 'TO_DISABLE') as tmp_share:
             with smb_connection(
-                host=ip,
                 share='TO_DISABLE',
                 username=SMB_USER,
                 password=SMB_PWD,

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -241,7 +241,7 @@ def test_007_test_disable_autoinherit(request):
     with create_dataset(f'{pool_name}/{ds}', {'share_type': 'SMB'}):
         with smb_share(path, 'NFS4_INHERIT'):
             c = SMB()
-            c.connect(host=ip, share='NFS4_INHERIT', username=SMB_USER, password=SMB_PWD, smb1=False)
+            c.connect(share='NFS4_INHERIT', username=SMB_USER, password=SMB_PWD, smb1=False)
             c.mkdir('foo')
             sd = c.get_sd('foo')
             assert 'SEC_DESC_DACL_PROTECTED' not in sd['control']['parsed'], str(sd)

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -41,7 +41,7 @@ def test_001_net_share_enum(setup_smb_user, setup_smb_share):
     path = setup_smb_share['share']['path']
     share_name = setup_smb_share['share']['name']
 
-    with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
+    with MS_RPC(username=SMB_USER, password=SMB_PWD) as hdl:
         shares = hdl.shares()
         # IPC$ share should always be present
         assert len(shares) == 2, str(shares)
@@ -62,7 +62,7 @@ def test_002_enum_users(setup_smb_user, setup_smb_share):
     assert results.status_code == 200, results.text
     user_info = results.json()
 
-    with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
+    with MS_RPC(username=SMB_USER, password=SMB_PWD) as hdl:
         entry = None
         users = hdl.users()
         for u in users:
@@ -94,7 +94,7 @@ def test_003_access_based_share_enum(setup_smb_user, setup_smb_share):
     results = GET("/sharing/smb")
     assert results.status_code == 200, results.text
 
-    with MS_RPC(username=SMB_USER, password=SMB_PWD, host=ip) as hdl:
+    with MS_RPC(username=SMB_USER, password=SMB_PWD) as hdl:
         shares = hdl.shares()
         assert len(shares) == 1, str({"enum": shares, "shares": results.json()})
 

--- a/tests/api2/test_450_staticroutes.py
+++ b/tests/api2/test_450_staticroutes.py
@@ -40,7 +40,7 @@ def test_02_check_staticroute_configured_using_api(sr_dict):
 
 
 def test_03_checking_staticroute_configured_using_ssh(request):
-    results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password, ip)
+    results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password)
     assert results['result'] is True, results
     assert results['stdout'].strip().split()[1] == GATEWAY, results
 
@@ -59,5 +59,5 @@ def test_05_check_staticroute_unconfigured_using_api(sr_dict):
 
 
 def test_06_checking_staticroute_unconfigured_using_ssh(request):
-    results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password, ip)
+    results = SSH_TEST(f'netstat -4rn|grep -E ^{DESTINATION}', user, password)
     assert results['result'] is False, results

--- a/tests/api2/test_470_system.py
+++ b/tests/api2/test_470_system.py
@@ -11,6 +11,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import ip
 from functions import GET, make_ws_request
+from middlewared.test.integration.utils import call
 
 
 def test_01_check_if_system_is_ready_to_use():
@@ -56,13 +57,7 @@ def test_06_check_system_set_time():
 
     # hop 300 seconds into the past
     target = datetime - 300
-    res = make_ws_request(ip, {
-        'msg': 'method',
-        'method': 'system.set_time',
-        'params': [int(target)]
-    })
-    error = res.get('error')
-    assert error is None, str(error)
+    call('system.set_time', int(target))
 
     results = GET("/system/info/")
     assert results.status_code == 200, results.text

--- a/tests/protocols/ms_rpc.py
+++ b/tests/protocols/ms_rpc.py
@@ -2,6 +2,7 @@ import re
 import subprocess
 
 from collections import namedtuple
+from functions import SRVTarget, get_host_ip
 
 RE_SAMR_ENUMDOMAINS = re.compile(r"name:\[(?P<name>\w+)\] idx:\[(?P<idx>\w+)\]")
 RE_SAMR_ENUMDOMUSER = re.compile(r"user:\[(?P<user>\w+)\] rid:\[(?P<rid>\w+)\]")
@@ -17,7 +18,7 @@ class MS_RPC():
         self.workgroup = kwargs.get('workgroup')
         self.kerberos = kwargs.get('use_kerberos', False)
         self.realm = kwargs.get('realm')
-        self.host = kwargs.get('host')
+        self.host = kwargs.get('host', get_host_ip(SRVTarget.DEFAULT))
         self.smb1 = kwargs.get('smb1', False)
 
     def connect(self):

--- a/tests/protocols/nfs_proto.py
+++ b/tests/protocols/nfs_proto.py
@@ -1,5 +1,5 @@
 import sys
-from functions import SSH_TEST
+from functions import SSH_TEST, SRVTarget, get_host_ip
 from platform import system
 
 # sys.real_prefix only found in old virtualenv
@@ -49,7 +49,7 @@ class NFS(object):
 
     def __init__(self, hostname, path, **kwargs):
         self._path = path
-        self._hostname = hostname
+        self._hostname = hostname or get_host_ip(SRVTarget.DEFAULT)
         self._version = kwargs.get('vers', 3)
         self._localpath = kwargs.get('localpath', '/mnt/testnfs')
         self._mounted = False

--- a/tests/protocols/smb_proto.py
+++ b/tests/protocols/smb_proto.py
@@ -1,7 +1,9 @@
 import sys
 import enum
 import subprocess
+from functions import SRVTarget, get_host_ip
 from platform import system
+
 
 # sys.real_prefix only found in old virtualenv
 # if detected set local site-packages to use for samba
@@ -81,7 +83,7 @@ class SMB(object):
         self._smb1 = False
 
     def connect(self, **kwargs):
-        host = kwargs.get("host")
+        host = kwargs.get("host", get_host_ip(SRVTarget.DEFAULT))
         share = kwargs.get("share")
         username = kwargs.get("username")
         domain = kwargs.get("domain")


### PR DESCRIPTION
Various test functions have now been modified to allow omitting the host IP (which in HA forces use of virtual IP).
This commit updates many tests to use the new functionality so that we have fewer failures on HA.