### PR TITLE
NAS-130015 / 24.10 / Fix failing SMB CI tests

### DIFF
--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -25,6 +25,7 @@ from utils import create_dataset
 SMB_USER = "smbacluser"
 SMB_PWD = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10))
 TEST_DATA = {}
+OWNER_RIGHTS_SID = 'S-1-3-4'
 
 
 permset = {
@@ -194,9 +195,9 @@ def test_005_test_map_modify(request):
 def test_006_test_preserve_dynamic_id_mapping(request):
     depends(request, ["SMB_SERVICE_STARTED"], scope="session")
 
-    def _find_owner_rights(acl):
+    def _find_owner_rights(acl, owner_rights_id):
         for entry in acl:
-            if 'owner rights' in entry['who']:
+            if entry['id'] == owner_rights_id:
                 return True
 
         return False
@@ -219,10 +220,18 @@ def test_006_test_preserve_dynamic_id_mapping(request):
             res = subprocess.run(cmd, capture_output=True)
             assert res.returncode == 0, res.stderr.decode() or res.stdout.decode()
 
+            # Since winbindd is by default not in nsswitch when we're standalone
+            # the GID won't resolve to name
+            res = call('idmap.convert_sids', [OWNER_RIGHTS_SID])
+            assert OWNER_RIGHTS_SID in res['mapped']
+            assert res['mapped'][OWNER_RIGHTS_SID]['id_type'] == 'GROUP'
+            assert res['mapped'][OWNER_RIGHTS_SID]['name'].endswith('Owner Rights')
+            owner_rights_id = res['mapped'][OWNER_RIGHTS_SID]['id']
+
             # verify "owner rights" entry is present
             # verify "owner rights" entry is still present
             the_acl = call('filesystem.getacl', path, False, True)['acl']
-            has_owner_rights = _find_owner_rights(the_acl)
+            has_owner_rights = _find_owner_rights(the_acl, owner_rights_id)
             assert has_owner_rights is True, str(the_acl)
 
             # force re-sync of group mapping database (and winbindd_idmap.tdb)
@@ -230,7 +239,7 @@ def test_006_test_preserve_dynamic_id_mapping(request):
 
             # verify "owner rights" entry is still present
             the_acl = call('filesystem.getacl', path, False, True)['acl']
-            has_owner_rights = _find_owner_rights(the_acl)
+            has_owner_rights = _find_owner_rights(the_acl, owner_rights_id)
             assert has_owner_rights is True, str(the_acl)
 
 

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -2,7 +2,6 @@ import contextlib
 import os
 import pytest
 
-from pytest_dependency import depends
 from middlewared.service_exception import ValidationError
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.assets.smb import smb_share
@@ -61,14 +60,13 @@ SAMPLE_OPTIONS = [
     'streams_xattr:store_stream_type=no',
     'strict locking=auto',
     '# oplocks=no  # breaks Time Machine',
-    ' level2 oplocks=no  #  breaks TM?',
+    ' level2 oplocks=no',
     '# spotlight=yes  # invalid without further config'
 ]
 
 
 @contextlib.contextmanager
-def create_smb_share(share_name, mkdir=False, options=None):
-    path = os.path.join(smb_registry_mp, share_name)
+def create_smb_share(path, share_name, mkdir=False, options=None):
     cr_opts = options or {}
 
     if mkdir:
@@ -80,7 +78,6 @@ def create_smb_share(share_name, mkdir=False, options=None):
 
 @contextlib.contextmanager
 def setup_smb_shares(mountpoint):
-    global SHARE_DICT
     SHARE_DICT = {}
 
     for share in SHARES:
@@ -102,9 +99,7 @@ def setup_smb_shares(mountpoint):
 
 
 @pytest.fixture(scope='module')
-def setup_for_tests(request):
-    global smb_registry_mp
-
+def setup_for_tests():
     with dataset(DATASET_NAME, data={'share_type': 'SMB'}) as ds:
         smb_registry_mp = os.path.join('/mnt', ds)
         call('filesystem.setperm', {
@@ -114,31 +109,35 @@ def setup_for_tests(request):
         }, job=True)
 
         with setup_smb_shares(smb_registry_mp) as shares:
-            yield (ds, shares)
+            yield (smb_registry_mp, ds, shares)
 
 
-@pytest.mark.dependency(name="SHARES_CREATED")
-def test_001_setup_for_tests(setup_for_tests):
+@pytest.fixture(scope='module')
+def share_presets():
+    yield call('sharing.smb.presets')
+
+
+def test__setup_for_tests(setup_for_tests):
     reg_shares = call('sharing.smb.reg_listshares')
     for share in SHARES:
         assert share in reg_shares
 
 
 @pytest.mark.parametrize('smb_share', SHARES)
-def test_006_rename_shares(request, smb_share):
-    depends(request, ["SHARES_CREATED"], scope="session")
+def test__rename_shares(setup_for_tests, smb_share):
+    mp, ds, SHARE_DICT = setup_for_tests
+
     call('sharing.smb.update', SHARE_DICT[smb_share], {
         'name': f'NEW_{smb_share}'
     })
 
 
-def test_007_renamed_shares_in_registry(request):
+def test__renamed_shares_in_registry(setup_for_tests):
     """
     Share renames need to be explicitly tested because
     it will actually result in share being removed from
     registry and re-added with different name.
     """
-    depends(request, ["SHARES_CREATED"], scope="session")
     reg_shares = call('sharing.smb.reg_listshares')
     for share in SHARES:
         assert f'NEW_{share}' in reg_shares
@@ -146,16 +145,23 @@ def test_007_renamed_shares_in_registry(request):
     assert len(reg_shares) == len(SHARES)
 
 
-def check_aux_param(param, share, expected):
+def check_aux_param(param, share, expected, fruit_enable=False):
     val = call('smb.getparm', param, share)
     if param == 'vfs objects':
-        assert set(expected.split()) == set(val)
+        expected_vfs_objects = expected.split()
+        # We have to override someone's poor life choices and insert
+        # vfs_fruit so that they don't have mysteriously broken time
+        # machine shares
+        if fruit_enable:
+            expected_vfs_objects.append('fruit')
+
+        assert set(expected_vfs_objects) == set(val)
     else:
         assert val == expected
 
 
 @pytest.mark.parametrize('preset', PRESETS)
-def test_008_test_presets(request, preset):
+def test__test_presets(setup_for_tests, share_presets, preset):
     """
     This test iterates through SMB share presets,
     applies them to a single share, and then validates
@@ -168,15 +174,11 @@ def test_008_test_presets(request, preset):
     be reflected in returned auxsmbconf and so we'll need
     to directly reach out and run smb.getparm.
     """
-    depends(request, ["SHARES_CREATED"], scope="session")
-    global DETECTED_PRESETS
-    if not DETECTED_PRESETS:
-        DETECTED_PRESETS = call('sharing.smb.presets')
-
+    mp, ds, SHARE_DICT = setup_for_tests
     if 'TIMEMACHINE' in preset:
         call('smb.update', {'aapl_extensions': True})
 
-    to_test = DETECTED_PRESETS[preset]['params']
+    to_test = share_presets[preset]['params']
     to_test_aux = to_test['auxsmbconf']
     new_conf = call('sharing.smb.update', SHARE_DICT['REGISTRYTEST_0'], {
         'purpose': preset
@@ -191,12 +193,12 @@ def test_008_test_presets(request, preset):
         assert to_test[k] == new_conf[k]
 
 
-def test_009_reset_smb(request):
+def test__reset_smb(setup_for_tests):
     """
     Remove all parameters that might turn us into
     a MacOS-style SMB server (fruit).
     """
-    depends(request, ["SHARES_CREATED"])
+    mp, ds, SHARE_DICT = setup_for_tests
     call('sharing.smb.update', SHARE_DICT['REGISTRYTEST_0'], {
         "purpose": "NO_PRESET",
         "timemachine": False
@@ -204,8 +206,8 @@ def test_009_reset_smb(request):
     call('smb.update', {'aapl_extensions': False})
 
 
-def test_010_test_aux_param_on_update(request):
-    depends(request, ["SHARES_CREATED"], scope="session")
+def test__test_aux_param_on_update(setup_for_tests):
+    SHARE_DICT = setup_for_tests[2]
     share_id = SHARE_DICT['REGISTRYTEST_0']
     share = call('sharing.smb.query', [['id', '=', share_id]], {'get': True})
 
@@ -266,22 +268,22 @@ def setup_aapl_extensions(newvalue):
 
 
 @pytest.fixture(scope='function')
-def setup_tm_share(request):
+def setup_tm_share(setup_for_tests):
+    share_name = 'AUX_CREATE'
+    path = os.path.join(setup_for_tests[0], share_name)
     with setup_aapl_extensions(True):
-        with create_smb_share('AUX_CREATE', True, {
+        with create_smb_share(path, share_name, True, {
             "home": False,
             "purpose": "ENHANCED_TIMEMACHINE",
             "auxsmbconf": '\n'.join(SAMPLE_AUX)
         }) as s:
-            yield (request, s)
+            yield s
 
 
-def test_011_test_aux_param_on_create(setup_tm_share):
-    request, share = setup_tm_share
-    depends(request, ["SHARES_CREATED"], scope="session")
-
+def test__test_aux_param_on_create(share_presets, setup_tm_share):
+    share = setup_tm_share
     new_aux = share['auxsmbconf']
-    pre_aux = DETECTED_PRESETS["ENHANCED_TIMEMACHINE"]["params"]["auxsmbconf"]
+    pre_aux = share_presets["ENHANCED_TIMEMACHINE"]["params"]["auxsmbconf"]
     ncomments_sent = 0
     ncomments_recv = 0
 
@@ -306,7 +308,7 @@ def test_011_test_aux_param_on_create(setup_tm_share):
             continue
 
         aux, val = entry.split('=', 1)
-        check_aux_param(aux.strip(), share['name'], val.strip())
+        check_aux_param(aux.strip(), share['name'], val.strip(), True)
 
     """
     Verify comments aren't being stripped on update
@@ -318,8 +320,8 @@ def test_011_test_aux_param_on_create(setup_tm_share):
     assert ncomments_sent == ncomments_recv, f'new: {new_aux}, sample: {SAMPLE_AUX}'
 
 
-def test_012_delete_shares(request):
-    depends(request, ["SHARES_CREATED"])
+def test__delete_shares(setup_for_tests):
+    SHARE_DICT = setup_for_tests[2]
     for key in list(SHARE_DICT.keys()):
         call('sharing.smb.delete', SHARE_DICT[key])
         SHARE_DICT.pop(key)
@@ -337,40 +339,38 @@ with regard to homes shares
 """
 
 
-@pytest.mark.dependency(name="HOME_SHARE_CREATED")
-def test_015_create_homes_share(request):
-    depends(request, ["SHARES_CREATED"])
-
-    HOME_PATH = os.path.join(smb_registry_mp, 'HOME_SHARE')
-    call('filesystem.mkdir', HOME_PATH)
+def test__create_homes_share(setup_for_tests):
+    mp, ds, share_dict = setup_for_tests
+    home_path = os.path.join(mp, 'HOME_SHARE')
+    call('filesystem.mkdir', home_path)
 
     new_share = call('sharing.smb.create', {
         "comment": "My Test SMB Share",
-        "path": HOME_PATH,
+        "path": home_path,
         "home": True,
         "purpose": "NO_PRESET",
         "name": 'HOME_SHARE',
     })
-    SHARE_DICT['HOME'] = new_share['id']
+    share_dict['HOME'] = new_share['id']
 
     reg_shares = call('sharing.smb.reg_listshares')
     assert any(['homes'.casefold() == s.casefold() for s in reg_shares]), str(reg_shares)
 
 
-def test_017_toggle_homes_share(request):
-    depends(request, ["HOME_SHARE_CREATED"])
+def test__toggle_homes_share(setup_for_tests):
+    mp, ds, share_dict = setup_for_tests
     try:
-        call('sharing.smb.update', SHARE_DICT['HOME'], {'home': False})
+        call('sharing.smb.update', share_dict['HOME'], {'home': False})
         reg_shares = call('sharing.smb.reg_listshares')
         assert not any(['homes'.casefold() == s.casefold() for s in reg_shares]), str(reg_shares)
     finally:
-        call('sharing.smb.update', SHARE_DICT['HOME'], {'home': True})
+        call('sharing.smb.update', share_dict['HOME'], {'home': True})
 
     reg_shares = call('sharing.smb.reg_listshares')
     assert any(['homes'.casefold() == s.casefold() for s in reg_shares]), str(reg_shares)
 
 
-def test_022_registry_rebuild_homes(request):
+def test__registry_rebuild_homes(setup_for_tests):
     """
     Abusive test.
     In this test we run behind middleware's back and
@@ -379,14 +379,13 @@ def test_022_registry_rebuild_homes(request):
     method is called (among other places) when the CIFS
     service reloads.
     """
-    depends(request, ["HOME_SHARE_CREATED"], scope="session")
     ssh('net conf delshare HOMES')
     call('service.reload', 'cifs')
     reg_shares = call('sharing.smb.reg_listshares')
     assert any(['homes'.casefold() == s.casefold() for s in reg_shares]), str(reg_shares)
 
 
-def test_023_test_smb_options():
+def test__test_smb_options():
     """
     Validate that user comments are preserved as-is
     """
@@ -394,18 +393,18 @@ def test_023_test_smb_options():
     assert new_config['smb_options'].splitlines() == SAMPLE_OPTIONS
 
 
-def test_024_test_invalid_share_aux_param_create():
+def test__test_invalid_share_aux_param_create(setup_for_tests):
     init_share_count = call('sharing.smb.query', [], {'count': True})
     with pytest.raises(ValidationError) as ve:
-        call('sharing.smb.create', {'name': 'FAIL', 'path': smb_registry_mp, 'auxsmbconf': 'oplocks = canary'})
+        call('sharing.smb.create', {'name': 'FAIL', 'path': setup_for_tests[0], 'auxsmbconf': 'oplocks = canary'})
 
     assert ve.value.attribute == 'sharingsmb_create.auxsmbconf'
 
     assert init_share_count == call('sharing.smb.query', [], {'count': True})
 
 
-def test_025_test_invalid_share_aux_param_update():
-    this_share = call('sharing.smb.create', {'name': 'FAIL', 'path': smb_registry_mp})
+def test__test_invalid_share_aux_param_update(setup_for_tests):
+    this_share = call('sharing.smb.create', {'name': 'FAIL', 'path': setup_for_tests[0]})
 
     try:
         with pytest.raises(ValidationError) as ve:


### PR DESCRIPTION
This commit cleans up some of the SMB CI tests and fixes a few issues:

* Rapid restarts of SMB service was hitting systemd service restart limit causing spurious test failures

* Dynamic generation of nsswitch.conf means that Owner Rights group will resolve via NSS and so the ACL inheritance test needs to use gid instead of name

* Convert a lot of test cases to use pytest fixtures to properly manage test state.

* Fix a few tests related to auxiliary parameters.