### PR TITLE
NAS-129539 / 24.10 / always show rear nvme on m-series

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -239,11 +239,12 @@ def map_nvme(dmi):
         # all nvme systems which we need to handle separately
         return map_r30_or_fseries(model, ctx)
     elif model in (
+        ControllerModels.M30.value,
+        ControllerModels.M40.value,
         ControllerModels.M50.value,
         ControllerModels.M60.value,
         ControllerModels.R50BM.value,
     ):
-        # M50, M60 and R50BM use same plx nvme bridge
         return map_plx_nvme(model, ctx)
     else:
         return []

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -44,6 +44,8 @@ def get_nvme_slot_info(model):
         ControllerModels.F60.value,
         ControllerModels.F100.value,
         ControllerModels.F130.value,
+        ControllerModels.M30.value,
+        ControllerModels.M40.value,
         ControllerModels.M50.value,
         ControllerModels.M60.value,
         ControllerModels.R30.value,
@@ -67,6 +69,23 @@ def get_nvme_slot_info(model):
                         'f130_nvme_enclosure': {
                             i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
                             for i in range(1, 25)
+                        },
+                        # ALL m-series platforms have 4 rear nvme drive bays.
+                        # The R50BM platform does as well and uses same plx
+                        # nvme bridge. HOWEVER, the m30 and the gen1/2 m40's do
+                        # NOT have the pcie switch that connects those 4 drive
+                        # bays but the gen3 M40 with 192GB RAM does. Since we
+                        # don't have (at time of writing) a proper way to track
+                        # generational m40's, we will always return 4 nvme drive
+                        # bays for all m-series platforms and they will be empty
+                        # on the platforms that can't physically support these drives
+                        'm30_nvme_enclosure': {
+                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
+                            for i, j in zip(range(1, 5), range(25, 29))
+                        },
+                        'm40_nvme_enclosure': {
+                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
+                            for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'm50_nvme_enclosure': {
                             i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}


### PR DESCRIPTION
Platform team notified us of a particular gen3 m40 SKU that actually has 4-rear nvme drive bays supported. The proposed and agreed upon solution is to always report 4 rear nvme drive bays for all mseries platforms since they all "have them" but some of them do not have the pcie switch that cables those bays up. The ones that do not have the pcie switch will still show 4 bays but they will always be empty. Not the most elegant but is the best solution.