### PR TITLE
NAS-130018 / 24.10 / Fix access issue for SMB quotas for local admins

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -108,7 +108,7 @@ class SMBService(Service):
         # Samba has special behavior if DomainRid.USERS is set for local domain
         # and so we map the builtin_users account to a normal sid then make it
         # a member of S-1-5-32-545
-        users = [groupmap['local'][SMBBuiltin.USERS]['sid']]
+        users = [groupmap['local'][SMBBuiltin.USERS.rid]['sid']]
 
         if (admin_group := self.middleware.call_sync('smb.config')['admin_group']):
             if (found := self.middleware.call_sync('group.query', [('group', '=', admin_group)])):

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -96,7 +96,7 @@ class SMBService(Service):
                 members=(SMBBuiltin.GUESTS.sid,)
             ),
             SMBGroupMembership(
-                sid=groupmap['local'][545]['sid'],
+                sid=groupmap['local'][SMBBuiltin.USERS.rid]['sid'],
                 members=(SMBBuiltin.USERS.sid,)
             ),
         ]
@@ -108,7 +108,7 @@ class SMBService(Service):
         # Samba has special behavior if DomainRid.USERS is set for local domain
         # and so we map the builtin_users account to a normal sid then make it
         # a member of S-1-5-32-545
-        users = [groupmap['local'][545]['sid']]
+        users = [groupmap['local'][SMBBuiltin.USERS]['sid']]
 
         if (admin_group := self.middleware.call_sync('smb.config')['admin_group']):
             if (found := self.middleware.call_sync('group.query', [('group', '=', admin_group)])):
@@ -158,7 +158,7 @@ class SMBService(Service):
                 '%s: unexpected account present in group mapping configuration for groups '
                 'with the following sid %s. This grants the account privileges beyond what '
                 'would normally be granted by the backend in TrueNAS potentially indicating '
-                'an underlying security issue with. This mapping entry will be automatically '
+                'an underlying security issue. This mapping entry will be automatically '
                 'removed to restore the TrueNAS to its expected configuration.',
                 entry['sid'], entry['members']
             )

--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -89,15 +89,15 @@ class SMBService(Service):
         entries = [
             SMBGroupMembership(
                 sid=f'{localsid}-{DomainRid.ADMINS}',
-                members=(SMBBuiltin.ADMINISTRATORS.sid,)
+                groups=(SMBBuiltin.ADMINISTRATORS.sid,)
             ),
             SMBGroupMembership(
                 sid=f'{localsid}-{DomainRid.GUESTS}',
-                members=(SMBBuiltin.GUESTS.sid,)
+                groups=(SMBBuiltin.GUESTS.sid,)
             ),
             SMBGroupMembership(
                 sid=groupmap['local'][SMBBuiltin.USERS.rid]['sid'],
-                members=(SMBBuiltin.USERS.sid,)
+                groups=(SMBBuiltin.USERS.sid,)
             ),
         ]
 
@@ -114,7 +114,7 @@ class SMBService(Service):
             if (found := self.middleware.call_sync('group.query', [('group', '=', admin_group)])):
                 entries.append(SMBGroupMembership(
                     sid=found[0]['sid'],
-                    members=(SMBBuiltin.ADMINISTRATORS.sid,)
+                    groups=(SMBBuiltin.ADMINISTRATORS.sid,)
                 ))
                 admins.append(found[0]['sid'])
             else:
@@ -129,17 +129,17 @@ class SMBService(Service):
                 # add domain account SIDS
                 entries.append((SMBGroupMembership(
                     sid=f'{domain_sid}-{DomainRid.ADMINS}',
-                    members=(SMBBuiltin.ADMINISTRATORS.sid,)
+                    groups=(SMBBuiltin.ADMINISTRATORS.sid,)
                 )))
                 admins.append(f'{domain_sid}-{DomainRid.ADMINS}')
                 entries.append((SMBGroupMembership(
                     sid=f'{domain_sid}-{DomainRid.USERS}',
-                    members=(SMBBuiltin.USERS.sid,)
+                    groups=(SMBBuiltin.USERS.sid,)
                 )))
                 users.append(f'{domain_sid}-{DomainRid.USERS}')
                 entries.append((SMBGroupMembership(
                     sid=f'{domain_sid}-{DomainRid.GUESTS}',
-                    members=(SMBBuiltin.GUESTS.sid,)
+                    groups=(SMBBuiltin.GUESTS.sid,)
                 )))
                 guests.append(f'{domain_sid}-{DomainRid.GUESTS}')
             except Exception:
@@ -156,11 +156,11 @@ class SMBService(Service):
         for entry in unexpected_memberof_entries:
             self.logger.error(
                 '%s: unexpected account present in group mapping configuration for groups '
-                'with the following sid %s. This grants the account privileges beyond what '
+                'with the following sids %s. This grants the account privileges beyond what '
                 'would normally be granted by the backend in TrueNAS potentially indicating '
                 'an underlying security issue. This mapping entry will be automatically '
-                'removed to restore the TrueNAS to its expected configuration.',
-                entry['sid'], entry['members']
+                'removed to restore TrueNAS to its expected configuration.',
+                entry['sid'], entry['groups']
             )
 
             try:

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -181,7 +181,7 @@ def delete_groupmap_entry(
         hdl.delete(tdb_key)
 
 
-def list_foreign_group_memberships(
+def foreign_group_memberships(
     groupmap_file: GroupmapFile,
     entry_sid: str
 ) -> SMBGroupMembership:
@@ -192,3 +192,18 @@ def list_foreign_group_memberships(
         tdb_key = f'{MEMBEROF_PREFIX}{entry_sid}'
         tdb_val = hdl.get(tdb_key)
         return _parse_memberof(tdb_key, tdb_val)
+
+
+def list_foreign_group_memberships(
+    groupmap_file: GroupmapFile,
+    alias_sid: str
+) -> list[str]:
+    if not isinstance(groupmap_file, GroupmapFile):
+        raise TypeError(f'{type(groupmap_file)}: expected GroupmapFile type.')
+
+    return [
+        entry['sid'] for entry in query_groupmap_entries(groupmap_file, [
+            ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
+            ['members', 'rin', alias_sid]
+        ], {})
+    ]

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -142,8 +142,8 @@ def _parse_memberof(tdb_key: str, tdb_val: str) -> SMBGroupMembership:
     specified in the TDB key is a member of.
 
     Returns SMBGroupMembership object in which the `sid` attribute is set
-    based on the TDB key and the `members` attribute is a tuple of the sids
-    specified in TDB value.
+    based on the TDB key and the `groups` attribute is a tuple of the sids
+    specified in TDB value (groups of which _this_ sid is a member of).
     """
     sid = tdb_key[len(MEMBEROF_PREFIX):]
     data = b64decode(tdb_val)

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -96,7 +96,7 @@ class SMBGroupMap:
 @dataclass(frozen=True)
 class SMBGroupMembership:
     sid: str
-    members: tuple[str]
+    groups: tuple[str]
 
 
 def _parse_unixgroup(tdb_key: str, tdb_val: str) -> SMBGroupMap:
@@ -148,8 +148,8 @@ def _parse_memberof(tdb_key: str, tdb_val: str) -> SMBGroupMembership:
     sid = tdb_key[len(MEMBEROF_PREFIX):]
     data = b64decode(tdb_val)
 
-    members = tuple(data[:-1].decode().split())
-    return SMBGroupMembership(sid, members)
+    groups = tuple(data[:-1].decode().split())
+    return SMBGroupMembership(sid, groups)
 
 
 def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, str]:
@@ -167,7 +167,7 @@ def _groupmap_to_tdb_key_val(group_map: SMBGroupMap) -> tuple[str, str]:
 def _groupmem_to_tdb_key_val(group_mem: SMBGroupMembership) -> tuple[str, str]:
     """ convert a SMBGroupMembership object to TDB key-value pair for insertion into TDB file """
     tdb_key = f'{MEMBEROF_PREFIX}{group_mem.sid}'
-    data = ' '.join(set(group_mem.members)).encode() + b'\x00'
+    data = ' '.join(set(group_mem.groups)).encode() + b'\x00'
     return (tdb_key, b64encode(data))
 
 
@@ -279,6 +279,6 @@ def list_foreign_group_memberships(
     return [
         entry['sid'] for entry in query_groupmap_entries(groupmap_file, [
             ['entry_type', '=', GroupmapEntryType.MEMBERSHIP.name],
-            ['members', 'rin', alias_sid]
+            ['groups', 'rin', alias_sid]
         ], {})
     ]

--- a/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_groupmap.py
@@ -107,7 +107,7 @@ def _parse_unixgroup(tdb_key: str, tdb_val: str) -> SMBGroupMap:
     "UNIXGROUP/S-1-5-21-1137207236-3870220311-645177593-200042\00"
 
     Sample TDB value:
-    "\B8\03\00\00\04\00\00\00truenas_sharing_administrators\00\00"
+    "\\B8\03\00\00\04\00\00\00truenas_sharing_administrators\00\00"
 
     first four bytes are gid, second four are sid type,
     remainder are two null-terminated strings.


### PR DESCRIPTION
The SID check for user being member of BUILTIN\Administrators was failing due to a regression introduced by removing subprocess calls to net groupmap. This fixes how groupmem entries are generated and adds more comprehensive checks to remove unexpected entries.