### PR TITLE
NAS-130263 / 24.10 / There is no need to stop when redeploying app now

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/app_scale.py
+++ b/src/middlewared/middlewared/plugins/apps/app_scale.py
@@ -44,8 +44,4 @@ class AppService(Service):
         Redeploy `app_name` app.
         """
         app = await self.middleware.call('app.get_instance', app_name)
-        stop_job = await self.middleware.call('app.stop', app_name)
-        await stop_job.wait()
-        if stop_job.error:
-            raise CallError(f'Failed to redeploy app: {stop_job.error}')
         return await self.middleware.call('app.update_internal', job, app, {'values': {}}, 'Redeployment')

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -63,11 +63,8 @@ def list_apps(
             continue
 
         workloads = translate_resources_to_desired_workflow(app_resources)
-        # TODO: So when we stop an app, we remove all it's related resources and we wouldn't be in this for loop at all
-        #  however, when we stop docker service and start it again - the containers can be in exited state which means
-        #  we need to account for this.
-        #  This TODO however is for figuring out why app.start doesn't work with the compose actions we have in place
-        #  atm and should then we be maybe doing docker compose down on apps when stopping docker service
+        # When we stop docker service and start it again - the containers can be in exited
+        # state which means we need to account for this.
         state = 'STOPPED'
         for container in workloads['container_details']:
             if container['state'] == 'starting':


### PR DESCRIPTION
## Context

Now as on compose up action when we force_recreate resources (this happens when update_internal runs), we do compose down automatically to make sure we account for the docker case where it did not account for interfaces for networks. So running a stop job before running `update_internal` is redundant now and not required.