### PR TITLE
NAS-129027 / 24.10 / Add some tests to check the state of things before all tests are done

### DIFF
--- a/tests/api2/test_zzz_tests_completed.py
+++ b/tests/api2/test_zzz_tests_completed.py
@@ -1,0 +1,12 @@
+import faulthandler
+import threading
+
+
+def test__thread_count(request):
+    """Having outstanding threads can prevent python from exiting cleanly."""
+    count = threading.active_count()
+    if count > 1:
+        faulthandler.dump_traceback()
+        with open('threads.trace', 'w') as f:
+            faulthandler.dump_traceback(f)
+        assert count == 1


### PR DESCRIPTION
We have noticed some CI runs stalling right at the end of the `pytest` run.

For example, the following might have been printed to the console
```
...
...
= 50 failed, 1823 passed, 241 skipped, 4 warnings, 52 errors, 2 rerun in 10048.89s (2:47:28) =
```

Examination of the CI host system shows that the `pytest` command was still running.  It appears that that it stalled during its exit.  One potential cause for this is non-daemon threads that are still running.

This (pseudo) test is to gather some information immediately before finishing a `pytest` run.  Hopefully it will aide us track down the source of the stalls (if indeed caused by threads).
