### PR TITLE
NAS-129148 / 24.04.1 / no really disable swap (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/swap_configure.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_configure.py
@@ -200,7 +200,7 @@ class DiskService(Service):
         # NOTE: We disable swap partitions by default. See NAS-128873 for details.
         # If the user wants to re-enable the swap partition(s), they will need to
         # run "swapon -a" manually (or in a post-init script).
-        await run('swapoff -a', check=False, shell=True)
+        await run(['swapoff', '-a'], check=False)
 
         return existing_swap_devices['partitions'] + existing_swap_devices['mirrors'] + created_swap_devices
 


### PR DESCRIPTION
`shell=True` is not allowed since we're doing asyncio based fork+exec'ing.....(gross). Anyways, properly run the command by putting params in a list.

Original PR: https://github.com/truenas/middleware/pull/13774
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129148