### PR TITLE
NAS-129033 / 24.04.2 / Fix CallError arguments in ACL plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_linux.py
@@ -155,8 +155,7 @@ class FilesystemService(Service, ACLBase):
             check=False
         )
         if stripacl.returncode != 0:
-            raise CallError("Failed to strip ACL on path: %s",
-                            stripacl.stderr.decode())
+            raise CallError(f"{path}: Failed to strip ACL on path: {stripacl.stderr.decode()}")
 
         return
 
@@ -247,8 +246,7 @@ class FilesystemService(Service, ACLBase):
             check=False
         )
         if getacl.returncode != 0:
-            raise CallError("Failed to get ACL for path [%s]: %s",
-                            path, getacl.stderr.decode())
+            raise CallError(f"Failed to get ACL for path [{path}]: {getacl.stderr.decode()}")
 
         output = json.loads(getacl.stdout.decode())
         for ace in output['acl']:


### PR DESCRIPTION
It appears that there were a few instances where we had converted log messages to CallError without converting to an fstring.

Original PR: https://github.com/truenas/middleware/pull/13739
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129033