### PR TITLE
NAS-130575 / 24.10-RC.1 / Add missing import of MatchNotFound (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_net_conf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_net_conf.py
@@ -1,10 +1,8 @@
 import errno
 import json
-import os
 import subprocess
 
-from middlewared.service_exception import CallError
-from .utils import smb_strip_comments
+from middlewared.service_exception import CallError, MatchNotFound
 from .constants import SMBCmd
 
 CONF_JSON_VERSION = {"major": 0, "minor": 1}


### PR DESCRIPTION
Add missing import of `MatchNotFound`

Also remove some unused imports.

Original PR: https://github.com/truenas/middleware/pull/14204
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130575