### PR TITLE
add missing keys to nvme only and jbof enclosures

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
@@ -1,8 +1,17 @@
 from logging import getLogger
 
-from middlewared.plugins.enclosure_.enums import (ElementStatus,
-                                                  RedfishStatusHealth,
-                                                  RedfishStatusState)
+from middlewared.plugins.enclosure_.constants import (
+    DISK_FRONT_KEY,
+    DISK_REAR_KEY,
+    DISK_TOP_KEY,
+    DISK_INTERNAL_KEY,
+    SUPPORTS_IDENTIFY_KEY,
+)
+from middlewared.plugins.enclosure_.enums import (
+    ElementStatus,
+    RedfishStatusHealth,
+    RedfishStatusState
+)
 from middlewared.plugins.enclosure_.slot_mappings import get_jbof_slot_info
 
 LOGGER = getLogger(__name__)
@@ -28,7 +37,6 @@ def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={})
     # can get rid of duplicate logic in this module and in that class
     fake_enclosure = {
         'id': uuid,
-        'dmi': uuid,
         'model': model,
         'should_ignore': False,
         'sg': None,
@@ -62,12 +70,22 @@ def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={})
             value_raw = 0x5000000
 
         mapped_slot = disks_map['versions']['DEFAULT']['model'][model][slot]['mapped_slot']
+        light = disks_map['versions']['DEFAULT']['id'][model][slot][SUPPORTS_IDENTIFY_KEY]
+        dfk = disks_map['versions']['DEFAULT']['id'][model][slot][DISK_FRONT_KEY]
+        drk = disks_map['versions']['DEFAULT']['id'][model][slot][DISK_REAR_KEY]
+        dtk = disks_map['versions']['DEFAULT']['id'][model][slot][DISK_TOP_KEY]
+        dik = disks_map['versions']['DEFAULT']['id'][model][slot][DISK_INTERNAL_KEY]
         fake_enclosure['elements']['Array Device Slot'][mapped_slot] = {
             'descriptor': f'Disk #{slot}',
             'status': status,
             'value': None,
             'value_raw': value_raw,
             'dev': device,
+            SUPPORTS_IDENTIFY_KEY: light,
+            DISK_FRONT_KEY: dfk,
+            DISK_REAR_KEY: drk,
+            DISK_TOP_KEY: dtk,
+            DISK_INTERNAL_KEY: dik,
             'original': {
                 'enclosure_id': uuid,
                 'enclosure_sg': None,
@@ -125,7 +143,7 @@ def map_redfish_psu_to_value(psu):
 
 def map_redfish_psu(psu):
     """Utility function to map a Redfish PSU data to our enclosure services format"""
-    # Redfish Data Model Specification https://www.dmtf.org/dsp/DSP0268 
+    # Redfish Data Model Specification https://www.dmtf.org/dsp/DSP0268
     # DSP0268_2024.1 6.103 PowerSupply 1.6.0
     # DSP0268_2023.2 6.103 PowerSupply 1.5.2
     # DSP0268_2023.1 6.97 PowerSupply 1.5.1
@@ -135,8 +153,12 @@ def map_redfish_psu(psu):
     # Example data from redfish
     # {'@odata.id': '/redfish/v1/Chassis/2U24/PowerSubsystem/PowerSupplies/PSU1',
     #  '@odata.type': '#PowerSupply.v1_5_1.PowerSupply',
-    #  'Actions': {'#PowerSupply.Reset': {'ResetType@Redfish.AllowableValues': ['On','ForceOff'],
-    #                                     'target': '/redfish/v1/Chassis/2U24/PowerSubsystem/PowerSupplies/PSU1/Actions/PowerSupply.Reset'}},
+    #  'Actions': {
+    #       '#PowerSupply.Reset': {
+    #           'ResetType@Redfish.AllowableValues': ['On','ForceOff'],
+    #           'target': '/redfish/v1/Chassis/2U24/PowerSubsystem/PowerSupplies/PSU1/Actions/PowerSupply.Reset'
+    #       }
+    #   },
     #  'FirmwareVersion': 'A00',
     #  'Id': 'PSU1',
     #  'LineInputStatus': 'Normal',

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
@@ -37,6 +37,7 @@ def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={})
     # can get rid of duplicate logic in this module and in that class
     fake_enclosure = {
         'id': uuid,
+        'dmi': uuid,
         'model': model,
         'should_ignore': False,
         'sg': None,

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -8,6 +8,13 @@ import re
 
 from pyudev import Context, Devices, DeviceNotFoundAtPathError
 
+from .constants import (
+    DISK_FRONT_KEY,
+    DISK_REAR_KEY,
+    DISK_TOP_KEY,
+    DISK_INTERNAL_KEY,
+    SUPPORTS_IDENTIFY_KEY
+)
 from .enums import ControllerModels
 from .slot_mappings import get_nvme_slot_info
 
@@ -70,12 +77,22 @@ def fake_nvme_enclosure(model, num_of_nvme_slots, mapped, ui_info=None):
             value_raw = 0x5000000
 
         mapped_slot = disks_map['versions']['DEFAULT']['id'][dmi][slot]['mapped_slot']
+        light = disks_map['versions']['DEFAULT']['id'][dmi][slot][SUPPORTS_IDENTIFY_KEY]
+        dfk = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_FRONT_KEY]
+        drk = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_REAR_KEY]
+        dtk = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_TOP_KEY]
+        dik = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_INTERNAL_KEY]
         fake_enclosure['elements']['Array Device Slot'][mapped_slot] = {
             'descriptor': f'Disk #{slot}',
             'status': status,
             'value': None,
             'value_raw': value_raw,
             'dev': device,
+            SUPPORTS_IDENTIFY_KEY: light,
+            DISK_FRONT_KEY: dfk,
+            DISK_REAR_KEY: drk,
+            DISK_TOP_KEY: dtk,
+            DISK_INTERNAL_KEY: dik,
             'original': {
                 'enclosure_id': dmi,
                 'enclosure_sg': None,

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -3,7 +3,15 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 
-from .constants import SYSFS_SLOT_KEY, MAPPED_SLOT_KEY, SUPPORTS_IDENTIFY_KEY
+from .constants import (
+    DISK_FRONT_KEY,
+    DISK_TOP_KEY,
+    DISK_REAR_KEY,
+    DISK_INTERNAL_KEY,
+    SYSFS_SLOT_KEY,
+    MAPPED_SLOT_KEY,
+    SUPPORTS_IDENTIFY_KEY
+)
 from .enums import ControllerModels, JbodModels, JbofModels
 
 
@@ -17,8 +25,15 @@ def get_jbof_slot_info(model):
                 'DEFAULT': {
                     'model': {
                         model: {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(1, 25)
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: i,
+                                SUPPORTS_IDENTIFY_KEY: True,
+                                DISK_FRONT_KEY: True,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                DISK_INTERNAL_KEY: False
+                            } for i in range(1, 25)
                         },
                     }
                 }
@@ -59,16 +74,37 @@ def get_nvme_slot_info(model):
                 'DEFAULT': {
                     'id': {
                         'f60_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(1, 25)
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: i,
+                                SUPPORTS_IDENTIFY_KEY: True,
+                                DISK_FRONT_KEY: True,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                DISK_INTERNAL_KEY: False
+                            } for i in range(1, 25)
                         },
                         'f100_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(1, 25)
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: i,
+                                SUPPORTS_IDENTIFY_KEY: True,
+                                DISK_FRONT_KEY: True,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                DISK_INTERNAL_KEY: False
+                            } for i in range(1, 25)
                         },
                         'f130_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(1, 25)
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: i,
+                                SUPPORTS_IDENTIFY_KEY: True,
+                                DISK_FRONT_KEY: True,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                DISK_INTERNAL_KEY: False
+                            } for i in range(1, 25)
                         },
                         # ALL m-series platforms have 4 rear nvme drive bays.
                         # The R50BM platform does as well and uses same plx
@@ -80,36 +116,94 @@ def get_nvme_slot_info(model):
                         # bays for all m-series platforms and they will be empty
                         # on the platforms that can't physically support these drives
                         'm30_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 5), range(25, 29))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'm40_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 5), range(25, 29))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'm50_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 5), range(25, 29))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'm60_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 5), range(25, 29))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 5), range(25, 29))
                         },
                         'r30_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(1, 17)
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: i,
+                                SUPPORTS_IDENTIFY_KEY: True,
+                                DISK_FRONT_KEY: True if i <= 12 else False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: False,
+                                # at time of writing, r30 is only platform with "internal"
+                                # drive slots
+                                DISK_INTERNAL_KEY: True if i > 12 else False,
+                            } for i in range(1, 17)
                         },
                         'r50_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 4), range(25, 28))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 4), range(25, 28))
                         },
                         'r50b_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 3), range(25, 27))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 3), range(25, 27))
                         },
                         'r50bm_nvme_enclosure': {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
-                            for i, j in zip(range(1, 5), range(25, 29))
+                            i: {
+                                SYSFS_SLOT_KEY: i,
+                                MAPPED_SLOT_KEY: j,
+                                SUPPORTS_IDENTIFY_KEY: False,
+                                DISK_FRONT_KEY: False,
+                                DISK_TOP_KEY: False,
+                                DISK_REAR_KEY: True,
+                                DISK_INTERNAL_KEY: False
+                            } for i, j in zip(range(1, 5), range(25, 29))
                         },
                     }
                 }


### PR DESCRIPTION
The traditional SES devices had keys added to them (requested by UI) in PR: https://github.com/truenas/middleware/pull/13859. Unfortunately, I failed to add the same logic to our "fake" nvme enclosure devices (rear slots on m-series), our nvme only systems and our jbof enclosures. This brings those devices into parity with SES devices.

It's unfortunate, but the `TODO` listed in each `fake_nvme_enclosure` function highlights that the duplicate logic should be merged into the `enclosure_class.py::Enclosure` class. In theory, this would have prevented this problem from occurring.