### PR TITLE
NAS-129187 / 24.04.1.1 / Add stats in chart.release entry schema (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -87,6 +87,7 @@ class ChartReleaseService(CRUDService):
             List('truenas_certificate_authorities', items=[Int('certificate_authority_id')]),
             *[List(r.value) for r in Resources],
         ),
+        Dict('stats', additional_attrs=True)
     )
 
     @filterable


### PR DESCRIPTION
## Problem
The `stats` schema is not defined in the `chart.release` schema, causing schema errors when using `chart.release.query` with stats for read-only user permissions.

## Solution
Add the `stats` schema to the `chart.release` schema to resolve this error.

Original PR: https://github.com/truenas/middleware/pull/13805
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129187