### PR TITLE
NAS-130341 / 24.10 / Allow port choices for apps to start from 1

### DIFF
--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -229,7 +229,7 @@ class CatalogService(Service):
         return {
             'timezones': await self.middleware.call('system.general.timezone_choices'),
             'system.general.config': await self.middleware.call('system.general.config'),
-            'unused_ports': await self.middleware.call('port.get_unused_ports'),
+            'unused_ports': await self.middleware.call('port.get_unused_ports', 1),
             'certificates': await self.middleware.call('app.certificate_choices'),
             'certificate_authorities': await self.middleware.call('app.certificate_authority_choices'),
             'ip_choices': await self.middleware.call('app.ip_choices'),


### PR DESCRIPTION
This commit adds changes to allow port choices for apps to start from 1 as we already validate if the port is in use or not (earlier it was 1025).