### PR TITLE
NAS-129958 / 24.10 / Fix a minor regression in NFS api tests

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1365,7 +1365,7 @@ def test_45_check_setting_runtime_debug(request):
         with pytest.raises(Exception) as ve:
             # This should generate an ValueError exception on the system
             call('nfs.set_debug', failure)
-            assert ve.value.errno == errno.EINVAL, ve
+        assert ve.value.errno == errno.EINVAL, ve
     finally:
         assert call('nfs.set_debug', disabled)
         debug_values = call('nfs.get_debug')

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1359,15 +1359,17 @@ def test_45_check_setting_runtime_debug(request):
     try:
         assert call('nfs.get_debug') == disabled
         assert call('nfs.set_debug', enabled)
-        assert call('nfs.get_debug') == enabled
+        debug_values = call('nfs.get_debug')
+        assert all((set(enabled[i]) == set(debug_values[i]) for i in debug_values)), debug_values
 
         with pytest.raises(Exception) as ve:
             # This should generate an ValueError exception on the system
             call('nfs.set_debug', failure)
-        assert ve.value.errno == errno.EINVAL
+            assert ve.value.errno == errno.EINVAL, ve
     finally:
         assert call('nfs.set_debug', disabled)
-        assert call('nfs.get_debug') == disabled
+        debug_values = call('nfs.get_debug')
+        assert all((set(disabled[i]) == set(debug_values[i]) for i in debug_values)), debug_values
 
 
 def test_46_set_bind_ip():


### PR DESCRIPTION
When introducing the rate limiting functionality in https://github.com/truenas/middleware/pull/13912, I had no choice but to update this file considerably. As part of this process, I caused a minor regression. The return values are an array and so an equivalency test will fail if the values of the array are out of order between the 2 different sides. Fix this by converting the values to a set (like the test did before I changed it). Passing tests are [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1258/testReport/api2/test_300_nfs/test_45_check_setting_runtime_debug/)