### PR TITLE
NAS-128941 / 24.04.3 / Allow VM deletion if virtualization is not supported (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -33,3 +33,11 @@ def get_pci_device_class(pci_path: str) -> str:
             return r.read().strip()
 
     return ''
+
+
+def get_default_status() -> dict:
+    return {
+        'state': 'ERROR',
+        'pid': None,
+        'domain_state': 'ERROR',
+    }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 16a091204df0ca0986f52585414f878dc456514d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7585be9396b6b51f21481e54a9e14486cfb1d82b

### Context

A user switched from virtualization supported TN system to virtualization not supported and encountered this issue where he couldn't query and  then remove the VMs from the TN system. 

### Fix

PR adds the change to enable deletion of VMs even if virtualization is not supported. After the changes vm query will show the existing VMs but in error state like below. 

`"status": {
      "state": "ERROR",
      "pid": null,
      "domain_state": "ERROR"
    }`

Original PR: https://github.com/truenas/middleware/pull/13776
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128941