### PR TITLE
NAS-129286 / 24.10 / Do not try to dump result when it is a job

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1438,6 +1438,9 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                 for i, arg in enumerate(args)]
 
     def dump_result(self, method, result, expose_secrets):
+        if isinstance(result, Job):
+            return result
+
         if hasattr(method, "new_style_returns"):
             return serialize_result(method.new_style_returns, result, expose_secrets)
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -131,7 +131,7 @@ class PoolService(CRUDService):
 
     @private
     @accepts(Str('pool_name'))
-    @returns(Ref('pool_entry'))
+    @returns(Patch('pool_entry', 'pool_normalize', ('rm', {'name': 'id'}), ('rm', {'name': 'guid'})))
     async def pool_normalize_info(self, pool_name):
         """
         Returns the current state of 'pool_name' including all vdevs, properties and datasets.

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -8,6 +8,8 @@ from middlewared.validators import Range
 
 from .enums import Status, StatusReason
 
+
+CONNECTING_STATUS_REASON = 'Waiting for connection from Truecommand.'
 TRUECOMMAND_UPDATE_LOCK = asyncio.Lock()
 
 
@@ -41,7 +43,7 @@ class TruecommandService(ConfigService):
         Int('id', required=True),
         Password('api_key', required=True, null=True),
         Str('status', required=True, enum=[s.value for s in Status]),
-        Str('status_reason', required=True, enum=[s.value for s in StatusReason]),
+        Str('status_reason', required=True, enum=[s.value for s in StatusReason] + [CONNECTING_STATUS_REASON]),
         Str('remote_url', required=True, null=True),
         IPAddr('remote_ip_address', required=True, null=True),
         Bool('enabled', required=True),
@@ -61,7 +63,7 @@ class TruecommandService(ConfigService):
                 if await self.middleware.call('truecommand.wireguard_connection_health'):
                     await self.set_status(Status.CONNECTED.value)
                 else:
-                    status_reason = 'Waiting for connection from Truecommand.'
+                    status_reason = CONNECTING_STATUS_REASON
         else:
             if self.STATUS != Status.DISABLED:
                 await self.set_status(Status.DISABLED.value)


### PR DESCRIPTION
## Problem
Currently, `call_with_audit` is not working for APIs that have a return type defined but are jobs. This happens because `call_with_audit` tries to call `schema.dump` for the result, but instead of getting a dict, it gets a job object, which causes an error.

## Solution
Dump the result only if the API has a return type and it is not a job.