### PR TITLE
NAS-128090 / 24.10 / Track system dataset migration state for failover disabled reasons

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -324,6 +324,14 @@ class SystemDatasetService(ConfigService):
     @accepts(Str('exclude_pool', default=None, null=True))
     @private
     def setup(self, exclude_pool):
+        self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': True})
+        try:
+            return self.setup_impl(exclude_pool)
+        finally:
+            self.middleware.call_hook_sync('sysdataset.setup', data={'in_progress': False})
+
+    @private
+    def setup_impl(self, exclude_pool):
         self.force_pool = None
         config = self.middleware.call_sync('systemdataset.config')
 


### PR DESCRIPTION
## Context

Changes have been added to track system dataset migration state in HA machines so we can correctly report that is in place when UI consumes `failover.disabled.reasons` to see if we have any reason to mark HA has disabled for now.