### PR TITLE
NAS-129002 / 24.10 / More API test HA-related cleanups

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/directory_service.py
+++ b/src/middlewared/middlewared/test/integration/assets/directory_service.py
@@ -10,10 +10,8 @@ from middlewared.test.integration.utils import call, fail
 try:
     apifolder = os.getcwd()
     sys.path.append(apifolder)
-    from auto_config import ip as default_ip
     from auto_config import ha, hostname
 except ImportError:
-    default_ip = None
     ha = False
     hostname = None
 

--- a/src/middlewared/middlewared/test/integration/assets/smb.py
+++ b/src/middlewared/middlewared/test/integration/assets/smb.py
@@ -7,13 +7,8 @@ import sys
 
 from base64 import b64encode, b64decode
 from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
 
-try:
-    apifolder = os.getcwd()
-    sys.path.append(apifolder)
-    from auto_config import ip as default_ip
-except ImportError:
-    default_ip = None
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +45,8 @@ def smb_share(path, name, options=None):
 
 
 @contextlib.contextmanager
-def smb_mount(share, username, password, local_path='/mnt/cifs', options=None, ip=default_ip):
+def smb_mount(share, username, password, local_path='/mnt/cifs', options=None, ip=None):
+    ip = ip or truenas_server.ip
     mount_options = [f'username={username}', f'password={password}'] + (options or [])
     escaped_path = shlex.quote(local_path)
     mount_cmd = [

--- a/src/middlewared/middlewared/test/integration/utils/ssh.py
+++ b/src/middlewared/middlewared/test/integration/utils/ssh.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     default_user = None
     default_password = None
-    default_ip = None
 
 __all__ = ["ssh"]
 

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -7,14 +7,14 @@ import json
 import pytest
 
 from functions import if_key_listed, SSH_TEST
-from auto_config import ip, sshKey, user, password
+from auto_config import sshKey, user, password
 from middlewared.test.integration.utils import fail
-from middlewared.test.integration.utils.client import client
+from middlewared.test.integration.utils.client import client, truenas_server
 
 
 @pytest.fixture(scope='module')
 def ws_client():
-    with client(host_ip=ip) as c:
+    with client(host_ip=truenas_server.ip) as c:
         yield c
 
 
@@ -83,7 +83,7 @@ def test_004_enable_and_start_ssh(ws_client):
 
 
 def test_005_ssh_using_root_password():
-    results = SSH_TEST('ls -la', user, password, ip)
+    results = SSH_TEST('ls -la', user, password)
     if not results['result']:
         fail(f"SSH is not usable: {results['output']}. Aborting tests.")
 
@@ -91,7 +91,7 @@ def test_005_ssh_using_root_password():
 def test_006_setup_and_login_using_root_ssh_key():
     assert os.environ.get('SSH_AUTH_SOCK') is not None
     assert if_key_listed() is True  # horrible function name
-    results = SSH_TEST('ls -la', user, None, ip)
+    results = SSH_TEST('ls -la', user, None)
     assert results['result'] is True, results['output']
 
 
@@ -112,7 +112,7 @@ def test_007_check_local_accounts(ws_client, account):
 
 
 def test_008_check_root_dataset_settings(ws_client):
-    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password, ip)
+    data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password)
     if not data['result']:
         fail(f'Unable to get dataset schema: {data["output"]}')
 
@@ -121,7 +121,7 @@ def test_008_check_root_dataset_settings(ws_client):
     except Exception as e:
         fail(f'Unable to load dataset schema: {e}')
 
-    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password, ip)
+    data = SSH_TEST('zfs get -o value -H truenas:developer /', user, password)
     if not data['result']:
         fail('Failed to determine whether developer mode enabled')
 

--- a/tests/api2/test_002_system_license.py
+++ b/tests/api2/test_002_system_license.py
@@ -2,14 +2,14 @@ import os
 import sys
 import time
 sys.path.append(os.getcwd())
-from auto_config import ip, ha, ha_license
+from auto_config import ha, ha_license
 
 from middlewared.test.integration.utils import client
 
 # Only read the test on HA
 if ha:
     def test_apply_and_verify_license():
-        with client(host_ip=ip) as c:
+        with client() as c:
             if ha_license:
                 _license_string = ha_license
             else:

--- a/tests/api2/test_003_network_global.py
+++ b/tests/api2/test_003_network_global.py
@@ -81,4 +81,4 @@ def test_002_verify_network_global_settings_state(request, ws_client, netinfo):
 def test_003_verify_network_general_summary(request, ws_client, netinfo):
     depends(request, ['NET_CONFIG'])
     summary = ws_client.call('network.general.summary')
-    assert any(i.startswith(ip) for i in summary['ips'][interface]['IPV4'])
+    assert any(i.startswith(truenas_server.ip) for i in summary['ips'][interface]['IPV4'])

--- a/tests/api2/test_003_network_global.py
+++ b/tests/api2/test_003_network_global.py
@@ -6,13 +6,13 @@ sys.path.append(apifolder)
 import pytest
 from pytest_dependency import depends
 
-from auto_config import ha, interface, hostname, domain, ip, gateway
-from middlewared.test.integration.utils.client import client
+from auto_config import ha, interface, hostname, domain, gateway
+from middlewared.test.integration.utils.client import client, truenas_server
 
 
 @pytest.fixture(scope='module')
 def ws_client():
-    with client(host_ip=ip) as c:
+    with client(host_ip=truenas_server.ip) as c:
         yield c
 
 

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -55,7 +55,7 @@ def ws_client():
     # by the time this test is called in the pipeline,
     # the HA VM should have networking configured so
     # we can use the VIP
-    with client(host_ip=vip if ha else ip) as c:
+    with client() as c:
         yield c
 
 

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -7,7 +7,7 @@ sys.path.append(apifolder)
 import pytest
 from pytest_dependency import depends
 
-from auto_config import ha, ip, vip, pool_name
+from auto_config import ha, vip, pool_name
 from middlewared.client.client import ValidationErrors
 from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import fail

--- a/tests/api2/test_007_early_settings.py
+++ b/tests/api2/test_007_early_settings.py
@@ -1,6 +1,5 @@
 import stat
 
-from auto_config import ha
 from middlewared.test.integration.utils import call
 
 # this is found in middlewared.plugins.sysctl.sysctl_info

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -14,7 +14,7 @@ from middlewared.test.integration.assets.pool import dataset as dataset_asset
 from middlewared.test.integration.utils import call, ssh
 
 from functions import SSH_TEST, wait_on_job
-from auto_config import pool_name, password, user, ip
+from auto_config import pool_name, password, user
 SHELL = '/usr/bin/bash'
 VAR_EMPTY = '/var/empty'
 ROOT_GROUP = 'root'
@@ -119,7 +119,7 @@ class UserAssets:
 
 
 def check_config_file(file_name, expected_line):
-    results = SSH_TEST(f'cat {file_name}', user, password, ip)
+    results = SSH_TEST(f'cat {file_name}', user, password)
     assert results['result'], results['output']
     assert expected_line in results['stdout'].splitlines(), results['output']
 
@@ -185,7 +185,7 @@ def test_001_create_and_verify_testuser():
     # red flags in the CI
     results = SSH_TEST(
         f'grep -R {UserAssets.TestUser01["create_payload"]["password"]!r} /var/log/middlewared.log',
-        user, password, ip
+        user, password
     )
     assert results['result'] is False, str(results['output'])
 
@@ -267,7 +267,7 @@ def test_005_convert_non_smbuser_to_smbuser(request):
     # verify converted smb user doesn't leak password
     results = SSH_TEST(
         f'grep -R {UserAssets.TestUser01["create_payload"]["password"]!r} /var/log/middlewared.log',
-        user, password, ip
+        user, password
     )
     assert results['result'] is False, str(results['output'])
 
@@ -370,7 +370,7 @@ def test_020_create_and_verify_shareuser():
     # red flags in the CI
     results = SSH_TEST(
         f'grep -R {UserAssets.ShareUser01["create_payload"]["password"]!r} /var/log/middlewared.log',
-        user, password, ip
+        user, password
     )
     assert results['result'] is False, str(results['output'])
 
@@ -409,7 +409,7 @@ def test_031_create_user_with_homedir(request):
     # so it sets off a bunch of red flags in the CI
     results = SSH_TEST(
         f'grep -R {UserAssets.TestUser02["create_payload"]["password"]!r} /var/log/middlewared.log',
-        user, password, ip
+        user, password
     )
     assert results['result'] is False, str(results['output'])
 
@@ -455,7 +455,7 @@ def test_036_create_testfile_in_homedir(request):
     filepath = f'{UserAssets.TestUser02["query_response"]["home"]}/{filename}'
     results = SSH_TEST(
         f'touch {filepath}; chown {UserAssets.TestUser01["query_response"]["uid"]} {filepath}',
-        user, password, ip
+        user, password
     )
     assert results['result'] is True, results['output']
     assert call('filesystem.stat', filepath)
@@ -511,7 +511,7 @@ def test_038_change_homedir_to_existing_path(request):
         HomeAssets.Dataset01['create_payload']['name'],
         HomeAssets.Dataset01['new_home']
     )
-    results = SSH_TEST(f'mkdir {new_home}', user, password, ip)
+    results = SSH_TEST(f'mkdir {new_home}', user, password)
     assert results['result'] is True, results['output']
 
     # Move the homedir to existing dir

--- a/tests/api2/test_012_directory_service_ssh.py
+++ b/tests/api2/test_012_directory_service_ssh.py
@@ -6,7 +6,6 @@
 import pytest
 from pytest_dependency import depends
 from functions import SSH_TEST
-from auto_config import hostname, ip
 
 from middlewared.test.integration.assets.directory_service import active_directory, ldap
 from middlewared.test.integration.utils import call
@@ -44,7 +43,7 @@ def test_08_test_ssh_ad(do_ad_connection):
     groupobj = call('group.get_group_obj', {'gid': userobj['pw_gid']})
     call('ssh.update', {"password_login_groups": [groupobj['gr_name']]})
     cmd = 'ls -la'
-    results = SSH_TEST(cmd, f'{ADUSERNAME}@{AD_DOMAIN}', ADPASSWORD, ip)
+    results = SSH_TEST(cmd, f'{ADUSERNAME}@{AD_DOMAIN}', ADPASSWORD)
     call('ssh.update', {"password_login_groups": []})
     assert results['result'] is True, results
 
@@ -54,6 +53,6 @@ def test_09_test_ssh_ldap(do_ldap_connection):
     groupobj = call('group.get_group_obj', {'gid': userobj['pw_gid']})
     call('ssh.update', {"password_login_groups": [groupobj['gr_name']]})
     cmd = 'ls -la'
-    results = SSH_TEST(cmd, LDAPUSER, LDAPPASSWORD, ip)
+    results = SSH_TEST(cmd, LDAPUSER, LDAPPASSWORD)
     call('ssh.update', {"password_login_groups": []})
     assert results['result'] is True, results

--- a/tests/api2/test_023_kubernetes.py
+++ b/tests/api2/test_023_kubernetes.py
@@ -3,8 +3,9 @@ import time
 
 from pytest_dependency import depends
 from functions import GET, PUT, wait_on_job
-from auto_config import ha, pool_name, interface, ip
+from auto_config import ha, pool_name, interface
 from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
 
 
 # Read all the test below only on non-HA
@@ -14,7 +15,7 @@ if not ha:
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
         assert '0.0.0.0' in results.json(), results.text
-        assert ip in results.json(), results.text
+        assert truenas_server.ip in results.json(), results.text
 
     @pytest.mark.dependency(name='setup_kubernetes')
     def test_02_setup_kubernetes(request):
@@ -24,7 +25,7 @@ if not ha:
             'pool': pool_name,
             'route_v4_interface': interface,
             'route_v4_gateway': gateway,
-            'node_ip': ip
+            'node_ip': truenas_server.ip
         }
         results = PUT('/kubernetes/', payload)
         assert results.status_code == 200, results.text
@@ -45,7 +46,7 @@ if not ha:
         results = GET('/kubernetes/node_ip/')
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), str), results.text
-        assert results.json() == ip, results.text
+        assert results.json() == truenas_server.ip, results.text
 
     def test_05_get_kubernetes_events(request):
         depends(request, ["setup_kubernetes"])

--- a/tests/api2/test_024_container.py
+++ b/tests/api2/test_024_container.py
@@ -11,7 +11,8 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, PUT, POST, DELETE, wait_on_job
-from auto_config import ha, interface, ip, pool_name
+from auto_config import ha, interface, pool_name
+from middlewared.test.integration.utils.client import truenas_server
 
 container_reason = "Can't import docker_username and docker_password"
 try:
@@ -310,7 +311,7 @@ if not ha:
                         'hostInterface': f'{interface}',
                         'ipam': {
                             'type': 'static',
-                            'staticIPConfigurations': [f'{ip}/24'],
+                            'staticIPConfigurations': [f'{truenas_server.ip}/24'],
                             'staticRoutes': [
                                 {
                                     'destination': '0.0.0.0/0',
@@ -342,7 +343,7 @@ if not ha:
         assert results.status_code == 200, results.text
         assert isinstance(results.json(), dict), results.text
         ipam = results.json()['config']['externalInterfaces'][0]['ipam']
-        assert f'{ip}/24' in ipam['staticIPConfigurations'], results.text
+        assert f'{truenas_server.ip}/24' in ipam['staticIPConfigurations'], results.text
         assert {'destination': '0.0.0.0/0', 'gateway': gateway} in ipam['staticRoutes'], results.text
         assert ipam['type'] == 'static', results.text
 

--- a/tests/api2/test_026_kubernetes_backup_chart_releases.py
+++ b/tests/api2/test_026_kubernetes_backup_chart_releases.py
@@ -7,7 +7,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, DELETE, SSH_TEST, wait_on_job
-from auto_config import ha, artifacts, password, ip, pool_name
+from auto_config import ha, artifacts, password, pool_name
 from middlewared.test.integration.utils import call, ssh
 
 from middlewared.test.integration.assets.apps import chart_release
@@ -234,7 +234,7 @@ if not ha:
         assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
     def test_25_get_k3s_logs():
-        results = SSH_TEST('journalctl --no-pager -u k3s', 'root', password, ip)
+        results = SSH_TEST('journalctl --no-pager -u k3s', 'root', password)
         ks3_logs = open(f'{artifacts}/k3s-scale.log', 'w')
         ks3_logs.writelines(results['output'])
         ks3_logs.close()

--- a/tests/api2/test_035_ad_idmap.py
+++ b/tests/api2/test_035_ad_idmap.py
@@ -11,7 +11,7 @@ import json
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, DELETE, SSH_TEST, wait_on_job
-from auto_config import ip, hostname, password, user
+from auto_config import hostname, password, user
 from base64 import b64decode
 from middlewared.test.integration.assets.directory_service import active_directory
 from middlewared.test.integration.utils import call, ssh
@@ -358,7 +358,7 @@ def test_13_idmap_new_domain(request):
     depends(request, ["AD_IS_HEALTHY"], scope="session")
     global dom_id
     cmd = 'midclt call idmap.get_next_idmap_range'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
     low, high = json.loads(results['stdout'].strip())
 
@@ -381,7 +381,7 @@ def test_14_idmap_new_domain_duplicate_fail(request):
     """
     depends(request, ["AD_IS_HEALTHY"], scope="session")
     cmd = 'midclt call idmap.get_next_idmap_range'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
     low, high = json.loads(results['stdout'].strip())
 

--- a/tests/api2/test_036_ad_ldap.py
+++ b/tests/api2/test_036_ad_ldap.py
@@ -11,7 +11,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 
 from middlewared.test.integration.assets.directory_service import active_directory, ldap
-from auto_config import ip, hostname, password, pool_name, user, ha
+from auto_config import hostname, password, pool_name, user, ha
 from functions import GET, POST, PUT, SSH_TEST, make_ws_request, wait_on_job
 from protocols import nfs_share, SSH_NFS
 from pytest_dependency import depends

--- a/tests/api2/test_040_ad_user_group_cache.py
+++ b/tests/api2/test_040_ad_user_group_cache.py
@@ -8,7 +8,7 @@ import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, SSH_TEST, wait_on_job
-from auto_config import ip, hostname, password, user
+from auto_config import hostname, password, user
 from pytest_dependency import depends
 from middlewared.test.integration.assets.account import user as create_user
 from middlewared.test.integration.assets.directory_service import active_directory
@@ -67,7 +67,7 @@ def test_07_check_for_ad_users(request):
     """
     depends(request, ["INITIAL_CACHE_FILL"], scope="session")
     cmd = "wbinfo -u"
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'], str(results['output'])
     wbinfo_entries = results['stdout'].splitlines()
 
@@ -91,7 +91,7 @@ def test_08_check_for_ad_groups(request):
     """
     depends(request, ["INITIAL_CACHE_FILL"], scope="session")
     cmd = "wbinfo -g"
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'], str(results['output'])
     wbinfo_entries = results['stdout'].splitlines()
 
@@ -123,7 +123,7 @@ def test_09_check_directoryservices_cache_refresh(request):
     Cache resides in tdb files. Remove the files to clear cache.
     """
     cmd = 'rm -f /root/tdb/persistent/*'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     """
@@ -177,7 +177,7 @@ def test_10_check_lazy_initialization_of_users_and_groups_by_name(request):
     ad_group = f'{domain_prefix}domain users'
 
     cmd = 'rm -f /root/tdb/persistent/*'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     if not results['result']:
@@ -239,7 +239,7 @@ def test_11_check_lazy_initialization_of_users_and_groups_by_id(request):
     depends(request, ["LAZY_INITIALIZATION_BY_NAME"], scope="session")
 
     cmd = 'rm -f /root/tdb/persistent/*'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
     if not results['result']:

--- a/tests/api2/test_050_alert.py
+++ b/tests/api2/test_050_alert.py
@@ -8,7 +8,7 @@ from time import sleep
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, SSH_TEST
-from auto_config import ip, password, user, pool_name
+from auto_config import password, user, pool_name
 from middlewared.test.integration.utils import call
 
 
@@ -40,14 +40,14 @@ def test_04_degrading_a_pool_to_create_an_alert(request):
     id_path = '/dev/disk/by-partuuid/'
     gptid = get_pool['topology']['data'][0]['path'].replace(id_path, '')
     cmd = f'zinject -d {gptid} -A fault {pool_name}'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
 
 def test_05_verify_the_pool_is_degraded(request):
     depends(request, ['degrade_pool'], scope="session")
     cmd = f'zpool status {pool_name} | grep {gptid}'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
     assert 'DEGRADED' in results['output'], results['output']
 
@@ -109,14 +109,14 @@ def test_11_verify_the_alert_is_restored(request):
 def test_12_clear_the_pool_degradation(request):
     depends(request, ["degrade_pool"], scope="session")
     cmd = f'zpool clear {pool_name}'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
 
 
 def test_13_verify_the_pool_is_not_degraded(request):
     depends(request, ["degrade_pool"], scope="session")
     cmd = f'zpool status {pool_name} | grep {gptid}'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
     assert 'DEGRADED' not in results['output'], results['output']
 

--- a/tests/api2/test_130_cloudsync.py
+++ b/tests/api2/test_130_cloudsync.py
@@ -9,7 +9,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, POST, GET, DELETE, SSH_TEST
-from auto_config import pool_name, ip, password, user
+from auto_config import pool_name, password, user
 
 dataset = f"{pool_name}/cloudsync"
 dataset_path = os.path.join("/mnt", dataset)
@@ -127,7 +127,7 @@ def test_06_run_cloud_sync(request, task):
             continue
         assert state["job"]["state"] == "SUCCESS", state
         cmd = f'cat {dataset_path}/freenas-test.txt'
-        ssh_result = SSH_TEST(cmd, user, password, ip)
+        ssh_result = SSH_TEST(cmd, user, password)
         assert ssh_result['result'] is True, ssh_result['output']
         assert ssh_result['stdout'] == 'freenas-test\n', ssh_result['output']
         return

--- a/tests/api2/test_140_core.py
+++ b/tests/api2/test_140_core.py
@@ -10,7 +10,7 @@ from urllib.request import urlretrieve
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST
-from auto_config import ip
+from middlewared.test.integration.utils.client import truenas_server
 
 
 def test_01_get_core_jobs():
@@ -48,7 +48,7 @@ def test_04_verify_job_id_state_is_running():
 
 
 def test_05_download_from_url():
-    rv = urlretrieve(f'http://{ip}{url}')
+    rv = urlretrieve(f'http://{truenas_server.ip}{url}')
     stat = os.stat(rv[0])
     assert stat.st_size > 0
 

--- a/tests/api2/test_150_cronjob.py
+++ b/tests/api2/test_150_cronjob.py
@@ -9,7 +9,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import POST, PUT, SSH_TEST, GET, DELETE
-from auto_config import user, password, ip
+from auto_config import user, password
 
 TESTFILE = '/tmp/.testFileCreatedViaCronjob'
 
@@ -55,7 +55,7 @@ def test_05_Checking_that_API_reports_the_cronjob_as_updated(cronjob_dict):
 
 
 def test_06_Deleting_test_file_created_by_cronjob(request):
-    results = SSH_TEST(f'rm "{TESTFILE}"', user, password, ip)
+    results = SSH_TEST(f'rm "{TESTFILE}"', user, password)
     assert results['result'] is True, results['output']
 
 

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -13,7 +13,7 @@ sys.path.append(apifolder)
 
 from copy import deepcopy
 from functions import POST, PUT, SSH_TEST, wait_on_job
-from auto_config import pool_name, ip, user, password
+from auto_config import pool_name, user, password
 from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.filesystem import directory
 from middlewared.test.integration.assets.pool import dataset
@@ -82,12 +82,12 @@ def test_04_test_filesystem_statfs_fstype(request):
     # mkdir
     nested_path = f'{parent_path}/tmpfs'
     cmd1 = f'mkdir -p {nested_path}'
-    results = SSH_TEST(cmd1, user, password, ip)
+    results = SSH_TEST(cmd1, user, password)
     assert results['result'] is True, results['output']
 
     # mount tmpfs
     cmd2 = f'mount -t tmpfs -o size=10M tmpfstest {nested_path}'
-    results = SSH_TEST(cmd2, user, password, ip)
+    results = SSH_TEST(cmd2, user, password)
     assert results['result'] is True, results['output']
 
     # test fstype
@@ -99,10 +99,10 @@ def test_04_test_filesystem_statfs_fstype(request):
 
     # cleanup
     cmd3 = f'umount {nested_path}'
-    results = SSH_TEST(cmd3, user, password, ip)
+    results = SSH_TEST(cmd3, user, password)
     assert results['result'] is True, results['output']
     cmd4 = f'rmdir {nested_path}'
-    results = SSH_TEST(cmd4, user, password, ip)
+    results = SSH_TEST(cmd4, user, password)
     assert results['result'] is True, results['output']
 
 
@@ -159,7 +159,7 @@ def test_07_test_filesystem_stat_filetype(request):
     ]
 
     with create_dataset(f'{pool_name}/{ds_name}'):
-        results = SSH_TEST(' && '.join(cmds), user, password, ip)
+        results = SSH_TEST(' && '.join(cmds), user, password)
         assert results['result'] is True, str(results)
 
         for x in targets:
@@ -258,7 +258,7 @@ def test_09_test_dosmodes():
             f'touch {testpaths[0]}',
             f'mkdir {testpaths[1]}'
         ]
-        results = SSH_TEST(' && '.join(cmd), user, password, ip)
+        results = SSH_TEST(' && '.join(cmd), user, password)
         assert results['result'] is True, str(results)
 
         for p in testpaths:

--- a/tests/api2/test_210_group.py
+++ b/tests/api2/test_210_group.py
@@ -11,7 +11,7 @@ import pytest
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, PUT, DELETE, SSH_TEST
-from auto_config import user, password, ip
+from auto_config import user, password
 from middlewared.test.integration.utils import call
 from pytest_dependency import depends
 GroupIdFile = "/tmp/.ixbuild_test_groupid"
@@ -259,7 +259,7 @@ def test_27_full_groupmap_check(request):
     """
     depends(request, ["SMB_GROUP_CREATED"], scope="session")
     cmd = "midclt call smb.groupmap_list"
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'], str(results['output'])
 
     gm = json.loads(results['stdout'].strip())
@@ -290,13 +290,13 @@ def test_27_full_groupmap_check(request):
     assert str(gid_to_check) in gm['local'], str(gm)
 
     cmd = "midclt call smb.groupmap_listmem S-1-5-32-544"
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'], str(results['output'])
     ba = json.loads(results['stdout'].strip())
     assert gm['local_builtins']['544']['sid'] in ba, str(ba)
 
     cmd = "midclt call smb.groupmap_listmem S-1-5-32-546"
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'], str(results['output'])
     bg = json.loads(results['stdout'].strip())
     assert gm['local_builtins']['546']['sid'] in bg, str(bg)

--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -11,8 +11,9 @@ from time import sleep
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ip, pool_name, hostname
+from auto_config import pool_name, hostname
 from functions import PUT, POST, GET, SSH_TEST, DELETE
+from middlewared.test.integration.utils.client import truenas_server
 
 try:
     Reason = 'BSD host configuration is missing in ixautomation.conf'
@@ -169,7 +170,7 @@ def test_08_Verify_the_iSCSI_service_is_enabled(request):
 @pytest.mark.dependency(name="iscsi_09")
 def test_09_Connecting_to_iSCSI_target(request):
     depends(request, ["iscsi_05"], scope='session')
-    cmd = f'iscsictl -A -p {ip}:3260 -t {basename}:{target_name}'
+    cmd = f'iscsictl -A -p {truenas_server.ip}:3260 -t {basename}:{target_name}'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, f"{results['output']}, {results['stderr']}"
 
@@ -388,7 +389,7 @@ def test_33_verify_the_iscsi_service_is_running(request):
 @pytest.mark.dependency(name="iscsi_34")
 def test_34_connecting_to_the_zvol_iscsi_target(request):
     depends(request, ["iscsi_32"])
-    cmd = f'iscsictl -A -p {ip}:3260 -t {basename}:{zvol_name}'
+    cmd = f'iscsictl -A -p {truenas_server.ip}:3260 -t {basename}:{zvol_name}'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'], f"{results['output']}, {results['stderr']}"
 
@@ -506,7 +507,7 @@ def test_46_disconnect_iscsi_zvol_target(request):
 @pytest.mark.dependency(name="iscsi_47")
 def test_47_connecting_to_the_zvol_iscsi_target(request):
     depends(request, ["iscsi_32"])
-    cmd = f'iscsictl -A -p {ip}:3260 -t {basename}:{zvol_name}'
+    cmd = f'iscsictl -A -p {truenas_server.ip}:3260 -t {basename}:{zvol_name}'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'], f"{results['output']}, {results['stderr']}"
 

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -5,18 +5,10 @@ import sys
 import os
 import time
 from pytest_dependency import depends
+from auto_config import pool_name
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import (
-    GET,
-    PUT,
-    POST,
-    DELETE,
-    SSH_TEST,
-    cmd_test,
-    wait_on_job
-)
-from auto_config import pool_name, ip, user, password
+from functions import GET, POST
 
 from middlewared.test.integration.assets.directory_service import ldap
 from middlewared.test.integration.assets.privilege import privilege

--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -6,8 +6,8 @@ import os
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
+from auto_config import pool_name
 from functions import POST, GET, PUT, DELETE, SSH_TEST
-from auto_config import user, password, pool_name
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.pool import dataset as make_dataset
 

--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job
-from auto_config import ip, pool_name, user, password
+from auto_config import pool_name, user, password
 from middlewared.client import ClientException
 from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.pool import dataset as dataset_asset

--- a/tests/api2/test_341_pool_dataset_encryption.py
+++ b/tests/api2/test_341_pool_dataset_encryption.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, PUT, wait_on_job, SSH_TEST
-from auto_config import ha, ip, password, user
+from auto_config import ha, password, user
 
 # genrated token_hex 32bit for
 pool_token_hex = secrets.token_hex(32)
@@ -67,7 +67,7 @@ def test_create_a_passphrase_encrypted_root_on_normal_pool(request):
 
 def test_verify_pool_dataset_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -180,7 +180,7 @@ def test_try_to_create_an_encrypted_dataset_with_inherit_encryption_true(request
 
 def test_verify_pool_encrypted_dataset_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -238,7 +238,7 @@ def test_create_an_encrypted_root_with_a_key(request):
 
 def test_verify_pool_encrypted_root_dataset_does_not_leak_encryption_key_into_middleware_log(request):
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -283,7 +283,7 @@ def test_verify_that_the_dataset_changed_to_passphrase(request):
 
 def test_verify_pool_dataset_change_key_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -456,7 +456,7 @@ def test_create_a_passphrase_encrypted_pool(request):
 
 def test_verify_pool_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_pool_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -487,7 +487,7 @@ def test_create_a_passphrase_encrypted_root_on_passphrase_encrypted_pool(request
 
 def test_verify_pool_encrypted_root_dataset_change_key_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -508,7 +508,7 @@ def test_try_to_change_a_passphrase_encrypted_root_to_key_on_passphrase_encrypte
 
 def test_verify_pool_dataset_change_key_does_not_leak_passphrase_into_middleware_log_after_key_change(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -565,7 +565,7 @@ def test_try_to_create_an_encrypted_root_with_key_on_passphrase_encrypted_pool(r
 
 def test_verify_pool_key_encrypted_dataset_does_not_leak_encryption_key_into_middleware_log(request):
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -610,7 +610,7 @@ def test_creating_a_key_encrypted_pool(request):
 
 def test_verify_pool_does_not_leak_encryption_key_into_middleware_log(request):
     cmd = f"""grep -R "{pool_token_hex}" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -639,7 +639,7 @@ def test_creating_a_key_encrypted_root_on_key_encrypted_pool(request):
 
 def test_verify_pool_dataset_does_not_leak_encryption_hex_key_into_middleware_log(request):
     cmd = f"""grep -R "{dataset_token_hex}" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -660,7 +660,7 @@ def test_change_a_key_encrypted_root_to_passphrase_on_key_encrypted_pool(request
 
 def test_verify_pool_encrypted_root_key_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -737,7 +737,7 @@ def test_unlock_passphrase_key_encrypted_datasets(request):
 
 def test_verify_pool_dataset_unlock_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -820,7 +820,7 @@ def test_create_a_passphrase_encrypted_root_dataset_parrent(request):
 
 def test_verify_pool_passphrase_encrypted_root_dataset_parrent_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -840,7 +840,7 @@ def test_create_a_passphrase_encrypted_root_child_of_passphrase_parent(request):
 
 def test_verify_encrypted_root_child_of_passphrase_parent_dataset_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase2" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -935,7 +935,7 @@ def test_try_to_unlock_the_child_of_lock_parent_encrypted_root(request):
 
 def test_verify_child_of_lock_parent_encrypted_root_dataset_unlock_do_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase2" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -987,10 +987,10 @@ def test_unlock_parent_dataset_with_child_recursively(request):
 
 def test_verify_pool_dataset_unlock_with_child_dataset_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
     cmd = """grep -R "my_passphrase2" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -1073,7 +1073,7 @@ def test_creating_a_key_encrypted_dataset_on_key_encrypted_pool(request):
 
 def test_verify_pool_encrypted_dataset_on_key_encrypted_pool_does_not_leak_encryption_key_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 
@@ -1093,7 +1093,7 @@ def test_create_a_passphrase_encrypted_root_from_key_encrypted_root(request):
 
 def test_verify_ncrypted_root_from_key_encrypted_root_does_not_leak_passphrase_into_middleware_log(request):
     cmd = """grep -R "my_passphrase" /var/log/middlewared.log"""
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is False, str(results['output'])
 
 

--- a/tests/api2/test_345_acl_nfs4.py
+++ b/tests/api2/test_345_acl_nfs4.py
@@ -10,7 +10,7 @@ import pytest
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
-from auto_config import ip, pool_name, user, password
+from auto_config import pool_name
 from pytest_dependency import depends
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user as create_user
@@ -327,21 +327,21 @@ def test_13_recursive_no_traverse(request):
     # INHERIT_ONLY should be set to False at this depth.
     acl_result = call('filesystem.getacl', f'/mnt/{ACLTEST_DATASET}/dir1', False)
     theacl = acl_result['acl']
-    assert theacl[0]['flags'] == expected_flags_0, results.text
-    assert theacl[1]['flags'] == expected_flags_1, results.text
+    assert theacl[0]['flags'] == expected_flags_0, acl_result 
+    assert theacl[1]['flags'] == expected_flags_1, acl_result
 
     # Verify that user was changed on subdirectory
-    assert acl_result['uid'] == 65534, results.text
+    assert acl_result['uid'] == 65534, acl_result
 
     # check on dir 2 - the no propogate inherit flag should have taken
     # effect and ACL length should be 1
     acl_result = call('filesystem.getacl', f'/mnt/{ACLTEST_DATASET}/dir1/dir2', False)
     theacl = acl_result['acl']
-    assert theacl[0]['flags'] == expected_flags_0, results.text
-    assert len(theacl) == 1, results.text
+    assert theacl[0]['flags'] == expected_flags_0, acl_result
+    assert len(theacl) == 1, acl_result
 
     # Verify that user was changed two deep
-    assert acl_result['uid'] == 65534, results.text
+    assert acl_result['uid'] == 65534, acl_result
 
 
 def test_14_recursive_with_traverse(request):
@@ -360,11 +360,11 @@ def test_14_recursive_with_traverse(request):
 
     acl_result = call('filesystem.getacl', f'/mnt/{ACLTEST_SUBDATASET}', True)
     theacl = acl_result['acl']
-    assert theacl[0]['flags'] == expected_flags_0, results.text
-    assert theacl[1]['flags'] == expected_flags_1, results.text
+    assert theacl[0]['flags'] == expected_flags_0, acl_result
+    assert theacl[1]['flags'] == expected_flags_1, acl_result
 
     # Verify that user was changed
-    assert acl_result['uid'] == 65534, results.text
+    assert acl_result['uid'] == 65534, acl_result
 
 
 def test_15_strip_acl_from_dataset(request):

--- a/tests/api2/test_347_posix_mode.py
+++ b/tests/api2/test_347_posix_mode.py
@@ -9,7 +9,7 @@ import stat
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
-from auto_config import ip, pool_name, user, password
+from auto_config import pool_name, user, password
 from pytest_dependency import depends
 
 MODE_DATASET = f'{pool_name}/modetest'

--- a/tests/api2/test_348_posix_acl.py
+++ b/tests/api2/test_348_posix_acl.py
@@ -9,7 +9,7 @@ import pytest
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST, wait_on_job
-from auto_config import ip, pool_name, user, password
+from auto_config import pool_name, user, password
 from pytest_dependency import depends
 
 

--- a/tests/api2/test_350_pool_dataset_quota_alert.py
+++ b/tests/api2/test_350_pool_dataset_quota_alert.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST
-from auto_config import ip, pool_name, user, password
+from auto_config import pool_name, user, password
 
 G = 1024 * 1024 * 1024
 

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -10,7 +10,7 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from protocols import smb_connection
 from utils import create_dataset
-from auto_config import ip, pool_name
+from auto_config import pool_name
 from middlewared.test.integration.assets.account import user, group
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.assets.pool import dataset as make_dataset
@@ -117,7 +117,7 @@ def test_019_change_sharing_smd_home_to_true_and_set_guestok_to_false(request):
     share_path = call('smb.getparm', 'path', new_info['name'])
     assert share_path == share['path_local']
     obey_pam_restrictions = call('smb.getparm', 'obey pam restrictions', 'GLOBAL')
-    assert obey_pam_restrictions == False
+    assert obey_pam_restrictions is False
 
 
 def test_034_change_timemachine_to_true(request):

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -11,7 +11,6 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, GET, SSH_TEST
 from auto_config import (
-    ip,
     user,
     password,
 )
@@ -19,6 +18,7 @@ from middlewared.test.integration.assets.account import user as create_user
 from middlewared.test.integration.assets.smb import copy_stream, get_stream, smb_share, smb_mount
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
 from pytest_dependency import depends
 from protocols import SMB, smb_connection
 from samba import ntstatus
@@ -732,7 +732,7 @@ def test_155_ssh_read_afp_xattr(request, xat):
 
 
 def test_175_check_external_path(request):
-    with smb_share(f'EXTERNAL:{ip}\\{SMB_NAME}', 'EXTERNAL'):
+    with smb_share(f'EXTERNAL:{truenas_server.ip}\\{SMB_NAME}', 'EXTERNAL'):
         with smb_connection(
             share=SMB_NAME,
             username=SMB_USER,

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -639,7 +639,7 @@ def test_151_set_xattr_via_ssh(request, xat):
     cmd += f'echo -n \"{AFPXattr[xat]["text"]}\" | base64 -d | '
     cmd += f'attr -q -s {xat} {afptestfile}'
 
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, {"cmd": cmd, "res": results['output']}
 
 
@@ -725,7 +725,7 @@ def test_155_ssh_read_afp_xattr(request, xat):
     smb_path = TEST_DATA['share']['path']
     afptestfile = f'{smb_path}/afp_xattr_testfile'
     cmd = f'attr -q -g {xat} {afptestfile} | base64'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results['output']
     xat_data = b64decode(results['stdout'])
     assert AFPXattr[xat]['bytes'] == xat_data, results['output']
@@ -747,7 +747,7 @@ def test_175_check_external_path(request):
         cmd += '-c "get external_test_file"'
         ssh(cmd)
 
-        results = SSH_TEST('cat external_test_file', user, password, ip)
+        results = SSH_TEST('cat external_test_file', user, password)
         assert results['result'] is True, results['output']
         assert results['stdout'] == 'EXTERNAL_TEST'
 

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -9,13 +9,13 @@ import subprocess
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import (
-    ip,
     pool_name,
 )
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
 from protocols import SMB
 from pytest_dependency import depends
 from time import sleep
@@ -210,7 +210,7 @@ def test_006_test_preserve_dynamic_id_mapping(request):
             sleep(5)
             cmd = [
                 'smbcacls',
-                f'//{ip}/DYNAMIC',
+                f'//{truenas_server.ip}/DYNAMIC',
                 '\\',
                 '-a', r'ACL:S-1-3-4:ALLOWED/0x0/FULL',
                 '-d', '0',

--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -5,7 +5,6 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import (ip, pool_name)
 from functions import GET, POST
 from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.account import user

--- a/tests/api2/test_430_smb_sharesec.py
+++ b/tests/api2/test_430_smb_sharesec.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call, client
 from functions import PUT, POST, GET, DELETE, SSH_TEST
-from auto_config import pool_name, user, password, ip
+from auto_config import user, password
 
 Guests = {
     "domain": "BUILTIN",
@@ -90,7 +90,7 @@ def test_06_set_smb_acl_by_sid(request):
         {'get': True}
     )['cifs_share_acl']
 
-    assert b64acl is not ""
+    assert b64acl != ""
 
     call('smb.sharesec.synchronize_acls')
 

--- a/tests/api2/test_438_snapshots.py
+++ b/tests/api2/test_438_snapshots.py
@@ -6,7 +6,7 @@ from middlewared.test.integration.assets.pool import dataset, snapshot
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import hostname, ip, pool_name
+from auto_config import pool_name
 from functions import DELETE, GET, POST, PUT, wait_on_job
 
 

--- a/tests/api2/test_450_staticroutes.py
+++ b/tests/api2/test_450_staticroutes.py
@@ -9,7 +9,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import DELETE, GET, POST, SSH_TEST
-from auto_config import user, password, ip
+from auto_config import user, password
 DESTINATION = '127.1.1.1'
 GATEWAY = '127.0.0.1'
 

--- a/tests/api2/test_470_system.py
+++ b/tests/api2/test_470_system.py
@@ -9,7 +9,6 @@ import sys
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ip
 from functions import GET, make_ws_request
 from middlewared.test.integration.utils import call
 

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -1,8 +1,9 @@
 from time import sleep
 
 import pytest
-from auto_config import ip, password, user
+from auto_config import password, user
 from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
 
 
 
@@ -17,7 +18,7 @@ def do_syslog(ident, message, facility='syslog.LOG_USER', priority='syslog.LOG_I
     ssh(cmd)
 
 
-def check_syslog(log_path, message, target_ip=ip, target_user=user, target_passwd=password, timeout=30):
+def check_syslog(log_path, message, target_ip=None, target_user=user, target_passwd=password, timeout=30):
     """
     Common function to check whether a particular message exists in a log file.
     This will be used to check local and remote syslog servers.
@@ -26,6 +27,7 @@ def check_syslog(log_path, message, target_ip=ip, target_user=user, target_passw
     onus is on test developer to not under-specify `message` in order to avoid
     false positives.
     """
+    target_ip = target_ip or truenas_server.ip
     sleep_time = 1
     while timeout > 0:
         found = ssh(

--- a/tests/api2/test_480_system_advanced.py
+++ b/tests/api2/test_480_system_advanced.py
@@ -8,7 +8,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, GET, SSH_TEST
-from auto_config import user, password, ip
+from auto_config import user, password
 MOTD = 'FREENAS_MOTD'
 SYSLOGLEVEL = "F_CRIT"
 
@@ -53,7 +53,7 @@ def test_04_system_advanced_check_serial_port_using_api(sysadv_dict):
 
 def test_05_system_advanced_check_serial_port_using_ssh(sysadv_dict, request):
     cmd = f'systemctl | grep "{sysadv_dict["serial_choices"][0]}"'
-    results = SSH_TEST(cmd, user, password, ip)
+    results = SSH_TEST(cmd, user, password)
     assert results['result'] is True, results
 
 
@@ -67,7 +67,7 @@ def test_06_system_advanced_disable_serial_port():
 
 
 def test_07_system_advanced_check_disabled_serial_port_using_ssh(sysadv_dict, request):
-    results = SSH_TEST(f'cat /boot/loader.conf.local | grep "{sysadv_dict["serial_choices"][0]}"', user, password, ip)
+    results = SSH_TEST(f'cat /boot/loader.conf.local | grep "{sysadv_dict["serial_choices"][0]}"', user, password)
     assert results['result'] is False, results
 
 
@@ -89,7 +89,7 @@ def test_09_system_advanced_check_motd_using_api():
 
 
 def test_10_system_advanced_check_motd_using_ssh(request):
-    results = SSH_TEST(f'cat /etc/motd | grep "{MOTD}"', user, password, ip)
+    results = SSH_TEST(f'cat /etc/motd | grep "{MOTD}"', user, password)
     assert results['result'] is True, results
 
 

--- a/tests/api2/test_490_system_general.py
+++ b/tests/api2/test_490_system_general.py
@@ -11,7 +11,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import PUT, GET, SSH_TEST
-from auto_config import user, password, ip
+from auto_config import user, password
 TIMEZONE = "America/New_York"
 
 
@@ -64,5 +64,5 @@ def test_07_Checking_timezone_using_api():
 
 def test_08_Checking_timezone_using_ssh(request):
     results = SSH_TEST(f'diff /etc/localtime /usr/share/zoneinfo/{TIMEZONE}',
-                       user, password, ip)
+                       user, password)
     assert results['result'] is True, results

--- a/tests/api2/test_500_system_ntpservers.py
+++ b/tests/api2/test_500_system_ntpservers.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import badNtpServer, ip, password, user
+from auto_config import badNtpServer, password, user
 from functions import DELETE, GET, POST, PUT, SSH_TEST
 
 CONFIG_FILE = '/etc/chrony/chrony.conf'
@@ -65,7 +65,7 @@ class TestBadNtpServer:
 
     def test_03_Checking_ntpserver_configured_using_ssh(self, request):
         cmd = f'fgrep "{badNtpServer}" {CONFIG_FILE}'
-        results = SSH_TEST(cmd, user, password, ip)
+        results = SSH_TEST(cmd, user, password)
         assert results['result'] is True, results
 
     def test_04_Check_ntpservers(self, ntp_dict):
@@ -87,7 +87,7 @@ class TestBadNtpServer:
             ntp_dict['servers'].pop(k)
 
     def test_06_Checking_ntpservers_num_configured_using_ssh(self, ntp_dict, request):
-        results = SSH_TEST(f'grep -R ^server {CONFIG_FILE}', user, password, ip)
+        results = SSH_TEST(f'grep -R ^server {CONFIG_FILE}', user, password)
         assert results['result'] is True, results
         assert len(results['stdout'].strip().split('\n')) == \
             len(ntp_dict['servers']), results['output']

--- a/tests/api2/test_550_vmware.py
+++ b/tests/api2/test_550_vmware.py
@@ -10,7 +10,7 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, SSH_TEST
-from auto_config import ip, user, password
+from auto_config import user, password
 
 try:
     Reason = 'VMWARE credentials credential is missing'
@@ -40,5 +40,5 @@ if vmw_credentials:
     def test_03_verify_vmware_get_datastore_do_not_leak_password(request):
         cmd = f"grep -R \"{os.environ['VMWARE_PASSWORD']}\" " \
             "/var/log/middlewared.log"
-        results = SSH_TEST(cmd, user, password, ip)
+        results = SSH_TEST(cmd, user, password)
         assert results['result'] is False, str(results['output'])

--- a/tests/api2/test_790_update.py
+++ b/tests/api2/test_790_update.py
@@ -10,8 +10,9 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, SSH_TEST, vm_state, vm_start, ping_host
-from auto_config import vm_name, ip, user, password, update
+from auto_config import vm_name, user, password, update
 from time import sleep
+from middlewared.test.integration.utils.client import truenas_server
 
 url = "https://raw.githubusercontent.com/iXsystems/ixbuild/master/prepnode/"
 
@@ -22,9 +23,9 @@ if update:
         fetch_cmd = f'fetch {url}{update_conf}'
         mv_cmd = f'mv {update_conf} /data/update.conf'
         if 'INTERNAL' in version:
-            results = SSH_TEST(fetch_cmd, user, password, ip)
+            results = SSH_TEST(fetch_cmd, user, password)
             assert results['result'] is True, results['output']
-            results = SSH_TEST(mv_cmd, user, password, ip)
+            results = SSH_TEST(mv_cmd, user, password)
             assert results['result'] is True, results['output']
         assert True
 
@@ -151,9 +152,9 @@ if update:
         if reboot is False:
             pytest.skip('Reboot is False skip')
         else:
-            while ping_host(ip, 1) is not True:
+            while ping_host(truenas_server.ip, 1) is not True:
                 sleep(5)
-            assert ping_host(ip, 1) is True
+            assert ping_host(truenas_server.ip, 1) is True
         sleep(10)
 
     def test_14_verify_initial_version_is_not_current_FreeNAS_version(request):

--- a/tests/api2/test_900_docs.py
+++ b/tests/api2/test_900_docs.py
@@ -9,9 +9,9 @@ from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import SSH_TEST
-from auto_config import ip, user, password
+from auto_config import user, password
 
 
 def test_core_get_methods(request):
-    results = SSH_TEST("midclt call core.get_methods", user, password, ip)
+    results = SSH_TEST("midclt call core.get_methods", user, password)
     assert results['result'] is True, results

--- a/tests/api2/test_999_pool_dataset_unlock.py
+++ b/tests/api2/test_999_pool_dataset_unlock.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_dependency import depends
 from samba import ntstatus, NTSTATUSError
 
-from auto_config import ip, pool_name, password, user
+from auto_config import pool_name, password, user
 from functions import POST, DELETE, SSH_TEST, wait_on_job
 from protocols import SMB
 
@@ -126,13 +126,13 @@ def test_pool_dataset_unlock_smb(request, toggle_attachments):
             with dataset("encrypted", passphrase_encryption()) as encrypted:
                 with smb_share("encrypted", f"/mnt/{encrypted}"):
                     cmd = f"touch /mnt/{encrypted}/secret"
-                    results = SSH_TEST(cmd, user, password, ip)
+                    results = SSH_TEST(cmd, user, password)
                     assert results['result'] is True, results['output']
                     results = POST("/service/start/", {"service": "cifs"})
                     assert results.status_code == 200, results.text
                     lock_dataset(encrypted)
                     # Mount test SMB share
-                    with smb_connection(host=ip, share="normal") as normal_connection:
+                    with smb_connection(share="normal") as normal_connection:
                         # Locked share should not be mountable
                         with pytest.raises(NTSTATUSError) as e:
                             with smb_connection(host=ip, share="encrypted"):
@@ -148,12 +148,12 @@ def test_pool_dataset_unlock_smb(request, toggle_attachments):
 
                     if toggle_attachments:
                         # We should be able to mount encrypted share
-                        with smb_connection(host=ip, share="encrypted") as encrypted_connection:
+                        with smb_connection(share="encrypted") as encrypted_connection:
                             assert [x["name"] for x in encrypted_connection.ls("")] == ["secret"]
                     else:
                         # We should still not be able to mount encrypted share as we did not reload attachments
                         with pytest.raises(NTSTATUSError) as e:
-                            with smb_connection(host=ip, share="encrypted"):
+                            with smb_connection(share="encrypted"):
                                 pass
 
                         assert e.value.args[0] == ntstatus.NT_STATUS_BAD_NETWORK_NAME

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -6,10 +6,11 @@ import pytest
 import sys
 sys.path.append(os.getcwd())
 from functions import POST, GET, DELETE, SSH_TEST
-from auto_config import password, user as user_, ip
+from auto_config import password, user as user_
 
 from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.utils import call, client
+from middlewared.test.integration.utils.client import truenas_server
 
 
 @contextlib.contextmanager
@@ -32,10 +33,11 @@ def user():
 
 def test_root_api_key_websocket(request):
     """We should be able to call a method with root API key using Websocket."""
+    ip = truenas_server.ip
     with api_key([{"method": "*", "resource": "*"}]) as key:
         with user():
             cmd = f"sudo -u testuser midclt -u ws://{ip}/websocket --api-key {key} call system.info"
-            results = SSH_TEST(cmd, user_, password, ip)
+            results = SSH_TEST(cmd, user_, password)
         assert results['result'] is True, f'out: {results["output"]}, err: {results["stderr"]}'
         assert 'uptime' in str(results['stdout'])
 
@@ -53,20 +55,22 @@ def test_root_api_key_websocket(request):
 
 def test_allowed_api_key_websocket(request):
     """We should be able to call a method with API key that allows that call using Websocket."""
+    ip = truenas_server.ip
     with api_key([{"method": "CALL", "resource": "system.info"}]) as key:
         with user():
             cmd = f"sudo -u testuser midclt -u ws://{ip}/websocket --api-key {key} call system.info"
-            results = SSH_TEST(cmd, user_, password, ip)
+            results = SSH_TEST(cmd, user_, password)
         assert results['result'] is True, f'out: {results["output"]}, err: {results["stderr"]}'
         assert 'uptime' in str(results['stdout'])
 
 
 def test_denied_api_key_websocket(request):
     """We should not be able to call a method with API key that does not allow that call using Websocket."""
+    ip = truenas_server.ip
     with api_key([{"method": "CALL", "resource": "system.info_"}]) as key:
         with user():
             cmd = f"sudo -u testuser midclt -u ws://{ip}/websocket --api-key {key} call system.info"
-            results = SSH_TEST(cmd, user_, password, ip)
+            results = SSH_TEST(cmd, user_, password)
         assert results['result'] is False
 
 

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -1,4 +1,3 @@
-from auto_config import ip
 from middlewared.test.integration.assets.account import user, unprivileged_user_client
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share

--- a/tests/api2/test_auth_token.py
+++ b/tests/api2/test_auth_token.py
@@ -8,10 +8,10 @@ import os
 import sys
 sys.path.append(os.getcwd())
 from functions import GET
-from auto_config import ip
 
 from middlewared.test.integration.assets.account import unprivileged_user as unprivileged_user_template
 from middlewared.test.integration.utils import call, client, ssh
+from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.shell import assert_shell_works
 
 
@@ -27,7 +27,7 @@ def test_download_auth_token_cannot_be_used_for_restful_api_call(download_token)
 
 def test_download_auth_token_cannot_be_used_for_upload(download_token):
     r = requests.post(
-        f"http://{ip}/_upload",
+        f"http://{truenas_server.ip}/_upload",
         headers={"Authorization": f"Token {download_token}"},
         data={
             "data": json.dumps({

--- a/tests/api2/test_rest_api_authentication.py
+++ b/tests/api2/test_rest_api_authentication.py
@@ -9,12 +9,12 @@ import requests
 from middlewared.test.integration.assets.account import unprivileged_user as unprivileged_user_template
 from middlewared.test.integration.assets.api_key import api_key
 from middlewared.test.integration.utils import client
+from middlewared.test.integration.utils.client import truenas_server
 
 import os
 import sys
 sys.path.append(os.getcwd())
 from functions import POST, GET, DELETE, SSH_TEST
-from auto_config import password, ip
 
 
 @contextlib.contextmanager
@@ -86,6 +86,7 @@ def test_denied_api_key_rest(auth):
 
 def test_root_api_key_upload(auth):
     """We should be able to call a method with root a credential using file upload endpoint."""
+    ip = truenas_server.ip
     with auth([{"method": "*", "resource": "*"}]) as kwargs:
         kwargs.pop("anonymous", None)  # This key is only used for our test requests library
         r = requests.post(
@@ -107,6 +108,7 @@ def test_root_api_key_upload(auth):
 
 def test_allowed_api_key_upload(auth):
     """We should be able to call a method with an API that allows that call using file upload endpoint."""
+    ip = truenas_server.ip
     with auth([{"method": "CALL", "resource": "filesystem.put"}]) as kwargs:
         kwargs.pop("anonymous", None)  # This key is only used for our test requests library
         r = requests.post(
@@ -130,6 +132,7 @@ def test_denied_api_key_upload(auth):
     """
     We should not be able to call a method with a credential that does not allow that call using file upload endpoint.
     """
+    ip = truenas_server.ip
     with auth([{"method": "CALL", "resource": "filesystem.put_"}]) as kwargs:
         kwargs.pop("anonymous", None)  # This key is only used for our test requests library
         r = requests.post(

--- a/tests/api2/test_vmware.py
+++ b/tests/api2/test_vmware.py
@@ -12,13 +12,13 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.snapshot_task import snapshot_task
 from middlewared.test.integration.assets.vmware import vmware
 from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils.client import truenas_server
 from middlewared.test.integration.utils.string import random_string
 
 import os
 import sys
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ip
 
 try:
     from config import (
@@ -156,7 +156,7 @@ def test_vmware():
                 for rds in result["datastores"]:
                     if (
                         rds["name"] == ds.name and
-                        rds["description"] == f"NFS mount '/mnt/{ds.dataset}' on {ip}" and
+                        rds["description"] == f"NFS mount '/mnt/{ds.dataset}' on {truenas_server.ip}" and
                         rds["filesystems"] == [ds.dataset]
                     ):
                         break

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -238,8 +238,6 @@ cfg_content = f"""#!{sys.executable}
 
 user = "root"
 password = "{passwd}"
-ip = "{ip}"
-ip2 = "{ip2}"
 netmask = "{netmask}"
 gateway = "{gateway}"
 vip = "{vip}"


### PR DESCRIPTION
This commit fixes many tests that are failing on HA after a failover happens due to using hard-coded controller IP address rather than the virtual IP address.