### PR TITLE
Fix truecommand issues on HA in CORE 13

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1845,6 +1845,7 @@ async def service_remote(middleware, service, verb, options):
         'smartd',
         'system_datasets',
         'nfs',
+        'truecommand',
     ) or await middleware.call('failover.status') != 'MASTER':
         return
     # Nginx should never be stopped on standby node

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -48,7 +48,12 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if middleware.call_sync('truecommand.connected')['connected'] and wg_config['wg_address']:
+    if middleware.call_sync('failover.is_single_master_node') and wg_config['api_key_state'] == 'CONNECTED' and wg_config['wg_address']:
+        # We use api key state to determine connected because sometimes when nginx config is reloaded
+        # it is not necessary that health of wireguard connection has been established at that point
+        # and another reload of nginx config is required then at that point then which is redundant
+        # An example is that when failover takes place, system knows it is master now but wireguard health hasn't
+        # been established at this point and we miss out on adding wireguard address to listen directive
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -44,11 +44,17 @@ class TruecommandService(Service, TruecommandAPIMixin):
                 )
                 if status.get('tc_state') == 'running':
                     await self.middleware.call('truecommand.dismiss_alerts')
+                    await self.middleware.call('truecommand.start_truecommand_service')
                 else:
                     await self.middleware.call('truecommand.dismiss_alerts', True)
                     await self.middleware.call('alert.oneshot_create', 'TruecommandContainerHealth', None)
 
-                await self.middleware.call('truecommand.start_truecommand_service')
+                    asyncio.get_event_loop().call_later(
+                        self.POLLING_GAP_MINUTES * 60,
+                        lambda: self.middleware.create_task(
+                            self.middleware.call('truecommand.start_truecommand_service')
+                        ),
+                    )
 
                 break
 

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -131,8 +131,8 @@ class TruecommandService(Service):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
                 asyncio.get_event_loop().call_later(
-                    HEALTH_CHECK_SECONDS,
-                    lambda: asyncio.ensure_future(self.middleware.call('truecommand.health_check')),
+                    30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
+                    lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),
                 )
             else:
                 # start polling iX Portal to see what's up and why we don't have these values set

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import subprocess
 import time
@@ -129,7 +130,10 @@ class TruecommandService(Service):
             ):
                 await self.middleware.call('service.start', 'truecommand')
                 await self.middleware.call('service.reload', 'http')
-                self.middleware.create_task(self.middleware.call('truecommand.health_check'))
+                asyncio.get_event_loop().call_later(
+                    HEALTH_CHECK_SECONDS,
+                    lambda: asyncio.ensure_future(self.middleware.call('truecommand.health_check')),
+                )
             else:
                 # start polling iX Portal to see what's up and why we don't have these values set
                 # This can happen in instances where system was polling and then was rebooted,

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -129,7 +129,7 @@ class TruecommandService(Service):
                 config[k] for k in ('wg_private_key', 'remote_address', 'endpoint', 'tc_public_key', 'wg_address')
             ):
                 await self.middleware.call('service.start', 'truecommand')
-                await self.middleware.call('service.reload', 'http')
+                await self.middleware.call('service.reload', 'http', {'ha_propagate': False})
                 asyncio.get_event_loop().call_later(
                     30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
                     lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),


### PR DESCRIPTION
This PR adds changes to backport some of the fixes which were made to SCALE and not backported to CORE and also fix an issue where wireguard service started on standby whenever the service was started on active. Reason behind that was that we propagate service actions to standby automatically by default and that is not desirable in this case as wireguard should only be running on 1 node at a time. To address that `truecommand` has been added to list of blacklisted services which shouldn't be touched when any of the service verb is called for it.

An edge case for nginx config has also been handled where we were not adding wireguard interface ip to listen directive on failover and a subsequent nginx config reload was warranted because of that.