### PR TITLE
NAS-130744 / 25.04 / Add Glacier Instant Retrieval storage class to AWS S3 Cloud Sync Task configuration

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -36,7 +36,7 @@ class S3RcloneRemote(BaseRcloneRemote):
         Str("encryption", title="Server-Side Encryption", enum=[None, "AES256"], default=None, null=True),
         Str("storage_class", title="The storage class to use", enum=["", "STANDARD", "REDUCED_REDUNDANCY",
                                                                      "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING",
-                                                                     "GLACIER", "DEEP_ARCHIVE"]),
+                                                                     "GLACIER", "GLACIER_IR", "DEEP_ARCHIVE"]),
     ]
 
     def _get_client(self, credentials):


### PR DESCRIPTION
Add Glacier Instant Retrieval storage class for AWS S3 Cloud Sync.

`GLACIER_IR` was added to Rclone in v1.58.0: https://rclone.org/changelog/#v1-58-0-2022-03-18