### PR TITLE
NAS-130508 / 24.10 / Fix test regression in snapshot task deletion

### DIFF
--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -283,6 +283,8 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         if (task := await self.query([['id','=', id_]])):
             audit_callback(task[0]['dataset'])
+        else:
+            audit_callback(f'Task id {id_} not found')
 
         for replication_task in await self.middleware.call('replication.query', [
             ['direction', '=', 'PUSH'],

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -281,8 +281,8 @@ class PeriodicSnapshotTaskService(CRUDService):
             }
         """
 
-        dataset = (await self.get_instance(id_))['dataset']
-        audit_callback(dataset)
+        if (task := await self.query([['id','=', id_]])):
+            audit_callback(task[0]['dataset'])
 
         for replication_task in await self.middleware.call('replication.query', [
             ['direction', '=', 'PUSH'],


### PR DESCRIPTION
Adding an audit callback function with dataset name introduced a new failure condition for case where snapshot task matching the id does not exist.