### PR TITLE
NAS-130538 / 24.10 / Fix broken NFS test

### DIFF
--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -318,21 +318,12 @@ def test_02_creating_dataset_nfs():
 
 @pytest.mark.dependency(depends=['NFS_DATASET_CREATED'])
 def test_03_changing_dataset_permissions_of_nfs_dataset():
-    payload = {
-        "acl": [],
-        "mode": "777",
-        "user": "root",
-        "group": 'root'
-    }
-    results = POST(f"/pool/dataset/id/{dataset_url}/permission/", payload)
-    assert results.status_code == 200, results.text
-    global job_id
-    job_id = results.json()
-
-
-def test_04_verify_the_job_id_is_successfull():
-    job_status = wait_on_job(job_id, 180)
-    assert job_status['state'] == 'SUCCESS', str(job_status['results'])
+    call('filesystem.setperm', {
+        'path': os.path.join('/mnt', dataset),
+        'mode': '777',
+        'uid': 0,
+        'gid': 0,
+    }, job=True)
 
 
 @pytest.mark.dependency(name='NFSID_SHARE_CREATED', depends=['NFS_DATASET_CREATED'])


### PR DESCRIPTION
Replace usage of pool.dataset.permission with filesystem.setperm.