### PR TITLE
NAS-129470 / 24.10 / Restart idmap service after SMB has been configured

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -300,6 +300,7 @@ class DirectoryServices(Service):
             job.set_progress(100, f'{failover_status}: skipping directory service setup due to failover status')
             return
 
+        self.middleware.call_sync('sevice.restart', 'idmap')
         ldap_enabled = self.middleware.call_sync('ldap.config')['enable']
         ad_enabled = self.middleware.call_sync('activedirectory.config')['enable']
         if not ldap_enabled and not ad_enabled:


### PR DESCRIPTION
We need to ensure that the idmap service is always restarted after generating a clean idmap configuration to ensure that the in-memory copy of the SMB configuration in winbindd contains required idmap entries for the builtin domain otherwise xid-to-sid requests will fail. This issue occurred for some users after rebooting TrueNAS.