### PR TITLE
NAS-128993 / 24.10 / Enhance WebSocket Handling with Dynamic Connection Header for VM Display devices

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -127,6 +127,11 @@ http {
         keepalive 64;
     }
 
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
     server {
         server_name  localhost;
 % if ssl_configuration:
@@ -199,7 +204,7 @@ http {
             proxy_set_header X-Real-Remote-Port $remote_port;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "Upgrade";
+            proxy_set_header Connection $connection_upgrade;
         }
 
 % endfor


### PR DESCRIPTION
## Problem
WebSocket connections require a long-running connection between the client and server. When using WebSocket connections with a reverse proxy in Nginx, a problem arises because reverse proxy connections follow the hop-by-hop protocol, meaning they open once and then close. To upgrade this connection to support WebSocket, the Upgrade header is used, which keeps the connection open on every hop. The main issue in the code is that we are not closing the connection ever. It remains open because this header is hard-coded. As a result, when a user opens their VM display more than 1000 times without rebooting, they start experiencing problems with the display.

## Solution
Close the WebSocket connection when `http_upgrade` is none.

## Reference
https://stackoverflow.com/questions/49488091/getting-connection-reset-by-peer-while-proxying-upgraded-connection-connectio