### PR TITLE
NAS-128872 / 24.04.2 / When deleting a target attempt to cleanup associated initiator (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -357,12 +357,14 @@ class iSCSITargetService(CRUDService):
 
         # Attempt to cleanup initiators as the wizard may have created a single-use one
         try:
-            initiators = [group['initiator'] for group in target['groups']]
-            for initiator in initiators:
-                # Ensure not used elsewhere
-                targets = await self.middleware.call('iscsi.target.query', [['groups.*.initiator', '=', initiator]])
-                if not targets:
-                    await self.middleware.call('iscsi.initiator.delete', initiator)
+            target_initiators = {group['initiator'] for group in target['groups']}
+            # Ensure not used elsewhere
+            all_initiators = set()
+            for t in await self.middleware.call('iscsi.target.query', [], {'select': ['groups']}):
+                all_initiators.update([group['initiator'] for group in t['groups']])
+
+            for initiator in target_initiators - all_initiators:
+                await self.middleware.call('iscsi.initiator.delete', initiator)
         except Exception:
             self.logger.error('Failed to clean up target initiators for %r', target['name'], exc_info=True)
         return rv

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -355,6 +355,16 @@ class iSCSITargetService(CRUDService):
         await self.middleware.call('iscsi.target.remove_target', target["name"])
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
+        # Attempt to cleanup initiators as the wizard may have created a single-use one
+        try:
+            initiators = [group['initiator'] for group in target['groups']]
+            for initiator in initiators:
+                # Ensure not used elsewhere
+                targets = await self.middleware.call('iscsi.target.query', [['groups.*.initiator', '=', initiator]])
+                if not targets:
+                    await self.middleware.call('iscsi.initiator.delete', initiator)
+        except Exception:
+            self.logger.error('Failed to clean up target initiators for %r', target['name'], exc_info=True)
         return rv
 
     @private

--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -49,7 +49,9 @@ def initiator():
     try:
         yield initiator_config
     finally:
-        call('iscsi.initiator.delete', initiator_config['id'])
+        # Very likely that already cleaned up (by removing only target using it)
+        if call('iscsi.initiator.query', [['id', '=', initiator_config['id']]]):
+            call('iscsi.initiator.delete', initiator_config['id'])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
When using the iSCSI wizard entries under `Initiator Groups` can be created one-per-target without any user interaction.  As such these therefore invite also being cleaned up without user interaction when the target is deleted.

Since when creating the target without using the wizard these entities can be reused/shared by several targets, during cleanup we check first that no other target is using them.

Original PR: https://github.com/truenas/middleware/pull/13844
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128872