### PR TITLE
NAS-129458 / 24.10 / Fix syslog tests

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -49,7 +49,6 @@ import fcntl
 import functools
 import inspect
 import itertools
-import logging
 import multiprocessing
 import os
 import pickle
@@ -79,8 +78,6 @@ from truenas_api_client import json
 from . import logger
 
 SYSTEMD_EXTEND_USECS = 240000000  # 4mins in microseconds
-
-k8s_logger = logging.getLogger('k8s_api')
 
 
 @dataclass

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -46,14 +46,14 @@ def check_syslog(log_path, message, target_ip=None, target_user=user, target_pas
 
 @pytest.mark.parametrize('params', [
     {
-        'ident': 'systemd',
-        'msg': 'ZZZZ: docker filter mount: test',
-        'path': '/var/log/app_mounts.log',
+        'ident': 'iscsi-scstd',
+        'msg': 'ZZZZ: random scst test',
+        'path': '/var/log/scst.log',
     },
     {
-        'ident': 'systemd',
-        'msg': 'ZZZZ: kubelet filter mount: test',
-        'path': '/var/log/app_mounts.log',
+        'ident': 'iscsi-scstd',
+        'msg': 'ZZZZ: random scst test',
+        'path': '/var/log/scst.log',  # This is just to make sure our exclude filter works as intended
     },
 ])
 def test_local_syslog_filter(request, params):


### PR DESCRIPTION
## Problem

With k8s removal, 2 problems were seen with logging:

1) Leftover `k8s_api.log` file
2) Syslog tests failing because they were relying on `app_mounts.log` to be around which is no longer the case

## Solution

For (1) make sure that log file is no longer created and for second fix the test to make sure we adapt to our updated filters keeping in line with removal of k8s