### PR TITLE
NAS-129453 / 24.04.3 / Allow VM deletion if virtualization is not supported

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -33,3 +33,11 @@ def get_pci_device_class(pci_path: str) -> str:
             return r.read().strip()
 
     return ''
+
+
+def get_default_status() -> dict:
+    return {
+        'state': 'ERROR',
+        'pid': None,
+        'domain_state': 'ERROR',
+    }


### PR DESCRIPTION
## Context

This change was made to EE but not backported (https://github.com/truenas/middleware/pull/13776).
Essentially `vm.query` was failing on an unrelated operation as it was being called by filesystem attachment delegates in the case when virtualization was not supported.