### PR TITLE
NAS-129170 / 24.10 / Fix nss wrapper

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -1,7 +1,12 @@
-import pwd as py_pwd
 import grp as py_grp
+import pwd as py_pwd
 
+import pytest
 from middlewared.utils.nss import grp, pwd
+
+BAD_UIDS = [987654, -2]
+BAD_GIDS = [987654, -2]
+BAD_NAMES = ["BogusName"]
 
 
 def test__check_user_count():
@@ -49,10 +54,44 @@ def test__check_user_dict_conversion():
 
 
 def test__check_group_dict_conversion():
-    py_groups = grp.getgrall()['FILES']
-    groups = grp.getgrall(as_dict=True)['FILES']
+    groups_normal = grp.getgrall()['FILES']
+    groups_dict = grp.getgrall(as_dict=True)['FILES']
 
-    for py_entry, entry in zip(py_groups, groups):
+    for py_entry, entry in zip(groups_normal, groups_dict):
         assert py_entry.gr_name == entry['gr_name']
         assert py_entry.gr_gid == entry['gr_gid']
         assert py_entry.gr_mem == entry['gr_mem']
+
+
+def test__check_user_misses():
+    for uid in BAD_UIDS:
+        with pytest.raises(KeyError) as ve:
+            py_pwd.getpwuid(uid)
+        assert 'uid not found' in str(ve)
+        with pytest.raises(KeyError) as ve:
+            pwd.getpwuid(uid)
+        assert 'uid not found' in str(ve)
+    for name in BAD_NAMES:
+        with pytest.raises(KeyError) as ve:
+            py_pwd.getpwnam(name)
+        assert 'name not found' in str(ve)
+        with pytest.raises(KeyError) as ve:
+            pwd.getpwnam(name)
+        assert 'name not found' in str(ve)
+
+
+def test__check_group_misses():
+    for uid in BAD_GIDS:
+        with pytest.raises(KeyError) as ve:
+            py_grp.getgrgid(uid)
+        assert 'uid not found' in str(ve)
+        with pytest.raises(KeyError) as ve:
+            grp.getgrgid(uid)
+        assert 'uid not found' in str(ve)
+    for name in BAD_NAMES:
+        with pytest.raises(KeyError) as ve:
+            py_grp.getgrnam(name)
+        assert 'name not found' in str(ve)
+        with pytest.raises(KeyError) as ve:
+            grp.getgrnam(name)
+        assert 'name not found' in str(ve)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -84,10 +84,10 @@ def test__check_group_misses():
     for uid in BAD_GIDS:
         with pytest.raises(KeyError) as ve:
             py_grp.getgrgid(uid)
-        assert 'uid not found' in str(ve)
+        assert 'gid not found' in str(ve)
         with pytest.raises(KeyError) as ve:
             grp.getgrgid(uid)
-        assert 'uid not found' in str(ve)
+        assert 'gid not found' in str(ve)
     for name in BAD_NAMES:
         with pytest.raises(KeyError) as ve:
             py_grp.getgrnam(name)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -4,8 +4,8 @@ import pwd as py_pwd
 import pytest
 from middlewared.utils.nss import grp, pwd
 
-BAD_UIDS = [987654, -2]
-BAD_GIDS = [987654, -2]
+BAD_UIDS = [987654, -1]
+BAD_GIDS = [987654, -1]
 BAD_NAMES = ["BogusName"]
 
 

--- a/src/middlewared/middlewared/utils/nss/grp.py
+++ b/src/middlewared/middlewared/utils/nss/grp.py
@@ -20,6 +20,8 @@ group_struct = namedtuple('struct_group', ['gr_name', 'gr_gid', 'gr_mem', 'sourc
 
 
 def __parse_nss_result(result, as_dict, module_name):
+    if result.gr_name is None:
+        return None
     name = result.gr_name.decode()
     members = list()
 

--- a/src/middlewared/middlewared/utils/nss/pwd.py
+++ b/src/middlewared/middlewared/utils/nss/pwd.py
@@ -25,10 +25,13 @@ pwd_struct = namedtuple('struct_passwd', [
 
 
 def __parse_nss_result(result, as_dict, module_name):
-    name = result.pw_name.decode()
-    gecos = result.pw_gecos.decode()
-    homedir = result.pw_dir.decode()
-    shell = result.pw_shell.decode()
+    try:
+        name = result.pw_name.decode()
+        gecos = result.pw_gecos.decode()
+        homedir = result.pw_dir.decode()
+        shell = result.pw_shell.decode()
+    except AttributeError:
+        return None
 
     if as_dict:
         return {


### PR DESCRIPTION
Found that the nss wrapper pwd and grp were not failing in exactly the same manner as python builtin equivalents

For example:
```
>>> from middlewared.utils.nss import pwd
>>> import pwd as pypwd
>>>
>>> pwd.getpwuid(0)
struct_passwd(pw_name='root', pw_uid=0, pw_gid=0, pw_gecos='root', pw_dir='/root', pw_shell='/usr/bin/zsh', source='FILES')
>>> pypwd.getpwuid(0)
pwd.struct_passwd(pw_name='root', pw_passwd='x', pw_uid=0, pw_gid=0, pw_gecos='root', pw_dir='/root', pw_shell='/usr/bin/zsh')
>>>
>>> pypwd.getpwuid(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'getpwuid(): uid not found: -1'
>>>
>>> pwd.getpwuid(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/middlewared/utils/nss/pwd.py", line 239, in getpwuid
    if (result := __getpwuid_impl(uid, mod.name, as_dict)):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/nss/pwd.py", line 216, in __getpwuid_impl
    return  __parse_nss_result(result, as_dict, mod.name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/nss/pwd.py", line 28, in __parse_nss_result
    name = result.pw_name.decode()
           ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'decode'
```
So, a `KeyError` vs an `AttributeError`.  Rectify.