### PR TITLE
NAS-129811 / 24.10 / Perform additional fixup wrt CORE ctl device names

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -137,6 +137,7 @@
     missing_extents = []
     extents_io = {'vdisk_fileio': [], 'vdisk_blockio': []}
     for extent in extents.values():
+        extent['name'] = extent['name'].replace('.', '_').replace('/', '-')  # CORE ctl device names are incompatible with SCALE SCST
         if extent['locked']:
             middleware.logger.debug(
                 'Skipping generation of extent %r as the underlying resource is locked', extent['name']
@@ -160,7 +161,6 @@
                 missing_extents.append(extent['id'])
                 continue
 
-        extent['name'] = extent['name'].replace('.', '_')  # CORE ctl device names are incompatible with SCALE SCST
         extents_io[extents_io_key].append(extent)
         all_extent_names.append(extent['name'])
 

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -108,8 +108,8 @@ class ISCSIGlobalService(Service):
 
         try:
             # CORE ctl device names are incompatible with SCALE SCST
-            # so (similarly to scst.mako.conf) replace period with underscore
-            extent_name = extent[0]["name"].replace('.', '_')
+            # so (similarly to scst.mako.conf) replace period with underscore, slash with dash
+            extent_name = extent[0]["name"].replace('.', '_').replace('/', '-')
             with open(f'/sys/kernel/scst_tgt/devices/{extent_name}/resync_size', 'w') as f:
                 f.write('1')
         except Exception as e:


### PR DESCRIPTION
### CORE ctl device names are incompatible with SCALE SCST

Previously we were replacing period with underscore in extent names to take account of differences between CORE and SCALE.

In this PR, also replace slash with dash.

(Also move this replacement a little earlier in `scst.conf.mako` so that logging will also be updated/robustness.)