### PR TITLE
NAS-129973 / 24.10 / More verbosely indicate unexpected test state in SMB simple share test

### DIFF
--- a/tests/api2/test_simple_share.py
+++ b/tests/api2/test_simple_share.py
@@ -14,7 +14,8 @@ PASSWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in r
 
 
 def test__smb_simple_share_validation():
-    assert call('user.query', [['smb', '=', True]], {'count': True}) == 0
+    existing_smb_users = [x['username'] for x in call('user.query', [['smb', '=', True]])]
+    assert len(existing_smb_users) == 0, str(existing_smb_users)
 
     with pytest.raises(ValidationErrors):
         call('sharing.smb.share_precheck')


### PR DESCRIPTION
This SMB test may fail if other tests fail to properly clean up temporary users. We should report the usernames so that it's easier to track down offending tests.