### PR TITLE
NAS-129685 / 24.10 / Ensure correct user homedir ownership

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -842,7 +842,14 @@ class UserService(CRUDService):
     def recreate_homedir_if_not_exists(self, user, group, mode):
         # sigh, nothing is stopping someone from removing the homedir
         # from the CLI so recreate the original directory in this case
-        if not os.path.isdir(user['home']):
+        if os.path.isdir(user['home']):
+            if user['home'].startswith('/mnt/'):
+                self.middleware.call_sync('filesystem.chown', {
+                    'path': user['home'],
+                    'uid': user['uid'],
+                    'gid': group['bsdgrp_gid'],
+                }).wait_sync(raise_error=True)
+        else:
             if os.path.exists(user['home']):
                 raise CallError(f'{user["home"]!r} already exists and is not a directory')
 

--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -160,7 +160,7 @@ class FilesystemService(Service):
             verrors.add("filesystem.chown.uid",
                         "Please specify either user or group to change.")
 
-        loc = self._common_perm_path_validate("filesystem.chown", data, verrors)
+        self._common_perm_path_validate("filesystem.chown", data, verrors)
         verrors.check()
 
         if not options['recursive']:
@@ -246,7 +246,7 @@ class FilesystemService(Service):
         uid = -1 if data['uid'] is None else data.get('uid', -1)
         gid = -1 if data['gid'] is None else data.get('gid', -1)
 
-        loc = self._common_perm_path_validate("filesystem.setperm", data, verrors)
+        self._common_perm_path_validate("filesystem.setperm", data, verrors)
 
         current_acl = self.middleware.call_sync('filesystem.getacl', data['path'])
         acl_is_trivial = current_acl['trivial']

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -704,6 +704,8 @@ class KeychainCredentialService(CRUDService):
 
         # Write public key in user authorized_keys for SSH
         with open(f"{dotsshdir}/authorized_keys", "a+") as f:
+            os.fchmod(f.fileno(), 0o600)
+            os.fchown(f.fileno(), user["uid"], user["group"]["bsdgrp_gid"])
             f.seek(0)
             if data["public_key"] not in f.read():
                 f.write("\n" + data["public_key"] + "\n")

--- a/tests/api2/test_account_home.py
+++ b/tests/api2/test_account_home.py
@@ -1,0 +1,21 @@
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+
+def test_chown_on_update():
+    with dataset("unpriv_homedir") as homedir:
+        with user({
+            "username": "unpriv",
+            "full_name": "unpriv",
+            "group_create": True,
+            "password": "pass",
+        }) as u:
+            path = f"/mnt/{homedir}"
+
+            call("user.update", u["id"], {"home": path})
+
+            assert {
+                "user": "unpriv",
+                "group": "unpriv",
+            }.items() < call("filesystem.stat", path).items()


### PR DESCRIPTION
If user homedir is not owner by user, it won't be able to log in via SSH using key auth