### PR TITLE
NAS-129288 / 24.10 / Fix permissions and owner of snmpd.conf

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -252,7 +252,9 @@ class EtcService(Service):
             ]
         },
         'snmpd': [
-            {'type': 'mako', 'path': 'snmp/snmpd.conf', 'local_path': 'local/snmpd.conf'},
+            {'type': 'mako', 'path': 'snmp/snmpd.conf',
+                'local_path': 'local/snmpd.conf', 'owner': 'root', 'group': 'Debian-snmp', 'mode': 0o640
+            },
         ],
         'syslogd': {
             'ctx': [


### PR DESCRIPTION
The permissions and owner of the snmpd.conf file did not match the Debian default.
This then generated an error:
`[2024/05/29 09:33:50] (ERROR) EtcService.make_changes():372 - /etc/snmp/snmpd.conf: unexpected changes [GID, PERMS] were made to configuration file that may allow unauthorized user to alter service behavior`

Change the permissions and owners to match the expected values.