### PR TITLE
NAS-129693 / 24.10 / Change audit dataset quota setting from 'refquota' to 'quota'

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -414,7 +414,7 @@ class AuditService(ConfigService):
         payload = {}
         if new['quota'] != old_quota / _GIB:
             quota_val = "none" if new['quota'] == 0 else f'{new["quota"]}G'
-            payload['refquota'] = {'parsed': quota_val}
+            payload['quota'] = {'parsed': quota_val}
 
         if new['reservation'] != old_reservation / _GIB:
             reservation_val = "none" if new['reservation'] == 0 else f'{new["reservation"]}G'


### PR DESCRIPTION
Fix audit dataset quota setting.   
We were using `refquota` when we should be using `quota`.

This change can be safely backported.