### PR TITLE
NAS-129908 / 24.10 / Unset syslog certs if tls transport is not being used

### DIFF
--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -168,6 +168,8 @@ class SystemAdvancedService(ConfigService):
                     'certificate.cert_services_validation', data['syslog_tls_certificate'],
                     f'{schema}.syslog_tls_certificate', False
                 ))
+        elif data['syslog_tls_certificate_authority'] or data['syslog_tls_certificate']:
+            data['syslog_tls_certificate_authority'] = data['syslog_tls_certificate'] = None
 
         for invalid_char in ('\n', '"'):
             if invalid_char in data['kernel_extra_options']:


### PR DESCRIPTION
## Problem
When users switch from system advanced TLS settings to UDP/TCP, they are unable to delete the certificate and certificate authority (CA) that were previously used by TLS settings. This occurs because the certificates still exist in the system advanced syslog settings. As a result, the middleware still sees those certificates as being used by the syslog.

## Solution
Set the certificate and CA to null if TLS is not configured in the system advanced syslog settings.