### PR TITLE
NAS-129204 / 24.10 / Add final flag to audit log statements to prevent propagation

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -83,6 +83,7 @@ log {
   parser(p_tnaudit);
   rewrite(r_rewrite_success);
   destination(d_tnaudit_${svc.lower()});
+  flags(final);
 };
 %endif
 % endfor
@@ -141,6 +142,7 @@ log {
   rewrite(r_rewrite_sudo_accept);
   rewrite(r_rewrite_sudo_common);
   destination(d_tnaudit_sudo);
+  flags(final);
 };
 log {
   source(s_src);
@@ -151,5 +153,6 @@ log {
   rewrite(r_rewrite_sudo_reject);
   rewrite(r_rewrite_sudo_common);
   destination(d_tnaudit_sudo);
+  flags(final);
 };
 </%text>


### PR DESCRIPTION
Without this failed `sudo` events (especially) were spamming console (or root ssh sessions).

----
Some helpful docs:
https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.25/administration-guide/55#TOPIC-1349501