### PR TITLE
NAS-130170 / 24.10 / Add available node bind ips to questions context

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Int, List, Ref, returns
+from middlewared.schema import accepts, Dict, Int, List, Ref, returns, Str
 from middlewared.service import Service
 
 
@@ -41,3 +41,14 @@ class AppService(Service):
             for port_entry in app['active_workloads']['used_ports']
             for host_port in port_entry['host_ports']
         })))
+
+    @accepts()
+    @returns(Dict(Str('ip_choice')))
+    async def ip_choices(self):
+        """
+        Returns IP choices which can be used by applications.
+        """
+        return {
+            ip['address']: ip['address']
+            for ip in await self.middleware.call('interface.ip_in_use', {'static': True, 'any': True})
+        }

--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -228,6 +228,7 @@ class CatalogService(Service):
             'unused_ports': await self.middleware.call('port.get_unused_ports'),
             'certificates': await self.middleware.call('app.certificate_choices'),
             'certificate_authorities': await self.middleware.call('app.certificate_authority_choices'),
+            'ip_choices': await self.middleware.call('app.ip_choices'),
         }
 
     @private


### PR DESCRIPTION
## Context

`apps_validation` requires available node bind ips available in questions context so it can properly render available bind ips which user can consume with an application.