### PR TITLE
NAS-129370 / 24.10 / Minor logical fix in enclosure_class._get_model_and_controller

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -115,7 +115,7 @@ class Enclosure:
                 # to using the parenthesis approach because that matches
                 # an entry in the enum by value
                 dmi_model = ControllerModels(model)
-            except KeyError:
+            except ValueError:
                 # this shouldn't ever happen because the instantiator of this class
                 # checks DMI before we even get here but better safe than sorry
                 logger.warning('Unexpected model: %r from dmi: %r', model, self.dmi)


### PR DESCRIPTION
Catch ValueError instead of KeyError when accessing ControllerModels values with parentheses (line 118). Python enums throw ValueError when using parentheses.