### PR TITLE
NAS-130160 / 24.10 / Prevent bug tickets from vendored install

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -6,6 +6,7 @@ import json
 
 from middlewared.utils.serial import serial_port_choices
 from middlewared.utils.db import query_config_table
+from middlewared.utils.vendor import Vendors
 
 
 def get_serial_ports():
@@ -16,10 +17,10 @@ if __name__ == "__main__":
     advanced = query_config_table("system_advanced", prefix="adv_")
     kernel_extra_options = advanced.get("kernel_extra_options") or ""
 
-    vendor = "TrueNAS Scale"
+    vendor = Vendors.TRUENAS_SCALE
     try:
         with open("/data/.vendor", "r") as f:
-            vendor = json.loads(f.read()).get("name", "TrueNAS Scale")
+            vendor = json.loads(f.read()).get("name", Vendors.TRUENAS_SCALE)
     except Exception:
         pass
 

--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -3,11 +3,13 @@ import math
 import psutil
 import os
 import json
+import logging
 
 from middlewared.utils.serial import serial_port_choices
 from middlewared.utils.db import query_config_table
 from middlewared.utils.vendor import Vendors
 
+logger = logging.getLogger(__name__)
 
 def get_serial_ports():
     return {e['start']: e['name'].replace('uart', 'ttyS') for e in serial_port_choices()}
@@ -21,8 +23,10 @@ if __name__ == "__main__":
     try:
         with open("/data/.vendor", "r") as f:
             vendor = json.loads(f.read()).get("name", Vendors.TRUENAS_SCALE)
-    except Exception:
+    except FileNotFoundError:
         pass
+    except Exception:
+        logger.error("Failed to parse /data/.vendor", exc_info=True)
 
     # We need to allow tpm in grub as sedutil-cli requires it
     # `zfsforce=1` is needed because FreeBSD bootloader imports boot pool with hostid=0 while SCALE releases up to

--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -16,12 +16,12 @@ if __name__ == "__main__":
     advanced = query_config_table("system_advanced", prefix="adv_")
     kernel_extra_options = advanced.get("kernel_extra_options") or ""
 
-    # check for /data/.vendor
+    vendor = "TrueNAS Scale"
     try:
         with open("/data/.vendor", "r") as f:
             vendor = json.loads(f.read()).get("name", "TrueNAS Scale")
-    except FileNotFoundError:
-        vendor = "TrueNAS Scale"
+    except Exception:
+        pass
 
     # We need to allow tpm in grub as sedutil-cli requires it
     # `zfsforce=1` is needed because FreeBSD bootloader imports boot pool with hostid=0 while SCALE releases up to

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -108,6 +108,9 @@ class SupportService(ConfigService):
         Returns whether Proactive Support is available for this product type and current license.
         """
 
+        if await self.middleware.call('system.vendor.name'):
+            return False
+
         if not await self.middleware.call('system.is_enterprise'):
             return False
 

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -224,6 +224,9 @@ class SupportService(ConfigService):
         For SCALE Enterprise `token` and `type` attributes are not required.
         """
 
+        if await self.middleware.call('system.vendor.name'):
+            raise CallError('Support is not available for this product', errno.EINVAL)
+
         await self.middleware.call('network.general.will_perform_activity', 'support')
 
         job.set_progress(1, 'Gathering data')

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -227,8 +227,9 @@ class SupportService(ConfigService):
         For SCALE Enterprise `token` and `type` attributes are not required.
         """
 
-        if await self.middleware.call('system.vendor.name'):
-            raise CallError('Support is not available for this product', errno.EINVAL)
+        vendor = await self.middleware.call('system.vendor.name')
+        if vendor:
+            raise CallError(f'Support is not available for this product ({vendor})', errno.EINVAL)
 
         await self.middleware.call('network.general.will_perform_activity', 'support')
 


### PR DESCRIPTION
On a vendored system, we want to prevent tickets made via the API from going through. On top of returning false in `is_available`, we also raise an error if the ticket creation API method is called directly.

I also updated the grub generation to match the paradigm in [this PR](https://github.com/truenas/truenas-installer/pull/87).

If there are other areas that need to have these safeguards, let me know! 