### PR TITLE
NAS-130234 / 24.10 / Add errno entry to exc_info in core.get_jobs schema

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -184,6 +184,7 @@ class CoreService(Service):
             'exc_info',
             Str('repr', null=True),
             Str('type', null=True),
+            Int('errno', null=True),
             Any('extra', null=True),
             null=True
         ),


### PR DESCRIPTION
A recent change to exc_info dictionary inside core.get_jobs output was not reflected in the returns decorator schema.