### PR TITLE
NAS-129152 / 24.10 / Fix /data/license perms

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
+++ b/src/middlewared/middlewared/plugins/failover_/zpool_cachefile.py
@@ -53,4 +53,4 @@ class FailoverZpoolCacheFileService(Service):
                 saved.unlink(missing_ok=True)
             overwrite.unlink(missing_ok=True)
         except Exception:
-            self.logger.warning('Failed setting up zpool cacheilfe', exc_info=True)
+            self.logger.warning('Failed setting up zpool cachefile', exc_info=True)

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -16,6 +16,7 @@ from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
 LICENSE_FILE = '/data/license'
+LICENSE_FILE_MODE = 0o600
 
 
 class SystemService(Service):
@@ -209,7 +210,7 @@ class SystemService(Service):
                     raise ValidationError('system.license', 'This is not an HA capable system.')
 
         prev_product_type = self.middleware.call_sync('system.product_type')
-        with open(LICENSE_FILE, 'w+') as f:
+        with open(os.open(LICENSE_FILE, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, mode=LICENSE_FILE_MODE), 'w+') as f:
             f.write(license_)
 
         self.middleware.call_sync('etc.generate', 'rc')

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -210,8 +210,9 @@ class SystemService(Service):
                     raise ValidationError('system.license', 'This is not an HA capable system.')
 
         prev_product_type = self.middleware.call_sync('system.product_type')
-        with open(os.open(LICENSE_FILE, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, mode=LICENSE_FILE_MODE), 'w+') as f:
+        with open(LICENSE_FILE, 'w+') as f:
             f.write(license_)
+            os.fchmod(f.fileno(), LICENSE_FILE_MODE)
 
         self.middleware.call_sync('etc.generate', 'rc')
         SystemService.PRODUCT_TYPE = None


### PR DESCRIPTION
Noticed that a CI test (`test_007_early_settings.test_data_dir_perms`, #13707) was failing because of the mode of _/data/license_ in a HA system.

Fix that particular issue.  (Other issues remain.)