### PR TITLE
NAS-130178 / 24.10 / Disable IPv6 link_local addresses in Send Targets output

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -310,6 +310,7 @@ HANDLER ${handler} {
 
 TARGET_DRIVER iscsi {
     enabled 1
+    link_local 0
 ## Currently SCST only supports one iSNS server
 % if global_config['isns_servers']:
     iSNSServer ${global_config['isns_servers'][0]}


### PR DESCRIPTION
When link-local addresses are included in Send Targets response, it can cause breakage at the initiator, depending on whether or not it handles the zone-index and/or whether the client interface names _happen_ to line up with the TrueNAS system.  This is currently broken in `open-iscsi`.

Since link-local addresses are non-routable, the safest approach is to not include them in the Send Targets output.  [If no non-link-local addresses are present then querying the link-local IPv6 will still include that address (only).]

(See upstream `scst` PR #[228 ](https://github.com/SCST-project/scst/pull/228)for more info)

---
CI run with passing iSCSI tests is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1615/).