### PR TITLE
NAS-130127 / 24.10 / Extra temporary file created by __tmp_krb5_keytab

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/krb5.py
+++ b/src/middlewared/middlewared/utils/directoryservices/krb5.py
@@ -100,7 +100,6 @@ def __tmp_krb5_keytab() -> str:
     """
     Create a temporary keytab file with appropriate header
     """
-    tmpfile = NamedTemporaryFile(delete=False)
     with NamedTemporaryFile(delete=False) as tmpfile:
         tmpfile.write(KRB5_KT_VNO)
         tmpfile.flush()


### PR DESCRIPTION
It appears that `__tmp_krb5_keytab` was creating **two** temp files.