### PR TITLE
NAS-129901 / 24.10 / Fix REST methods with versioned API

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -388,7 +388,7 @@ class CoreService(Service):
                     continue
 
                 # Skip private methods
-                if hasattr(method, '_private'):
+                if hasattr(method, '_private') and method._private is True:
                     continue
                 if target == 'CLI' and hasattr(method, '_cli_private'):
                     continue


### PR DESCRIPTION
Due to changes in behavior with new api_method decorator the _private attribute is always present for these methods and so we must explicitly check for whether it is True.