### PR TITLE
fix cosmetic typo

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -414,7 +414,7 @@ class FailoverEventsService(Service):
             if offline:
                 # this isn't common but we're very verbose in this file so let's
                 # log the offline interfaces while we're here
-                self.logger.warning('Offline interfaces detected: %r', ', '.join(offline))
+                logger.warning('Offline interfaces detected: %r', ', '.join(offline))
 
             # this means that we received a master event and the interface was
             # in a failover group. And in that failover group, there were other
@@ -755,7 +755,7 @@ class FailoverEventsService(Service):
         if offline:
             # this isn't common but we're very verbose in this file so let's
             # log the offline interfaces while we're here
-            self.logger.warning('Offline interfaces detected: %r', ', '.join(offline))
+            logger.warning('Offline interfaces detected: %r', ', '.join(offline))
 
         # this means that we received a BACKUP event and the interface was
         # in a failover group. And in that failover group, there were other


### PR DESCRIPTION
During testing, I realized the log message that I added was going to `/var/log/middlewared.log` instead of `/var/log/failover.log`. This fixes it so it goes to the latter since the `failover.events.event` method exclusively logs to the same location.