### PR TITLE
NAS-129750 / 24.10 / fix scrambing start sector of data partitions in pool.expand

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -5,6 +5,7 @@ import pyudev
 
 import libsgio
 from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
+from middlewared.plugins.disk_.disk_info import get_partition_size_info
 from middlewared.schema import Dict, returns
 from middlewared.service import Service, accepts, private
 from middlewared.utils.functools_ import cache
@@ -100,6 +101,9 @@ class DeviceService(Service):
         for i in filter(lambda x: all(x.get(k) for k in keys), dev.children):
             part_num = int(i['ID_PART_ENTRY_NUMBER'])
             part_name = self.middleware.call_sync('disk.get_partition_for_disk', parent, part_num)
+            lbs, start_sector, end_sector, sect_size = get_partition_size_info(
+                parent, int(i['ID_PART_ENTRY_OFFSET']), int(i['ID_PART_ENTRY_SIZE'])
+            )
             part = {
                 'name': part_name,
                 'id': part_name,
@@ -109,13 +113,13 @@ class DeviceService(Service):
                 'partition_type': i['ID_PART_ENTRY_TYPE'],
                 'partition_number': part_num,
                 'partition_uuid': i['ID_PART_ENTRY_UUID'],
-                'start_sector': int(i['ID_PART_ENTRY_OFFSET']),
-                'end_sector': int(i['ID_PART_ENTRY_OFFSET']) + int(i['ID_PART_ENTRY_SIZE']) - 1,
+                'start_sector': start_sector,
+                'end_sector': end_sector,
                 'encrypted_provider': None,
             }
-            part['start'] = part['start_sector'] * 512
-            part['end'] = part['end_sector'] * 512
-            part['size'] = int(i['ID_PART_ENTRY_SIZE']) * 512
+            part['start'] = start_sector * lbs  # bytes
+            part['end'] = end_sector * lbs  # bytes
+            part['size'] = sect_size * lbs  # bytes
 
             for attr in filter(lambda x: x.startswith('holders/md'), i.attributes.available_attributes):
                 # looks like `holders/md123`

--- a/src/middlewared/middlewared/plugins/device_/device_info.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info.py
@@ -101,9 +101,7 @@ class DeviceService(Service):
         for i in filter(lambda x: all(x.get(k) for k in keys), dev.children):
             part_num = int(i['ID_PART_ENTRY_NUMBER'])
             part_name = self.middleware.call_sync('disk.get_partition_for_disk', parent, part_num)
-            lbs, start_sector, end_sector, sect_size = get_partition_size_info(
-                parent, int(i['ID_PART_ENTRY_OFFSET']), int(i['ID_PART_ENTRY_SIZE'])
-            )
+            pinfo = get_partition_size_info(parent, int(i['ID_PART_ENTRY_OFFSET']), int(i['ID_PART_ENTRY_SIZE']))
             part = {
                 'name': part_name,
                 'id': part_name,
@@ -113,13 +111,13 @@ class DeviceService(Service):
                 'partition_type': i['ID_PART_ENTRY_TYPE'],
                 'partition_number': part_num,
                 'partition_uuid': i['ID_PART_ENTRY_UUID'],
-                'start_sector': start_sector,
-                'end_sector': end_sector,
+                'start_sector': pinfo.start_sector,
+                'end_sector': pinfo.end_sector,
+                'start': pinfo.start_byte,
+                'end': pinfo.end_byte,
+                'size': pinfo.total_bytes,
                 'encrypted_provider': None,
             }
-            part['start'] = start_sector * lbs  # bytes
-            part['end'] = end_sector * lbs  # bytes
-            part['size'] = sect_size * lbs  # bytes
 
             for attr in filter(lambda x: x.startswith('holders/md'), i.attributes.available_attributes):
                 # looks like `holders/md123`


### PR DESCRIPTION
A fix was done here recently to ensure we maintain the start sector offset of the data partition for `pool.expand`. However, it uncovered the fact that we're not calculating the start _sector_ properly because the kernel has 0 documentation on these sysfs files (which is where we enumerate this information) and so we made an incorrect assumption of how it works. This manifests itself on 4kn drives. Almost all userspace tools for manipulating partitions will default to expecting the information is provided in sectors. Without these changes, we're not doing that properly. Reproduced in-house trivially and was able to test these changes afterwards.

NOTE: I will be pushing another proper PR with tests after this is merged. However, I need to add 4kn emulated drives to our VM environment for the tests to be valid. This needs to be merged in time for 24.04.2 so this is why I'm opening it up without tests right now.

NOTE 2: I've found that we have a bunch of code duplication related to enumerating partition info. I will push, yet another, PR to master that consolidates this code and makes this situation much harder to hit in the future.