### PR TITLE
NAS-129046 / 24.10 / Fix several test regressions due to removing ip

### DIFF
--- a/tests/api2/test_014_failover_related.py
+++ b/tests/api2/test_014_failover_related.py
@@ -13,11 +13,7 @@ from pytest_dependency import depends
 from middlewared.client import ClientException
 from middlewared.test.integration.assets.account import unprivileged_user
 from middlewared.test.integration.utils import call, client
-
-if ha and "virtual_ip" in os.environ:
-    ip = os.environ["virtual_ip"]
-else:
-    from auto_config import ip
+from middlewared.test.integration.utils.client import truenas_server
 
 
 @pytest.fixture(scope='module')
@@ -36,14 +32,14 @@ def readonly_admin():
 
 @pytest.mark.dependency(name='hactl_install_dir')
 def test_01_check_hactl_installed(request):
-    rv = SSH_TEST('which hactl', user, password, ip)
+    rv = SSH_TEST('which hactl', user, password)
     assert rv['stdout'].strip() == '/usr/local/sbin/hactl', rv['output']
 
 
 @pytest.mark.dependency(name='hactl_status')
 def test_02_check_hactl_status(request):
     depends(request, ['hactl_install_dir'])
-    rv = SSH_TEST('hactl', user, password, ip)
+    rv = SSH_TEST('hactl', user, password)
     output = rv['stdout'].strip()
     if ha:
         for i in ('Node status:', 'This node serial:', 'Other node serial:', 'Failover status:'):
@@ -56,7 +52,7 @@ def test_02_check_hactl_status(request):
 def test_03_check_hactl_takeover(request):
     # integration tests run against the master node (at least they should...)
     depends(request, ['hactl_status'])
-    rv = SSH_TEST('hactl takeover', user, password, ip)
+    rv = SSH_TEST('hactl takeover', user, password)
     output = rv['stdout'].strip()
     if ha:
         assert 'This command can only be run on the standby node.' in output, output
@@ -68,7 +64,7 @@ def test_03_check_hactl_takeover(request):
 def test_04_check_hactl_enable(request):
     # integration tests run against the master node (at least they should...)
     depends(request, ['hactl_takeover'])
-    rv = SSH_TEST('hactl enable', user, password, ip)
+    rv = SSH_TEST('hactl enable', user, password)
     output = rv['stdout'].strip()
     if ha:
         assert 'Failover already enabled.' in output, output
@@ -79,20 +75,20 @@ def test_04_check_hactl_enable(request):
 def test_05_check_hactl_disable(request):
     # integration tests run against the master node (at least they should...)
     depends(request, ['hactl_enable'])
-    rv = SSH_TEST('hactl disable', user, password, ip)
+    rv = SSH_TEST('hactl disable', user, password)
     output = rv['stdout'].strip()
     if ha:
         assert 'Failover disabled.' in output, output
 
-        rv = make_ws_request(ip, {'msg': 'method', 'method': 'failover.config', 'params': []})
+        rv = make_ws_request(truenas_server.ip, {'msg': 'method', 'method': 'failover.config', 'params': []})
         assert isinstance(rv['result'], dict), rv['result']
         assert rv['result']['disabled'] is True, rv['result']
 
-        rv = SSH_TEST('hactl enable', user, password, ip)
+        rv = SSH_TEST('hactl enable', user, password)
         output = rv['stdout'].strip()
         assert 'Failover enabled.' in output, output
 
-        rv = make_ws_request(ip, {'msg': 'method', 'method': 'failover.config', 'params': []})
+        rv = make_ws_request(truenas_server.ip, {'msg': 'method', 'method': 'failover.config', 'params': []})
         assert isinstance(rv['result'], dict), rv['result']
         assert rv['result']['disabled'] is False, rv['result']
     else:

--- a/tests/api2/test_278_freeipa.py
+++ b/tests/api2/test_278_freeipa.py
@@ -11,11 +11,6 @@ from middlewared.test.integration.assets.directory_service import ldap
 from middlewared.test.integration.utils import call
 from auto_config import ha, user, password
 
-if ha and "virtual_ip" in os.environ:
-    ip = os.environ["virtual_ip"]
-else:
-    from auto_config import ip
-
 try:
     from config import (
         FREEIPA_IP,
@@ -32,13 +27,13 @@ except ImportError:
 @pytest.fixture(scope="module")
 def do_freeipa_connection(request):
     # Confirm DNS forward
-    res = SSH_TEST(f"host {FREEIPA_HOSTNAME}", user, password, ip)
+    res = SSH_TEST(f"host {FREEIPA_HOSTNAME}", user, password)
     assert res['result'] is True, res
     # stdout: "<FREEIPA_HOSTNAME> has address <FREEIPA_IP>"
     assert res['stdout'].split()[-1] == FREEIPA_IP
 
     # DNS reverse
-    res = SSH_TEST(f"host {FREEIPA_IP}", user, password, ip)
+    res = SSH_TEST(f"host {FREEIPA_IP}", user, password)
     assert res['result'] is True, res
     # stdout: <FREEIPA_IP_reverse_format>.in-addr.arpa domain name pointer <FREEIPA_HOSTNAME>.
     assert res['stdout'].split()[-1] == FREEIPA_HOSTNAME + "."
@@ -101,7 +96,7 @@ def test_10_verify_support_for_netgroups(request):
     'getent netgroup' should be able to retrieve netgroup
     """
     depends(request, ["FREEIPA_NSS_WORKING"], scope="session")
-    res = SSH_TEST("getent netgroup ixtestusers", user, password, ip)
+    res = SSH_TEST("getent netgroup ixtestusers", user, password)
     assert res['result'] is True, f"Failed to find netgroup 'ixgroup', returncode={res['returncode']}"
 
     # Confirm expected set of users or hosts

--- a/tests/api2/test_330_pool_acltype.py
+++ b/tests/api2/test_330_pool_acltype.py
@@ -17,7 +17,7 @@ dataset_url = test1_dataset.replace("/", "%2F")
 
 @pytest.fixture(scope='module')
 def create_test_dataset():
-    with make_dataset(test1_dataset) as ds:
+    with make_dataset('test1') as ds:
         yield ds
 
 

--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -13,13 +13,8 @@ apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import ha, interface, password, user
 from functions import GET, POST, PUT, SSH_TEST, async_SSH_done, async_SSH_start
+from middlewared.test.integration.utils.client import truenas_server
 
-if ha and "virtual_ip" in os.environ:
-    ip = os.environ["virtual_ip"]
-    controller1_ip = os.environ['controller1_ip']
-    controller2_ip = os.environ['controller2_ip']
-else:
-    from auto_config import ip
 
 skip_ha_tests = pytest.mark.skipif(not (ha and "virtual_ip" in os.environ), reason="Skip HA tests")
 COMMUNITY = 'public'
@@ -126,11 +121,11 @@ def test_08_Validate_that_SNMP_settings_are_preserved():
 
 
 def test_09_get_sysname_reply_uses_same_ip():
-    validate_snmp_get_sysname_uses_same_ip(ip)
+    validate_snmp_get_sysname_uses_same_ip(truenas_server.ip)
 
 
 @skip_ha_tests
 def test_10_ha_get_sysname_reply_uses_same_ip():
-    validate_snmp_get_sysname_uses_same_ip(ip)
-    validate_snmp_get_sysname_uses_same_ip(controller1_ip)
-    validate_snmp_get_sysname_uses_same_ip(controller2_ip)
+    validate_snmp_get_sysname_uses_same_ip(truenas_server.ip)
+    validate_snmp_get_sysname_uses_same_ip(truenas_server.nodea_ip)
+    validate_snmp_get_sysname_uses_same_ip(truenas_server.nodeb_ip)

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -117,7 +117,6 @@ def test_audit_config_updates(audit_config):
 def test_audit_query(initialize_for_smb_tests):
     share = initialize_for_smb_tests['share']
     with smb_connection(
-        host=ip,
         share=share['name'],
         username=SMBUSER,
         password=PASSWD,


### PR DESCRIPTION
In an earlier commit `ip` was removed from auto_conf generated by runtest.py. This exposed several remaining usages of it in our tests when running as a non-HA that were not caught in earlier testing.