### PR TITLE
NAS-129758 / 24.10 / Try to use persistent connection for CI tests

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/call.py
+++ b/src/middlewared/middlewared/test/integration/utils/call.py
@@ -1,9 +1,12 @@
 # -*- coding=utf-8 -*-
-from .client import client
+from .client import client, truenas_server
 
 __all__ = ["call"]
 
 
 def call(*args, **kwargs):
-    with client(**kwargs.pop("client_kwargs", {})) as c:
+    if not (client_kwargs := kwargs.pop("client_kwargs", {})) and truenas_server.ip:
+        return truenas_server.client.call(*args, **kwargs)
+
+    with client(client_kwargs) as c:
         return c.call(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,14 +18,10 @@ def log_test_name_to_middlewared_log(request):
     # Beware that this is executed after session/package/module/class fixtures
     # are applied so the logs will still not be exactly precise.
     test_name = request.node.name
-    ip_to_use = truenas_server.ip
-    with client(host_ip=ip_to_use) as c:
-        c.call("test.notify_test_start", test_name)
-
+    truenas_server.client.call("test.notify_test_start", test_name)
     yield
 
     # That's why we also notify test ends. What happens between a test end
     # and the next test start is caused by session/package/module/class
     # fixtures setup code.
-    with client(host_ip=ip_to_use) as c:
-        c.call("test.notify_test_end", test_name)
+    truenas_server.client.call("test.notify_test_end", test_name)


### PR DESCRIPTION
Store a persistent websocket client connection in the truenas_server object we allocate for test runs, and use this for general case where test simply uses `call` test utility. This is to avoid potentially running into issues with rate-limiting on auth endpoints.