### PR TITLE
NAS-130440 / 24.10 / fix pool.replace regression (introduced in 026691d39e4711107f40c7d0e8b48bbfc4788e9e)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -1,5 +1,4 @@
 import errno
-import os
 
 from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
 from middlewared.service import item_method, job, Service, ValidationErrors
@@ -46,11 +45,11 @@ class PoolService(Service):
         verrors = ValidationErrors()
         unused_disks = await self.middleware.call('disk.get_unused')
         if not (disk := list(filter(lambda x: x['identifier'] == options['disk'], unused_disks))):
-            verrors.add('options.disk', 'Disk not found.', errno.ENOENT)
+            verrors.add('options.disk', f'Disk {options["disk"]!r} not found.', errno.ENOENT)
         else:
             disk = disk[0]
             if not options['force'] and not await self.middleware.call('disk.check_clean', disk['devname']):
-                verrors.add('options.force', 'Disk is not clean, partitions were found.')
+                verrors.add('options.force', f'Disk {options["disk"]!r} is not clean, partitions were found.')
 
         if not await self.middleware.call(
             'pool.find_disk_from_topology', options['label'], pool, {'include_siblings': True}

--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -7,28 +7,19 @@ from truenas_api_client import ValidationErrors
 from middlewared.service_exception import InstanceNotFound
 from middlewared.test.integration.utils import call, fail, pool
 
-
-mirror_topology = (2, lambda disks: {
-    "data": [
-        {"type": "MIRROR", "disks": disks[0:2]}
-    ],
+_1_disk_stripe_topology = (1, lambda disks: {
+    "data": [{"type": "STRIPE", "disks": disks[0:1]}],
 })
-
+_2_disk_mirror_topology = (2, lambda disks: {
+    "data": [{"type": "MIRROR", "disks": disks[0:2]}],
+})
+_4_disk_raidz2_topology = (4, lambda disks: {
+    "data": [{"type": "RAIDZ2", "disks": disks[0:4]}],
+})
 another_pool_topologies = [
-    (1, lambda disks: {
-        "data": [
-            {"type": "STRIPE", "disks": disks[0:1]},
-        ],
-    }),
-    mirror_topology,
-    (4, lambda disks: {
-        "data": [
-            {
-                "type": "RAIDZ2",
-                "disks": disks[0:4]
-            }
-        ],
-    }),
+    _1_disk_stripe_topology,
+    _2_disk_mirror_topology,
+    _4_disk_raidz2_topology,
 ]
 
 


### PR DESCRIPTION
In https://github.com/truenas/middleware/commit/026691d39e4711107f40c7d0e8b48bbfc4788e9e, a commit was made to also wipe the disk that was being replaced when `pool.replace` was being called. I looked at that ticket but it's still not clear to me why this logic was added. In every possible scenario, it's entirely unnecessary to wipe the disk that is being replaced. Remove that logic and update `pool_replace_disk` api test accordingly. (also improve the test by documenting it as well).