### PR TITLE
NAS-130556 / 24.10 / Fix edge case when listing docker resources

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/docker/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/docker/query.py
@@ -1,3 +1,5 @@
+import docker.errors
+
 from collections import defaultdict
 from itertools import chain, repeat
 
@@ -5,6 +7,17 @@ from .utils import get_docker_client, PROJECT_KEY
 
 
 def list_resources_by_project(project_name: str | None = None) -> dict[str, dict[str, list]]:
+    retries = 2
+    while retries > 0:
+        try:
+            return list_resources_by_project_internal(project_name)
+        except docker.errors.NotFound:
+            retries -= 1
+            if retries == 0:
+                raise
+
+
+def list_resources_by_project_internal(project_name: str | None = None) -> dict[str, dict[str, list]]:
     with get_docker_client() as client:
         label_filter = {'label': f'{PROJECT_KEY}={project_name}' if project_name else PROJECT_KEY}
         containers = client.containers.list(all=True, filters=label_filter, sparse=False)


### PR DESCRIPTION
## Problem

When re-deploying an app which had some failing containers i ran into this issue
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/apps/ix_apps/docker/query.py", line 10, in list_resources_by_project
    containers = client.containers.list(all=True, filters=label_filter, sparse=False)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/models/containers.py", line 1018, in list
    containers.append(self.get(r['Id']))
                      ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/models/containers.py", line 954, in get
    resp = self.client.api.inspect_container(container_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/api/container.py", line 793, in inspect_container
    return self._result(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/api/client.py", line 281, in _result
    self._raise_for_status(response)
  File "/usr/lib/python3/dist-packages/docker/api/client.py", line 277, in _raise_for_status
    raise create_api_error_from_http_exception(e) from e
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation) from e
docker.errors.NotFound: 404 Client Error for http+docker://localhost/v1.46/containers/904ea1c2387d922edf5001932d5b525442406cbf865411341ef3fb0666952f49/json: Not Found ("No such container: 904ea1c2387d922edf5001932d5b525442406cbf865411341ef3fb0666952f49")
```
It seems the docker `client.containers.list` operation is not idempotent and can run into race conditions where container dying/removed can be missed when it tries to retrieve details.

## Solution

Have a retry mechanism in place so we retry just one time more, i was consistently able to reproduce the issue before with the failing containers case but with this change the issue could not be reproduced anymore.