### PR TITLE
NAS-130095 / 24.10 / Fix typos in directory services plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -220,7 +220,7 @@ class DirectoryServices(Service):
 
         self.middleware.call_sync('service.restart', 'idmap')
 
-        self.middlware.call_sync('directoryservices.health.check')
+        self.middleware.call_sync('directoryservices.health.check')
         if DSHealthObj.dstype is None:
             return
 
@@ -234,7 +234,6 @@ class DirectoryServices(Service):
 
 
 async def __init_directory_services(middleware, event_type, args):
-    await middleware.call('directoryservices.persistent_keyring_session')
     await middleware.call('directoryservices.setup')
 
 


### PR DESCRIPTION
This fixes two bugs that were introduced on fresh boot of TrueNAS and weren't caught in testing due to particulars of how reinstalling middleware happens in our CI. The method to create a persistent keyring was refactored away during development and a typo was present in code path only exercised on first boot.