### PR TITLE
NAS-129459 / 24.10 / Adjust netdata db size after k8s removal

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -8,7 +8,6 @@ from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 from .netdata.graph_base import GraphBase
 
 
-K8S_PODS_COUNT = 20  # A default value has been assumed for now
 # https://learn.netdata.cloud/docs/netdata-agent/configuration/optimizing-metrics-database/
 # change-how-long-netdata-stores-metrics
 TIER_0_POINT_SIZE = 1
@@ -143,11 +142,6 @@ def get_metrics_approximation(
             'zfs.prefetch_data_hits_rate': 2,
             'zfs.hash_elements': 2,
             'zfs.hash_chains': 2,
-
-            # k8s pods stats
-            'k8s_cpu': K8S_PODS_COUNT,
-            'k8s_mem': K8S_PODS_COUNT,
-            'k8s_net': K8S_PODS_COUNT * 2,
 
             # cputemp
             'cputemp.temperatures': core_count,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 966, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 44565, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 1433, 60: 10}),
+    (4, 2, 1, 2, 10, 2, {1: 886, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 44485, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 1353, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
@@ -19,14 +19,14 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 557),
-        (4, 2, 1, 2, 10, 1, 7, 4, 60, 35),
-        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 14744),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 511),
+        (4, 2, 1, 2, 10, 1, 7, 4, 60, 32),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 14718),
         (1600, 32, 4, 10, 1, 4, 4, 4, 900, 65),
-        (10, 16, 2, 2, 12, 1, 3, 1, 1, 330),
-        (10, 16, 2, 2, 10, 3, 3, 4, 60, 23),
-        (1600, 32, 4, 4, 12, 3,  18, 1, 1, 66296),
-        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 294),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 310),
+        (10, 16, 2, 2, 10, 3, 3, 4, 60, 22),
+        (1600, 32, 4, 4, 12, 3,  18, 1, 1, 66177),
+        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 293),
     ],
 )
 def test_netdata_disk_space_approximation(


### PR DESCRIPTION
## Context

With k8s being removed, we no longer need to factor in it's metrics when we calculate an approximation for netdata db size.