### PR TITLE
NAS-129688 / 24.10 / Do not use ps for determining upsmon service status

### DIFF
--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -32,7 +32,7 @@ nut_ups_check() {
   nut_names=()
   nut_ids=()
 
-  if [ $(ps -aux | grep upsmon | wc -l) -le 1 ]; then
+  if [ ! -f /run/nut/upsmon.pid ]; then
     nut_ids["ix-dummy-ups"]="$(fixid "ix-dummy-ups")"
     return 0
   fi


### PR DESCRIPTION
## Problem

We were using `ps -aux` for determining UPS service health status which is quite expensive especially when invoked periodically.

## Solution

Check existence of upsmon pid file to determine if upsmon is running or not instead of using `ps`