### PR TITLE
NAS-130574 / 24.10-BETA.1 / handle unexpected whitespace between LDAP DN components (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -823,7 +823,7 @@ class LDAPService(ConfigService):
         elif conf['basedn']:
             # No realm in ldap config and so we need to guess at it
             realm = '.'.join(
-                [x.strip('dc=') for x in conf['basedn'].split(',')]
+                [x.strip().strip('dc=') for x in conf['basedn'].split(',')]
             ).upper()
         else:
             raise CallError('Unable to determine kerberos realm')


### PR DESCRIPTION
libldap (which we use for validation of LDAP DNs) apparently does not treat these extra spaces as invalid. We should strip whitespace on DN components before stripping the dn key from the LDAP base DN when trying to determine our kerberos realm name.

Original PR: https://github.com/truenas/middleware/pull/14201
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130574