### PR TITLE
NAS-128704 / 24.04.2 / Fix truecommand issues on HA (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1297,7 +1297,7 @@ async def service_remote(middleware, service, verb, options):
 
     This is the middleware side of what legacy UI did on service changes.
     """
-    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter', 'netdata')
+    ignore = ('system', 'smartd', 'nfs', 'kubernetes', 'kuberouter', 'netdata', 'truecommand')
     if not options['ha_propagate'] or service in ignore or service == 'nginx' and verb == 'stop':
         return
     elif await middleware.call('failover.status') != 'MASTER':

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -139,7 +139,7 @@ class TruecommandService(Service):
                 config[k] for k in ('wg_private_key', 'remote_address', 'endpoint', 'tc_public_key', 'wg_address')
             ):
                 await self.middleware.call('service.start', 'truecommand')
-                await self.middleware.call('service.reload', 'http')
+                await self.middleware.call('service.reload', 'http', {'ha_propagate': False})
                 asyncio.get_event_loop().call_later(
                     30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
                     lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x cdf1303a67a4049b699632d22b2890accbde5cce
    git cherry-pick -x e535b36f37f656ca521449411aea3f632b6ca102

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~2
    git cherry-pick -x f543ceb3ef351fced348fc0b5f982789df57be83

This PR adds changes to backport some of the fixes which were made to SCALE and not backported to CORE and also fix an issue where wireguard service started on standby whenever the service was started on active. Reason behind that was that we propagate service actions to standby automatically by default and that is not desirable in this case as wireguard should only be running on 1 node at a time. To address that `truecommand` has been added to list of blacklisted services which shouldn't be touched when any of the service verb is called for it.

An edge case for nginx config has also been handled where we were not adding wireguard interface ip to listen directive on failover and a subsequent nginx config reload was warranted because of that.

Original PR: https://github.com/truenas/middleware/pull/13756
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128704

Original PR: https://github.com/truenas/middleware/pull/13757
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128704