### PR TITLE
NAS-129327 / 24.10 / Fix the API tests that were (incorrectly) using disk.get_unused

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -60,7 +60,7 @@ def another_pool(data=None, topology=None):
         yield pool
     finally:
         try:
-            call("pool.export", pool["id"], job=True)
+            call("pool.export", pool["id"], {"destroy": True}, job=True)
         except ValidationErrors as e:
             if not any(error.errcode == errno.ENOENT for error in e.errors):
                 raise

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -162,7 +162,7 @@ def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(ws_client, p
         disk_deets = ws_client.call('disk.details')
         # disk should not show up in `exported_zpool` keys since it's still imported
         assert not any((i['exported_zpool'] == pool['name'] for i in disk_deets['unused']))
-        # on the contrary, the disk should show up as being part of an imported zpool
+        # disk should show up in `imported_zpool` key
         assert any((i['imported_zpool'] == pool['name'] for i in disk_deets['used']))
 
         sysds = ws_client.call('systemdataset.config')
@@ -190,7 +190,7 @@ def test_003_verify_unused_disk_and_sysds_functionality_on_2nd_pool(ws_client, p
 def test_004_verify_pool_property_unused_disk_functionality(request, ws_client, pool_data):
     """
     This does a few things:
-    1. export the zpool without wiping the disk and verify that disk.get_unused
+    1. export the zpool without wiping the disk and verify that disk.get_used
         still shows the relevant disk as being part of an exported zpool
     2. clean up the pool by exporting and wiping the disks
     3. finally, if this is HA enable failover since all tests after this one
@@ -212,8 +212,8 @@ def test_004_verify_pool_property_unused_disk_functionality(request, ws_client, 
     try:
         # disk should show up in `exported_zpool` keys since zpool was exported
         # without wiping the disk
-        unused_disks = ws_client.call('disk.get_unused', False)
-        assert any((i['exported_zpool'] == zp_name for i in unused_disks))
+        used_disks = ws_client.call('disk.get_used')
+        assert any((i['exported_zpool'] == zp_name for i in used_disks))
 
         # pool should be available to be imported again
         available_pools = ws_client.call('pool.import_find', job=True)

--- a/tests/api2/test_disk_format.py
+++ b/tests/api2/test_disk_format.py
@@ -68,7 +68,7 @@ def test_disk_format(unused_disk):
 
     # Uses (almost) all the disk
     assert partitions[0]['start_sector'] == first_sector
-    assert partitions[0]['end_sector'] >= dd['blocks'] - grain_size
+    assert partitions[0]['end_sector'] <= dd['blocks'] - grain_size
 
     # And does not clobber the MBR data at the end
     assert partitions[0]['end_sector'] < dd['blocks'] - MBR_SECTOR_GAP

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -1,36 +1,14 @@
 import time
 
 import pytest
-from middlewared.test.integration.assets.pool import another_pool
-from middlewared.test.integration.utils import call, ssh
 
 from auto_config import ha
-
-
-def test_disk_wipe_exported_zpool_in_disk_get_unused():
-    with another_pool() as tmp_pool:
-        tmp_pool_name = tmp_pool['name']
-        flat = call('pool.flatten_topology', tmp_pool['topology'])
-        used_disks = [i['disk'] for i in flat if i['type'] == 'DISK']
-
-    for disk in filter(lambda x: x['name'] in used_disks, call('disk.get_unused')):
-        # disks should still show as being part of an exported zpool
-        assert disk['exported_zpool'] == tmp_pool_name
-
-        # since we're here we'll wipe the disks
-        call('disk.wipe', disk['name'], 'QUICK', job=True)
-
-    for disk in filter(lambda x: x['name'] in used_disks, call('disk.get_unused')):
-        # now disks should no longer show as being part of the exported zpool
-        assert disk['exported_zpool'] is None
+from middlewared.test.integration.utils import call, ssh
 
 
 def test_disk_wipe_partition_clean():
-    """
-    Confirm we clean up around the middle partitions
-    """
+    """Confirm we clean up around the middle partitions"""
     signal_msg = "ix private data"
-
     disk = call("disk.get_unused")[0]["name"]
 
     # Create a data partition


### PR DESCRIPTION
The disk.get_unused endpoint now actually returns disks that are "unused" (i.e. no partition zfs partition labels on them). We made a bad decision to show an `exported_zpool` key for disks but they showed up in "unused" disks.

`disk.details` now returns an `used` and `unused` set of keys that return disk information. There are `exported_zpool` and `imported_zpool` keys for each disk. If either of those are filled, they will show up in `disk.get_used` (or `disk.details['used']`).

Our `another_pool` context manager wasn't wiping the disks and so the zpool label was left on them even though the zpool was being exported. To fix the majority of tests, I've changed it so that we're now wiping (quickly) the disks that the `another_pool` context manager uses. This fixes the majority of tests.

While I was here I removed a redundant disk wipe test and fixed another assert.