### PR TITLE
NAS-128941 / 24.10 / Allow VM deletion if virtualization is not supported

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -38,3 +38,11 @@ def get_pci_device_class(pci_path: str) -> str:
 
 def get_vm_nvram_file_name(vm_data: dict) -> str:
     return f'{vm_data["id"]}_{vm_data["name"]}_VARS.fd'
+
+
+def get_default_status() -> dict:
+    return {
+        'state': 'ERROR',
+        'pid': None,
+        'domain_state': 'ERROR',
+    }


### PR DESCRIPTION
### Context

A user switched from virtualization supported TN system to virtualization not supported and encountered this issue where he couldn't query and  then remove the VMs from the TN system. 

### Fix

PR adds the change to enable deletion of VMs even if virtualization is not supported. After the changes vm query will show the existing VMs but in error state like below. 

`"status": {
      "state": "ERROR",
      "pid": null,
      "domain_state": "ERROR"
    }`