### PR TITLE
NAS-129714 / 24.10 / fix references to system.is_freenas

### DIFF
--- a/src/middlewared/middlewared/migration/0003_iscsi_vendor.py
+++ b/src/middlewared/middlewared/migration/0003_iscsi_vendor.py
@@ -1,5 +1,4 @@
 async def migrate(middleware):
-    is_freenas = await middleware.call('system.is_freenas')
     extents = await middleware.call(
         'iscsi.extent.query', [['vendor', '=', None]], {'select': ['id', 'vendor']}
     )
@@ -8,7 +7,7 @@ async def migrate(middleware):
             'datastore.update',
             'services.iscsitargetextent',
             extent['id'], {
-                'iscsi_target_extent_vendor': 'FreeNAS' if is_freenas else 'TrueNAS'
+                'iscsi_target_extent_vendor': 'TrueNAS'
             }
         )
 

--- a/src/middlewared/middlewared/pytest/unit/middleware.py
+++ b/src/middlewared/middlewared/pytest/unit/middleware.py
@@ -15,7 +15,6 @@ class Middleware(SchemasMixin, dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self['failover.licensed'] = AsyncMock(return_value=False)
-        self['system.is_freenas'] = AsyncMock(return_value=True)
 
         self.call_hook = AsyncMock()
         self.call_hook_inline = Mock()


### PR DESCRIPTION
The method `system.is_freenas` has been deprecated for 1+ year(s) and was recently removed [here](https://github.com/truenas/middleware/pull/13900) However, I missed other places where it was being called.