### PR TITLE
NAS-129719 / 24.10 / Replace hard-coded defaults with values from the audit/utils.py

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -6,6 +6,9 @@ import re
 
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.filesystem.constants import ZFSCTL
+from middlewared.plugins.audit.utils import (
+    AUDIT_DEFAULT_FILL_CRITICAL, AUDIT_DEFAULT_FILL_WARNING
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +30,13 @@ class TNUserProp(enum.Enum):
     def default(self):
         match self:
             case TNUserProp.QUOTA_WARN:
-                return 80
+                return AUDIT_DEFAULT_FILL_WARNING
             case TNUserProp.QUOTA_CRIT:
-                return 95
+                return AUDIT_DEFAULT_FILL_CRITICAL
             case TNUserProp.REFQUOTA_WARN:
-                return 80
+                return AUDIT_DEFAULT_FILL_WARNING
             case TNUserProp.REFQUOTA_CRIT:
-                return 95
+                return AUDIT_DEFAULT_FILL_CRITICAL
             case _:
                 raise ValueError(f'{self.value}: no default value is set')
 

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -34,6 +34,7 @@ def initialize_for_smb_tests(request):
             }) as u:
                 yield {'dataset': ds, 'share': s, 'user': u}
 
+
 class AUDIT_CONFIG():
     defaults = {
         'retention': 7,
@@ -42,6 +43,7 @@ class AUDIT_CONFIG():
         'quota_fill_warning': 75,
         'quota_fill_critical': 95
     }
+
 
 @pytest.fixture(scope='module')
 def audit_config(request):
@@ -74,6 +76,12 @@ def test_audit_config_defaults(request):
         assert key in config['space'], str(config['space'])
 
     assert 'SMB' in config['enabled_services']
+
+
+def test_audit_config_dataset_defaults():
+    ds_config = call('audit.get_audit_dataset')
+    assert ds_config['org.freenas:quota_warning'] == AUDIT_CONFIG.defaults['quota_fill_warning']
+    assert ds_config['org.freenas:quota_critical'] == AUDIT_CONFIG.defaults['quota_fill_critical']
 
 
 def test_audit_config_updates(audit_config):


### PR DESCRIPTION
`zfs_/utils.py` was using hard-coded values for audit quota default settings.  The audit subsystem has these same values specified in `plugins/audit/utils.py`.   This PR removes the hard-coded values and replaces with the names associated with the default settings from `plugins/audit/utils.py`.

Includes a targeted CI test.