### PR TITLE
NAS-130493 / 24.10 / No need to provide unused ports to questions context

### DIFF
--- a/src/middlewared/middlewared/plugins/catalog/apps_details.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_details.py
@@ -229,7 +229,6 @@ class CatalogService(Service):
         return {
             'timezones': await self.middleware.call('system.general.timezone_choices'),
             'system.general.config': await self.middleware.call('system.general.config'),
-            'unused_ports': await self.middleware.call('port.get_unused_ports', 1),
             'certificates': await self.middleware.call('app.certificate_choices'),
             'certificate_authorities': await self.middleware.call('app.certificate_authority_choices'),
             'ip_choices': await self.middleware.call('app.ip_choices'),


### PR DESCRIPTION
This PR adds changes to not pass on unused ports to apps validation, this does not mean that ports will not be validated - but just that the end result would be users not being presented with a select field to select which port they want and instead having to type it in manually.