### PR TITLE
NAS-129676 / 24.10 / Regenerate nsswitch.conf as-needed

### DIFF
--- a/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf.mako
@@ -1,0 +1,27 @@
+<%
+    enabled_ds = middleware.call_sync('directoryservices.status')['type']
+%>
+#
+# nsswitch.conf(5) - name service switch configuration file
+#
+
+% if enabled_ds is None:
+group: files
+passwd: files
+netgroup: files
+% elif enabled_ds == 'ACTIVEDIRECTORY':
+group: files winbind
+passwd: files winbind
+netgroup: files
+% else:
+group: files sss
+passwd: files sss
+netgroup: files sss
+% endif
+hosts: files dns
+networks: files
+shells: files
+services: files
+protocols: files
+rpc: files
+sudoers: files

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -804,6 +804,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('etc.generate', 'smb')
         await self.middleware.call('service.restart', 'idmap')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
         if ret == neterr.JOINED:
             await self.set_state(DSStatus['HEALTHY'].name)
             job.set_progress(90, 'Restarting dependent services.')
@@ -845,6 +846,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('service.restart', 'idmap')
         job.set_progress(40, 'Reconfiguring pam and nss.')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'].name)
         job.set_progress(60, 'clearing caches.')
         await self.middleware.call('service.stop', 'dscache')
@@ -1180,6 +1182,7 @@ class ActiveDirectoryService(ConfigService):
 
         job.set_progress(60, 'Regenerating configuration.')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
         await self.middleware.call('etc.generate', 'smb')
 
         job.set_progress(60, 'Restarting services.')

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -241,6 +241,9 @@ class EtcService(Service):
         'nscd': [
             {'type': 'mako', 'path': 'nscd.conf'},
         ],
+        'nss': [
+            {'type': 'mako', 'path': 'nsswitch.conf'},
+        ],
         'wsd': [
             {'type': 'mako', 'path': 'local/wsdd.conf', 'checkpoint': 'post_init'},
         ],

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -916,6 +916,7 @@ class LDAPService(ConfigService):
         await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('etc.generate', 'ldap')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
 
         job.set_progress(30, 'Starting sssd service')
         await self.middleware.call('service.restart', 'sssd')
@@ -942,6 +943,7 @@ class LDAPService(ConfigService):
         await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('etc.generate', 'ldap')
         await self.middleware.call('etc.generate', 'pam')
+        await self.middleware.call('etc.generate', 'nss')
 
         job.set_progress(50, 'Clearing directory service cache.')
         await self.middleware.call('service.stop', 'dscache')


### PR DESCRIPTION
Starting with glibc 2.33, the nsswitch.conf is automatically reloaded if the file is changed, which allows us to only keep needed nss modules present in the configuration file.