### PR TITLE
Restrict read access to sudoers file

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -88,7 +88,7 @@ class EtcService(Service):
                 {'type': 'mako', 'path': 'group'},
                 {'type': 'mako', 'path': 'passwd', 'local_path': 'master.passwd'},
                 {'type': 'mako', 'path': 'shadow', 'group': 'shadow', 'mode': 0o0640},
-                {'type': 'mako', 'path': 'local/sudoers'},
+                {'type': 'mako', 'path': 'local/sudoers', 'mode': 0o440},
                 {'type': 'mako', 'path': 'aliases', 'local_path': 'mail/aliases'},
                 {'type': 'py', 'path': 'web_ui_root_login_alert'},
             ]


### PR DESCRIPTION
This change alters permissions on /etc/sudoers to make it consistent with upstream debian (was 0o644).