### PR TITLE
NAS-129124 / 24.10 / Add temporary filter to non-critical SNMP warning.

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -60,6 +60,11 @@ filter f_scst {
   program("kernel") and match("dlm:" value("MESSAGE"));
 };
 
+# Temporary SNMP filter: NAS-129124
+filter f_snmp {
+  program("snmpd") and match("unexpected header length" value("MESSAGE"));
+};
+
 filter f_truenas_exclude {
 % if not nfs_conf['mountd_log']:
   not filter(f_nfs_mountd) and
@@ -69,7 +74,9 @@ filter f_truenas_exclude {
   not filter(f_containerd) and
   not filter(f_kube_router) and
   not filter(f_app_mounts) and
-  not filter(f_scst)
+  not filter(f_scst) and
+  # Temporary SNMP filter: NAS-129124
+  not filter(f_snmp)
 };
 
 #####################


### PR DESCRIPTION
A fix for this is available in the SNMP tip, but not in any Debian version. This filter will be removed when Debian provides a version with the fix.

This syslog spamming occurs on any Linux TrueNAS that runs with the Debian snmp v5.9.3 and the Linux 6.6 or later kernel (e.g. Dragonfish)

This filter can be removed when the Debian snmpd package includes the fix. See https://ixsystems.atlassian.net/browse/NAS-129206

