### PR TITLE
Robustize standby_after_start

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -595,15 +595,16 @@ class iSCSITargetService(CRUDService):
         When called on a HA BACKUP node will attempt to login to all internal HA targets,
         used in ALUA.
         """
-        iqns = await self.middleware.call('iscsi.target.active_ha_iqns')
+        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
+        ha_iqn_prefix = f'{global_basename}:HA:'
 
         # Check what's already logged in
         existing = await self.middleware.call('iscsi.target.logged_in_iqns')
 
         # Generate the set of things we want to logout (don't assume every IQN, just the HA ones)
         todo = set()
-        for iqn in iqns.values():
-            if iqn in existing:
+        for iqn in existing.keys():
+            if iqn.startswith(ha_iqn_prefix):
                 todo.add(iqn)
 
         if todo:

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -595,8 +595,7 @@ class iSCSITargetService(CRUDService):
         When called on a HA BACKUP node will attempt to login to all internal HA targets,
         used in ALUA.
         """
-        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
-        ha_iqn_prefix = f'{global_basename}:HA:'
+        ha_iqn_prefix_str = await self.middleware.call('iscsi.target.ha_iqn_prefix')
 
         # Check what's already logged in
         existing = await self.middleware.call('iscsi.target.logged_in_iqns')
@@ -604,7 +603,7 @@ class iSCSITargetService(CRUDService):
         # Generate the set of things we want to logout (don't assume every IQN, just the HA ones)
         todo = set()
         for iqn in existing.keys():
-            if iqn.startswith(ha_iqn_prefix):
+            if iqn.startswith(ha_iqn_prefix_str):
                 todo.add(iqn)
 
         if todo:
@@ -790,10 +789,15 @@ class iSCSITargetService(CRUDService):
                 targetname.parent.joinpath(param).write_text(text)
 
     @private
+    async def ha_iqn_prefix(self):
+        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
+        return f'{global_basename}:HA:'
+
+    @private
     async def ha_iqn(self, name):
         """Return the IQN of the specified internal target."""
-        global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
-        return f'{global_basename}:HA:{name}'
+        prefix = await self.middleware.call('iscsi.target.ha_iqn_prefix')
+        return f'{prefix}{name}'
 
     @private
     def iqn_ha_luns(self, iqn):


### PR DESCRIPTION
Make `logout_ha_targets` slightly less restricted by using the HA IQN prefix to filter targets to be logged out, rather than using
`iscsi.target.active_ha_iqns`.  The latter will **not** include targets which have been removed from the config (so in highly unlikely circumstances we could have failed to logout some targets).

Also, make `standby_after_start` only wait for HA targets to be logged out.  If we _**happened**_ to have another target logged into the TrueNAS controller (not something that we currently do), then this code would have stalled.

(Refactor to add `ha_iqn_prefix` for re-use.)

----
Passing test (wrt iSCSI) is [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1697/).