### PR TITLE
NAS-130498 / 24.10 / Omit SMB audit results from audit.query output by default

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -129,7 +129,7 @@ class AuditService(ConfigService):
 
     @accepts(Dict(
         'audit_query',
-        List('services', items=[Str('db_name', enum=ALL_AUDITED)], default=ALL_AUDITED),
+        List('services', items=[Str('db_name', enum=ALL_AUDITED)], default=['MIDDLEWARE', 'SUDO']),
         Ref('query-filters'),
         Ref('query-options'),
         register=True

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -39,6 +39,9 @@ from middlewared.validators import Range
 
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]
+BULK_AUDIT = ['SMB']
+NON_BULK_AUDIT = [svc for svc in ALL_AUDITED if svc not in BULK_AUDIT]
+
 # We set the refquota limit
 QUOTA_WARN = TNUserProp.REFQUOTA_WARN.value
 QUOTA_CRIT = TNUserProp.REFQUOTA_CRIT.value
@@ -129,7 +132,7 @@ class AuditService(ConfigService):
 
     @accepts(Dict(
         'audit_query',
-        List('services', items=[Str('db_name', enum=ALL_AUDITED)], default=['MIDDLEWARE', 'SUDO']),
+        List('services', items=[Str('db_name', enum=ALL_AUDITED)], default=NON_BULK_AUDIT),
         Ref('query-filters'),
         Ref('query-options'),
         register=True

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -105,7 +105,7 @@ def parse_query_filters(
     can loosen these restrictions with appropriate levels of testing and
     validation in auditbackend plugin.
     """
-    services_to_check = set(services)
+    services_to_check = services_in = set(services)
     filters_out = []
 
     for f in filters:
@@ -122,7 +122,10 @@ def parse_query_filters(
 
             match f[1]:
                 case '=' | 'in':
-                    services_to_check = services_to_check & svcs
+                    if services_in == services_to_check:
+                        services_to_check = svcs
+                    else:
+                        services_to_check = services_to_check & svcs
                 case '!=' | 'nin':
                     services_to_check = services_to_check - svcs
                 case _:


### PR DESCRIPTION
This is an optimization to improve memory consumption by default queries used by the webui. Initially we included SMB audit results by default with the expectation that user would specify the exact audited service they wanted to query. Since SMB audit logs can span upwards to hundreds of thousands of entries in some extreme cases we need to ensure that UI / API consumers use optimized SQL queryfilters with appropriate pagination.