### PR TITLE
NAS-130194 / 24.10 / Add additional ARC stats for UI

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -47,6 +47,10 @@ class RealtimeEventSource(EventSource):
             'zfs',
             Int('arc_max_size'),
             Int('arc_size'),
+            Int('arc_demand_data_hits'),
+            Int('arc_prefetch_data_hits'),
+            Int('arc_demand_metadata_hits'),
+            Int('arc_prefetch_metadata_hits'),
             Float('cache_hit_ratio'),
         ),
     )

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/arcstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/arcstat.py
@@ -9,10 +9,24 @@ def get_arc_stats(netdata_metrics: dict) -> dict:
         'arc_size': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'zfs.arc_size', 'size', 0), multiplier=1024 * 1024,
         ),
+        'arc_demand_data_hits': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'zfs.demand_data_hits', 'hits', 0)
+        ),
+        'arc_prefetch_data_hits': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'zfs.prefetch_data_hits', 'hits', 0)
+        ),
+        'arc_demand_metadata_hits': 0,
+        'arc_prefetch_metadata_hits': 0,
         'cache_hit_ratio': 0.0,
     }
     hits = safely_retrieve_dimension(netdata_metrics, 'zfs.hits', 'hits', 0)
     misses = safely_retrieve_dimension(netdata_metrics, 'zfs.hits', 'misses', 0)
+    data['arc_demand_metadata_hits'] = normalize_value(safely_retrieve_dimension(
+        netdata_metrics, 'zfs.dhits', 'hits', 0
+    ) - data['arc_demand_data_hits'])
+    data['arc_prefetch_metadata_hits'] = normalize_value(safely_retrieve_dimension(
+        netdata_metrics, 'zfs.phits', 'hits', 0
+    ) - data['arc_prefetch_data_hits'])
 
     if total := (hits + misses):
         data['cache_hit_ratio'] = hits / total


### PR DESCRIPTION
## Problem

The UI requires new files that are currently missing in the `realtime.reporting` event.

## Solution

The necessary fields have been added to the `realtime.reporting` event. The UI can now retrieve the relevant information from the following keys in ZFS ARC reporting:

- Current size: `arc_size`
- Maximum size: `arc_max_size`
- Demand data hits: `arc_demand_data_hits`
- Demand metadata hits: `arc_demand_metadata_hits`
- Prefetch data hits: `arc_prefetch_data_hits`
- Prefetch metadata hits: `arc_prefetch_metadata_hits`

---
## Reference
https://learn.netdata.cloud/docs/collecting-metrics/freebsd/zfs
https://github.com/netdata/netdata/blob/master/src/collectors/proc.plugin/zfs_common.c#L19C24-L19C28