### PR TITLE
NAS-130338 / 24.10 / Allow overriding execute check in setacl in some cases

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -796,6 +796,7 @@ class PoolDatasetService(CRUDService):
             acl_job = await self.middleware.call('filesystem.setacl', {
                 'path': mountpoint,
                 'dacl': acl_to_set,
+                'options': {'skip_execute_check': True}
             })
             await acl_job.wait(raise_error=True)
 


### PR DESCRIPTION
When TrueNAS is joined to active directory it's possible that the AD administrator has created nested security groups in such a way that it becomes non-trivial to validate whether a user can gain access to a path by virtue of being a member of a particular group.

This is because the nested security groups are flattened only when resolving the groups for a particular user via getgrouplist(3).

Since nested groups only exist if directory services are enabled, this bypass raises a ValidationError if the server is in a standalone configuration.

We still default to checking access (previous behavior) because using nested security groups in this way is a security anti-pattern as it renders the effective permissions on filesystem paths very difficult or impossible to easily audit.