### PR TITLE
NAS-129531 / 24.10 / Break large winbind requests into smaller chunks

### DIFF
--- a/src/middlewared/middlewared/utils/itertools.py
+++ b/src/middlewared/middlewared/utils/itertools.py
@@ -32,8 +32,8 @@ def batched(iterable, n):
     last batch may be shorter than `n`.
 
     batched iter recipe from python 3.11 documentation. Python 3.12 adds a
-    cpython variant of this and so this method should be replaced when
-    TrueNAS python version upgrades to 3.12.
+    cpython variant of this to `itertools` and so this method should be
+    replaced when TrueNAS python version upgrades to 3.12.
     """
     if n < 1:
         raise ValueError('n must be at least one')

--- a/src/middlewared/middlewared/utils/itertools.py
+++ b/src/middlewared/middlewared/utils/itertools.py
@@ -24,3 +24,20 @@ def infinite_multiplier_generator(multiplier, max_value, initial_value):
         next_val = cur * multiplier
         if next_val <= max_value:
             cur = next_val
+
+
+def batched(iterable, n):
+    """
+    Batch data from the `iterable` into tuples of length `n`. The
+    last batch may be shorter than `n`.
+
+    batched iter recipe from python 3.11 documentation. Python 3.12 adds a
+    cpython variant of this and so this method should be replaced when
+    TrueNAS python version upgrades to 3.12.
+    """
+    if n < 1:
+        raise ValueError('n must be at least one')
+
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch


### PR DESCRIPTION
When building user and group caches we can end up with very large requests to libwbclient to resolve into SIDs. This commit breaks the large requests into chunks of 100 users and groups.