### PR TITLE
NAS-127804 / 24.10 / Add AsyncRedfishClient

### DIFF
--- a/src/middlewared/middlewared/plugins/jbof/redfish/__init__.py
+++ b/src/middlewared/middlewared/plugins/jbof/redfish/__init__.py
@@ -1,1 +1,1 @@
-from .client import AuthMethod, RedfishClient, InvalidCredentialsError # noqa
+from .client import AsyncRedfishClient, AuthMethod, InvalidCredentialsError, RedfishClient  # noqa

--- a/src/middlewared/middlewared/plugins/jbof/redfish/client.py
+++ b/src/middlewared/middlewared/plugins/jbof/redfish/client.py
@@ -386,7 +386,7 @@ class AsyncRedfishClient(AbstractRedfishClient):
         self._sessions = {}
         # Implement a little value cache
         self._attributes = {}
-        self.logged = {}
+        self.logged = set()
 
     def _add_session(self, base_url, session):
         """Add a session corresponding to the base_url"""


### PR DESCRIPTION
This (`aiohttp`-based) async client is capable of transparently utilizing multiple redfish interfaces to the same JBOF.

It will be used by the new JBOF enclosure services for performing redfish operations.  (Will be introduced in a separate PR.)  When multiple JBOFs are present, this client will be used to fetch the data from them in parallel.

(The existing synchronous `requests`-based client is also being retained for initial setup/config operations.  With that client we _deliberately_ do **not** transparently handle switching between redfish interfaces.)