### PR TITLE
NAS-130142 / 24.10 / Default to redacting result from core.get_jobs

### DIFF
--- a/tests/api2/test_job_result.py
+++ b/tests/api2/test_job_result.py
@@ -22,6 +22,6 @@ def test_job_result():
         job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
         assert job["result"] != "canary"
 
-        # but we should also
+        # but we should also be able to get unredacted result if needed
         job = call("core.get_jobs", [["id", "=", job_id]], {"get": True, "extra": {"raw_result": True}})
         assert job["result"] == "canary"

--- a/tests/api2/test_job_result.py
+++ b/tests/api2/test_job_result.py
@@ -1,0 +1,27 @@
+from middlewared.test.integration.utils import call, mock
+
+
+def test_job_result():
+
+    with mock("test.test1", """
+        from middlewared.service import job
+        from middlewared.schema import returns, Password
+
+        @job()
+        @returns(Password("my_password"))
+        def mock(self, job, *args):
+            return "canary"
+    """):
+        job_id = call("test.test1")
+
+        result = call("core.job_wait", job_id, job=True)
+        # Waiting for result should give unredacted version
+        assert result == "canary"
+
+        # Querying by default should redact
+        job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
+        assert job["result"] != "canary"
+
+        # but we should also
+        job = call("core.get_jobs", [["id", "=", job_id]], {"get": True, "extra": {"raw_result": True}})
+        assert job["result"] == "canary"


### PR DESCRIPTION
This commit makes it slightly easier to avoid user foot-shooting by defaulting to redacting job result in external calls to core.get_jobs.