### PR TITLE
NAS-129273 / 24.10 / fix enclosure2.query logic on R20/MINI3XP/MINI3E

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -72,8 +72,11 @@ class Enclosure:
                 ControllerModels.MINI3E.value,
             )),
         )):
-            # These platforms have 2x virtual AHCI enclosures but we only map the
-            # drives on 1 of them
+            # If this platform is a R20*, a MINI-3.0-X+, or MINI-3.0-E, there are
+            # 2x Virtual AHCI enclosure devices. However, the physical drive slots
+            # only get mapped to the Virtual AHCI enclosure of the 1st one. (i.e.
+            # the one whose enclosure id is "3000000000000001"). So we ignore the
+            # other enclosure device otherwise.
             self.should_ignore = True
         else:
             self.should_ignore = False

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -65,13 +65,12 @@ class Enclosure:
             # if this isn't an R20 or MINI platform and this is the Virtual AHCI
             # enclosure, then we can ignore them
             self.should_ignore = True
-        elif all((
+        elif self.encid == '3000000000000002' and any((
             self.is_r20_series,
             (self.model in (
                 ControllerModels.MINI3XP.value,
                 ControllerModels.MINI3E.value,
             )),
-            self.encid == '3000000000000002'
         )):
             # These platforms have 2x virtual AHCI enclosures but we only map the
             # drives on 1 of them


### PR DESCRIPTION
We were including the 2nd virtual AHCI enclosure object in `enclosure2.query` which was causing `webui.enclosure.dashboard` to crash with a `KeyError`.

This fixes that logic and prevents the key error.