### PR TITLE
NAS-129905 / 24.10 / Mark GPU as critical if it has devices which are in an iommu group which has a critical device

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -1,5 +1,3 @@
-import contextlib
-import os
 from xml.etree import ElementTree as etree
 
 
@@ -26,14 +24,6 @@ def get_virsh_command_args():
 
 def convert_pci_id_to_vm_pci_slot(pci_id: str) -> str:
     return f'pci_{pci_id.replace(".", "_").replace(":", "_")}'
-
-
-def get_pci_device_class(pci_path: str) -> str:
-    with contextlib.suppress(FileNotFoundError):
-        with open(os.path.join(pci_path, 'class'), 'r') as r:
-            return r.read().strip()
-
-    return ''
 
 
 def get_vm_nvram_file_name(vm_data: dict) -> str:

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_gpu_critical.py
@@ -1,0 +1,159 @@
+import textwrap
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from middlewared.utils.gpu import get_gpus
+
+
+DEVICE_DATA = {
+    '0000:17:00.0': {
+        'PCI_ID': '1AF4:1050',
+        'ID_VENDOR_FROM_DATABASE': 'NVIDIA Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'VGA compatible controller',
+        'PCI_SLOT_NAME': '0000:17:00.0',
+    },
+    '0000:17:00.1': {
+        'PCI_ID': '1AF4:1050',
+        'ID_VENDOR_FROM_DATABASE': 'NVIDIA Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'Audio device',
+        'PCI_SLOT_NAME': '0000:17:00.1',
+    },
+    '0000:00:1f.4': {
+        'PCI_ID': '1AF4:1050',
+        'ID_VENDOR_FROM_DATABASE': 'Intel Corporation',
+        'ID_PCI_SUBCLASS_FROM_DATABASE': 'SMBus',
+        'PCI_SLOT_NAME': '0000:00:1f.4',
+    },
+}
+
+
+@pytest.mark.parametrize(
+    'ls_pci,gpu_pci_id,child_ids,iommu_group,uses_system_critical_devices,critical_reason',
+    [
+        (
+            textwrap.dedent('''
+                0000:17:00.0 VGA compatible controller: NVIDIA Corporation TU117GL [T400 4GB] (rev a1)
+                0000:17:00.1 Audio device: NVIDIA Corporation Device 10fa (rev a1)
+            '''),
+            '0000:17:00.0',
+            ['0000:17:00.1'],
+            {
+                '0000:17:00.1': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:17:00.0': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+            },
+            False,
+            None
+        ),
+        (
+            textwrap.dedent('''
+                0000:17:00.0 VGA compatible controller: NVIDIA Corporation TU117GL [T400 4GB] (rev a1)
+                0000:17:00.1 Audio device: NVIDIA Corporation Device 10fa (rev a1)
+                0000:00:1f.4 SMBus: Intel Corporation C620 Series Chipset Family SMBus (rev 09)
+            '''),
+            '0000:17:00.0',
+            ['0000:17:00.1', '0000:00:1f.4'],
+            {
+                '0000:17:00.1': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:17:00.0': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:00:1f.4': {
+                    'number': 31,
+                    'addresses': [],
+                    'critical': True
+                },
+            },
+            True,
+            'Critical devices found: 0000:00:1f.4\nCritical devices found in same IOMMU group: 0000:00:1f.4'
+        ),
+        (
+            textwrap.dedent('''
+                0000:17:00.0 VGA compatible controller: NVIDIA Corporation TU117GL [T400 4GB] (rev a1)
+                0000:17:00.1 Audio device: NVIDIA Corporation Device 10fa (rev a1)
+                0000:00:1f.4 SMBus: Intel Corporation C620 Series Chipset Family SMBus (rev 09)
+            '''),
+            '0000:17:00.0',
+            ['0000:17:00.1'],
+            {
+                '0000:17:00.1': {
+                    'number': 10,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:17:00.0': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:00:1f.4': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': True
+                },
+            },
+            True,
+            'Critical devices found in same IOMMU group: 0000:17:00.0'
+        ),
+        (
+            textwrap.dedent('''
+                0000:17:00.0 VGA compatible controller: NVIDIA Corporation TU117GL [T400 4GB] (rev a1)
+                0000:17:00.1 Audio device: NVIDIA Corporation Device 10fa (rev a1)
+                0000:00:1f.4 SMBus: Intel Corporation C620 Series Chipset Family SMBus (rev 09)
+            '''),
+            '0000:17:00.0',
+            ['0000:17:00.1'],
+            {
+                '0000:17:00.1': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:17:00.0': {
+                    'number': 10,
+                    'addresses': [],
+                    'critical': False
+                },
+                '0000:00:1f.4': {
+                    'number': 9,
+                    'addresses': [],
+                    'critical': True
+                },
+            },
+            True,
+            'Critical devices found in same IOMMU group: 0000:17:00.1'
+        )
+    ]
+)
+def test_critical_gpu(
+    ls_pci, gpu_pci_id, child_ids, iommu_group, uses_system_critical_devices, critical_reason
+):
+    with patch('middlewared.utils.gpu.pyudev.Devices.from_name', MagicMock()) as from_name_mock:
+        udev_mock = MagicMock()
+        udev_mock.get = lambda key, default: DEVICE_DATA[gpu_pci_id].get(key, default)
+        udev_mock.parent.children = [DEVICE_DATA[child_id] for child_id in child_ids]
+        from_name_mock.return_value = udev_mock
+        with patch('middlewared.utils.gpu.subprocess.Popen', MagicMock()) as popen_mock:
+            comm_mock = MagicMock()
+            comm_mock.returncode = 0
+            comm_mock.communicate.return_value = ls_pci.strip().encode(), b''
+            popen_mock.return_value = comm_mock
+
+            with patch('middlewared.utils.gpu.get_iommu_groups_info', lambda *args, **kwargs: iommu_group):
+                gpus = get_gpus()[0]
+                assert gpus['uses_system_critical_devices'] == uses_system_critical_devices
+                assert gpus['critical_reason'] == critical_reason

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_pci_device_iommu_groups.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_pci_device_iommu_groups.py
@@ -1,8 +1,7 @@
 from pathlib import PosixPath
 from unittest.mock import Mock, patch
 
-from middlewared.pytest.unit.middleware import Middleware
-from middlewared.plugins.vm.pci import VMDeviceService
+from middlewared.utils.iommu import get_iommu_groups_info
 
 
 DEVICES_PATH = [
@@ -86,6 +85,6 @@ IOMMU_GROUPS = {
 
 
 def test_iommu_groups():
-    with patch('middlewared.plugins.vm.pci.pathlib.PosixPath.is_dir', Mock(return_value=True)):
-        with patch('middlewared.plugins.vm.pci.pathlib.Path.glob', Mock(return_value=DEVICES_PATH)):
-            assert VMDeviceService(Middleware()).get_iommu_groups_info() == IOMMU_GROUPS
+    with patch('middlewared.utils.iommu.pathlib.PosixPath.is_dir', Mock(return_value=True)):
+        with patch('middlewared.utils.iommu.pathlib.Path.glob', Mock(return_value=DEVICES_PATH)):
+            assert get_iommu_groups_info() == IOMMU_GROUPS

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_gpu_pci_choices.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_gpu_pci_choices.py
@@ -209,7 +209,7 @@ IOMMU_GROUPS = {
 
 
 def test_get_pci_ids_for_gpu_isolation():
-    with patch('middlewared.plugins.vm.pci.VMDeviceService.get_iommu_groups_info', Mock(return_value=IOMMU_GROUPS)):
+    with patch('middlewared.plugins.vm.pci.get_iommu_groups_info', Mock(return_value=IOMMU_GROUPS)):
         with patch('middlewared.plugins.vm.pci.get_gpus', Mock(return_value=AVAILABLE_GPUs)):
             assert set(VMDeviceService(Middleware()).get_pci_ids_for_gpu_isolation('0000:16:0e.0')) == {
                 'pci_0000_16_0e_0', 'pci_0000_16_0e_2'

--- a/src/middlewared/middlewared/utils/iommu.py
+++ b/src/middlewared/middlewared/utils/iommu.py
@@ -1,0 +1,40 @@
+import collections
+import contextlib
+import os.path
+import pathlib
+import re
+
+from .pci import get_pci_device_class, SENSITIVE_PCI_DEVICE_TYPES
+
+
+RE_DEVICE_NAME = re.compile(r'(\w+):(\w+):(\w+).(\w+)')
+
+
+def get_iommu_groups_info(get_critical_info: bool = False) -> dict[str, dict]:
+    addresses = collections.defaultdict(list)
+    final = dict()
+    with contextlib.suppress(FileNotFoundError):
+        for i in pathlib.Path('/sys/kernel/iommu_groups').glob('*/devices/*'):
+            if not i.is_dir() or not i.parent.parent.name.isdigit() or not RE_DEVICE_NAME.fullmatch(i.name):
+                continue
+
+            iommu_group = int(i.parent.parent.name)
+            dbs, func = i.name.split('.')
+            dom, bus, slot = dbs.split(':')
+            addresses[iommu_group].append({
+                'domain': f'0x{dom}',
+                'bus': f'0x{bus}',
+                'slot': f'0x{slot}',
+                'function': f'0x{func}',
+            })
+            final[i.name] = {
+                'number': iommu_group,
+                'addresses': addresses[iommu_group],
+            }
+            if get_critical_info:
+                final[i.name]['critical'] = any(
+                    k.lower() in get_pci_device_class(os.path.join('/sys/bus/pci/devices', i.name))
+                    for k in SENSITIVE_PCI_DEVICE_TYPES.keys()
+                )
+
+    return final

--- a/src/middlewared/middlewared/utils/pci.py
+++ b/src/middlewared/middlewared/utils/pci.py
@@ -1,0 +1,20 @@
+import contextlib
+import os
+
+
+# get capability classes for relevant pci devices from
+# https://github.com/pciutils/pciutils/blob/3d2d69cbc55016c4850ab7333de8e3884ec9d498/lib/header.h#L1429
+SENSITIVE_PCI_DEVICE_TYPES = {
+    '0x0604': 'PCI Bridge',
+    '0x0601': 'ISA Bridge',
+    '0x0500': 'RAM memory',
+    '0x0c05': 'SMBus',
+}
+
+
+def get_pci_device_class(pci_path: str) -> str:
+    with contextlib.suppress(FileNotFoundError):
+        with open(os.path.join(pci_path, 'class'), 'r') as r:
+            return r.read().strip()
+
+    return ''


### PR DESCRIPTION
## Problem

When we want to passthrough a GPU, what needs to happen is that all the IOMMU groups with all their devices including ones which are not GPU related in which the GPU's devices are placed need to be isolated.

Currently we had validation in place where we didn't allow to isolate a GPU if any of it's devices were critical for the system like CPU/memory etc - however this can result in a scenario where the following happens:

A GPU having a device which is in an IOMMU group which has a critical device, so when that GPU is going to be configured for passthrough and an attempt to start the VM is going to be made, that will crash.

## Solution

Properly mark a GPU as critical covering the case discussed above so we don't allow isolating such GPU's in the first place. Secondly a reasonable critical reason has been added as well which will clarify why the GPU has been marked as critical.