### PR TITLE
NAS-130490 / 24.10 / Fix order_by when using raw sql queries on audit backend

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -218,6 +218,8 @@ class AuditBackendService(Service, FilterMixin, SchemaMixin):
                 if wrapper is not None:
                     order_by[i] = wrapper(order_by[i])
 
+            qs = qs.order_by(*order_by)
+
         if options['offset']:
             qs = qs.offset(options['offset'])
 

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -215,6 +215,24 @@ class TestAuditOps:
             retries -= 1
         assert ops_count > initial_ops_count, f"retries remaining = {retries}"
 
+    def test_audit_order_by(self):
+        entries_forward = call('audit.query', {'services': ['SMB'], 'query-options': {
+            'order_by': ['audit_id']
+        }})
+
+        entries_reverse = call('audit.query', {'services': ['SMB'], 'query-options': {
+            'order_by': ['-audit_id']
+        }})
+
+        head_forward_id = entries_forward[0]['audit_id']
+        tail_forward_id = entries_forward[-1]['audit_id']
+
+        head_reverse_id = entries_reverse[0]['audit_id']
+        tail_reverse_id = entries_reverse[-1]['audit_id']
+
+        assert head_forward_id == tail_reverse_id
+        assert tail_forward_id == head_reverse_id
+
     def test_audit_export(self):
         for backend in ['CSV', 'JSON', 'YAML']:
             report_path = call('audit.export', {'export_format': backend}, job=True)


### PR DESCRIPTION
Order_by directives were not being applied to the generated SQL queryset that was being passed to the individual audit backend services. This wasn't caught because often filtering for generic audit queries happens via filter_list because the filters cannot be fully duplicated using native SQL features.