### PR TITLE
NAS-130256 / 24.10 / Avoid deadlocking during DS health initialization

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/health.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/health.py
@@ -96,6 +96,14 @@ class DomainHealth(
         if initial_status in (DSStatus.LEAVING, DSStatus.JOINING):
             self.logger.debug("Deferring health check due to status of %s", initial_status.name)
             return True
+        elif initial_status is None:
+            # Our directory service hasn't been initialized.
+            #
+            # We'll be optimistic and call it HEALTHY before we run the
+            # the actual health checks below. The reason for this is so that
+            # if we attempt to etc.generate files during health check a
+            # second call to directoryservices.status won't land us here again.
+            DSHealthObj.update(enabled_ds, DSStatus.HEALTHY, None)
 
         try:
             match enabled_ds:


### PR DESCRIPTION
There are some edge cases with restarting middleware in which we can deadlock on the etc.generate lock for the kerberos group if we're joined to AD (by calling into directoryservices.health.check repeatedly). This fixes the issue by initializing the health state if required when we first enter the directoryservices.health.check method.