### PR TITLE
NAS-129588 / 24.10 / Properly reference event name when subscribing to event sources

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -379,7 +379,7 @@ class Application:
                 pong['id'] = message['id']
             self._send(pong)
         elif message['msg'] == 'sub':
-            if not self.can_subscribe(message['name']):
+            if not self.can_subscribe(message['name'].split(':', 1)[0]):
                 self.send_error(message, errno.EACCES, 'Not authorized')
             else:
                 await self.subscribe(message['id'], message['name'])

--- a/src/middlewared/middlewared/plugins/reporting/processes.py
+++ b/src/middlewared/middlewared/plugins/reporting/processes.py
@@ -63,4 +63,4 @@ class ProcessesEventSource(EventSource):
 
 
 def setup(middleware):
-    middleware.register_event_source("reporting.processes", ProcessesEventSource)
+    middleware.register_event_source("reporting.processes", ProcessesEventSource, roles=['REPORTING_READ'])


### PR DESCRIPTION
## Problem

For event sources we have the event name come in as `kubernetes.pod_log_follow:{"release_name":"emby", "pod_name":"emby-6cb49545f9-b6xsq", "container_name":"emby", "tail_lines": 500}`. Now when we try to see if a user which is not an administrator is able to actually access an event source and that event source has args specified like in the example earlier - we fail to pass the authorization check because we are gauging in the args passed in as well.

## Solution

Make sure when we try to see if a consumer can subscribe to an event source we strip off the args specified for the event source.