### PR TITLE
NAS-130014 / 24.10 / Fix regression in restrict admin account query

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -117,14 +117,12 @@ class DSCache(Service):
                         return None
 
                 self._insert(data['idtype'], entry)
-                entry['nt_name'] = entry[name_key]
             except KeyError:
                 entry = None
 
         if entry and not options['smb']:
             # caller has not requested SMB information and so we should strip it
             entry['sid'] = None
-            entry['nt_name'] = None
 
         if entry is not None:
             entry['roles'] = []
@@ -173,7 +171,6 @@ class DSCache(Service):
         if not get_smb:
             for entry in entries:
                 entry['sid'] = None
-                entry['nt_name'] = None
 
         return sorted(entries, key=lambda i: i['id'])
 


### PR DESCRIPTION
An area where nt_name was being added to cache query results was missed when user and group entries were being simplified, which caused the schema dump for restricted users to fail due to extra entry. This was not caught during testing due to AD restricted admin tests being skipped, but regression was caught by normal full CI runs.