### PR TITLE
NAS-129569 / 24.04.2 / Add missing str() in is_in_use_by_portals_targets (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -123,7 +123,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
         )
         if portals:
             usages.append(
-                f'Authorized access of {id_} is being used by portal(s): {", ".join(p["id"] for p in portals)}'
+                f'Authorized access of {id_} is being used by portal(s): {", ".join(str(p["id"]) for p in portals)}'
             )
         groups = await self.middleware.call(
             'datastore.query', 'services.iscsitargetgroups', [['iscsi_target_authgroup', '=', config['tag']]]


### PR DESCRIPTION
With this change it'll present a prettier error message, e.g.:
`[EFAULT] Authorized access of 171 is being used by portal(s): 1800
`


Original PR: https://github.com/truenas/middleware/pull/13879
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129569