### PR TITLE
NAS-130492 / 24.10 / fix-except

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -31,7 +31,7 @@ async def resolve_hostname(middleware, verrors, name, hostname):
     try:
         aw = middleware.create_task(middleware.run_in_thread(resolve_host_name_thread, hostname))
         result = await asyncio.wait_for(aw, timeout=5)
-    except asyncio.futures.TimeoutError:
+    except TimeoutError:
         result = False
 
     if not result:


### PR DESCRIPTION
As of Python 3.11, `asyncio.wait_for` raises the built-in `TimeoutError` ([doc page](https://docs.python.org/3.11/library/asyncio-task.html#asyncio.wait_for:~:text=Changed%20in%20version%203.11%3A%20Raises%20TimeoutError%20instead%20of%20asyncio.TimeoutError.)).

`asyncio.TimeoutError` is an alias of `TimeoutError` for backwards compatibility. However, `asyncio.futures.TimeoutError` is not defined and will cause an error.