### PR TITLE
NAS-127735 / 24.10 / Add alerts for critical audit service failures

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import enum
 import json
 import logging
-import os
 import typing
 
 import html2text
@@ -154,6 +153,7 @@ class DismissableAlertClass:
 
 class AlertCategory(enum.Enum):
     APPLICATIONS = "APPLICATIONS"
+    AUDIT = "Audit"
     CERTIFICATES = "CERTIFICATES"
     CLUSTERING = "CLUSTERING"
     DIRECTORY_SERVICE = "DIRECTORY_SERVICE"
@@ -172,6 +172,7 @@ class AlertCategory(enum.Enum):
 
 alert_category_names = {
     AlertCategory.APPLICATIONS: "Applications",
+    AlertCategory.AUDIT: "Audit",
     AlertCategory.CERTIFICATES: "Certificates",
     AlertCategory.CLUSTERING: "Clustering",
     AlertCategory.DIRECTORY_SERVICE: "Directory Service",

--- a/src/middlewared/middlewared/alert/source/audit.py
+++ b/src/middlewared/middlewared/alert/source/audit.py
@@ -40,8 +40,7 @@ class AuditServiceHealthAlertSource(AlertSource):
         try:
             await self.middleware.call(
                 'audit.query', {
-                    "query-filters": [["event", "=", "AUTHENTICATION"]],
-                    "query-options": {"offset": -1}
+                    "query-options": {"count": True}
                 }
             )
         except Exception as e:

--- a/src/middlewared/middlewared/alert/source/audit.py
+++ b/src/middlewared/middlewared/alert/source/audit.py
@@ -1,0 +1,52 @@
+from datetime import timedelta
+import logging
+from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource, SimpleOneShotAlertClass
+from middlewared.alert.schedule import IntervalSchedule
+
+log = logging.getLogger("audit_check_alertmod")
+
+
+# -------------- OneShot Alerts ------------------
+class AuditBackendSetupAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.AUDIT
+    level = AlertLevel.ERROR
+    title = "Audit Service Backend Failed"
+    text = "Audit service failed backend setup: %(service)s. See /var/log/middlewared.log"
+
+
+class AuditSetupAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.AUDIT
+    level = AlertLevel.ERROR
+    title = "Audit Service Setup Failed"
+    text = "Audit service failed to complete setup. See /var/log/middlewared.log"
+
+
+# --------------- Monitored Alerts ----------------
+class AuditServiceHealthAlertClass(AlertClass):
+    category = AlertCategory.AUDIT
+    level = AlertLevel.ERROR
+    title = "Audit Service Health Failure"
+    text = "Failed to perform audit query: %(verrs)s"
+
+
+class AuditServiceHealthAlertSource(AlertSource):
+    '''
+    Run simple query every 20 minutes as a heath check
+    '''
+    schedule = IntervalSchedule(timedelta(minutes=20))
+    run_on_backup_node = False
+
+    async def check(self):
+        try:
+            await self.middleware.call(
+                'audit.query', {
+                    "query-filters": [["event", "=", "AUTHENTICATION"]],
+                    "query-options": {"offset": -1}
+                }
+            )
+        except Exception as e:
+            return Alert(
+                AuditServiceHealthAlertClass,
+                {'verrs': str(e)},
+                key=None
+            )

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -554,6 +554,8 @@ class AuditService(ConfigService):
                     'cleanup may be required', ds['id'], exc_info=True
                 )
 
+        # Dismiss any existing AuditSetup one-shot alerts
+        await self.middleware.call('alert.oneshot_delete', 'AuditSetup', None)
         audit_config = await self.middleware.call('audit.config')
         try:
             await self.middleware.call('audit.update_audit_dataset', audit_config)

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -558,6 +558,7 @@ class AuditService(ConfigService):
         try:
             await self.middleware.call('audit.update_audit_dataset', audit_config)
         except Exception:
+            await self.middleware.call('alert.oneshot_create', 'AuditSetup', None)
             self.logger.error('Failed to apply auditing dataset configuration.', exc_info=True)
 
     @private

--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -129,6 +129,7 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
             try:
                 conn.setup()
             except Exception:
+                self.middleware.call_sync('alert.oneshot_create', 'AuditBackendSetup', {"service": svc})
                 self.logger.error(
                     '%s: failed to set up auditing database connection.',
                     svc, exc_info=True

--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -126,6 +126,8 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
         - after audit database deletion or rename
         """
         for svc, conn in self.connections.items():
+            # Dismiss any existing AuditSetup one-shot alerts
+            self.middleware.call_sync('alert.oneshot_delete', 'AuditBackendSetup', {"service": svc})
             try:
                 conn.setup()
             except Exception:

--- a/tests/api2/test_audit_alerts.py
+++ b/tests/api2/test_audit_alerts.py
@@ -1,0 +1,127 @@
+import pytest
+
+from middlewared.test.integration.utils import call, ssh, mock
+from time import sleep
+
+
+def setup_test(alert_class, alert_key, path):
+    restore_val = None
+    match alert_class:
+        case 'AuditBackendSetup':
+            # A file in the dataset: set it immutable
+            ssh(f'chattr +i {path}')
+            lsattr = ssh(f'lsattr {path}')
+            assert lsattr[4] == 'i', lsattr
+            restore_val = path
+        case 'AuditDatasetCleanup':
+            # Directly tweak the zfs settings
+            call(
+                "zfs.dataset.update",
+                "boot-pool/ROOT/24.10.0-MASTER-20240709-021413/audit",
+                {"properties": {"org.freenas:refquota_warning": {"parsed": "70"}}}
+            )
+        case _:
+            pass
+
+    return restore_val
+
+
+def restore_test(alert_key, restore_val=()):
+    match alert_key:
+        case 'SMB':
+            # Remove immutable flag from file
+            assert restore_val != ""
+            ssh(f'chattr -i {restore_val}')
+            lsattr = ssh(f'lsattr {restore_val}')
+            assert lsattr[4] == '-', lsattr
+        case _:
+            pass
+
+
+@pytest.fixture(scope='function')
+def setup_state(request):
+    """
+    Parametrize the test setup
+    The hope was that both 'backend' and 'setup' one-shot tests would be similar, however
+    the 'setup' test ended up requiring 'with mock'
+    """
+    path = '/audit'
+    alert_key = request.param[0]
+    if alert_key is not None:
+        path += f"/{alert_key}.db"
+    alert_class = request.param[1]
+    restore_data = ()
+    try:
+        call('alert.oneshot_delete', alert_class, alert_key if alert_key is None else {'service': alert_key})
+
+        alerts = call("alert.list")
+        class_alerts = [alert for alert in alerts if alert['klass'] == alert_class]
+        assert len(class_alerts) == 0, class_alerts
+        restore_data = setup_test(alert_class, alert_key, path)
+        yield request.param
+    finally:
+        restore_test(alert_key, restore_data)
+        call('alert.oneshot_delete', alert_class, alert_key if alert_key is None else {'service': alert_key})
+        alerts = call("alert.list")
+        class_alerts = [alert for alert in alerts if alert['klass'] == alert_class]
+        assert len(class_alerts) == 0, class_alerts
+
+
+@pytest.mark.parametrize(
+    'setup_state', [
+        ['SMB', 'AuditBackendSetup', 'auditbackend.setup'],
+    ],
+    indirect=True
+)
+def test_audit_backend_alert(setup_state):
+    db_path, alert_class, audit_method = setup_state
+    call(audit_method)
+    sleep(1)
+    alerts = call("alert.list")
+    class_alerts = [alert for alert in alerts if alert['klass'] == alert_class]
+    assert len(class_alerts) > 0, class_alerts
+    assert class_alerts[0]['klass'] == 'AuditBackendSetup', class_alerts
+    assert class_alerts[0]['args']['service'] == db_path, class_alerts
+    assert class_alerts[0]['formatted'].startswith("Audit service failed backend setup"), class_alerts
+
+
+@pytest.mark.parametrize(
+    'setup_state', [
+        [None, 'AuditSetup', 'audit.setup']
+    ],
+    indirect=True
+)
+def test_audit_setup_alert(setup_state):
+    with mock("audit.update_audit_dataset", """
+        from middlewared.service import private
+        @private
+        async def mock(self, new):
+            raise Exception()
+    """):
+        unused, alert_class, audit_method = setup_state
+        call(audit_method)
+        sleep(1)
+        alerts = call("alert.list")
+        class_alerts = [alert for alert in alerts if alert['klass'] == alert_class]
+        assert len(class_alerts) > 0, class_alerts
+        assert class_alerts[0]['klass'] == 'AuditSetup', class_alerts
+        assert class_alerts[0]['formatted'].startswith("Audit service failed to complete setup"), class_alerts
+
+
+def test_audit_health_monitor_alert():
+    with mock("auditbackend.query", """
+        from middlewared.service import private
+        from middlewared.schema import accepts, Str, List, Dict
+        @private
+        @accepts(
+            Str('db_name', required=True),
+            List('query-filters'),
+            Dict('query-options')
+        )
+        async def mock(self, db_name, filters, options):
+            raise CallError('TEST_SERVICE: connection to audit database is not initialized.')
+    """):
+        alert = call("alert.run_source", "AuditServiceHealth")[0]
+        assert alert['source'] == 'AuditServiceHealth', alert
+        assert alert['text'].startswith("Failed to perform audit query"), alert
+        assert "connection to audit database is not initialized" in alert['args']['verrs'], alert


### PR DESCRIPTION
### Alerts for Audit service failures.
* Add one-shot alert for failure to start audit backends.
* Add one-shot alert for failure to run audit setup configuration
* Add an audit 'health' check that performs a simple query every 20 mins and generate an alert if the query fails.

Some Flake8 cleanup.

Add CI tests for all three.
The CI test results are [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1456/testReport/api2/test_audit_alerts/).

