### PR TITLE
NAS-130230 / 24.10 / Prevent removing failover group from critical interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1026,6 +1026,12 @@ class InterfaceService(CRUDService):
                     'Failover needs to be disabled to perform network configuration changes.'
                 )
 
+            if data.get('failover_critical') and data.get('failover_group') is None:
+                verrors.add(
+                    f'{schema_name}.failover_group',
+                    'A failover group is required when configuring a critical failover interface.'
+                )
+
             # have to make sure that active, standby and virtual ip addresses are equal
             active_node_ips = len(data.get('aliases', []))
             standby_node_ips = len(data.get('failover_aliases', []))

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1026,12 +1026,6 @@ class InterfaceService(CRUDService):
                     'Failover needs to be disabled to perform network configuration changes.'
                 )
 
-            if data.get('failover_critical') and data.get('failover_group') is None:
-                verrors.add(
-                    f'{schema_name}.failover_group',
-                    'A failover group is required when configuring a critical failover interface.'
-                )
-
             # have to make sure that active, standby and virtual ip addresses are equal
             active_node_ips = len(data.get('aliases', []))
             standby_node_ips = len(data.get('failover_aliases', []))
@@ -1055,6 +1049,12 @@ class InterfaceService(CRUDService):
                             f'{schema_name}.{i}',
                             f'{str(validation_attrs[i][0]) + str(validation_attrs[i][2])}',
                         )
+            else:
+                if data.get('failover_critical') and data.get('failover_group') is None:
+                    verrors.add(
+                        f'{schema_name}.failover_group',
+                        'A failover group is required when configuring a critical failover interface.'
+                    )
 
             # creating a "failover" lagg interface on HA systems and trying
             # to mark it "critical for failover" isn't allowed as it can cause

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -128,6 +128,6 @@ def test_004_remove_critical_failover_group(request):
             ValidationError(
                 'interface_update.failover_group',
                 'A failover group is required when configuring a critical failover interface.',
-                errno.EAGAIN
+                errno.EINVAL
             )
         ]


### PR DESCRIPTION
This prevents clearing `failover_group` from a NIC marked as `failover_critical`