### PR TITLE
NAS-129187 / 24.10 / Add stats in chart.release entry schema

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -87,6 +87,7 @@ class ChartReleaseService(CRUDService):
             List('truenas_certificate_authorities', items=[Int('certificate_authority_id')]),
             *[List(r.value) for r in Resources],
         ),
+        Dict('stats', additional_attrs=True)
     )
 
     @filterable


### PR DESCRIPTION
## Problem
The `stats` schema is not defined in the `chart.release` schema, causing schema errors when using `chart.release.query` with stats for read-only user permissions.

## Solution
Add the `stats` schema to the `chart.release` schema to resolve this error.