### PR TITLE
NAS-130116 / 24.10 / Fix ipa join admin privileges and keytab

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf.py
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.py
@@ -64,7 +64,12 @@ def generate_krb5_conf(
             else:
                 default_realm = default_realm[0]['realm']
         case DSType.IPA.value:
-            default_realm = middleware.call_sync('ldap.ipa_config')['realm']
+            try:
+                default_realm = middleware.call_sync('ldap.ipa_config')['realm']
+            except Exception:
+                # This can potenitally happen if we're simultaneously disabling IPA service
+                # while generating the krb5.conf file
+                default_realm = None
 
             # This matches defaults from ipa-client-install
             libdefaults.update({

--- a/src/middlewared/middlewared/etc_files/krb5.conf.py
+++ b/src/middlewared/middlewared/etc_files/krb5.conf.py
@@ -67,7 +67,7 @@ def generate_krb5_conf(
             try:
                 default_realm = middleware.call_sync('ldap.ipa_config')['realm']
             except Exception:
-                # This can potenitally happen if we're simultaneously disabling IPA service
+                # This can happen if we're simultaneously disabling IPA service
                 # while generating the krb5.conf file
                 default_realm = None
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -167,12 +167,7 @@ class DomainHealth(
                 if status_msg is None:
                     raise CallError('status_msg is required when setting state to FAULTED')
             case DSStatus.DISABLED:
-                # Only change current state if the specified DS matches
-                # our current running configuration
-                current_ds = DSHealthObj.dstype
-                if ds is current_ds:
-                    DSHealthObj.update(None, None, None)
-
+                DSHealthObj.update(None, None, None)
                 return
 
         DSHealthObj.update(ds, status, status_msg)

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -433,6 +433,3 @@ class IPAJoinMixin:
         # Wrap around cache fill because this forces a wait until IPA becomes ready
         cache_fill = self.middleware.call_sync('directoryservices.cache.refresh_impl')
         cache_fill.wait_sync()
-
-        job.set_progress(75, 'Granting IPA admins access to TrueNAS.')
-        self._ipa_grant_privileges()

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -132,8 +132,8 @@ class IPAJoinMixin:
         try:
             self.middleware.call_sync('privilege.create', {
                 'name': ipa_config['domain'].upper(),
-                'ds_groups': [admins_grp['gid']],
-                'allowlist': [{'method': '*', 'resource': '*'}],
+                'ds_groups': [admins_grp['gr_gid']],
+                'roles': ['FULL_ADMIN'],
                 'web_shell': True
             })
         except Exception:
@@ -174,10 +174,7 @@ class IPAJoinMixin:
             (IpaOperation.SET_NFS_PRINCIPAL, ipa_constants.IpaConfigName.IPA_NFS_KEYTAB)
         ):
             try:
-                setspn = subprocess.run([
-                    IPACTL,
-                    '-a', IpaOperation.SET_SMB_PRINCIPAL.name
-                ], check=False, capture_output=True)
+                setspn = subprocess.run([IPACTL, '-a', op.name], check=False, capture_output=True)
             except FileNotFoundError:
                 continue
 
@@ -432,5 +429,10 @@ class IPAJoinMixin:
         self._ipa_setup_services(job)
         job.set_progress(75, 'Activating IPA service.')
         self._ipa_activate()
+
+        # Wrap around cache fill because this forces a wait until IPA becomes ready
+        cache_fill = self.middleware.call_sync('directoryservices.cache.refresh_impl')
+        cache_fill.wait_sync()
+
         job.set_progress(75, 'Granting IPA admins access to TrueNAS.')
         self._ipa_grant_privileges()

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -942,7 +942,7 @@ class LDAPService(ConfigService):
                 # went sideways while enabling
                 await self.middleware.call('directoryservices.health.check')
             case _:
-                raise CallError(f'{dom_join_response}: unexpected domain join response')
+                raise CallError(f'{dom_join_resp}: unexpected domain join response')
 
         job.set_progress(100, 'LDAP directory service started.')
 

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -33,7 +33,7 @@ def test_ldap_schema_choices():
     assert set(choices) == expected
 
 
-def test_05_get_ldap_ssl_choices():
+def test_get_ldap_ssl_choices():
     expected = {"OFF", "ON", "START_TLS"}
 
     choices = call("ldap.ssl_choices")

--- a/tests/api2/test_ipa_join.py
+++ b/tests/api2/test_ipa_join.py
@@ -85,7 +85,9 @@ def test_smb_keytab_exists(do_freeipa_connection):
 def test_admin_privilege(do_freeipa_connection, enable_ds_auth):
     ipa_config = call('ldap.ipa_config')
 
-    priv = call('privilege.query', [['name', '=', ipa_config['domain']]], {'get': True})
+    priv_names = [priv['name'] for priv in call('privilege.query')]
+    assert ipa_config['domain'].upper() in priv_names
+
     admins_grp = call('group.get_group_obj', {'groupname': 'admins', 'sid_info': True})
 
     assert len(priv['ds_groups']) == 1

--- a/tests/api2/test_ipa_join.py
+++ b/tests/api2/test_ipa_join.py
@@ -18,7 +18,7 @@ def override_product():
         yield
     else:
         with product_type():
-           yield
+            yield
 
 
 @pytest.fixture(scope="function")
@@ -27,7 +27,7 @@ def enable_ds_auth(override_product):
     try:
         yield sys_config
     finally:
-       call('system.general.update', {'ds_auth': False})
+        call('system.general.update', {'ds_auth': False})
 
 
 def test_setup_and_enabling_freeipa(do_freeipa_connection):
@@ -88,13 +88,14 @@ def test_admin_privilege(do_freeipa_connection, enable_ds_auth):
     priv_names = [priv['name'] for priv in call('privilege.query')]
     assert ipa_config['domain'].upper() in priv_names
 
+    priv = call('privilege.query', [['name', '=', ipa_config['domain'].upper()]], {'get': True})
     admins_grp = call('group.get_group_obj', {'groupname': 'admins', 'sid_info': True})
 
     assert len(priv['ds_groups']) == 1
     assert priv['ds_groups'][0]['gid'] == admins_grp['gr_gid']
     assert priv['ds_groups'][0]['sid'] == admins_grp['sid']
 
-    assert priv['roles'] == ['FULL_ADMIN']
+    assert priv['roles'] == {'FULL_ADMIN'}
 
     with client(auth=('ipaadmin', FREEIPA_ADMIN_BINDPW)) as c:
         me = c.call('auth.me')


### PR DESCRIPTION
This adds back in missing cherry-pick from development branch to properly grant privileges to the admins group in an IPA domain.