### PR TITLE
NAS-129976 / 24.10 / Fix disk format api test

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info.py
@@ -59,7 +59,7 @@ def get_partition_size_info(disk_name, s_offset, s_size):
     end_sector = total_sectors + start_sector - 1
     # bytes
     start_byte = start_sector * lbs
-    end_byte = end_sector * lbs
+    end_byte = (end_sector * lbs) + lbs - 1
     total_bytes = total_sectors * lbs
 
     return PART_INFO(*(


### PR DESCRIPTION
Back in https://github.com/truenas/middleware/pull/13945, it was found that we were scrambling the start byte in the `pool.expand` method because we didn't consider 4kn formatted drives. After a long road of despair, the root cause of the problem was found but more importantly a solution was implemented. In my haste, I did not update this test (which was already failing) so I've gone ahead and fixed this test while here.

While working on this test, I uncovered a legitimate bug in our `get_partition_size_info()` function and so I've fixed that as well as tested for it here. The passing test is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1321/testReport/api2/test_disk_format/)