### PR TITLE
NAS-128480 / 24.10 / Make changes in netdata nut plugin to support SLAVE UPS

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -13,6 +13,9 @@ K8S_PODS_COUNT = 20  # A default value has been assumed for now
 # change-how-long-netdata-stores-metrics
 TIER_0_POINT_SIZE = 1
 TIER_1_POINT_SIZE = 4
+NETDATA_GID = 997
+NETDATA_UID = 999
+NETDATA_UPS_INFO_FILE = 'ups_info.json'
 
 
 def calculate_disk_space_for_netdata(

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -1,5 +1,7 @@
 import os
 
+from middlewared.plugins.reporting.utils import NETDATA_GID, NETDATA_UID
+
 from .utils import SYSDATASET_PATH
 
 
@@ -160,8 +162,8 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
                 'canmount': 'noauto',
             },
             'chown_config': {
-                'uid': 999,
-                'gid': 997,
+                'uid': NETDATA_UID,
+                'gid': NETDATA_GID,
                 'mode': 0o755,
             },
             'mountpoint': os.path.join(SYSDATASET_PATH, 'netdata'),

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -258,6 +258,9 @@ class UPSService(SystemServiceService):
 
             await self._update_service(old_config, config)
 
+            if set(data) & {'remotehost', 'remoteport'}:
+                await self.middleware.call('reporting.generate_netdata_ups_info_file')
+
         return await self.config()
 
     @private


### PR DESCRIPTION
## Problem
There were two issues with the existing netdata nut plugin:
1. It doesn't support UPS SLAVE mode because it requires a remote address.
2. When UPS is not configured, the failed `upsc -l` command returns an error, which keeps spamming the netdata logs and causes the log file size to increase continuously.

## Solution
1. Store the UPS configuration in netdata's storage dataset in JSON format, including information related to UPS mode and its address. The Netdata plugin will use this info to run the upsc command accordingly.
2. Also, store information about whether the service has started or not. Modify the netdata plugin to avoid executing the `upsc` command when the UPS configuration is not stored or the UPS service has not started successfully.