### PR TITLE
NAS-130240 / 24.10 / skip known failing test

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -109,7 +109,6 @@ def test_007_check_local_accounts(ws_client, account):
         fail(f'Group has unexpected name: {account["name"]} -> {entry["group"]}')
 
 
-@pytest.mark.skip(reason='known issue c.f. NAS-127825')
 def test_008_check_root_dataset_settings(ws_client):
     data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password)
     if not data['result']:
@@ -146,7 +145,10 @@ def test_008_check_root_dataset_settings(ws_client):
             # This is a run where root filesystem is unlocked. Don't obther checking remaining
             continue
 
-        for opt in fhs_entry['options']:
+        # FIXME: c.f. NAS-127825
+        # NOSUID is broken at boot, OS team is aware but fix is complicated.
+        # Skip this specific property for now.
+        for opt in filter(lambda x: x != 'NOSUID', fhs_entry['options']):
             if opt not in fs['mount_opts']:
                 assert opt in fs['mount_opts'], f'{opt}: mount option not present for {mp}: {fs["mount_opts"]}'
 

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -112,6 +112,7 @@ def test_007_check_local_accounts(ws_client, account):
         fail(f'Group has unexpected name: {account["name"]} -> {entry["group"]}')
 
 
+@pytest.mark.skip(reason='known issue c.f. NAS-127825')
 def test_008_check_root_dataset_settings(ws_client):
     data = SSH_TEST('cat /conf/truenas_root_ds.json', user, password)
     if not data['result']:

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -1,10 +1,7 @@
-from collections import defaultdict
-import sys
-import os
-apifolder = os.getcwd()
-sys.path.append(apifolder)
-
+import collections
 import json
+import os
+
 import pytest
 
 from functions import if_key_listed, SSH_TEST
@@ -155,7 +152,7 @@ def test_008_check_root_dataset_settings(ws_client):
 
 
 def test_009_check_listening_ports():
-    listen = defaultdict(set)
+    listen = collections.defaultdict(set)
     for line in ssh("netstat -tuvpan | grep LISTEN").splitlines():
         proto, _, _, local, _, _, process = line.split(maxsplit=6)
         if proto == "tcp":


### PR DESCRIPTION
We have 1 failing API test and its this one. This is a known problem and the OS team has been made aware. They're working on a fix but it's complicated so we'll skip it for now. We  have a high priority ticket internally.