### PR TITLE
NAS-129603 / 24.10 / Do not load alerts for resources that do not exist

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -120,6 +120,16 @@ class OneShotAlertClass:
         """
         raise NotImplementedError
 
+    async def load(self, alerts):
+        """
+        This is called on system startup. Returns only those `alerts` that are still applicable to this system (i.e.,
+        corresponsing resources still exist).
+
+        :param alerts: all the existing alerts of the class
+        :return: `alerts` that should exist on this system.
+        """
+        return alerts
+
 
 class SimpleOneShotAlertClass(OneShotAlertClass):
     """

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -547,6 +547,10 @@ class CloudSyncTaskFailedAlertClass(AlertClass, OneShotAlertClass):
             alerts
         ))
 
+    async def load(self, alerts):
+        task_ids = {str(task["id"]) for task in await self.middleware.call("cloudsync.query")}
+        return [alert for alert in alerts if alert.key in task_ids]
+
 
 def lsjson_error_excerpt(error):
     excerpt = error.split("\n")[0]


### PR DESCRIPTION
Dangling cloud sync task alerts should have been fixed in 22.12, but the issue presented itself again. Let's put an additional layer of protection.