### PR TITLE
NAS-129751 / 24.10 / Fix audit export test

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -708,7 +708,7 @@ class CoreService(Service):
     async def _download(self, app, method, args, filename, buffered):
         serviceobj, methodobj = self.middleware._method_lookup(method)
         job = await self.middleware.call_with_audit(
-            method, serviceobj, methodobj, *args, app=app,
+            method, serviceobj, methodobj, args, app=app,
             pipes=Pipes(output=self.middleware.pipe(buffered))
         )
         token = await self.middleware.call('auth.generate_token', 300, {'filename': filename, 'job': job.id}, app=app)

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -152,9 +152,9 @@ def test_audit_export(request):
         st = call('filesystem.stat', report_path)
         assert st['size'] != 0, str(st)
 
-        job_id, path = call("core.download", "audit.download_report", [{
+        job_id, path = call("core.download", "audit.download_report", [[{
             "report_name": os.path.basename(report_path)
-        }], f"report.{backend.lower()}")
+        }]], f"report.{backend.lower()}")
         r = requests.get(f"{url()}{path}")
         r.raise_for_status()
         assert len(r.content) == st['size']
@@ -173,9 +173,9 @@ def test_audit_export_nonroot(request):
             st = c.call('filesystem.stat', report_path)
             assert st['size'] != 0, str(st)
 
-            job_id, path = c.call("core.download", "audit.download_report", [{
+            job_id, path = c.call("core.download", "audit.download_report", [[{
                 "report_name": os.path.basename(report_path)
-            }], f"report.{backend.lower()}")
+            }]], f"report.{backend.lower()}")
             r = requests.get(f"{url()}{path}")
             r.raise_for_status()
             assert len(r.content) == st['size']

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -152,9 +152,9 @@ def test_audit_export(request):
         st = call('filesystem.stat', report_path)
         assert st['size'] != 0, str(st)
 
-        job_id, path = call("core.download", "audit.download_report", [[{
+        job_id, path = call("core.download", "audit.download_report", [{
             "report_name": os.path.basename(report_path)
-        }]], f"report.{backend.lower()}")
+        }], f"report.{backend.lower()}")
         r = requests.get(f"{url()}{path}")
         r.raise_for_status()
         assert len(r.content) == st['size']
@@ -173,9 +173,9 @@ def test_audit_export_nonroot(request):
             st = c.call('filesystem.stat', report_path)
             assert st['size'] != 0, str(st)
 
-            job_id, path = c.call("core.download", "audit.download_report", [[{
+            job_id, path = c.call("core.download", "audit.download_report", [{
                 "report_name": os.path.basename(report_path)
-            }]], f"report.{backend.lower()}")
+            }], f"report.{backend.lower()}")
             r = requests.get(f"{url()}{path}")
             r.raise_for_status()
             assert len(r.content) == st['size']


### PR DESCRIPTION
The change to add audit `core.download` was passing parameters incorrectly.  This resulted in breaking the API. 
The fix:  change the parameters from `*args` to `args`