### PR TITLE
NAS-129674 / 24.10 / Give core.ping no_authz_required status

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -556,6 +556,7 @@ class CoreService(Service):
         kwargs = kwargs or {}
         self.middleware.send_event(name, event_type, **kwargs)
 
+    @no_authz_required
     @accepts()
     def ping(self):
         """


### PR DESCRIPTION
As per [NAS-129674](https://ixsystems.atlassian.net/browse/NAS-129674), `midclt call core.ping` would output `Not authorized` for users with the read-only admin role.