### PR TITLE
NAS-130078 / 24.10 / Add features support for apps in app schema

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -139,7 +139,7 @@ class AppService(CRUDService):
 
         # The idea is to validate the values provided first and if it passes our validation test, we
         # can move forward with setting up the datasets and installing the catalog item
-        new_values, context = self.middleware.call_sync(
+        new_values = self.middleware.call_sync(
             'app.schema.normalize_and_validate_values', app_version_details, data['values'], False,
             get_installed_app_path(app_name)
         )
@@ -199,7 +199,7 @@ class AppService(CRUDService):
             'catalog.app_version_details', get_installed_app_version_path(app_name, app['version'])
         )
 
-        new_values, context = self.middleware.call_sync(
+        new_values = self.middleware.call_sync(
             'app.schema.normalize_and_validate_values', app_version_details, config, False,
             get_installed_app_path(app_name),
         )

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -140,7 +140,7 @@ class AppService(CRUDService):
         # The idea is to validate the values provided first and if it passes our validation test, we
         # can move forward with setting up the datasets and installing the catalog item
         new_values, context = self.middleware.call_sync(
-            'app.schema.normalise_and_validate_values', app_version_details, data['values'], False,
+            'app.schema.normalize_and_validate_values', app_version_details, data['values'], False,
             get_installed_app_path(app_name)
         )
 
@@ -200,7 +200,7 @@ class AppService(CRUDService):
         )
 
         new_values, context = self.middleware.call_sync(
-            'app.schema.normalise_and_validate_values', app_version_details, config, False,
+            'app.schema.normalize_and_validate_values', app_version_details, config, False,
             get_installed_app_path(app_name),
         )
 

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -202,7 +202,7 @@ class AppService(CRUDService):
 
         new_values = self.middleware.call_sync(
             'app.schema.normalize_and_validate_values', app_version_details, config, False,
-            get_installed_app_path(app_name),
+            get_installed_app_path(app_name), app
         )
 
         job.set_progress(25, 'Initial Validation completed')

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
@@ -11,6 +11,14 @@ def get_app_parent_config_path() -> str:
     return os.path.join(IX_APPS_MOUNT_PATH, 'app_configs')
 
 
+def get_app_parent_volume_path() -> str:
+    return os.path.join(IX_APPS_MOUNT_PATH, 'app_mounts')
+
+
+def get_app_volume_path(app_name: str) -> str:
+    return os.path.join(get_app_parent_volume_path(), app_name)
+
+
 def get_installed_app_path(app_name: str) -> str:
     return os.path.join(get_app_parent_config_path(), app_name)
 

--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -1,0 +1,30 @@
+from middlewared.schema import accepts, List, Ref, returns
+from middlewared.service import Service
+
+
+class AppService(Service):
+
+    class Config:
+        namespace = 'app'
+        cli_namespace = 'app'
+
+    @accepts()
+    @returns(List(items=[Ref('certificate_entry')]))
+    async def certificate_choices(self):
+        """
+        Returns certificates which can be used by applications.
+        """
+        return await self.middleware.call(
+            'certificate.query', [['revoked', '=', False], ['cert_type_CSR', '=', False], ['parsed', '=', True]],
+            {'select': ['name', 'id']}
+        )
+
+    @accepts()
+    @returns(List(items=[Ref('certificateauthority_entry')]))
+    async def certificate_authority_choices(self):
+        """
+        Returns certificate authorities which can be used by applications.
+        """
+        return await self.middleware.call(
+            'certificateauthority.query', [['revoked', '=', False], ['parsed', '=', True]], {'select': ['name', 'id']}
+        )

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -41,7 +41,7 @@ class AppService(Service):
         )
         config = get_current_app_config(app_name, options['app_version'])
         new_values, context = self.middleware.call_sync(
-            'app.schema.normalise_and_validate_values', rollback_version, config, False,
+            'app.schema.normalize_and_validate_values', rollback_version, config, False,
             get_installed_app_path(app_name),
         )
         new_values = add_context_to_values(app_name, new_values, rollback=True)

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -43,7 +43,7 @@ class AppService(Service):
         config = get_current_app_config(app_name, options['app_version'])
         new_values = self.middleware.call_sync(
             'app.schema.normalize_and_validate_values', rollback_version, config, False,
-            get_installed_app_path(app_name),
+            get_installed_app_path(app_name), app,
         )
         new_values = add_context_to_values(app_name, new_values, rollback=True)
         update_app_config(app_name, options['app_version'], new_values)

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -40,7 +40,7 @@ class AppService(Service):
             'catalog.app_version_details', get_installed_app_version_path(app_name, options['app_version'])
         )
         config = get_current_app_config(app_name, options['app_version'])
-        new_values, context = self.middleware.call_sync(
+        new_values = self.middleware.call_sync(
             'app.schema.normalize_and_validate_values', rollback_version, config, False,
             get_installed_app_path(app_name),
         )

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Dict, List, Ref, returns, Str
+from middlewared.schema import accepts, Bool, Dict, List, Ref, returns, Str
 from middlewared.service import job, Service, ValidationErrors
 
 from .compose_utils import compose_action
@@ -19,6 +19,7 @@ class AppService(Service):
         Dict(
             'options',
             Str('app_version', empty=False, required=True),
+            Bool('rollback_snapshot', default=True),
         )
     )
     @returns(Ref('app_query'))
@@ -56,10 +57,26 @@ class AppService(Service):
         # 2) Compose files should be rendered
         # 3) Metadata should be updated to reflect new version
         # 4) Docker should be notified to recreate resources and to let rollback commence
-        # 5) Finally update collective metadata config to reflect new version
+        # 5) Roll back ix_volume dataset's snapshots if available
+        # 6) Finally update collective metadata config to reflect new version
         update_app_metadata(app_name, rollback_version)
-        job.set_progress(40, f'Rolling back {app_name!r} app to {options["app_version"]!r} version')
         try:
+            if options['rollback_snapshot'] and (
+                app_volume_ds := self.middleware.call_sync('app.get_app_volume_ds', app_name)
+            ):
+                snap_name = f'{app_volume_ds}@{options["app_version"]}'
+                if self.middleware.call_sync('zfs.snapshot.query', [['id', '=', snap_name]]):
+                    job.set_progress(40, f'Rolling back {app_name!r} app to {options["app_version"]!r} version')
+
+                    self.middleware.call_sync(
+                        'zfs.snapshot.rollback', snap_name, {
+                            'force': True,
+                            'recursive': True,
+                            'recursive_clones': True,
+                            'recursive_rollback': True,
+                        }
+                    )
+
             compose_action(app_name, options['app_version'], 'up', force_recreate=True, remove_orphans=True)
         finally:
             self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -1,6 +1,6 @@
 import os
 
-from middlewared.service import Service
+from middlewared.service import CallError, Service
 
 from .utils import DATASET_DEFAULTS
 
@@ -29,3 +29,20 @@ class AppSchemaActions(Service):
                 }
             )
             await self.middleware.call('zfs.dataset.mount', create_ds)
+
+    async def apply_acls(self, acls_to_apply):
+        bulk_job = await self.middleware.call(
+            'core.bulk', 'filesystem.add_to_acl', [[acls_to_apply[acl_path]] for acl_path in acls_to_apply],
+        )
+        await bulk_job.wait()
+
+        failures = []
+        for status, acl_path in zip(bulk_job.result, acls_to_apply):
+            if status['error']:
+                failures.append((acl_path, status['error']))
+
+        if failures:
+            err_str = 'Failed to apply ACLs to the following paths: \n'
+            for index, entry in enumerate(failures):
+                err_str += f'{index + 1}) {entry[0]}: {entry[1]}\n'
+            raise CallError(err_str)

--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -1,0 +1,31 @@
+import os
+
+from middlewared.service import Service
+
+from .utils import DATASET_DEFAULTS
+
+
+class AppSchemaActions(Service):
+
+    class Config:
+        namespace = 'app.schema.action'
+        private = True
+
+    async def update_volumes(self, app_name, volumes):
+        app_volume_ds = os.path.join((await self.middleware.call('docker.config'))['dataset'], 'app_mounts', app_name)
+
+        user_wants = {app_volume_ds: {'properties': {}}} | {os.path.join(app_volume_ds, v['name']): v for v in volumes}
+        existing_datasets = {
+            d['id'] for d in await self.middleware.call(
+                'zfs.dataset.query', [['id', 'in', list(user_wants)]], {'extra': {'retrieve_properties': False}}
+            )
+        }
+
+        for create_ds in sorted(set(user_wants) - existing_datasets):
+            await self.middleware.call(
+                'zfs.dataset.create', {
+                    'properties': user_wants[create_ds]['properties'] | DATASET_DEFAULTS,
+                    'name': create_ds, 'type': 'FILESYSTEM',
+                }
+            )
+            await self.middleware.call('zfs.dataset.mount', create_ds)

--- a/src/middlewared/middlewared/plugins/apps/schema_normalization.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_normalization.py
@@ -24,7 +24,7 @@ class AppSchemaService(Service):
         for method in REF_MAPPING.values():
             assert isinstance(getattr(self, f'normalize_{method}'), Callable) is True
 
-    async def normalise_and_validate_values(self, item_details, values, update, app_dir, app_data=None):
+    async def normalize_and_validate_values(self, item_details, values, update, app_dir, app_data=None):
         dict_obj = await self.middleware.call(
             'app.schema.validate_values', item_details, values, update, app_data,
         )

--- a/src/middlewared/middlewared/plugins/apps/schema_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_utils.py
@@ -13,7 +13,7 @@ RESERVED_NAMES = [
     ('ix_certificateAuthorities', dict),
     ('ix_externalInterfacesConfiguration', list),
     ('ix_externalInterfacesConfigurationNames', list),  # TODO: Fix the casing here please
-    ('ix_volumes', list),
+    ('ix_volumes', dict),
     (CONTEXT_KEY_NAME, dict),
 ]
 SCHEMA_MAPPING = {

--- a/src/middlewared/middlewared/plugins/apps/schema_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_utils.py
@@ -10,9 +10,7 @@ from middlewared.validators import Match, Range, validate_schema
 CONTEXT_KEY_NAME = 'ix_context'
 RESERVED_NAMES = [
     ('ix_certificates', dict),
-    ('ix_certificateAuthorities', dict),
-    ('ix_externalInterfacesConfiguration', list),
-    ('ix_externalInterfacesConfigurationNames', list),  # TODO: Fix the casing here please
+    ('ix_certificate_authorities', dict),
     ('ix_volumes', dict),
     (CONTEXT_KEY_NAME, dict),
 ]

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -117,7 +117,7 @@ class AppSchemaService(Service):
             return
 
         if not filter_list(
-                await self.middleware.call('app.certificate_authority_choices'), [['id', '=', value]]
+            await self.middleware.call('app.certificate_authority_choices'), [['id', '=', value]]
         ):
             verrors.add(schema_name, 'Unable to locate certificate authority.')
 

--- a/src/middlewared/middlewared/plugins/apps/schema_validation.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_validation.py
@@ -1,10 +1,14 @@
 from middlewared.schema import Dict
 from middlewared.service import Service
+from middlewared.utils import filter_list
 
 from .schema_utils import construct_schema, get_list_item_from_value, NOT_PROVIDED, RESERVED_NAMES
 
 
-VALIDATION_REF_MAPPING = {}
+VALIDATION_REF_MAPPING = {
+    'definitions/certificate': 'certificate',
+    'definitions/certificateAuthority': 'certificate_authority',
+}
 # FIXME: See which are no longer valid
 # https://github.com/truenas/middleware/blob/249ed505a121e5238e225a89d3a1fa60f2e55d27/src/middlewared/middlewared/
 # plugins/chart_releases_linux/validation.py#L13
@@ -96,3 +100,19 @@ class AppSchemaService(Service):
                     )
 
         return verrors
+
+    async def validate_certificate(self, verrors, value, question, schema_name, app_data):
+        if not value:
+            return
+
+        if not filter_list(await self.middleware.call('app.certificate_choices'), [['id', '=', value]]):
+            verrors.add(schema_name, 'Unable to locate certificate.')
+
+    async def validate_certificate_authority(self, verrors, value, question, schema_name, app_data):
+        if not value:
+            return
+
+        if not filter_list(
+                await self.middleware.call('app.certificate_authority_choices'), [['id', '=', value]]
+        ):
+            verrors.add(schema_name, 'Unable to locate certificate authority.')

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -52,7 +52,7 @@ class AppService(Service):
             config = get_current_app_config(app_name, app['version'])
             config.update(options['values'])
             app_version_details = self.middleware.call_sync('catalog.app_version_details', version_path)
-            new_values, context = self.middleware.call_sync(
+            new_values = self.middleware.call_sync(
                 'app.schema.normalize_and_validate_values', app_version_details, config, False,
                 get_installed_app_path(app_name),
             )

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -53,7 +53,7 @@ class AppService(Service):
             config.update(options['values'])
             app_version_details = self.middleware.call_sync('catalog.app_version_details', version_path)
             new_values, context = self.middleware.call_sync(
-                'app.schema.normalise_and_validate_values', app_version_details, config, False,
+                'app.schema.normalize_and_validate_values', app_version_details, config, False,
                 get_installed_app_path(app_name),
             )
             new_values = add_context_to_values(app_name, new_values, upgrade=True, upgrade_metadata={})

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -55,7 +55,7 @@ class AppService(Service):
             app_version_details = self.middleware.call_sync('catalog.app_version_details', version_path)
             new_values = self.middleware.call_sync(
                 'app.schema.normalize_and_validate_values', app_version_details, config, False,
-                get_installed_app_path(app_name),
+                get_installed_app_path(app_name), app,
             )
             new_values = add_context_to_values(app_name, new_values, upgrade=True, upgrade_metadata={})
             update_app_config(app_name, upgrade_version['version'], new_values)

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from middlewared.plugins.docker.state_utils import IX_APPS_MOUNT_PATH  # noqa
+from middlewared.plugins.docker.state_utils import DATASET_DEFAULTS, IX_APPS_MOUNT_PATH  # noqa
 
 
 PROJECT_PREFIX = 'ix-'

--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -226,6 +226,8 @@ class CatalogService(Service):
             'timezones': await self.middleware.call('system.general.timezone_choices'),
             'system.general.config': await self.middleware.call('system.general.config'),
             'unused_ports': await self.middleware.call('port.get_unused_ports'),
+            'certificates': await self.middleware.call('app.certificate_choices'),
+            'certificate_authorities': await self.middleware.call('app.certificate_authority_choices'),
         }
 
     @private


### PR DESCRIPTION
This PR restores features support in apps schema so app developer can have a way of retrieving information from the running SCALE instance.

We would be adding more refs but after coordinating with Stavros on what needs to be added so that we are enforcing it on apps side as well (that should be relatively straight forward now considering the framework is in place to support those).