### PR TITLE
NAS-129879 / 24.10 / Fix issues with directory service cache build

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -607,7 +607,7 @@ class IdmapDomainService(CRUDService):
     async def query(self, filters, options):
         extra = options.get("extra", {})
         more_info = extra.get("additional_information", [])
-        ret = await super().query(filters, options)
+        ret = await super().query()
         if 'DOMAIN_INFO' in more_info:
             for entry in ret:
                 try:
@@ -622,7 +622,7 @@ class IdmapDomainService(CRUDService):
 
                 entry.update({'domain_info': domain_info})
 
-        return ret
+        return filter_list(ret, filters, options)
 
     @accepts(Dict(
         'idmap_domain_create',
@@ -1188,6 +1188,9 @@ class IdmapDomainService(CRUDService):
             'sshpubkey': None,
             'local': False,
             'id_type_both': id_type_both,
+            'roles': [],
+            'two_factor_auth_configured': False,
+            'immutable': True,
             'smb': True,
             'sid': sid
         }
@@ -1214,6 +1217,7 @@ class IdmapDomainService(CRUDService):
             'users': [],
             'local': False,
             'id_type_both': id_type_both,
+            'roles': [],
             'smb': True,
             'sid': sid
         }

--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -204,7 +204,7 @@ class TDBHandle:
         """
         self.hdl.clear()
 
-    def entries(self, include_keys: bool = True) -> Iterable[dict]:
+    def entries(self, include_keys: bool = True, key_prefix: str = None) -> Iterable[dict]:
         """
         Iterate entries in TDB file:
 
@@ -220,6 +220,9 @@ class TDBHandle:
             tdb_key = key.decode()
             if self.keys_null_terminated:
                 tdb_key = tdb_key[:-1]
+
+            if key_prefix and not tdb_key.startswith(key_prefix):
+                continue
 
             tdb_val = self.get(tdb_key)
             if include_keys:


### PR DESCRIPTION
This fixes the following issues:
1. Directory service cache query could return duplicate entries
2. Cache query result keys were out of sync with normal user.query and group.query
3. Detection of id_type_both was broken

Test coverage is added for the above through the following:
1. We were already using set of names returned from cache. Compare set length with original list length.
2. Grant privilege for user.query and group.query for our AD privilege tests. Since it's a limited user the output will pass through schema validation and raise error if they get out of sync with expected.
3. Check id_type_both is set when using RID backend.

There is still an outstanding issue that new schema has broken account queries for directory services as a limited user account. This will cause (2) to fail until the underlying schema issue is fixed.