### PR TITLE
NAS-129171 / 24.04.1 / Also catch ValueError when looking up JbofModels (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -162,7 +162,7 @@ def get_enclosure_model(rclient):
                 try:
                     model = JbofModels(info.json().get('Model', '')).name
                     break
-                except KeyError:
+                except (KeyError, ValueError):
                     continue
     except Exception:
         LOGGER.error('Unexpected failure determing enclosure model', exc_info=True)


### PR DESCRIPTION
Found that `ValueError` was being raised by the type of lookup we were doing.

Original PR: https://github.com/truenas/middleware/pull/13782
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129171