### PR TITLE
NAS-130161 / 24.10 / Regenerate grub config on unvendor

### DIFF
--- a/src/middlewared/middlewared/plugins/system_vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system_vendor/vendor.py
@@ -36,4 +36,4 @@ class VendorService(Service):
         except Exception:
             self.logger.exception('Unexpected error attempting to remove %r', SENTINEL_FILE_PATH)
 
-        self.middleware.call('etc.generate', 'grub')
+        self.middleware.call_sync('etc.generate', 'grub')

--- a/src/middlewared/middlewared/plugins/system_vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system_vendor/vendor.py
@@ -35,3 +35,5 @@ class VendorService(Service):
             pass
         except Exception:
             self.logger.exception('Unexpected error attempting to remove %r', SENTINEL_FILE_PATH)
+
+        self.middleware.call('etc.generate', 'grub')


### PR DESCRIPTION
The existing grub generation code properly sets the vendor text, rerunning after we delete the `/data/.vendor` file generates our default TrueNAS Scale grub config