### PR TITLE
NAS-129124 / 24.04.2 / Add temporary filter to non-critical SNMP warning. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -50,6 +50,11 @@ filter f_nfs_mountd {
   program("rpc.mountd") and level(debug..notice);
 };
 
+# Temporary SNMP filter: NAS-129124
+filter f_snmp {
+  program("snmpd") and match("unexpected header length" value("MESSAGE"));
+};
+
 filter f_truenas_exclude {
 % if not nfs_conf['mountd_log']:
   not filter(f_nfs_mountd) and
@@ -58,7 +63,9 @@ filter f_truenas_exclude {
   not filter(f_k3s) and
   not filter(f_containerd) and
   not filter(f_kube_router) and
-  not filter(f_app_mounts)
+  not filter(f_app_mounts) and
+  # Temporary SNMP filter: NAS-129124
+  not filter(f_snmp)
 };
 
 #####################


### PR DESCRIPTION
A fix for this is available in the SNMP tip, but not in any Debian version. This filter will be removed when Debian provides a version with the fix.

This syslog spamming occurs on any Linux TrueNAS that runs with the Debian snmp v5.9.3 and the Linux 6.6 or later kernel (e.g. Dragonfish)

This filter can be removed when the Debian snmpd package includes the fix. See https://ixsystems.atlassian.net/browse/NAS-129206



Original PR: https://github.com/truenas/middleware/pull/13800
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129124