### PR TITLE
NAS-129925 / 24.10 / Fix test cleanup after creating temporary admin user

### DIFF
--- a/tests/api2/test_user_admin.py
+++ b/tests/api2/test_user_admin.py
@@ -29,7 +29,8 @@ def admin():
         try:
             yield admin
         finally:
-            call("user.delete", admin["id"])
+            call("datastore.delete", "account.bsdusers", admin["id"])
+            call("etc.generate", "user")
 
 
 def test_installer_admin_has_local_administrator_privilege(admin):


### PR DESCRIPTION
This fixes a test failure due to recent bugfix to prevent deletion of immutable users. The test in question manually edits the account.bsdusers table to allow testing logic related to case when root account is disabled, but then uses user.delete to remove the temporary admin account. The fix is to use datastore plugin to directly delete the new admin user.