### PR TITLE
NAS-129019 / 24.10 / More statx improvements

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -560,7 +560,7 @@ class FilesystemService(Service):
             fd = os.open(path, os.O_PATH)
             try:
                 st = os.fstatvfs(fd)
-                mntid = stat_x.statx('', {'dir_fd': fd, 'flags': stat_x.ATFlags.EMPTY_PATH}).stx_mnt_id
+                mntid = stat_x.statx('', dir_fd=fd, flags=stat_x.ATFlags.EMPTY_PATH.value).stx_mnt_id
             finally:
                 os.close(fd)
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_statx.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_statx.py
@@ -96,7 +96,7 @@ def test__check_statx_empty_path(tmpdir):
     stx1 = sx.statx(testfile)
     try:
         fd = os.open(testfile, os.O_PATH)
-        stx2 = sx.statx('', dir_fd=fd, flags=sx.ATFlags.EMPTY_PATH)
+        stx2 = sx.statx('', dir_fd=fd, flags=sx.ATFlags.EMPTY_PATH.value)
     finally:
         os.close(fd)
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_statx.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_statx.py
@@ -80,7 +80,7 @@ def test__check_dirfd(tmpdir):
     stx1 = sx.statx(testfile)
     try:
         dirfd = os.open(tmpdir, os.O_PATH)
-        stx2 = sx.statx('testfile', {'dir_fd': dirfd})
+        stx2 = sx.statx('testfile', dir_fd=dirfd)
     finally:
         os.close(dirfd)
 
@@ -96,7 +96,7 @@ def test__check_statx_empty_path(tmpdir):
     stx1 = sx.statx(testfile)
     try:
         fd = os.open(testfile, os.O_PATH)
-        stx2 = sx.statx('', {'dir_fd': fd, 'flags': sx.ATFlags.EMPTY_PATH})
+        stx2 = sx.statx('', dir_fd=fd, flags=sx.ATFlags.EMPTY_PATH)
     finally:
         os.close(fd)
 

--- a/src/middlewared/middlewared/utils/filesystem/directory.py
+++ b/src/middlewared/middlewared/utils/filesystem/directory.py
@@ -212,7 +212,7 @@ class DirectoryIterator():
         while (st := self.__check_dir_entry(dirent)) is None:
             dirent = next(self.__path_iter)
 
-        if request_mask == 0:
+        if self.__request_mask == 0:
             # Skip an unnecessary file open/close if we only need stat info
             return self.__return_fn(dirent, st, None, None, None, None, None)
 

--- a/src/middlewared/middlewared/utils/filesystem/directory.py
+++ b/src/middlewared/middlewared/utils/filesystem/directory.py
@@ -212,6 +212,10 @@ class DirectoryIterator():
         while (st := self.__check_dir_entry(dirent)) is None:
             dirent = next(self.__path_iter)
 
+        if request_mask == 0:
+            # Skip an unnecessary file open/close if we only need stat info
+            return self.__return_fn(dirent, st, None, None, None, None, None)
+
         try:
             fd = os.open(dirent.name, os.O_RDONLY, dir_fd=self.dir_fd)
         except FileNotFoundError:

--- a/src/middlewared/middlewared/utils/filesystem/stat_x.py
+++ b/src/middlewared/middlewared/utils/filesystem/stat_x.py
@@ -122,8 +122,10 @@ __statx_default_mask = int(Mask.BASIC_STATS | Mask.BTIME)
 __statx_lstat_flags = int(ATFlags.STATX_SYNC_AS_STAT | ATFlags.SYMLINK_NOFOLLOW)
 
 
-def statx(path, dir_fd=AT_FDCWD, flags=ATFlags.STATX_SYNC_AS_STAT.value):
+def statx(path, dir_fd=None, flags=ATFlags.STATX_SYNC_AS_STAT.value):
     path = path.encode() if isinstance(path, str) else path
+
+    dir_fd = dir_fd or AT_FDCWD
 
     if dir_fd == AT_FDCWD and flags & ATFlags.EMPTY_PATH.value:
         raise ValueError('dir_fd is required when using AT_EMPTY_PATH')
@@ -141,7 +143,7 @@ def statx(path, dir_fd=AT_FDCWD, flags=ATFlags.STATX_SYNC_AS_STAT.value):
         return data
 
 
-def statx_entry_impl(entry, dir_fd=AT_FDCWD, get_ctldir=True):
+def statx_entry_impl(entry, dir_fd=None, get_ctldir=True):
     """
     This is a convenience wrapper around stat_x that was originally
     located within the filesystem plugin

--- a/src/middlewared/middlewared/utils/filesystem/stat_x.py
+++ b/src/middlewared/middlewared/utils/filesystem/stat_x.py
@@ -133,7 +133,7 @@ def statx(path, dir_fd=AT_FDCWD, flags=ATFlags.STATX_SYNC_AS_STAT.value):
         raise ValueError(f'{hex(invalid_flags)}: unsupported statx flags')
 
     data = StructStatx()
-    result = __statx_fn(dirfd, path, flags, __statx_default_mask, ctypes.byref(data))
+    result = __statx_fn(dir_fd, path, flags, __statx_default_mask, ctypes.byref(data))
     if result < 0:
         err = ctypes.get_errno()
         raise OSError(err, os.strerror(err))


### PR DESCRIPTION
Bitwise comparisons with IntFlag enum types can incur significant cost if performing it repeatedly since it requires creating a new enum instance. Avoid this where possible. This also improves API for statx to make it more consistent with syscall interface.