### PR TITLE
NAS-129740 / 24.10 / Add tests for SMB client encryption

### DIFF
--- a/tests/api2/test_smb_encryption.py
+++ b/tests/api2/test_smb_encryption.py
@@ -1,0 +1,96 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+from protocols import smb_connection
+
+SHAREUSER = 'smbuser420'
+PASSWD = 'abcd1234'
+SMB_NAME = 'enc_share'
+
+
+@pytest.fixture(scope='module')
+def smb_setup(request):
+    with dataset('smb-encrypt', data={'share_type': 'SMB'}) as ds:
+        with user({
+            'username': SHAREUSER,
+            'full_name': SHAREUSER,
+            'group_create': True,
+            'password': PASSWD
+        }, get_instance=False):
+            with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
+                try:
+                    call('service.start', 'cifs')
+                    yield {'dataset': ds, 'share': s}
+                finally:
+                    call('service.stop', 'cifs')
+
+
+def test__smb_client_encrypt_default(smb_setup):
+    with smb_connection(
+        share=smb_setup['share']['name'],
+        username=SHAREUSER,
+        password=PASSWD,
+        encryption='DEFAULT'
+    ) as c:
+        # perform basic op to fully initialize SMB session
+        assert c.get_smb_encryption() == 'DEFAULT'
+
+        c.ls('/')
+        smb_status = call('smb.status')[0]
+
+        # check session
+        assert smb_status['encryption']['cipher'] == '-'
+        assert smb_status['encryption']['degree'] == 'none'
+
+        # check share
+        assert smb_status['share_connections'][0]['encryption']['cipher'] == '-'
+        assert smb_status['share_connections'][0]['encryption']['degree'] == 'none'
+
+
+def test__smb_client_encrypt_desired(smb_setup):
+    with smb_connection(
+        share=smb_setup['share']['name'],
+        username=SHAREUSER,
+        password=PASSWD,
+        encryption='DESIRED'
+    ) as c:
+        assert c.get_smb_encryption() == 'DESIRED'
+
+        # perform basic op to fully initialize SMB session
+        c.ls('/')
+        smb_status = call('smb.status')[0]
+
+        # check session
+        assert smb_status['encryption']['cipher'] == 'AES-128-GCM'
+        assert smb_status['encryption']['degree'] == 'partial'
+
+        # check share
+        assert smb_status['share_connections'][0]['encryption']['cipher'] == 'AES-128-GCM'
+        assert smb_status['share_connections'][0]['encryption']['degree'] == 'full'
+
+
+def test__smb_client_encrypt_required(smb_setup):
+    with smb_connection(
+        share=smb_setup['share']['name'],
+        username=SHAREUSER,
+        password=PASSWD,
+        encryption='REQUIRED'
+    ) as c:
+        assert c.get_smb_encryption() == 'REQUIRED'
+
+        # perform basic op to fully initialize SMB session
+        c.ls('/')
+        smb_status = call('smb.status')[0]
+
+        # check session
+        assert smb_status['encryption']['cipher'] == 'AES-128-GCM'
+        assert smb_status['encryption']['degree'] == 'partial'
+
+        # check share
+        assert smb_status['share_connections'][0]['encryption']['cipher'] == 'AES-128-GCM'
+        assert smb_status['share_connections'][0]['encryption']['degree'] == 'full'

--- a/tests/protocols/smb_proto.py
+++ b/tests/protocols/smb_proto.py
@@ -51,6 +51,13 @@ class ACLControl(enum.IntFlag):
     SEC_DESC_SELF_RELATIVE          = 0x8000
 
 
+class SMBEncryption(enum.IntEnum):
+    """ Specify SMB encryption level for client. Used during negotiate """
+    DEFAULT = credentials.SMB_ENCRYPTION_DEFAULT
+    DESIRED = credentials.SMB_ENCRYPTION_DESIRED
+    REQUIRED = credentials.SMB_ENCRYPTION_REQUIRED
+
+
 class SMB(object):
     """
     Python implementation of basic SMB operations for protocol testing.
@@ -85,6 +92,7 @@ class SMB(object):
     def connect(self, **kwargs):
         host = kwargs.get("host", get_host_ip(SRVTarget.DEFAULT))
         share = kwargs.get("share")
+        encryption = SMBEncryption[kwargs.get("encryption", "DEFAULT")]
         username = kwargs.get("username")
         domain = kwargs.get("domain")
         password = kwargs.get("password")
@@ -94,6 +102,7 @@ class SMB(object):
         self._lp.load_default()
         self._cred = credentials.Credentials()
         self._cred.guess(self._lp)
+        self._cred.set_smb_encryption(encryption)
 
         if username is not None:
             self._cred.set_username(username)
@@ -115,6 +124,9 @@ class SMB(object):
             self._cred,
             force_smb1=smb1,
         )
+
+    def get_smb_encryption(self):
+        return SMBEncryption(self._cred.get_smb_encryption()).name
 
     def disconnect(self):
         open_files = list(self._open_files.keys())


### PR DESCRIPTION
This commit adds tests to validate that SMB clients can properly negotiate SMB encryption levels via normal protocol mechanisms.