### PR TITLE
NAS-129929 / 24.10 / Improve SID handling

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -40,7 +40,6 @@ class UserEntry(BaseModel):
     local: bool
     immutable: bool
     twofactor_auth_configured: bool
-    nt_name: str | None
     sid: str | None
     roles: list[str]
 
@@ -54,7 +53,6 @@ class UserCreate(UserEntry):
     local: Excluded = excluded_field()
     immutable: Excluded = excluded_field()
     twofactor_auth_configured: Excluded = excluded_field()
-    nt_name: Excluded = excluded_field()
     sid: Excluded = excluded_field()
     roles: Excluded = excluded_field()
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -277,7 +277,7 @@ class UserService(CRUDService):
         Query users with `query-filters` and `query-options`.
 
         If users provided by Active Directory or LDAP are not desired, then
-        a "local", "=", False should be added to filters.
+        "local", "=", True should be added to filters.
         """
         ds_users = []
         options = options or {}

--- a/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
@@ -264,7 +264,6 @@ class DSCacheFill:
                     'twofactor_auth_configured': False,
                     'local': False,
                     'id_type_both': id_type_both,
-                    'nt_name': user_data.pw_name,
                     'smb': u['sid'] is not None,
                     'sid': u['sid'],
                     'roles': []
@@ -303,7 +302,6 @@ class DSCacheFill:
                     'users': [],
                     'local': False,
                     'id_type_both': id_type_both,
-                    'nt_name': group_data.gr_name,
                     'smb': g['sid'] is not None,
                     'sid': g['sid'],
                     'roles': []

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -15,6 +15,12 @@ from middlewared.plugins.idmap_.idmap_winbind import (WBClient, WBCErr)
 from middlewared.plugins.idmap_.idmap_sss import SSSClient
 import middlewared.sqlalchemy as sa
 from middlewared.utils import filter_list
+from middlewared.utils.sid import (
+    get_domain_rid,
+    BASE_RID_GROUP,
+    BASE_RID_USER,
+    DomainRid,
+)
 from middlewared.utils.tdb import (
     get_tdb_handle,
     TDBDataType,
@@ -29,7 +35,6 @@ except ImportError:
 
 WINBIND_IDMAP_FILE = '/var/run/samba-lock/gencache.tdb'
 WINBIND_IDMAP_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
-
 
 def clear_winbind_cache():
     with get_tdb_handle(WINBIND_IDMAP_FILE, WINBIND_IDMAP_TDB_OPTIONS) as hdl:
@@ -954,11 +959,14 @@ class IdmapDomainService(CRUDService):
         unmapped = {}
         to_check = []
 
+        server_sid = self.middleware.call_sync('smb.local_server_sid')
+        netbiosname = self.middleware.call_sync('smb.config')['netbiosname']
+
         for sid in sidlist:
             try:
-                entry = self.__unixsid_to_name(sid, client.separator)
-            except KeyError:
-                # This is a Unix Sid, but account doesn't exist
+                entry = self.__local_sid_to_entry(server_sid, netbiosname, sid, client.separator)
+            except (KeyError, ValidationErrors):
+                # This is a Unix SID or a local SID, but account doesn't exist
                 unmapped.update({sid: sid})
                 continue
 
@@ -1044,7 +1052,7 @@ class IdmapDomainService(CRUDService):
 
         return output
 
-    def __unixsid_to_name(self, sid, separator='\\'):
+    def __unixsid_to_entry(self, sid, separator):
         if not sid.startswith((SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX)):
             return None
 
@@ -1066,6 +1074,59 @@ class IdmapDomainService(CRUDService):
             'id_type': IDType.GROUP.name,
             'sid': sid
         }
+
+    def __local_sid_to_entry(self, server_sid, netbiosname, sid, separator):
+        """
+        Attempt to resolve SID to an ID entry without querying winbind or
+        SSSD for it. This should be possible for local user accounts.
+        """
+        if sid.startswith((SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX)):
+            return self.__unixsid_to_entry(sid)
+
+        if not sid.startswith(server_sid):
+            return None
+
+        rid = get_domain_rid(sid)
+        if rid == DomainRid.ADMINS:
+            return {
+                'name': f'{netbiosname}{separator}builtin_administrators',
+                'id': 544,
+                'id_type': IDType.GROUP.value,
+                'sid': sid,
+            }
+        elif rid == DomainRid.GUESTS:
+            return {
+                'name': f'{netbiosname}{separator}builtin_guests',
+                'id': 546,
+                'id_type': IDType.GROUP.value,
+                'sid': sid,
+            }
+        elif rid > BASE_RID_GROUP:
+            id_type = IDType.GROUP.name
+            method = 'group.get_instance'
+            xid_key = 'gid'
+            name_key = 'name'
+            db_id = rid - BASE_RID_GROUP
+        elif rid > BASE_RID_USER:
+            id_type = IDType.USER.name
+            method = 'user.get_instance'
+            xid_key = 'uid'
+            name_key = 'username'
+            db_id = rid - BASE_RID_USER
+        else:
+            # Log an error message and fall through to winbind or sssd to resolve it
+            self.logger.warning('%s: unexpected local SID value', sid)
+            return None
+
+        entry = self.middleware.call_sync(method, db_id)
+
+        return {
+            'name': f'{netbiosname}{separator}{entry[name_key]}',
+            'id': entry[xid_key],
+            'id_type': id_type,
+            'sid': sid
+        }
+
 
     @private
     @filterable

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1082,7 +1082,7 @@ class IdmapDomainService(CRUDService):
         SSSD for it. This should be possible for local user accounts.
         """
         if sid.startswith((SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX)):
-            return self.__unixsid_to_entry(sid)
+            return self.__unixsid_to_entry(sid, separator)
 
         if not sid.startswith(server_sid):
             return None

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -36,6 +36,7 @@ except ImportError:
 WINBIND_IDMAP_FILE = '/var/run/samba-lock/gencache.tdb'
 WINBIND_IDMAP_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
 
+
 def clear_winbind_cache():
     with get_tdb_handle(WINBIND_IDMAP_FILE, WINBIND_IDMAP_TDB_OPTIONS) as hdl:
         return hdl.clear()

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -368,7 +368,7 @@ class SMBService(ConfigService):
             self.logger.warning("Failed to set immutable flag on /var/empty", exc_info=True)
 
         job.set_progress(30, 'Setting up server SID.')
-        await self.middleware.call('smb.set_sid', data['cifs_SID'])
+        await self.middleware.call('smb.set_system_sid')
 
         """
         If the ldap passdb backend is being used, then the remote LDAP server
@@ -697,11 +697,8 @@ class SMBService(ConfigService):
             await self.apply_aapl_changes()
 
         if old['netbiosname_local'] != new_config['netbiosname_local']:
-            new_sid = await self.middleware.call("smb.get_system_sid")
-            await self.middleware.call("smb.set_database_sid", new_sid)
-            new_config["cifs_SID"] = new_sid
+            await self.middleware.call('smb.set_system_sid')
             await self.middleware.call('idmap.gencache.flush')
-            await self.middleware.call("smb.synchronize_group_mappings")
             srv = (await self.middleware.call("network.configuration.config"))["service_announcement"]
             await self.middleware.call("network.configuration.toggle_announcement", srv)
 

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -52,6 +52,18 @@ class SMBBuiltin(enum.Enum):
     GUESTS = ('builtin_guests', 'S-1-5-32-546')
     USERS = ('builtin_users', 'S-1-5-32-545')
 
+    @property
+    def nt_name(self):
+        return self.value[0][8:].capitalize()
+
+    @property
+    def sid(self):
+        return self.value[1]
+
+    @property
+    def rid(self):
+        return int(self.value[1].split('-')[-1])
+
     def unix_groups():
         return [x.value[0] for x in SMBBuiltin]
 

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -326,7 +326,7 @@ class SMBService(Service):
         return self.validate_groupmap_hwm(low_range)
 
     @private
-    @job(lock="groupmap_sync",  lock_queue_size=1)
+    @job(lock="groupmap_sync", lock_queue_size=1)
     def synchronize_group_mappings(self, job, bypass_sentinel_check=False):
         """
         This method does the following:

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -94,8 +94,8 @@ class SMBService(Service):
 
         if user['pdb'] is None:
             cmd = [SMBCmd.PDBEDIT.value, '-d', '0', '-a', username]
-            next_rid = db_id_to_rid(IDType.USER, user['id'])
-            cmd.extend(['-U', str(next_rid)])
+            rid = db_id_to_rid(IDType.USER, user['id'])
+            cmd.extend(['-U', str(rid)])
 
             cmd.append('-t')
 

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -1,6 +1,8 @@
 from middlewared.service import filterable, Service, job, private
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils import run, filter_list
+from middlewared.utils.sid import db_id_to_rid
+from middlewared.plugins.idmap_.idmap_constants import IDType
 from middlewared.plugins.smb import SMBCmd, SMBPath
 
 import os
@@ -92,8 +94,7 @@ class SMBService(Service):
 
         if user['pdb'] is None:
             cmd = [SMBCmd.PDBEDIT.value, '-d', '0', '-a', username]
-
-            next_rid = await self.middleware.call('smb.get_next_rid', 'USER', user.get('id'))
+            next_rid = db_id_to_rid(IDType.USER, user['id'])
             cmd.extend(['-U', str(next_rid)])
 
             cmd.append('-t')

--- a/src/middlewared/middlewared/plugins/smb_/sid.py
+++ b/src/middlewared/middlewared/plugins/smb_/sid.py
@@ -1,10 +1,10 @@
+import subprocess
+
 from middlewared.service import Service, private
-from middlewared.utils import run
-from middlewared.plugins.smb import SMBCmd
-
-import re
-
-RE_SID = re.compile(r"S-\d-\d+-(\d+-){1,14}\d+$")
+from middlewared.service_exception import CallError
+from middlewared.utils.functools_ import cache
+from middlewared.utils.sid import random_sid
+from .constants import SMBCmd
 
 
 class SMBService(Service):
@@ -13,70 +13,24 @@ class SMBService(Service):
         service = 'cifs'
         service_verb = 'restart'
 
+    @cache
     @private
-    async def get_system_sid(self):
-        getSID = await run([SMBCmd.NET.value, "-d", "0", "getlocalsid"], check=False)
-        if getSID.returncode != 0:
-            self.logger.debug('Failed to retrieve local system SID: %s',
-                              getSID.stderr.decode())
-            return None
+    def local_server_sid(self):
+        if (db_sid := self.middleware.call_sync('smb.config')['cifs_SID']):
+            return db_sid
 
-        m = RE_SID.search(getSID.stdout.decode().strip())
-        if m:
-            return m.group(0)
-
-        self.logger.debug("getlocalsid returned invalid SID: %s",
-                          getSID.stdout.decode().strip())
-        return None
+        new_sid = random_sid()
+        self.middleware.call_sync('datastore.update', 'services.cifs', 1, {'cifs_SID': new_sid})
+        return new_sid
 
     @private
-    async def set_sid(self, db_sid):
-        system_SID = await self.get_system_sid()
+    def set_system_sid(self):
+        server_sid = self.local_server_sid()
 
-        if system_SID == db_sid:
-            return True
+        setsid = subprocess.run([
+            SMBCmd.NET.value, '-d', '0',
+            'setlocalsid', server_sid,
+        ], capture_output=True, check=False)
 
-        if db_sid:
-            if not await self.set_system_sid(db_sid):
-                self.logger.debug('Unable to set set SID to %s', db_sid)
-                return False
-        else:
-            if not system_SID:
-                self.logger.warning('Unable to determine system and database SIDs')
-                return False
-
-            await self.set_database_sid(system_SID)
-            return True
-
-    @private
-    async def set_database_sid(self, SID):
-        await self.middleware.call('datastore.update', 'services.cifs', 1, {'cifs_SID': SID})
-
-    @private
-    async def set_system_sid(self, SID):
-        if not SID:
-            return False
-
-        setSID = await run([SMBCmd.NET.value, "-d", "0", "setlocalsid", SID], check=False)
-        if setSID.returncode != 0:
-            self.logger.debug("setlocalsid failed with error: %s",
-                              setSID.stderr.decode())
-            return False
-
-        return True
-
-    @private
-    async def fixsid(self, groupmap=None):
-        """
-        Samba generates a new domain sid when its netbios name changes or if samba's secrets.tdb
-        has been deleted. passdb.tdb will automatically reflect the new mappings, but the groupmap
-        database is not automatically updated in these circumstances. This check is performed when
-        synchronizing group mapping database. In case there entries that no longer match our local
-        system sid, group_mapping.tdb will be removed and re-generated.
-        """
-        db_SID = (await self.middleware.call('smb.config'))['cifs_SID']
-        system_sid = await self.get_system_sid()
-
-        if db_SID != system_sid:
-            self.logger.warning(f"Domain SID in group_mapping.tdb ({system_sid}) is not SID in nas config ({db_SID}). Updating db")
-            await self.set_database_sid(system_sid)
+        if setsid.returncode != 0:
+            raise CallError(f'setlocalsid failed: {setsid.stderr.decode()}')

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -1,0 +1,194 @@
+import enum
+
+from base64 import b64decode, b64encode
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
+from middlewared.utils import filter_list
+from middlewared.utils.sid import (
+    lsa_sidtype
+)
+from middlewared.utils.tdb import (
+    get_tdb_handle,
+    TDBBatchAction,
+    TDBBatchOperation,
+    TDBDataType,
+    TDBOptions,
+    TDBPathType,
+)
+from socket import htonl, ntohl
+
+UNIX_GROUP_KEY_PREFIX = 'UNIXGROUP/'
+MEMBEROF_PREFIX = 'MEMBEROF/'
+
+GROUP_MAPPING_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
+
+
+class GroupmapEntryType(enum.Enum):
+    GROUP_MAPPING = enum.auto()  # conventional group mapping entry
+    MEMBERSHIP = enum.auto()  # foreign alias member
+
+
+class GroupmapFile(enum.Enum):
+    DEFAULT = f'{SYSDATASET_PATH}/samba4/group_mapping.tdb'
+    REJECT = f'{SYSDATASET_PATH}/samba4/group_mapping_rejects.tdb'
+
+
+@dataclass(frozen=True)
+class SMBGroupMap:
+    sid: str
+    gid: int
+    sid_type: lsa_sidtype
+    name: str
+    comment: str
+
+
+@dataclass(frozen=True)
+class SMBGroupMembership:
+    sid: str
+    members: tuple[str]
+
+
+def _parse_unixgroup(tdb_key: str, tdb_val: str) -> SMBGroupMap:
+    """ parsing function to convert TDB key/value pair into SMBGroupMap """
+    sid = tdb_key[len(UNIX_GROUP_KEY_PREFIX):]
+    data = b64decode(tdb_val)
+
+    # unix groups are written into tdb file via tdb_pack
+    gid = htonl(int.from_bytes(data[0:4]))
+    sid_type = lsa_sidtype(htonl(int.from_bytes(data[4:8])))
+
+    # remaining bytes are two null-terminated strings
+    bname, bcomment = data[8:-1].split(b'\x00')
+    return SMBGroupMap(sid, gid, sid_type, bname.decode(), bcomment.decode())
+
+
+def _parse_memberof(tdb_key: str, tdb_val: str) -> SMBGroupMembership:
+    """ parsing function to convert TDB key/value pair into SMBGroupMembership """
+    sid = tdb_key[len(MEMBEROF_PREFIX):]
+    data = b64decode(tdb_val)
+
+    members = tuple(data[:-1].decode().split())
+    return SMBGroupMembership(sid, members)
+
+
+def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, str]:
+    tdb_key = f'{UNIX_GROUP_KEY_PREFIX}{group_map.sid}'
+    gid = ntohl(group_map.gid).to_bytes(4)
+    sid_type = ntohl(group_map.sid_type).to_bytes(4)
+    name = group_map.name.encode()
+    comment = group_map.comment.encode()
+
+    data = gid + sid_type + name + b'\x00' + comment + b'\x00'
+    return (tdb_key, b64encode(data))
+
+
+def _groupmem_to_tdb_key_val(group_mem: SMBGroupMembership) -> tuple[str, str]:
+    tdb_key = f'{MEMBEROF_PREFIX}{group_mem.sid}'
+    data = ' '.join(set(group_mem.members)).encode() + b'\x00'
+    return (tdb_key, b64encode(data))
+
+
+def groupmap_entries(
+    groupmap_file: GroupmapFile,
+    as_dict: bool = False
+) -> Iterable[SMBGroupMap, SMBGroupMembership, dict]:
+    """ iterate the specified group_mapping.tdb file
+
+    Params:
+       as_dict - return as dictionary
+
+    Returns:
+       SMBGroupMap or SMBGroupMembership
+
+    Raises:
+       RuntimeError
+       FileNotFoundError
+    """
+    if not isinstance(groupmap_file, GroupmapFile):
+        raise TypeError(f'{type(groupmap_file)}: expected GroupmapFile type.')
+
+    with get_tdb_handle(groupmap_file.value, GROUP_MAPPING_TDB_OPTIONS) as hdl:
+        for entry in hdl.entries():
+            if entry['key'].startswith(UNIX_GROUP_KEY_PREFIX):
+                parser_fn = _parse_unixgroup
+                entry_type = GroupmapEntryType.GROUP_MAPPING.name
+            elif entry['key'].startswith(MEMBEROF_PREFIX):
+                parser_fn = _parse_memberof
+                entry_type = GroupmapEntryType.MEMBERSHIP.name
+            else:
+                continue
+
+            if as_dict:
+                yield {'entry_type': entry_type} | asdict(parser_fn(entry['key'], entry['value']))
+            else:
+                yield parser_fn(entry['key'], entry['value'])
+
+
+def query_groupmap_entries(groupmap_file: GroupmapFile, filters: list, options: dict) -> list[dict]:
+    try:
+        return filter_list(groupmap_entries(groupmap_file, as_dict=True), filters, options)
+    except FileNotFoundError:
+        return []
+
+
+def insert_groupmap_entries(
+    groupmap_file: GroupmapFile,
+    entries: list[SMBGroupMap | SMBGroupMembership]
+) -> None:
+    """ Insert multiple groupmap entries under a transaction lock """
+
+    batch_ops = []
+
+    for entry in entries:
+        if isinstance(entry, SMBGroupMap):
+            tdb_key, tdb_val = _groupmap_to_tdb_key_val(entry)
+        elif isinstance(entry, SMBGroupMembership):
+            tdb_key, tdb_val = _groupmem_to_tdb_key_val(entry)
+        else:
+            raise TypeError(f'{type(entry)}: unexpected group_mapping.tdb entry type')
+
+        batch_ops.append(TDBBatchOperation(action=TDBBatchAction.SET, key=tdb_key, value=tdb_val))
+
+    if len(batch_ops) == 0:
+        # nothing to do, avoid taking lock
+        return
+
+    with get_tdb_handle(groupmap_file.value, GROUP_MAPPING_TDB_OPTIONS) as hdl:
+        hdl.batch_op(batch_ops)
+
+
+def delete_groupmap_entry(
+    groupmap_file: GroupmapFile,
+    entry_type: GroupmapEntryType,
+    entry_sid: str
+):
+    if not isinstance(groupmap_file, GroupmapFile):
+        raise TypeError(f'{type(groupmap_file)}: expected GroupmapFile type.')
+
+    if not isinstance(entry_type, GroupmapEntryType):
+        raise TypeError(f'{type(entry_type)}: expected GroumapEntryType.')
+
+    match entry_type:
+        case GroupmapEntryType.GROUP_MAPPING:
+            tdb_key = f'{UNIX_GROUP_KEY_PREFIX}{entry_sid}'
+        case GroupmapEntryType.MEMBERSHIP:
+            tdb_key = f'{MEMBEROF_PREFIX}{entry_sid}'
+        case _:
+            raise TypeError(f'{entry_type}: unexpected GroumapEntryType.')
+
+    with get_tdb_handle(groupmap_file.value, GROUP_MAPPING_TDB_OPTIONS) as hdl:
+        hdl.delete(tdb_key)
+
+
+def list_foreign_group_memberships(
+    groupmap_file: GroupmapFile,
+    entry_sid: str
+) -> SMBGroupMembership:
+    if not isinstance(groupmap_file, GroupmapFile):
+        raise TypeError(f'{type(groupmap_file)}: expected GroupmapFile type.')
+
+    with get_tdb_handle(groupmap_file.value, GROUP_MAPPING_TDB_OPTIONS) as hdl:
+        tdb_key = f'{MEMBEROF_PREFIX}{entry_sid}'
+        tdb_val = hdl.get(tdb_key)
+        return _parse_memberof(tdb_key, tdb_val)

--- a/src/middlewared/middlewared/plugins/smb_/utils.py
+++ b/src/middlewared/middlewared/plugins/smb_/utils.py
@@ -1,4 +1,14 @@
 from .constants import SMBSharePreset
+from secrets import randbits
+
+
+def random_sid():
+    """ See MS-DTYP 2.4.2 SID """
+    subauth_1 = randbits(32)
+    subauth_2 = randbits(32)
+    subauth_3 = randbits(32)
+
+    return f'S-1-5-21-{subauth_1}-{subauth_2}-{subauth_3}'
 
 
 def smb_strip_comments(auxparam_in):

--- a/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
@@ -1,0 +1,156 @@
+import os
+import pytest
+
+from middlewared.plugins.smb_.util_groupmap import (
+    insert_groupmap_entries,
+    delete_groupmap_entry,
+    list_foreign_group_memberships,
+    query_groupmap_entries,
+    SMBGroupMap,
+    SMBGroupMembership,
+    GroupmapEntryType,
+    GroupmapFile,
+)
+from middlewared.service_exception import MatchNotFound
+from middlewared.utils.sid import (
+    lsa_sidtype,
+    random_sid
+)
+from middlewared.utils.tdb import close_sysdataset_tdb_handles
+
+
+@pytest.fixture(scope='module')
+def groupmap_dir():
+    os.makedirs('/var/db/system/samba4', exist_ok=True)
+
+
+@pytest.fixture(scope='module')
+def local_sid():
+    try:
+       yield random_sid()
+    finally:
+       # cleanup our tdb handles
+       close_sysdataset_tdb_handles()
+
+
+def test__insert_groupmap(groupmap_dir, local_sid):
+    entries = [
+        SMBGroupMap(
+            sid=f'{local_sid}-2000010',
+            gid=3000,
+            sid_type=lsa_sidtype.ALIAS,
+            name='bob',
+            comment=''
+        ),
+        SMBGroupMap(
+            sid=f'{local_sid}-2000011',
+            gid=3001,
+            sid_type=lsa_sidtype.ALIAS,
+            name='larry',
+            comment=''
+        )
+    ]
+
+    insert_groupmap_entries(GroupmapFile.DEFAULT, entries)
+
+    bob = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.GROUP_MAPPING.name],
+        ['name', '=', 'bob']
+    ], {'get': True})
+    assert bob['sid'] == f'{local_sid}-2000010'
+    assert bob['gid'] == 3000
+    assert bob['sid_type'] == lsa_sidtype.ALIAS
+    assert bob['name'] == 'bob'
+    assert bob['comment'] == ''
+
+    larry = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.GROUP_MAPPING.name],
+        ['name', '=', 'larry']
+    ], {'get': True})
+    assert larry['sid'] == f'{local_sid}-2000011'
+    assert larry['gid'] == 3001
+    assert larry['sid_type'] == lsa_sidtype.ALIAS
+    assert larry['name'] == 'larry'
+    assert larry['comment'] == ''
+
+    delete_groupmap_entry(
+        GroupmapFile.DEFAULT,
+        GroupmapEntryType.GROUP_MAPPING,
+        f'{local_sid}-2000010'
+    )
+
+    delete_groupmap_entry(
+        GroupmapFile.DEFAULT,
+        GroupmapEntryType.GROUP_MAPPING,
+        f'{local_sid}-2000011'
+    )
+
+    with pytest.raises(MatchNotFound):
+        query_groupmap_entries(GroupmapFile.DEFAULT, [
+            ['entry_type', '=', GroupmapEntryType.GROUP_MAPPING.name],
+            ['name', '=', 'larry']
+        ], {'get': True})
+
+    groupmaps = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.GROUP_MAPPING.name],
+    ], {})
+
+    assert len(groupmaps) == 0
+
+
+def test__insert_group_membership(groupmap_dir, local_sid):
+    entries = [
+        SMBGroupMembership(
+            sid='S-1-5-32-544',
+            members=(f'{local_sid}-2000010', f'{local_sid}-2000011')
+        ),
+        SMBGroupMembership(
+            sid='S-1-5-32-545',
+            members=(f'{local_sid}-2000012', f'{local_sid}-2000013')
+        ),
+    ]
+    insert_groupmap_entries(GroupmapFile.DEFAULT, entries)
+
+    res = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+        ['sid', '=', 'S-1-5-32-544']
+    ], {'get': True})
+
+    assert res['sid'] == 'S-1-5-32-544'
+    assert set(res['members']) == set((f'{local_sid}-2000010', f'{local_sid}-2000011'))
+
+    res = list_foreign_group_memberships(GroupmapFile.DEFAULT, 'S-1-5-32-544')
+    assert res.sid == 'S-1-5-32-544'
+    assert set(res.members) == set((f'{local_sid}-2000010', f'{local_sid}-2000011'))
+
+    res = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+        ['sid', '=', 'S-1-5-32-545']
+    ], {'get': True})
+
+    assert res['sid'] == 'S-1-5-32-545'
+    assert set(res['members']) == set((f'{local_sid}-2000012', f'{local_sid}-2000013'))
+
+    delete_groupmap_entry(
+        GroupmapFile.DEFAULT,
+        GroupmapEntryType.MEMBERSHIP,
+        'S-1-5-32-544'
+    )
+
+    delete_groupmap_entry(
+        GroupmapFile.DEFAULT,
+        GroupmapEntryType.MEMBERSHIP,
+        'S-1-5-32-545'
+    )
+
+    with pytest.raises(MatchNotFound):
+        query_groupmap_entries(GroupmapFile.DEFAULT, [
+            ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+            ['sid', '=', 'S-1-5-32-544']
+        ], {'get': True})
+
+    entries = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+    ], {})
+
+    assert len(entries) == 0

--- a/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
@@ -27,10 +27,10 @@ def groupmap_dir():
 @pytest.fixture(scope='module')
 def local_sid():
     try:
-       yield random_sid()
+        yield random_sid()
     finally:
-       # cleanup our tdb handles
-       close_sysdataset_tdb_handles()
+        # cleanup our tdb handles
+        close_sysdataset_tdb_handles()
 
 
 def test__insert_groupmap(groupmap_dir, local_sid):

--- a/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_groupmap.py
@@ -79,6 +79,12 @@ def test__insert_groupmap(groupmap_dir, local_sid):
         f'{local_sid}-2000010'
     )
 
+    entry = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.GROUP_MAPPING.name],
+    ], {'get': True})
+
+    assert entry['name'] == 'larry'
+
     delete_groupmap_entry(
         GroupmapFile.DEFAULT,
         GroupmapEntryType.GROUP_MAPPING,
@@ -136,6 +142,12 @@ def test__insert_group_membership(groupmap_dir, local_sid):
         GroupmapEntryType.MEMBERSHIP,
         'S-1-5-32-544'
     )
+
+    entry = query_groupmap_entries(GroupmapFile.DEFAULT, [
+        ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+    ], {'get': True})
+
+    assert res['sid'] == 'S-1-5-32-545'
 
     delete_groupmap_entry(
         GroupmapFile.DEFAULT,

--- a/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
@@ -38,8 +38,8 @@ def test__db_id_to_rid(id_type, db_id, expected_rid, valid):
     ('S-1-2-0', False),  # technically valid SID but we don't permit it
     ('S-1-5-21-3510196835-1033636670-2319939847-200108-200108', False),
     ('S-1-5-21-3510196835-200108', False),
-    ('S-1-5-21-3510196835-1033636670-231993009847-200108', False),
-    ('S-1-5-21-351019683b-1033636670-231993009847-200108', False),
+    ('S-1-5-21-3510196835-1033636670-231993008847-200108', False),
+    ('S-1-5-21-351019683b-1033636670-2319939847-200108', False),
 ])
 def test__sid_is_valid(sid, valid):
     assert sid_is_valid(sid) is valid

--- a/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_sid.py
@@ -1,0 +1,62 @@
+import pytest
+
+from middlewared.plugins.idmap_.idmap_constants import (
+    BASE_SYNTHETIC_DATASTORE_ID,
+    IDType
+)
+from middlewared.utils.sid import (
+    db_id_to_rid,
+    get_domain_rid,
+    random_sid,
+    sid_is_valid,
+    BASE_RID_GROUP,
+    BASE_RID_USER,
+)
+
+
+@pytest.fixture(scope='module')
+def local_sid():
+    yield random_sid()
+
+
+@pytest.mark.parametrize('id_type,db_id,expected_rid,valid', [
+    (IDType.USER, 1000, 1000 + BASE_RID_USER, True),
+    (IDType.GROUP, 1000, 1000 + BASE_RID_GROUP, True),
+    (IDType.USER, 1000 + BASE_SYNTHETIC_DATASTORE_ID, None, False),
+])
+def test__db_id_to_rid(id_type, db_id, expected_rid, valid):
+    if valid:
+        assert db_id_to_rid(id_type, db_id) == expected_rid
+    else:
+        with pytest.raises(ValueError):
+            db_id_to_rid(id_type, db_id)
+
+
+@pytest.mark.parametrize('sid,valid', [
+    ('S-1-5-21-3510196835-1033636670-2319939847-200108', True),
+    ('S-1-5-32-544', True),
+    ('S-1-2-0', False),  # technically valid SID but we don't permit it
+    ('S-1-5-21-3510196835-1033636670-2319939847-200108-200108', False),
+    ('S-1-5-21-3510196835-200108', False),
+    ('S-1-5-21-3510196835-1033636670-231993009847-200108', False),
+    ('S-1-5-21-351019683b-1033636670-231993009847-200108', False),
+])
+def test__sid_is_valid(sid, valid):
+    assert sid_is_valid(sid) is valid
+
+
+@pytest.mark.parametrize('sid,rid,valid', [
+    ('S-1-5-21-3510196835-1033636670-2319939847-200108', 200108, True),
+    ('S-1-5-21-3510196835-1033636670-2319939847', None, False),
+    ('S-1-5-32-544', None, False),
+])
+def test__get_domain_rid(sid, rid, valid):
+    if valid:
+        assert get_domain_rid(sid) == rid
+    else:
+        with pytest.raises(ValueError):
+            get_domain_rid(sid)
+
+
+def test__random_sid_is_valid(local_sid):
+    assert sid_is_valid(local_sid)

--- a/src/middlewared/middlewared/utils/sid.py
+++ b/src/middlewared/middlewared/utils/sid.py
@@ -1,0 +1,145 @@
+import enum
+
+from secrets import randbits
+from middlewared.plugins.idmap_.idmap_constants import BASE_SYNTHETIC_DATASTORE_ID, IDType
+
+
+DOM_SID_PREFIX = 'S-1-5-21-'
+DOM_SID_SUBAUTHS = 3
+MAX_VALUE_SUBAUTH = 2 ** 32
+BASE_RID_USER = 20000
+BASE_RID_GROUP = 200000
+
+
+class DomainRid(enum.IntEnum):
+    """ Defined in MS-DTYP Section 2.4.2.4
+    This is subsest of well-known RID values defined in above document
+    focused on ones that are of particular significance to permissions and
+    SMB server behavior
+    """
+    ADMINISTRATOR = 500  # local administrator account
+    GUEST = 501  # guest account
+    ADMINS = 512  # domain admins account (local or joined)
+    USERS = 513
+    GUESTS = 514
+    COMPUTERS = 515
+
+
+class WellKnownSid(enum.Enum):
+    """ Defined in MS-DTYP Section 2.4.2.4 """
+    WORLD = 'S-1-1-0'
+    CREATOR_OWNER = 'S-1-3-0'
+    CREATOR_GROUP = 'S-1-3-1'
+    OWNER_RIGHTS = 'S-1-3-4'
+    AUTHENTICATED_USERS = 'S-1-5-11'
+    SYSTEM = 'S-1-5-18'
+    NT_AUTHORITY = 'S-1-5-19'
+    BUILTIN_ADMINISTRATORS = 'S-1-5-32-544'
+    BUILTIN_USERS = 'S-1-5-32-545'
+    BUILTIN_GUESTS = 'S-1-5-32-546'
+
+    @property
+    def sid(self):
+        return self.value
+
+
+class lsa_sidtype(enum.IntEnum):
+    """ librpc/idl/lsa.idl
+    used for passdb and group mapping databases
+    """
+    USE_NONE = 0  # NOTUSED
+    USER = 1  # user
+    DOM_GRP = 2  # domain group
+    DOMAIN = 3
+    ALIAS = 4  # local group
+    WKN_GRP = 5  # well-known group
+    DELETED = 6  # deleted account
+    INVALID = 7  # invalid account
+    UNKNOWN = 8
+    COMPUTER = 9
+    LABEL = 10  # mandatory label
+
+
+def random_sid() -> str:
+    """ See MS-DTYP 2.4.2 SID """
+    subauth_1 = randbits(32)
+    subauth_2 = randbits(32)
+    subauth_3 = randbits(32)
+
+    return f'S-1-5-21-{subauth_1}-{subauth_2}-{subauth_3}'
+
+
+def sid_is_valid(sid: str) -> bool:
+    """
+    This is validation function should be used with some caution
+    as it only applies to SID values we reasonably expect to be used
+    in SMB ACLs or for local user / group accounts
+    """
+    if not isinstance(sid, str):
+        return False
+
+    # Whitelist some well-known SIDs user may have
+    if sid in (
+        WellKnownSid.WORLD.sid,
+        WellKnownSid.OWNER_RIGHTS.sid,
+        WellKnownSid.BUILTIN_ADMINISTRATORS.sid,
+        WellKnownSid.BUILTIN_USERS.sid,
+        WellKnownSid.BUILTIN_GUESTS.sid,
+    ):
+        return True
+
+    if not sid.startswith(DOM_SID_PREFIX):
+        # not a domain sid
+        return False
+
+    subauths = sid[len(DOM_SID_PREFIX):].split('-')
+
+    # SID may have a RID component appended
+    if len(subauths) < DOM_SID_SUBAUTHS or len(subauths) > DOM_SID_SUBAUTHS + 1:
+        return False
+
+    for subauth in subauths:
+        if not subauth.isdigit():
+            return False
+
+        subauth_val = int(subauth)
+        if subauth_val < 1 or subauth_val > MAX_VALUE_SUBAUTH:
+            return False
+
+    return True
+
+
+def get_domain_rid(sid: str) -> str:
+    """ get rid component of the specified SID """
+    if not sid_is_valid(sid):
+        raise ValueError(f'{sid}: not a valid SID')
+
+    if not sid.startswith(DOM_SID_PREFIX):
+        raise ValueError(f'{sid}: not a domain SID')
+
+    subauths = sid[len(DOM_SID_PREFIX):].split('-')
+    if len(subauths) == DOM_SID_SUBAUTHS:
+        raise ValueError(f'{sid}: does not contain a RID component')
+
+    return int(subauths[-1])
+
+
+def db_id_to_rid(id_type: IDType, db_id: int) -> int:
+    """
+    Simple algorithm to convert a datastore ID into RID value. Has been
+    in use since TrueNAS 12. May not be changed because it will break
+    SMB share ACLs
+    """
+    if not isinstance(db_id, int):
+        raise ValueError(f'{db_id}: Not an int')
+
+    if db_id >= BASE_SYNTHETIC_DATASTORE_ID:
+        raise ValueError('Not valid for users and groups from directory services')
+
+    match id_type:
+        case IDType.USER:
+            return db_id + BASE_RID_USER
+        case IDType.GROUP:
+            return db_id + BASE_RID_GROUP
+        case _:
+            raise ValueError(f'{id_type}: unknown ID type')

--- a/src/middlewared/middlewared/utils/sid.py
+++ b/src/middlewared/middlewared/utils/sid.py
@@ -109,7 +109,7 @@ def sid_is_valid(sid: str) -> bool:
     return True
 
 
-def get_domain_rid(sid: str) -> str:
+def get_domain_rid(sid: str) -> int:
     """ get rid component of the specified SID """
     if not sid_is_valid(sid):
         raise ValueError(f'{sid}: not a valid SID')

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -190,8 +190,7 @@ def test_001_create_and_verify_testuser():
     assert results['result'] is False, str(results['output'])
 
     # non-smb users shouldn't show up in smb's passdb
-    assert not qry['sid']
-    assert not qry['nt_name']
+    assert qry['sid'] is None
 
 
 def test_002_verify_user_exists_in_pwd(request):
@@ -285,7 +284,6 @@ def test_006_verify_converted_smbuser_passdb_entry_exists(request):
     )
     assert qry
     assert qry['sid']
-    assert qry['nt_name']
 
 
 def test_007_add_smbuser_to_sudoers(request):
@@ -433,7 +431,6 @@ def test_031_create_user_with_homedir(request):
 
     # verify smb user passdb entry
     assert qry['sid']
-    assert qry['nt_name']
 
     # verify homedir acl is stripped
     st_info = call('filesystem.stat', UserAssets.TestUser02['query_response']['home'])
@@ -564,8 +561,7 @@ def test_042_disable_smb_user(request):
         {'get': True, 'extra': {'additional_information': ['SMB']}}
     )
     assert qry
-    assert qry['sid'] == ''
-    assert qry['nt_name'] == ''
+    assert qry['sid'] is None
 
 
 def test_043_raise_validation_error_on_homedir_collision(request):

--- a/tests/api2/test_smb_groupmap.py
+++ b/tests/api2/test_smb_groupmap.py
@@ -1,0 +1,72 @@
+import pytest
+
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.assets.account import group
+
+BASE_RID_GROUP = 200000
+
+
+@pytest.mark.parametrize('groupname,expected_memberof,expected_rid', [
+    ('builtin_administrators', 'S-1-5-32-544', 512),
+    ('builtin_guests', 'S-1-5-32-546', 514)
+])
+def test__local_builtin_accounts(groupname, expected_memberof, expected_rid):
+    entry = call('group.query', [['group', '=', groupname]], {'get': True})
+    rid = int(entry['sid'].split('-')[-1])
+    assert rid == expected_rid
+
+    groupmap = call('smb.groupmap_list')
+    assert str(entry['gid']) in groupmap['local_builtins']
+    assert groupmap['local_builtins'][str(entry['gid'])]['sid'] == entry['sid']
+
+    members = call('smb.groupmap_listmem', expected_memberof)
+    assert entry['sid'] in members
+
+
+def test__local_builtin_users_account():
+    entry = call('group.query', [['group', '=', 'builtin_users']], {'get': True})
+
+    rid = int(entry['sid'].split('-')[-1])
+    assert rid == entry['id'] + BASE_RID_GROUP
+
+    members_dom_users = call('smb.groupmap_listmem', 'S-1-5-32-545')
+    assert entry['sid'] in members_dom_users
+
+
+def test__new_group():
+    with group({"name": "group1"}) as g:
+        # Validate GID is being assigned as expected
+        assert g['sid'] is not None
+        rid = int(g['sid'].split('-')[-1])
+        assert rid == g['id'] + BASE_RID_GROUP
+
+        groupmap = call('smb.groupmap_list')
+
+        assert groupmap['local'][str(g['gid'])]['sid'] == g['sid']
+
+        # Validate that disabling SMB removes SID value from query results
+        call('group.update', g['id'], {'smb': False})
+
+        new = call('group.get_instance', g['id'])
+        assert new['sid'] is None
+
+        # Check for presence in group_mapping.tdb
+        groupmap = call('smb.groupmap_list')
+        assert new['gid'] not in groupmap['local']
+
+        # Validate that re-enabling restores SID value
+        call('group.update', g['id'], {'smb': True})
+        new = call('group.get_instance', g['id'])
+        assert new['sid'] == g['sid']
+
+        groupmap = call('smb.groupmap_list')
+        assert str(new['gid']) in groupmap['local']
+
+@pytest.mark.parametrize('name,gid,sid', [
+    ('Administrators', 90000001, 'S-1-5-32-544'),
+    ('Users', 90000002, 'S-1-5-32-545'),
+    ('Guests', 90000003, 'S-1-5-32-546')
+])
+def test__builtins(name, gid, sid):
+    builtins = call('smb.groupmap_list')['builtins']
+    assert str(gid) in builtins

--- a/tests/api2/test_smb_groupmap.py
+++ b/tests/api2/test_smb_groupmap.py
@@ -62,6 +62,7 @@ def test__new_group():
         groupmap = call('smb.groupmap_list')
         assert str(new['gid']) in groupmap['local']
 
+
 @pytest.mark.parametrize('name,gid,sid', [
     ('Administrators', 90000001, 'S-1-5-32-544'),
     ('Users', 90000002, 'S-1-5-32-545'),


### PR DESCRIPTION
Do not rely on Samba to generate a new system SID and make randomized
SID persistent across server changes. This is to help prevent admin
foot-shooting when they choose to make major server changes that force
Samba to regenrate a new SID and thus invalidate their share ACLs.
on production servers.

Since local user / group RID values are deterministic based on the id
key for user / group accounts, populate `sid` key in user.query and
group.query extend methods. Apply similar logic to short-circuit
SID conversion.

The nt_name key provides little value to API consumers and so remove
for account entries.

Remove subprocess call to `net groupmap` in favor of using our tdb
utilities to directly alter the group_mapping.tdb file. This generally
performs better and avoids having to synchronize group mappings during
group CRUD methods.