### PR TITLE
NAS-129261 / 24.10 / Fix validation for httpproxy

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/global_config.py
+++ b/src/middlewared/middlewared/plugins/network_/global_config.py
@@ -5,7 +5,7 @@ import signal
 
 import middlewared.sqlalchemy as sa
 from middlewared.service import ConfigService, private
-from middlewared.schema import accepts, Patch, List, Dict, Int, Str, Bool, IPAddr, Ref, ValidationErrors
+from middlewared.schema import accepts, Patch, List, Dict, Int, Str, Bool, IPAddr, Ref, URI, ValidationErrors
 from middlewared.validators import Match, Hostname
 
 HOSTS_FILE_EARMARKER = '# STATIC ENTRIES'
@@ -49,7 +49,7 @@ class NetworkConfigurationService(ConfigService):
         IPAddr('nameserver1', required=True),
         IPAddr('nameserver2', required=True),
         IPAddr('nameserver3', required=True),
-        Str('httpproxy', required=True),
+        URI('httpproxy', required=True),
         List('hosts', required=True, items=[Str('host')]),
         List('domains', required=True, items=[Str('domain')]),
         Dict(


### PR DESCRIPTION
## Problem
Users are entering incorrect proxy URL formats in the network configuration.

## Solution
Add validation in the network global configuration to prevent users from adding incorrectly formatted proxy URLs.

Ref:
https://requests.readthedocs.io/en/latest/api/#requests.Session.proxies
https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
