### PR TITLE
NAS-130103 / 24.10 / Allow extent to be deleted even if underlying storage is missing

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -475,8 +475,9 @@ class iSCSITargetExtentService(SharingService):
     async def remove_extent_file(self, data):
         if data['type'] == 'FILE':
             try:
-                if os.path.exists(data['path']):
-                    os.unlink(data['path'])
+                os.unlink(data['path'])
+            except FileNotFoundError:
+                pass
             except Exception as e:
                 return e
 


### PR DESCRIPTION
When a user does a `zfs destroy` at the command line, middleware can end up in a situation where it cannot delete an iSCSI extent.  Rectify.

Added a CI test for this, plus one wrt `volthreading`.

---
Passing CI run is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1628/).