### PR TITLE
NAS-128634 / 24.10 / Show IPv6 autoconf default, also reflect preference with sysctl

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -90,6 +90,9 @@ class InterfaceService(Service):
                 iface.replace_address(addr)
             # TODO: what are we doing with ipv6auto??
 
+        autoconf = '1' if has_ipv6 else '0'
+        self.middleware.call_sync('tunable.set_sysctl', f'net.ipv6.conf.{name}.autoconf', autoconf)
+
         if vip or alias_vips:
             if not self.middleware.call_sync('service.started', 'keepalived'):
                 self.middleware.call_sync('service.start', 'keepalived')

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -674,6 +674,7 @@ class InterfaceService(CRUDService):
         the interfaces changes happened as planned from the user. If checkin does not happen
         within this period of time the changes will get reverted.
         """
+        self.logger.debug("This is our commit sanity check")
         verrors = ValidationErrors()
         schema = 'interface.commit'
         await self.middleware.call('network.common.check_failover_disabled', schema, verrors)
@@ -1669,6 +1670,7 @@ class InterfaceService(CRUDService):
         """
         Sync interfaces configured in database to the OS.
         """
+        self.logger.debug("This is our sync sanity check")
         await self.middleware.call_hook('interface.pre_sync')
         # The VRRP event thread just reads directly from the database
         # so there is no reason to actually configure the interfaces

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -674,7 +674,6 @@ class InterfaceService(CRUDService):
         the interfaces changes happened as planned from the user. If checkin does not happen
         within this period of time the changes will get reverted.
         """
-        self.logger.debug("This is our commit sanity check")
         verrors = ValidationErrors()
         schema = 'interface.commit'
         await self.middleware.call('network.common.check_failover_disabled', schema, verrors)
@@ -1670,7 +1669,6 @@ class InterfaceService(CRUDService):
         """
         Sync interfaces configured in database to the OS.
         """
-        self.logger.debug("This is our sync sanity check")
         await self.middleware.call_hook('interface.pre_sync')
         # The VRRP event thread just reads directly from the database
         # so there is no reason to actually configure the interfaces

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -270,7 +270,7 @@ class InterfaceService(CRUDService):
             'state': iface_state,
             'aliases': [],
             'ipv4_dhcp': False if configs else True,
-            'ipv6_auto': False,
+            'ipv6_auto': False if configs else True,
             'description': '',
             'mtu': None,
         }

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -8,7 +8,7 @@ import pytest
 
 from auto_config import interface, ha, netmask
 from middlewared.test.integration.utils.client import client, truenas_server
-from middlewared.test.integration.utils import fail, call
+from middlewared.test.integration.utils import call
 
 @pytest.fixture(scope='module')
 def ws_client():
@@ -65,7 +65,7 @@ def get_payload(ws_client):
 def test_001_check_ipvx(request):
     # Verify that dhclient is running
     running, _ = call('interface.dhclient_status', interface)
-    assert running
+    assert running is True
 
     # Check that our proc entry is set to its default 1.
     assert int(call('tunable.get_sysctl', f'net.ipv6.conf.{interface}.autoconf')) == 1

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -8,6 +8,7 @@ import pytest
 
 from auto_config import interface, ha, netmask
 from middlewared.test.integration.utils.client import client, truenas_server
+from middlewared.test.integration.utils import fail
 
 
 @pytest.fixture(scope='module')
@@ -21,6 +22,7 @@ def get_payload(ws_client):
     if ha:
         payload = {
             'ipv4_dhcp': False,
+            'ipv6_auto': False,
             'failover_critical': True,
             'failover_group': 1,
             'aliases': [
@@ -49,7 +51,7 @@ def get_payload(ws_client):
         # that the machine has been handed an IPv4 address
         # from a DHCP server. That's why we're getting this information.
         ans = ws_client.call('interface.query', [['name', '=', interface]], {'get': True})
-        payload = {'ipv4_dhcp': False, 'aliases': []}
+        payload = {'ipv4_dhcp': False, 'ipv6_auto': False, 'aliases': []}
         to_validate = []
         ip = truenas_server.ip
         for info in filter(lambda x: x['address'] == ip, ans['state']['aliases']):
@@ -60,8 +62,17 @@ def get_payload(ws_client):
 
     return payload, to_validate
 
+# Make sure that our initial conditions are met
+def test_001_check_ipvx(request, ws_client, get_payload):
+    # Verify that dhclient is running
+    ps_count = int(SSH_TEST('ps -aux | grep dhclient | wc -l', user, password, truenas_server.ip)['stdout'])
+    assert ps_count > 1 # account for the grep
 
-def test_001_configure_interface(request, ws_client, get_payload):
+    # Check that our proc entry is set to its default 1.
+    autoconf = int(SSH_TEST(f'cat /proc/sys/net/ipv6/conf/{interface}/autoconf', user, password, truenas_server.ip)['stdout'])
+    assert autoconf == 1
+
+def test_002_configure_interface(request, ws_client, get_payload):
     if ha:
         # can not make network changes on an HA system unless failover has
         # been explicitly disabled
@@ -106,3 +117,9 @@ def test_001_configure_interface(request, ws_client, get_payload):
         truenas_server.nodea_ip = os.environ['controller1_ip']
         truenas_server.nodeb_ip = os.environ['controller2_ip']
         truenas_server.server_type = os.environ['SERVER_TYPE']
+
+def test_003_recheck_ipvx(request, ws_client, get_payload):
+    pass
+
+def test_004_exit_early():
+    fail('exiting early')

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -95,9 +95,6 @@ def test_002_configure_interface(request, ws_client, get_payload):
     assert ws_client.call('interface.checkin_waiting') is None
     assert ws_client.call('interface.has_pending_changes') is False
 
-    autoconf = int(SSH_TEST(f'cat /proc/sys/net/ipv6/conf/{interface}/autoconf', user, password, truenas_server.ip)['stdout'])
-    assert autoconf == 0
-
     if ha:
         # on HA, keepalived is responsible for configuring the VIP so let's give it
         # some time to settle
@@ -123,7 +120,5 @@ def test_002_configure_interface(request, ws_client, get_payload):
         truenas_server.server_type = os.environ['SERVER_TYPE']
 
 def test_003_recheck_ipvx(request, ws_client, get_payload):
-    pass
-
-def test_004_exit_early():
-    fail('exiting early')
+    autoconf = int(SSH_TEST(f'cat /proc/sys/net/ipv6/conf/{interface}/autoconf', user, password, truenas_server.ip)['stdout'])
+    assert autoconf == 0

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -68,7 +68,7 @@ def test_001_check_ipvx(request):
     assert running
 
     # Check that our proc entry is set to its default 1.
-    assert int(call('tunable.get_sysctl', 'net.ipv6.conf.ens1.autoconf')) == 1
+    assert int(call('tunable.get_sysctl', f'net.ipv6.conf.{interface}.autoconf')) == 1
 
 def test_002_configure_interface(request, ws_client, get_payload):
     if ha:
@@ -117,4 +117,4 @@ def test_002_configure_interface(request, ws_client, get_payload):
         truenas_server.server_type = os.environ['SERVER_TYPE']
 
 def test_003_recheck_ipvx(request):
-    assert int(call('tunable.get_sysctl', 'net.ipv6.conf.ens1.autoconf')) == 0
+    assert int(call('tunable.get_sysctl', f'net.ipv6.conf.{interface}.autoconf')) == 0

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -6,7 +6,7 @@ sys.path.append(apifolder)
 
 import pytest
 
-from auto_config import interface, ha, netmask
+from auto_config import interface, ha, netmask, user, password
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils import fail
 from functions import SSH_TEST

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -94,6 +94,9 @@ def test_002_configure_interface(request, ws_client, get_payload):
     assert ws_client.call('interface.checkin_waiting') is None
     assert ws_client.call('interface.has_pending_changes') is False
 
+    autoconf = int(SSH_TEST(f'cat /proc/sys/net/ipv6/conf/{interface}/autoconf', user, password, truenas_server.ip)['stdout'])
+    assert autoconf == 0
+
     if ha:
         # on HA, keepalived is responsible for configuring the VIP so let's give it
         # some time to settle

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -9,6 +9,7 @@ import pytest
 from auto_config import interface, ha, netmask
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils import fail
+from functions import SSH_TEST
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
When creating a network interface, the system automatically configures IPv6 despite the default setting being False. In the UI, this creates an issue where the "Autoconfigure IPv6" checkbox is unchecked but the value under /proc/sys/net/ipv6/conf/[interface]/autoconf is 1.

This is also true of DHCP, but was fixed in the UI by setting the value to True specifically if we haven't created/configured the interface yet. I applied the same fix to ipv6_auto. I've also made it set the proper /proc/.../autoconf value when an existing interface is updated so the user's settings are respected.