### PR TITLE
NAS-129038 / 24.10 / Add synchronous version of standard path validator

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -1,10 +1,6 @@
 import asyncio
-import os
 import socket
-from pathlib import Path
 
-from middlewared.plugins.zfs_.utils import ZFSCTL
-from middlewared.utils.path import path_location
 from middlewared.validators import IpAddress, check_path_resides_within_volume_sync
 
 

--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -4,12 +4,15 @@ import socket
 from middlewared.validators import IpAddress, check_path_resides_within_volume_sync
 
 
-async def check_path_resides_within_volume(verrors, middleware, name, path):
+async def check_path_resides_within_volume(verrors, middleware, schema_name, path):
     """
     async wrapper around synchronous general-purpose path validation function
     """
     vol_names = [vol["vol_name"] for vol in await middleware.call("datastore.query", "storage.volume")]
-    return await middleware.run_in_thread(check_path_resides_within_volume_sync, verrors, name, path, vol_names)
+    return await middleware.run_in_thread(
+        check_path_resides_within_volume_sync,
+        verrors, schema_name, path, vol_names
+    )
 
 
 async def resolve_hostname(middleware, verrors, name, hostname):

--- a/src/middlewared/middlewared/pytest/unit/test_validators.py
+++ b/src/middlewared/middlewared/pytest/unit/test_validators.py
@@ -52,6 +52,7 @@ def setup_mnt(tmpdir):
         yield
     finally:
         shutil.rmtree('/mnt/pool')
+        os.rmdir('/mnt/foo')
 
 
 @pytest.mark.parametrize("path,should_raise", [

--- a/src/middlewared/middlewared/pytest/unit/test_validators.py
+++ b/src/middlewared/middlewared/pytest/unit/test_validators.py
@@ -58,7 +58,7 @@ def setup_mnt(tmpdir):
     ('/mnt/does_not_exist', True),
     ('/mnt/pool/foo', False),
     ('/mnt/pool', False),
-    ('/mnt/pool//symlink', True)
+    ('/mnt/pool/symlink', True)
 ])
 def test___check_path_resides_within_volume(setup_mnt, path, should_raise):
     volumes = ['pool']

--- a/src/middlewared/middlewared/pytest/unit/test_validators.py
+++ b/src/middlewared/middlewared/pytest/unit/test_validators.py
@@ -1,7 +1,10 @@
+import os
+import shutil
 import pytest
 
 from middlewared.schema import Dict, Int, Str
-from middlewared.validators import validate_schema, Range, Email
+from middlewared.service_exception import ValidationErrors
+from middlewared.validators import check_path_resides_within_volume_sync, validate_schema, Range, Email
 
 
 @pytest.mark.parametrize("schema,data,result", [
@@ -37,3 +40,32 @@ def test__email_schema(email, should_raise):
     else:
         with pytest.raises(ValueError):
             Email()(email)
+
+
+@pytest.fixture(scope="function")
+def setup_mnt(tmpdir):
+    os.makedirs('/mnt/pool/foo')
+    try:
+        os.symlink(tmpdir, '/mnt/pool/symlink')
+        yield
+    finally:
+        shutil.rmtree('/mnt/pool')
+
+
+@pytest.mark.parametrize("path,should_raise", [
+    ('/tmp', True),
+    ('EXTERNAL://smb_server.local/SHARE', True),
+    ('/mnt/does_not_exist', True),
+    ('/mnt/pool/foo', False),
+    ('/mnt/pool', False),
+    ('/mnt/pool//symlink', True)
+])
+def test___check_path_resides_within_volume(setup_mnt, path, should_raise):
+    volumes = ['pool']
+    verr = ValidationErrors()
+    check_path_resides_within_volume_sync(verr, "test.path", path, volumes)
+    if should_raise:
+        with pytest.raises(ValidationErrors):
+            verr.check()
+    else:
+        verr.check()

--- a/src/middlewared/middlewared/pytest/unit/test_validators.py
+++ b/src/middlewared/middlewared/pytest/unit/test_validators.py
@@ -45,8 +45,10 @@ def test__email_schema(email, should_raise):
 @pytest.fixture(scope="function")
 def setup_mnt(tmpdir):
     os.makedirs('/mnt/pool/foo')
+    os.mkdir('/mnt/foo')
     try:
         os.symlink(tmpdir, '/mnt/pool/symlink')
+        os.symlink('/mnt/foo', '/mnt/pool/symlink2')
         yield
     finally:
         shutil.rmtree('/mnt/pool')
@@ -56,9 +58,12 @@ def setup_mnt(tmpdir):
     ('/tmp', True),
     ('EXTERNAL://smb_server.local/SHARE', True),
     ('/mnt/does_not_exist', True),
+    ('/mnt/foo', True),
     ('/mnt/pool/foo', False),
     ('/mnt/pool', False),
-    ('/mnt/pool/symlink', True)
+    ('/mnt/pool/..', True),
+    ('/mnt/pool/symlink', True),
+    ('/mnt/pool/symlink2', True)
 ])
 def test___check_path_resides_within_volume(setup_mnt, path, should_raise):
     volumes = ['pool']

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -7,8 +7,8 @@ import uuid
 from string import digits, ascii_uppercase, ascii_lowercase, punctuation
 from pathlib import Path
 
-from middlewared.plugins.zfs_.utils import ZFSCTL
 from middlewared.utils import filters
+from midddlewared.utils.filesystem.constants import ZFSCTL
 from middlewared.utils.path import path_location
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
@@ -415,7 +415,7 @@ def check_path_resides_within_volume_sync(verrors, schema_name, path, vol_names)
     ):
         verrors.add(schema_name, "The path must reside within a pool mount point")
 
-    if inode in (ZFSCTL.INO_ROOT, ZFSCTL.INO_SNAPDIR):
+    if inode in (ZFSCTL.INO_ROOT.value, ZFSCTL.INO_SNAPDIR.value):
         verrors.add(schema_name,
                     "The ZFS control directory (.zfs) and snapshot directory (.zfs/snapshot) "
                     "are not permitted paths. If a snapshot within this directory must "

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -396,7 +396,7 @@ def check_path_resides_within_volume_sync(verrors, schema_name, path, vol_names)
     * path is not explicitly a `.zfs` or `.zfs/snapshot` directory
     * path is not ix-applications dataset
     """
-    if path_location(path) == 'EXTERNAL':
+    if path_location(path).name == 'EXTERNAL':
         # There are some fields where we allow external paths
         verrors.add(schema_name, "Path is external to TrueNAS.")
         return

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -8,7 +8,7 @@ from string import digits, ascii_uppercase, ascii_lowercase, punctuation
 from pathlib import Path
 
 from middlewared.utils import filters
-from midddlewared.utils.filesystem.constants import ZFSCTL
+from middlewared.utils.filesystem.constants import ZFSCTL
 from middlewared.utils.path import path_location
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -1,11 +1,15 @@
 from datetime import time
 import ipaddress
+import os
 import re
 from urllib.parse import urlparse
 import uuid
 from string import digits, ascii_uppercase, ascii_lowercase, punctuation
+from pathlib import Path
 
+from middlewared.plugins.zfs_.utils import ZFSCTL
 from middlewared.utils import filters
+from middlewared.utils.path import path_location
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 RE_MAC_ADDRESS = re.compile(r"^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$")
@@ -371,3 +375,63 @@ class URL:
 
         if not result.netloc:
             raise ValueError('Invalid URL: no netloc specified')
+
+
+def check_path_resides_within_volume_sync(verrors, schema_name, path, vol_names):
+    """
+    This provides basic validation of whether a given `path` is allowed to
+    be exposed to end-users.
+
+    `verrors` - ValidationErrors created by calling function
+
+    `schema_name` - schema name to use in validation error message
+
+    `path` - path to validate
+
+    `vol_names` - list of expected pool names
+
+    It checks the following:
+    * path is within /mnt
+    * path is located within one of the specified `vol_names`
+    * path is not explicitly a `.zfs` or `.zfs/snapshot` directory
+    * path is not ix-applications dataset
+    """
+    if path_location(path) == 'EXTERNAL':
+        # There are some fields where we allow external paths
+        verrors.add(schema_name, "Path is external to TrueNAS.")
+        return
+
+    try:
+        inode = os.stat(path).st_ino
+    except FileNotFoundError:
+        inode = None
+
+    rp = Path(os.path.realpath(path))
+    is_mountpoint = os.path.ismount(path)
+
+    vol_paths = [os.path.join("/mnt", vol_name) for vol_name in vol_names]
+    if not path.startswith("/mnt/") or not any(
+        os.path.commonpath([parent]) == os.path.commonpath([parent, rp]) for parent in vol_paths
+    ):
+        verrors.add(schema_name, "The path must reside within a pool mount point")
+
+    if inode in (ZFSCTL.INO_ROOT, ZFSCTL.INO_SNAPDIR):
+        verrors.add(schema_name,
+                    "The ZFS control directory (.zfs) and snapshot directory (.zfs/snapshot) "
+                    "are not permitted paths. If a snapshot within this directory must "
+                    "be accessed through the path-based API, then it should be called "
+                    "directly, e.g. '/mnt/dozer/.zfs/snapshot/mysnap'.")
+
+    for check_path, svc_name in (('ix-applications', 'Applications'),):
+        in_use = False
+        if is_mountpoint and rp.name == check_path:
+            in_use = True
+        else:
+            # subtract 2 here to remove the '/' and 'mnt' parents
+            for i in range(0, len(rp.parents) - 2):
+                p = rp.parents[i]
+                if p.is_mount() and p.name == check_path:
+                    in_use = True
+                    break
+        if in_use:
+            verrors.add(schema_name, f'A path being used by {svc_name} is not allowed')


### PR DESCRIPTION
Convert `check_path_resides_within_volume` to a wrapper around a synchronous validator `check_path_resides_within_volume_sync` since basically all of logic there relies on stat-related calls.