### PR TITLE
NAS-129383 / 24.04.2 / Prevent k3s from spamming logs

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tndestinations.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tndestinations.conf.mako
@@ -26,5 +26,7 @@ destination d_console { usertty("root"); };
 #
 destination d_console_all { getvirtconsole(); };
 
-
 destination d_xconsole { pipe("/dev/xconsole"); };
+
+# Drop logs
+destination d_null { file("/dev/null"); };

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -39,7 +39,12 @@ filter f_tnremote {
 
 # These filters are used for applications that have
 # special logging behavior
-filter f_k3s { program("k3s"); };
+filter f_drop_systemd_containerd {
+  program("systemd") and
+  match("container" value("MESSAGE"));
+};
+filter f_k3s { program("k3s") and match("level=(err|crit|alert|emerg)" value("MESSAGE")); };
+filter f_k3s_exclude { program("k3s"); };
 filter f_containerd { program("containerd") or program("dockerd") };
 filter f_kube_router { program("kube-router"); };
 filter f_app_mounts {
@@ -60,7 +65,7 @@ filter f_truenas_exclude {
   not filter(f_nfs_mountd) and
 % endif
   not filter(f_tnaudit_all) and
-  not filter(f_k3s) and
+  not filter(f_k3s_exclude) and
   not filter(f_containerd) and
   not filter(f_kube_router) and
   not filter(f_app_mounts) and
@@ -99,7 +104,7 @@ filter f_cron {
 };
 
 filter f_daemon {
-  facility(daemon) and not filter(f_dbg);
+  facility(daemon) and not filter(f_dbg) and not filter(f_drop_systemd_containerd);
 };
 
 filter f_kern {

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -122,6 +122,19 @@ log {
 
 log {
   source(s_src);
+  filter(f_k3s_exclude);
+  destination(d_null);
+  flags(final);
+};
+
+log {
+  source(s_src);
+  filter(f_drop_systemd_containerd);
+  destination(d_null);
+};
+
+log {
+  source(s_src);
   filter(f_containerd);
   destination { file("/var/log/containerd.log"); };
   flags(final);

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -45,7 +45,22 @@ def check_syslog(log_path, message, target_ip=ip, target_user=user, target_passw
 @pytest.mark.parametrize('params', [
     {
         'ident': 'k3s',
-        'msg': 'ZZZZ: k3s syslog filter test',
+        'msg': 'level=error: k3s syslog filter test',
+        'path': '/var/log/k3s_daemon.log',
+    },
+    {
+        'ident': 'k3s',
+        'msg': 'level=critical: k3s syslog filter test',
+        'path': '/var/log/k3s_daemon.log',
+    },
+    {
+        'ident': 'k3s',
+        'msg': 'level=alert: k3s syslog filter test',
+        'path': '/var/log/k3s_daemon.log',
+    },
+    {
+        'ident': 'k3s',
+        'msg': 'level=emerg: k3s syslog filter test',
         'path': '/var/log/k3s_daemon.log',
     },
     {


### PR DESCRIPTION
## Problem

The system logs were experiencing a high volume of entries due to routine operations reported by `k3s` and `systemd` for `cri-containerd` containers. This constant logging, including informational and routine operational messages, was leading to continuous writes to the boot pool, which could potentially affect system performance and disk longevity. Examples of such spamming include:

```
Jun 13 07:57:10 truenas systemd[1]: Started cri-containerd-2f73b0226a75644e2fd025bb494f2b1a424538ae0d0c034c1c95e06c893d7b31.scope - libcontainer container 2f73b0226a75644e2fd025bb494f2b1a424538ae0d0c034c1c95e06c893d7b31.
Jun 13 07:57:10 truenas systemd[1]: Started cri-containerd-dc1e1ebbbe7c44922b0d0f5d67f851bbae1b902f59a440dda2900abb3a43733d.scope - libcontainer container dc1e1ebbbe7c44922b0d0f5d67f851bbae1b902f59a440dda2900abb3a43733d.
```


These logs, primarily informational, indicate routine synchronizations and container startups, which do not typically require logging at such a verbose level for system operation and monitoring.

## Solution

To address the excessive logging, we implemented several changes in the `syslog-ng` configuration:

1. **Filtering `k3s` Logs**: We modified the filters for `k3s` logs to capture only critical logs (`err`, `crit`, `alert`, `emerg`). All non-critical logs from `k3s` are now redirected to `/dev/null`, effectively dropping them from being written to disk.

    ```plaintext
    filter f_k3s { program("k3s") and level(err..emerg); };
    filter f_k3s_exclude { program("k3s"); };
    ```

    This ensures that only significant error conditions are logged, reducing disk write operations and improving the readability of the logs.

2. **Dropping Excessive `systemd` Logs for `cri-containerd`**: We added a filter to drop verbose logs generated by `systemd` related to routine `cri-containerd` container startups.

    These logs are now being discarded entirely, which helps in minimizing the unnecessary logging of routine container lifecycle events.

These configuration adjustments will reduce unnecessary writes to the boot pool, enhancing the overall system performance and disk health. Moreover, the logs will now primarily contain critical information, aiding in more effective monitoring and troubleshooting.
