### PR TITLE
NAS-129490 / 24.10 / Always include zfs cache as a free memory in vm memory info

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -64,7 +64,7 @@ class VMService(Service):
         arc_total = await self.middleware.call('sysctl.get_arcstats_size')
         arc_min = await self.middleware.call('sysctl.get_arc_min')
         arc_shrink = max(0, arc_total - arc_min)
-        total_free = free + arc_shrink if overcommit else free
+        total_free = free + arc_shrink
 
         vms_memory_used = 0
         if overcommit is False:


### PR DESCRIPTION
## Problem

The ZFS ARC (Adaptive Replacement Cache) is configured to use almost all available free memory. This often results in insufficient free memory to launch a virtual machine, triggering a concerning memory over-commitment dialog.

## Solution

Include the shrinkable ZFS ARC cache in the calculation of free memory to prevent the ENOMEM (Out of Memory) warning.
