### PR TITLE
NAS-130264 / 24.10 / Pass more context to apps when doing app operations

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -183,7 +183,7 @@ class AppService(CRUDService):
             app_version_details = self.middleware.call_sync(
                 'catalog.app_version_details', get_installed_app_version_path(app_name, version)
             )
-            new_values = add_context_to_values(app_name, new_values, install=True)
+            new_values = add_context_to_values(app_name, new_values, app_version_details['app_metadata'], install=True)
             update_app_config(app_name, version, new_values)
             update_app_metadata(app_name, app_version_details)
 
@@ -239,7 +239,7 @@ class AppService(CRUDService):
 
         job.set_progress(25, 'Initial Validation completed')
 
-        new_values = add_context_to_values(app_name, new_values, update=True)
+        new_values = add_context_to_values(app_name, new_values, app['metadata'], update=True)
         update_app_config(app_name, app['version'], new_values)
         update_app_metadata_for_portals(app_name, app['version'])
         job.set_progress(60, 'Configuration updated, updating docker resources')

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/lifecycle.py
@@ -53,12 +53,13 @@ def get_action_context(app_name: str) -> dict[str, typing.Any]:
         'is_upgrade': False,
         'upgrade_metadata': {},
         'app_name': app_name,
+        'app_metadata': {},
     })
 
 
 def add_context_to_values(
-    app_name: str, values: dict[str, typing.Any], *, install: bool = False, update: bool = False, upgrade: bool = False,
-    upgrade_metadata: dict[str, typing.Any] = None, rollback: bool = False,
+    app_name: str, values: dict[str, typing.Any], app_metadata: dict, *, install: bool = False, update: bool = False,
+    upgrade: bool = False, upgrade_metadata: dict[str, typing.Any] = None, rollback: bool = False,
 ) -> dict[str, typing.Any]:
     assert install or update or upgrade or rollback, 'At least one of install, update, rollback or upgrade must be True'
     assert sum([install, rollback, update, upgrade]) <= 1, 'Only one of install, update, or upgrade can be True.'
@@ -77,6 +78,7 @@ def add_context_to_values(
     for operation, _ in filter(lambda i: i[1], operation_map.items()):
         action_context.update({
             'operation': operation,
+            'app_metadata': app_metadata,
             f'is_{operation.lower()}': True,
             **({'upgrade_metadata': upgrade_metadata} if operation == 'UPGRADE' else {})
         })

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -45,7 +45,7 @@ class AppService(Service):
             'app.schema.normalize_and_validate_values', rollback_version, config, False,
             get_installed_app_path(app_name), app,
         )
-        new_values = add_context_to_values(app_name, new_values, rollback=True)
+        new_values = add_context_to_values(app_name, new_values, rollback_version['app_metadata'], rollback=True)
         update_app_config(app_name, options['app_version'], new_values)
 
         job.set_progress(


### PR DESCRIPTION
## Context

It was requested by Stavros that app have more context passed to them when the app is rendering it's compose file - requested changes have been made and some minor improvements in upgrade have also been done.