### PR TITLE
NAS-129862 / 24.10 / fix failover.mismatch_nics

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1916,9 +1916,11 @@ class InterfaceService(CRUDService):
     @private
     def get_nic_names(self) -> set:
         """Get network interface names excluding internal interfaces"""
+        res, ignore = set(), set(self.middleware.call_sync('interface.internal_interfaces'))
         with scandir('/sys/class/net/') as nics:
-            res = set(nic.name for nic in nics)
-        ignore = set(self.middleware.call_sync('interface.internal_interfaces'))
+            for nic in filter(lambda x: x.is_symlink() and x.name not in ignore, nics):
+                res.add(nic.name)
+
         return res - ignore
 
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1921,7 +1921,7 @@ class InterfaceService(CRUDService):
             for nic in filter(lambda x: x.is_symlink() and x.name not in ignore, nics):
                 res.add(nic.name)
 
-        return res - ignore
+        return res
 
 
 async def configure_http_proxy(middleware, *args, **kwargs):


### PR DESCRIPTION
Logged into an internal HA system and noticed that the system was half-updated. A controller was running newer version while the B controller was running old.

I saw that the A controller was master and was reporting that the nics didn't match between the controllers. Investigation found 2 issues:
- iterating over `/sys/class/net` included all entries inside that directory (including files) so this means, if a bond was created a "nic" was being picked up called `bonding_masters`. This is a file so we can fix this method by looking if the object inside `/sys/class/net` is a symlink
- the `failover.mismatch_nics` method was _always_ returning missing nics in the event of a failure because we had bad logic where we were always initializing the variable to a set (i.e. `or set()`) and `{'eno1', 'eno2'} - {} == {'eno1', 'eno2'}`

This fixes all issues.