### PR TITLE
NAS-129763 / 24.10 / Expose ability for users to configure SMB encryption behavior

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-06-26_19-44_add_smb_encryption.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-06-26_19-44_add_smb_encryption.py
@@ -1,0 +1,21 @@
+"""add smb encryption parameter
+
+Revision ID: d8bfbf4e277e
+Revises: 91724c382023
+Create Date: 2024-06-26 19:44:55.116098+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd8bfbf4e277e'
+down_revision = '91724c382023'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_cifs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('cifs_srv_encryption', sa.String(length=120), nullable=True))

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -40,6 +40,13 @@ class SMBCmd(enum.Enum):
     WBINFO = 'wbinfo'
 
 
+class SMBEncryption(enum.Enum):
+    DEFAULT = 'default'
+    NEGOTIATE = 'if_required'
+    DESIRED = 'desired'
+    REQUIRED = 'required'
+
+
 class SMBBuiltin(enum.Enum):
     ADMINISTRATORS = ('builtin_administrators', 'S-1-5-32-544')
     GUESTS = ('builtin_guests', 'S-1-5-32-546')

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -3,7 +3,7 @@ import os
 from logging import getLogger
 from middlewared.utils import filter_list
 from middlewared.plugins.account import DEFAULT_HOME_PATH
-from middlewared.plugins.smb_.constants import LOGLEVEL_MAP, SMBPath
+from middlewared.plugins.smb_.constants import LOGLEVEL_MAP, SMBEncryption, SMBPath
 
 LOGGER = getLogger(__name__)
 
@@ -114,6 +114,7 @@ def generate_smb_conf_dict(
         'server string': smb_service_config['description'],
         'log level': loglevelint,
         'logging': 'file',
+        'server smb encrypt': SMBEncryption[smb_service_config['encryption']].value,
     }
 
     """

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
@@ -31,6 +31,7 @@ BASE_SMB_CONFIG = {
     'admin_group': None,
     'next_rid': 0,
     'multichannel': False,
+    'encryption': 'DEFAULT',
     'netbiosname_local': 'TESTSERVER'
 }
 
@@ -43,6 +44,10 @@ SMB_NTLMV1 = BASE_SMB_CONFIG | {'ntlmv1_auth': True}
 SMB_SMB1 = BASE_SMB_CONFIG | {'enable_smb1': True}
 SMB_MULTICHANNEL = BASE_SMB_CONFIG | {'multichannel': True}
 SMB_OPTIONS = BASE_SMB_CONFIG | {'smb_options': 'canary = bob\n canary2 = bob2 \n #comment\n ;othercomment'}
+SMB_ENCRYPTION_NEGOTIATE = BASE_SMB_CONFIG | {'encryption': 'NEGOTIATE'}
+SMB_ENCRYPTION_DESIRED = BASE_SMB_CONFIG | {'encryption': 'DESIRED'}
+SMB_ENCRYPTION_REQUIRED = BASE_SMB_CONFIG | {'encryption': 'REQUIRED'}
+
 
 BASE_SMB_SHARE = {
     'id': 1,
@@ -194,6 +199,7 @@ def test__base_smb():
     assert conf['server multichannel support'] is False
     assert conf['idmap config * : backend'] == 'tdb'
     assert conf['idmap config * : range'] == '90000001 - 100000000'
+    assert conf['server smb encrypt'] == 'default'
 
 
 def test__syslog():
@@ -366,3 +372,27 @@ def test__ad_autorid():
     )
     assert conf['idmap config * : backend'] == 'autorid'
     assert conf['idmap config * : range'] == '10000 - 200000000'
+
+
+def test__encryption_negotiate():
+    conf = generate_smb_conf_dict(
+        BASE_DS_STATUS, None, SMB_ENCRYPTION_NEGOTIATE, [],
+        BIND_IP_CHOICES, BASE_IDMAP
+    )
+    assert conf['server smb encrypt'] == 'if_required'
+
+
+def test__encryption_desired():
+    conf = generate_smb_conf_dict(
+        BASE_DS_STATUS, None, SMB_ENCRYPTION_DESIRED, [],
+        BIND_IP_CHOICES, BASE_IDMAP
+    )
+    assert conf['server smb encrypt'] == 'desired'
+
+
+def test__encryption_required():
+    conf = generate_smb_conf_dict(
+        BASE_DS_STATUS, None, SMB_ENCRYPTION_REQUIRED, [],
+        BIND_IP_CHOICES, BASE_IDMAP
+    )
+    assert conf['server smb encrypt'] == 'required'

--- a/tests/api2/test_smb_encryption.py
+++ b/tests/api2/test_smb_encryption.py
@@ -116,9 +116,11 @@ def test__smb_client_server_encrypt(smb_setup, enc_param):
             password=PASSWD,
             encryption='DEFAULT'
         ) as c:
-            # perform basic op to fully initialize SMB session
+            # check that client credential desired encryption is
+            # set to expected value
             assert c.get_smb_encryption() == 'DEFAULT'
 
+            # perform basic op to fully initialize SMB session
             c.ls('/')
             smb_status = call('smb.status')[0]
 

--- a/tests/api2/test_smb_encryption.py
+++ b/tests/api2/test_smb_encryption.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+from contextlib import contextmanager
 from middlewared.test.integration.assets.account import user
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.assets.pool import dataset
@@ -28,6 +29,16 @@ def smb_setup(request):
                     yield {'dataset': ds, 'share': s}
                 finally:
                     call('service.stop', 'cifs')
+
+
+@contextmanager
+def server_encryption(param):
+    call('smb.update', {'encryption': param})
+
+    try:
+        yield
+    finally:
+        call('smb.update', {'encryption': 'DEFAULT'})
 
 
 def test__smb_client_encrypt_default(smb_setup):
@@ -94,3 +105,27 @@ def test__smb_client_encrypt_required(smb_setup):
         # check share
         assert smb_status['share_connections'][0]['encryption']['cipher'] == 'AES-128-GCM'
         assert smb_status['share_connections'][0]['encryption']['degree'] == 'full'
+
+
+@pytest.mark.parametrize('enc_param', ('DESIRED', 'REQUIRED'))
+def test__smb_client_server_encrypt(smb_setup, enc_param):
+    with server_encryption(enc_param):
+        with smb_connection(
+            share=smb_setup['share']['name'],
+            username=SHAREUSER,
+            password=PASSWD,
+            encryption='DEFAULT'
+        ) as c:
+            # perform basic op to fully initialize SMB session
+            assert c.get_smb_encryption() == 'DEFAULT'
+
+            c.ls('/')
+            smb_status = call('smb.status')[0]
+
+            # check session
+            assert smb_status['encryption']['cipher'] == 'AES-128-GCM'
+            assert smb_status['encryption']['degree'] == 'full'
+
+            # check share
+            assert smb_status['share_connections'][0]['encryption']['cipher'] == 'AES-128-GCM'
+            assert smb_status['share_connections'][0]['encryption']['degree'] == 'full'


### PR DESCRIPTION
This commit adds a new SMB server global parameter for SMB transport encryption. It exposes 4 options:

DEFAULT -- follow upstream / truenas default (reflected as a null in db) -- currently NEGOTIATE
NEGOTIATE -- only encrypt transport if explicitly requested by the SMB client
DESIRED -- encrypt transport if supported by client during session negotiation.
REQUIRED -- always encrypt transport (rejecting access if client does not support encryption -- incompatible with SMB1 server).