### PR TITLE
NAS-130562 / 24.10-RC.1 / Fix setting machine account FreeIPA domain (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -282,14 +282,6 @@ class IPAJoinMixin:
                 'cifs_srv_workgroup': domain_info['netbios_name']
             })
 
-            # We must write the password encoded in the SMB keytab
-            # to secrets.tdb at this point.
-            self.middleware.call_sync(
-                'directoryservices.secrets.set_ipa_secret',
-                domain_info['netbios_name'],
-                base64.b64encode(password.encode())
-            )
-
             # regenerate our SMB config to apply our new domain
             self.middleware.call_sync('etc.generate', 'smb')
 
@@ -300,6 +292,14 @@ class IPAJoinMixin:
 
             if setsid.returncode:
                 raise CallError(f'Failed to set domain SID: {setsid.stderr.decode()}')
+
+            # We must write the password encoded in the SMB keytab
+            # to secrets.tdb at this point.
+            self.middleware.call_sync(
+                'directoryservices.secrets.set_ipa_secret',
+                domain_info['netbios_name'],
+                base64.b64encode(password.encode())
+            )
 
             self.middleware.call_sync('directoryservices.secrets.backup')
 

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -966,6 +966,6 @@ class LDAPService(ConfigService):
             {'ccache': krb5ccache.SYSTEM.name},
             False
         ):
-            await self.middleware.call('kerberos.kdestory')
+            await self.middleware.call('kerberos.kdestroy')
 
         job.set_progress(100, 'LDAP directory service stopped.')


### PR DESCRIPTION
We need to initialize the value of machine account secret in secrets.tdb prior to actually setting the password via the net command.

Subprocessing is required because unlike other stored secrets, this is a packaged struct and so the simplest solution to writing it is to use existing tools (which is same behavior as FreeIPA samba setup script).

Original PR: https://github.com/truenas/middleware/pull/14191
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130562