### PR TITLE
NAS-128988 / 24.04.2 / disable swap by default (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -197,6 +197,11 @@ class DiskService(Service):
             else:
                 existing_swap_devices['partitions'] = []
 
+        # NOTE: We disable swap partitions by default. See NAS-128873 for details.
+        # If the user wants to re-enable the swap partition(s), they will need to
+        # run "swapon -a" manually (or in a post-init script).
+        await run('swapoff -a', check=False)
+
         return existing_swap_devices['partitions'] + existing_swap_devices['mirrors'] + created_swap_devices
 
     @private


### PR DESCRIPTION
This is a safety belt for 24.04.1. A more involved and proper fix will follow but this solves the immediate issue.

NOTE: if a user wants to re-enable the swap partition(s), they will need to run `swapon -a` manually or use a post-init script (which is what the overwhelming majority of users are doing on the forums, except they're doing `swapoff -a` :smile: )

Original PR: https://github.com/truenas/middleware/pull/13710
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128988