### PR TITLE
NAS-130475 / 24.10 / Change field name for bypassing ACL validation

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -590,7 +590,7 @@ class FilesystemService(Service):
             self._strip_acl_nfs4(path)
 
         else:
-            if not options['skip_execute_check']:
+            if options['validate_effective_acl']:
                 uid_to_check = current_acl['uid'] if uid == -1 else uid
                 gid_to_check = current_acl['gid'] if gid == -1 else gid
 
@@ -746,7 +746,7 @@ class FilesystemService(Service):
             )
 
         if not do_strip:
-            if not options['skip_execute_check']:
+            if options['validate_effective_acl']:
                 try:
                     # check execute on parent paths
                     uid_to_check = current_acl['uid'] if uid == -1 else uid
@@ -869,7 +869,7 @@ class FilesystemService(Service):
                 Bool('recursive', default=False),
                 Bool('traverse', default=False),
                 Bool('canonicalize', default=True),
-                Bool('skip_execute_check', default=False)
+                Bool('validate_effective_acl', default=True)
             )
         ), roles=['FILESYSTEM_ATTRS_WRITE'], audit='Filesystem set ACL', audit_extended=lambda data: data['path']
     )

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -793,10 +793,12 @@ class PoolDatasetService(CRUDService):
         created_ds = await self.get_instance(data['id'])
 
         if acl_to_set:
+            # We're potentially auto-inheriting an ACL containing nested
+            # security groups and so we need to skip the ACL validation
             acl_job = await self.middleware.call('filesystem.setacl', {
                 'path': mountpoint,
                 'dacl': acl_to_set,
-                'options': {'skip_execute_check': True}
+                'options': {'validate_effective_acl': False}
             })
             await acl_job.wait(raise_error=True)
 


### PR DESCRIPTION
Per feedback from UI team, invert the value of skip_execute_check and rename to validate_effective_acl to give a better hint as to what it is for and dissuade users from the option.