### PR TITLE
NAS-127040 / 25.04 / Add alert for local admin account use

### DIFF
--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -1,0 +1,14 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class AdminSessionActiveAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SYSTEM
+    level = AlertLevel.WARNING
+    title = "Active administrator session on TrueNAS server"
+    text = (
+        "System administrator (root or truenas_admin) has one or more "
+        "active sessions on the TrueNAS server with the following session ids: %(sessions)s"
+    )
+
+    async def delete(self, alerts, query):
+        return []

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -17,6 +17,7 @@ from middlewared.service import (
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils.origin import UnixSocketOrigin
+from middlewared.utils.privilege import credential_is_root_or_equivalent
 from middlewared.utils.crypto import generate_token
 
 
@@ -93,6 +94,14 @@ class SessionManager:
 
         self.middleware = None
 
+    def root_sessions(self):
+        root_sessions = []
+        for session_id, session in self.sessions.items():
+            if not is_internal_session(session) and credential_is_root_or_equivalent(session.credentials):
+                root_sessions.append(session_id)
+
+        return root_sessions
+
     async def login(self, app, credentials):
         if app.authenticated:
             self.sessions[app.session_id].credentials = credentials
@@ -109,6 +118,13 @@ class SessionManager:
         app.register_callback("on_close", self._app_on_close)
 
         if not is_internal_session(session):
+            if credential_is_root_or_equivalent(credentials):
+                await self.middleware.call(
+                    "alert.oneshot_create",
+                    "AdminSessionActive",
+                    {'sessions': ', '.join(self.root_sessions())}
+                )
+
             self.middleware.send_event("auth.sessions", "ADDED", fields=dict(id=app.session_id, **session.dump()))
             await app.log_audit_message("AUTHENTICATION", {
                 "credentials": dump_credentials(credentials),
@@ -119,9 +135,19 @@ class SessionManager:
         session = self.sessions.pop(app.session_id, None)
 
         if session is not None:
+            was_root_session = credential_is_root_or_equivalent(session.credentials)
             session.credentials.logout()
 
             if not is_internal_session(session):
+                if was_root_session:
+                    self.middleware.call_sync("alert.oneshot_delete", "AdminSessionActive")
+                    if (root_sessions := self.root_sessions()):
+                        self.middleware.call_sync(
+                            "alert.oneshot_create",
+                            "AdminSessionActive",
+                            {'sessions': ', '.join(root_sessions)}
+                        )
+
                 self.middleware.send_event("auth.sessions", "REMOVED", fields=dict(id=app.session_id))
 
         app.authenticated = False

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -100,3 +100,11 @@ def credential_is_limited_to_own_jobs(credential: object | None) -> bool:
         return False
 
     return not credential_has_full_admin(credential)
+
+
+def credential_is_root_or_equivalent(credential: object | None) -> bool:
+    if credential is None or not credential.is_user_session:
+        return False
+
+    # SYS_ADMIN is set when user UID is 0 (root) or 950 (truenas_admin).
+    return 'SYS_ADMIN' in credential.user['account_attributes']


### PR DESCRIPTION
Since it's trivial for users to create dedicated service accounts for administrative purposes via RBAC we should add an alert per GPOS STIG.