### PR TITLE
NAS-129054 / 24.10 / Fix permissions on files under data directory

### DIFF
--- a/src/middlewared/middlewared/etc_files/systemd.py
+++ b/src/middlewared/middlewared/etc_files/systemd.py
@@ -1,5 +1,6 @@
 import json
 import re
+import os
 
 from middlewared.service import CallError
 from middlewared.utils import run
@@ -38,4 +39,5 @@ async def render(service, middleware):
 
     # Write out a user enabled services to json file which shows which services user has enabled/disabled
     with open('/data/user-services.json', 'w') as f:
+        os.fchmod(f.fileno(), 0o600)
         f.write(json.dumps(services_enabled))

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -9,6 +9,7 @@ from datetime import date
 from licenselib.license import ContractType, Features, License
 from pathlib import Path
 
+from middlewared.plugins.truenas import EULA_PENDING_PATH
 from middlewared.schema import accepts, Bool, returns, Str
 from middlewared.service import no_auth_required, no_authz_required, private, Service, ValidationError
 from middlewared.utils import sw_info
@@ -217,7 +218,8 @@ class SystemService(Service):
         self.middleware.call_sync('etc.generate', 'rc')
         SystemService.PRODUCT_TYPE = None
         if self.middleware.call_sync('system.is_enterprise'):
-            Path('/data/truenas-eula-pending').touch(exist_ok=True)
+            with open(EULA_PENDING_PATH, 'a+') as f:
+                os.fchmod(f.fileno(), 0o600)
 
         self.middleware.call_sync('alert.alert_source_clear_run', 'LicenseStatus')
         self.middleware.call_sync('failover.configure.license', dser_license)

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -92,7 +92,7 @@ class TrueNASService(Service):
     @accepts(roles=['READONLY_ADMIN'])
     @returns(Bool('system_eula_accepted'))
     @cli_private
-    async def is_eula_accepted(self):
+    def is_eula_accepted(self):
         """
         Returns whether the EULA is accepted or not.
         """
@@ -100,7 +100,7 @@ class TrueNASService(Service):
 
     @accepts()
     @returns()
-    async def accept_eula(self):
+    def accept_eula(self):
         """
         Accept TrueNAS EULA.
         """
@@ -111,9 +111,9 @@ class TrueNASService(Service):
                 raise
 
     @private
-    async def unaccept_eula(self):
-        with open(EULA_PENDING_PATH, "w"):
-            pass
+    def unaccept_eula(self):
+        with open(EULA_PENDING_PATH, "w") as f:
+            os.fchmod(f.fileno(), 0o600)
 
     # TODO: Document this please
     @accepts()


### PR DESCRIPTION
## Problem

The `test_data_dir_perms` of the early_settings integration test was failing because some files, including `user-services.json`, `truenas-eula-pending`, and `dhparam.pem`, do not have `0o600` permissions when created by middlewared.

## Solution

Specify the permissions of these files to be `0o600` when they are created by middlewared.

P.S permission for dhparam are not fixed as they should be handled in another PR we have open