### PR TITLE
Set vm.swappiness=1

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -4,3 +4,4 @@ kernel.panic_on_io_nmi = 1
 kernel.panic_on_unrecovered_nmi = 1
 kernel.unknown_nmi_panic = 1
 kernel.watchdog_thresh = 60
+vm.swappiness=1


### PR DESCRIPTION
It should allow system to swap anonymous pages actively when it is one step from OOM, while otherwise prefer to flush file-backed pages back into ZFS ARC, freeing more memory for it.

(cherry picked from commit afeb08c67889d90c7836de227a1ac2be7643b0a5)