### PR TITLE
Close persistent client connection at end of run

### DIFF
--- a/tests/api2/test_zzz_tests_completed.py
+++ b/tests/api2/test_zzz_tests_completed.py
@@ -1,9 +1,16 @@
 import faulthandler
 import threading
 
+from middlewared.test.integration.utils.client import truenas_server
+
 
 def test__thread_count(request):
     """Having outstanding threads can prevent python from exiting cleanly."""
+
+    # Tear down our persistent connection
+    truenas_server.client.close()
+    truenas_server._client = None
+
     count = threading.active_count()
     if count > 1:
         faulthandler.dump_traceback()


### PR DESCRIPTION
The persistent client connection increases our thread count beyond what this test expects. This commit closes it since the connection shouldn't be needed anymore by this point in the test run.