### PR TITLE
NAS-129012 / 24.04.1 / fix swapoff typo

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -200,7 +200,7 @@ class DiskService(Service):
         # NOTE: We disable swap partitions by default. See NAS-128873 for details.
         # If the user wants to re-enable the swap partition(s), they will need to
         # run "swapon -a" manually (or in a post-init script).
-        await run('swapoff -a', check=False)
+        await run('swapoff -a', check=False, shell=True)
 
         return existing_swap_devices['partitions'] + existing_swap_devices['mirrors'] + created_swap_devices
 


### PR DESCRIPTION
This crashes with `FileNotFoundError` because the argument to the function is a string. 