### PR TITLE
NAS-129112 / 24.10 / fix TypeError crash in disk.wipe

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -47,8 +47,9 @@ class DiskService(Service):
                 sectsize = int((path_obj / 'queue/logical_block_size').read_text().strip())
                 with os.scandir(path_obj) as dir_contents:
                     for partdir in filter(lambda x: x.is_dir() and x.name.startswith(dev_name), dir_contents):
-                        part_num = int((partdir / 'partition').read_text().strip())
-                        part_start = int((partdir / 'start').read_text().strip()) * sectsize
+                        partdir_obj = pathlib.Path(partdir.path)
+                        part_num = int((partdir_obj / 'partition').read_text().strip())
+                        part_start = int((partdir_obj / 'start').read_text().strip()) * sectsize
                         startsect[part_num] = part_start
             except (FileNotFoundError, ValueError):
                 continue


### PR DESCRIPTION
```
[2024/05/18 09:04:43] (ERROR) DiskService.get_partitions_quick():57 - Unexpected failure gathering partition info
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/wipe.py", line 50, in get_partitions_quick
    part_num = int((partdir / 'partition').read_text().strip())
                    ~~~~~~~~^~~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'posix.DirEntry' and 'str'
```