### PR TITLE
Fix login banner

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -592,7 +592,7 @@ class AuthService(Service):
 
         return {**user, 'attributes': attributes, 'two_factor_config': twofactor_config}
 
-    @no_authz_required
+    @no_auth_required
     @accepts(
         Str('key'),
         Any('value'),


### PR DESCRIPTION
The login_banner endpoint needs to be accessible, authenticated or not.