### PR TITLE
NAS-129260 / 24.10 / Replace shareuser with UserAssets.ShareUser01 in depends

### DIFF
--- a/tests/api2/test_340_pool_dataset.py
+++ b/tests/api2/test_340_pool_dataset.py
@@ -3,18 +3,17 @@
 # License: BSD
 
 import errno
-import sys
-import os
+
 import pytest
-from pytest_dependency import depends
-apifolder = os.getcwd()
-sys.path.append(apifolder)
-from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job
-from auto_config import pool_name, user, password
 from middlewared.client import ClientException
 from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.pool import dataset as dataset_asset
 from middlewared.test.integration.utils import call
+from pytest_dependency import depends
+from test_011_user import UserAssets
+
+from auto_config import password, pool_name, user
+from functions import DELETE, GET, POST, PUT, SSH_TEST, wait_on_job
 
 dataset = f'{pool_name}/dataset1'
 dataset_url = dataset.replace('/', '%2F')
@@ -164,7 +163,7 @@ def test_13_strip_acl_from_dataset(request):
 
 
 def test_14_setting_various_quotas(request):
-    depends(request, ['shareuser'], scope='session')
+    depends(request, [UserAssets.ShareUser01['depends_name']], scope='session')
     user = group = 'shareuser'
     user_gid = GET('/group/?group=shareuser').json()[0]['gid']
     user_uid = GET('/user/?username=shareuser').json()[0]['uid']
@@ -405,14 +404,14 @@ def test_33_simplified_charts_api(request):
     USER2_TO_ADD = 8765310
     GROUP_TO_ADD = 1138
     NFS4_ACL_PAYLOAD = [
-       {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'MODIFY'},
-       {'id_type': 'GROUP', 'id': GROUP_TO_ADD, 'access': 'READ'},
-       {'id_type': 'USER', 'id': USER2_TO_ADD, 'access': 'FULL_CONTROL'},
+        {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'MODIFY'},
+        {'id_type': 'GROUP', 'id': GROUP_TO_ADD, 'access': 'READ'},
+        {'id_type': 'USER', 'id': USER2_TO_ADD, 'access': 'FULL_CONTROL'},
     ]
     ACL_PAYLOAD = [
-       {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'MODIFY'},
-       {'id_type': 'GROUP', 'id': GROUP_TO_ADD, 'access': 'READ'},
-       {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'FULL_CONTROL'},
+        {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'MODIFY'},
+        {'id_type': 'GROUP', 'id': GROUP_TO_ADD, 'access': 'READ'},
+        {'id_type': 'USER', 'id': USER_TO_ADD, 'access': 'FULL_CONTROL'},
     ]
 
     # TEST NFS4 ACL type

--- a/tests/api2/test_810_delete_user.py
+++ b/tests/api2/test_810_delete_user.py
@@ -4,17 +4,14 @@
 # License: BSD
 # Location for tests into REST API of FreeNAS
 
-import pytest
-import sys
-import os
 from pytest_dependency import depends
-apifolder = os.getcwd()
-sys.path.append(apifolder)
-from functions import GET, DELETE
+from test_011_user import UserAssets
+
+from functions import DELETE, GET
 
 
 def test_01_deleting_user_shareuser(request):
-    depends(request, ["shareuser"], scope="session")
+    depends(request, [UserAssets.ShareUser01['depends_name']], scope="session")
     userid = GET('/user?username=shareuser').json()[0]['id']
     results = DELETE("/user/id/%s/" % userid, {"delete_group": True})
     assert results.status_code == 200, results.text


### PR DESCRIPTION
During PR #13491 the following:
```
@pytest.mark.dependency(name="shareuser")
def test_27_creating_shareuser_to_test_sharing(request):
```
was replaced with
```
@pytest.mark.dependency(name=UserAssets.ShareUser01['depends_name'])
def test_020_create_and_verify_shareuser():
```

However, dependent changes were only made in _test_011_user.py_, e.g.
```
def test_038_change_homedir_to_existing_path(request):
    depends(request, [UserAssets.ShareUser01['depends_name'], UserAssets.TestUser01['depends_name']])
    ....
```
(Note that the actual string referred to by `depends_name` has changed to "share_user_01")

This PR updates a couple of **other** tests in different modules that also depend on "shareuser".  Also did some tidy/`flake8` fixes.

Before this PR they were being skipped.   (PR tested in CI run [550](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/550/))

Question: worth backporting to 24.04.2 ?