### PR TITLE
NAS-129429 / 24.10 / fix docstring for disk.get_unused

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -110,8 +110,7 @@ class DiskService(Service):
     @accepts(Bool('join_partitions', default=False), roles=['REPORTING_READ'])
     async def get_unused(self, join_partitions):
         """
-        Return disks that are NOT in use by any zpool that is currently imported. It will
-        also return disks that are in use by any zpool that is exported.
+        Return disks that are NOT in use by any zpool that is currently imported OR exported.
 
         `join_partitions`: Bool, when True will return all partitions currently written to disk
             NOTE: this is an expensive operation


### PR DESCRIPTION
This method was changed but the docstring was copy and pasted from `disk.get_used`. Update it to reflect reality.