### PR TITLE
NAS-129164 / 24.10 / Fix (recently) broken test test_058_create_new_user_knownfails

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -647,11 +647,13 @@ def test_058_create_new_user_knownfails(request):
             # fail (no users may share same home path)
             call('user.create', user2)
 
+        with pytest.raises(ValidationErrors):
             # Attempting to put homedir in subdirectory of existing homedir
             # should also rase validation error
             user2.update({'home_create': True})
             call('user.create', user2)
 
+        with pytest.raises(ValidationErrors):
             # Attempting to create a user with non-existing path
             user2.update({'home': os.path.join(user2['home'], 'canary')})
             call('user.create', user2)


### PR DESCRIPTION
Broken during a recent refactor (#13491).

Without additional with `pytest.raises(ValidationErrors):` we were jumping out on the first exception and not testing the remaining (expected) failures.