### PR TITLE
NAS-129735 / 24.10 / Force directory service cache insertion on share ACL read

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1095,7 +1095,7 @@ class IdmapDomainService(CRUDService):
         options = {'extra': {'additional_information': ['DS']}, 'get': True}
 
         match idtype:
-            # IDType.BOTH is possibly return by nss_winbind / nss_sss
+            # IDType.BOTH is possible return by nss_winbind / nss_sss
             # and is special case when idmapping backend converts a SID
             # to both a user and a group. For most practical purposes it
             # can be treated interally as a group.


### PR DESCRIPTION
When user / group enumeration are disabled for a directory service we rely on user.query and group.query to perform cache insertions as we have successes on lookups so that UI can present users with more useful options. This commit slightly refactors the getacl method for SMB shares to contribute to the lazy caching effort.