### PR TITLE
NAS-129355 / 24.10 / Fix dhparam permissions

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/dhparams.py
+++ b/src/middlewared/middlewared/plugins/crypto_/dhparams.py
@@ -15,7 +15,6 @@ class CertificateService(Service):
     async def dhparam(self):
         return DHPARAM_PEM_PATH
 
-
     @private
     @job()
     def dhparam_setup(self, job):
@@ -23,5 +22,7 @@ class CertificateService(Service):
         with open(DHPARAM_PEM_PATH, 'a+') as f:
             if os.fstat(f.fileno()).st_size == 0:
                 subprocess.run(
-                    ['openssl', 'dhparam', '-out', DHPARAM_PEM_PATH, '-rand', '/dev/urandom', '2048'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True
+                    ['openssl', 'dhparam', '-out', DHPARAM_PEM_PATH, '-rand', '/dev/urandom', '2048'],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True,
                 )
+                os.fchmod(f.fileno(), 0o600)


### PR DESCRIPTION
## Problem

`DHPARAM_PEM_PATH` file when created has incorrect permissions applied which do not conform to what we want them to do.

## Solution

Fix the permissions for `DHPARAM_PEM_PATH` and flake8 issues.