### PR TITLE
NAS-129782 / 24.10 / Add auditing of audit ops

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -396,7 +396,7 @@ class AuditService(ConfigService):
         if new['quota'] and (old['quota'] != new['quota']):
             new_volsize = new['quota'] * _GIB
             used = new['space']['used_by_dataset'] + new['space']['used_by_snapshots']
-            if used // new_volsize > new['quota_fill_warning'] // 100:
+            if used / new_volsize > new['quota_fill_warning'] / 100:
                 verrors.add(
                     'audit_update.quota',
                     'Specified quota would result in the percentage used of the '
@@ -420,6 +420,7 @@ class AuditService(ConfigService):
         old_crit = int(ds_props.get(QUOTA_CRIT, {}).get('rawvalue', '0'))
 
         payload = {}
+        # Using floor division for conversion from bytes to GiB
         if new['quota'] != old_quota // _GIB:
             quota_val = "none" if new['quota'] == 0 else f'{new["quota"]}G'
             # Using refquota gives better fidelity with dataset settings

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -39,8 +39,9 @@ from middlewared.validators import Range
 
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]
-QUOTA_WARN = TNUserProp.QUOTA_WARN.value
-QUOTA_CRIT = TNUserProp.QUOTA_CRIT.value
+# We set the refquota limit
+QUOTA_WARN = TNUserProp.REFQUOTA_WARN.value
+QUOTA_CRIT = TNUserProp.REFQUOTA_CRIT.value
 _GIB = 1024 ** 3
 
 

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -27,11 +27,13 @@ SQL_SAFE_FIELDS = (
 
 AuditBase = declarative_base()
 
+
 def audit_program(svc):
     if svc == 'SUDO':
         return 'sudo'
     else:
         return f'TNAUDIT_{svc}'
+
 
 def audit_custom_section(svc, section):
     """
@@ -40,6 +42,7 @@ def audit_custom_section(svc, section):
     if svc == 'SUDO' and section == 'log':
         return True
     return False
+
 
 def audit_file_path(svc):
     return f'{AUDIT_DATASET_PATH}/{svc}.db'

--- a/tests/api2/test_audit_audit.py
+++ b/tests/api2/test_audit_audit.py
@@ -1,0 +1,174 @@
+import os
+import sys
+
+import operator
+import pytest
+import requests
+import time
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.utils import call, url
+from middlewared.test.integration.utils.audit import expect_audit_log, expect_audit_method_calls
+from unittest.mock import ANY
+
+sys.path.append(os.getcwd())
+from functions import POST, PUT
+
+
+# =====================================================================
+#                     Fixtures and utilities
+# =====================================================================
+@pytest.fixture(scope='class')
+def report_exists(request):
+    report_pathname = request.config.cache.get('report_pathname', None)
+    assert report_pathname is not None
+    yield report_pathname
+
+
+# =====================================================================
+#                           Tests
+# =====================================================================
+@pytest.mark.parametrize('payload,success', [
+    ({'retention': 20}, True),
+    ({'retention': 0}, False)
+])
+@pytest.mark.parametrize('api', ['ws', 'rest'])
+def test_audit_config_audit(api, payload, success):
+    '''
+    Test the auditing of Audit configuration changes
+    '''
+    initial_audit_config = call('audit.config')
+    protocol = 'WEBSOCKET' if api == 'ws' else 'REST'
+    rest_operator = operator.eq if success else operator.ne
+    expected_log_template = {
+        "service_data": {
+            "vers": {
+                "major": 0,
+                "minor": 1,
+            },
+            "origin": ANY,
+            "protocol": protocol,
+            "credentials": {
+                "credentials": "LOGIN_PASSWORD",
+                "credentials_data": {"username": "root"},
+            },
+        },
+        "event": "METHOD_CALL",
+        "event_data": {
+            "authenticated": True,
+            "authorized": True,
+            "method": "audit.update",
+            "params": [payload],
+            "description": "Update Audit Configuration",
+        },
+        "success": success
+    }
+    try:
+        with expect_audit_log([expected_log_template]):
+            if api == 'ws':
+                if success:
+                    call('audit.update', payload)
+                else:
+                    with pytest.raises(ValidationErrors):
+                        call('audit.update', payload)
+            elif api == 'rest':
+                result = PUT('/audit/', payload)
+                assert rest_operator(result.status_code, 200), result.text
+            else:
+                raise ValueError(api)
+    finally:
+        # Restore initial state
+        restore_payload = {
+            'retention': initial_audit_config['retention'],
+        }
+        if api == 'ws':
+            call('audit.update', restore_payload)
+        elif api == 'rest':
+            result = PUT('/audit/', restore_payload)
+            assert result.status_code == 200, result.text
+        else:
+            raise ValueError(api)
+
+
+@pytest.mark.parametrize('api', ['ws', 'rest'])
+def test_audit_export_audit(request, api):
+    '''
+    Test the auditing of the audit export function
+    '''
+    payload = {
+        'export_format': 'CSV'
+    }
+    with expect_audit_method_calls([{
+        'method': 'audit.export',
+        'params': [payload],
+        'description': 'Export Audit Data',
+    }]):
+        if api == 'ws':
+            report_pathname = call('audit.export', payload, job=True)
+            request.config.cache.set('report_pathname', report_pathname)
+        elif api == 'rest':
+            results = POST("/audit/export/", payload)
+            assert results.status_code == 200, results.text
+        else:
+            raise ValueError(api)
+
+
+class TestAuditDownload:
+    """
+    Wrap these tests in a class for the 'report_exists' fixture
+    """
+    @pytest.mark.parametrize('api', ['ws', 'rest'])
+    def test_audit_download_audit(self, report_exists, api):
+        '''
+        Test the auditing of the audit download function
+        '''
+        report_pathname = report_exists
+        st = call('filesystem.stat', report_pathname)
+
+        init_audit_query = call("audit.query", {
+            "query-filters": [["event_data.method", "=", "audit.download_report"]],
+            "query-options": {"select": ["event_data", "success"]}
+        })
+        init_len = len(init_audit_query)
+
+        report_name = os.path.basename(report_pathname)
+        payload = {
+            'report_name': report_name
+        }
+        if api == 'ws':
+            job_id, download_data = call(
+                'core.download', 'audit.download_report', [payload], 'report.csv'
+            )
+            r = requests.get(f"{url()}{download_data}")
+            r.raise_for_status()
+            assert len(r.content) == st['size']
+        elif api == 'rest':
+            results = POST("/audit/download_report/", payload)
+            assert results.status_code == 200, results.text
+        else:
+            raise ValueError(api)
+
+        post_audit_query = call("audit.query", {
+            "query-filters": [["event_data.method", "=", "audit.download_report"]],
+            "query-options": {"select": ["event_data", "success"]}
+        })
+        post_len = len(post_audit_query)
+
+        # This usually requires only one cycle
+        count_down = 10
+        while count_down > 0 and post_len == init_len:
+            time.sleep(1)
+            count_down -= 1
+            post_audit_query = call("audit.query", {
+                "query-filters": [["event_data.method", "=", "audit.download_report"]],
+                "query-options": {"select": ["event_data", "success"]}
+            })
+            post_len = len(post_audit_query)
+
+        assert count_down > 0, "Timed out waiting for the audit entry"
+        assert post_len > init_len
+
+        # Confirm this download is recorded
+        entry = post_audit_query[-1]
+        event_data = entry['event_data']
+        params = event_data['params'][0]
+        assert report_name in params['report_name']

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -3,7 +3,6 @@ from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call, url
 from protocols import smb_connection
-from pytest_dependency import depends
 from time import sleep
 
 import os
@@ -15,10 +14,60 @@ import string
 
 SMBUSER = 'audit-smb-user'
 PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
+AUDIT_DATASET_CONFIG = {
+    # keyname : "audit"=audit only setting, "zfs"=zfs dataset setting, "ro"=read-only (not a setting)
+    'retention': 'audit',
+    'quota': 'zfs',
+    'reservation': 'zfs',
+    'quota_fill_warning': 'zfs',
+    'quota_fill_critical': 'zfs',
+    'remote_logging_enabled': 'other',
+    'space': 'ro'
+}
+MiB = 1024**2
+GiB = 1024**3
 
 
-@pytest.fixture(scope='module')
-def initialize_for_smb_tests(request):
+# =====================================================================
+#                     Fixtures and utilities
+# =====================================================================
+class AUDIT_CONFIG():
+    defaults = {
+        'retention': 7,
+        'quota': 0,
+        'reservation': 0,
+        'quota_fill_warning': 75,
+        'quota_fill_critical': 95
+    }
+
+
+# def get_zfs(key, zfs_config):
+def get_zfs(type, key, zfs_config):
+    """ Get the equivalent ZFS value associated with the audit config setting """
+
+    types = {
+        'zfs': {
+            'reservation': zfs_config['properties']['refreservation']['parsed'] or 0,
+            'quota': zfs_config['properties']['refquota']['parsed'] or 0,  # audit quota == ZFS refquota
+            'refquota': zfs_config['properties']['refquota']['parsed'] or 0,
+            'quota_fill_warning': zfs_config['org.freenas:quota_warning'],
+            'quota_fill_critical': zfs_config['org.freenas:quota_critical']
+        },
+        'space': {
+            'used': zfs_config['properties']['used']['parsed'],
+            'used_by_snapshots': zfs_config['properties']['usedbysnapshots']['parsed'],
+            'available': zfs_config['properties']['available']['parsed'],
+            'used_by_dataset': zfs_config['properties']['usedbydataset']['parsed'],
+            # We set 'refreservation' and there is no 'usedbyreservation'
+            'used_by_reservation': zfs_config['properties']['usedbyrefreservation']['parsed']
+        }
+    }
+    # return zfs[key]
+    return types[type][key]
+
+
+@pytest.fixture(scope='class')
+def initialize_for_smb_tests():
     with dataset('audit-test-basic', data={'share_type': 'SMB'}) as ds:
         with smb_share(os.path.join('/mnt', ds), 'AUDIT_BASIC_TEST', {
             'purpose': 'NO_PRESET',
@@ -35,147 +84,156 @@ def initialize_for_smb_tests(request):
                 yield {'dataset': ds, 'share': s, 'user': u}
 
 
-class AUDIT_CONFIG():
-    defaults = {
-        'retention': 7,
-        'quota': 0,
-        'reservation': 0,
-        'quota_fill_warning': 75,
-        'quota_fill_critical': 95
-    }
-
-
-@pytest.fixture(scope='module')
-def audit_config(request):
+@pytest.fixture(scope='class')
+def init_audit():
+    """ Provides the audit and dataset configs and cleans up afterwared """
     try:
-        yield
+        dataset = call('audit.get_audit_dataset')
+        config = call('audit.config')
+        yield (config, dataset)
     finally:
         call('audit.update', AUDIT_CONFIG.defaults)
 
 
-def test_audit_config_defaults(request):
-    config = call('audit.config')
-    for key in [
-        'retention',
-        'quota',
-        'reservation',
-        'quota_fill_warning',
-        'quota_fill_critical',
-        'remote_logging_enabled',
-        'space'
-    ]:
-        assert key in config, str(config)
+# =====================================================================
+#                           Tests
+# =====================================================================
+class TestAuditConfig:
+    def test_audit_config_defaults(self, init_audit):
+        (config, dataset) = init_audit
 
-    assert config['retention'] == AUDIT_CONFIG.defaults['retention']
-    assert config['quota'] == AUDIT_CONFIG.defaults['quota']
-    assert config['reservation'] == AUDIT_CONFIG.defaults['reservation']
-    assert config['quota_fill_warning'] == AUDIT_CONFIG.defaults['quota_fill_warning']
-    assert config['quota_fill_critical'] == AUDIT_CONFIG.defaults['quota_fill_critical']
-    assert config['remote_logging_enabled'] is False
-    for key in ['used', 'used_by_snapshots', 'used_by_dataset', 'used_by_reservation', 'available']:
-        assert key in config['space'], str(config['space'])
+        # Confirm existence of config entries
+        for key in [k for k in AUDIT_DATASET_CONFIG]:
+            assert key in config, str(config)
 
-    assert 'SMB' in config['enabled_services']
+        # Confirm audit default config settings
+        assert config['retention'] == AUDIT_CONFIG.defaults['retention']
+        assert config['quota'] == AUDIT_CONFIG.defaults['quota']
+        assert config['reservation'] == AUDIT_CONFIG.defaults['reservation']
+        assert config['quota_fill_warning'] == AUDIT_CONFIG.defaults['quota_fill_warning']
+        assert config['quota_fill_critical'] == AUDIT_CONFIG.defaults['quota_fill_critical']
+        assert config['remote_logging_enabled'] is False
+        for key in ['used', 'used_by_snapshots', 'used_by_dataset', 'used_by_reservation', 'available']:
+            assert key in config['space'], str(config['space'])
 
+        for service in ['MIDDLEWARE', 'SMB', 'SUDO']:
+            assert service in config['enabled_services']
 
-def test_audit_config_dataset_defaults():
-    ds_config = call('audit.get_audit_dataset')
-    assert ds_config['org.freenas:quota_warning'] == AUDIT_CONFIG.defaults['quota_fill_warning']
-    assert ds_config['org.freenas:quota_critical'] == AUDIT_CONFIG.defaults['quota_fill_critical']
+        # Confirm audit dataset settings
+        for key in [k for k in AUDIT_DATASET_CONFIG if AUDIT_DATASET_CONFIG[k] == 'zfs']:
+            assert get_zfs('zfs', key, dataset) == config[key], f"config[{key}] = {config[key]}"
 
+    def test_audit_config_dataset_defaults(self):
+        """ Confirm Audit dataset uses Audit default settings """
+        ds_config = call('audit.get_audit_dataset')
+        assert ds_config['org.freenas:quota_warning'] == AUDIT_CONFIG.defaults['quota_fill_warning']
+        assert ds_config['org.freenas:quota_critical'] == AUDIT_CONFIG.defaults['quota_fill_critical']
 
-def test_audit_config_updates(audit_config):
-    """
-    This test just validates that setting values has expected results.
-    """
-    new_config = call('audit.update', {'retention': 10})
-    assert new_config['retention'] == 10
+    def test_audit_config_updates(self):
+        """
+        This test validates that setting values has expected results.
+        """
+        new_config = call('audit.update', {'retention': 10})
+        assert new_config['retention'] == 10
 
-    new_config = call('audit.update', {'quota': 1})
-    assert new_config['quota'] == 1
+        # quota are in units of GiB
+        new_config = call('audit.update', {'quota': 1})
+        assert new_config['quota'] == 1
+        audit_dataset = call('audit.get_audit_dataset')
 
-    # Check that we're actually setting the quota by evaluating available space
-    # we should be within 10 Mib of quota target (sql database will already be written)
-    assert abs(new_config['space']['available'] - 1024 ** 3) < (1024 ** 2) * 10
+        # ZFS value is in units of bytes.  Convert to GiB for comparison.
+        assert get_zfs('zfs', 'refquota', audit_dataset) // GiB == new_config['quota']
 
-    new_config = call('audit.update', {'reservation': 1})
-    assert new_config['reservation'] == 1
-    assert new_config['space']['used_by_reservation'] != 0
+        # Confirm ZFS and audit config are in sync
+        assert new_config['space']['available'] == get_zfs('space', 'available', audit_dataset)
+        assert new_config['space']['used_by_dataset'] == get_zfs('space', 'used', audit_dataset)
 
-    new_config = call('audit.update', {
-        'quota_fill_warning': 70,
-        'quota_fill_critical': 80
-    })
+        # Check that we're actually setting the quota by evaluating available space
+        # Change the the quota to something more interesting
+        new_config = call('audit.update', {'quota': 2})
+        assert new_config['quota'] == 2
 
-    assert new_config['quota_fill_warning'] == 70
-    assert new_config['quota_fill_critical'] == 80
+        audit_dataset = call('audit.get_audit_dataset')
+        assert get_zfs('zfs', 'refquota', audit_dataset) == 2*GiB  # noqa (allow 2*GiB)
 
-    # Test disable reservation
-    new_config = call('audit.update', {'reservation': 0})
-    assert new_config['reservation'] == 0
+        used_in_dataset = get_zfs('space', 'used_by_dataset', audit_dataset)
+        assert abs(new_config['space']['available'] - 2*GiB) == used_in_dataset  # noqa (allow 2*GiB)
 
-    # Test disable quota
-    new_config = call('audit.update', {'quota': 0})
-    assert new_config['quota'] == 0
+        new_config = call('audit.update', {'reservation': 1})
+        assert new_config['reservation'] == 1
+        assert new_config['space']['used_by_reservation'] != 0
 
-    # TODO: Get values from zfs.dataset.query
+        new_config = call('audit.update', {
+            'quota_fill_warning': 70,
+            'quota_fill_critical': 80
+        })
 
+        assert new_config['quota_fill_warning'] == 70
+        assert new_config['quota_fill_critical'] == 80
 
-@pytest.mark.dependency(name="AUDIT_OPS_PERFORMED")
-def test_audit_query(initialize_for_smb_tests):
-    share = initialize_for_smb_tests['share']
-    with smb_connection(
-        share=share['name'],
-        username=SMBUSER,
-        password=PASSWD,
-    ) as c:
-        fd = c.create_file('testfile.txt', 'w')
-        for i in range(0, 3):
-            c.write(fd, b'foo')
-            c.read(fd, 0, 3)
-        c.close(fd, True)
+        # Test disable reservation
+        new_config = call('audit.update', {'reservation': 0})
+        assert new_config['reservation'] == 0
 
-    sleep(10)
-    ops = call('audit.query', {
-        'services': ['SMB'],
-        'query-filters': [['username', '=', SMBUSER]],
-        'query-options': {'count': True}
-    })
-    assert ops > 0
+        # Test disable quota
+        new_config = call('audit.update', {'quota': 0})
+        assert new_config['quota'] == 0
 
 
-def test_audit_export(request):
-    depends(request, ["AUDIT_OPS_PERFORMED"], scope="session")
-    for backend in ['CSV', 'JSON', 'YAML']:
-        report_path = call('audit.export', {'export_format': backend}, job=True)
-        assert report_path.startswith('/audit/reports/root/')
-        st = call('filesystem.stat', report_path)
-        assert st['size'] != 0, str(st)
+class TestAuditOps:
+    def test_audit_query(self, initialize_for_smb_tests):
+        share = initialize_for_smb_tests['share']
+        with smb_connection(
+            share=share['name'],
+            username=SMBUSER,
+            password=PASSWD,
+        ) as c:
+            fd = c.create_file('testfile.txt', 'w')
+            for i in range(0, 3):
+                c.write(fd, b'foo')
+                c.read(fd, 0, 3)
+            c.close(fd, True)
 
-        job_id, path = call("core.download", "audit.download_report", [{
-            "report_name": os.path.basename(report_path)
-        }], f"report.{backend.lower()}")
-        r = requests.get(f"{url()}{path}")
-        r.raise_for_status()
-        assert len(r.content) == st['size']
+        sleep(10)
+        ops = call('audit.query', {
+            'services': ['SMB'],
+            'query-filters': [['username', '=', SMBUSER]],
+            'query-options': {'count': True}
+        })
+        assert ops > 0
 
-
-def test_audit_export_nonroot(request):
-    depends(request, ["AUDIT_OPS_PERFORMED"], scope="session")
-
-    with unprivileged_user_client(roles=['SYSTEM_AUDIT_READ', 'FILESYSTEM_ATTRS_READ']) as c:
-        me = c.call('auth.me')
-        username = me['pw_name']
-
+    def test_audit_export(self):
         for backend in ['CSV', 'JSON', 'YAML']:
-            report_path = c.call('audit.export', {'export_format': backend}, job=True)
-            assert report_path.startswith(f'/audit/reports/{username}/')
-            st = c.call('filesystem.stat', report_path)
+            report_path = call('audit.export', {'export_format': backend}, job=True)
+            assert report_path.startswith('/audit/reports/root/')
+            st = call('filesystem.stat', report_path)
             assert st['size'] != 0, str(st)
 
-            job_id, path = c.call("core.download", "audit.download_report", [{
-                "report_name": os.path.basename(report_path)
-            }], f"report.{backend.lower()}")
+            job_id, path = call(
+                "core.download", "audit.download_report",
+                [{"report_name": os.path.basename(report_path)}],
+                f"report.{backend.lower()}"
+            )
             r = requests.get(f"{url()}{path}")
             r.raise_for_status()
             assert len(r.content) == st['size']
+
+    def test_audit_export_nonroot(self):
+        with unprivileged_user_client(roles=['SYSTEM_AUDIT_READ', 'FILESYSTEM_ATTRS_READ']) as c:
+            me = c.call('auth.me')
+            username = me['pw_name']
+
+            for backend in ['CSV', 'JSON', 'YAML']:
+                report_path = c.call('audit.export', {'export_format': backend}, job=True)
+                assert report_path.startswith(f'/audit/reports/{username}/')
+                st = c.call('filesystem.stat', report_path)
+                assert st['size'] != 0, str(st)
+
+                job_id, path = c.call(
+                    "core.download", "audit.download_report",
+                    [{"report_name": os.path.basename(report_path)}],
+                    f"report.{backend.lower()}"
+                )
+                r = requests.get(f"{url()}{path}")
+                r.raise_for_status()
+                assert len(r.content) == st['size']


### PR DESCRIPTION
Added auditing of audit ops.  Also includes:
- Returning to `refquota`
- Fixing a typo and converting the unit conversion divisions to `//`

Very minor cleanup of audit utils:  Fix Flake8 complaint about extra lines

Refactored test_audit_basic:
- Enhanced testing
-- More checks with ZFS dataset values
- Converted to using refquota.

Added CI tests for the new auditing in test_audit_audit.py.
