### PR TITLE
properly detect nvme devices in smart plugin

### DIFF
--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -27,6 +27,9 @@ async def get_smartctl_args(context, disk, smartoptions):
     if device is None:
         return
 
+    if device["vendor"].lower().strip() == "nvme":
+        return [f"/dev/{disk}", "-d", "nvme"] + smartoptions
+
     args = [f"/dev/{disk}"] + smartoptions
     if not enterprise_hardware and device['bus'] == 'USB':
         args = args + ["-d", "sat"]

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -128,10 +128,11 @@ class DeviceService(Service):
 
     @private
     def get_disk_details(self, ctx, dev, get_partitions=False):
-        is_nvme = dev.sys_name.startswith('nvme')
         blocks = self.safe_retrieval(dev.attributes, 'size', None, asint=True)
         ident = serial = self.get_disk_serial(dev)
         model = descr = self.safe_retrieval(dev.properties, 'ID_MODEL', None)
+        vendor = self.safe_retrieval(dev.properties, 'ID_VENDOR', None)
+        is_nvme = dev.sys_name.startswith('nvme') or (vendor and vendor.lower().strip() == 'nvme')
         driver = self.safe_retrieval(dev.parent.properties, 'DRIVER', '') if not is_nvme else 'nvme'
         sectorsize = self.safe_retrieval(dev.attributes, 'queue/logical_block_size', None, asint=True)
 
@@ -148,6 +149,7 @@ class DeviceService(Service):
             'hctl': self.safe_retrieval(dev.parent.properties, 'DEVPATH', '').split('/')[-1],
             'size': size,
             'mediasize': mediasize,
+            'vendor': vendor,
             'ident': ident,
             'serial': serial,
             'model': model,


### PR DESCRIPTION
This is required for the h-series platform. Disks sit behind a tri-mode HBA and so nvme devices appear to OS as `sd` devices.