### PR TITLE
NAS-129532 / 24.10 / Add generators for pwd and grp

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -95,3 +95,30 @@ def test__check_group_misses():
         with pytest.raises(KeyError) as ve:
             grp.getgrnam(name)
         assert 'name not found' in str(ve)
+
+
+def test___iter_pwd():
+    py_users = {u.pw_uid: u for u in py_pwd.getpwall()}
+
+    for entry in pwd.iterpw():
+        py_entry = py_users.pop(entry.pw_uid)
+
+        assert py_entry.pw_name == entry.pw_name
+        assert py_entry.pw_uid == entry.pw_uid
+        assert py_entry.pw_gid == entry.pw_gid
+        assert py_entry.pw_gecos == entry.pw_gecos
+        assert py_entry.pw_dir == entry.pw_dir
+        assert py_entry.pw_shell == entry.pw_shell
+
+    assert py_users == {}, str(py_users)
+
+
+def test___iter_grp():
+    py_groups = {g.gr_name: g for g in py_grp.getgrall()}
+
+    for entry in grp.itergrp():
+        py_entry = py_groups.pop(entry.gr_name)
+
+        assert py_entry.gr_name == entry.gr_name
+        assert py_entry.gr_gid == entry.gr_gid
+        assert py_entry.gr_mem == entry.gr_mem

--- a/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_nss.py
@@ -122,3 +122,5 @@ def test___iter_grp():
         assert py_entry.gr_name == entry.gr_name
         assert py_entry.gr_gid == entry.gr_gid
         assert py_entry.gr_mem == entry.gr_mem
+
+    assert py_groups == {}, str(py_groups)


### PR DESCRIPTION
Since these databases can contain thousands or tens of thousands of entries it's a good idea to allow more memory-efficient iteration than creating a list with all entries.

Directory services will use these functions to build caches as part of PR to add IPA support.