### PR TITLE
NAS-130159 / 24.10 / Add IPA leave and expand testing

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -230,14 +230,14 @@ class IPAJoinMixin:
             (IpaOperation.SET_SMB_PRINCIPAL, ipa_constants.IpaConfigName.IPA_SMB_KEYTAB),
             (IpaOperation.SET_NFS_PRINCIPAL, ipa_constants.IpaConfigName.IPA_NFS_KEYTAB)
         ):
-            try:
-                setspn = subprocess.run([IPACTL, '-a', op.name], check=False, capture_output=True)
-            except FileNotFoundError:
-                continue
+            setspn = subprocess.run([IPACTL, '-a', op.name], check=False, capture_output=True)
 
             try:
                 resp = _parse_ipa_response(setspn)
                 output.append(resp | {'keytab_type': spn_type})
+            except FileNotFoundError:
+                self.logger.debug('IPA domain does not provide support for SMB protocol')
+                continue
             except Exception:
                 self.logger.error('%s: failed to create keytab', op.name, exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -72,9 +72,9 @@ class IPAJoinMixin:
             _parse_ipa_response(join)
         except Exception:
             self.logger.warning(
-                'Failed to disable TrueNAS machine account in IPA domain '
-                'further action by the IPA administrator to fully remove '
-                'the server from the domain.', exc_info=True
+                'Failed to disable TrueNAS machine account in the IPA domain. '
+                'Further action by the IPA administrator to fully remove '
+                'the server from the domain will be required.', exc_info=True
             )
 
         # At this point we can start removing local configuration

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -240,7 +240,7 @@ def generate_smb_conf_dict(
         smbconf.update({
             'server role': 'member server',
             'kerberos method': 'dedicated keytab',
-            'dedicated keytab file': 'FILE:/etc/smb.keytab',
+            'dedicated keytab file': 'FILE:/etc/ipa/smb.keytab',
             'workgroup': ipa_domain['netbios_name'],
             'realm': ipa_config['realm'],
             f'idmap config {domain_short} : backend': 'sss',

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
@@ -439,7 +439,7 @@ def test__ipa_base():
     assert conf['workgroup'] == 'TN'
     assert conf['server role'] == 'member server'
     assert conf['kerberos method'] == 'dedicated keytab'
-    assert conf['dedicated keytab file'] == 'FILE:/etc/smb.keytab'
+    assert conf['dedicated keytab file'] == 'FILE:/etc/ipa/smb.keytab'
     assert conf['realm'] == 'TESTDOM.TEST'
     assert conf['idmap config TN : backend'] == 'sss'
     assert conf['idmap config TN : range'] == '925000000 - 925199999'

--- a/tests/api2/test_ipa_leave.py
+++ b/tests/api2/test_ipa_leave.py
@@ -1,0 +1,74 @@
+import errno
+import pytest
+
+from middlewared.service_exception import CallError
+from middlewared.test.integration.assets.directory_service import ipa
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(scope="module")
+def ipa_config():
+    """ join then leave IPA domain so that we can evaluate server after leaving the IPA domain """
+    with ipa() as config:
+        ipa_config = config['ipa_config']
+
+    yield ipa_config
+
+
+def test_cache_cleared(ipa_config):
+    ipa_users_cnt = call('user.query', [['local', '=', False]], {'count': True})
+    assert ipa_users_cnt == 0
+
+    ipa_groups_cnt = call('group.query', [['local', '=', False]], {'count': True})
+    assert ipa_groups_cnt == 0
+
+
+@pytest.mark.parametrize('keytab_name', [
+    'IPA_MACHINE_ACCOUNT',
+    'IPA_NFS_KEYTAB',
+    'IPA_SMB_KEYTAB'
+])
+def test_keytabs_deleted(ipa_config, keytab_name):
+    kt = call('kerberos.keytab.query', [['name', '=', keytab_name]])
+    assert len(kt) == 0
+
+
+def test_check_no_kerberos_ticket(ipa_config):
+    with pytest.raises(CallError) as ce:
+        call('kerberos.check_ticket')
+
+    assert ce.value.errno == errno.ENOKEY
+
+
+def test_check_no_kerberos_realm(ipa_config):
+    realms = call('kerberos.realm.query')
+    assert len(realms) == 0, str(realms)
+
+
+def test_system_keytab_has_no_nfs_principal(ipa_config):
+    assert not call('kerberos.keytab.has_nfs_principal')
+
+
+def test_smb_keytab_does_not_exist(ipa_config):
+    with pytest.raises(CallError) as ce:
+        call('filesystem.stat', '/etc/ipa/smb.keytab')
+
+    assert ce.value.errno == errno.ENOENT
+
+
+def test_no_admin_privilege(ipa_config):
+    priv = call('privilege.query', [['name', '=', ipa_config['domain'].upper()]])
+    assert priv == []
+
+
+def test_no_certificate(ipa_config):
+    certs = call('certificateauthority.query', [['name', '=', 'IPA_DOMAIN_CACERT']])
+    assert len(certs) == 0, str(certs)
+
+
+def test_no_dns_resolution(ipa_config):
+    try:
+        results = call('dnsclient.forward_lookup', {'names': [ipa_config['host']]})
+        assert len(results) == 0
+    except Exception:
+        pass


### PR DESCRIPTION
Although leaving IPA domain isn't exposed currently via public API or GUI, it is useful for cleaning up after CI runs.

This commit adds:
- internal endpoint to use nsupdate to remove DNS entries
- DNS-related tests for IPA domain
- tests for cleanly leaving IPA domain