### PR TITLE
NAS-130517 / 24.10 / Make checking image updates configurable again

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-08-09_14-35_image_update.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-08-09_14-35_image_update.py
@@ -1,0 +1,25 @@
+"""
+Add flag to see if image update is requried
+
+Revision ID: 4b0b7ba46e63
+Revises: 81b8bae8fb11
+Create Date: 2024-08-09 14:35:35.379137+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '4b0b7ba46e63'
+down_revision = '81b8bae8fb11'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_docker', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('enable_image_updates', sa.Boolean(), nullable=False, server_default='1'))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -95,8 +95,10 @@ class DockerStateService(Service):
 
         await (await self.middleware.call('catalog.sync')).wait()
 
-        await self.middleware.call('app.image.op.check_update')
-        # TODO: Add app upgrade alerts and account for update image check
+        docker_config = await self.middleware.call('docker.config')
+        if docker_config['enable_image_updates']:
+            self.middleware.create_task(self.middleware.call('app.image.op.check_update'))
+        # TODO: Add app upgrade alerts
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -61,6 +61,8 @@ class DockerService(SimpleService):
     async def after_start(self):
         await self.middleware.call('docker.state.set_status', Status.RUNNING.value)
         await self.middleware.call('catalog.sync')
+        if (await self.middleware.call('docker.config'))['enable_image_updates']:
+            self.middleware.create_task(self.middleware.call('app.image.op.check_update'))
 
     async def before_stop(self):
         await self.middleware.call('docker.state.set_status', Status.STOPPING.value)


### PR DESCRIPTION
## Context

Checking image updates earlier used to be configurable as it could potentially result in users exhausting their rate limits for docker in conjunction with pulling images etc. Changes have been added to account for this so we allow user to toggle it as required and also progress reporting has been added when configuring docker service.