### PR TITLE
NAS-130172 / 24.10 / Fix portals when querying apps

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -1,8 +1,10 @@
 import os
 import typing
+
 import yaml
 
 from .path import get_collective_config_path, get_collective_metadata_path, get_installed_app_metadata_path
+from .portals import get_portals_and_app_notes
 
 
 def get_app_metadata(app_name: str) -> dict[str, typing.Any]:
@@ -17,7 +19,18 @@ def update_app_metadata(app_name: str, app_version_details: dict):
     with open(get_installed_app_metadata_path(app_name), 'w') as f:
         f.write(yaml.safe_dump({
             'metadata': app_version_details['app_metadata'],
-            **{k: app_version_details[k] for k in ('version', 'human_version')}
+            **{k: app_version_details[k] for k in ('version', 'human_version')},
+            **get_portals_and_app_notes(app_name, app_version_details['version']),
+        }))
+
+
+def update_app_metadata_for_portals(app_name: str, version: str):
+    # This should be called after config of app has been updated as that will render compose files
+    app_metadata = get_app_metadata(app_name)
+    with open(get_installed_app_metadata_path(app_name), 'w') as f:
+        f.write(yaml.safe_dump({
+            **app_metadata,
+            **get_portals_and_app_notes(app_name, version),
         }))
 
 

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/portals.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/portals.py
@@ -1,0 +1,44 @@
+import contextlib
+
+import yaml
+
+from apps_validation.portals import IX_NOTES_KEY, IX_PORTAL_KEY, validate_portals_and_notes, ValidationErrors
+
+from .lifecycle import get_rendered_templates_of_app
+
+
+def normalized_port_value(scheme: str, port: int) -> str:
+    return '' if ((scheme == 'http' and port == 80) or (scheme == 'https' and port == 443)) else f':{port}'
+
+
+def get_portals_and_app_notes(app_name: str, version: str) -> dict:
+    rendered_config = {}
+    for rendered_file in get_rendered_templates_of_app(app_name, version):
+        with contextlib.suppress(FileNotFoundError, yaml.YAMLError):
+            with open(rendered_file, 'r') as f:
+                rendered_config.update(yaml.safe_load(f.read()))
+
+    portal_and_notes_config = {
+        k: rendered_config[k]
+        for k in (IX_NOTES_KEY, IX_PORTAL_KEY)
+        if k in rendered_config
+    }
+    config = {
+        'portals': {},
+        'notes': None,
+    }
+    if portal_and_notes_config:
+        try:
+            validate_portals_and_notes('portal', portal_and_notes_config)
+        except ValidationErrors:
+            return config
+
+    portals = {}
+    for portal in portal_and_notes_config.get(IX_PORTAL_KEY, []):
+        port_value = normalized_port_value(portal['scheme'], portal['port'])
+        portals[portal['name']] = f'{portal["scheme"]}://{portal["host"]}{port_value}{portal.get("path", "")}'
+
+    return {
+        'portals': portals,
+        'notes': portal_and_notes_config.get(IX_NOTES_KEY),
+    }

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -33,9 +33,21 @@ def upgrade_available_for_app(
         return False
 
 
+def normalize_portal_uri(portal_uri: str, host_ip: str | None) -> str:
+    if not host_ip or '0.0.0.0' not in portal_uri:
+        return portal_uri
+
+    return portal_uri.replace('0.0.0.0', host_ip)
+
+
+def normalize_portal_uris(portals: dict[str, str], host_ip: str | None) -> dict[str, str]:
+    return {name: normalize_portal_uri(uri, host_ip) for name, uri in portals.items()}
+
+
 def list_apps(
     train_to_apps_version_mapping: dict[str, dict[str, dict[str, str]]],
-    specific_app: str | None = None
+    specific_app: str | None = None,
+    host_ip: str | None = None,
 ) -> list[dict]:
     apps = []
     app_names = set()
@@ -71,7 +83,7 @@ def list_apps(
             'active_workloads': get_default_workload_values() if state == 'STOPPED' else workloads,
             'state': state,
             'upgrade_available': upgrade_available_for_app(train_to_apps_version_mapping, app_metadata['metadata']),
-            **app_metadata,
+            **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
         })
 
     if specific_app and specific_app in app_names:
@@ -94,7 +106,7 @@ def list_apps(
                 'active_workloads': get_default_workload_values(),
                 'state': 'STOPPED',
                 'upgrade_available': upgrade_available_for_app(train_to_apps_version_mapping, app_metadata['metadata']),
-                **app_metadata,
+                **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
             })
 
     return apps


### PR DESCRIPTION
## Problem

Portals or app install notes were not being shown when apps were being queried.

## Solution

Portals / app install notes have been added to app metadata which is being saved to optimize querying them and it will be included in query output when querying apps.