### PR TITLE
NAS-128825 / 24.10 / Add auditing for sudo

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/sudoers.mako
+++ b/src/middlewared/middlewared/etc_files/local/sudoers.mako
@@ -33,6 +33,8 @@ ${f'%{group["group"]}'} ALL=(ALL) ${sudo_entry(group['sudo_commands'], group['su
 % endfor
 Defaults syslog_goodpri = debug
 Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+Defaults log_subcmds
+Defaults log_format=json
 
 # Let find_alias_for_smtplib.py runs as root (it needs database access)
 ALL ALL=(ALL) NOPASSWD: /etc/find_alias_for_smtplib.py

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -1,7 +1,7 @@
 <%
     import textwrap
 
-    from middlewared.plugins.audit.utils import AUDITED_SERVICES, audit_file_path, AUDIT_DATASET_PATH
+    from middlewared.plugins.audit.utils import AUDITED_SERVICES, audit_file_path, AUDIT_DATASET_PATH, audit_custom_section
 
     COLUMNS = textwrap.dedent('''
         "audit_id varchar",
@@ -76,6 +76,7 @@ ${textwrap.indent(get_db(svc), '  ')}
   indexes());
 };
 
+% if not audit_custom_section(svc, 'log'):
 log {
   source(s_src);
   filter(f_tnaudit_${svc.lower()});
@@ -83,4 +84,72 @@ log {
   rewrite(r_rewrite_success);
   destination(d_tnaudit_${svc.lower()});
 };
+%endif
 % endfor
+
+# SUDO service is a special case because we do not control the format of the
+# events it logs.  Instead we will MAP the events into our database, plus we
+# retain the original sudo generated JSON in the event_data
+<%text>
+filter f_tnaudit_sudo_accept { match(".+" value("sudo.accept.uuid")) };
+filter f_tnaudit_sudo_reject { match(".+" value("sudo.reject.uuid")) };
+
+parser p_tnaudit_sudo_accept {
+  date-parser(
+      format("%Y%m%d%H%M%SZ")
+      template("${sudo.accept.server_time.iso8601}")
+  );
+};
+parser p_tnaudit_sudo_reject {
+  date-parser(
+      format("%Y%m%d%H%M%SZ")
+      template("${sudo.reject.server_time.iso8601}")
+  );
+};
+
+rewrite r_rewrite_sudo_common {
+  set("${PID}", value("TNAUDIT.sess"));
+  set("SUDO", value("TNAUDIT.svc"));
+  set("0", value("TNAUDIT.vers.major"));
+  set("1", value("TNAUDIT.vers.minor"));
+  set('{"vers": {"major": 0, "minor": 1}}', value("TNAUDIT.svc_data"));
+  set("$(format-json --scope none sudo.*)", value("TNAUDIT.event_data"));
+};
+rewrite r_rewrite_sudo_accept {
+  set("${sudo.accept.uuid}", value("TNAUDIT.aid"));
+  set('${S_YEAR}-${S_MONTH}-${S_DAY} ${S_HOUR}:${S_MIN}:${S_SEC}.$(substr "${sudo.accept.server_time.nanoseconds}" "0" "6")', value("TNAUDIT.time"));
+  set("${sudo.accept.submithost}", value("TNAUDIT.addr"));
+  set("${sudo.accept.submituser}", value("TNAUDIT.user"));
+  set("ACCEPT", value("TNAUDIT.event"));
+  set("1", value("TNAUDIT.success"));
+};
+rewrite r_rewrite_sudo_reject {
+  set("${sudo.reject.uuid}", value("TNAUDIT.aid"));
+  set('${S_YEAR}-${S_MONTH}-${S_DAY} ${S_HOUR}:${S_MIN}:${S_SEC}.$(substr "${sudo.reject.server_time.nanoseconds}" "0" "6")', value("TNAUDIT.time"));
+  set("${sudo.reject.submithost}", value("TNAUDIT.addr"));
+  set("${sudo.reject.submituser}", value("TNAUDIT.user"));
+  set("REJECT", value("TNAUDIT.event"));
+  set("0", value("TNAUDIT.success"));
+};
+
+log {
+  source(s_src);
+  filter(f_tnaudit_sudo);
+  parser(p_tnaudit);
+  filter(f_tnaudit_sudo_accept);
+  parser(p_tnaudit_sudo_accept);
+  rewrite(r_rewrite_sudo_accept);
+  rewrite(r_rewrite_sudo_common);
+  destination(d_tnaudit_sudo);
+};
+log {
+  source(s_src);
+  filter(f_tnaudit_sudo);
+  parser(p_tnaudit);
+  filter(f_tnaudit_sudo_reject);
+  parser(p_tnaudit_sudo_reject);
+  rewrite(r_rewrite_sudo_reject);
+  rewrite(r_rewrite_sudo_common);
+  destination(d_tnaudit_sudo);
+};
+</%text>

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -1,5 +1,5 @@
 <%
-    from middlewared.plugins.audit.utils import AUDITED_SERVICES
+    from middlewared.plugins.audit.utils import audit_program, AUDITED_SERVICES
 
     adv_conf = render_ctx['system.advanced.config']
 
@@ -13,7 +13,7 @@
 
 # Filter TrueNAS audit-related messages
 % for svc, vers in AUDITED_SERVICES:
-filter f_tnaudit_${svc.lower()} { program("TNAUDIT_${svc}") };
+filter f_tnaudit_${svc.lower()} { program("${audit_program(svc)}") };
 % endfor
 filter f_tnaudit_all {
   ${' or\n  '.join(audit_filters)}

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -23,6 +23,7 @@ from .utils import (
 )
 from .schema.middleware import AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS, AUDIT_EVENT_MIDDLEWARE_PARAM_SET
 from .schema.smb import AUDIT_EVENT_SMB_JSON_SCHEMAS, AUDIT_EVENT_SMB_PARAM_SET
+from .schema.sudo import AUDIT_EVENT_SUDO_JSON_SCHEMAS, AUDIT_EVENT_SUDO_PARAM_SET
 from middlewared.client import ejson
 from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.schema import (
@@ -107,7 +108,7 @@ class AuditService(ConfigService):
         data['space']['used_by_reservation'] = ds_info['properties']['usedbyrefreservation']['parsed']
         data['space']['used_by_snapshots'] = ds_info['properties']['usedbysnapshots']['parsed']
         data['space']['available'] = ds_info['properties']['available']['parsed']
-        data['enabled_services'] = {'MIDDLEWARE': [], 'SMB': []}
+        data['enabled_services'] = {'MIDDLEWARE': [], 'SMB': [], 'SUDO': []}
         audited_smb_shares = self.middleware.call_sync(
             'sharing.smb.query', [['audit.enable', '=', True]], {'select': ['name', 'audit']}
         )
@@ -195,7 +196,7 @@ class AuditService(ConfigService):
                 if isinstance(entry, list):
                     entry = entry[0]
 
-                if entry not in (AUDIT_EVENT_MIDDLEWARE_PARAM_SET | AUDIT_EVENT_SMB_PARAM_SET):
+                if entry not in (AUDIT_EVENT_MIDDLEWARE_PARAM_SET | AUDIT_EVENT_SMB_PARAM_SET | AUDIT_EVENT_SUDO_PARAM_SET):
                     verrors.add(
                         f'audit.query.query-options.select.{idx}',
                         f'{entry}: column does not exist'
@@ -547,4 +548,4 @@ class AuditService(ConfigService):
     @private
     @filterable
     async def json_schemas(self, filters, options):
-        return filter_list(AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS + AUDIT_EVENT_SMB_JSON_SCHEMAS, filters, options)
+        return filter_list(AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS + AUDIT_EVENT_SMB_JSON_SCHEMAS + AUDIT_EVENT_SUDO_JSON_SCHEMAS, filters, options)

--- a/src/middlewared/middlewared/plugins/audit/schema/sudo.py
+++ b/src/middlewared/middlewared/plugins/audit/schema/sudo.py
@@ -1,0 +1,73 @@
+from middlewared.schema import (
+    Bool,
+    Dict,
+    Int,
+    IPAddr,
+    Str,
+    UUID,
+)
+from .common import (
+    AuditEnum,
+    AuditEventParam,
+    AuditSchema,
+    AUDIT_VERS,
+    audit_schema_from_base,
+    convert_schema_to_set,
+)
+
+
+class AuditSudoEventType(AuditEnum):
+    ACCEPT = 'ACCEPT'
+    REJECT = 'REJECT'
+
+
+AUDIT_EVENT_DATA_SUDO_ACCEPT = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    AUDIT_VERS,
+)
+
+
+AUDIT_EVENT_DATA_SUDO_REJECT = Dict(
+    str(AuditEventParam.EVENT_DATA),
+    AUDIT_VERS,
+)
+
+
+AUDIT_EVENT_SUDO_SCHEMAS = []
+
+
+AUDIT_EVENT_SUDO_BASE_SCHEMA = AuditSchema(
+    'audit_entry_sudo',
+    UUID(AuditEventParam.AUDIT_ID.value),
+    Int(AuditEventParam.MESSAGE_TIMESTAMP.value),
+    Dict(AuditEventParam.TIMESTAMP.value),
+    IPAddr(AuditEventParam.ADDRESS.value),
+    Str(AuditEventParam.USERNAME.value),
+    UUID(AuditEventParam.SESSION.value),
+    Str(AuditEventParam.SERVICE.value, enum=['SUDO']),
+    Bool('success'),
+)
+
+
+AUDIT_EVENT_SUDO_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SUDO_BASE_SCHEMA,
+    'audit_entry_sudo_accept',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSudoEventType.ACCEPT.name]),
+    AUDIT_EVENT_DATA_SUDO_ACCEPT,
+))
+
+
+AUDIT_EVENT_SUDO_SCHEMAS.append(audit_schema_from_base(
+    AUDIT_EVENT_SUDO_BASE_SCHEMA,
+    'audit_entry_sudo_reject',
+    Str(AuditEventParam.EVENT.value, enum=[AuditSudoEventType.REJECT.name]),
+    AUDIT_EVENT_DATA_SUDO_REJECT,
+))
+
+
+AUDIT_EVENT_SUDO_JSON_SCHEMAS = [
+    schema.to_json_schema() for schema in AUDIT_EVENT_SUDO_SCHEMAS
+]
+
+
+AUDIT_EVENT_SUDO_PARAM_SET = convert_schema_to_set(AUDIT_EVENT_SUDO_JSON_SCHEMAS)

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import declarative_base
 from .schema.common import AuditEventParam
 
 AUDIT_DATASET_PATH = '/audit'
-AUDITED_SERVICES = [('MIDDLEWARE', 0.1), ('SMB', 0.1)]
+AUDITED_SERVICES = [('MIDDLEWARE', 0.1), ('SMB', 0.1), ('SUDO', 0.1)]
 AUDIT_TABLE_PREFIX = 'audit_'
 AUDIT_LIFETIME = 7
 AUDIT_DEFAULT_RESERVATION = 0
@@ -27,6 +27,19 @@ SQL_SAFE_FIELDS = (
 
 AuditBase = declarative_base()
 
+def audit_program(svc):
+    if svc == 'SUDO':
+        return 'sudo'
+    else:
+        return f'TNAUDIT_{svc}'
+
+def audit_custom_section(svc, section):
+    """
+    Can be used to control whether generic SVC mako rendering applies for this section/service.
+    """
+    if svc == 'SUDO' and section == 'log':
+        return True
+    return False
 
 def audit_file_path(svc):
     return f'{AUDIT_DATASET_PATH}/{svc}.db'

--- a/tests/api2/test_audit_sudo.py
+++ b/tests/api2/test_audit_sudo.py
@@ -1,0 +1,254 @@
+import contextlib
+import secrets
+import string
+import time
+
+import pytest
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import call, ssh
+
+EVENT_KEYS = {'timestamp', 'message_timestamp', 'service_data', 'username', 'service', 'audit_id', 'address', 'event_data', 'event', 'session', 'success'}
+ACCEPT_KEYS = {'command', 'submituser', 'lines', 'submithost', 'uuid', 'runenv', 'server_time', 'runcwd', 'submitcwd', 'runuid', 'runargv', 'columns', 'runuser', 'submit_time'}
+REJECT_KEYS = {'command', 'submituser', 'lines', 'submithost', 'uuid', 'reason', 'runenv', 'server_time', 'runcwd', 'submitcwd', 'runuid', 'runargv', 'columns', 'runuser', 'submit_time'}
+
+LS_COMMAND = '/bin/ls'
+ECHO_COMMAND = '/bin/echo'
+
+SUDO_TO_USER = 'sudo-to-user'
+SUDO_TO_PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+
+def user_sudo_events(username, count=False):
+    payload = {
+        'services': ['SUDO'],
+        'query-filters': [['username', '=', username]],
+    }
+    if count:
+        payload['query-options'] = {'count': True}
+    return call('audit.query', payload)
+
+
+def wait_for_events(username, newcount, retries=20, delay=0.5):
+    assert retries > 0 and retries <= 20
+    assert delay >= 0.1 and delay <= 1
+    while newcount != user_sudo_events(username, True) and retries:
+        time.sleep(delay)
+        retries -= 1
+    return newcount
+
+
+def assert_accept(event):
+    assert type(event) is dict
+    set(event.keys()) == EVENT_KEYS
+    assert set(event['event_data'].keys()) == {'sudo'}
+    assert set(event['event_data']['sudo'].keys()) == {'accept'}
+    assert set(event['event_data']['sudo']['accept'].keys()) == ACCEPT_KEYS
+    return event['event_data']['sudo']['accept']
+
+
+def assert_reject(event):
+    assert type(event) is dict
+    set(event.keys()) == EVENT_KEYS
+    assert set(event['event_data'].keys()) == {'sudo'}
+    assert set(event['event_data']['sudo'].keys()) == {'reject'}
+    assert set(event['event_data']['sudo']['reject'].keys()) == REJECT_KEYS
+    return event['event_data']['sudo']['reject']
+
+
+@contextlib.contextmanager
+def initialize_for_sudo_tests(username, password, data):
+    data.update({
+        'username': username,
+        'full_name': username,
+        'group_create': True,
+        'password': password,
+        'shell': '/usr/bin/bash',
+        'ssh_password_enabled': True,
+    })
+    with user(data) as newuser:
+        yield newuser
+
+
+@pytest.fixture(scope='module')
+def sudo_to_user():
+    with initialize_for_sudo_tests(SUDO_TO_USER, SUDO_TO_PASSWORD, {}) as u:
+        yield u
+
+
+class SudoTests:
+
+    def generate_command(self, cmd, runuser=None, password=None):
+        command = ['sudo']
+        if password:
+            command.append('-S')
+        if runuser:
+            command.extend(['-u', runuser])
+        command.append(cmd)
+        return " ".join(command)
+
+    def allowed_all(self):
+        """All of the sudo commands are allowed"""
+        # First get a baseline # of events
+        count = user_sudo_events(self.USER, True)
+
+        # Now create an event and do some basic checking
+        self.sudo_command('ls /etc')
+        assert count + 1 == wait_for_events(self.USER, count + 1)
+        accept = assert_accept(user_sudo_events(self.USER)[-1])
+        assert accept['submituser'] == self.USER
+        assert accept['command'] == LS_COMMAND
+        assert accept['runuser'] == 'root'
+        assert accept['runargv'].split(',') == ['ls', '/etc']
+
+        # One more completely unique command
+        magic = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(20))
+        self.sudo_command(f'echo {magic}')
+        assert count + 2 == wait_for_events(self.USER, count + 2)
+        accept = assert_accept(user_sudo_events(self.USER)[-1])
+        assert accept['submituser'] == self.USER
+        assert accept['command'] == ECHO_COMMAND
+        assert accept['runuser'] == 'root'
+        assert accept['runargv'].split(',') == ['echo', magic]
+
+        # sudo to a non-root user
+        self.sudo_command('ls /tmp', SUDO_TO_USER)
+        assert count + 3 == wait_for_events(self.USER, count + 3)
+        accept = assert_accept(user_sudo_events(self.USER)[-1])
+        assert accept['submituser'] == self.USER
+        assert accept['command'] == LS_COMMAND
+        assert accept['runuser'] == SUDO_TO_USER
+        assert accept['runargv'].split(',') == ['ls', '/tmp']
+
+    def allowed_some(self):
+        """Some of the sudo commands are allowed"""
+        # First get a baseline # of events
+        count = user_sudo_events(self.USER, True)
+
+        # Generate a sudo command that we ARE allowed perform
+        magic = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(20))
+        self.sudo_command(f'echo {magic}')
+        assert count + 1 == wait_for_events(self.USER, count + 1)
+        accept = assert_accept(user_sudo_events(self.USER)[-1])
+        assert accept['submituser'] == self.USER
+        assert accept['command'] == ECHO_COMMAND
+        assert accept['runuser'] == 'root'
+        assert accept['runargv'].split(',') == ['echo', magic]
+
+        # Generate a sudo command that we are NOT allowed perform
+        with pytest.raises(AssertionError):
+            self.sudo_command('ls /etc')
+        # Returned exception depends upon whether passwd or nopasswd
+        assert count + 2 == wait_for_events(self.USER, count + 2)
+        reject = assert_reject(user_sudo_events(self.USER)[-1])
+        assert reject['submituser'] == self.USER
+        assert reject['command'] == LS_COMMAND
+        assert reject['runuser'] == 'root'
+        assert reject['runargv'].split(',') == ['ls', '/etc']
+        assert reject['reason'] == 'command not allowed'
+
+    def allowed_none(self):
+        """None of the sudo commands are allowed"""
+        # First get a baseline # of events
+        count = user_sudo_events(self.USER, True)
+
+        # Now create an event and do some basic checking to ensure it failed
+        with pytest.raises(AssertionError) as ve:
+            self.sudo_command('ls /etc')
+        assert 'is not allowed to execute ' in str(ve), str(ve)
+        assert count + 1 == wait_for_events(self.USER, count + 1)
+        reject = assert_reject(user_sudo_events(self.USER)[-1])
+        assert reject['submituser'] == self.USER
+        assert reject['command'] == LS_COMMAND
+        assert reject['runuser'] == 'root'
+        assert reject['runargv'].split(',') == ['ls', '/etc']
+        assert reject['reason'] == 'command not allowed'
+
+
+class SudoNoPasswd:
+    def sudo_command(self, cmd, runuser=None):
+        command = self.generate_command(cmd, runuser)
+        ssh(command, user=self.USER, password=self.PASSWORD)
+
+
+class SudoPasswd:
+    def sudo_command(self, cmd, runuser=None):
+        command = f'echo {self.PASSWORD} | {self.generate_command(cmd, runuser, self.PASSWORD)}'
+        ssh(command, user=self.USER, password=self.PASSWORD)
+
+
+class TestSudoAllowedAllNoPasswd(SudoTests, SudoNoPasswd):
+
+    USER = 'sudo-allowed-all-nopw-user'
+    PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+    @pytest.fixture(scope='class')
+    def create_user(self):
+        with initialize_for_sudo_tests(self.USER,
+                                       self.PASSWORD,
+                                       {'sudo_commands_nopasswd': ['ALL']}) as u:
+            yield u
+
+    def test_audit_query(self, sudo_to_user, create_user):
+        self.allowed_all()
+
+
+class TestSudoAllowedAllPasswd(SudoTests, SudoPasswd):
+
+    USER = 'sudo-allowed-all-pw-user'
+    PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+    @pytest.fixture(scope='class')
+    def create_user(self):
+        with initialize_for_sudo_tests(self.USER,
+                                       self.PASSWORD,
+                                       {'sudo_commands': ['ALL']}) as u:
+            yield u
+
+    def test_audit_query(self, sudo_to_user, create_user):
+        self.allowed_all()
+
+
+class TestSudoAllowedNonePasswd(SudoTests, SudoPasswd):
+
+    USER = 'sudo-allowed-none-pw-user'
+    PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+    @pytest.fixture(scope='class')
+    def create_user(self):
+        with initialize_for_sudo_tests(self.USER, self.PASSWORD, {}) as u:
+            yield u
+
+    def test_audit_query(self, create_user):
+        self.allowed_none()
+
+
+class TestSudoAllowedSomeNoPasswd(SudoTests, SudoNoPasswd):
+
+    USER = 'sudo-allowed-some-nopw-user'
+    PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+    @pytest.fixture(scope='class')
+    def create_user(self):
+        with initialize_for_sudo_tests(self.USER,
+                                       self.PASSWORD,
+                                       {'sudo_commands_nopasswd': [ECHO_COMMAND]}) as u:
+            yield u
+
+    def test_audit_query(self, create_user):
+        self.allowed_some()
+
+
+class TestSudoAllowedSomePasswd(SudoTests, SudoPasswd):
+
+    USER = 'sudo-allowed-some-pw-user'
+    PASSWORD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+
+    @pytest.fixture(scope='class')
+    def create_user(self):
+        with initialize_for_sudo_tests(self.USER,
+                                       self.PASSWORD,
+                                       {'sudo_commands': [ECHO_COMMAND]}) as u:
+            yield u
+
+    def test_audit_query(self, create_user):
+        self.allowed_some()


### PR DESCRIPTION
Add audit support for `sudo`
- Turn on JSON logging in _/etc/sudoers_, including logging sub commands (e.g. commands issued after `sudo bash`)
- Tweak the generation of _/etc/syslog-ng/conf.d/_{_tnaudit.conf_,_tnfilters.conf_}.  Unlike when we are adding audit support to our own code, we are not changing the events generated by sudo, merely **_mapping_** them into our audit framework.  So, several hand-rolled `filter`, `parser`, `rewrite `and `log`.  Also some code to allow suppressing the usual boilerplate.
- Add tests