### PR TITLE
NAS-130324 / 24.10 / Treat ix-apps dataset specially in pool.dataset namespace

### DIFF
--- a/src/middlewared/middlewared/alert/source/datasets.py
+++ b/src/middlewared/middlewared/alert/source/datasets.py
@@ -22,9 +22,11 @@ class UnencryptedDatasetsAlertSource(AlertSource):
         unencrypted_datasets = []
         for dataset in await self.middleware.call('pool.dataset.query', [['encrypted', '=', True]]):
             for child in dataset['children']:
-                if child['name'] == f'{child["pool"]}/ix-applications' or child['name'].startswith(
-                    f'{child["pool"]}/ix-applications/'
-                ):
+                if child['name'] in (
+                    f'{child["pool"]}/ix-applications', f'{child["pool"]}/ix-apps'
+                ) or child['name'].startswith((
+                    f'{child["pool"]}/ix-applications/', f'{child["pool"]}/ix-apps/'
+                )):
                     continue
 
                 if not child['encrypted']:

--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -63,7 +63,7 @@ class CatalogService(Service):
                     'name': 'chia',
                     'categories': ['storage', 'crypto'],
                     'app_readme': 'app readme here',
-                    'location': '/mnt/evo/ix-applications/catalogs/github_com_truenas_charts_git_master/charts/chia',
+                    'location': '/mnt/evo/ix-apps/catalogs/github_com_truenas_charts_git_master/charts/chia',
                     'healthy': True,
                     'healthy_error': None,
                     'latest_version': '1.2.0',

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -105,8 +105,12 @@ class RcloneConfig:
 
             if self.cloud_sync.get("path"):
                 if os.path.dirname(self.cloud_sync.get("path").rstrip("/")) == "/mnt":
-                    rclone_filter.append("- /ix-applications")
-                    rclone_filter.append("- /ix-applications/**")
+                    rclone_filter.extend([
+                        "- /ix-applications",
+                        "- /ix-apps",
+                        "- /ix-applications/**",
+                        "- /ix-apps/**",
+                    ])
 
             for item in self.cloud_sync.get("exclude") or []:
                 rclone_filter.append(f"- {item}")

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -273,9 +273,9 @@ class FilesystemService(Service):
         if not path.is_dir():
             raise CallError(f'Path {path} is not a directory', errno.ENOTDIR)
 
-        # TODO: once new apps implementation is in-place remove this check
-        if 'ix-applications' in path.parts:
-            raise CallError('Ix-applications is a system managed dataset and its contents cannot be listed')
+        for ds in ('ix-applications', 'ix-apps'):
+            if ds in path.parts:
+                raise CallError(f'{ds!r} is a system managed dataset and its contents cannot be listed')
 
         file_type = None
         for filter_ in filters:

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -166,6 +166,7 @@ class PoolDatasetService(CRUDService):
             ['pool', '!=', await self.middleware.call('boot.pool_name')],
             ['id', 'rnin', '/.system'],
             ['id', 'rnin', '/ix-applications/'],
+            ['id', 'rnin', '/ix-apps/'],
         ]
 
     @private

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -17,7 +17,7 @@ class PoolService(Service):
     def cleanup_after_export(self, poolinfo, opts):
         try:
             if all((opts['destroy'], opts['cascade'])) and (contents := os.listdir(poolinfo['path'])):
-                if len(contents) == 1 and contents[0] == 'ix-applications':
+                if len(contents) == 1 and contents[0] in ('ix-applications', 'ix-apps'):
                     # This means:
                     #   1. zpool was destroyed (disks were wiped)
                     #   2. end-user chose to delete all share configuration associated

--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -129,9 +129,10 @@ class PoolService(Service):
         # Recursively reset dataset mountpoints for the zpool.
         recursive = True
         for child in await self.middleware.call('zfs.dataset.child_dataset_names', pool_name):
-            if child == os.path.join(pool_name, 'ix-applications'):
+            if child in (os.path.join(pool_name, k) for k in ('ix-applications', 'ix-apps')):
                 # We exclude `ix-applications` dataset since resetting it will
                 # cause PVC's to not mount because "mountpoint=legacy" is expected.
+                # We exclude `ix-apps` dataset since it has a custom mountpoint in place
                 continue
             try:
                 # Reset all mountpoints

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -400,7 +400,7 @@ def check_path_resides_within_volume_sync(verrors, schema_name, path, vol_names)
     * path is within /mnt
     * path is located within one of the specified `vol_names`
     * path is not explicitly a `.zfs` or `.zfs/snapshot` directory
-    * path is not ix-applications dataset
+    * path is not ix-applications /ix-apps dataset
     """
     if path_location(path).name == 'EXTERNAL':
         # There are some fields where we allow external paths
@@ -428,7 +428,7 @@ def check_path_resides_within_volume_sync(verrors, schema_name, path, vol_names)
                     "be accessed through the path-based API, then it should be called "
                     "directly, e.g. '/mnt/dozer/.zfs/snapshot/mysnap'.")
 
-    for check_path, svc_name in (('ix-applications', 'Applications'),):
+    for check_path, svc_name in (('ix-applications', 'Applications'), ('ix-apps', 'Applications'),):
         in_use = False
         if is_mountpoint and rp.name == check_path:
             in_use = True


### PR DESCRIPTION
## Context

We treated `ix-applications` specially in different places to avoid spam and make sure nothing unintended happened as the dataset had custom properties in place. This is mostly true for `ix-apps` dataset as well where we don't want to show it's children in the UI to reduce spam and also make sure in other places where we managed `ix-applications`, we have similar handling in place for `ix-apps` to avoid breaking new apps functionality.