### PR TITLE
Remove `dotenv`

### DIFF
--- a/src/middlewared/middlewared/scripts/vendor_service.py
+++ b/src/middlewared/middlewared/scripts/vendor_service.py
@@ -4,9 +4,20 @@ import subprocess
 import sys
 import time
 
-from dotenv import dotenv_values
-
 from truenas_api_client import Client
+
+
+def load_envvars(envvars_file: str):
+    try:
+        envvars = []
+        with open(envvars_file, "r") as f:
+            for line in f:
+                l = line.strip()
+                if l and not l.startswith("#"):
+                    envvars.append(l.split("=", 1))
+        return dict(envvars)
+    except (OSError, ValueError):
+        return dict()
 
 
 def get_hostid() -> str | None:
@@ -20,7 +31,7 @@ def get_hostid() -> str | None:
 def start_hexos_websocat():
     url = "wss://api.hexos.com"
     envvars_file = "/etc/default/websocat"
-    envvars = dotenv_values(envvars_file)
+    envvars = load_envvars(envvars_file)
 
     systemd_opts = (
         "--unit=websocat",


### PR DESCRIPTION
Continuation of https://github.com/truenas/middleware/pull/14009

1. `dotenv` is not included in SCALE. Replace it.
2. The context manager `get_client()` caused a runtime error since it yielded more than once. Replace the context manager with a function that reliably retrieves the vendor name.