### PR TITLE
NAS-128872 / 24.10 / When deleting a target attempt to cleanup associated initiator

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -364,6 +364,16 @@ class iSCSITargetService(CRUDService):
         await self.middleware.call('iscsi.target.remove_target', target["name"])
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
+        # Attempt to cleanup initiators as the wizard may have created a single-use one
+        try:
+            initiators = [group['initiator'] for group in target['groups']]
+            for initiator in initiators:
+                # Ensure not used elsewhere
+                targets = await self.middleware.call('iscsi.target.query', [['groups.*.initiator', '=', initiator]])
+                if not targets:
+                    await self.middleware.call('iscsi.initiator.delete', initiator)
+        except Exception:
+            self.logger.error('Failed to clean up target initiators for %r', target['name'], exc_info=True)
         return rv
 
     @private


### PR DESCRIPTION
When using the iSCSI wizard entries under `Initiator Groups` can be created one-per-target without any user interaction.  As such these therefore invite also being cleaned up without user interaction when the target is deleted.

Since when creating the target without using the wizard these entities can be reused/shared by several targets, during cleanup we check first that no other target is using them.