### PR TITLE
NAS-129999 / 24.10 / Fix login banner perms

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -592,7 +592,7 @@ class AuthService(Service):
 
         return {**user, 'attributes': attributes, 'two_factor_config': twofactor_config}
 
-    @no_auth_required
+    @no_authz_required
     @accepts(
         Str('key'),
         Any('value'),

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import middlewared.sqlalchemy as sa
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Patch, Password, returns, Str
-from middlewared.service import ConfigService, private, no_authz_required, ValidationErrors
+from middlewared.service import ConfigService, private, no_auth_required, ValidationErrors
 from middlewared.validators import Range
 from middlewared.utils import run
 
@@ -318,7 +318,7 @@ class SystemAdvancedService(ConfigService):
         ))['sed_passwd']
         return passwd if passwd else await self.middleware.call('kmip.sed_global_password')
 
-    @no_authz_required
+    @no_auth_required
     @accepts()
     @returns(Str())
     def login_banner(self):


### PR DESCRIPTION
Our login banner endpoint needs to be accessible to unauthenticated users

This also fixes an issue from yesterday where I somehow changed the wrong endpoint, I don't know how that happened but I caught it