### PR TITLE
NAS-129341 / 24.04.2 / Change scope of unprivileged_user_fixture fixture to module (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/roles.py
+++ b/src/middlewared/middlewared/test/integration/assets/roles.py
@@ -13,7 +13,7 @@ from middlewared.test.integration.utils import call, client
 USER_FIXTURE_TUPLE = collections.namedtuple('UserFixture', 'username password group_name')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def unprivileged_user_fixture(request):
     suffix = ''.join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
     group_name = f'unprivileged_users_fixture_{suffix}'


### PR DESCRIPTION
Change the scope of the `change_unprivileged_user_fixture` to module.

Otherwise, the user remains in play and interferes with other tests (e.g. `test__smb_simple_share_validation`)

Original PR: https://github.com/truenas/middleware/pull/13824
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129341