### PR TITLE
NAS-130314 / 24.10 / properly exclude internal ifaces in get_nic_names

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1922,9 +1922,9 @@ class InterfaceService(CRUDService):
     @private
     def get_nic_names(self) -> set:
         """Get network interface names excluding internal interfaces"""
-        res, ignore = set(), set(self.middleware.call_sync('interface.internal_interfaces'))
+        res, ignore = set(), tuple(self.middleware.call_sync('interface.internal_interfaces'))
         with scandir('/sys/class/net/') as nics:
-            for nic in filter(lambda x: x.is_symlink() and x.name not in ignore, nics):
+            for nic in filter(lambda x: x.is_symlink() and not x.name.startswith(ignore), nics):
                 res.add(nic.name)
 
         return res


### PR DESCRIPTION
We chose a poor method name `interface.internal_interfaces` isn't actually the interface names. It's the prefixes of interface names. QE found that the `ix-truecommand` interface was triggering an HA mismatch nics alert message. This fixes the problem.