### PR TITLE
NAS-130444 / 24.10 / Remove deprecated user.set_root_password method

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1195,21 +1195,6 @@ class UserService(CRUDService):
 
     @no_auth_required
     @accepts(
-        Password('password'),
-        Dict('options')
-    )
-    @returns()
-    @pass_app()
-    async def set_root_password(self, app, password, options):
-        """
-        Deprecated method. Use `user.setup_local_administrator`
-        """
-        warnings.warn("`user.set_root_password` has been deprecated. Use `user.setup_local_administrator`",
-                      DeprecationWarning)
-        return await self.setup_local_administrator(app, 'root', password, options)
-
-    @no_auth_required
-    @accepts(
         Str('username', enum=['root', 'truenas_admin']),
         Password('password'),
         Dict(


### PR DESCRIPTION
We don't currently consume this endpoint and have already marked it as deprecated. Remove it completely to eliminate an endpoint that allows unauthenticated access.