### PR TITLE
NAS-129559 / 24.10 / Replace int(x/y) pattern with x // y

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -472,8 +472,8 @@ if __name__ == "__main__":
 
             zfs_l2arc_hits.update(int(kstat[f"{prefix}.l2_hits"] % 2 ** 32))
             zfs_l2arc_misses.update(int(kstat[f"{prefix}.l2_misses"] % 2 ** 32))
-            zfs_l2arc_read.update(int(kstat[f"{prefix}.l2_read_bytes"] / 1024 % 2 ** 32))
-            zfs_l2arc_write.update(int(kstat[f"{prefix}.l2_write_bytes"] / 1024 % 2 ** 32))
+            zfs_l2arc_read.update(kstat[f"{prefix}.l2_read_bytes"] // 1024 % 2 ** 32)
+            zfs_l2arc_write.update(kstat[f"{prefix}.l2_write_bytes"] // 1024 % 2 ** 32)
             zfs_l2arc_size.update(kstat[f"{prefix}.l2_asize"] // 1024)
 
             if zilstat_1_thread:

--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -460,12 +460,12 @@ if __name__ == "__main__":
             arc_efficiency = get_arc_efficiency(kstat)
 
             prefix = "kstat.zfs.misc.arcstats"
-            zfs_arc_size.update(int(kstat[f"{prefix}.size"] / 1024))
-            zfs_arc_meta.update(int(kstat[f"{prefix}.arc_meta_used"] / 1024))
-            zfs_arc_data.update(int(kstat[f"{prefix}.data_size"] / 1024))
+            zfs_arc_size.update(kstat[f"{prefix}.size"] // 1024)
+            zfs_arc_meta.update(kstat[f"{prefix}.arc_meta_used"] // 1024)
+            zfs_arc_data.update(kstat[f"{prefix}.data_size"] // 1024)
             zfs_arc_hits.update(int(kstat[f"{prefix}.hits"] % 2 ** 32))
             zfs_arc_misses.update(int(kstat[f"{prefix}.misses"] % 2 ** 32))
-            zfs_arc_c.update(int(kstat[f"{prefix}.c"] / 1024))
+            zfs_arc_c.update(kstat[f"{prefix}.c"] // 1024)
             zfs_arc_miss_percent.update(str(get_zfs_arc_miss_percent(kstat)).encode("ascii"))
             zfs_arc_cache_hit_ratio.update(str(arc_efficiency["cache_hit_ratio"]["per"][:-1]).encode("ascii"))
             zfs_arc_cache_miss_ratio.update(str(arc_efficiency["cache_miss_ratio"]["per"][:-1]).encode("ascii"))
@@ -474,7 +474,7 @@ if __name__ == "__main__":
             zfs_l2arc_misses.update(int(kstat[f"{prefix}.l2_misses"] % 2 ** 32))
             zfs_l2arc_read.update(int(kstat[f"{prefix}.l2_read_bytes"] / 1024 % 2 ** 32))
             zfs_l2arc_write.update(int(kstat[f"{prefix}.l2_write_bytes"] / 1024 % 2 ** 32))
-            zfs_l2arc_size.update(int(kstat[f"{prefix}.l2_asize"] / 1024))
+            zfs_l2arc_size.update(kstat[f"{prefix}.l2_asize"] // 1024)
 
             if zilstat_1_thread:
                 zfs_zilstat_ops1.update(zilstat_1_thread.value)

--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -11,7 +11,7 @@
     # man page for mountd says "The default is 1 thread, which is probably enough.",
     # but mount storms at restart benefit from additional mountd.  As such, we recommend
     # the number of mountd be 1/4 the number of nfsd.
-    num_mountd = max(int(num_nfsd / 4), 1)
+    num_mountd = max(num_nfsd // 4, 1)
     manage_gids = 'y' if config["userd_manage_gids"] else 'n'
 %>
 [nfsd]

--- a/src/middlewared/middlewared/plugins/boot_/format.py
+++ b/src/middlewared/middlewared/plugins/boot_/format.py
@@ -53,10 +53,10 @@ class BootService(Service):
         total_partition_size = sum(map(lambda y: y[1], partitions))
         if disk_details['size'] < total_partition_size:
             partitions = [
-                '%s: %s blocks' % (p[0], '{:,}'.format(int(p[1] / disk_details['sectorsize']))) for p in partitions
+                '%s: %s blocks' % (p[0], '{:,}'.format(p[1] // disk_details['sectorsize'])) for p in partitions
             ]
             partitions.append(
-                'total of %s blocks' % '{:,}'.format(int(total_partition_size / disk_details['sectorsize']))
+                'total of %s blocks' % '{:,}'.format(total_partition_size // disk_details['sectorsize'])
             )
             disk_blocks = '{:,}'.format(disk_details["blocks"])
             raise CallError(
@@ -66,15 +66,15 @@ class BootService(Service):
                 'booting procedure.'
             )
 
-        zfs_part_size = f'+{int(options["size"]/1024)}K' if options.get('size') else 0
+        zfs_part_size = f'+{options["size"] // 1024}K' if options.get('size') else 0
         if options['legacy_schema']:
             if options['legacy_schema'] == 'BIOS_ONLY':
                 commands.extend((
-                    ['sgdisk', f'-a{int(4096 / disk_details["sectorsize"])}', '-n1:0:+512K', '-t1:EF02', f'/dev/{dev}'],
+                    ['sgdisk', f'-a{4096 // disk_details["sectorsize"]}', '-n1:0:+512K', '-t1:EF02', f'/dev/{dev}'],
                 ))
             elif options['legacy_schema'] == 'EFI_ONLY':
                 commands.extend((
-                    ['sgdisk', f'-a{int(4096 / disk_details["sectorsize"])}', '-n1:0:+260M', '-t1:EF00', f'/dev/{dev}'],
+                    ['sgdisk', f'-a{4096 // disk_details["sectorsize"]}', '-n1:0:+260M', '-t1:EF00', f'/dev/{dev}'],
                 ))
 
             # Creating standard-size partitions first leads to better alignment and more compact disk usage
@@ -84,7 +84,7 @@ class BootService(Service):
             ])
         else:
             commands.extend((
-                ['sgdisk', f'-a{int(4096/disk_details["sectorsize"])}', '-n1:0:+1024K', '-t1:EF02', f'/dev/{dev}'],
+                ['sgdisk', f'-a{4096 // disk_details["sectorsize"]}', '-n1:0:+1024K', '-t1:EF02', f'/dev/{dev}'],
                 ['sgdisk', '-n2:0:+524288K', '-t2:EF00', f'/dev/{dev}'],
             ))
 

--- a/src/middlewared/middlewared/plugins/disk_/power_management_linux.py
+++ b/src/middlewared/middlewared/plugins/disk_/power_management_linux.py
@@ -16,10 +16,10 @@ class DiskService(Service):
         if disk['hddstandby'] != 'ALWAYS ON':
             if int(disk['hddstandby']) <= 20:
                 # Values from 1 to 240 specify multiples of 5 seconds
-                idle = int(int(disk['hddstandby']) * 60 / 5)
+                idle = int(disk['hddstandby']) * 60 // 5
             else:
                 # values from 241 to 251 specify multiples of 30 minutes.
-                idle = 240 + int(int(disk['hddstandby']) / 30)
+                idle = 240 + int(disk['hddstandby']) // 30
         else:
             idle = 0
 

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -384,7 +384,7 @@ class IdmapDomainService(CRUDService):
         range_size = sssd_config.get('range_size', 200000)
         range_low = sssd_config.get('range_low', 10001)
         range_max = sssd_config.get('range_max', 2000200000)
-        max_slices = int((range_max - range_low) / range_size)
+        max_slices = (range_max - range_low) // range_size
 
         data = sid.encode()
         hash_ = murmurhash3(data, len(data), seed)

--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -868,7 +868,7 @@ class JBOFService(CRUDService):
             # We know all_count is > 0 because of the return above.
             all_count = len(jbofs)
             fail_count = len(failures)
-            percent = int((percent_available * (all_count - fail_count)) / all_count)
+            percent = (percent_available * (all_count - fail_count)) // all_count
             err = f'Failure connecting {fail_count} JBOFs: {", ".join(failures)}'
             self.logger.error(err)
             job.set_progress(percent, err)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -233,7 +233,7 @@ class PoolDatasetService(Service):
                 failed[name]['error'] = 'Missing key'
                 continue
 
-            job.set_progress(name_i // len(names) * 90 + 0.5, f'Unlocking {name!r}')
+            job.set_progress(int(name_i / len(names) * 90 + 0.5), f'Unlocking {name!r}')
             try:
                 self.middleware.call_sync(
                     'zfs.dataset.load_key', name, {'key': datasets[name]['key'], 'mount': False}

--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_lock.py
@@ -233,7 +233,7 @@ class PoolDatasetService(Service):
                 failed[name]['error'] = 'Missing key'
                 continue
 
-            job.set_progress(int(name_i / len(names) * 90 + 0.5), f'Unlocking {name!r}')
+            job.set_progress(name_i // len(names) * 90 + 0.5, f'Unlocking {name!r}')
             try:
                 self.middleware.call_sync(
                     'zfs.dataset.load_key', name, {'key': datasets[name]['key'], 'mount': False}

--- a/src/middlewared/middlewared/plugins/smart_/event_source.py
+++ b/src/middlewared/middlewared/plugins/smart_/event_source.py
@@ -56,7 +56,7 @@ class SMARTTestEventSource(EventSource):
 
             if data:
                 # Check every percent
-                interval = int((data['end_monotime'] - data['start_monotime']) / 100)
+                interval = (data['end_monotime'] - data['start_monotime']) // 100
 
                 if time.monotonic() < data['end_monotime']:
                     # but not more often than every ten seconds

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -426,7 +426,7 @@ class CoreService(Service):
                     """
                     sections = re.split(r'^.. (.+?)::$', doc, flags=re.M)
                     doc = sections[0]
-                    for i in range(int((len(sections) - 1) / 2)):
+                    for i in range((len(sections) - 1) // 2):
                         idx = (i + 1) * 2 - 1
                         reg = re.search(r'examples(?:\((.+)\))?', sections[idx])
                         if reg is None:

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -1134,13 +1134,13 @@ def test_060_bandwidth_limiter(request, testwho, ftp_setup_func):
                 f.write(os.urandom(1024 * FileSize))
 
             ElapsedTime = int(ftp_upload_binary_file(ftpObj, localfname, ftpfname))
-            xfer_rate = int(FileSize / ElapsedTime)
+            xfer_rate = FileSize // ElapsedTime
             # This typically will match exactly, but in actual testing this might vary
             assert (ulRate - 8) <= xfer_rate <= (ulRate + 20), \
                 f"Failed upload rate limiter: Expected {ulRate}, but sensed rate is {xfer_rate}"
 
             ElapsedTime = int(ftp_download_binary_file(ftpObj, ftpfname, localfname))
-            xfer_rate = int(FileSize / ElapsedTime)
+            xfer_rate = FileSize // ElapsedTime
             # Allow for variance
             assert (dlRate - 8) <= xfer_rate <= (dlRate + 20), \
                 f"Failed download rate limiter: Expected {dlRate}, but sensed rate is {xfer_rate}"
@@ -1203,7 +1203,7 @@ def test_070_resume_xfer(request, ftpConf, expect_to_pass):
         with open(src, 'rb') as file:
             ftp.voidcmd('TYPE I')
             with ftpObj.transfercmd(f'STOR {tgt}', None) as conn:
-                blksize = int(NumKiB / 8)
+                blksize = NumKiB // 8
                 for xfer in range(0, 8):
                     # Send some of the file
                     buf = file.read(1024 * blksize)
@@ -1214,7 +1214,7 @@ def test_070_resume_xfer(request, ftpConf, expect_to_pass):
         with open(tgt, 'wb') as file:
             ftp.voidcmd('TYPE I')
             with ftp.transfercmd(f'RETR {src}', None) as conn:
-                NumXfers = int(NumKiB / 8)
+                NumXfers = NumKiB // 8
                 for xfer in range(0, NumXfers):
                     # Receive and write some of the file
                     data = conn.recv(8192)

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -15,7 +15,7 @@ def test_disk_wipe_partition_clean():
     call('disk.format', disk)
     parts = call('disk.list_partitions', disk)
     seek_blk = parts[0]['start_sector']
-    blk_size = int(parts[0]['start'] / parts[0]['start_sector'])
+    blk_size = parts[0]['start'] // parts[0]['start_sector']
 
     # Write some private data into the start of the data partition
     ssh(

--- a/tests/api2/test_snapshots.py
+++ b/tests/api2/test_snapshots.py
@@ -20,7 +20,7 @@ def common_min_max_txg_snapshot_test(test_min_txg=False, test_max_txg=False):
 
         assert call('zfs.snapshot.query', [['dataset', '=', test_dataset]], {'count': True}) == len(created_snaps)
 
-        for i in range((total_snaps // 2) - 1):
+        for i in range(total_snaps // 2 - 1):
             new_list = created_snaps
             extra_args = {}
             if test_min_txg:

--- a/tests/api2/test_snapshots.py
+++ b/tests/api2/test_snapshots.py
@@ -20,14 +20,14 @@ def common_min_max_txg_snapshot_test(test_min_txg=False, test_max_txg=False):
 
         assert call('zfs.snapshot.query', [['dataset', '=', test_dataset]], {'count': True}) == len(created_snaps)
 
-        for i in range(int(total_snaps / 2) - 1):
+        for i in range((total_snaps // 2) - 1):
             new_list = created_snaps
             extra_args = {}
             if test_min_txg:
                 new_list = created_snaps[i:]
                 extra_args['min_txg'] = new_list[0]
             if test_max_txg:
-                new_list = new_list[:int(len(new_list) / 2)]
+                new_list = new_list[:len(new_list) // 2]
                 extra_args['max_txg'] = new_list[-1]
 
             assert call(


### PR DESCRIPTION
I noticed that we use the `int(x / y)` pattern in a few areas. While this is completely valid, especially for our use cases, it's better practice to do `x // y` instead. 

We only deal with positive numbers in all of these cases, so the truncation that `int` does is equivalent to floor division. The only difference becomes floating point rounding errors when we do our normal division inside of the `int`.
![image](https://github.com/truenas/middleware/assets/53726630/4fc03db0-febc-47d1-ac1c-4f0a406bee6a)

We likely wont deal with values large enough for these rounding errors to take effect, but especially since we're dealing with stat reporting it's in our best interest to ensure accuracy regardless.