### PR TITLE
NAS-130345 / 24.10 / Fix KeyError in acltemplate plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -206,7 +206,7 @@ class ACLTemplateService(CRUDService):
         if 'ACTIVE_DIRECTORY' not in domain_info['domain_flags']['parsed']:
             self.logger.warning(
                 '%s: domain is not identified properly as an Active Directory domain.',
-                domain_info['alt_name']
+                domain_info['dns_name']
             )
             return
 


### PR DESCRIPTION
Since this method was originally written the python winbind client bindings have changed so that the key is dns_name instead of alt_name.