### PR TITLE
NAS-130344 / 24.10 / Fixed UI rollback test

### DIFF
--- a/tests/api2/test_system_general_ui_rollback.py
+++ b/tests/api2/test_system_general_ui_rollback.py
@@ -1,57 +1,102 @@
 import time
+from contextlib import contextmanager
 
-import pytest
-import requests
+from middlewared.test.integration.utils import call, client, ssh
+from middlewared.test.integration.utils.client import truenas_server
 
-from middlewared.test.integration.utils import call, ssh, url
+ROLLBACK = 20
+UI_DELAY = 3
+ORIG_PORT = 80
+NEW_PORT = 81
+
+
+def fallback_ui_fix():
+    """Fix the UI port settings using SSH in case an
+    unexpected failure is met or we just want to reset
+    our changes"""
+    ssh(f"midclt call system.general.update '{{\"ui_port\": {ORIG_PORT}}}'")
+    ssh("midclt call system.general.ui_restart 0")
+    time.sleep(5)
+
+
+@contextmanager
+def client_with_timeout(host_ip=None, tries=30):
+    for _ in range(tries):
+        try:
+            with client(host_ip=host_ip) as c:
+                assert c.call("core.ping") == "pong"
+                yield c
+                break
+        except ConnectionRefusedError:
+            time.sleep(1)
+    else:
+        assert False, "Could not connect to client."
 
 
 def test_system_general_ui_rollback():
+    """This tests the following:
+        1. change the port the nginx service binds to (our UI)
+        2. sleep a bit and allow the settings to be applied automatically
+        3. ensure communication with the API on the original port failsinal port fails
+        4. ensure communication with the API on the new port succeeds
+        5. check the time left before the changes are rolled back
+        6. sleep that amount of time (plus a few seconds for a buffer)
+        7. ensure communication with the API on the original port succeeds
+        8. if any above steps fail, revert the UI port settings via ssh"""
     try:
-        # Apply incorrect changes
-        call("system.general.update", {"ui_port": 81, "rollback_timeout": 20, "ui_restart_delay": 3})
+        # Step 1
+        call(
+            "system.general.update",
+            {"ui_port": NEW_PORT, "rollback_timeout": ROLLBACK, "ui_restart_delay": UI_DELAY}
+        )
 
-        # Wait for changes to be automatically applied
-        time.sleep(10)
+        # Step 2
+        time.sleep(UI_DELAY + 5)
 
-        # Ensure that changes were applied and the UI is now inaccessible
-        with pytest.raises(requests.ConnectionError):
-            requests.get(url(), timeout=10)
+        # Step 3
+        try:
+            assert call("core.ping") != "pong"
+        except Exception:
+            pass
 
-        # Additionally ensure that it is still working
-        assert requests.get(url() + ":81", timeout=10).status_code == 200
+        # Step 4
+        with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
+            rollback_left = c.call("system.general.checkin_waiting")
+            # Step 5
+            assert rollback_left < ROLLBACK
 
-        # Ensure that the check-in timeout is ticking back
-        assert 3 <= int(ssh("midclt call system.general.checkin_waiting").strip()) < 10
-
-        # Wait for changes to be automatically rolled back
-        time.sleep(15)
-
-        # Ensure that the UI is now accessible
-        assert requests.get(url(), timeout=10).status_code == 200
+        # Step 6
+        time.sleep(rollback_left + 5)
+        # Step 7
+        assert call("core.ping") == "pong"
     except Exception:
-        # Bring things back to normal via SSH in case of any error
-        ssh("midclt call system.general.update '{\"ui_port\": 80}'")
-        ssh("midclt call system.general.ui_restart 0")
-        time.sleep(10)
+        # Step 8
+        fallback_ui_fix()
         raise
 
 
 def test_system_general_ui_checkin():
+    """This tests the following:
+        1. change the port the nginx service binds to (our UI)
+        2. sleep a bit and allow the settings to be applied automatically
+        3. immediately checkin the UI port changes
+        4. ensure we don't have a checkin pending
+        5. revert any UI port settings via ssh"""
     try:
-        # Apply incorrect changes
-        call("system.general.update", {"ui_port": 81, "rollback_timeout": 20, "ui_restart_delay": 3})
+        # Step 1
+        call(
+            "system.general.update",
+            {"ui_port": NEW_PORT, "rollback_timeout": ROLLBACK, "ui_restart_delay": UI_DELAY}
+        )
 
-        # Wait for changes to be automatically applied
-        time.sleep(10)
+        # Step 2
+        time.sleep(UI_DELAY + 5)
 
-        # Check-in our new settings
-        assert ssh("midclt call system.general.checkin")
-
-        # Checking should not be pending anymore
-        assert ssh("midclt call system.general.checkin_waiting").strip() == "null"
+        # Step 3
+        with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
+            # Step 4
+            c.call("system.general.checkin")
+            # Step 5
+            assert c.call("system.general.checkin_waiting") is None
     finally:
-        # Bring things back to normal via SSH
-        ssh("midclt call system.general.update '{\"ui_port\": 80}'")
-        ssh("midclt call system.general.ui_restart 0")
-        time.sleep(10)
+        fallback_ui_fix()

--- a/tests/api2/test_system_general_ui_rollback.py
+++ b/tests/api2/test_system_general_ui_rollback.py
@@ -36,13 +36,12 @@ def client_with_timeout(host_ip=None, tries=30):
 def test_system_general_ui_rollback():
     """This tests the following:
         1. change the port the nginx service binds to (our UI)
-        2. sleep a bit and allow the settings to be applied automatically
-        3. ensure communication with the API on the original port failsinal port fails
-        4. ensure communication with the API on the new port succeeds
-        5. check the time left before the changes are rolled back
-        6. sleep that amount of time (plus a few seconds for a buffer)
-        7. ensure communication with the API on the original port succeeds
-        8. if any above steps fail, revert the UI port settings via ssh"""
+        2. ensure communication with the API on the original port failsinal port fails
+        3. ensure communication with the API on the new port succeeds
+        4. check the time left before the changes are rolled back
+        5. sleep that amount of time (plus a few seconds for a buffer)
+        6. ensure communication with the API on the original port succeeds
+        7. if any above steps fail, revert the UI port settings via ssh"""
     try:
         # Step 1
         call(
@@ -51,26 +50,23 @@ def test_system_general_ui_rollback():
         )
 
         # Step 2
-        time.sleep(UI_DELAY + 5)
-
-        # Step 3
         try:
             assert call("core.ping") != "pong"
         except Exception:
             pass
 
-        # Step 4
+        # Step 3
         with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
             rollback_left = c.call("system.general.checkin_waiting")
-            # Step 5
+            # Step 4
             assert rollback_left < ROLLBACK
 
-        # Step 6
+        # Step 5
         time.sleep(rollback_left + 5)
-        # Step 7
+        # Step 6
         assert call("core.ping") == "pong"
     except Exception:
-        # Step 8
+        # Step 7
         fallback_ui_fix()
         raise
 
@@ -78,10 +74,9 @@ def test_system_general_ui_rollback():
 def test_system_general_ui_checkin():
     """This tests the following:
         1. change the port the nginx service binds to (our UI)
-        2. sleep a bit and allow the settings to be applied automatically
-        3. immediately checkin the UI port changes
-        4. ensure we don't have a checkin pending
-        5. revert any UI port settings via ssh"""
+        2. immediately checkin the UI port changes
+        3. ensure we don't have a checkin pending
+        4. revert any UI port settings via ssh"""
     try:
         # Step 1
         call(
@@ -90,13 +85,10 @@ def test_system_general_ui_checkin():
         )
 
         # Step 2
-        time.sleep(UI_DELAY + 5)
-
-        # Step 3
         with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
-            # Step 4
+            # Step 3
             c.call("system.general.checkin")
-            # Step 5
+            # Step 4
             assert c.call("system.general.checkin_waiting") is None
     finally:
         fallback_ui_fix()


### PR DESCRIPTION
This fixes our UI rollback test by wrapping our update dependent client calls in a contextmanager that retires connecting to the client or a set amount of tries.

[Passing test](http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1795/console)