### PR TITLE
NAS-129619 / 24.10 / Fix docker etc file

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -46,11 +46,10 @@ def render(service, middleware):
 
     os.makedirs('/etc/docker', exist_ok=True)
     data_root = os.path.join(IX_APPS_MOUNT_PATH, 'docker')
-    with open('/etc/docker/daemon.json', 'w') as f:
-        f.write(json.dumps({
-            'data-root': data_root,
-            'exec-opts': ['native.cgroupdriver=cgroupfs'],
-            'iptables': False,
-            'storage-driver': 'overlay2',
-            **gpu_configuration(middleware),
-        }))
+    return json.dumps({
+        'data-root': data_root,
+        'exec-opts': ['native.cgroupdriver=cgroupfs'],
+        'iptables': False,
+        'storage-driver': 'overlay2',
+        **gpu_configuration(middleware),
+    })

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -69,7 +69,7 @@ class EtcService(Service):
 
     GROUPS = {
         'docker': [
-            {'type': 'py', 'path': 'docker'},
+            {'type': 'py', 'path': 'docker/daemon.json'},
         ],
         'truenas_nvdimm': [
             {'type': 'py', 'path': 'truenas_nvdimm', 'checkpoint': 'post_init'},


### PR DESCRIPTION
Python etc files should be named after the file they are creating if FileShouldNotExist is raised within them. File contents should also be returned from the method so that we properly note when it is changing.