### PR TITLE
NAS-130485 / 24.10 / Improve auditing for middleware methods

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -16,6 +16,7 @@ from .service_exception import (
     get_errname,
 )
 from .utils import MIDDLEWARE_RUN_DIR, sw_version
+from .utils.audit import audit_username_from_session
 from .utils.debug import get_frame_details, get_threads_stacks
 from .utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
 from .utils.nginx import get_remote_addr_port
@@ -1547,8 +1548,8 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                     "major": 0,
                     "minor": 1
                 },
-                "addr": "127.0.0.1",
-                "user": "root",
+                "addr": app.origin.repr() if isinstance(app.origin, TCPIPOrigin) else "127.0.0.1",
+                "user": audit_username_from_session(app.authenticated_credentials),
                 "sess": app.session_id,
                 "time": datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f'),
                 "svc": "MIDDLEWARE",

--- a/src/middlewared/middlewared/pytest/unit/utils/test_audit.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_audit.py
@@ -1,0 +1,29 @@
+import pytest
+
+from middlewared.auth import (
+    ApiKeySessionManagerCredentials,
+    UserSessionManagerCredentials,
+    TrueNasNodeSessionManagerCredentials
+)
+
+from middlewared.utils.audit import audit_username_from_session
+from types import SimpleNamespace
+
+
+API_KEY = SimpleNamespace(api_key={'id': 1, 'name': 'MY_KEY'})
+
+USER_SESSION = UserSessionManagerCredentials({'username': 'bob', 'privilege': {'allowlist': []}})
+API_KEY_SESSION = ApiKeySessionManagerCredentials(API_KEY)
+TOKEN_USER_SESSION = SimpleNamespace(root_credentials=USER_SESSION, is_user_session=True, user=USER_SESSION.user)
+NODE_SESSION = TrueNasNodeSessionManagerCredentials()
+
+
+@pytest.mark.parametrize('cred,expected', [
+    (None, '.UNAUTHENTICATED'),
+    (USER_SESSION, 'bob'),
+    (API_KEY_SESSION, '.API_KEY:MY_KEY'),
+    (TOKEN_USER_SESSION, 'bob'),
+    (NODE_SESSION, '.TRUENAS_NODE')
+])
+def test_privilege_has_webui_access(cred, expected):
+    assert audit_username_from_session(cred) == expected

--- a/src/middlewared/middlewared/utils/audit.py
+++ b/src/middlewared/middlewared/utils/audit.py
@@ -1,0 +1,33 @@
+from middlewared.auth import (
+    ApiKeySessionManagerCredentials,
+    TokenSessionManagerCredentials,
+    TrueNasNodeSessionManagerCredentials
+)
+
+# Special values start with dot to ensure they cannot collide with local usernames
+# created via APIs
+API_KEY_PREFIX = '.API_KEY:'
+NODE_SESSION = '.TRUENAS_NODE'
+UNAUTHENTICATED = '.UNAUTHENTICATED'
+UNKNOWN_SESSION = '.UNKNOWN'
+
+
+def audit_username_from_session(cred) -> str:
+    if cred is None:
+        return UNAUTHENTICATED
+
+    # This works for regular user session and tokens formed on them
+    if cred.is_user_session:
+        return cred.user['username']
+
+    # Track back to root credential if necessary (token session)
+    if isinstance(cred, TokenSessionManagerCredentials):
+        cred = cred.root_credentials
+
+    if isinstance(cred, ApiKeySessionManagerCredentials):
+        return f'{API_KEY_PREFIX}{cred.api_key.api_key["name"]}'
+
+    elif isinstance(cred, TrueNasNodeSessionManagerCredentials):
+        return NODE_SESSION
+
+    return UNKNOWN_SESSION


### PR DESCRIPTION
Populate `username` and `address` fields in middleware audit entries based on information from the middleware session.

The UI prominently displays the `username` field which is currently hard-coded to root. This commit adds a helper function to generate a username string based on the current authenticated credentials for the session generating the audit entry.