### PR TITLE
NAS-130440 / 24.04.3 / fix pool.replace regression (introduced in 026691d39e4711107f40c7d0e8b48bbfc4788e9e) (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -73,7 +73,6 @@ class PoolService(Service):
                             min_size = min(min_size, size)
 
         swap_disks = [disk['devname']]
-        from_disk = None
         if found[1] and await self.middleware.run_in_thread(os.path.exists, found[1]['path']):
             if from_disk := await self.middleware.call('disk.label_to_disk', found[1]['path'].replace('/dev/', '')):
                 # If the disk we are replacing is still available, remove it from swap as well
@@ -96,9 +95,6 @@ class PoolService(Service):
             await self.middleware.call('zfs.pool.replace', pool['name'], options['label'], new_devname)
         except Exception:
             raise
-        else:
-            if from_disk:
-                await self.middleware.call('disk.wipe', from_disk, 'QUICK')
         finally:
             # Needs to happen even if replace failed to put back disk that had been
             # removed from swap prior to replacement

--- a/src/middlewared/middlewared/plugins/pool_/replace_disk.py
+++ b/src/middlewared/middlewared/plugins/pool_/replace_disk.py
@@ -1,5 +1,4 @@
 import errno
-import os
 
 from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
 from middlewared.service import item_method, job, Service, ValidationErrors
@@ -46,11 +45,11 @@ class PoolService(Service):
         verrors = ValidationErrors()
         unused_disks = await self.middleware.call('disk.get_unused')
         if not (disk := list(filter(lambda x: x['identifier'] == options['disk'], unused_disks))):
-            verrors.add('options.disk', 'Disk not found.', errno.ENOENT)
+            verrors.add('options.disk', f'Disk {options["disk"]!r} not found.', errno.ENOENT)
         else:
             disk = disk[0]
             if not options['force'] and not await self.middleware.call('disk.check_clean', disk['devname']):
-                verrors.add('options.force', 'Disk is not clean, partitions were found.')
+                verrors.add('options.force', f'Disk {options["disk"]!r} is not clean, partitions were found.')
 
         if not (found := await self.middleware.call('pool.find_disk_from_topology', options['label'], pool, {
             'include_siblings': True,

--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -6,28 +6,19 @@ from middlewared.client import ValidationErrors
 from middlewared.service_exception import InstanceNotFound
 from middlewared.test.integration.utils import call, fail, pool
 
-
-mirror_topology = (2, lambda disks: {
-    "data": [
-        {"type": "MIRROR", "disks": disks[0:2]}
-    ],
+_1_disk_stripe_topology = (1, lambda disks: {
+    "data": [{"type": "STRIPE", "disks": disks[0:1]}],
 })
-
+_2_disk_mirror_topology = (2, lambda disks: {
+    "data": [{"type": "MIRROR", "disks": disks[0:2]}],
+})
+_4_disk_raidz2_topology = (4, lambda disks: {
+    "data": [{"type": "RAIDZ2", "disks": disks[0:4]}],
+})
 another_pool_topologies = [
-    (1, lambda disks: {
-        "data": [
-            {"type": "STRIPE", "disks": disks[0:1]},
-        ],
-    }),
-    mirror_topology,
-    (4, lambda disks: {
-        "data": [
-            {
-                "type": "RAIDZ2",
-                "disks": disks[0:4]
-            }
-        ],
-    }),
+    _1_disk_stripe_topology,
+    _2_disk_mirror_topology,
+    _4_disk_raidz2_topology,
 ]
 
 

--- a/tests/api2/test_pool_replace_disk.py
+++ b/tests/api2/test_pool_replace_disk.py
@@ -1,77 +1,68 @@
+from time import sleep
+
 import pytest
 
-from time import sleep
-from middlewared.test.integration.assets.pool import mirror_topology, another_pool_topologies, another_pool
+from middlewared.test.integration.assets.pool import _2_disk_mirror_topology, _4_disk_raidz2_topology, another_pool
 from middlewared.test.integration.utils import call
-from auto_config import ha
-pytestmark = [
-    pytest.mark.skipif(ha, reason='Skipping for HA testing'),
-]
 
 
-def disks(topology):
-    flat = call("pool.flatten_topology", topology)
-    return [vdev for vdev in flat if vdev["type"] == "DISK"]
+@pytest.mark.parametrize("topology", [_2_disk_mirror_topology, _4_disk_raidz2_topology])
+def test_pool_replace_disk(topology):
+    """This tests the following:
+        1. create a zpool based on the `topology`
+        2. flatten the newly created zpools topology
+        3. verify the zpool vdev size matches reality
+        4. choose 1st vdev from newly created zpool
+        5. choose 1st disk in vdev from step #4
+        6. choose 1st disk in disk.get_unused as replacement disk
+        7. call pool.replace using disk from step #5 with disk from step #6
+        8. validate that the disk being replaced still has zfs partitions
+        9. validate pool.get_instance topology info shows the replacement disk
+        10. validate disk.get_instance associates the replacement disk with the zpool
+    """
+    with another_pool(topology=topology) as pool:  # step 1
+        # step 2
+        flat_top = call("pool.flatten_topology", pool["topology"])
+        pool_top = [vdev for vdev in flat_top if vdev["type"] == "DISK"]
+        # step 3
+        assert len(pool_top) == topology[0]
 
-
-@pytest.mark.parametrize("topology", another_pool_topologies[1:])
-@pytest.mark.parametrize("i", list(range(0, max(topology[0] for topology in another_pool_topologies))))
-def test_pool_replace_disk(topology, i):
-    count = topology[0]
-    if i >= count:
-        return
-
-    with another_pool(topology=topology) as pool:
-        assert len(disks(pool["topology"])) == count
-
-        to_replace_vdev = disks(pool["topology"])[i]
-        to_replace_disk = call("disk.query", [["devname", "=", to_replace_vdev["disk"]]],
-                               {"get": True, "extra": {"pools": True}})
+        # step 4
+        to_replace_vdev = pool_top[0]
+        # step 5
+        to_replace_disk = call(
+            "disk.query", [["devname", "=", to_replace_vdev["disk"]]], {"get": True, "extra": {"pools": True}}
+        )
         assert to_replace_disk["pool"] == pool["name"]
 
+        # step 6
         new_disk = call("disk.get_unused")[0]
 
-        call("pool.replace", pool["id"], {
-            "label": to_replace_vdev["guid"],
-            "disk": new_disk["identifier"],
-            "force": True,
-        }, job=True)
+        # step 7
+        call("pool.replace", pool["id"], {"label": to_replace_vdev["guid"], "disk": new_disk["identifier"]}, job=True)
 
-        # Sometimes the VM is slow so look 5 times with 1 second in between
-        for _ in range(5):
-            pool = call("pool.get_instance", pool["id"])
-            if len(disks(pool["topology"])) == count:
+        # step 8
+        assert call("disk.gptid_from_part_type", to_replace_disk["devname"], call("disk.get_zfs_part_type"))
+
+        # step 9
+        found = False
+        for _ in range(10):
+            if not found:
+                for i in call("pool.flatten_topology", call("pool.get_instance", pool["id"])["topology"]):
+                    if i["type"] == "DISK" and i["disk"] == new_disk["devname"]:
+                        found = True
+                        break
+                else:
+                    sleep(1)
+
+        assert found, f'Failed to detect replacement disk {new_disk["devname"]!r} in zpool {pool["name"]!r}'
+
+        # step 10 (NOTE: disk.sync_all takes awhile so we retry a few times here)
+        for _ in range(30):
+            cmd = ("disk.get_instance", new_disk["identifier"], {"extra": {"pools": True}})
+            if call(*cmd)["pool"] == pool["name"]:
                 break
-            sleep(1)
-
-        assert len(disks(pool["topology"])) == count
-        assert disks(pool["topology"])[i]["disk"] == new_disk["devname"]
-
-        assert call("disk.get_instance", new_disk["identifier"], {"extra": {"pools": True}})["pool"] == pool["name"]
-        assert call("disk.get_instance", to_replace_disk["identifier"], {"extra": {"pools": True}})["pool"] is None
-
-
-@pytest.mark.parametrize("swaps", [[0, 0], [2, 2], [2, 4]])
-def test_pool_replace_disk_swap(swaps):
-    unused = call("disk.get_unused")
-    if len(unused) < 3:
-        raise RuntimeError(f"At least 3 unused disks required to run this test")
-
-    test_disks = unused[:3]
-
-    sizes = {disk["name"]: disk["size"] for disk in test_disks}
-    assert len(set(sizes.values())) == 1, sizes
-
-    call("system.advanced.update", {"swapondrive": swaps[0]})
-    try:
-        with another_pool(topology=mirror_topology) as pool:
-            to_replace_vdev = disks(pool["topology"])[0]
-
-            call("system.advanced.update", {"swapondrive": swaps[1]})
-            call("pool.replace", pool["id"], {
-                "label": to_replace_vdev["guid"],
-                "disk": test_disks[2]["identifier"],
-                "force": True,
-            }, job=True)
-    finally:
-        call("system.advanced.update", {"swapondrive": 2})
+            else:
+                sleep(1)
+        else:
+            assert False, f"{' '.join(cmd)} failed to update with pool information"


### PR DESCRIPTION
In https://github.com/truenas/middleware/commit/026691d39e4711107f40c7d0e8b48bbfc4788e9e, a commit was made to also wipe the disk that was being replaced when `pool.replace` was being called. I looked at that ticket but it's still not clear to me why this logic was added. In every possible scenario, it's entirely unnecessary to wipe the disk that is being replaced. Remove that logic and update `pool_replace_disk` api test accordingly. (also improve the test by documenting it as well).

Original PR: https://github.com/truenas/middleware/pull/14151
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130440