### PR TITLE
NAS-129610 / 24.10 / Fix typos related to directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -300,7 +300,7 @@ class DirectoryServices(Service):
             job.set_progress(100, f'{failover_status}: skipping directory service setup due to failover status')
             return
 
-        self.middleware.call_sync('sevice.restart', 'idmap')
+        self.middleware.call_sync('service.restart', 'idmap')
         ldap_enabled = self.middleware.call_sync('ldap.config')['enable']
         ad_enabled = self.middleware.call_sync('activedirectory.config')['enable']
         if not ldap_enabled and not ad_enabled:

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -536,7 +536,7 @@ class LDAPService(ConfigService):
             if data['server_type'] == constants.SERVER_TYPE_ACTIVE_DIRECTORY:
                 verrors.add(
                     'ldap_update.hostname',
-                    'Active Directoy plugin must be used to join Active Directory domains.'
+                    'Active Directory plugin must be used to join Active Directory domains.'
                 )
 
     @private


### PR DESCRIPTION
First one is in the directoryservices plugin

* sevice -> service

This one has functional impact that may result in-memory configuration of winbindd not being properly refreshed on boot.

Second one is a typo in an error message that we present users when for some reason the choose to try to set up an AD domain via the LDAP plugin.