### PR TITLE
NAS-130317 / 24.10 / Robustize nfs manage gids and v4 domain tests

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1636,6 +1636,8 @@ def test_52_manage_gids(state, expected):
         if state is not None:
             sleep(3)  # In Cobia: Prevent restarting NFS too quickly.
             call("nfs.update", {"userd_manage_gids": state})
+            # Allow config file to be updated
+            sleep(1)
 
         s = parse_server_config()
         assert s['mountd']['manage-gids'] == expected, str(s)
@@ -1661,6 +1663,8 @@ def test_54_v4_domain():
         # Make a setting change and confirm
         db = call('nfs.update', {"v4_domain": "ixsystems.com"})
         assert db['v4_domain'] == 'ixsystems.com', f"v4_domain failed to be updated in nfs DB: {db}"
+        # Allow config file to be updated
+        sleep(1)
         s = parse_server_config("idmapd")
         assert s['General'].get('Domain') == 'ixsystems.com', f"'Domain' failed to be updated in idmapd.conf: {s}"
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -300,6 +300,7 @@ pytest_command = [
     "--junitxml",
     'results/api_v2_tests_result.xml',
 ]
+testexpr = 'not test_03_changing_dataset_permissions_of_nfs_dataset and not test_04_verify_the_job_id_is_successfull and not test_06_starting_nfs_service_at_boot and not test_07_checking_to_see_if_nfs_service_is_enabled_at_boot and not test_09_checking_to_see_if_nfs_service_is_running and not test_10_confirm_state_directory and not test_11_perform_basic_nfs_ops and not test_12_perform_server_side_copy and not test_19_updating_the_nfs_service and not test_20_update_nfs_share and not test_21_checking_to_see_if_nfs_service_is_enabled and not test_31_check_nfs_share_network and not test_32_check_nfs_share_hosts and not test_33_check_nfs_share_ro and not test_34_check_nfs_share_maproot and not test_35_check_nfs_share_mapall and not test_36_check_nfsdir_subtree_behavior and not test_37_check_nfsdir_subtree_share and not test_38_check_nfs_allow_nonroot_behavior and not test_39_check_nfs_service_protocols_parameter and not test_40_check_nfs_service_udp_parameter and not test_41_check_nfs_service_ports and not test_42_check_nfs_client_status and not test_43_check_nfsv4_acl_support and not test_44_check_nfs_xattr_support and not test_45_check_setting_runtime_debug and not test_46_set_bind_ip and not test_48_syslog_filters and not test_50_nfs_invalid_user_group_mapping and not test_71_checking_to_see_if_nfs_service_is_stop and not test_72_check_adjusting_threadpool_mode and not test_74_disable_nfs_service_at_boot and not test_75_checking_nfs_disable_at_boot and not test_80_start_nfs_service_with_missing_or_empty_exports and not test_82_files_in_exportsd '
 if testexpr:
     pytest_command.extend(['-k', testexpr])
 
@@ -313,6 +314,15 @@ def parse_test_name(test):
     return test
 
 
+tests = ['api2/test_001_ssh.py',
+         'api2/test_002_system_license.py',
+         'api2/test_003_network_global.py',
+         'api2/test_005_interface.py',
+         'api2/test_006_pool_and_sysds.py',
+         'api2/test_007_early_settings.py',
+         'api2/test_300_nfs.py']
+# Account for the parse strippage
+tests = ['api2/'+v for v in tests]
 if tests:
     pytest_command.extend(list(map(parse_test_name, tests)))
 else:

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -300,7 +300,6 @@ pytest_command = [
     "--junitxml",
     'results/api_v2_tests_result.xml',
 ]
-testexpr = 'not test_03_changing_dataset_permissions_of_nfs_dataset and not test_04_verify_the_job_id_is_successfull and not test_06_starting_nfs_service_at_boot and not test_07_checking_to_see_if_nfs_service_is_enabled_at_boot and not test_09_checking_to_see_if_nfs_service_is_running and not test_10_confirm_state_directory and not test_11_perform_basic_nfs_ops and not test_12_perform_server_side_copy and not test_19_updating_the_nfs_service and not test_20_update_nfs_share and not test_21_checking_to_see_if_nfs_service_is_enabled and not test_31_check_nfs_share_network and not test_32_check_nfs_share_hosts and not test_33_check_nfs_share_ro and not test_34_check_nfs_share_maproot and not test_35_check_nfs_share_mapall and not test_36_check_nfsdir_subtree_behavior and not test_37_check_nfsdir_subtree_share and not test_38_check_nfs_allow_nonroot_behavior and not test_39_check_nfs_service_protocols_parameter and not test_40_check_nfs_service_udp_parameter and not test_41_check_nfs_service_ports and not test_42_check_nfs_client_status and not test_43_check_nfsv4_acl_support and not test_44_check_nfs_xattr_support and not test_45_check_setting_runtime_debug and not test_46_set_bind_ip and not test_48_syslog_filters and not test_50_nfs_invalid_user_group_mapping and not test_71_checking_to_see_if_nfs_service_is_stop and not test_72_check_adjusting_threadpool_mode and not test_74_disable_nfs_service_at_boot and not test_75_checking_nfs_disable_at_boot and not test_80_start_nfs_service_with_missing_or_empty_exports and not test_82_files_in_exportsd '
 if testexpr:
     pytest_command.extend(['-k', testexpr])
 
@@ -314,15 +313,6 @@ def parse_test_name(test):
     return test
 
 
-tests = ['api2/test_001_ssh.py',
-         'api2/test_002_system_license.py',
-         'api2/test_003_network_global.py',
-         'api2/test_005_interface.py',
-         'api2/test_006_pool_and_sysds.py',
-         'api2/test_007_early_settings.py',
-         'api2/test_300_nfs.py']
-# Account for the parse strippage
-tests = ['api2/'+v for v in tests]
 if tests:
     pytest_command.extend(list(map(parse_test_name, tests)))
 else:


### PR DESCRIPTION
Over the weekend there was a spate of failures on the NFS `manage gids` and `v4 domain` tests. 
It appears the problem was reading the config file too quickly. 

To avoid this in the future this PR adds a one second sleep between the `update` call and the parsing of the config file.