### PR TITLE
NAS-130174 / 24.10 / Prevent test run state pollution from test

### DIFF
--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -264,12 +264,15 @@ def test__recyclebin_functional_test_subdir(smb_info, smb_config):
 
 def test__netbios_name_change_check_sid():
     """ changing netbiosname should not alter our local sid value """
-    old_sid = call('smb.config')['cifs_SID']
+    orig = call('smb.config')
     new_sid = call('smb.update', {'netbiosname': 'nb_new'})['cifs_SID']
 
-    assert new_sid == old_sid
-    localsid = call('smb.groupmap_list')['localsid']
-    assert new_sid == localsid
+    try:
+        assert new_sid == orig['cifs_SID']
+        localsid = call('smb.groupmap_list')['localsid']
+        assert new_sid == localsid
+    finally:
+        call('smb.update', {'netbiosname': orig['netbiosname']})
 
 
 AUDIT_FIELDS = [


### PR DESCRIPTION
Each test run initializes the SMB netbiosname to a randomized value. We need to restore this after testing the a netbiosname change doesn't change the server's domain SID.