### PR TITLE
NAS-129922 / 24.10 / Fix groupmap test for nsswitch changes

### DIFF
--- a/tests/api2/test_210_group.py
+++ b/tests/api2/test_210_group.py
@@ -283,7 +283,7 @@ def test_27_full_groupmap_check(request):
         gid, sid = i
         entry = gm['builtins'][gid]
         assert entry['sid'] == sid, str(entry)
-        assert entry['unix_group'] == f'BUILTIN\\{entry["nt_name"].lower()}', str(entry)
+        assert entry['unix_group'] == gid, str(entry)
         assert entry['group_type_int'] == 4, str(entry)
         assert int(gid) == entry['gid'], str(entry)
 


### PR DESCRIPTION
Auto-generated winbind groups will no longer resolve into unix groups when generating verbose groupmap output because winbind is no longer by default in the nsswitch.conf due to product improvements allowed by newer GCC in electric eel.