### PR TITLE
NAS-129230 / 24.10 / Fix progress reporting in formatting disks and it's related usages

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from middlewared.service import private, Service
 from middlewared.utils.asyncio_ import asyncio_map
 
@@ -15,7 +13,6 @@ class PoolService(Service):
 
         formatted = 0
         len_disks = len(disks)
-        percentage_lock = asyncio.Lock()
         current_percentage = base_percentage
         single_disk_percentage = (upper_percentage - base_percentage) / len_disks
 
@@ -23,10 +20,9 @@ class PoolService(Service):
             nonlocal formatted, current_percentage
             disk, config = arg
             await self.middleware.call('disk.format', disk)
-            async with percentage_lock:
-                formatted += 1
-                current_percentage += single_disk_percentage
-                job.set_progress(current_percentage, f'Formatting disks ({formatted}/{len_disks})')
+            formatted += 1
+            current_percentage += single_disk_percentage
+            job.set_progress(current_percentage, f'Formatting disks ({formatted}/{len_disks})')
 
         await asyncio_map(format_disk, disks.items(), limit=16)
 

--- a/src/middlewared/middlewared/plugins/pool_/format_disks.py
+++ b/src/middlewared/middlewared/plugins/pool_/format_disks.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from middlewared.service import private, Service
 from middlewared.utils.asyncio_ import asyncio_map
 
@@ -5,7 +7,7 @@ from middlewared.utils.asyncio_ import asyncio_map
 class PoolService(Service):
 
     @private
-    async def format_disks(self, job, disks):
+    async def format_disks(self, job, disks, base_percentage=0, upper_percentage=100):
         """
         Format all disks, putting all ZFS partitions created into their respective vdevs.
         """
@@ -13,17 +15,23 @@ class PoolService(Service):
 
         formatted = 0
         len_disks = len(disks)
+        percentage_lock = asyncio.Lock()
+        current_percentage = base_percentage
+        single_disk_percentage = (upper_percentage - base_percentage) / len_disks
+
         async def format_disk(arg):
-            nonlocal formatted
+            nonlocal formatted, current_percentage
             disk, config = arg
             await self.middleware.call('disk.format', disk)
-            formatted += 1
-            job.set_progress(15, f'Formatting disks ({formatted}/{len_disks})')
+            async with percentage_lock:
+                formatted += 1
+                current_percentage += single_disk_percentage
+                job.set_progress(current_percentage, f'Formatting disks ({formatted}/{len_disks})')
 
         await asyncio_map(format_disk, disks.items(), limit=16)
 
         disk_sync_job = await self.middleware.call('disk.sync_all')
-        await job.wrap(disk_sync_job)
+        await disk_sync_job.wait(raise_error=True)
 
         zfs_part_type = await self.middleware.call('disk.get_zfs_part_type')
         for disk, config in disks.items():

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -566,7 +566,7 @@ class PoolService(CRUDService):
                 # will log errors if there are any so it won't crash here (this matches CORE behavior)
                 await (await self.middleware.call('disk.resize', log_disks, True)).wait()
 
-        await self.middleware.call('pool.format_disks', job, disks)
+        await self.middleware.call('pool.format_disks', job, disks, 0, 30)
 
         options = {
             'feature@lz4_compress': 'enabled',
@@ -713,7 +713,7 @@ class PoolService(CRUDService):
             disks, vdevs = await self._process_topology('pool_update', data, pool)
 
         if disks and vdevs:
-            await self.middleware.call('pool.format_disks', job, disks)
+            await self.middleware.call('pool.format_disks', job, disks, 0, 80)
 
             job.set_progress(90, 'Extending ZFS Pool')
             extend_job = await self.middleware.call('zfs.pool.extend', pool['name'], vdevs)

--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -69,7 +69,7 @@ class PoolService(Service):
                 'vdev': vdev,
                 'size': None,  # pool.format_disks checks size of disk
             },
-        })
+        }, 0, 25)
 
         try:
             job.set_progress(30, 'Replacing disk')


### PR DESCRIPTION
## Problem

`pool.format_disks` was being used where it expected job as input and it updated progress without discriminating from where it was being called which would result in incorrect job progress reporting.

## Solution

Make sure we properly report job progress reporting for endpoints which consume `pool.format_disks`