### PR TITLE
NAS-129295 / 24.10 / Audit changes to the SMB server configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -624,7 +624,7 @@ class SMBService(ConfigService):
         List('bindip', items=[IPAddr('ip')]),
         Str('smb_options', max_length=None),
         update=True,
-    ))
+    ), audit='Update SMB configuration')
     @pass_app(rest=True)
     async def do_update(self, app, data):
         """
@@ -818,7 +818,8 @@ class SharingSMBService(SharingService):
                 List('ignore_list', default=NOT_PROVIDED)
             ),
             register=True
-        )
+        ),
+        audit='Create SMB share', audit_extended=lambda data: data['name']
     )
     @pass_app(rest=True)
     async def do_create(self, app, data):
@@ -967,17 +968,19 @@ class SharingSMBService(SharingService):
             'sharingsmb_create',
             'sharingsmb_update',
             ('attr', {'update': True})
-        )
+        ),
+        audit='Update SMB share',
+        audit_callback=True,
     )
     @pass_app(rest=True)
-    async def do_update(self, app, id_, data):
+    async def do_update(self, app, audit_callback, id_, data):
         """
         Update SMB Share of `id`.
         """
-        ha_mode = SMBHAMODE[(await self.middleware.call('smb.get_smb_ha_mode'))]
+        old = await self.get_instance(id_)
+        audit_callback(old['name'])
 
         verrors = ValidationErrors()
-        old = await self.get_instance(id_)
         old_audit = old['audit']
 
         new = old.copy()
@@ -1070,13 +1073,15 @@ class SharingSMBService(SharingService):
 
         return await self.get_instance(id_)
 
-    @accepts(Int('id'))
-    async def do_delete(self, id_):
+    @accepts(Int('id'), audit='Delete SMB share', audit_callback=True)
+    async def do_delete(self, audit_callback, id_):
         """
         Delete SMB Share of `id`. This will forcibly disconnect SMB clients
         that are accessing the share.
         """
         share = await self.get_instance(id_)
+        audit_callback(share['name'])
+
         result = await self.middleware.call('datastore.delete', self._config.datastore, id_)
 
         share_name = 'homes' if share['home'] else share['name']
@@ -1562,7 +1567,7 @@ class SharingSMBService(SharingService):
             ),
         ], default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]),
         register=True
-    ), roles=['SHARING_SMB_WRITE'])
+    ), roles=['SHARING_SMB_WRITE'], audit='Setacl SMB share', audit_extended=lambda data: data['share_name'])
     @returns(Ref('smb_share_acl'))
     async def setacl(self, data):
         """
@@ -1673,7 +1678,10 @@ class SharingSMBService(SharingService):
             })
         return await self.getacl({'share_name': data['share_name']})
 
-    @accepts(Dict('smb_getacl', Str('share_name', required=True)), roles=['SHARING_SMB_READ'])
+    @accepts(Dict(
+        'smb_getacl',
+        Str('share_name', required=True)
+    ), roles=['SHARING_SMB_READ'], audit='Getacl SMB share', audit_extended=lambda data: data['share_name'])
     @returns(Ref('smb_share_acl'))
     async def getacl(self, data):
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/smb_/util_sd.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_sd.py
@@ -145,6 +145,7 @@ class SMBService(Service):
         service = 'cifs'
         service_verb = 'restart'
 
+    @private
     @accepts(
         Dict(
             'get_remote_acl',

--- a/tests/api2/test_audit_smb.py
+++ b/tests/api2/test_audit_smb.py
@@ -53,7 +53,7 @@ def test_smb_share_audit(smb_audit_dataset):
         with expect_audit_method_calls([{
             'method': 'sharing.smb.create',
             'params': [payload],
-            'description': f'SMB share create {smb_share_path}',
+            'description': f'SMB share create audit_share',
         }]):
             share_config = call('sharing.smb.create', payload)
 
@@ -67,7 +67,7 @@ def test_smb_share_audit(smb_audit_dataset):
                 share_config['id'],
                 payload,
             ],
-            'description': f'SMB share update {smb_share_path}',
+            'description': f'SMB share update audit_share',
         }]):
             share_config = call('sharing.smb.update', share_config['id'], payload)
 
@@ -78,6 +78,6 @@ def test_smb_share_audit(smb_audit_dataset):
             with expect_audit_method_calls([{
                 'method': 'sharing.smb.delete',
                 'params': [share_id],
-                'description': f'SMB share delete {smb_share_path}',
+                'description': f'SMB share delete audit_share',
             }]):
                 call('sharing.smb.delete', share_id)

--- a/tests/api2/test_audit_smb.py
+++ b/tests/api2/test_audit_smb.py
@@ -1,0 +1,83 @@
+import os
+import sys
+
+import pytest
+from middlewared.service_exception import CallError
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.audit import expect_audit_method_calls
+
+sys.path.append(os.getcwd())
+
+REDACTED_SECRET = '********'
+
+
+@pytest.fixture(scope='module')
+def smb_audit_dataset(request):
+    with dataset('audit-test-smb') as ds:
+        try:
+            yield ds
+        finally:
+            pass
+
+
+def test_smb_update_audit():
+    '''
+    Test the auditing of SMB configuration changes
+    '''
+    initial_smb_config = call('smb.config')
+    payload = {'enable_smb1': True}
+    try:
+        with expect_audit_method_calls([{
+            'method': 'smb.update',
+            'params': [payload],
+            'description': 'Update SMB configuration',
+        }]):
+            call('smb.update', payload)
+    finally:
+        call('smb.update', {'enable_smb1': False})
+
+
+def test_smb_share_audit(smb_audit_dataset):
+    '''
+    Test the auditing of SMB share operations
+    '''
+    smb_share_path = os.path.join('/mnt', smb_audit_dataset)
+    try:
+        # CREATE
+        payload = {
+            "comment": "My Test Share",
+            "path": smb_share_path,
+            "name": "audit_share"
+        }
+        with expect_audit_method_calls([{
+            'method': 'sharing.smb.create',
+            'params': [payload],
+            'description': f'SMB share create {smb_share_path}',
+        }]):
+            share_config = call('sharing.smb.create', payload)
+
+        # UPDATE
+        payload = {
+            "ro": True 
+        }
+        with expect_audit_method_calls([{
+            'method': 'sharing.smb.update',
+            'params': [
+                share_config['id'],
+                payload,
+            ],
+            'description': f'SMB share update {smb_share_path}',
+        }]):
+            share_config = call('sharing.smb.update', share_config['id'], payload)
+
+    finally:
+        if share_config is not None:
+            # DELETE
+            share_id = share_config['id']
+            with expect_audit_method_calls([{
+                'method': 'sharing.smb.delete',
+                'params': [share_id],
+                'description': f'SMB share delete {smb_share_path}',
+            }]):
+                call('sharing.smb.delete', share_id)


### PR DESCRIPTION
Add auditing for changes to smb.update, smb.getacl, smb.setacl, sharing.smb.create, sharing.smb.update, and sharing.smb.delete.