### PR TITLE
Fix FTP audit test: remove rootlogin setting.

### DIFF
--- a/tests/api2/test_audit_ftp.py
+++ b/tests/api2/test_audit_ftp.py
@@ -29,7 +29,6 @@ def test_ftp_config_audit(api):
         # UPDATE
         payload = {
             'clients': 1000,
-            'rootlogin': True,
             'banner': "Hello, from New York"
         }
         with expect_audit_method_calls([{
@@ -48,7 +47,6 @@ def test_ftp_config_audit(api):
         # Restore initial state
         restore_payload = {
             'clients': initial_ftp_config['clients'],
-            'rootlogin': initial_ftp_config['rootlogin'],
             'banner': initial_ftp_config['banner']
         }
         if api == 'ws':


### PR DESCRIPTION
The `rootlogin` setting was removed as an FTP configuration option.  The FTP audit test used `rootlogin` as one of the audited change items.  The removal of `rootlogin` caused the audit test to fail.  The fix for the audit test is to remove `rootlogin`.