### PR TITLE
NAS-129963 / 24.10 / Remove fail from test runs on network issues

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/directory_service.py
+++ b/src/middlewared/middlewared/test/integration/assets/directory_service.py
@@ -124,12 +124,7 @@ def active_directory(
             # This is definitely unexpected and not recoverable
             fail('Failed to retrieve domain information')
 
-        try:
-            dc_info = call('activedirectory.lookup_dc', domain)
-        except Exception:
-            # This is definitely unexpected and not recoverable
-            fail('Failed to retrieve domain controller information')
-
+        dc_info = call('activedirectory.lookup_dc', domain)
         u = f'{dc_info["Pre-Win2k Domain"]}\\{ADUSERNAME.lower()}'
 
         try:


### PR DESCRIPTION
We should properly clean up after failure in looking up AD domain. While this isn't great because it will report test failures that are external to TrueNAS, we can still get useful info out of test runs.