### PR TITLE
NAS-130330 / 24.10 / Fix switching docker pools

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -53,12 +53,12 @@ class DockerService(ConfigService):
         config.update(data)
 
         if old_config != config:
-            if not config['pool']:
-                try:
-                    await self.middleware.call('service.stop', 'docker')
-                except Exception as e:
-                    raise CallError(f'Failed to stop docker service: {e}')
-                await self.middleware.call('docker.state.set_status', Status.UNCONFIGURED.value)
+            try:
+                await self.middleware.call('service.stop', 'docker')
+            except Exception as e:
+                raise CallError(f'Failed to stop docker service: {e}')
+
+            await self.middleware.call('docker.state.set_status', Status.UNCONFIGURED.value)
 
             await self.middleware.call('datastore.update', self._config.datastore, old_config['id'], config)
             await self.middleware.call('docker.setup.status_change')


### PR DESCRIPTION
## Problem

When we switch from one pool to another pool in docker, it is not seamless because we are not stopping docker service and it is only being stopped if we unconfigure the docker pool first.

## Solution

Make sure we stop docker service and then setup the other pool.