### PR TITLE
NAS-129308 / 24.10 / Remove cifs-utils from debian control

### DIFF
--- a/debian/debian/control
+++ b/debian/debian/control
@@ -9,7 +9,6 @@ Homepage: http://www.truenas.com
 Package: truenas
 Architecture: all
 Depends: acl,
-         cifs-utils,
          console-setup,
          cpuid,
          gdb,


### PR DESCRIPTION
This package is not required to build middleware and is now included in the base-packages in scale-build.