### PR TITLE
NAS-129533 / 24.10 / Tune ARC memory pressure parameters

### DIFF
--- a/src/freenas/usr/lib/modprobe.d/truenas.conf
+++ b/src/freenas/usr/lib/modprobe.d/truenas.conf
@@ -1,3 +1,3 @@
 options spl spl_panic_halt=1
-options zfs zfs_default_ibs=15
+options zfs zfs_default_ibs=15 zfs_arc_shrinker_limit=0 zfs_arc_pc_percent=300
 blacklist irdma


### PR DESCRIPTION
 - Setting zfs_arc_shrinker_limit=0 should make ARC more obedient to all kernel shrinker KPI requests, that should help to avoid OOMs.

 - zfs_arc_pc_percent=300 should prevent file-backed part of page cache from getting bigger than 1/3 of ARC, that should help with ARC shrinking to its minimum by heavy mmap() I/O.  It is not perfect from perspective of adapting to different workloads, but the best we can do for now.