### PR TITLE
NAS-129126 / 24.10 / Do not spam middleware logs if path does not exist in smb share

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1317,8 +1317,11 @@ class SharingSMBService(SharingService):
             await self.middleware.run_in_thread(
                 self.validate_mount_info, verrors, name, path
             )
-        except FileNotFoundError:
-            verrors.add(name, 'Path does not exist.')
+        except CallError as e:
+            if e.errno == errno.ENOENT and e.errmsg == f'Path {path} not found':
+                verrors.add(name, 'Path does not exist.')
+            else:
+                raise
 
     @private
     async def validate_share_name(self, name, schema_name, verrors, exist_ok=True):


### PR DESCRIPTION
This commit fixes an issue where if a path in smb share did not exist, we were running an alert source which errored out and resulted in middleware spam and the alert source execution failing as well.

```
[2024/05/20 16:55:12] (ERROR) middlewared.check():138 - Failed to validate path field
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/alert/source/smb.py", line 133, in check
    await self.middleware.call(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1575, in call
    return await self._call(
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1428, in _call
    return await methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/service/sharing_service.py", line 85, in validate_path_field
    await self.validate_local_path(verrors, name, path)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/smb.py", line 1317, in validate_local_path
    await self.middleware.run_in_thread(
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1335, in run_in_thread
    return await self.run_in_executor(io_thread_pool_executor, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1332, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/smb.py", line 1258, in validate_mount_info
    st = self.middleware.call_sync('filesystem.stat', path)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1611, in call_sync
    return methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 191, in nf
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 53, in nf
    res = f(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/filesystem.py", line 399, in stat
    raise CallError(f'Path {_path} not found', errno.ENOENT)
middlewared.service_exception.CallError: [ENOENT] Path /mnt/failure/smb not found
```