### PR TITLE
NAS-129792 / 24.10 / Add settle delay after snmp start

### DIFF
--- a/tests/api2/test_snmp_agent.py
+++ b/tests/api2/test_snmp_agent.py
@@ -1,16 +1,17 @@
 import re
 import subprocess
 import tempfile
+import time
 
 import pytest
 
-from middlewared.test.integration.utils import call, ssh, host
-
+from middlewared.test.integration.utils import call, host, ssh
 
 
 @pytest.fixture()
 def snmpd_running():
     call("service.start", "snmp")
+    time.sleep(2)
     yield
 
 


### PR DESCRIPTION
(Possibly following some recent changes in EE ...) When the snmp agent starts it takes a second or so before it initializes **all** the fields, so when the test was querying too quickly after starting it, the test failed.

Just add a short (2 second) delay to avoid the race.

(Passed test with this change in CI run [1019](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1019/))