### PR TITLE
NAS-129045 / 24.10 / Improve disk.get_partitions_quick

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -47,10 +47,7 @@ class DiskService(Service):
         parted_disk.addPartition(part, constraint=dev.optimalAlignedConstraint)
         parted_disk.commit()
 
-        # Found that this was necessary to avoid a possible race wrt disk.get_partitions_quick
-        self.middleware.call_sync('device.settle_udev_events')
-
-        if len(self.middleware.call_sync('disk.get_partitions_quick', disk)) != len(parted_disk.partitions):
+        if len(self.middleware.call_sync('disk.get_partitions_quick', disk, 10)) != len(parted_disk.partitions):
             # In some rare cases udev does not re-read the partition table correctly; force it
             self.middleware.call_sync('device.trigger_udev_events', f'/dev/{disk}')
             self.middleware.call_sync('device.settle_udev_events')

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -41,7 +41,7 @@ class DiskService(Service):
                 # so we'll break out early
                 return startsect
             else:
-                time.sleep(0.2)
+                time.sleep(0.5)
 
             try:
                 sectsize = int((path_obj / 'queue/logical_block_size').read_text().strip())

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -53,7 +53,7 @@ class DiskService(Service):
             except (FileNotFoundError, ValueError):
                 continue
             except Exception:
-                if _try == retries:
+                if _try == tries:
                     self.logger.error('Unexpected failure gathering partition info', exc_info=True)
 
         return startsect

--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -53,7 +53,7 @@ class DiskService(Service):
             except (FileNotFoundError, ValueError):
                 continue
             except Exception:
-                if _try == tries:
+                if _try + 1 == tries:  # range() built-in is half-open
                     self.logger.error('Unexpected failure gathering partition info', exc_info=True)
 
         return startsect


### PR DESCRIPTION
As pointed out in recent PR: https://github.com/truenas/middleware/pull/13738, `device.settle_udev_events` is needed (sporadically) after partitioning disks. The reason why is that certain operations will generate udev events. We try to access the information before those events have been processed and so sysfs information will not be complete.

The problem by calling `settle_udev_events` is that it will tell udev to drain the entire event queue. The queue holds information for ALL hardware and related events. This means, depending on what the system is doing at the time this is called, it can block and wait for 120 seconds (default timeout).

This PR changes it so that `disk.get_partitions_quick` actually tries 10 times (maximum) for the sysfs files to be generated. While I'm here, I noticed that if a disk had > 9 partitions, this would not return correct information. To be fair, however, we don't have any logic to handle disks with that many partitions but I went ahead and fixed this while I was here.