### PR TITLE
fix pool.expand tests

### DIFF
--- a/tests/api2/test_pool_expand.py
+++ b/tests/api2/test_pool_expand.py
@@ -1,5 +1,16 @@
+import time
+
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, ssh
+
+
+def retry_get_parts_on_disk(disk, max_tries=10):
+    for i in range(max_tries):
+        if parts := call('disk.list_partitions', disk):
+            return parts
+        time.sleep(1)
+    else:
+        assert False, f'Failed after {max_tries} seconds for partition info on {disk!r}'
 
 
 def test_expand_pool():
@@ -13,14 +24,13 @@ def test_expand_pool():
         ssh(f"zpool export {pool['name']}")
         ssh(f"sgdisk -d 1 /dev/{disk}")
         ssh(f"sgdisk -n 1:0:+2GiB -t 1:BF01 /dev/{disk}")
-        small_partition = call("disk.list_partitions", disk)[-1]
+        small_partition = retry_get_parts_on_disk(disk)[-1]
         assert small_partition["size"] < 2147483648 * 1.01
         device = "disk/by-partuuid/" + small_partition["partition_uuid"]
         ssh(f"zpool create {pool['name']} -o altroot=/mnt -f {device}")
         # Ensure that the pool size is small now
         assert call("pool.get_instance", pool["id"])["size"] < 2147483648 * 1.01
         ssh(f"touch /mnt/{pool['name']}/test")
-
         call("pool.expand", pool["id"], job=True)
 
         new_partition = call("disk.list_partitions", disk)[-1]
@@ -34,13 +44,10 @@ def test_expand_pool():
 
 def test_expand_partition_keeps_initial_offset():
     disk = call("disk.get_unused")[0]["name"]
-
     call("disk.wipe", disk, "QUICK", job=True)
     ssh(f"sgdisk -n 0:8192:1GiB /dev/{disk}")
-    partition = call("disk.list_partitions", disk)[0]
-
+    partition = retry_get_parts_on_disk(disk)[0]
     call("pool.expand_partition", partition)
-
-    expanded_partition = call("disk.list_partitions", disk)[0]
+    expanded_partition = retry_get_parts_on_disk(disk)[0]
     assert expanded_partition["size"] > partition["size"]
     assert expanded_partition["start"] == partition["start"]


### PR DESCRIPTION
These are failing because there is a race between when we're shell'ing out to `sgdisk` and reading the partitions via our API. Adds a simple `retry_get_parts_on_disk` function that checks for partitions on disks. The link for passing tests are [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1339/testReport/api2/test_pool_expand/)