### PR TITLE
NAS-129457 / 24.10 / Update iSCSI test to take account of initiator autodelete

### DIFF
--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -49,7 +49,9 @@ def initiator():
     try:
         yield initiator_config
     finally:
-        call('iscsi.initiator.delete', initiator_config['id'])
+        # Very likely that already cleaned up (by removing only target using it)
+        if call('iscsi.initiator.query', [['id', '=', initiator_config['id']]]):
+            call('iscsi.initiator.delete', initiator_config['id'])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Update iSCSI test to take account that initiator may have been autodeleted.

This test was broken by recent PR #13844.

(Fix tested in shortened CI run [659 ](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/659/))

FYI, wrt the DF backport, have included this PR into the main feature backport (#13849)