### PR TITLE
NAS-129996 / 24.10 / Robustize get_iscsi_sessions function used in tests

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -200,13 +200,23 @@ def zvol_resize(zvol, volsize):
     call('pool.dataset.update', zvol, payload)
 
 
-def get_iscsi_sessions(filters=None, check_length=None):
+def _get_iscsi_sessions(filters=None):
     if filters:
-        data = call('iscsi.global.sessions', filters)
+        return call('iscsi.global.sessions', filters)
     else:
-        data = call('iscsi.global.sessions')
+        return call('iscsi.global.sessions')
+
+
+def get_iscsi_sessions(filters=None, check_length=None):
     if isinstance(check_length, int):
+        for _ in range(10):
+            data = _get_iscsi_sessions(filters)
+            if len(data) == check_length:
+                return data
+            sleep(1)
         assert len(data) == check_length, data
+    else:
+        data = _get_iscsi_sessions(filters)
     return data
 
 


### PR DESCRIPTION
Add some retries if we don't have the expected number of entries.

----

Passing CI test run [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1726/)