### PR TITLE
NAS-129776 / 24.10 / Fix iSCSI ALUA LUN removal issue

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -159,12 +159,16 @@ class iSCSITargetToExtentService(CRUDService):
             # Check that the HA target is no longer offering the LUN that we just deleted.  Wait a short period
             # if necessary (though this should not be required).
             retries = 5
+            lun_removed = False
             iqn = await self.middleware.call('iscsi.target.ha_iqn', target_name)
             while retries:
                 if associated_target['lunid'] not in await self.middleware.call('iscsi.target.iqn_ha_luns', iqn):
+                    lun_removed = True
                     break
                 retries -= 1
                 await asyncio.sleep(1)
+            if not lun_removed:
+                self.logger.warning('Failed to remove lun %r of target %r from internal target', associated_target['lunid'], target_name, exc_info=True)
 
             try:
                 # iscsi.alua.removed_target_extent includes a local service reload

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -168,7 +168,7 @@ class iSCSITargetToExtentService(CRUDService):
                 retries -= 1
                 await asyncio.sleep(1)
             if not lun_removed:
-                self.logger.warning('Failed to remove lun %r of target %r from internal target', associated_target['lunid'], target_name, exc_info=True)
+                self.logger.warning('Failed to remove lun %r from internal target %r', associated_target['lunid'], iqn, exc_info=True)
 
             try:
                 # iscsi.alua.removed_target_extent includes a local service reload

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -2,8 +2,7 @@ import asyncio
 
 import middlewared.sqlalchemy as sa
 from middlewared.schema import Bool, Dict, Int, Patch, accepts
-from middlewared.service import (CallError, CRUDService, ValidationErrors,
-                                 private)
+from middlewared.service import CallError, CRUDService, ValidationErrors, private
 
 
 class iSCSITargetToExtentModel(sa.Model):

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -1,7 +1,9 @@
-import middlewared.sqlalchemy as sa
+import asyncio
 
-from middlewared.schema import accepts, Bool, Dict, Int, Patch
-from middlewared.service import CallError, CRUDService, private, ValidationErrors
+import middlewared.sqlalchemy as sa
+from middlewared.schema import Bool, Dict, Int, Patch, accepts
+from middlewared.service import (CallError, CRUDService, ValidationErrors,
+                                 private)
 
 
 class iSCSITargetToExtentModel(sa.Model):
@@ -141,6 +143,11 @@ class iSCSITargetToExtentService(CRUDService):
             'datastore.delete', self._config.datastore, id_
         )
 
+        # Reload the target, so that the LUN is removed from what is being offered ... including
+        # on the internal target, if this is an ALUA system.
+        await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
+
+        # Next, perform any necessary fixup on the STANDBY system if ALUA is enabled.
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             target_name = (await self.middleware.call('iscsi.target.query',
                                                       [['id', '=', associated_target['target']]],
@@ -148,6 +155,17 @@ class iSCSITargetToExtentService(CRUDService):
             extent_name = (await self.middleware.call('iscsi.extent.query',
                                                       [['id', '=', associated_target['extent']]],
                                                       {'select': ['name'], 'get': True}))['name']
+
+            # Check that the HA target is no longer offering the LUN that we just deleted.  Wait a short period
+            # if necessary (though this should not be required).
+            retries = 5
+            iqn = await self.middleware.call('iscsi.target.ha_iqn', target_name)
+            while retries:
+                if associated_target['lunid'] not in await self.middleware.call('iscsi.target.iqn_ha_luns', iqn):
+                    break
+                retries -= 1
+                await asyncio.sleep(1)
+
             try:
                 # iscsi.alua.removed_target_extent includes a local service reload
                 await self.middleware.call('failover.call_remote', 'iscsi.alua.removed_target_extent', [target_name, associated_target['lunid'], extent_name])
@@ -157,7 +175,6 @@ class iSCSITargetToExtentService(CRUDService):
                     # Better to continue than to raise the exception
                 await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
-        await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
         return result
 

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -7,12 +7,9 @@ import subprocess
 from collections import defaultdict
 
 import middlewared.sqlalchemy as sa
-from middlewared.schema import (Bool, Dict, Int, IPAddr, List, Patch, Str,
-                                accepts)
-from middlewared.service import (CallError, CRUDService, ValidationErrors,
-                                 private)
+from middlewared.schema import Bool, Dict, Int, IPAddr, List, Patch, Str, accepts
+from middlewared.service import CallError, CRUDService, ValidationErrors, private
 from middlewared.utils import UnexpectedFailure, run
-
 from .utils import AUTHMETHOD_LEGACY_MAP
 
 RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -4,13 +4,14 @@ import os
 import pathlib
 import re
 import subprocess
+from collections import defaultdict
 
 import middlewared.sqlalchemy as sa
-
-from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Patch, Str
-from middlewared.service import CallError, CRUDService, private, ValidationErrors
+from middlewared.schema import (Bool, Dict, Int, IPAddr, List, Patch, Str,
+                                accepts)
+from middlewared.service import (CallError, CRUDService, ValidationErrors,
+                                 private)
 from middlewared.utils import UnexpectedFailure, run
-from collections import defaultdict
 
 from .utils import AUTHMETHOD_LEGACY_MAP
 
@@ -789,3 +790,21 @@ class iSCSITargetService(CRUDService):
         for targetname in sys_platform.glob('host*/session*/iscsi_session/session*/targetname'):
             if targetname.read_text().startswith(iqn_prefix):
                 targetname.parent.joinpath(param).write_text(text)
+
+    @private
+    async def ha_iqn(self, name):
+        """Return the IQN of the specified internal target."""
+        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
+        return f'{global_basename}:HA:{name}'
+
+    @private
+    def iqn_ha_luns(self, iqn):
+        """Return a list of (integer) LUNs which are offered by the specified IQN."""
+        result = []
+        try:
+            with os.scandir(f'/sys/kernel/scst_tgt/targets/iscsi/{iqn}/luns') as entries:
+                for entry in filter(lambda x: x.name.isnumeric(), entries):
+                    result.append(int(entry.name))
+        except FileNotFoundError:
+            pass
+        return result

--- a/tests/api2/assets/websocket/iscsi.py
+++ b/tests/api2/assets/websocket/iscsi.py
@@ -1,0 +1,161 @@
+import contextlib
+from time import sleep
+
+from middlewared.test.integration.utils import call
+
+
+@contextlib.contextmanager
+def initiator(comment='Default initiator', initiators=[]):
+    payload = {
+        'comment': comment,
+        'initiators': initiators,
+    }
+    initiator_config = call('iscsi.initiator.create', payload)
+
+    try:
+        yield initiator_config
+    finally:
+        call('iscsi.initiator.delete', initiator_config['id'])
+
+
+@contextlib.contextmanager
+def portal(listen=[{'ip': '0.0.0.0'}], comment='Default portal', discovery_authmethod='NONE'):
+    payload = {
+        'listen': listen,
+        'comment': comment,
+        'discovery_authmethod': discovery_authmethod
+    }
+    portal_config = call('iscsi.portal.create', payload)
+
+    try:
+        yield portal_config
+    finally:
+        call('iscsi.portal.delete', portal_config['id'])
+
+
+@contextlib.contextmanager
+def initiator_portal():
+    with initiator() as initiator_config:
+        with portal() as portal_config:
+            yield {
+                'initiator': initiator_config,
+                'portal': portal_config,
+            }
+
+
+@contextlib.contextmanager
+def alua_enabled(delay=10):
+    payload = {'alua': True}
+    call('iscsi.global.update', payload)
+    if delay:
+        sleep(delay)
+        call('iscsi.alua.wait_for_alua_settled', 5, 8)
+    try:
+        yield
+    finally:
+        payload = {'alua': False}
+        call('iscsi.global.update', payload)
+        if delay:
+            sleep(delay)
+
+
+@contextlib.contextmanager
+def target(target_name, groups, alias=None):
+    payload = {
+        'name': target_name,
+        'groups': groups,
+    }
+    if alias:
+        payload.update({'alias': alias})
+    target_config = call('iscsi.target.create', payload)
+
+    try:
+        yield target_config
+    finally:
+        call('iscsi.target.delete', target_config['id'], True)
+
+
+@contextlib.contextmanager
+def target_extent_associate(target_id, extent_id, lun_id=0):
+    alua_enabled = call('iscsi.global.alua_enabled')
+    payload = {
+        'target': target_id,
+        'lunid': lun_id,
+        'extent': extent_id
+    }
+    associate_config = call('iscsi.targetextent.create', payload)
+    if alua_enabled:
+        # Give a little time for the STANDBY target to surface
+        sleep(2)
+
+    try:
+        yield associate_config
+    finally:
+        call('iscsi.targetextent.delete', associate_config['id'], True)
+    if alua_enabled:
+        sleep(2)
+
+
+def _extract_luns(rl):
+    """
+    Return a list of LUNs.
+
+    :param rl: a ReportLuns instance (response)
+    :return result a list of int LUNIDs
+
+    Currently the results from pyscsi.ReportLuns.unmarshall_datain are (a) subject
+    to change & (b) somewhat lacking for our purposes.  Therefore we will parse
+    the datain here in a manner more useful for us.
+    """
+    result = []
+    # First 4 bytes are LUN LIST LENGTH
+    lun_list_length = int.from_bytes(rl.datain[:4], "big")
+    # Next 4 Bytes are RESERVED
+    # Remaining bytes are LUNS (8 bytes each)
+    luns = rl.datain[8:]
+    assert len(luns) >= lun_list_length
+    for i in range(0, lun_list_length, 8):
+        lun = luns[i: i + 8]
+        addr_method = (lun[0] >> 6) & 0x3
+        assert addr_method == 0, f"Unsupported Address Method: {addr_method}"
+        if addr_method == 0:
+            # peripheral device addressing method, don't care about bus.
+            result.append(lun[1])
+    return result
+
+
+def verify_luns(s, expected_luns):
+    """
+    Verify that the supplied SCSI has the expected LUNs.
+
+    :param s: a pyscsi.SCSI instance
+    :param expected_luns: a list of int LUNIDs
+    """
+    s.testunitready()
+    # REPORT LUNS
+    rl = s.reportluns()
+    data = rl.result
+    assert isinstance(data, dict), data
+    assert 'luns' in data, data
+    # Check that we only have LUN 0
+    luns = _extract_luns(rl)
+    assert len(luns) == len(expected_luns), luns
+    assert set(luns) == set(expected_luns), luns
+
+
+def read_capacity16(s):
+    # READ CAPACITY (16)
+    data = s.readcapacity16().result
+    return (data['returned_lba'] + 1 - data['lowest_aligned_lba']) * data['block_length']
+
+
+def verify_capacity(s, expected_capacity):
+    """
+    Verify that the supplied SCSI has the expected capacity.
+
+    :param s: a pyscsi.SCSI instance
+    :param expected_capacity: an int
+    """
+    s.testunitready()
+    returned_size = read_capacity16(s)
+    assert returned_size == expected_capacity

--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+#
+# test_261_iscsi_cmd contains some general ALUA tests, but this file will contain some
+# more detailed ALUA tests
+import contextlib
+import random
+import string
+from time import sleep
+
+import pytest
+from assets.websocket.iscsi import (alua_enabled, initiator_portal, target,
+                                    target_extent_associate, verify_capacity,
+                                    verify_luns)
+from assets.websocket.service import ensure_service_enabled
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
+
+from auto_config import ha, pool_name
+from protocols import iscsi_scsi_connection
+
+if not ha:
+    pytest.skip("skipping ALUA tests", allow_module_level=True)
+
+
+SERVICE_NAME = 'iscsitarget'
+MB = 1024 * 1024
+
+
+@contextlib.contextmanager
+def zvol(name, volsizeMB):
+    payload = {
+        'name': f'{pool_name}/{name}',
+        'type': 'VOLUME',
+        'volsize': volsizeMB * MB,
+        'volblocksize': '16K'
+    }
+    config = call('pool.dataset.create', payload)
+    try:
+        yield config
+    finally:
+        call('pool.dataset.delete', config['id'])
+
+
+@contextlib.contextmanager
+def zvol_extent(zvol, extent_name):
+    payload = {
+        'type': 'DISK',
+        'disk': f'zvol/{zvol}',
+        'name': extent_name,
+    }
+    config = call('iscsi.extent.create', payload)
+    try:
+        yield config
+    finally:
+        call('iscsi.extent.delete', config['id'], True, True)
+
+
+class TestFixtureConfiguredALUA:
+    """Fixture for with iSCSI enabled and ALUA configured"""
+
+    def wait_for_settle(self, verbose=False):
+        if verbose:
+            print("Checking ALUA status...")
+        retries = 12
+        while retries:
+            if call('iscsi.alua.settled'):
+                if verbose:
+                    print("ALUA is settled")
+                break
+            retries -= 1
+            if verbose:
+                print("Waiting for ALUA to settle")
+            sleep(5)
+
+    @pytest.fixture(scope='class')
+    def alua_configured(self):
+        with ensure_service_enabled(SERVICE_NAME):
+            call('service.start', SERVICE_NAME)
+            with alua_enabled():
+                self.wait_for_settle()
+                with initiator_portal() as config:
+                    yield config
+
+    @contextlib.contextmanager
+    def target_lun(self, target_id, zvol_name, mb, lun):
+        with zvol(zvol_name, mb) as zvol_config:
+            with zvol_extent(zvol_config['id'], zvol_name) as extent_config:
+                with target_extent_associate(target_id, extent_config['id'], lun):
+                    yield
+
+    def verify_luns(self, iqn, lun_size_list):
+        lun_list = [lun for lun, _ in lun_size_list]
+        for lun, mb in lun_size_list:
+            # Node A
+            with iscsi_scsi_connection(truenas_server.nodea_ip, iqn, lun) as s:
+                verify_luns(s, lun_list)
+                verify_capacity(s, mb * MB)
+            # Node B
+            with iscsi_scsi_connection(truenas_server.nodeb_ip, iqn) as s:
+                verify_luns(s, lun_list)
+                verify_capacity(s, 100 * MB)
+
+    def test_alua_luns(self, alua_configured):
+        """Test whether an ALUA target reacts correctly to having a LUN added
+        and removed again (in terms of REPORT LUNS response)"""
+        config = alua_configured
+        portal_id = config['portal']['id']
+        digits = ''.join(random.choices(string.digits, k=4))
+        target_name = f"target{digits}"
+        iqn = f'iqn.2005-10.org.freenas.ctl:{target_name}'
+        with target(target_name, [{'portal': portal_id}]) as target_config:
+            target_id = target_config['id']
+            # First configure a single extent at LUN 0 and ensure that we
+            # can see it from both interfaces.
+            with self.target_lun(target_id, f'extent0_{digits}', 100, 0):
+                sleep(2)
+                self.wait_for_settle()
+                self.verify_luns(iqn, [(0, 100)])
+
+                # Next add a 2nd extent at LUN 1 and ensure that we can see both LUNs
+                # from both interfaces.
+                with self.target_lun(target_id, f'extent1_{digits}', 200, 1):
+                    sleep(2)
+                    self.wait_for_settle()
+                    self.verify_luns(iqn, [(0, 100), (1, 200)])
+
+                # After the LUN 1 extent has been removed again, ensure that we cannot see it
+                # any longer.
+                sleep(2)
+                self.wait_for_settle()
+                self.verify_luns(iqn, [(0, 100)])
+
+                # Next add back a 2nd extent at LUN 1 (with a different size) and ensure
+                # that we can still see both LUNs from both interfaces.
+                with self.target_lun(target_id, f'extent1_{digits}', 250, 1):
+                    sleep(2)
+                    self.wait_for_settle()
+                    self.verify_luns(iqn, [(0, 100), (1, 250)])
+                    # Add a third LUN
+                    with self.target_lun(target_id, f'extent2_{digits}', 300, 2):
+                        sleep(2)
+                        self.wait_for_settle()
+                        self.verify_luns(iqn, [(0, 100), (1, 250), (2, 300)])
+                    sleep(2)
+                    self.wait_for_settle()
+                    self.verify_luns(iqn, [(0, 100), (1, 250)])
+                sleep(2)
+                self.wait_for_settle()
+                self.verify_luns(iqn, [(0, 100)])

--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -96,9 +96,9 @@ class TestFixtureConfiguredALUA:
                 verify_luns(s, lun_list)
                 verify_capacity(s, mb * MB)
             # Node B
-            with iscsi_scsi_connection(truenas_server.nodeb_ip, iqn) as s:
+            with iscsi_scsi_connection(truenas_server.nodeb_ip, iqn, lun) as s:
                 verify_luns(s, lun_list)
-                verify_capacity(s, 100 * MB)
+                verify_capacity(s, mb * MB)
 
     def test_alua_luns(self, alua_configured):
         """Test whether an ALUA target reacts correctly to having a LUN added

--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -18,9 +18,7 @@ from middlewared.test.integration.utils.client import truenas_server
 from auto_config import ha, pool_name
 from protocols import iscsi_scsi_connection
 
-if not ha:
-    pytest.skip("skipping ALUA tests", allow_module_level=True)
-
+pytestmark = pytest.mark.skipif(not ha, reason='Tests applicable to HA only')
 
 SERVICE_NAME = 'iscsitarget'
 MB = 1024 * 1024


### PR DESCRIPTION
When a LUN is removed from an ALUA target, we were already calling `iscsi.alua.removed_target_extent` to perform some fixup.  However, because this was being called on the STANDBY **before** the MASTER node was updated the LUN was still available and logged into by the STANDBY node.  Simply reordering _avoids_ the issue.

(For robustness, this PR also adds a check/delay to ensure that the LUN is removed from the MASTER before `removed_target_extent` is called on the STANDBY.)

Add CI tests to check proper operation wrt adding and removing LUNs from an existing ALUA target.  Separated these tests out into a new file (_test_262_iscsi_alua.py_) and structured to ease adding additional ALUA tests (e.g. to `TestFixtureConfiguredALUA`)

Passing CI test [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1327/).