### PR TITLE
Fix NoneType - set() regression

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -439,12 +439,12 @@ class FailoverService(ConfigService):
     async def mismatch_nics(self):
         """Determine if NICs match between both controllers."""
         result = {'missing_local': list(), 'missing_remote': list()}
-        local_nics = await self.middleware.call('interface.get_nic_names')
+        local_nics = await self.middleware.call('interface.get_nic_names') or set()
         try:
             remote_nics = await self.middleware.call(
                 'failover.call_remote', 'interface.get_nic_names', [],
                 {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2}
-            )
+            ) or set()
         except Exception:
             self.logger.error('Unhandled exception in get_nic_names on remote controller', exc_info=True)
         else:


### PR DESCRIPTION
To fix this NoneType regression, we null coalesce our NIC sets so they return an empty set if our `get_nic_names`.
This was chosen over updating the `get_nic_names` function as in the scenario that caused the regression was there not being a `get_nic_names` function on NodeB. This caused our remote call to return nothing.