### PR TITLE
NAS-129197 / 24.10 / Fix failing app roles integration tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -52,7 +52,9 @@ def common_checks(
                 with pytest.raises(Exception) as exc_info:
                     client.call(method, *method_args, **method_kwargs)
 
-                assert not isinstance(exc_info.value, ClientException)
+                assert isinstance(exc_info.value, ClientException) is False or (
+                    exc_info.value.errno != errno.EACCES and exc_info.value.error != 'Not authorized'
+                )
 
             elif is_return_type_none:
                 assert client.call(method, *method_args, **method_kwargs) is None


### PR DESCRIPTION
This PR fixes app roles integration tests which were failing because k8s was not running. Testing roles should not require k8s to be running, some changes have been made to accommodate for this and handle both cases when k8s is running or not running so we appropriately manage those cases and gracefully handle role based tests.
