### PR TITLE
NAS-130662 / 25.04 / Fix failing first-time scrub

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/scrub.py
+++ b/src/middlewared/middlewared/plugins/pool_/scrub.py
@@ -281,7 +281,7 @@ class PoolScrubService(CRUDService):
             return False
 
         last_scrubs = (await run(
-            'sh', '-c', f'zpool history {shlex.quote(name)} | grep -E "zpool (scrub|create)"',
+            'sh', '-c', f'zpool history {shlex.quote(name)} | grep -E "zpool (scrub|create|import)"',
             encoding='utf-8',
             errors='ignore',
         )).stdout


### PR DESCRIPTION
We noticed that our TrueNAS server never started scrubbing the disks even though we configured a task for this.

Some investigation showed that this was failing due to a recent optimization in 738fd2ad10eccb83fd080536c057b55996eba298. Namely, the following:

```diff
- run('zpool', 'history', name, encoding='utf-8')
+ run('sh', '-c', f'zpool history {shlex.quote(name)} | grep -E "zpool (scrub|create)"')
```

In case `zpool history` does not contain neither `zpool scrub` nor `zpool create` the command has exit status 1 which leads to an exception. I believe this is the case in our setup due to having imported the pool instead of creating it.

```
Traceback:
  File "/usr/lib/python3/dist-packages/middlewared/plugins/pool_/scrub.py", line 283, in __run
    last_scrubs = (await run(
                   ^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/__init__.py", line 80, in run
    cp.check_returncode()
  File "/usr/lib/python3.11/subprocess.py", line 502, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError:
    Command '('sh', '-c', 'zpool history zfs_pool | grep -E "zpool (scrub|create)"')' returned non-zero exit status 1.
```

The output of `zpool history` shows only `import` statements:

```
# zpool history zfs_pool | grep 'zpool'
2024-05-07.15:52:53 zpool import 10881422585498422060 -R /mnt -m -f -o cachefile=/data/zfs/zpool.cache
2024-05-23.10:11:58 zpool import 10881422585498422060 -R /mnt -m -f -o cachefile=/data/zfs/zpool.cache
2024-05-23.10:32:12 zpool import 10881422585498422060 -R /mnt -m -f -o cachefile=/data/zfs/zpool.cache
2024-06-06.12:55:16 zpool import 10881422585498422060 -R /mnt -m -f -o cachefile=/data/zfs/zpool.cache
2024-06-06.14:01:29 zpool import 10881422585498422060 -R /mnt -m -f -o cachefile=/data/zfs/zpool.cache
```

I first thought about adding `check=False` to `run()` but then decided for simply adding `import` to the list of strings to grep for. Otherwise, errors thrown by `zpool history` might be missed. I am no export in ZFS so I am not sure if this is the correct fix.

----

## Other things

* It took us a while to find this bug because the cron jobs hide all errors. From `/var/log/cron.log`:

```
(PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin"
       midclt call pool.scrub.run zfs_pool 35 > /dev/null 2> /dev/null)
```

I think that's a mistake. An exception in a cron job should create an alert.

* Unfortunately, I was not able to test the fix. All changes I made to the Python file on our server did not seem to have any effect.
* This code should likely receive some more test coverage since scrubbing is such an important component of data integrity.