### PR TITLE
NAS-130537 / 24.10 / Fix readonly usage with app image

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/images.py
+++ b/src/middlewared/middlewared/plugins/apps_images/images.py
@@ -20,6 +20,7 @@ class AppImageService(CRUDService):
         List('repo_digests', items=[Str('repo_digest')]),
         Int('size'),
         Bool('dangling'),
+        Bool('update_available'),
         Str('created'),
         Str('author'),
         Str('comment'),
@@ -30,8 +31,10 @@ class AppImageService(CRUDService):
                 Str('tag'),
                 Str('registry'),
                 Str('complete_tag'),
+                additional_attrs=True,
             )]
         ),
+        additional_attrs=True,
     )
 
     @filterable


### PR DESCRIPTION
## Context

Changes were introduced recently to fix readonly role viewing apps but the same problem existed in `app.image` namespace as well and have been fixed here.