### PR TITLE
NAS-129028 / 24.10 / Reintroduce device.settle_udev_events to avoid race

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -46,6 +46,10 @@ class DiskService(Service):
         part.name = 'data'  # give a human readable name to the label
         parted_disk.addPartition(part, constraint=dev.optimalAlignedConstraint)
         parted_disk.commit()
+
+        # Found that this was necessary to avoid a possible race wrt disk.get_partitions_quick
+        self.middleware.call_sync('device.settle_udev_events')
+
         if len(self.middleware.call_sync('disk.get_partitions_quick', disk)) != len(parted_disk.partitions):
             # In some rare cases udev does not re-read the partition table correctly; force it
             self.middleware.call_sync('device.trigger_udev_events', f'/dev/{disk}')


### PR DESCRIPTION
Found that CI test `test_002_create_permanent_zpool` started (intermittently) failing recently (following PR #13695 I believe).

The headline was
```
AssertionError: Unable to create test pool: ClientException("[Errno 2] No such file or directory: '/sys/block/sdf/sdf1/start'"). Aborting tests.
```

Reintroducing the `device.settle_udev_events` call removed in the above PR seems to rectify the issue.

----
Tested in CI runs #[399 ](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/399/) and #[400](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/400/)