### PR TITLE
NAS-129150 / 24.10 / fix apps when interface has a description

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -226,11 +226,9 @@ class KubernetesService(Service):
                 errno=CallError.EDATASETISLOCKED,
             )
 
-        iface_errors = await self.middleware.call('kubernetes.validate_interfaces', config)
-        if iface_errors:
-            iface = iface_errors[1]
-            err_msg = iface_errors[-1]
-            raise CallError(f'Failed to setup {iface!r} with error: {err_msg}')
+        for _, iface, err_msg in await self.middleware.call('kubernetes.validate_interfaces', config):
+            if err_msg:
+                raise CallError(f'Failed to setup {iface!r} with error: {err_msg}')
 
         errors = await self.middleware.call('kubernetes.validate_config')
         if errors:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/update.py
@@ -399,9 +399,7 @@ class KubernetesService(ConfigService):
         interfaces = await self.route_interface_choices()
         for k in filter(lambda k: data[k], ('route_v4_interface', 'route_v6_interface')):
             iface = data[k]
-            try:
-                valid_iface = interfaces[iface]
-            except KeyError:
+            if iface not in interfaces:
                 errors.append(
                     (k, iface, f'{iface!r} is invalid. Valid interfaces are {", ".join([i for i in interfaces])!r}.')
                 )
@@ -411,10 +409,10 @@ class KubernetesService(ConfigService):
                 # this is particularly important when the interface that's
                 # configured for apps is a bridge (or lagg) for example
                 is_up, err_str = await self.middleware.run_in_thread(
-                    self.wait_on_interface_link_state_up, valid_iface
+                    self.wait_on_interface_link_state_up, iface
                 )
                 if not is_up:
-                    errors.append((k, valid_iface, err_str))
+                    errors.append((k, iface, err_str))
 
         return errors
 


### PR DESCRIPTION
`route_interface_choices` returns a dictionary whose keys are the interface names and the values are the interface names OR the interface name suffixed with a colon and a description (if the user has set one OR if the OS set one on upgrade from CORE)

We need the interface name as the OS sees it since we end up checking files in sysfs. This fixes the scenario.