### PR TITLE
NAS-129827 / 24.10 / Force alphabetical ordering id_to_name results

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1122,7 +1122,7 @@ class IdmapDomainService(CRUDService):
 
         try:
             ret = await asyncio.wait_for(
-                self.middleware.create_task(self.middleware.call(method, filters, options)),
+                self.middleware.create_task(self.middleware.call(method, filters, options | {'order_by': [key]})),
                 timeout=idmap_timeout
             )
             name = ret[key]


### PR DESCRIPTION
This commit restores previous behavior where we were relying on NSS lookups to convert posix IDs to names. This forced ordering based on names which means that `root` appears before `wheel`.