### PR TITLE
NAS-129408 / 24.10 / add missing log statement when importing pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -278,6 +278,7 @@ class PoolService(Service):
 
         if opts['properties']:
             try:
+                self.logger.debug('Calling zfs.dateset.update on %r with opts %r', vol_name, opts['properties'])
                 self.middleware.call_sync('zfs.dataset.update', vol_name, opts)
             except Exception:
                 self.logger.warning('%r: failed to normalize properties of root-level dataset', vol_name, exc_info=True)


### PR DESCRIPTION
This was added in the backport to 24.04.2 but was missed in master. This adds it so the branches are aligned with each other.