### PR TITLE
NAS-128998 / 24.04.1 / prevent middleware service from starting when config is reset (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -23,7 +23,7 @@ class ReportingService(Service):
             return
 
         try:
-            self.NETDATA_GID = await self.middleware.call('group.get_builtin_user_id', NETDATA_GROUPNAME)
+            self.NETDATA_GID = await self.middleware.call('group.get_builtin_group_id', NETDATA_GROUPNAME)
         except Exception:
             self.logger.error('Unexpected failure resolving groupname %r to gid', NETDATA_GROUPNAME, exc_info=True)
             return

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -3,6 +3,8 @@ import os
 from middlewared.service import lock, private, Service
 from middlewared.utils.shutil import rmtree_one_filesystem
 
+NETDATA_USERNAME = NETDATA_GROUPNAME = 'netdata'
+
 
 class ReportingService(Service):
 
@@ -11,9 +13,8 @@ class ReportingService(Service):
 
     @private
     async def cache_netdata_uid_gid(self):
-        user_obj = await self.middleware.call('user.get_user_obj', {'username': 'netdata'})
-        self.NETDATA_UID = user_obj['pw_uid']
-        self.NETDATA_GID = user_obj['pw_gid']
+        self.NETDATA_UID = await self.middleware.call('user.get_builtin_user_id', NETDATA_USERNAME)
+        self.NETDATA_GID = await self.middleware.call('group.get_builtin_user_id', NETDATA_GROUPNAME)
 
     @private
     def netdata_storage_location(self):

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -19,12 +19,20 @@ class ReportingService(Service):
         try:
             self.NETDATA_UID = await self.middleware.call('user.get_builtin_user_id', NETDATA_USERNAME)
         except Exception:
+            # unhandled error so we'll set to -1 because
+            # chown'ing with this value is handled specially
+            # which means no perms will be altered on disk
+            self.NETDATA_UID = -1
             self.logger.error('Unexpected failure resolving username %r to uid', NETDATA_USERNAME, exc_info=True)
             return
 
         try:
             self.NETDATA_GID = await self.middleware.call('group.get_builtin_group_id', NETDATA_GROUPNAME)
         except Exception:
+            # unhandled error so we'll set to -1 because
+            # chown'ing with this value is handled specially
+            # which means no perms will be altered on disk
+            self.NETDATA_GID = -1
             self.logger.error('Unexpected failure resolving groupname %r to gid', NETDATA_GROUPNAME, exc_info=True)
             return
 


### PR DESCRIPTION
If someone resets the configuration database to defaults, middlewared service will not start-up on config upload. The reason why is because the netdata plugin isn't handling this specific case. This does 2 things:

1. be extra safe and catch all exceptions here so that we don't prevent the middlewared service from starting
2. use the proper methods to return the builtin user `netdata`

Original PR: https://github.com/truenas/middleware/pull/13727
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128998