### PR TITLE
NAS-129798 / 24.10 / New plugin that checks for the vendor sentinel file

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -16,9 +16,10 @@ def api_method(
     audit_callback: bool = False,
     audit_extended: Callable[..., str] | None = None,
     roles: list[str] | None = None,
+    private: bool = False,
 ):
     """
-    Mark a `Service` class method as a public API method.
+    Mark a `Service` class method as an API method.
 
     `accepts` and `returns` are classes derived from `BaseModel` that correspond to the method's call arguments and
     return value.
@@ -33,6 +34,8 @@ def api_method(
     that will be appended to the audit message to be logged.
 
     `roles` is a list of user roles that will gain access to this method.
+
+    `private` is `True` when the method should not be exposed in the public API. By default, the method is public.
     """
     if list(returns.model_fields.keys()) != ["result"]:
         raise TypeError("`returns` model must only have one field called `result`")
@@ -61,6 +64,7 @@ def api_method(
         wrapped.audit_callback = audit_callback
         wrapped.audit_extended = audit_extended
         wrapped.roles = roles or []
+        wrapped._private = private
 
         # FIXME: This is only here for backwards compatibility and should be removed eventually
         wrapped.accepts = []

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -1,3 +1,4 @@
 from .cloud_sync import *  # noqa
 from .common import *  # noqa
 from .user import *  # noqa
+from .vendor import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from middlewared.api.base import BaseModel
 
-__all__ = ["QueryOptions", "QueryArgs", "NoArgs", "NoneReturn"]
+__all__ = ["QueryOptions", "QueryArgs"]
 
 
 class QueryOptions(BaseModel):
@@ -23,11 +23,3 @@ class QueryOptions(BaseModel):
 class QueryArgs(BaseModel):
     filters: list[Any] = []  # FIXME: Add validation here
     options: QueryOptions = QueryOptions()
-
-
-class NoArgs(BaseModel):
-    pass
-
-
-class NoneReturn(BaseModel):
-    result: None

--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from middlewared.api.base import BaseModel
 
-__all__ = ["QueryOptions", "QueryArgs"]
+__all__ = ["QueryOptions", "QueryArgs", "NoArgs", "NoneReturn"]
 
 
 class QueryOptions(BaseModel):
@@ -23,3 +23,11 @@ class QueryOptions(BaseModel):
 class QueryArgs(BaseModel):
     filters: list[Any] = []  # FIXME: Add validation here
     options: QueryOptions = QueryOptions()
+
+
+class NoArgs(BaseModel):
+    pass
+
+
+class NoneReturn(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/api/v25_04_0/vendor.py
+++ b/src/middlewared/middlewared/api/v25_04_0/vendor.py
@@ -1,5 +1,17 @@
 from middlewared.api.base import BaseModel
 
 
+class VendorNameArgs(BaseModel):
+    pass
+
+
 class VendorNameResult(BaseModel):
     result: str | None
+
+
+class UnvendorArgs(BaseModel):
+    pass
+
+
+class UnvendorResult(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/api/v25_04_0/vendor.py
+++ b/src/middlewared/middlewared/api/v25_04_0/vendor.py
@@ -1,0 +1,5 @@
+from middlewared.api.base import BaseModel
+
+
+class VendorNameResult(BaseModel):
+    result: str | None

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -1,6 +1,8 @@
 import os
 
-from middlewared.service import private, Service
+from middlewared.api import api_method
+from middlewared.api.current import NoArgs, NoneReturn, VendorNameResult
+from middlewared.service import Service
 
 
 SENTINEL_FILE_PATH = '/data/.vendor'
@@ -8,7 +10,7 @@ SENTINEL_FILE_PATH = '/data/.vendor'
 
 class VendorService(Service):
 
-    @private
+    @api_method(NoArgs, VendorNameResult, private=True)
     def name(self) -> str | None:
         try:
             with open(SENTINEL_FILE_PATH, 'r') as file:
@@ -17,7 +19,7 @@ class VendorService(Service):
         except FileNotFoundError:
             return None
 
-    @private
+    @api_method(NoArgs, NoneReturn, private=True)
     def unvendor(self):
         try:
             os.remove(SENTINEL_FILE_PATH)

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from middlewared.api import api_method
@@ -15,7 +16,7 @@ class VendorService(Service):
         try:
             with open(SENTINEL_FILE_PATH, 'r') as file:
                 if contents := file.read():
-                    return contents
+                    return json.loads(contents).get('name')
         except FileNotFoundError:
             return None
 

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -17,7 +17,7 @@ class VendorService(Service):
             with open(SENTINEL_FILE_PATH, 'r') as file:
                 if contents := file.read():
                     return json.loads(contents).get('name')
-        except FileNotFoundError:
+        except (FileNotFoundError, json.JSONDecodeError):
             return None
 
     @api_method(UnvendorArgs, UnvendorResult, private=True)

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -1,0 +1,24 @@
+import os
+
+from middlewared.service import private, Service
+
+
+SENTINEL_FILE_PATH = '/data/.vendor'
+
+
+class VendorService(Service):
+
+    @private
+    def name(self) -> str | None:
+        try:
+            with open(SENTINEL_FILE_PATH, 'r') as file:
+                if contents := file.read():
+                    return contents
+        except FileNotFoundError:
+            # Do anything here?
+            pass
+
+    @private
+    def unvendor(self):
+        if os.path.isfile(SENTINEL_FILE_PATH):
+            os.remove(SENTINEL_FILE_PATH)

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -15,10 +15,11 @@ class VendorService(Service):
                 if contents := file.read():
                     return contents
         except FileNotFoundError:
-            # Do anything here?
-            pass
+            return None
 
     @private
     def unvendor(self):
-        if os.path.isfile(SENTINEL_FILE_PATH):
+        try:
             os.remove(SENTINEL_FILE_PATH)
+        except FileNotFoundError:
+            return None

--- a/src/middlewared/middlewared/plugins/system/vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system/vendor/vendor.py
@@ -1,7 +1,7 @@
 import os
 
 from middlewared.api import api_method
-from middlewared.api.current import NoArgs, NoneReturn, VendorNameResult
+from middlewared.api.current import VendorNameArgs, VendorNameResult, UnvendorArgs, UnvendorResult
 from middlewared.service import Service
 
 
@@ -10,7 +10,7 @@ SENTINEL_FILE_PATH = '/data/.vendor'
 
 class VendorService(Service):
 
-    @api_method(NoArgs, VendorNameResult, private=True)
+    @api_method(VendorNameArgs, VendorNameResult, private=True)
     def name(self) -> str | None:
         try:
             with open(SENTINEL_FILE_PATH, 'r') as file:
@@ -19,7 +19,7 @@ class VendorService(Service):
         except FileNotFoundError:
             return None
 
-    @api_method(NoArgs, NoneReturn, private=True)
+    @api_method(UnvendorArgs, UnvendorResult, private=True)
     def unvendor(self):
         try:
             os.remove(SENTINEL_FILE_PATH)


### PR DESCRIPTION
This new vendor plugin will be used in the soon upcoming [NAS-129798](https://ixsystems.atlassian.net/browse/NAS-129797).

Its job is simply to check for the existence of the vendor sentinel file /data/.vendor and return its contents, the vendor name.

I am also proposing two new common API models, `NoArgs` and `NoneReturn`.