### PR TITLE
NAS-130099 / 24.10 / Fix test regressions related to krb5 ccache change

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/krb5_constants.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5_constants.py
@@ -1,5 +1,7 @@
 import enum
 
+from middlewared.utils import MIDDLEWARE_RUN_DIR
+
 KRB_TKT_CHECK_INTERVAL = 1800
 PERSISTENT_KEYRING_PREFIX = 'KEYRING:persistent:'
 
@@ -10,6 +12,7 @@ class KRB_Keytab(enum.Enum):
 
 class krb5ccache(enum.Enum):
     SYSTEM = f'{PERSISTENT_KEYRING_PREFIX}0'
+    TEMP = f'{MIDDLEWARE_RUN_DIR}/krb5cc_middleware_temp'
     USER = PERSISTENT_KEYRING_PREFIX  # middleware appends UID number to this
 
 

--- a/tests/api2/test_032_ad_kerberos.py
+++ b/tests/api2/test_032_ad_kerberos.py
@@ -333,8 +333,8 @@ def test_verify_nfs_krb_disabled():
 def test_kerberos_ticket_management(do_ad_connection):
     klist_out = call('kerberos.klist')
     assert klist_out['default_principal'].startswith(hostname.upper()), str(klist_out)
-    assert klist_out['ticket_cache']['type'] == 'FILE'
-    assert klist_out['ticket_cache']['name'] == '/var/run/middleware/krb5cc_0'
+    assert klist_out['ticket_cache']['type'] == 'KEYRING'
+    assert klist_out['ticket_cache']['name'].startswith('persistent:0')
     assert len(klist_out['tickets']) != 0
 
     to_check = None


### PR DESCRIPTION
We still need to have a temporary ccache for validating credentials within secrets.tdb, and the test for klist output needs to be updated for the keyring-backed kerberos ccache.