### PR TITLE
NAS-129564 / 24.10 / More type hints

### DIFF
--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -1,12 +1,10 @@
+from __future__ import annotations
 import asyncio
 from collections import defaultdict
 import errno
 import functools
 import typing
 from uuid import uuid4
-
-if typing.TYPE_CHECKING:
-    from middlewared.main import Application, Middleware
 
 from middlewared.event import EventSource
 from middlewared.schema import ValidationErrors

--- a/src/middlewared/middlewared/common/event_source/manager.py
+++ b/src/middlewared/middlewared/common/event_source/manager.py
@@ -5,8 +5,10 @@ import functools
 import typing
 from uuid import uuid4
 
+if typing.TYPE_CHECKING:
+    from middlewared.main import Application, Middleware
+
 from middlewared.event import EventSource
-from middlewared.main import Application, Middleware
 from middlewared.schema import ValidationErrors
 from middlewared.service_exception import CallError, CallException
 

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -4,6 +4,7 @@ import json
 import threading
 import typing
 
+from middlewared.main import Middleware
 from middlewared.role import RoleManager
 from middlewared.schema import Any, clean_and_validate_arg, ValidationErrors
 from middlewared.settings import conf
@@ -68,7 +69,8 @@ class EventSource(metaclass=EventSourceMetabase):
     ACCEPTS = NotImplementedError
     RETURNS = NotImplementedError
 
-    def __init__(self, middleware, name, arg, send_event, unsubscribe_all):
+    def __init__(self, middleware: Middleware, name: str, arg: typing.Optional[str], send_event: typing.Callable[[str, dict[str, typing.Any]], None], 
+                 unsubscribe_all: typing.Callable[[typing.Optional[Exception]], typing.Awaitable[None]]):
         self.middleware = middleware
         self.name = name
         self.arg = arg

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -4,8 +4,10 @@ import json
 import threading
 import typing
 
-from middlewared.main import Middleware
-from middlewared.role import RoleManager
+if typing.TYPE_CHECKING:
+    from middlewared.main import Middleware
+    from middlewared.role import RoleManager
+    
 from middlewared.schema import Any, clean_and_validate_arg, ValidationErrors
 from middlewared.settings import conf
 

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -1,12 +1,9 @@
+from __future__ import annotations
 import asyncio
 import contextlib
 import json
 import threading
 import typing
-
-if typing.TYPE_CHECKING:
-    from middlewared.main import Middleware
-    from middlewared.role import RoleManager
     
 from middlewared.schema import Any, clean_and_validate_arg, ValidationErrors
 from middlewared.settings import conf

--- a/src/middlewared/middlewared/event.py
+++ b/src/middlewared/middlewared/event.py
@@ -15,7 +15,7 @@ class Events:
         self._events: typing.Dict[str, dict[str, typing.Any]] = {}
         self.__events_private: typing.Set[str] = set()
 
-    def register(self, name: str, description: str, private: bool, returns, no_auth_required, no_authz_required, roles: typing.Iterable[str]):
+    def register(self, name: str, description: str, private: bool, returns, no_auth_required: bool, no_authz_required: bool, roles: typing.Iterable[str]):
         if name in self._events:
             raise ValueError(f'Event {name!r} already registered.')
         self.role_manager.register_event(name, roles)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -124,7 +124,7 @@ class Application:
           on_close(app)
         """
         self.__callbacks = defaultdict(list)
-        self.__subscribed = {}
+        self.__subscribed: typing.Dict[str, str] = {}
 
     @functools.cached_property
     def origin(self) -> typing.Union[UnixSocketOrigin, TCPIPOrigin, None]:
@@ -254,7 +254,7 @@ class Application:
 
         return self.authenticated_credentials.authorize('SUBSCRIBE', name)
 
-    async def subscribe(self, ident, name):
+    async def subscribe(self, ident: str, name: str):
         shortname, arg = self.middleware.event_source_manager.short_name_arg(name)
         if shortname in self.middleware.event_source_manager.event_sources:
             await self.middleware.event_source_manager.subscribe_app(self, self.__esm_ident(ident), shortname, arg)
@@ -266,16 +266,16 @@ class Application:
             'subs': [ident],
         })
 
-    async def unsubscribe(self, ident):
+    async def unsubscribe(self, ident: str):
         if ident in self.__subscribed:
             self.__subscribed.pop(ident)
         elif self.__esm_ident(ident) in self.middleware.event_source_manager.idents:
             await self.middleware.event_source_manager.unsubscribe(self.__esm_ident(ident))
 
-    def __esm_ident(self, ident):
+    def __esm_ident(self, ident: str):
         return self.session_id + ident
 
-    def send_event(self, name, event_type, **kwargs):
+    def send_event(self, name: str, event_type: str, **kwargs):
         if (
             not any(i == name or i == '*' for i in self.__subscribed.values()) and
             self.middleware.event_source_manager.short_name_arg(

--- a/src/middlewared/middlewared/schema/attribute.py
+++ b/src/middlewared/middlewared/schema/attribute.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
 import copy
 import json
 import textwrap
 import typing
 
 from middlewared.service_exception import ValidationErrors
-from middlewared.validators import ValidatorBase
 
 from .exceptions import Error
 from .utils import NOT_PROVIDED, REDACTED_VALUE
@@ -13,8 +13,8 @@ from .utils import NOT_PROVIDED, REDACTED_VALUE
 class Attribute:
 
     def __init__(
-        self, name='', title=None, description=None, required=False, null=False, empty=True, private=False,
-        validators: typing.List[ValidatorBase]=None, register=False, hidden=False, editable=True, example=None, **kwargs
+        self, name='', title: typing.Optional[str]=None, description: typing.Optional[str]=None, required=False, null=False, empty=True, private=False,
+        validators: typing.Optional[list[ValidatorBase]]=None, register=False, hidden=False, editable=True, example=None, **kwargs
     ):
         self.name = name
         self.has_default = 'default' in kwargs and kwargs['default'] is not NOT_PROVIDED
@@ -100,7 +100,7 @@ class Attribute:
 
         return schema
 
-    def resolve(self, schemas):
+    def resolve(self, schemas: typing.Set['Attribute']):
         """
         After every plugin is initialized this method is called for every method param
         so that the real attribute is evaluated.

--- a/src/middlewared/middlewared/schema/dict_schema.py
+++ b/src/middlewared/middlewared/schema/dict_schema.py
@@ -1,5 +1,6 @@
 import copy
 import collections
+import typing
 
 from datetime import datetime, time
 
@@ -23,18 +24,18 @@ class Dict(Attribute):
             attrs = list(attrs[1:])
         else:
             name = ''
-        self.additional_attrs = kwargs.pop('additional_attrs', False)
-        self.conditional_defaults = kwargs.pop('conditional_defaults', {})
-        self.private_keys = kwargs.pop('private_keys', [])
-        self.strict = kwargs.pop('strict', False)
+        self.additional_attrs: bool = kwargs.pop('additional_attrs', False)
+        self.conditional_defaults: dict = kwargs.pop('conditional_defaults', {})
+        self.private_keys: list = kwargs.pop('private_keys', [])
+        self.strict: bool = kwargs.pop('strict', False)
         # Update property is used to disable requirement on all attributes
         # as well to not populate default values for not specified attributes
-        self.update = kwargs.pop('update', False)
+        self.update: bool = kwargs.pop('update', False)
         if 'default' not in kwargs:
             kwargs['default'] = {}
         super(Dict, self).__init__(name, **kwargs)
 
-        self.attrs = {}
+        self.attrs: typing.Dict[str, Attribute] = {}
         for i in attrs:
             self.attrs[i.name] = i
 
@@ -119,7 +120,7 @@ class Dict(Attribute):
                 data[attr.name] = self._clean_attr(attr, NOT_PROVIDED, verrors)
         return data
 
-    def _clean_attr(self, attr, value, verrors):
+    def _clean_attr(self, attr: Attribute, value, verrors: ValidationErrors):
         try:
             return attr.clean(value)
         except Error as e:

--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -57,7 +57,7 @@ class ValidationErrors(CallException):
         self.errors = errors or []
         super().__init__(self.errors)
 
-    def add(self, attribute, errmsg: str, errno: int=errno.EINVAL):
+    def add(self, attribute: str, errmsg: str, errno: int=errno.EINVAL):
         self.errors.append(ValidationError(attribute, errmsg, errno))
 
     def add_validation_error(self, validation_error: ValidationError):

--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -14,7 +14,7 @@ class CallException(ErrnoMixin, Exception):
 
 
 class CallError(CallException):
-    def __init__(self, errmsg: str, errno: int=errno.EFAULT, extra=None):
+    def __init__(self, errmsg: str, errno: int=errno.EFAULT, extra: typing.Optional[list]=None):
         self.errmsg = errmsg
         self.errno = errno
         self.extra = extra

--- a/src/middlewared/middlewared/utils/asyncio_.py
+++ b/src/middlewared/middlewared/utils/asyncio_.py
@@ -1,7 +1,8 @@
 import asyncio
+from typing import Awaitable, Iterable, Optional
 
 
-async def asyncio_map(func, arguments, limit=None, *, semaphore=None):
+async def asyncio_map(func: Awaitable, arguments: Iterable, limit: Optional[int]=None, *, semaphore: Optional[asyncio.BoundedSemaphore]=None):
     if limit is not None and semaphore is not None:
         raise ValueError("`limit` and `semaphore` can not be specified simultaneously")
 

--- a/src/middlewared/middlewared/utils/plugins.py
+++ b/src/middlewared/middlewared/utils/plugins.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import importlib
 import inspect
@@ -5,13 +6,14 @@ import itertools
 import logging
 import os
 import sys
+import typing
 
 from middlewared.schema import Schemas
 
 logger = logging.getLogger(__name__)
 
 
-def load_modules(directory, base=None, depth=0):
+def load_modules(directory: str, base: typing.Optional[str]=None, depth=0):
     directory = os.path.normpath(directory)
     if base is None:
         middlewared_root = os.path.dirname(os.path.dirname(__file__))
@@ -132,7 +134,7 @@ class LoadPluginsMixin(SchemasMixin):
         # to make sure every schema is patched and references match
         self._resolve_methods(list(self._services.values()), self.get_events())
 
-    def add_service(self, service):
+    def add_service(self, service: Service):
         self._services[service._config.namespace] = service
         if service._config.namespace_alias:
             self._services_aliases[service._config.namespace_alias] = service


### PR DESCRIPTION
Part 2 of https://ixsystems.atlassian.net/browse/NAS-129505

The goal of adding type hints is to enable us to more quickly write error-free code and improve readability. That said, please let me know if certain type hints are unnecessary, if there are any places that need type hints more than others, or if any of the type hints actually _hurt_ readability.

In some cases, type hinting requires importing a class or type from another file. Doing this every time, however, results in circular imports. One solution that I tried was the conditional import statement:
```
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    import mymodule
```
where `TYPE_CHECKING` is `False` at runtime but is treated as `True` by type checkers. Our CI build check didn't like this, so instead I resort to:
```
from __future__ import annotations
```
which treats all type hints as forward references. The downside of this solution is that type hints may not be picked up by the IDE if the type isn't directly imported.

Alternatively to importing `annotations`, we could use strings in the type hints that require an import (denoting a forward reference).

https://stackoverflow.com/a/39757388