### PR TITLE
NAS-129430 / 24.10 / fix drive count on mini-3.0-x+

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -697,10 +697,8 @@ class Enclosure:
         if self.front_loaded:
             if any((self.is_mini_3e, self.is_mini_3e_plus)):
                 return 6
-            elif self.is_mini_3_x:
+            elif any((self.is_mini_3_x, self.is_mini_3_x_plus)):
                 return 7
-            elif self.is_mini_3_x_plus:
-                return 8
             elif self.is_mini_3_xl_plus:
                 return 10
             elif any((self.is_xseries, self.is_r30, self.is_12_bay_jbod)):

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -437,7 +437,7 @@ def get_slot_info(enc):
                     'id': {
                         '3000000000000001': {
                             i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: False}
-                            for i in range(1, 9)
+                            for i in range(1, 8)
                         }
                     }
                 }


### PR DESCRIPTION
MINI-3.0-X+ has 7 slots only.