### PR TITLE
NAS-130199 / 24.10 / Make sure docker networks get recreated with compose up action

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -24,6 +24,12 @@ def compose_action(
         args.append('-d')
         if force_recreate:
             args.append('--force-recreate')
+            # This needs to happen because --force-recreate doesn't recreate docker networks
+            # So for example, an app was running and then system has been rebooted - the docker network
+            # remains there but the relevant interfaces it created do not and if the app didn't had a restart
+            # policy of always, when attempting to start the app again - it will fail because the network
+            # is not recreated with compose up action and we need an explicit down
+            compose_action(app_name, app_version, 'down', remove_orphans=True)
         if remove_orphans:
             args.append('--remove-orphans')
     elif action == 'down':


### PR DESCRIPTION
## Problem

When we have a running app and system is rebooted, any docker networks which might have been created don't have their associated interfaces anymore present after the reboot. So if an attempt to start the app is made, what happens is that process fails. For starting the app `docker compose up --force-recreate` is used, however this does not re-create the docker networks and eventually the interfaces as well which are associated with it. It fails with something like
```
Error response from daemon: failed to create endpoint ix-nginx-perms-1 on network ix-nginx_default: adding interface vethb6475a1 to bridge br-62cbfa232e0b failed: Device does not exist
```

## Solution

We make sure whenever compose up action is desired, any networks in place are removed first for the app so that the app can safely start.
