### PR TITLE
NAS-130414 / 24.10 / handle Unicode errors in authorized key file

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -214,7 +214,7 @@ class UserService(CRUDService):
 
     @private
     def _read_authorized_keys(self, homedir):
-        with suppress(FileNotFoundError):
+        with suppress(FileNotFoundError, UnicodeDecodeError):
             with open(f'{homedir}/.ssh/authorized_keys') as f:
                 return f.read().strip()
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -214,9 +214,12 @@ class UserService(CRUDService):
 
     @private
     def _read_authorized_keys(self, homedir):
-        with suppress(FileNotFoundError, UnicodeDecodeError):
+        with suppress(FileNotFoundError):
             with open(f'{homedir}/.ssh/authorized_keys') as f:
-                return f.read().strip()
+                try:
+                    return f.read().strip()
+                except UnicodeDecodeError:
+                    self.logger.warning('Invalid encoding detected in authorized_keys file')
 
     @private
     async def user_extend(self, user, ctx):


### PR DESCRIPTION
We've seen users upload invalid contents to the authorized key file for a local user. We can't prevent this foot-shooting, but we should squelch the error since our API fails pretty spectacularly here.