### PR TITLE
NAS-129065 / 24.10 / Handle mDNS SRV record for NUT service

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/services/ADISK.service.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/services/ADISK.service.py
@@ -56,7 +56,7 @@ def render(service, middleware, render_ctx):
         return mdns.generate_avahi_srv_record('ADISK', iindexes, txt_records=txt_records)
     except Exception:
         middleware.logger.error(
-            'Failed to generate mDNS SRV record for the HTTP service',
+            'Failed to generate mDNS SRV record for the ADISK service',
             exc_info=True
         )
 

--- a/src/middlewared/middlewared/etc_files/local/avahi/services/SMB.service.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/services/SMB.service.py
@@ -19,7 +19,7 @@ def render(service, middleware, render_ctx):
         return mdns.generate_avahi_srv_record('SMB', iindexes)
     except Exception:
         middleware.logger.error(
-            'Failed to generate mDNS SRV record for the HTTP service',
+            'Failed to generate mDNS SRV record for the SMB service',
             exc_info=True
         )
 

--- a/src/middlewared/middlewared/etc_files/local/avahi/services/nut.service.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/services/nut.service.py
@@ -1,0 +1,19 @@
+from middlewared.plugins.etc import FileShouldNotExist
+from middlewared.utils import mdns
+
+
+def render(service, middleware, render_ctx):
+
+    conf = render_ctx['ups.config']
+    if not render_ctx['ups.service.started_or_enabled']:
+        raise FileShouldNotExist()
+
+    try:
+        return mdns.generate_avahi_srv_record('NUT', custom_port=conf['remoteport'])
+    except Exception:
+        middleware.logger.error(
+            'Failed to generate mDNS SRV record for the nut service',
+            exc_info=True
+        )
+
+    raise FileShouldNotExist()

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -21,6 +21,10 @@ class UPSService(SimpleService):
             await self._systemd_unit("nut-driver-enumerator", "start")
         await self._unit_action("Start")
 
+    async def after_start(self):
+        # Reconfigure mdns (add nut service)
+        await self.middleware.call('service.reload', 'mdns')
+
     async def before_stop(self):
         await self.middleware.call("ups.dismiss_alerts")
 
@@ -29,3 +33,7 @@ class UPSService(SimpleService):
         await self._systemd_unit("nut-driver-enumerator", "stop")
         await self._systemd_unit("nut-server", "stop")
         await self._systemd_unit("nut-driver.target", "stop")
+
+    async def after_stop(self):
+        # Reconfigure mdns (remove nut service)
+        await self.middleware.call('service.reload', 'mdns')

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -23,7 +23,7 @@ class UPSService(SimpleService):
 
     async def after_start(self):
         # Reconfigure mdns (add nut service)
-        await self.middleware.call('service.reload', 'mdns')
+        await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
 
     async def before_stop(self):
         await self.middleware.call("ups.dismiss_alerts")
@@ -36,4 +36,4 @@ class UPSService(SimpleService):
 
     async def after_stop(self):
         # Reconfigure mdns (remove nut service)
-        await self.middleware.call('service.reload', 'mdns')
+        await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -879,7 +879,7 @@ class SharingSMBService(SharingService):
             await self._service_change('cifs', 'reload')
 
         if is_time_machine_share(data):
-            await self.middleware.call('service.reload', 'mdns')
+            await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
 
         return await self.get_instance(data['id'])
 
@@ -1067,7 +1067,7 @@ class SharingSMBService(SharingService):
                 self.logger.warn('Failed to remove registry entry for [%s].', share_name, exc_info=True)
 
         if is_time_machine_share(share):
-            await self.middleware.call('service.reload', 'mdns')
+            await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
 
         if share_name == 'homes':
             await self.middleware.call('etc.generate', 'smb')

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -36,7 +36,7 @@ from middlewared.plugins.smb_.constants import SMBBuiltin  # noqa (imported so m
 from middlewared.plugins.smb_.util_param import smbconf_getparm, lpctx_validate_global_parm
 from middlewared.plugins.smb_.util_net_conf import reg_delshare, reg_listshares, reg_setparm
 from middlewared.plugins.smb_.util_smbconf import generate_smb_conf_dict
-from middlewared.plugins.smb_.utils import apply_presets, smb_strip_comments
+from middlewared.plugins.smb_.utils import apply_presets, is_time_machine_share, smb_strip_comments
 from middlewared.plugins.tdb.utils import TDBError
 from middlewared.plugins.idmap_.utils import IDType, SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX
 from middlewared.utils import filter_list, run
@@ -878,7 +878,7 @@ class SharingSMBService(SharingService):
         else:
             await self._service_change('cifs', 'reload')
 
-        if data['timemachine']:
+        if is_time_machine_share(data):
             await self.middleware.call('service.reload', 'mdns')
 
         return await self.get_instance(data['id'])
@@ -1066,7 +1066,7 @@ class SharingSMBService(SharingService):
             except Exception:
                 self.logger.warn('Failed to remove registry entry for [%s].', share_name, exc_info=True)
 
-        if share['timemachine']:
+        if is_time_machine_share(share):
             await self.middleware.call('service.reload', 'mdns')
 
         if share_name == 'homes':

--- a/src/middlewared/middlewared/plugins/smb_/utils.py
+++ b/src/middlewared/middlewared/plugins/smb_/utils.py
@@ -69,3 +69,6 @@ def apply_presets(data_in):
         data["auxsmbconf"] = auxsmbconf_dict(preset_aux, direction="FROM")
 
     return data
+
+def is_time_machine_share(share):
+    return share.get('timemachine', False) or share.get('purpose') in [SMBSharePreset.TIMEMACHINE.name, SMBSharePreset.ENHANCED_TIMEMACHINE.name]

--- a/src/middlewared/middlewared/utils/mdns.py
+++ b/src/middlewared/middlewared/utils/mdns.py
@@ -32,6 +32,7 @@ class ServiceType(enum.Enum):
     DEV_INFO = ('_device-info._tcp.', DISCARD)
     HTTP = ('_http._tcp.', 80)
     SMB = ('_smb._tcp.', 445)
+    NUT = ('_nut._tcp.', 3493)
     CUSTOM = (None, None)
 
 

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -19,7 +19,7 @@ from middlewared.test.integration.utils.client import truenas_server
 from pytest_dependency import depends
 from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
 
-from auto_config import password, pool_name, user
+from auto_config import ha, password, pool_name, user
 from functions import SSH_TEST
 from protocols import smb_share
 
@@ -330,7 +330,10 @@ def test_001_initial_config(request):
 
     network_config = call('network.configuration.config')
     sa = network_config['service_announcement']
-    current_hostname = network_config['hostname']
+    if ha:
+        current_hostname = network_config['hostname_virtual']
+    else:
+        current_hostname = network_config['hostname']
     # At the moment we only care about mdns
     assert sa['mdns'] is True, sa
 

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -1,33 +1,27 @@
 import contextlib
-import os
 import random
 import re
 import socket
 import string
-import sys
 from datetime import datetime, timedelta
 from time import sleep
 from typing import cast
 
 import pytest
-from pytest_dependency import depends
-from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
-
-apifolder = os.getcwd()
-sys.path.append(apifolder)
 from assets.websocket.server import reboot
 from assets.websocket.service import (ensure_service_disabled,
                                       ensure_service_enabled,
                                       ensure_service_started,
                                       ensure_service_stopped)
-from auto_config import password, pool_name, user
-from functions import SSH_TEST
-from protocols import smb_share
-
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
+from pytest_dependency import depends
+from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
 
+from auto_config import password, pool_name, user
+from functions import SSH_TEST
+from protocols import smb_share
 
 digits = ''.join(random.choices(string.digits, k=4))
 dataset_name = f"smb-cifs{digits}"
@@ -43,6 +37,7 @@ TIME_MACHINE = '_adisk._tcp.local.'  # Automatic Disk
 DEVICE_INFO = '_device-info._tcp.local.'  # Device Info
 HTTP = '_http._tcp.local.'
 SMB = '_smb._tcp.local.'
+NUT = '_nut._tcp'
 
 DO_MDNS_REBOOT_TEST = False
 USE_AVAHI_BROWSE = True
@@ -172,6 +167,7 @@ class AvahiBrowserCollector:
         'Web Site': HTTP,
         'Microsoft Windows Network': SMB,
         'Apple TimeMachine': TIME_MACHINE,
+        '_nut._tcp': NUT,
     }
 
     def find_items(self, service_announcement=None, timeout=5):
@@ -243,7 +239,7 @@ class abstractmDNSAnnounceCollector:
     Class to help in the discovery (and processing/checking)
     of services advertised by a particular IP address/server name.
     """
-    SERVICES = [TIME_MACHINE, DEVICE_INFO, HTTP, SMB]
+    SERVICES = [TIME_MACHINE, DEVICE_INFO, HTTP, SMB, NUT]
 
     def __init__(self, ip, tn_hostname):
         self.ip = socket.gethostbyname(ip)


### PR DESCRIPTION
Use our own mako infrastructure to handle the mDNS SRV record for the NUT service.  This will override the file installed by the upstream debian package, and will only be present when UPS is configured/running.

Also include make several small fixes to allow unit tests pass.