### PR TITLE
NAS-130001 / 24.10 / Catch exception thrown by ftp QUIT.

### DIFF
--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -3,7 +3,7 @@ import copy
 import json
 import os
 import subprocess
-from ftplib import all_errors
+from ftplib import all_errors, error_temp
 from time import sleep
 from timeit import default_timer as timer
 from types import SimpleNamespace
@@ -1154,7 +1154,10 @@ def test_070_resume_xfer(request, ftpConf, expect_to_pass):
             ftpObj.login()
             upload_partial(ftpObj, localfname, remotefname, 768)
             # Quit to simulate loss of connection
-            ftpObj.quit()
+            try:
+                ftpObj.quit()
+            except error_temp:
+                pass
             ftpObj = None
             sleep(1)
 
@@ -1178,7 +1181,10 @@ def test_070_resume_xfer(request, ftpConf, expect_to_pass):
             processing = "download"
             download_partial(ftpObj, remotefname, localfname, 768)
             # Quit to simulate loss of connection
-            ftpObj.quit()
+            try:
+                ftpObj.quit()
+            except error_temp:
+                pass
             ftpObj = None
             sleep(1)
 
@@ -1197,7 +1203,10 @@ def test_070_resume_xfer(request, ftpConf, expect_to_pass):
             assert results['result'] is True, results
             assert remotesize == localsize
             assert remote_chksum == local_chksum
-            ftpObj.quit()
+            try:
+                ftpObj.quit()
+            except error_temp:
+                pass
 
         except all_errors as e:
             assert not expect_to_pass, f"Unexpected failure in resumed {processing} test: {e}"


### PR DESCRIPTION
Previously the `test_070_resume_xfer` test was failing _**every**_ time with:
```
                processing = "download"
                download_partial(ftpObj, remotefname, localfname, 768)
                # Quit to simulate loss of connection
>               ftpObj.quit()

api2/test_200_ftp.py:1181: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.11/ftplib.py:659: in quit
    resp = self.voidcmd('QUIT')
/usr/lib/python3.11/ftplib.py:286: in voidcmd
    return self.voidresp()
/usr/lib/python3.11/ftplib.py:259: in voidresp
    resp = self.getresp()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ftplib.FTP object at 0x7fadb211af50>

    def getresp(self):
        resp = self.getmultiline()
        if self.debugging:
            print('*resp*', self.sanitize(resp))
        self.lastresp = resp[:3]
        c = resp[:1]
        if c in {'1', '2', '3'}:
            return resp
        if c == '4':
>           raise error_temp(resp)
E           ftplib.error_temp: 426 Transfer aborted. Data connection closed
```
Rectify by swallowing the exceptions generated during a QUIT operation.  That's unrelated to what we're trying to test.

----
Shortened passing CI test is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1377/).