### PR TITLE
NAS-128590 / 24.04.1 / Fix Range validator args (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -112,10 +112,10 @@ def get_schema(variable_details, update, existing=NOT_PROVIDED):
             obj.enum = [v['value'] for v in schema_details['enum']]
 
         if schema_class == Str:
-            if range_args.get('max'):
+            if range_args.get('max_'):
                 # This needs to be done as string schema has built in support for max length as
                 # well apart from the range validator we add
-                obj.max_length = range_args['max']
+                obj.max_length = range_args['max_']
             if 'valid_chars' in schema_details:
                 obj.validators.append(Match(
                     schema_details['valid_chars'], explanation=schema_details.get('valid_chars_error')

--- a/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_releases_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/chart_releases/test_chart_releases_schema.py
@@ -1,7 +1,13 @@
+import pytest
+import random
+import string
 import yaml
 
 from middlewared.plugins.chart_releases_linux.schema import get_schema
+from middlewared.service_exception import ValidationErrors
 
+
+random_string = "".join(random.choices(string.ascii_letters, k=2048))
 
 questions = yaml.safe_load("""
 variable: config
@@ -30,6 +36,23 @@ schema:
               immutable: true
 """)
 
+yaml_string = """
+variable: config
+schema:
+  type: dict
+  attrs:
+    - variable: test_string1
+      schema:
+        type: string
+        max_length: 1024
+    - variable: test_string2
+      schema:
+        type: string
+        max_length: 3072
+"""
+
+string_max_length_test = yaml.safe_load(yaml_string)
+
 
 def test__get_schema__handles_immutable():
     schema = get_schema(questions, True, {
@@ -44,3 +67,13 @@ def test__get_schema__handles_immutable():
 
     assert schema[0].attrs["advanced"].attrs["mtu"].default == "9000"
     assert schema[0].attrs["advanced"].attrs["mtu"].editable is False
+
+
+def test__string_schema__max_length():
+    schema = get_schema(string_max_length_test, True)[0].attrs
+
+    with pytest.raises(ValidationErrors) as e:
+        schema["test_string1"].validate(random_string)
+
+    assert e.value.errors[0].errmsg == "The value may not be longer than 1024 characters"
+    assert schema["test_string2"].validate(random_string) is None


### PR DESCRIPTION
This commit fixes an issue where when we change max to max_ in middleware api for validators, this change was not addressed.

Original PR: https://github.com/truenas/middleware/pull/13705
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128590