### PR TITLE
NAS-130119 / 24.10 / quick nvidia gpu detection for daemon.json

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -4,36 +4,7 @@ import subprocess
 
 from middlewared.plugins.etc import FileShouldNotExist
 from middlewared.plugins.docker.state_utils import IX_APPS_MOUNT_PATH
-
-
-def nvidia_configuration():
-    # this needs to happen for nvidia gpu to work properly for docker containers
-    # https://github.com/NVIDIA/nvidia-docker/issues/854#issuecomment-572175484
-    nvidia_config_path = '/etc/nvidia-container-runtime/config.toml'
-    if not os.path.exists(nvidia_config_path):
-        return {}
-
-    # TODO: See if this is even required anymore
-    '''
-    with open(nvidia_config_path, 'r') as f:
-        data = f.read()
-
-    with open(nvidia_config_path, 'w') as f:
-        f.write(data.replace('@/sbin/ldconfig', '/sbin/ldconfig'))
-    '''
-
-    return {
-        'runtimes': {'nvidia': {'path': '/usr/bin/nvidia-container-runtime', 'runtimeArgs': []}},
-        'default-runtime': 'nvidia',
-    }
-
-
-def gpu_configuration(middleware):
-    available_gpus = middleware.call_sync('device.get_info', {'type': 'GPU'})
-    if any(gpu['vendor'] == 'NVIDIA' and gpu['available_to_host'] for gpu in available_gpus):
-        return nvidia_configuration()
-
-    return {}
+from middlewared.utils.gpu import get_nvidia_gpus
 
 
 def render(service, middleware):
@@ -46,10 +17,23 @@ def render(service, middleware):
 
     os.makedirs('/etc/docker', exist_ok=True)
     data_root = os.path.join(IX_APPS_MOUNT_PATH, 'docker')
-    return json.dumps({
+    base = {
         'data-root': data_root,
         'exec-opts': ['native.cgroupdriver=cgroupfs'],
         'iptables': True,  # FIXME: VMs connectivity would be broken
         'storage-driver': 'overlay2',
-        **gpu_configuration(middleware),
-    })
+    }
+    isolated = middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']
+    for gpu in filter(lambda x: x not in isolated, get_nvidia_gpus()):
+        base.update({
+            'runtimes': {
+                'nvidia': {
+                    'path': '/usr/bin/nvidia-container-runtime',
+                    'runtimeArgs': []
+                }
+            },
+            'default-runtime': 'nvidia',
+        })
+        break
+
+    return json.dumps(base)


### PR DESCRIPTION
By bringing in docker proper, and using the upstream repo to follow latest stable release, we're able to clean this up since the hacks are no longer required (I've confirmed this on a system with 2x discrete nvidia gpus).

Furthermore, our `device.get_info` endpoint is entirely too complicated for what we do here when generating this daemon.json file. I've added a new `get_nvidia_gpus` function that is 100x faster than `device.get_info`. There is no functional change in behavior.