### PR TITLE
NAS-129354 / 24.10 / Make sure vendor key exists before trying string operation

### DIFF
--- a/src/middlewared/middlewared/common/smart/smartctl.py
+++ b/src/middlewared/middlewared/common/smart/smartctl.py
@@ -27,7 +27,7 @@ async def get_smartctl_args(context, disk, smartoptions):
     if device is None:
         return
 
-    if device["vendor"].lower().strip() == "nvme":
+    if device["vendor"] and device["vendor"].lower().strip() == "nvme":
         return [f"/dev/{disk}", "-d", "nvme"] + smartoptions
 
     args = [f"/dev/{disk}"] + smartoptions


### PR DESCRIPTION
## Problem

```
[2024/06/02 12:00:37] (ERROR) DiskService.update():32 - update_smartctl_args_for_disks failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/smartctl.py", line 27, in update
    await asyncio_map(
  File "/usr/lib/python3/dist-packages/middlewared/utils/asyncio_.py", line 19, in asyncio_map
    return await asyncio.gather(*futures)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/asyncio_.py", line 16, in func
    return await real_func(arg)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/common/smart/smartctl.py", line 30, in get_smartctl_args
    if device["vendor"].lower().strip() == "nvme":
       ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'lower'
```

## Solution

Make sure `vendor` key has an actual value before treating it as a string.