### PR TITLE
NAS-129827 / 24.04.3 / Force alphabetical ordering id_to_name results (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1147,7 +1147,7 @@ class IdmapDomainService(CRUDService):
 
         try:
             ret = await asyncio.wait_for(
-                self.middleware.create_task(self.middleware.call(method, filters, options)),
+                self.middleware.create_task(self.middleware.call(method, filters, options | {'order_by': [key]})),
                 timeout=idmap_timeout
             )
             name = ret[key]


### PR DESCRIPTION
This commit restores previous behavior where we were relying on NSS lookups to convert posix IDs to names. This forced ordering based on names which means that `root` appears before `wheel`.

Original PR: https://github.com/truenas/middleware/pull/13960
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129827