### PR TITLE
NAS-128704 / 24.10 / Fix truecommand issues on HA

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -52,7 +52,12 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if middleware.call_sync('truecommand.info')['connected'] and wg_config['wg_address']:
+    if middleware.call_sync('failover.is_single_master_node') and wg_config['api_key_state'] == 'CONNECTED' and wg_config['wg_address']:
+        # We use api key state to determine connected because sometimes when nginx config is reloaded
+        # it is not necessary that health of wireguard connection has been established at that point
+        # and another reload of nginx config is required then at that point then which is redundant
+        # An example is that when failover takes place, system knows it is master now but wireguard health hasn't
+        # been established at this point and we miss out on adding wireguard address to listen directive
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1299,7 +1299,7 @@ async def service_remote(middleware, service, verb, options):
 
     This is the middleware side of what legacy UI did on service changes.
     """
-    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter', 'netdata')
+    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter', 'netdata', 'truecommand')
     if not options['ha_propagate'] or service in ignore or service == 'nginx' and verb == 'stop':
         return
     elif await middleware.call('failover.status') != 'MASTER':

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -126,7 +126,7 @@ class TruecommandService(Service):
                 config[k] for k in ('wg_private_key', 'remote_address', 'endpoint', 'tc_public_key', 'wg_address')
             ):
                 await self.middleware.call('service.start', 'truecommand')
-                await self.middleware.call('service.reload', 'http')
+                await self.middleware.call('service.reload', 'http', {'ha_propagate': False})
                 asyncio.get_event_loop().call_later(
                     30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
                     lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -125,7 +125,7 @@ class TruecommandService(Service):
             if Status(config['api_key_state']) == Status.CONNECTED and all(
                 config[k] for k in ('wg_private_key', 'remote_address', 'endpoint', 'tc_public_key', 'wg_address')
             ):
-                await self.middleware.call('service.start', 'truecommand')
+                await self.middleware.call('service.start', 'truecommand', {'ha_propagate': False})
                 await self.middleware.call('service.reload', 'http', {'ha_propagate': False})
                 asyncio.get_event_loop().call_later(
                     30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive


### PR DESCRIPTION
This PR adds changes to backport some of the fixes which were made to SCALE and not backported to CORE and also fix an issue where wireguard service started on standby whenever the service was started on active. Reason behind that was that we propagate service actions to standby automatically by default and that is not desirable in this case as wireguard should only be running on 1 node at a time. To address that `truecommand` has been added to list of blacklisted services which shouldn't be touched when any of the service verb is called for it.

An edge case for nginx config has also been handled where we were not adding wireguard interface ip to listen directive on failover and a subsequent nginx config reload was warranted because of that.

Original PR: https://github.com/truenas/middleware/pull/13756
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128704