### PR TITLE
NAS-129464 / 24.10 / call truenas.is_ix_hardware

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -5,7 +5,6 @@ import re
 import pathlib
 from collections import OrderedDict
 
-from ixhardware import TRUENAS_UNKNOWN
 from libsg3.ses import EnclosureDevice
 
 from middlewared.schema import Dict, Int, Str, accepts
@@ -72,7 +71,7 @@ class EnclosureService(CRUDService):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if self.middleware.call_sync('truenas.get_chassis_hardware') == TRUENAS_UNKNOWN:
+        if not self.middleware.call_sync('truenas.is_ix_hardware'):
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -3,7 +3,6 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
-from ixhardware import TRUENAS_UNKNOWN
 from libsg3.ses import EnclosureDevice
 
 from middlewared.schema import accepts, Dict, Str, Int
@@ -139,7 +138,7 @@ class Enclosure2Service(Service):
     @filterable
     def query(self, filters, options):
         enclosures = []
-        if self.middleware.call_sync('truenas.get_chassis_hardware') == TRUENAS_UNKNOWN:
+        if not self.middleware.call_sync('truenas.is_ix_hardware'):
             # this feature is only available on hardware that ix sells
             return enclosures
 

--- a/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_enclosure2_query.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/enclosure/test_enclosure2_query.py
@@ -72,6 +72,7 @@ def test_enclosure2_query(enc2_data):
     e.middleware = Middleware()
     e.middleware._resolve_methods([Enclosure2Service], [])
     e.middleware['truenas.get_chassis_hardware'] = Mock(return_value=enc2_mocked.chassis)
+    e.middleware['truenas.is_ix_hardware'] = Mock(return_value=True)
     e.middleware['datastore.query'] = Mock(return_value=enc2_mocked.labels)
     e.middleware['system.dmidecode_info'] = Mock(return_value=enc2_mocked.dmi)
     e.middleware['jbof.query'] = Mock(return_value=[])


### PR DESCRIPTION
UI team asked me what the canonical way was for determining if the truenas system supported our enclosure plugin. I didn't know off the top of my head but I found the endpoint after some investigation. During that investigation, I realized we weren't calling this method internally so I've switched to using `truenas.is_ix_hardware` since that is the canonical way for determining this information.