### PR TITLE
NAS-129972 / 24.10 / fix test_simple_share_validation

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -718,3 +718,9 @@ def test_061_check_smb_configured_sentinel():
 
     assert call('smb.is_configured')
     call('smb.synchronize_passdb', job=True)
+
+
+def test_099_cleanup_share_user():
+    # we have a test that asserts there are no smb accounts created
+    # by the time it runs so clean up this account
+    call('user.delete', UserAssets.ShareUser01['query_response']['id'])


### PR DESCRIPTION
A distant refactor of test_011 caused a regression whereby the `UserAssets.ShareUser01` isn't being cleaned up after the test module runs. This caused an unrelated downstream test to fail (`test_simple_share`) because it asserts that there are 0 SMB share users by the time it runs.

The easiest path forward to fix this is to clean up the aforementioned account in `test_011` as the last step in that module. The link to the passing test is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1304/testReport/api2/)