### PR TITLE
NAS-129810 / 24.10 / Allow upsupported SFPs for Intel network cards

### DIFF
--- a/src/freenas/usr/lib/modprobe.d/truenas.conf
+++ b/src/freenas/usr/lib/modprobe.d/truenas.conf
@@ -1,3 +1,4 @@
 options spl spl_panic_halt=1
 options zfs zfs_default_ibs=15 zfs_arc_shrinker_limit=0 zfs_arc_pc_percent=300
+options ixgbe allow_unsupported_sfp=1
 blacklist irdma


### PR DESCRIPTION
There is a compain from user who lost connectivity after updating from CORE to SCALE, as unsupported SFPs are not allowed by default on Linux.

This commit updates the module parameter list to allow unsupported or unofficial SFPs for Intel network cards. Unsupported SFPs are allowed on TrueNAS CORE as well.