### PR TITLE
NAS-129200 / 24.10 / fix start_sector assert (invalid test)

### DIFF
--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -65,7 +65,6 @@ def test_disk_format(unused_disk):
 
     # Should be a modulo of grain_size
     assert partitions[0]['size'] % grain_size == 0
-    assert partitions[0]['start_sector'] % grain_size == 0
 
     # Uses (almost) all the disk
     assert partitions[0]['start_sector'] == first_sector


### PR DESCRIPTION
Api test is asserting because the check is invalid and incorrect (c.f. https://github.com/Distrotech/parted/blob/388bab890a4e09b09d2428c0e773ed083295f91b/parted/parted.c#L1643C51-L1643C61) for how parted does it)

We check for alignment in this same function here
```
    # Uses (almost) all the disk
    assert partitions[0]['start_sector'] == first_sector