### PR TITLE
NAS-130513 / 24.10 / Add app events

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -25,6 +25,7 @@ class AppService(CRUDService):
     class Config:
         namespace = 'app'
         datastore_primary_key_type = 'string'
+        event_send = False
         cli_namespace = 'app'
         role_prefix = 'APPS'
 

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -222,6 +222,8 @@ class AppService(CRUDService):
             new_values = add_context_to_values(app_name, new_values, app_version_details['app_metadata'], install=True)
             update_app_config(app_name, version, new_values)
             update_app_metadata(app_name, app_version_details, migrated_app)
+            # At this point the app exists
+            self.middleware.send_event('app.query', 'ADDED', id=app_name)
 
             job.set_progress(60, 'App installation in progress, pulling images')
             if dry_run is False:
@@ -235,6 +237,7 @@ class AppService(CRUDService):
                 with contextlib.suppress(Exception):
                     method(*args, **kwargs)
 
+            self.middleware.send_event('app.query', 'REMOVED', id=app_name)
             raise e from None
         else:
             if dry_run is False:
@@ -291,6 +294,7 @@ class AppService(CRUDService):
             # TODO: Eventually we would want this to be executed for custom apps as well
             update_app_metadata_for_portals(app_name, app['version'])
         job.set_progress(60, 'Configuration updated, updating docker resources')
+        self.middleware.send_event('app.query', 'CHANGED', id=app_name)
         compose_action(app_name, app['version'], 'up', force_recreate=True, remove_orphans=True)
 
         job.set_progress(100, f'{progress_keyword} completed for {app_name!r}')
@@ -326,6 +330,8 @@ class AppService(CRUDService):
                 self.middleware.call_sync('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
         finally:
             self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)
+
+        self.middleware.send_event('app.query', 'REMOVED', id=app_name)
         job.set_progress(100, f'Deleted {app_name!r} app')
         return True
 

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -331,7 +331,8 @@ class AppService(CRUDService):
         finally:
             self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)
 
-        self.middleware.send_event('app.query', 'REMOVED', id=app_name)
+        if options.get('send_event', True):
+            self.middleware.send_event('app.query', 'REMOVED', id=app_name)
         job.set_progress(100, f'Deleted {app_name!r} app')
         return True
 

--- a/src/middlewared/middlewared/plugins/apps/custom_app.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app.py
@@ -43,7 +43,6 @@ class AppCustomService(Service):
         return self.create({
             'app_name': app_name,
             'custom_compose_config': rendered_config,
-            'send_event': False,
             'conversion': True,
         }, job)
 
@@ -71,7 +70,7 @@ class AppCustomService(Service):
             update_app_config(app_name, version, compose_config, custom_app=True)
             update_app_metadata(app_name, app_version_details, migrated=False, custom_app=True)
 
-            if data.get('send_event', True):
+            if app_being_converted is False:
                 self.middleware.send_event('app.query', 'ADDED', id=app_name)
             if app_being_converted:
                 msg = 'App conversion in progress, pulling images'

--- a/src/middlewared/middlewared/plugins/apps/custom_app.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app.py
@@ -67,6 +67,7 @@ class AppCustomService(Service):
             update_app_config(app_name, version, compose_config, custom_app=True)
             update_app_metadata(app_name, app_version_details, migrated=False, custom_app=True)
 
+            self.middleware.send_event('app.query', 'ADDED', id=app_name)
             update_progress(60, 'App installation in progress, pulling images')
             compose_action(app_name, version, 'up', force_recreate=True, remove_orphans=True)
         except Exception as e:
@@ -78,6 +79,7 @@ class AppCustomService(Service):
                 with contextlib.suppress(Exception):
                     method(*args, **kwargs)
 
+            self.middleware.send_event('app.query', 'REMOVED', id=app_name)
             raise e from None
         else:
             self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/plugins/apps/events.py
+++ b/src/middlewared/middlewared/plugins/apps/events.py
@@ -1,11 +1,8 @@
-import asyncio
-
 from middlewared.service import Service
 
 from .ix_apps.utils import get_app_name_from_project_name
 
 
-EVENT_LOCK = asyncio.Lock()
 PROCESSING_APP_EVENT = set()
 
 
@@ -24,19 +21,17 @@ class AppEvents(Service):
 
 async def app_event(middleware, event_type, args):
     app_name = get_app_name_from_project_name(args['id'])
-    async with EVENT_LOCK:
-        if app_name in PROCESSING_APP_EVENT:
-            return
+    if app_name in PROCESSING_APP_EVENT:
+        return
 
-        PROCESSING_APP_EVENT.add(app_name)
+    PROCESSING_APP_EVENT.add(app_name)
 
     try:
         await middleware.call('app.events.process', app_name, args['fields'])
     except Exception as e:
         middleware.logger.warning('Unhandled exception: %s', e)
     finally:
-        async with EVENT_LOCK:
-            PROCESSING_APP_EVENT.remove(app_name)
+        PROCESSING_APP_EVENT.remove(app_name)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/apps/events.py
+++ b/src/middlewared/middlewared/plugins/apps/events.py
@@ -16,8 +16,7 @@ class AppEvents(Service):
         private = True
 
     async def process(self, app_name, container_event):
-        # TODO: Remove select from here
-        if app := await self.middleware.call('app.query', [['id', '=', app_name]], {'select': ['id', 'state']}):
+        if app := await self.middleware.call('app.query', [['id', '=', app_name]]):
             self.middleware.send_event(
                 'app.query', 'CHANGED', id=app_name, fields=app[0],
             )

--- a/src/middlewared/middlewared/plugins/apps/events.py
+++ b/src/middlewared/middlewared/plugins/apps/events.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from middlewared.service import Service
+
+from .ix_apps.utils import get_app_name_from_project_name
+
+
+EVENT_LOCK = asyncio.Lock()
+PROCESSING_APP_EVENT = set()
+
+
+class AppEvents(Service):
+
+    class Config:
+        namespace = 'app.events'
+        private = True
+
+    async def process(self, app_name, container_event):
+        pass
+
+
+async def app_event(middleware, event_type, args):
+    app_name = get_app_name_from_project_name(args['id'])
+    async with EVENT_LOCK:
+        if app_name in PROCESSING_APP_EVENT:
+            return
+
+        PROCESSING_APP_EVENT.add(app_name)
+
+    try:
+        await middleware.call('app.events.process', app_name, args['fields'])
+    except Exception as e:
+        middleware.logger.warning('Unhandled exception: %s', e)
+    finally:
+        async with EVENT_LOCK:
+            PROCESSING_APP_EVENT.remove(app_name)
+
+
+async def setup(middleware):
+    middleware.event_subscribe('docker.events', app_event)

--- a/src/middlewared/middlewared/plugins/apps/events.py
+++ b/src/middlewared/middlewared/plugins/apps/events.py
@@ -16,7 +16,11 @@ class AppEvents(Service):
         private = True
 
     async def process(self, app_name, container_event):
-        pass
+        # TODO: Remove select from here
+        if app := await self.middleware.call('app.query', [['id', '=', app_name]], {'select': ['id', 'state']}):
+            self.middleware.send_event(
+                'app.query', 'CHANGED', id=app_name, fields=app[0],
+            )
 
 
 async def app_event(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -6,7 +6,7 @@ from .docker.query import list_resources_by_project
 from .metadata import get_collective_config, get_collective_metadata
 from .lifecycle import get_current_app_config
 from .path import get_app_parent_config_path
-from .utils import PROJECT_PREFIX
+from .utils import PROJECT_PREFIX, get_app_name_from_project_name
 
 
 COMPOSE_SERVICE_KEY: str = 'com.docker.compose.service'
@@ -71,7 +71,7 @@ def list_apps(
     for app_name, app_resources in list_resources_by_project(
         project_name=f'{PROJECT_PREFIX}{specific_app}' if specific_app else None,
     ).items():
-        app_name = app_name[len(PROJECT_PREFIX):]
+        app_name = get_app_name_from_project_name(app_name)
         app_names.add(app_name)
         if app_name not in metadata:
             # The app is malformed or something is seriously wrong with it

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
@@ -1,3 +1,7 @@
 from catalog_reader.library import RE_VERSION  # noqa
 from middlewared.plugins.apps.schema_utils import CONTEXT_KEY_NAME  # noqa
 from middlewared.plugins.apps.utils import IX_APPS_MOUNT_PATH, PROJECT_PREFIX, run  # noqa
+
+
+def get_app_name_from_project_name(project_name: str) -> str:
+    return project_name[len(PROJECT_PREFIX):]

--- a/src/middlewared/middlewared/plugins/apps/rollback.py
+++ b/src/middlewared/middlewared/plugins/apps/rollback.py
@@ -61,6 +61,7 @@ class AppService(Service):
         # 5) Roll back ix_volume dataset's snapshots if available
         # 6) Finally update collective metadata config to reflect new version
         update_app_metadata(app_name, rollback_version)
+        self.middleware.send_event('app.query', 'CHANGED', id=app_name)
         try:
             if options['rollback_snapshot'] and (
                 app_volume_ds := self.middleware.call_sync('app.get_app_volume_ds', app_name)

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -67,6 +67,7 @@ class AppService(Service):
 
             job.set_progress(40, f'Configuration updated for {app_name!r}, upgrading app')
 
+        self.middleware.send_event('app.query', 'CHANGED', id=app_name)
         try:
             compose_action(app_name, upgrade_version['version'], 'up', force_recreate=True, remove_orphans=True)
         finally:

--- a/src/middlewared/middlewared/plugins/apps_images/images.py
+++ b/src/middlewared/middlewared/plugins/apps_images/images.py
@@ -106,6 +106,7 @@ class AppImageService(CRUDService):
 
             job.set_progress((progress['current']/progress['total']) * 90, 'Pulling image')
 
+        self.middleware.call_sync('docker.state.validate')
         auth_config = data['auth_config'] or {}
         image_tag = data['image']
         pull_image(image_tag, callback, auth_config.get('username'), auth_config.get('password'))

--- a/src/middlewared/middlewared/plugins/docker/events.py
+++ b/src/middlewared/middlewared/plugins/docker/events.py
@@ -1,0 +1,29 @@
+from middlewared.service import Service
+
+
+class DockerEventService(Service):
+
+    class Config:
+        namespace = 'docker.events'
+        private = True
+
+    def setup(self):
+        if not self.middleware.call_sync('docker.state.validate', False):
+            return
+
+        try:
+            self.process()
+        except Exception:
+            if not self.middleware.call('service.started', 'docker'):
+                # This is okay and can happen when docker is stopped
+                return
+            raise
+
+    def process(self):
+        pass
+
+
+async def setup(middleware):
+    middleware.event_register('docker.events', 'Docker container events')
+    # We are going to check in setup docker events if setting up events is relevant or not
+    middleware.create_task(middleware.call('docker.events.setup'))

--- a/src/middlewared/middlewared/plugins/docker/events.py
+++ b/src/middlewared/middlewared/plugins/docker/events.py
@@ -42,6 +42,6 @@ class DockerEventService(Service):
 
 
 async def setup(middleware):
-    middleware.event_register('docker.events', 'Docker container events')
+    middleware.event_register('docker.events', 'Docker container events', roles=['DOCKER_READ'])
     # We are going to check in setup docker events if setting up events is relevant or not
     middleware.create_task(middleware.call('docker.events.setup'))

--- a/src/middlewared/middlewared/plugins/docker/events.py
+++ b/src/middlewared/middlewared/plugins/docker/events.py
@@ -29,8 +29,8 @@ class DockerEventService(Service):
             decode=True, filters={
                 'type': ['container'],
                 'event': [
-                    'create', 'destroy', 'detach', 'die', 'health_status', 'kill', 'unpause', 'update',
-                    'oom', 'pause', 'rename', 'resize', 'restart', 'start', 'stop', 'top',
+                    'create', 'destroy', 'detach', 'die', 'health_status', 'kill', 'unpause',
+                    'oom', 'pause', 'rename', 'resize', 'restart', 'start', 'stop', 'update',
                 ]
             }
         ):

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -60,6 +60,7 @@ class DockerService(SimpleService):
 
     async def after_start(self):
         await self.middleware.call('docker.state.set_status', Status.RUNNING.value)
+        self.middleware.create_task(self.middleware.call('docker.events.setup'))
         await self.middleware.call('catalog.sync')
 
     async def before_stop(self):


### PR DESCRIPTION
This PR adds changes to listen for docker events and based off those trigger app events so UI can get app status when the actual app's status changes and there is no need to poll for it.