### PR TITLE
NAS-129754 / 24.10 / Update `api_key.py` to use the new API style

### DIFF
--- a/src/middlewared/middlewared/api/base/excluded.py
+++ b/src/middlewared/middlewared/api/base/excluded.py
@@ -9,7 +9,7 @@ from middlewared.utils.lang import undefined
 __all__ = ["Excluded", "excluded_field"]
 
 
-class ExcludedField(Any):
+class ExcludedField:
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler

--- a/src/middlewared/middlewared/api/base/excluded.py
+++ b/src/middlewared/middlewared/api/base/excluded.py
@@ -9,7 +9,7 @@ from middlewared.utils.lang import undefined
 __all__ = ["Excluded", "excluded_field"]
 
 
-class ExcludedField:
+class ExcludedField(Any):
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -1,3 +1,4 @@
+from .api_key import *  # noqa
 from .cloud_sync import *  # noqa
 from .common import *  # noqa
 from .user import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -17,8 +17,6 @@ class AllowListItem(BaseModel):
 
 class ApiKeyEntry(BaseModel):
     """Represents a record in the account.api_key table."""
-    #: This allows the model to be created from an instance of plugins/api_key.APIKeyModel
-    model_config = ConfigDict(from_attributes=True)
 
     id: int
     name: Annotated[NonEmptyString, StringConstraints(max_length=200)]

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Annotated, Literal
+
+from middlewared.api.base import BaseModel, NonEmptyString
+
+__all__ = ["ApiKeyCreateArgs", "ApiKeyCreateResult"]
+
+
+class AllowListItem(BaseModel):
+    method: Literal["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]
+    resource: NonEmptyString
+
+
+class ApiKeyCreate(BaseModel):
+    name: NonEmptyString
+    allowlist: list[AllowListItem]
+
+
+class ApiKeyCreateArgs(BaseModel):
+    api_key_create: ApiKeyCreate
+
+
+class ApiKeyCreateResult(ApiKeyCreate):
+    id: str
+    key: str
+    created_at: datetime

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -28,7 +28,9 @@ class ApiKeyCreateArgs(BaseModel):
 
 
 class ApiKeyCreateResult(ApiKeyCreate):
-    id: str
+    """Represents a record in the account.api_key table."""
+
+    id: int
     key: str
     created_at: datetime
 

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -1,9 +1,16 @@
 from datetime import datetime
-from typing import Annotated, Literal
+from typing import Literal
 
 from middlewared.api.base import BaseModel, NonEmptyString
 
-__all__ = ["ApiKeyCreateArgs", "ApiKeyCreateResult"]
+__all__ = [
+    "ApiKeyCreateArgs",
+    "ApiKeyCreateResult",
+    "ApiKeyUpdateArgs",
+    "ApiKeyUpdateResult",
+    "ApiKeyDeleteArgs",
+    "ApiKeyDeleteResult",
+]
 
 
 class AllowListItem(BaseModel):
@@ -24,3 +31,27 @@ class ApiKeyCreateResult(ApiKeyCreate):
     id: str
     key: str
     created_at: datetime
+
+
+class ApiKeyUpdate(ApiKeyCreate):
+    reset: bool
+    update: bool = True
+
+
+class ApiKeyUpdateArgs(BaseModel):
+    id: int
+    api_key_update: ApiKeyUpdate
+
+
+class ApiKeyUpdateResult(BaseModel):
+    # Needs implemented
+    pass
+
+
+class ApiKeyDeleteArgs(BaseModel):
+    id: int
+
+
+class ApiKeyDeleteResult(BaseModel):
+    # Needs implemented
+    pass

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -51,7 +51,11 @@ class PrivilegeService(CRUDService):
         Str("name", required=True, empty=False),
         List("local_groups", items=[Ref("group_entry")]),
         List("ds_groups", items=[Ref("group_entry")]),
-        List("allowlist", items=[Ref("allowlist_item")]),
+        List("allowlist", items=[Dict(
+            "allowlist_item",
+            Str("method", required=True, enum=["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]),
+            Str("resource", required=True),
+        )]),
         List("roles", items=[Str("role")]),
         Bool("web_shell", required=True),
     )

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -4,7 +4,9 @@ import string
 
 from passlib.hash import pbkdf2_sha256
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Str, Patch
+from middlewared.api import api_method
+from middlewared.api.current import ApiKeyCreateArgs, ApiKeyCreateResult
+from middlewared.schema import accepts, Bool, Int, Patch
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.allowlist import Allowlist
@@ -44,21 +46,7 @@ class ApiKeyService(CRUDService):
         item.pop("key")
         return item
 
-    @accepts(
-        Dict(
-            "api_key_create",
-            Str("name", required=True, empty=False),
-            List("allowlist", items=[
-                Dict(
-                    "allowlist_item",
-                    Str("method", required=True, enum=["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]),
-                    Str("resource", required=True),
-                    register=True,
-                ),
-            ]),
-            register=True,
-        )
-    )
+    @api_method(ApiKeyCreateArgs, ApiKeyCreateResult)
     async def do_create(self, data):
         """
         Creates API Key.

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -9,8 +9,7 @@ from middlewared.api import api_method
 from middlewared.api.current import (
     ApiKeyCreateArgs, ApiKeyCreateResult, ApiKeyUpdateArgs,
     ApiKeyUpdateResult, ApiKeyDeleteArgs, ApiKeyDeleteResult,
-    ApiKeyCreate, ApiKeyEntry, ApiKeyUpdate, HttpVerb,
-    NonEmptyString
+    HttpVerb, NonEmptyString
 )
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -10,7 +10,6 @@ from middlewared.api.current import (
     ApiKeyCreateArgs, ApiKeyCreateResult, ApiKeyUpdateArgs,
     ApiKeyUpdateResult, ApiKeyDeleteArgs, ApiKeyDeleteResult
 )
-from middlewared.schema import accepts, Bool, Int, Patch
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.allowlist import Allowlist
@@ -29,17 +28,17 @@ class APIKeyModel(sa.Model):
 
 
 class ApiKey:
-    def __init__(self, api_key: dict):
+    def __init__(self, api_key: dict[str, list[dict[str, str]]]):
         self.api_key = api_key
         self.allowlist = Allowlist(self.api_key["allowlist"])
 
-    def authorize(self, method, resource):
+    def authorize(self, method: str, resource: str):
         return self.allowlist.authorize(method, resource)
 
 
 class ApiKeyService(CRUDService):
 
-    keys = {}
+    keys: dict[int, dict[str, list[dict[str, str]]]] = {}
 
     class Config:
         namespace = "api_key"
@@ -53,7 +52,7 @@ class ApiKeyService(CRUDService):
         return item
 
     @api_method(ApiKeyCreateArgs, ApiKeyCreateResult)
-    async def do_create(self, data):
+    async def do_create(self, data: dict):
         """
         Creates API Key.
 
@@ -109,7 +108,7 @@ class ApiKeyService(CRUDService):
         return self._serve(await self.get_instance(id_), key)
 
     @api_method(ApiKeyDeleteArgs, ApiKeyDeleteResult)
-    async def do_delete(self, id_):
+    async def do_delete(self, id_: int):
         """
         Delete API Key `id`.
         """
@@ -131,7 +130,7 @@ class ApiKeyService(CRUDService):
         }
 
     @private
-    async def load_key(self, id_):
+    async def load_key(self, id_: int):
         self.keys[id_] = await self.middleware.call(
             "datastore.query",
             "account.api_key",

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -30,7 +30,7 @@ class APIKeyModel(sa.Model):
 
 
 class ApiKey:
-    def __init__(self, api_key: ApiKeyEntry):
+    def __init__(self, api_key: dict):
         self.api_key = api_key
         self.allowlist = Allowlist(self.api_key["allowlist"])
 
@@ -40,7 +40,7 @@ class ApiKey:
 
 class ApiKeyService(CRUDService):
 
-    keys: dict[int, ApiKeyEntry] = {}
+    keys: dict[int, dict] = {}
 
     class Config:
         namespace = "api_key"
@@ -49,7 +49,7 @@ class ApiKeyService(CRUDService):
         cli_namespace = "auth.api_key"
 
     @api_method(ApiKeyCreateArgs, ApiKeyCreateResult)
-    async def do_create(self, data: ApiKeyCreate) -> ApiKeyEntry:
+    async def do_create(self, data: dict) -> dict:
         """
         Creates API Key.
 
@@ -73,7 +73,7 @@ class ApiKeyService(CRUDService):
         return self._serve(data, key)
 
     @api_method(ApiKeyUpdateArgs, ApiKeyUpdateResult)
-    async def do_update(self, id_: int, data: ApiKeyUpdate) -> ApiKeyEntry:
+    async def do_update(self, id_: int, data: dict) -> dict:
         """
         Update API Key `id`.
 
@@ -153,7 +153,7 @@ class ApiKeyService(CRUDService):
 
         return ApiKey(db_key)
 
-    async def _validate(self, schema_name: str, data: ApiKeyEntry, id_: int=None):
+    async def _validate(self, schema_name: str, data: dict, id_: int=None):
         verrors = ValidationErrors()
 
         await self._ensure_unique(verrors, schema_name, "name", data["name"], id_)
@@ -163,7 +163,7 @@ class ApiKeyService(CRUDService):
     def _generate(self):
         return "".join([random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(64)])
 
-    def _serve(self, data: ApiKeyEntry, key: str | None) -> ApiKeyEntry:
+    def _serve(self, data: dict, key: str | None) -> dict:
         if key is None:
             return data
 

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -9,7 +9,7 @@ from middlewared.api import api_method
 from middlewared.api.current import (
     ApiKeyCreateArgs, ApiKeyCreateResult, ApiKeyUpdateArgs,
     ApiKeyUpdateResult, ApiKeyDeleteArgs, ApiKeyDeleteResult,
-    HttpVerb, NonEmptyString
+    HttpVerb
 )
 from middlewared.service import CRUDService, private, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -33,7 +33,7 @@ class ApiKey:
         self.api_key = api_key
         self.allowlist = Allowlist(self.api_key["allowlist"])
 
-    def authorize(self, method: HttpVerb, resource: NonEmptyString) -> bool:
+    def authorize(self, method: HttpVerb, resource: str) -> bool:
         return self.allowlist.authorize(method, resource)
 
 

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -1,14 +1,14 @@
 import fnmatch
 import re
 
-from middlewared.api.current import HttpVerb, NonEmptyString
+from middlewared.api.current import HttpVerb
 
 ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
 
 
 class Allowlist:
     def __init__(self, allowlist: list[dict]):
-        self.exact: dict[HttpVerb, set[NonEmptyString]] = {}
+        self.exact: dict[HttpVerb, set[str]] = {}
         self.full_admin = ALLOW_LIST_FULL_ADMIN in allowlist
         self.patterns: dict[HttpVerb, list[re.Pattern]] = {}
         for entry in allowlist:
@@ -21,10 +21,10 @@ class Allowlist:
                 self.exact.setdefault(method, set())
                 self.exact[method].add(resource)
 
-    def authorize(self, method: HttpVerb, resource: NonEmptyString):
+    def authorize(self, method: HttpVerb, resource: str):
         return self._authorize_internal("*", resource) or self._authorize_internal(method, resource)
 
-    def _authorize_internal(self, method: HttpVerb, resource: NonEmptyString):
+    def _authorize_internal(self, method: HttpVerb, resource: str):
         if (exact := self.exact.get(method)) and resource in exact:
             return True
 

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -5,10 +5,10 @@ ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
 
 
 class Allowlist:
-    def __init__(self, allowlist):
-        self.exact = {}
+    def __init__(self, allowlist: list[dict[str, str]]):
+        self.exact: dict[str, set[str]] = {}
         self.full_admin = ALLOW_LIST_FULL_ADMIN in allowlist
-        self.patterns = {}
+        self.patterns: dict[str, list[re.Pattern]] = {}
         for entry in allowlist:
             method = entry["method"]
             resource = entry["resource"]
@@ -19,10 +19,10 @@ class Allowlist:
                 self.exact.setdefault(method, set())
                 self.exact[method].add(resource)
 
-    def authorize(self, method, resource):
+    def authorize(self, method: str, resource: str):
         return self._authorize_internal("*", resource) or self._authorize_internal(method, resource)
 
-    def _authorize_internal(self, method, resource):
+    def _authorize_internal(self, method: str, resource: str):
         if (exact := self.exact.get(method)) and resource in exact:
             return True
 

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -1,13 +1,13 @@
 import fnmatch
 import re
 
-from middlewared.api.current import AllowListItem, HttpVerb, NonEmptyString
+from middlewared.api.current import HttpVerb, NonEmptyString
 
-ALLOW_LIST_FULL_ADMIN: AllowListItem = {'method': '*', 'resource': '*'}
+ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
 
 
 class Allowlist:
-    def __init__(self, allowlist: list[AllowListItem]):
+    def __init__(self, allowlist: list[dict]):
         self.exact: dict[HttpVerb, set[NonEmptyString]] = {}
         self.full_admin = ALLOW_LIST_FULL_ADMIN in allowlist
         self.patterns: dict[HttpVerb, list[re.Pattern]] = {}


### PR DESCRIPTION
The goal of this PR is to continue replacing the old `@accepts` and `@returns` decorators with the new `@api_method` decorator which enforces types using Pydantic. The eventual end goal is to entirely replace the old style.

Please note that the type hints added will work with the Pydantic validation and with the `@api_method` decorator, but they are not entirely truthful. This is because I have preserved our use of dictionaries for now until further discussion can be had about whether to completely move to using Pydantic models instead of dictionaries. This will enforce greater type control and allow for nicer syntax (e.g. `data.name` instead of `data["name"]`, but it may come at the cost of sometimes needing to convert between dictionaries and Pydantic models.