### PR TITLE
NAS-130192 / 24.10 / Include errno in exc_info for jobs

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -565,19 +565,24 @@ class Job:
             evalue = self.exc_info[1]
             if isinstance(evalue, ValidationError):
                 extra = [(evalue.attribute, evalue.errmsg, evalue.errno)]
+                errno = evalue.errno
                 etype = 'VALIDATION'
             elif isinstance(evalue, ValidationErrors):
                 extra = list(evalue)
+                errno = None
                 etype = 'VALIDATION'
             elif isinstance(evalue, CallError):
                 etype = etype.__name__
+                errno = evalue.errno
                 extra = evalue.extra
             else:
                 etype = etype.__name__
+                errno = None
                 extra = None
             exc_info = {
                 'repr': repr(evalue),
                 'type': etype,
+                'errno': errno,
                 'extra': extra,
             }
         return {

--- a/tests/api2/test_job_errno.py
+++ b/tests/api2/test_job_errno.py
@@ -1,0 +1,27 @@
+import pytest
+
+from middlewared.test.integration.utils import call, mock
+from truenas_api_client import ClientException
+
+
+def test_job_errno():
+
+    with mock("test.test1", """
+        from middlewared.service import job
+        from middlewared.schema import returns, Password
+        from middlewared.service_exception import CallError
+
+        @job()
+        @returns(Password("my_password"))
+        def mock(self, job, *args):
+            raise CallError("canary", 13)
+    """):
+        job_id = call("test.test1")
+
+        with pytest.raises(ClientException):
+            call("core.job_wait", job_id, job=True)
+
+        result = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
+
+        assert "errno" in result["exc_info"]
+        assert result["exc_info"]["errno"] == 13


### PR DESCRIPTION
We sometimes use errno to indiciate particular error reasons. Putting this in exc_info makes it easier for client to convert the job result back into a CallError without loss of information.