### PR TITLE
NAS-128439 / 24.10 / Send interface events when commit/rollback for network is performed

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/utils.py
+++ b/src/middlewared/middlewared/plugins/network_/utils.py
@@ -1,0 +1,69 @@
+import typing
+
+
+def get_interface_name(item: dict, key: str, interface_dict: dict) -> typing.Optional[str]:
+
+    def get_iface_name(iface_key: str, iface: dict) -> typing.Optional[str]:
+        iface_id = iface[iface_key]
+        if iface_id in interface_dict:
+            return interface_dict[iface_id]['int_interface']
+
+    if key == 'interfaces' and isinstance(item, dict) and 'int_interface' in item:
+        return item['int_interface']
+    elif key == 'bridge':
+        return get_iface_name('interface', item)
+    elif key == 'vlan' and 'vlan_vint' in item:
+        return item['vlan_vint']
+    elif key == 'lagg':
+        return get_iface_name('lagg_interface', item)
+    elif key == 'laggmembers' and 'lagg_interface' in item:
+        return item['lagg_interface']
+
+
+def find_interface_changes(original_datastores: dict, current_datastores: dict) -> typing.List[str]:
+    changed_interfaces = set()
+    original_items_dict = {}
+    current_items_dict = {}
+    current_ifaces = {iface['int_interface']: iface for iface in current_datastores.get('interfaces', [])}
+
+    for key in ('interfaces', 'alias', 'bridge', 'vlan', 'lagg', 'laggmembers'):
+        original_items_dict[key] = {item['id']: item for item in original_datastores.get(key, [])}
+        current_items_dict[key] = {item['id']: item for item in current_datastores.get(key, [])}
+
+        for id_, item in current_items_dict[key].items():
+            if id_ in original_items_dict[key] and item != original_items_dict[key][id_]:
+                if interface_name := get_interface_name(item, key, current_datastores['interfaces']):
+                    changed_interfaces.add(interface_name)
+
+            if key != 'laggmembers':
+                continue
+
+            # lagg members is special in the sense that if members have been added/removed, that also points out that
+            # lagg interface has changed
+            # So we will get added/removed lagg members and add the lagg interface to changed_interfaces
+            args = ['laggmembers', current_datastores['interfaces']]
+            for lagg_member in set(current_items_dict) - set(original_items_dict):
+                if (
+                    (interface_name := get_interface_name(*([current_items_dict[lagg_member]] + args))) and
+                    interface_name in current_ifaces
+                ):
+                    changed_interfaces.add(interface_name)
+
+            for lagg_member in set(original_items_dict) - set(current_items_dict):
+                if (
+                    (interface_name := get_interface_name(*([original_items_dict[lagg_member]] + args))) and
+                    interface_name in current_ifaces
+                ):
+                    changed_interfaces.add(interface_name)
+
+    return list(changed_interfaces)
+
+
+def retrieve_added_removed_interfaces(
+    original_datastores: dict, current_datastores: dict, retrieval_type: str
+) -> typing.List[str]:
+    original_ifaces = set([iface['int_interface'] for iface in original_datastores.get('interfaces', [])])
+    current_ifaces = set([iface['int_interface'] for iface in current_datastores.get('interfaces', [])])
+    return list(
+        original_ifaces - current_ifaces if retrieval_type == 'removed' else current_ifaces - original_ifaces
+    )

--- a/src/middlewared/middlewared/pytest/unit/plugins/network/test_network_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/network/test_network_utils.py
@@ -1,0 +1,192 @@
+from copy import deepcopy
+from middlewared.plugins.network_.utils import find_interface_changes, retrieve_added_interfaces, retrieve_removed_interfaces
+
+
+ORIGINAL = {
+    'interfaces': [
+        {
+            'id': 1,
+            'int_interface': 'enp1s0',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '192.0.1.253',
+            'int_address_b': '',
+            'int_version': 4,
+            'int_netmask': 24,
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 2,
+            'int_interface': 'enp10s0',
+            'int_name': '',
+            'int_dhcp': True,
+            'int_address': '',
+            'int_address_b': '',
+            'int_version': '',
+            'int_netmask': '',
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 28,
+            'int_interface': 'br0',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '',
+            'int_address_b': '',
+            'int_version': '',
+            'int_netmask': '',
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 29,
+            'int_interface': 'bond0',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '',
+            'int_address_b': '',
+            'int_version': '',
+            'int_netmask': '',
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 30,
+            'int_interface': 'vlan0',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '',
+            'int_address_b': '',
+            'int_version': '',
+            'int_netmask': '',
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        }
+    ],
+    'alias': [],
+    'bridge': [
+        {
+            'id': 20,
+            'members': ['enp17s0'],
+            'stp': True,
+            'enable_learning': True,
+            'interface': 28
+        }
+    ],
+    'vlan': [
+        {
+            'id': 5,
+            'vlan_vint': 'vlan0',
+            'vlan_pint': 'enp1s0',
+            'vlan_tag': 23,
+            'vlan_description': '',
+            'vlan_pcp': None
+         }
+    ],
+    'lagg': [
+        {
+            'id': 2,
+            'lagg_protocol': 'lacp',
+            'lagg_xmit_hash_policy': 'layer2+3',
+            'lagg_lacpdu_rate': 'slow',
+            'lagg_interface': 29
+        }
+    ],
+    'laggmembers': [
+        {
+            'id': 22,
+            'lagg_ordernum': 0,
+            'lagg_physnic': 'enp16s0',
+            'lagg_interfacegroup': 2,
+            'lagg_interface': 'bond0'
+        }
+    ],
+    'ipv4gateway': {
+        'gc_ipv4gateway': '192.168.122.1'
+    }
+}
+
+
+def test_physical_interface_changes():
+    current = deepcopy(ORIGINAL)
+    current['interfaces'][0]['int_dhcp'] = True
+    current['interfaces'][1]['int_netmask'] = '24'
+    assert set(find_interface_changes(ORIGINAL, current)) == {'enp1s0', 'enp10s0'}
+
+
+def test_bridge_interface_changes():
+    current = deepcopy(ORIGINAL)
+    current['interfaces'][2]['int_dhcp'] = True
+    assert set(find_interface_changes(ORIGINAL, current)) == {'br0'}
+
+
+def test_bridge_members_changes():
+    current = deepcopy(ORIGINAL)
+    current['bridge'][0]['stp'] = False
+    assert set(find_interface_changes(ORIGINAL, current)) == {'br0'}
+
+
+def test_bond_interface_changes():
+    current = deepcopy(ORIGINAL)
+    current['interfaces'][3]['int_dhcp'] = True
+    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+
+
+def test_lagg_changes():
+    current = deepcopy(ORIGINAL)
+    current['lagg'][0]['lagg_lacpdu_rate'] = False
+    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+
+
+def test_lagg_members_changes():
+    current = deepcopy(ORIGINAL)
+    current['laggmembers'][0]['vlan_tag'] = 231
+    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+
+
+def test_vlan_interface_changes():
+    current = deepcopy(ORIGINAL)
+    current['interfaces'][4]['int_dhcp'] = True
+    assert set(find_interface_changes(ORIGINAL, current)) == {'vlan0'}
+
+
+def test_vlan_changes():
+    current = deepcopy(ORIGINAL)
+    current['vlan'][0]['int_dhcp'] = True
+    assert set(find_interface_changes(ORIGINAL, current)) == {'vlan0'}
+
+
+def test_check_interface_removed():
+    current = deepcopy(ORIGINAL)
+    current['interfaces'].pop(0)
+    assert set(retrieve_removed_interfaces(ORIGINAL, current)) == {'enp1s0'}
+
+
+def test_check_interface_added():
+    current = deepcopy(ORIGINAL)
+    new_interface = deepcopy(current['interfaces'][0])
+    new_interface['int_interface'] = 'enp11s0'
+    current['interfaces'].append(new_interface)
+    assert set(retrieve_added_interfaces(ORIGINAL, current)) == {'enp11s0'}

--- a/src/middlewared/middlewared/pytest/unit/plugins/network/test_network_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/network/test_network_utils.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
-from middlewared.plugins.network_.utils import find_interface_changes, retrieve_added_interfaces, retrieve_removed_interfaces
-
+import copy
+import pytest
+from middlewared.plugins.network_.utils import find_interface_changes, retrieve_added_removed_interfaces
 
 ORIGINAL = {
     'interfaces': [
@@ -9,7 +9,7 @@ ORIGINAL = {
             'int_interface': 'enp1s0',
             'int_name': '',
             'int_dhcp': False,
-            'int_address': '192.0.1.253',
+            'int_address': '192.168.122.253',
             'int_address_b': '',
             'int_version': 4,
             'int_netmask': 24,
@@ -37,14 +37,14 @@ ORIGINAL = {
             'int_mtu': 1500
         },
         {
-            'id': 28,
+            'id': 32,
             'int_interface': 'br0',
             'int_name': '',
             'int_dhcp': False,
-            'int_address': '',
+            'int_address': '10.2.31.23',
             'int_address_b': '',
-            'int_version': '',
-            'int_netmask': '',
+            'int_version': 4,
+            'int_netmask': 24,
             'int_ipv6auto': False,
             'int_vip': '',
             'int_vhid': None,
@@ -53,14 +53,14 @@ ORIGINAL = {
             'int_mtu': 1500
         },
         {
-            'id': 29,
-            'int_interface': 'bond0',
+            'id': 33,
+            'int_interface': 'br1',
             'int_name': '',
             'int_dhcp': False,
-            'int_address': '',
+            'int_address': '34.32.123.22',
             'int_address_b': '',
-            'int_version': '',
-            'int_netmask': '',
+            'int_version': 4,
+            'int_netmask': 24,
             'int_ipv6auto': False,
             'int_vip': '',
             'int_vhid': None,
@@ -69,14 +69,62 @@ ORIGINAL = {
             'int_mtu': 1500
         },
         {
-            'id': 30,
+            'id': 34,
+            'int_interface': 'bond0',
+            'int_name': 'bond interface',
+            'int_dhcp': False,
+            'int_address': '172.3.2.1',
+            'int_address_b': '',
+            'int_version': 4,
+            'int_netmask': 24,
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 35,
+            'int_interface': 'bond1',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '56.43.1.23',
+            'int_address_b': '',
+            'int_version': 4,
+            'int_netmask': 24,
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 36,
             'int_interface': 'vlan0',
             'int_name': '',
             'int_dhcp': False,
-            'int_address': '',
+            'int_address': '174.21.3.2',
             'int_address_b': '',
-            'int_version': '',
-            'int_netmask': '',
+            'int_version': 4,
+            'int_netmask': 24,
+            'int_ipv6auto': False,
+            'int_vip': '',
+            'int_vhid': None,
+            'int_critical': False,
+            'int_group': None,
+            'int_mtu': 1500
+        },
+        {
+            'id': 37,
+            'int_interface': 'vlan1',
+            'int_name': '',
+            'int_dhcp': False,
+            'int_address': '87.21.3.2',
+            'int_address_b': '',
+            'int_version': 4,
+            'int_netmask': 24,
             'int_ipv6auto': False,
             'int_vip': '',
             'int_vhid': None,
@@ -85,108 +133,250 @@ ORIGINAL = {
             'int_mtu': 1500
         }
     ],
-    'alias': [],
+    'alias': [
+        {
+            'id': 3,
+            'alias_address': '10.2.3.12',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 32
+        },
+        {
+            'id': 4,
+            'alias_address': '10.32.32.14',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 32
+        },
+        {
+            'id': 5,
+            'alias_address': '32.32.12.43',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 33
+        },
+        {
+            'id': 6,
+            'alias_address': '172.3.2.3',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 34
+        },
+        {
+            'id': 8,
+            'alias_address': '56.54.32.3',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 35
+        },
+        {
+            'id': 9,
+            'alias_address': '56.53.32.5',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 35
+        },
+        {
+            'id': 10,
+            'alias_address': '173.21.23.4',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 36
+        },
+        {
+            'id': 11,
+            'alias_address': '34.21.23.4',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 37
+        },
+        {
+            'id': 12,
+            'alias_address': '176.2.1.2',
+            'alias_version': 4,
+            'alias_netmask': 24,
+            'alias_address_b': '',
+            'alias_vip': '',
+            'alias_interface': 34
+        }
+    ],
     'bridge': [
         {
-            'id': 20,
-            'members': ['enp17s0'],
+            'id': 21,
+            'members': ['enp10s0'],
             'stp': True,
             'enable_learning': True,
-            'interface': 28
-        }
+            'interface': 32
+        },
+        {
+            'id': 22,
+            'members': ['enp16s0', 'enp17s0'],
+            'stp': True,
+            'enable_learning': True,
+            'interface': 33
+         }
     ],
     'vlan': [
         {
-            'id': 5,
+            'id': 6,
             'vlan_vint': 'vlan0',
-            'vlan_pint': 'enp1s0',
-            'vlan_tag': 23,
+            'vlan_pint': 'enp22s0',
+            'vlan_tag': 231,
             'vlan_description': '',
-            'vlan_pcp': None
-         }
+            'vlan_pcp': 1
+        },
+        {
+            'id': 7,
+            'vlan_vint': 'vlan1',
+            'vlan_pint': 'enp23s0',
+            'vlan_tag': 231,
+            'vlan_description': '',
+            'vlan_pcp': 0
+        }
     ],
     'lagg': [
         {
-            'id': 2,
+            'id': 4,
             'lagg_protocol': 'lacp',
+            'lagg_xmit_hash_policy': 'LAYER2+3',
+            'lagg_lacpdu_rate': 'SLOW',
+            'lagg_interface': 34
+        },
+        {
+            'id': 5,
+            'lagg_protocol': 'loadbalance',
             'lagg_xmit_hash_policy': 'layer2+3',
-            'lagg_lacpdu_rate': 'slow',
-            'lagg_interface': 29
+            'lagg_lacpdu_rate': None,
+            'lagg_interface': 35
         }
     ],
     'laggmembers': [
         {
-            'id': 22,
+            'id': 29,
             'lagg_ordernum': 0,
-            'lagg_physnic': 'enp16s0',
-            'lagg_interfacegroup': 2,
+            'lagg_physnic': 'enp21s0',
+            'lagg_interfacegroup': 5,
+            'lagg_interface': 'bond1'
+        },
+        {
+            'id': 32,
+            'lagg_ordernum': 0,
+            'lagg_physnic': 'enp18s0',
+            'lagg_interfacegroup': 4,
+            'lagg_interface': 'bond0'
+        },
+        {
+            'id': 33,
+            'lagg_ordernum': 1,
+            'lagg_physnic': 'enp20s0',
+            'lagg_interfacegroup': 4,
             'lagg_interface': 'bond0'
         }
     ],
-    'ipv4gateway': {
-        'gc_ipv4gateway': '192.168.122.1'
-    }
 }
 
 
-def test_physical_interface_changes():
-    current = deepcopy(ORIGINAL)
-    current['interfaces'][0]['int_dhcp'] = True
-    current['interfaces'][1]['int_netmask'] = '24'
-    assert set(find_interface_changes(ORIGINAL, current)) == {'enp1s0', 'enp10s0'}
+@pytest.mark.parametrize('member_id,action,payload,changed_iface', [
+    (None, 'add', {
+        'id': 35,
+        'lagg_ordernum': 2,
+        'lagg_physnic': 'enp21s0',
+        'lagg_interfacegroup': 4,
+        'lagg_interface': 'bond0'
+    }, 'bond0'),
+    (32, 'remove', {}, 'bond0'),
+])
+def test_bond_changed(member_id, action, payload, changed_iface):
+    current = copy.deepcopy(ORIGINAL)
+    if action == 'add':
+        current['laggmembers'].append(payload)
+    else:
+        current['laggmembers'].pop(next(i for i, d in enumerate(current['laggmembers']) if d['id'] == member_id))
+
+    assert changed_iface in find_interface_changes(ORIGINAL, current)
+    assert changed_iface not in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert changed_iface not in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')
 
 
-def test_bridge_interface_changes():
-    current = deepcopy(ORIGINAL)
-    current['interfaces'][2]['int_dhcp'] = True
-    assert set(find_interface_changes(ORIGINAL, current)) == {'br0'}
+def test_vlan_changed():
+    current = copy.deepcopy(ORIGINAL)
+    current['vlan'][0]['vlan_description'] = 'Changed description'
+    assert 'vlan0' in find_interface_changes(ORIGINAL, current)
+    assert 'vlan0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert 'vlan0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')
 
 
-def test_bridge_members_changes():
-    current = deepcopy(ORIGINAL)
-    current['bridge'][0]['stp'] = False
-    assert set(find_interface_changes(ORIGINAL, current)) == {'br0'}
+def test_alias_changed():
+    current = copy.deepcopy(ORIGINAL)
+    current['alias'][0]['alias_netmask'] = 25
+    assert 'br0' in find_interface_changes(ORIGINAL, current)
+    assert 'br0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert 'br0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')
 
 
-def test_bond_interface_changes():
-    current = deepcopy(ORIGINAL)
-    current['interfaces'][3]['int_dhcp'] = True
-    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+def test_bridge_changed():
+    current = copy.deepcopy(ORIGINAL)
+    current['bridge'][1]['stp'] = False
+    assert 'br1' in find_interface_changes(ORIGINAL, current)
+    assert 'br1' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert 'br1' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')
 
 
-def test_lagg_changes():
-    current = deepcopy(ORIGINAL)
-    current['lagg'][0]['lagg_lacpdu_rate'] = False
-    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+def test_interface_changed():
+    current = copy.deepcopy(ORIGINAL)
+    changed_ifaces = []
+    iface_id_mapping = {i['id']: i['int_interface'] for i in ORIGINAL['interfaces']}
+    for index, interface in enumerate(current['interfaces']):
+        if index % 2 == 0:
+            interface['int_mtu'] = 1600
+            changed_ifaces.append(iface_id_mapping[interface['id']])
+
+    assert set(changed_ifaces) == set(find_interface_changes(ORIGINAL, current))
 
 
-def test_lagg_members_changes():
-    current = deepcopy(ORIGINAL)
-    current['laggmembers'][0]['vlan_tag'] = 231
-    assert set(find_interface_changes(ORIGINAL, current)) == {'bond0'}
+def test_addition_of_interfaces():
+    current = copy.deepcopy(ORIGINAL)
+    current['interfaces'].append({
+        'id': 200,
+        'int_interface': 'enps10s0',
+        'int_name': '',
+        'int_dhcp': True,
+        'int_address': '',
+        'int_address_b': '',
+        'int_version': '',
+        'int_netmask': '',
+        'int_ipv6auto': False,
+        'int_vip': '',
+        'int_vhid': None,
+        'int_critical': False,
+        'int_group': None,
+        'int_mtu': 1500
+    })
+
+    assert 'enps10s0' not in find_interface_changes(ORIGINAL, current)
+    assert 'enps10s0' in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert 'enps10s0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')
 
 
-def test_vlan_interface_changes():
-    current = deepcopy(ORIGINAL)
-    current['interfaces'][4]['int_dhcp'] = True
-    assert set(find_interface_changes(ORIGINAL, current)) == {'vlan0'}
-
-
-def test_vlan_changes():
-    current = deepcopy(ORIGINAL)
-    current['vlan'][0]['int_dhcp'] = True
-    assert set(find_interface_changes(ORIGINAL, current)) == {'vlan0'}
-
-
-def test_check_interface_removed():
-    current = deepcopy(ORIGINAL)
+def test_removal_of_interfaces():
+    current = copy.deepcopy(ORIGINAL)
     current['interfaces'].pop(0)
-    assert set(retrieve_removed_interfaces(ORIGINAL, current)) == {'enp1s0'}
-
-
-def test_check_interface_added():
-    current = deepcopy(ORIGINAL)
-    new_interface = deepcopy(current['interfaces'][0])
-    new_interface['int_interface'] = 'enp11s0'
-    current['interfaces'].append(new_interface)
-    assert set(retrieve_added_interfaces(ORIGINAL, current)) == {'enp11s0'}
+    assert 'enp1s0' not in find_interface_changes(ORIGINAL, current)
+    assert 'enp1s0' not in retrieve_added_removed_interfaces(ORIGINAL, current, 'added')
+    assert 'enp1s0' in retrieve_added_removed_interfaces(ORIGINAL, current, 'removed')

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -205,19 +205,24 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
     delete.audit_callback = True
 
     async def _get_crud_wrapper_func(self, func, action, event_type, oid=None):
+        def common_event_handling(action, rv, oid):
+            if self._config.event_send and (action == 'delete' or isinstance(rv, dict) and 'id' in rv):
+                event_kwargs = {'fields': rv} if isinstance(rv, dict) else {}
+                self.middleware.send_event(
+                    f'{self._config.namespace}.query', event_type, id=oid or rv['id'], **event_kwargs,
+                )
+
         if asyncio.iscoroutinefunction(func):
             async def nf(*args, **kwargs):
                 rv = await func(*args, **kwargs)
                 await self.middleware.call_hook(f'{self._config.namespace}.post_{action}', rv)
-                if self._config.event_send and (action == 'delete' or isinstance(rv, dict) and 'id' in rv):
-                    self.middleware.send_event(f'{self._config.namespace}.query', event_type, id=oid or rv['id'])
+                common_event_handling(action, rv, oid)
                 return rv
         else:
             def nf(*args, **kwargs):
                 rv = func(*args, **kwargs)
                 self.middleware.call_hook_sync(f'{self._config.namespace}.post_{action}', rv)
-                if self._config.event_send and (action == 'delete' or isinstance(rv, dict) and 'id' in rv):
-                    self.middleware.send_event(f'{self._config.namespace}.query', event_type, id=oid or rv['id'])
+                common_event_handling(action, rv, oid)
                 return rv
 
         copy_function_metadata(func, nf)


### PR DESCRIPTION
## Context

It was requested that we send events when commit/rollback for network is performed. Also it was requested that we provide not just the id of the interface in this case but the complete interface details so UI would not have to make a subsequent call.


## Proposed Solution

Requested cases have been addressed in following ways:

1. For added/removed/changed events, we try to send the complete payload in events if it is there for CRUD services
2. On commit/rollback of network changes, we isolate interfaces which were changed/removed/added and send their appropriate events in that case