### PR TITLE
NAS-130558 / 24.10 / Fix ports type reported by docker

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -167,10 +167,10 @@ def translate_resources_to_desired_workflow(app_resources: dict) -> dict:
                 # This will happen for ports which are not exposed on the host side
                 continue
             port_config = {
-                'container_port': container_port.split('/')[0],
+                'container_port': int(container_port.split('/')[0]),
                 'protocol': container_port.split('/')[1],
                 'host_ports': [
-                    {'host_port': host_port['HostPort'], 'host_ip': host_port['HostIp']}
+                    {'host_port': int(host_port['HostPort']), 'host_ip': host_port['HostIp']}
                     for host_port in host_config
                 ]
             }


### PR DESCRIPTION
## Problem
Currently, the Docker client is returning ports as strings, which is incompatible with our current port infrastructure. This is breaking the app's port validation.

## Solution
Convert the ports used by the app to integers to ensure compatibility with the rest of the port infrastructure.
