### PR TITLE
NAS-130278 / 13.3 / NAS-130278 - Community Patch - Switch to bhyve TCP mode to fix VNC connections

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -919,7 +919,7 @@ class VNC(Device):
             bool, [
                 '29',
                 'fbuf',
-                f'vncserver={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
+                f'tcp={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
                 f'w={width}',
                 f'h={height}',
                 f'password={attrs["vnc_password"]}' if attrs.get('vnc_password') else None,


### PR DESCRIPTION
Switch to tcp mode for bhyve VNC sessions with community provided patch. Breaks some RGB color pallet in the WebVNC, but otherwise is reported as functional and restores basic VNC functionality. 

Note: Bhyve is unsupported in 13.3, we will not be doing any additional testing of this. 