### PR TITLE
NAS-130037 / 24.10 / Run DRAID tests on HA

### DIFF
--- a/tests/api2/test_draid_record_and_block_size.py
+++ b/tests/api2/test_draid_record_and_block_size.py
@@ -7,11 +7,6 @@ from middlewared.test.integration.utils import call
 from auto_config import ha
 
 
-pytestmark = [
-    pytest.mark.skipif(ha, reason='Skipping for HA testing due to less disks'),
-]
-
-
 @pytest.fixture(scope='module')
 def check_unused_disks():
     if len(call('disk.get_unused')) < 4:


### PR DESCRIPTION
Now that our primary CI test runs are against HA targets we should avoid skipping due to HA whenever possible. The HA test runners are now capable of handling the larger disk count requirements..