### PR TITLE
NAS-129882 / 24.10 / Prevent deletion of immutable users

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -927,6 +927,9 @@ class UserService(CRUDService):
         if user['builtin']:
             raise CallError('Cannot delete a built-in user', errno.EINVAL)
 
+        if user['immutable']:
+            raise CallError('Cannot delete an immutable user', errno.EINVAL)
+
         self.middleware.call_sync('privilege.before_user_delete', user)
 
         if options['delete_group'] and not user['group']['bsdgrp_builtin']:


### PR DESCRIPTION
Currently the only situation where an immutable user is not also a builtin user is the root-alternative account (admin). It's a POLA violation to allow deletion of immutable account.