### PR TITLE
setup HA middleware connection on service restart

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/internal_interface.py
+++ b/src/middlewared/middlewared/plugins/failover_/internal_interface.py
@@ -95,3 +95,12 @@ class InternalInterfaceService(Service):
     async def post_sync(self, internal_ip):
         if self.http_site is None:
             self.http_site = await self.middleware.start_tcp_site(internal_ip)
+
+
+async def setup(middleware):
+    # on HA systems, we bind ourselves on 127.0.0.1:6000, however
+    # often times developers/CI/CD do `systemctl restart middlewared`
+    # which will tear down the local listening socket so we need to
+    # be sure and set it up everytime middleware starts. This is a
+    # NO-OP otherwise.
+    await middleware.call('failover.internal_interface.pre_sync')


### PR DESCRIPTION
Security requirements dictate that we should stop binding our internal HA connection on 0.0.0.0 so we did just that here: https://github.com/truenas/middleware/pull/13830. However, often times our developers (and our CI/CD) will `systemctl restart middlewared` routinely. When this happens, we don't re-bind the HA connection. This fixes that scenario so that we always re-bind on service restart.

NOTE: When this happens on a running HA machine, the local and remote sessions from _BEFORE_ the service restart go into a `TIME_WAIT` status and will eventually be reaped by the kernel (as expected). This is by design and expected.