### PR TITLE
NAS-129807 / 24.10 / Fix nut reporting in netdata

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -8,7 +8,10 @@ for file in \
     /lib/systemd/system/smartmontools.service \
     /usr/share/spice-html5/spice_auto.html \
     /usr/share/spice-html5/spice.css \
-    /etc/logrotate.d/netdata
+    /etc/logrotate.d/netdata \
+    /usr/lib/tmpfiles.d/nut-server.conf \
+    /usr/lib/tmpfiles.d/nut-client.conf \
+    /usr/lib/tmpfiles.d/nut-common.tmpfiles
 do
     dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"
 done

--- a/src/freenas/etc/tmpfiles.d/nut.conf
+++ b/src/freenas/etc/tmpfiles.d/nut.conf
@@ -1,0 +1,2 @@
+d /run/nut 0775 root nut - -
+s /run/nut/upssched.pipe 0660 nut nut - -

--- a/src/freenas/etc/tmpfiles.d/nut.conf
+++ b/src/freenas/etc/tmpfiles.d/nut.conf
@@ -1,2 +1,2 @@
 d /run/nut 0775 root nut - -
-s /run/nut/upssched.pipe 0660 nut nut - -
+d /run/nut/private 0770 root nut - -

--- a/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
+++ b/src/freenas/usr/lib/netdata/charts.d/nut_ups.chart.sh
@@ -1,14 +1,12 @@
 source /usr/lib/netdata/charts.d/nut.chart.sh
 
-nut_ups_update_every=60
-
 
 nut_get_all() {
-  run -t $nut_timeout upsc -l || echo "ix-dummy-ups"
+  run -t $nut_timeout upsc -l || echo "skip-get-values"
 }
 
 nut_get() {
-  if [ $1 == "ix-dummy-ups" ]; then
+  if [ $1 == "skip-get-values" ]; then
     return 0;
   fi
 
@@ -33,7 +31,6 @@ nut_ups_check() {
   nut_ids=()
 
   if [ ! -f /run/nut/upsmon.pid ]; then
-    nut_ids["ix-dummy-ups"]="$(fixid "ix-dummy-ups")"
     return 0
   fi
 
@@ -73,6 +70,10 @@ nut_ups_update() {
   # do all the work to collect / calculate the values
   # for each dimension
   # remember: KEEP IT SIMPLE AND SHORT
+  if [ ! -f /run/nut/upsmon.pid ]; then
+    return 0
+  fi
+
   nut_ups_check
   nut_ups_create
   nut_update $@

--- a/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
+++ b/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
@@ -16,7 +16,7 @@ def generate_ups_config(middleware):
 
     ups_group = middleware.call_sync('group.query', [['group', '=', UPS_USER]], {'get': True})
     os.chown(UPS_VARPATH, 0, ups_group['gid'])
-    os.chmod(UPS_VARPATH, 0o770)
+    os.chmod(UPS_VARPATH, 0o775)
 
 
 def render(service, middleware):

--- a/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
+++ b/src/middlewared/middlewared/etc_files/local/nut/ups_config.py
@@ -5,6 +5,7 @@ import shutil
 UPS_CONFPATH = '/etc/nut'
 UPS_USER = 'nut'
 UPS_VARPATH = '/var/run/nut'
+UPSSCHED_VARPATH = '/var/run/nut/private'
 
 
 def generate_ups_config(middleware):
@@ -13,10 +14,12 @@ def generate_ups_config(middleware):
 
     os.makedirs(UPS_CONFPATH)
     os.makedirs(UPS_VARPATH, exist_ok=True)
+    os.makedirs(UPSSCHED_VARPATH, exist_ok=True)
 
     ups_group = middleware.call_sync('group.query', [['group', '=', UPS_USER]], {'get': True})
     os.chown(UPS_VARPATH, 0, ups_group['gid'])
     os.chmod(UPS_VARPATH, 0o775)
+    os.chmod(UPSSCHED_VARPATH, 0o770)
 
 
 def render(service, middleware):

--- a/src/middlewared/middlewared/etc_files/local/nut/upssched.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nut/upssched.conf.mako
@@ -4,8 +4,8 @@
 	sudo_path = "/usr/bin/sudo"
 %>\
 CMDSCRIPT   "${sudo_path} /usr/local/bin/custom-upssched-cmd"
-PIPEFN      /var/run/nut/upssched.pipe
-LOCKFN      /var/run/nut/upssched.lock
+PIPEFN      /var/run/nut/private/upssched.pipe
+LOCKFN      /var/run/nut/private/upssched.lock
 
 AT NOCOMM   * EXECUTE NOTIFY-NOCOMM
 AT COMMBAD  * START-TIMER NOTIFY-COMMBAD 10


### PR DESCRIPTION
## Problem

Currently, the Netdata user cannot access the `/run/nut/upsmon.pid` file, causing it to return dummy UPS data even after UPS is started. Furthermore, the dummy UPS data is causing problems in the Netdata UI because users can see the dummy UPS when using netdata webui, which doesn't actually exist. Additionally, there is an issue with the UPS graphs showing spikes instead of a straight line. This is due to the UPS chart.d plugin sleeping for 60 seconds, and the Netdata natural points flag not working correctly.

## Solution

Refactor the UPS plugin to remove the need for dummy UPS data by not sending any metrics if the UPS is not running. This will keep the UPS plugin running without errors and it will start working normally once the UPS starts. Also, fix `/run/nut` permissions to make it accessible to the Netdata user. Restore the default timeout because checking `/run/nut/upsmon.pid` file existence is not an expensive operation.