### PR TITLE
NAS-128368 / 24.10 / nvme-of: Remove/Add disk on discovery change event

### DIFF
--- a/src/freenas/etc/systemd/system/nvmf-connect@.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/nvmf-connect@.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/bin/sh -c "/usr/local/bin/nvmf-wrapper.sh `/bin/echo -e '${CONNECT_ARGS}'`"

--- a/src/freenas/usr/local/bin/nvmf-connect.sh
+++ b/src/freenas/usr/local/bin/nvmf-connect.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+RECONNECT_TIMEOUT_SEC=5
+discovery_dev=$(echo "$@" | grep -oP '(?<=--device=)\w+')
+discovery_addr=$(</sys/class/nvme/${discovery_dev}/address)
+queue="/var/run/${discovery_dev}-fabric-queue"
+
+while [ -s $queue ]; do
+  truncate -s 0 $queue
+  local_nqns=""
+  disconnected=0
+  discovery_nqns=$(nvme discover $@ | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1')
+
+  for nqn_f in /sys/class/nvme-fabrics/ctl/nvme*/subsysnqn; do
+    dev=$(basename "$(dirname "$nqn_f")")
+    nqn=$(<"$nqn_f")
+    addr=$(</sys/class/nvme/${dev}/address)
+
+    if [[ "$dev" == "$discovery_dev" || "$addr" != "$discovery_addr" ]]; then
+      continue
+    fi
+
+    if [[ "$discovery_nqns" != *"$nqn"* ]]; then
+      nvme disconnect -d $dev
+      disconnected=1
+    else
+      local_nqns+="$nqn"$'\n'
+    fi
+  done
+
+  if [ $disconnected -eq 0 ]; then
+    counter=0
+    local_nqns=$(echo -e "$local_nqns" | tr -s '\n' | sort)
+
+    while [ $counter -lt $RECONNECT_TIMEOUT_SEC ]; do
+      connect_nqns=$(nvme discover "$@" | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1' \
+          | tr -s '\n' | sort)
+
+      if [ "$local_nqns" != "$connect_nqns" ]; then
+        break
+      fi
+
+      ((counter++))
+      sleep 1
+    done
+  fi
+
+  connect_all=$(nvme connect-all $@)
+done
+echo "EXIT" > $queue

--- a/src/freenas/usr/local/bin/nvmf-wrapper.sh
+++ b/src/freenas/usr/local/bin/nvmf-wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ "$#" -eq 0 ]; then
+  echo "Error: No arguments provided."
+  exit 1
+fi
+
+discovery_nqn="nqn.2014-08.org.nvmexpress.discovery"
+discovery_dev=$(echo "$@" | grep -oP '(?<=--device=)\w+')
+
+if [[ $(</sys/class/nvme/${discovery_dev}/subsysnqn) != $discovery_nqn ]]; then
+  echo "Error: Event not on discovery controller"
+  exit 1
+fi
+
+queue="/var/run/${discovery_dev}-fabric-queue"
+echo "QUEUE" > $queue
+systemd-run --unit=${discovery_dev}-of.service /bin/bash -c "/usr/local/bin/nvmf-connect.sh $*"
+
+# If service is still active and queue reads EXIT, we have a race. Wait for small interval since
+# we already know that nvmf-connect.sh is about to exit.
+if [ $? != 0 ] && [ "EXIT" = $(<$queue) ]; then
+  sleep 0.1
+  systemd-run --unit=${discovery_dev}-of.service /bin/bash -c "/usr/local/bin/nvmf-connect.sh $*"
+
+  if [ $? != 0 ]; then
+    echo "Error: ${discovery_dev}-of.service failed to start after waiting for 100 milliseconds"
+  fi
+fi


### PR DESCRIPTION
Jira Ticket: [NAS-128368](https://ixsystems.atlassian.net/browse/NAS-128368)

[NAS-128368](https://ixsystems.atlassian.net/browse/NAS-128368) reports three different issues related to NVMe-oF hotplugging:

### Problem:
NAS-128368 reports three different issues related to NVMe-oF hotplugging:
1. When a drive is physically removed while part of the pool, the Linux/zfs still sees it as ONLINE.
2. A drive is not visible to the OS upon insertion until the next drive is inserted, i.e., drive addition by OS is lagged by one event. For example, if a drive is inserted into Slot-1, it won't be added by Linux until another drive is inserted into a different slot. However, the addition of the next drive will then be lagged by the drive inserted after that.
3. If fenced is holding a drive, the new drive still points to the previous NVMe subsystem, showing the previous serial number of the last drive inserted.

### Solution:
1. The discovery controller receives the udev event, and by default, the NVMe-oF service runs the connect-all command, which is insufficient to remove the drive. To address this, we check the drives that are part of the enclosure and disconnect those not matched with the discovery log page.
2. It takes up to 3 seconds after receiving the discovery event for the drives to be ready for connection on the client side. To accommodate this, we added a timeout of five seconds to ensure the drive connects properly.
3. This issue is fixed by a Linux kernel patch: https://github.com/truenas/linux/pull/178. We now create a new subsystem if the previous one does not have any valid controllers.

Additionally, by default, systemd does not queue the events and ignores the service start if the service is already running. To resolve this, we added a simple queue to handle at most one event and created a wrapper to unblock systemd for the next udev events.

[NAS-128368]: https://ixsystems.atlassian.net/browse/NAS-128368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAS-128368]: https://ixsystems.atlassian.net/browse/NAS-128368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ