### PR TITLE
NAS-129384 / 24.04.2 / Fix netdata spamming logs (by Qubad786) (by bugclerk)

### DIFF
--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -1,7 +1,23 @@
 source /usr/lib/netdata/charts.d/nut.chart.sh
 
+nut_ups_update_every=60
+
+
 nut_get_all() {
   run -t $nut_timeout upsc -l || echo "ix-dummy-ups"
+}
+
+nut_get() {
+  if [ $1 == "ix-dummy-ups" ]; then
+    return 0;
+  fi
+
+  run -t $nut_timeout upsc "$1"
+
+  if [ "${nut_clients_chart}" -eq "1" ]; then
+    printf "ups.connected_clients: "
+    run -t $nut_timeout upsc -c "$1" | wc -l
+  fi
 }
 
 nut_ups_check() {
@@ -13,10 +29,15 @@ nut_ups_check() {
   local x
 
   require_cmd upsc || return 1
-
-  nut_ups="$(nut_get_all)"
   nut_names=()
   nut_ids=()
+
+  if [ $(ps -aux | grep upsmon | wc -l) -le 1 ]; then
+    nut_ids["ix-dummy-ups"]="$(fixid "ix-dummy-ups")"
+    return 0
+  fi
+
+  nut_ups="$(nut_get_all)"
   for x in $nut_ups; do
     nut_get "$x" > /dev/null
     # shellcheck disable=SC2181

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -48,6 +48,9 @@
 [statsd]
 	enabled = no
 
+[logs]
+	access = off
+
 [plugin:proc]
 	netdata server resources = yes
 	/proc/diskstats = yes


### PR DESCRIPTION
## Problem
We were seeing logs being continuously written to, after investigation, we found that only the UPS plugin of netdata is causing issues. When UPS is not configured, the failed `upsc -l` command returns an error, spamming the Netdata logs and causing the log file size to increase continuously.

## Solution
Modify the Netdata plugin to avoid executing the `upsc` command when `upsmon` process is not running. Additionally, disable access logs since only the `errors.log` is used for debugging, thereby preventing unnecessary log file growth.

Original PR: https://github.com/truenas/middleware/pull/13860
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129384

Original PR: https://github.com/truenas/middleware/pull/13884
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129384