### PR TITLE
NAS-130098 / 24.10 / Fix initial cache fill for LDAP and IPA

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -178,8 +178,11 @@ class DSCache(Service):
             if client.domain_info()['online']:
                 return
 
-            job.set_progress(10, 'Waiting for domain to come online')
-            self.logger.debug('Waiting for domain to come online')
+            # only log every 10th iteration
+            if waited % 10 == 0:
+                job.set_progress(10, 'Waiting for domain to come online')
+                self.logger.debug('Waiting for domain to come online')
+
             sleep(1)
             waited += 1
 
@@ -198,8 +201,11 @@ class DSCache(Service):
                 # We have an entry provided by sssd
                 return
 
-            job.set_progress(10, 'Waiting for domain to come online')
-            self.logger.debug('Waiting for domain to come online')
+            # only log every 10th iteration
+            if waited % 10 == 0:
+                job.set_progress(10, 'Waiting for domain to come online')
+                self.logger.debug('Waiting for domain to come online')
+
             sleep(1)
             waited += 1
 


### PR DESCRIPTION
SSSD will report a domain as online while it is still building internal caches and unable to properly handle NSS requests. This commit adds checks / sleeps in the directory services cache fill method until a getpwent call to the SSS NSS module returns an entry.