### PR TITLE
NAS-130450 / 24.10 / Add changes to allow executing apps migration more then once

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -192,7 +192,7 @@ class AppService(CRUDService):
             )
             new_values = add_context_to_values(app_name, new_values, app_version_details['app_metadata'], install=True)
             update_app_config(app_name, version, new_values)
-            update_app_metadata(app_name, app_version_details, True)
+            update_app_metadata(app_name, app_version_details, migrated_app)
 
             job.set_progress(60, 'App installation in progress, pulling images')
             if dry_run is False:

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -165,7 +165,9 @@ class AppService(CRUDService):
         return self.create_internal(job, app_name, version, data['values'], complete_app_details)
 
     @private
-    def create_internal(self, job, app_name, version, user_values, complete_app_details, dry_run=False):
+    def create_internal(
+        self, job, app_name, version, user_values, complete_app_details, dry_run=False, migrated_app=False,
+    ):
         app_version_details = complete_app_details['versions'][version]
         self.middleware.call_sync('catalog.version_supported_error_check', app_version_details)
 
@@ -190,7 +192,7 @@ class AppService(CRUDService):
             )
             new_values = add_context_to_values(app_name, new_values, app_version_details['app_metadata'], install=True)
             update_app_config(app_name, version, new_values)
-            update_app_metadata(app_name, app_version_details)
+            update_app_metadata(app_name, app_version_details, True)
 
             job.set_progress(60, 'App installation in progress, pulling images')
             if dry_run is False:

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/metadata.py
@@ -15,10 +15,12 @@ def get_app_metadata(app_name: str) -> dict[str, typing.Any]:
         return {}
 
 
-def update_app_metadata(app_name: str, app_version_details: dict):
+def update_app_metadata(app_name: str, app_version_details: dict, migrated: bool | None = None):
+    migrated = get_app_metadata(app_name).get('migrated', False) if migrated is None else migrated
     with open(get_installed_app_metadata_path(app_name), 'w') as f:
         f.write(yaml.safe_dump({
             'metadata': app_version_details['app_metadata'],
+            'migrated': migrated,
             **{k: app_version_details[k] for k in ('version', 'human_version')},
             **get_portals_and_app_notes(app_name, app_version_details['version']),
         }))

--- a/src/middlewared/middlewared/plugins/catalog/sync.py
+++ b/src/middlewared/middlewared/plugins/catalog/sync.py
@@ -1,5 +1,3 @@
-import os
-
 from middlewared.schema import accepts
 from middlewared.service import job, private, returns, Service
 

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -54,10 +54,10 @@ class DockerSetupService(Service):
     async def status_change(self):
         config = await self.middleware.call('docker.config')
         if not config['pool']:
+            await (await self.middleware.call('catalog.sync')).wait()
             return
 
         await self.create_update_docker_datasets(config['dataset'])
-        await self.middleware.call('catalog.sync')
         await self.middleware.call('docker.state.start_service')
 
     @private

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/list_utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/list_utils.py
@@ -38,7 +38,9 @@ def get_default_release_details(release_name: str) -> dict:
     }
 
 
-def release_details(release_name: str, release_path: str, catalog_path: str, apps_mapping: dict) -> dict:
+def release_details(
+    release_name: str, release_path: str, catalog_path: str, apps_mapping: dict, installed_apps: dict,
+) -> dict:
     config = get_default_release_details(release_name)
     if not (release_metadata := get_release_metadata(release_path)) or not all(
         k in release_metadata.get('metadata', {}).get('labels', {})
@@ -49,6 +51,9 @@ def release_details(release_name: str, release_path: str, catalog_path: str, app
     metadata_labels = release_metadata['metadata']['labels']
     if metadata_labels['catalog'] != 'TRUENAS' or metadata_labels['catalog_branch'] != 'master':
         return config | {'error': 'Release is not from TrueNAS catalog'}
+
+    if release_name in installed_apps:
+        return config | {'error': 'App with same name is already installed'}
 
     release_train = metadata_labels['catalog_train'] if metadata_labels['catalog_train'] != 'charts' else 'stable'
     config['train'] = release_train

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -126,7 +126,7 @@ class K8stoDockerMigrationService(Service):
             try:
                 self.middleware.call_sync(
                     'app.create_internal', dummy_job, chart_release['release_name'],
-                    chart_release['app_version'], new_config, complete_app_details, True,
+                    chart_release['app_version'], new_config, complete_app_details, True, True,
                 )
             except Exception as e:
                 release_config['error'] = f'Failed to create app: {e}'

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -1,12 +1,10 @@
-import contextlib
 import os.path
 import shutil
 
 from middlewared.plugins.apps.ix_apps.path import get_app_parent_volume_ds_name, get_installed_app_path
 from middlewared.plugins.docker.state_utils import DATASET_DEFAULTS
-from middlewared.plugins.docker.utils import applications_ds_name
 from middlewared.schema import accepts, Dict, List, returns, Str
-from middlewared.service import CallError, InstanceNotFound, job, Service
+from middlewared.service import CallError, job, Service
 
 from .migrate_config_utils import migrate_chart_release_config
 
@@ -62,12 +60,6 @@ class K8stoDockerMigrationService(Service):
 
         if not backup_config['releases']:
             raise CallError(f'No old apps found in {options["backup_name"]!r} backup which can be migrated')
-
-        # We will see if docker dataset exists on this pool and if it is there, we will error out
-        docker_ds = applications_ds_name(kubernetes_pool)
-        with contextlib.suppress(InstanceNotFound):
-            self.middleware.call_sync('pool.dataset.get_instance_quick', docker_ds)
-            raise CallError(f'Docker dataset {docker_ds!r} already exists on {kubernetes_pool!r}')
 
         # For good measure we stop docker service and unset docker pool if any configured
         self.middleware.call_sync('service.stop', 'docker')


### PR DESCRIPTION
This PR adds changes so that consumers can now execute app migration from k8s to docker even if it has already been applied. Motivation for this change is to allow users to migrate apps which were not migrated before because of perhaps the app not existing in the new catalog or it's migration script not being available on the apps side.
It also adds `migrated` flag which shows if the app was migrated over from k8s or is a newly installed app.