### PR TITLE
NAS-129515 / 24.04.2 / Robustize ALUA (by bmeagherix)

### DIFF
--- a/src/freenas/usr/local/bin/scst_util.sh
+++ b/src/freenas/usr/local/bin/scst_util.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+force_close() {
+	shopt -s nullglob
+	for fc in /sys/kernel/scst_tgt/targets/iscsi/*/sessions/*/force_close ; do
+		echo 1 > $fc &
+	done
+	wait
+}
+
+case "$1" in
+    force-close)
+        force_close
+        rc=$?
+        ;;
+    *)
+        echo "Usage: $0 {force-close}"
+        exit 2
+        ;;
+esac
+
+exit $rc
+

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -324,8 +324,9 @@ class DistributedLockManagerService(Service):
         retries = 10
         while retries and await self.middleware.call('dlm.peer_lockspaces'):
             await asyncio.sleep(1)
-            self.logger.info('Waited for lockspace to settle')
             retries -= 1
+        if retries != 10:
+            self.logger.info('Waited %d seconds for lockspace to settle', 10 - retries)
 
         # Finally turn off cluster mode locally on all extents
         try:

--- a/src/middlewared/middlewared/plugins/dlm.py
+++ b/src/middlewared/middlewared/plugins/dlm.py
@@ -312,6 +312,7 @@ class DistributedLockManagerService(Service):
     async def local_reset(self, disable_iscsi=True):
         """Locally remove the PEER node from all lockspaces and reset cluster_mode to
         zero, WITHOUT talking to the peer node."""
+        self.logger.info('local_reset starting: %r', disable_iscsi)
         # First turn off all access to targets from outside.
         if disable_iscsi:
             await self.middleware.call('iscsi.scst.disable')
@@ -319,12 +320,26 @@ class DistributedLockManagerService(Service):
         # Locally eject the peer.  Will prevent remote comms below.
         await self.eject_peer()
 
+        # Wait for up to 10 seconds for things to settle
+        retries = 10
+        while retries and await self.middleware.call('dlm.peer_lockspaces'):
+            await asyncio.sleep(1)
+            self.logger.info('Waited for lockspace to settle')
+            retries -= 1
+
         # Finally turn off cluster mode locally on all extents
         try:
             DistributedLockManagerService.resetting = True
             await self.middleware.call('iscsi.scst.set_all_cluster_mode', 0)
         finally:
             DistributedLockManagerService.resetting = False
+        self.logger.info('local_reset done')
+
+    @private
+    async def is_local_reset_complete(self):
+        if await self.middleware.call('dlm.peer_lockspaces'):
+            return False
+        return await self.middleware.call('iscsi.scst.check_cluster_modes_clear')
 
 
 async def udev_dlm_hook(middleware, data):

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -686,6 +686,8 @@ class FailoverEventsService(Service):
             logger.info('Clearing iSCSI suspend')
             if self.run_call('iscsi.scst.clear_suspend'):
                 logger.info('Cleared iSCSI suspend')
+            # Kick off a job to start clearing up HA targets from when we were STANDBY
+            self.run_call('iscsi.alua.reset_active')
 
         # restart the remaining "non-critical" services
         logger.info('Restarting remaining services')

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -284,13 +284,14 @@ class iSCSITargetAluaService(Service):
                     await self.middleware.call('failover.call_remote', 'iscsi.scst.set_device_cluster_mode', [device, 0], cr_opts)
             except Exception:
                 # This is a fail-safe exception catch.  Should never occur.
-                self.logger.warning('standby_start job', exc_info=True)
+                self.logger.warning('Unexpected failure while cleaning up ACTIVE cluster_mode', exc_info=True)
                 await asyncio.sleep(RETRY_SECONDS)
         if not self.standby_starting:
             job.set_progress(24, 'Abandoned job.')
             return
         else:
             job.set_progress(24, 'Cleared cluster_mode on ACTIVE node')
+            self.logger.debug('Cleared cluster_mode on ACTIVE node')
 
         # Reload on ACTIVE node.  This will ensure the HA targets are available
         if self.standby_starting:

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -295,6 +295,9 @@ class iSCSITargetAluaService(Service):
             try:
                 while self.standby_starting:
                     try:
+                        # Logout any targets that have no associated LUN (may have been BUSY during login)
+                        await self.middleware.call('iscsi.target.logout_empty_ha_targets')
+                        # Login any missing targets
                         before_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')
                         await self.middleware.call('iscsi.target.login_ha_targets')
                         after_iqns = await self.middleware.call('iscsi.target.logged_in_iqns')

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -104,16 +104,15 @@ class iSCSITargetAluaService(Service):
         job.set_progress(0, 'Start ACTIVE node ALUA reset on election')
         self.logger.debug('Start ACTIVE node ALUA reset on election')
         if await self.middleware.call('iscsi.global.alua_enabled'):
-            if await self.middleware.call('failover.status') == 'MASTER':
-                # Just do the bare minimum here.
-                try:
-                    await self.middleware.call('dlm.eject_peer')
-                except Exception as e:
-                    self.logger.warning('active_elected job: %r', e)
-
-                job.set_progress(100, 'ACTIVE node ALUA reset completed')
-                self.logger.debug('ACTIVE node ALUA reset completed')
-                return
+            # Just do the bare minimum here.  This API will only be called
+            # on the new MASTER.
+            try:
+                await self.middleware.call('dlm.eject_peer')
+            except Exception as e:
+                self.logger.warning('active_elected job: %r', e)
+            job.set_progress(100, 'ACTIVE node ALUA reset completed')
+            self.logger.debug('ACTIVE node ALUA reset completed')
+            return
         job.set_progress(100, 'ACTIVE node ALUA reset NOOP')
         self.logger.debug('ACTIVE node ALUA reset NOOP')
 

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -62,8 +62,19 @@ class iSCSITargetService(Service):
     def enable(self):
         pathlib.Path(SCST_TARGETS_ISCSI_ENABLED_PATH).write_text('1\n')
 
-    def suspend(self, value):
+    def suspend(self, value=10):
         pathlib.Path(SCST_SUSPEND).write_text(f'{value}\n')
+
+    def clear_suspend(self):
+        """suspend could have been called several times, and will need to be decremented
+        several times to clean"""
+        p = pathlib.Path(SCST_SUSPEND)
+        if p.exists():
+            for i in range(30):
+                if p.read_text().split()[0] == '0':
+                    return True
+                p.write_text('-1\n')
+        return False
 
     def enabled(self):
         try:

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -88,12 +88,16 @@ class iSCSITargetService(Service):
     def clear_suspend(self):
         """suspend could have been called several times, and will need to be decremented
         several times to clean"""
-        p = pathlib.Path(SCST_SUSPEND)
-        if p.exists():
+        try:
+            p = pathlib.Path(SCST_SUSPEND)
             for i in range(30):
-                if p.read_text().split()[0] == '0':
+                if p.read_text().strip() == '0':
                     return True
-                p.write_text('-1\n')
+                else:
+                    p.write_text('-1\n')
+        except FileNotFoundError:
+            pass
+
         return False
 
     def enabled(self):

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -482,6 +482,23 @@ class iSCSITargetService(CRUDService):
         return results
 
     @private
+    def logged_in_empty_iqns(self):
+        """
+        :return: list of logged in iqns without any associated unsurfaced disks
+        """
+        results = []
+        p = pathlib.Path('/sys/devices/platform')
+        for targetname in p.glob('host*/session*/iscsi_session/session*/targetname'):
+            found = False
+            iqn = targetname.read_text().strip()
+            for _item in targetname.parent.glob('device/target*/*/scsi_disk'):
+                found = True
+                break
+            if not found:
+                results.append(iqn)
+        return results
+
+    @private
     def set_genhd_hidden_ips(self, ips):
         """
         Set the kernel parameter /sys/module/iscsi_tcp/parameters/genhd_hidden_ips to the
@@ -577,6 +594,44 @@ class iSCSITargetService(CRUDService):
 
         # Check what's already logged in
         existing = await self.middleware.call('iscsi.target.logged_in_iqns')
+
+        # Generate the set of things we want to logout (don't assume every IQN, just the HA ones)
+        todo = set()
+        for iqn in iqns.values():
+            if iqn in existing:
+                todo.add(iqn)
+
+        if todo:
+            remote_ip = await self.middleware.call('failover.remote_ip')
+
+            # Logout the targets (in parallel)
+            exceptions = await asyncio.gather(*[self.logout_iqn(remote_ip, iqn, no_wait) for iqn in todo], return_exceptions=True)
+            failures = []
+            for iqn, exc in zip(todo, exceptions):
+                if isinstance(exc, Exception):
+                    failures.append(str(exc))
+                else:
+                    self.logger.info('Successfully logged out from %r', iqn)
+
+            if failures:
+                err = f'Failure logging out from targets: {", ".join(failures)}'
+                if raise_error:
+                    raise CallError(err)
+                else:
+                    self.logger.error(err)
+
+    @private
+    async def logout_empty_ha_targets(self, no_wait=False, raise_error=False):
+        """
+        When called on a HA BACKUP node will attempt to login to all HA targets,
+        used in ALUA which are not currently associated with a LUN.
+
+        This can occur if they target is reporting as BUSY (i.e. suspended) during login.
+        """
+        iqns = await self.middleware.call('iscsi.target.active_ha_iqns')
+
+        # Check what's already logged in, but has no LUNs
+        existing = await self.middleware.call('iscsi.target.logged_in_empty_iqns')
 
         # Generate the set of things we want to logout (don't assume every IQN, just the HA ones)
         todo = set()


### PR DESCRIPTION
This PR contains a few components.

Summary:
- Better recovery when an service failover takes > 15 seconds
- Avoid service failover taking > 15 seconds (session teardown)
- Avoid STANDBY causing the ACTIVE node to reboot in certain circumstances

#### Robustize ALUA STANDBY against empty targets

Add `logout_empty_ha_targets` and call from `standby_after_start`.  This will prevent targets that were suspended when the STANDBY node logged into them from remaining in place, preventing further logins once they have been unsuspended.

They will not recover without a fresh login.

#### Better iSCSI suspend / resume
Suspend iSCSI activity earlier in `vrrp_master` and force close all current sessions.

Also use `clear_suspend` to resume activity, either in `become_active` if it runs to conclusion, or later in `vrrp_master` if not.

#### Remove failover.status check from active_elected
It appears that during `vrrp_master`, and **_after_** we have become MASTER `failover.status` was **not** returning "MASTER" 100% of the time.  (Presumably some race condition.)  Since we _know_ active_elected is **only** called from vrrp_master after we become MASTER, just eliminate the check.

#### dlm state robustness
Add some checks to `standby_after_start` when bringing up the STANDBY node.  Remove the `local_reset` shortcut calls, and instead cleanup `cluster_mode` one extent at a time.

This avoids an issue whereby the ACTIVE node could reboot when STANDBY was coming up, leading to an APD (All Paths Down) event.

Original PR: https://github.com/truenas/middleware/pull/13865
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129515