### PR TITLE
NAS-129677 / 24.10 / Remove unnecessary dumping of args

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -386,13 +386,6 @@ class Application:
         elif message['msg'] == 'unsub':
             await self.unsubscribe(message['id'])
 
-        if message['msg'] == 'method' and isinstance(message.get('params'), list):
-            log_message = dict(
-                message, params=self.middleware.dump_args(message.get('params', []), method_name=message['method'])
-            )
-        else:
-            log_message = message
-
     def __getstate__(self):
         return {}
 


### PR DESCRIPTION
## Context

We removed websocket logging in 2982c2cfa39921917b646b8e254a050765526e38 but we left out a usage which resulted un us dumping args for method calls and it is no longer required/needed to do that anymore.