### PR TITLE
NAS-129541 / 24.10 / only query UP ifaces in virtual ip plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -406,10 +406,15 @@ class FailoverEventsService(Service):
             #           (maybe the event only gets triggered if the lagg goes down)
             #
             logger.info('Checking VIP failover groups')
-            _, backups = self.run_call(
+            _, backups, offline = self.run_call(
                 'failover.vip.check_failover_group', ifname, fobj['groups']
             )
             logger.info('Done checking VIP failover groups')
+
+            if offline:
+                # this isn't common but we're very verbose in this file so let's
+                # log the offline interfaces while we're here
+                self.logger.warning('Offline interfaces detected: %r', ', '.join(offline))
 
             # this means that we received a master event and the interface was
             # in a failover group. And in that failover group, there were other
@@ -743,9 +748,14 @@ class FailoverEventsService(Service):
         #   TODO: Not sure how keepalived and laggs operate so need to test this
         #           (maybe the event only gets triggered if the lagg goes down)
         #
-        masters, _ = self.run_call(
+        masters, _, offline = self.run_call(
             'failover.vip.check_failover_group', ifname, fobj['groups']
         )
+
+        if offline:
+            # this isn't common but we're very verbose in this file so let's
+            # log the offline interfaces while we're here
+            self.logger.warning('Offline interfaces detected: %r', ', '.join(offline))
 
         # this means that we received a BACKUP event and the interface was
         # in a failover group. And in that failover group, there were other


### PR DESCRIPTION
This fixes failover on SCALE in an edge-case scenario. The scenario is as follows:
1. configure `eno1` and `eno2` in the _same_ failover group
2. `eno2` is `LINK_STATE_DOWN` and `eno1` is functioning as normal
3. take down `eno1` on the primary controller
4. failover will _fail_ and a message like this is logged on the other controller. ``` Received MASTER event for 'eno1', but other interfaces (eno2) are still working on the MASTER node. Ignoring event.```

This happens because the _NEW_ controller that is becoming the primary will see `eno2` as being marked in the "backup" state locally. This is occurring because the interface is LINK_STATE_DOWN.

This fixes that scenario by adding a new `offline` list variable to `check_failover_groups` method. Instead of treating offline interfaces as "backup", we'll mark them as "offline". With these changes, I also log a message in the failover event logic so that we have a paper trail of this scenario (since it's not very common).