### PR TITLE
NAS-129907 / 24.10 / Fix logrotate to work properly

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -7,7 +7,8 @@ for file in \
     /usr/lib/netdata/conf.d/charts.d.conf \
     /lib/systemd/system/smartmontools.service \
     /usr/share/spice-html5/spice_auto.html \
-    /usr/share/spice-html5/spice.css
+    /usr/share/spice-html5/spice.css \
+    /etc/logrotate.d/netdata
 do
     dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"
 done


### PR DESCRIPTION
## Problem

The current log rotation setup has two netdata configurations: the original one and the overwritten one. These conflicting configurations cause issues while rotating logs.

## Solution

Remove the original Netdata log rotation configuration during the middleware package installation.