### PR TITLE
NAS-130390 / 25.04 / Move discovery auth from per-portal to system-wide (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-08-12_15-53_discoveryauth.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-08-12_15-53_discoveryauth.py
@@ -1,0 +1,86 @@
+"""Add iSCSI discoverauth
+
+Flatten the per-portal discovery auth to a system-wide discovery auth.
+
+Revision ID: 504a7bd32680
+Revises: 4b0b7ba46e63
+Create Date: 2024-08-12 15:53:48.342351+00:00
+
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '504a7bd32680'
+down_revision = '4b0b7ba46e63'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('services_iscsidiscoveryauth',
+                    sa.Column('id', sa.Integer(), nullable=False),
+                    sa.Column('iscsi_discoveryauth_authmethod', sa.String(length=120), nullable=False),
+                    sa.Column('iscsi_discoveryauth_authgroup', sa.Integer(), nullable=False),
+                    sa.PrimaryKeyConstraint('id', name=op.f('pk_services_iscsidiscoveryauth')),
+                    sa.UniqueConstraint('iscsi_discoveryauth_authgroup', name=op.f('uq_services_iscsidiscoveryauth_iscsi_discoveryauth_authgroup')),
+                    sqlite_autoincrement=True
+                    )
+
+    conn = op.get_bind()
+    data = conn.execute("SELECT iscsi_target_portal_discoveryauthgroup, iscsi_target_portal_discoveryauthmethod, id FROM services_iscsitargetportal").fetchall()
+
+    # Migrate the data into the new table.
+    # - Mutual CHAP first.
+    mutual_chap_auth_groups = []
+    for authgroup, authmethod, _portal_id in data:
+        if authmethod == 'CHAP Mutual' and authgroup not in mutual_chap_auth_groups:
+            # Let's not carry around 'CHAP Mutual' anymore.
+            conn.execute('INSERT INTO services_iscsidiscoveryauth (iscsi_discoveryauth_authmethod, iscsi_discoveryauth_authgroup) VALUES ("CHAP_MUTUAL",?)', authgroup)
+            mutual_chap_auth_groups.append(authgroup)
+    # - Simple CHAP next.
+    simple_chap_auth_groups = []
+    for authgroup, authmethod, _portal_id in data:
+        if authmethod == 'CHAP' and authgroup not in mutual_chap_auth_groups + simple_chap_auth_groups:
+            conn.execute('INSERT INTO services_iscsidiscoveryauth (iscsi_discoveryauth_authmethod, iscsi_discoveryauth_authgroup) VALUES ("CHAP",?)', authgroup)
+            simple_chap_auth_groups.append(authgroup)
+
+    # Things to test
+    # 1. Do we have a mix of None and non-None?
+    # 2. If not, do we have more than one CHAP/Mutual CHAP
+    # 3. Do we have more than one Mutual CHAP peeruser/secret?
+    none_list = list(filter(lambda t: t[1] == 'None', data))
+    none_count = len(none_list)
+    non_none_count = len(mutual_chap_auth_groups) + len(simple_chap_auth_groups)
+
+    if none_count and non_none_count:
+        portal_id_strs = list(str(item[2]) for item in none_list)
+        none_ips = conn.execute("SELECT iscsi_target_portalip_ip FROM services_iscsitargetportalip WHERE iscsi_target_portalip_portal_id IN (?)", ','.join(portal_id_strs)).fetchall()
+        conn.execute("INSERT INTO system_keyvalue (\"key\", value) VALUES (?, ?)",
+                     ("ISCSIDiscoveryAuthMixed", json.dumps({'ips': [ip[0] for ip in none_ips]})))
+    elif non_none_count > 1:
+        conn.execute("INSERT INTO system_keyvalue (\"key\", value) VALUES (?, ?)",
+                     ("ISCSIDiscoveryAuthMultipleCHAP", json.dumps({})))
+
+    if mutual_chap_auth_groups:
+        if len(mutual_chap_auth_groups) == 1:
+            data = conn.execute(f"SELECT DISTINCT iscsi_target_auth_peeruser FROM services_iscsitargetauthcredential WHERE iscsi_target_auth_tag = {mutual_chap_auth_groups[0]} AND iscsi_target_auth_peeruser != ''").fetchall()
+        else:
+            tags = ','.join(str(x) for x in mutual_chap_auth_groups)
+            data = conn.execute(f"SELECT DISTINCT iscsi_target_auth_peeruser FROM services_iscsitargetauthcredential WHERE iscsi_target_auth_tag in ({tags}) AND iscsi_target_auth_peeruser != ''").fetchall()
+        if len(list(data)) > 1:
+            active_peeruser = data[0][0]
+            conn.execute("INSERT INTO system_keyvalue (\"key\", value) VALUES (?, ?)",
+                         ("ISCSIDiscoveryAuthMultipleMutualCHAP", json.dumps({'peeruser': active_peeruser})))
+
+    # Remove the obsolete columns
+    with op.batch_alter_table('services_iscsitargetportal', schema=None) as batch_op:
+        batch_op.drop_column('iscsi_target_portal_discoveryauthgroup')
+        batch_op.drop_column('iscsi_target_portal_discoveryauthmethod')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-08-12_15-53_discoveryauth.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-08-12_15-53_discoveryauth.py
@@ -3,7 +3,7 @@
 Flatten the per-portal discovery auth to a system-wide discovery auth.
 
 Revision ID: 504a7bd32680
-Revises: 4b0b7ba46e63
+Revises: 5654da8713d1
 Create Date: 2024-08-12 15:53:48.342351+00:00
 
 """
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '504a7bd32680'
-down_revision = '4b0b7ba46e63'
+down_revision = '5654da8713d1'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/alert/source/discovery_auth.py
+++ b/src/middlewared/middlewared/alert/source/discovery_auth.py
@@ -1,0 +1,24 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+UPGRADE_ALERTS = ['ISCSIDiscoveryAuthMixed', 'ISCSIDiscoveryAuthMultipleCHAP', 'ISCSIDiscoveryAuthMultipleMutualCHAP']
+
+
+class ISCSIDiscoveryAuthMixedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "iSCSI Discovery Authorization Global"
+    text = "Prior to upgrade had specified iSCSI discovery auth on only some portals, now applies globally.  May need to update client configuration when using %(ips)s"
+
+
+class ISCSIDiscoveryAuthMultipleCHAPAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "iSCSI Discovery Authorization merged"
+    text = "Prior to upgrade different portals had different iSCSI discovery auth, now applies globally."
+
+
+class ISCSIDiscoveryAuthMultipleMutualCHAPAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "iSCSI Discovery Authorization Multiple Mutual CHAP"
+    text = "Multiple mutual CHAP peers defined for discovery auth, but only first one (\"%(peeruser)s\") applies.  May need to update client configuration."

--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -63,11 +63,14 @@ class iSCSITargetAuthCredentialService(CRUDService):
 
         verrors.check()
 
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+
         data['id'] = await self.middleware.call(
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix}
         )
 
+        await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
         await self._service_change('iscsitarget', 'reload')
 
         return await self.get_instance(data['id'])
@@ -95,17 +98,20 @@ class iSCSITargetAuthCredentialService(CRUDService):
         verrors = ValidationErrors()
         await self.validate(new, 'iscsi_auth_update', verrors)
         if new['tag'] != old['tag'] and not await self.query([['tag', '=', old['tag']], ['id', '!=', id_]]):
-            usages = await self.is_in_use_by_portals_targets(id_)
+            usages = await self.is_in_use(id_)
             if usages['in_use']:
                 verrors.add('iscsi_auth_update.tag', usages['usages'])
 
         verrors.check()
+
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
 
         await self.middleware.call(
             'datastore.update', self._config.datastore, id_, new,
             {'prefix': self._config.datastore_prefix}
         )
 
+        await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
         await self._service_change('iscsitarget', 'reload')
 
         return await self.get_instance(id_)
@@ -121,25 +127,34 @@ class iSCSITargetAuthCredentialService(CRUDService):
         audit_callback(_auth_summary(config))
 
         if not await self.query([['tag', '=', config['tag']], ['id', '!=', id_]]):
-            usages = await self.is_in_use_by_portals_targets(id_)
+            # We are attempting to delete the last auth in a particular group (aka tag)
+            usages = await self.is_in_use(id_)
             if usages['in_use']:
                 raise CallError(usages['usages'])
 
-        return await self.middleware.call(
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+
+        result = await self.middleware.call(
             'datastore.delete', self._config.datastore, id_
         )
+        if orig_peerusers:
+            await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
+
+        return result
 
     @private
-    async def is_in_use_by_portals_targets(self, id_):
+    async def is_in_use(self, id_):
         config = await self.get_instance(id_)
         usages = []
-        portals = await self.middleware.call(
-            'iscsi.portal.query', [['discovery_authgroup', '=', config['tag']]], {'select': ['id']}
+        # Check discovery auth
+        discovery_auths = await self.middleware.call(
+            'iscsi.discoveryauth.query', [['authgroup', '=', config['tag']]], {'select': ['id']}
         )
-        if portals:
+        if discovery_auths:
             usages.append(
-                f'Authorized access of {id_} is being used by portal(s): {", ".join(str(p["id"]) for p in portals)}'
+                f'Authorized access of {id_} is being used by discovery auth(s): {", ".join(str(a["id"]) for a in discovery_auths)}'
             )
+        # Check targets
         groups = await self.middleware.call(
             'datastore.query', 'services.iscsitargetgroups', [['iscsi_target_authgroup', '=', config['tag']]]
         )

--- a/src/middlewared/middlewared/plugins/iscsi_/discovery_auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/discovery_auth.py
@@ -1,0 +1,252 @@
+import middlewared.sqlalchemy as sa
+
+from middlewared.alert.source.discovery_auth import UPGRADE_ALERTS
+from middlewared.schema import accepts, Dict, Int, Patch, Str
+from middlewared.service import CRUDService, private, ValidationErrors
+from middlewared.validators import Range
+
+
+def _auth_summary(data):
+    authmethod = data.get('authmethod', '')
+    authgroup = data.get('authgroup', '')
+    return f'{authmethod} Group ID {authgroup}'
+
+
+class iSCSIDiscoveryAuthModel(sa.Model):
+    __tablename__ = 'services_iscsidiscoveryauth'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    iscsi_discoveryauth_authmethod = sa.Column(sa.String(120), default='CHAP')
+    iscsi_discoveryauth_authgroup = sa.Column(sa.Integer(), unique=True)
+
+
+class iSCSIDiscoveryAuthService(CRUDService):
+
+    class Config:
+        namespace = 'iscsi.discoveryauth'
+        datastore = 'services.iscsidiscoveryauth'
+        datastore_prefix = 'iscsi_discoveryauth_'
+        role_prefix = 'SHARING_ISCSI_AUTH'
+        cli_namespace = 'sharing.iscsi.discoveryauth'
+
+    ENTRY = Patch(
+        'iscsi_discoveryauth_create',
+        'iscsi_discoveryauth_entry',
+        ('add', Int('id', required=True)),
+    )
+
+    @accepts(Dict(
+        'iscsi_discoveryauth_create',
+        Str('authmethod', enum=['CHAP', 'CHAP_MUTUAL'], default='CHAP'),
+        Int('authgroup', validators=[Range(min_=0)]),
+        register=True
+    ), audit='Create iSCSI Discovery Authorized Access', audit_extended=lambda data: _auth_summary(data))
+    async def do_create(self, data):
+        """
+        Create an iSCSI Discovery Authorized Access.
+
+        `authmethod` specifies the CHAP mechanism that will be used for discovery authentication (only).
+        Note that only a single Mutual CHAP user may be specified system-wide for discovery auth.
+
+        `authgroup` specifies an authorized access group id to be used for discovery auth.
+        """
+        verrors = ValidationErrors()
+        await self.validate(data, 'iscsi_discoveryauth_create', verrors)
+
+        verrors.check()
+
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+
+        data['id'] = await self.middleware.call(
+            'datastore.insert', self._config.datastore, data,
+            {'prefix': self._config.datastore_prefix}
+        )
+
+        await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
+        await self._service_change('iscsitarget', 'reload')
+
+        return await self.get_instance(data['id'])
+
+    @accepts(
+        Int('id'),
+        Patch(
+            'iscsi_discoveryauth_create',
+            'iscsi_discoveryauth_update',
+            ('attr', {'update': True})
+        ),
+        audit='Update iSCSI Discovery Authorized Access',
+        audit_callback=True,
+    )
+    async def do_update(self, audit_callback, id_, data):
+        """
+        Update iSCSI Authorized Access of `id`.
+        """
+        old = await self.get_instance(id_)
+        audit_callback(_auth_summary(old))
+
+        new = old.copy()
+        new.update(data)
+
+        verrors = ValidationErrors()
+        await self.validate(new, 'iscsi_discoveryauth_update', verrors)
+        verrors.check()
+
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+
+        await self.middleware.call(
+            'datastore.update', self._config.datastore, id_, new,
+            {'prefix': self._config.datastore_prefix}
+        )
+
+        await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
+        await self._service_change('iscsitarget', 'reload')
+
+        return await self.get_instance(id_)
+
+    @accepts(Int('id'),
+             audit='Delete iSCSI Discovery Authorized Access',
+             audit_callback=True,)
+    async def do_delete(self, audit_callback, id_):
+        """
+        Delete iSCSI Discovery Authorized Access of `id`.
+        """
+        config = await self.get_instance(id_)
+        audit_callback(_auth_summary(config))
+
+        orig_peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+
+        result = await self.middleware.call(
+            'datastore.delete', self._config.datastore, id_
+        )
+
+        if not await self.middleware.call('iscsi.discoveryauth.query', [], {'count': True}):
+            # If we have cleared all the discovery auth, then don't need any alerts
+            await self.middleware.call('iscsi.discoveryauth.clear_alerts')
+        elif orig_peerusers and len(orig_peerusers) > 1:
+            # Have we eliminated the multiple mutual CHAP alert?
+            await self.middleware.call('iscsi.discoveryauth.recalc_mutual_chap_alert', orig_peerusers)
+
+        await self._service_change('iscsitarget', 'reload')
+        return result
+
+    @private
+    async def validate(self, data, schema_name, verrors):
+        """
+        If this is an update then data will contain an `id`
+        """
+        authgroup = data['authgroup']
+        authmethod = data['authmethod']
+        id_ = data.get('id')
+
+        # Check the specified authgroup
+        if authgroup >= 0:
+            if id_ is None:
+                # Adding a new entry
+                filters = [['authgroup', '=', authgroup]]
+            else:
+                # Updating an existing entry
+                filters = [['authgroup', '=', authgroup], ['id', '!=', id_]]
+            if await self.middleware.call('iscsi.discoveryauth.query', filters, {'count': True}):
+                verrors.add(
+                    f'{schema_name}.authgroup',
+                    'The specified authgroup is already in use.'
+                )
+            if not await self.middleware.call('iscsi.auth.query', [['tag', '=', authgroup]], {'count': True}):
+                verrors.add(
+                    f'{schema_name}.authgroup',
+                    'The specified authgroup does not contain any entries.'
+                )
+
+        if authmethod == 'CHAP_MUTUAL':
+            # Ensure that we don't add more than one MUTUAL
+            if id_ is None:
+                # Adding a new entry
+                filters = [['authmethod', '=', 'CHAP_MUTUAL']]
+            else:
+                # Updating an existing entry
+                filters = [['authmethod', '=', 'CHAP_MUTUAL'], ['id', '!=', id_]]
+            if await self.middleware.call('iscsi.discoveryauth.query', filters, {'count': True}):
+                verrors.add(
+                    f'{schema_name}.authmethod',
+                    'Another Mutual CHAP discovery auth has already been specified.'
+                )
+            else:
+                # Ensure that this auth does not have more than one peeruser
+                filters = [['tag', '=', authgroup], ['peeruser', '!=', '']]
+                if await self.middleware.call('iscsi.auth.query', filters, {'count': True}) > 1:
+                    verrors.add(
+                        f'{schema_name}.authgroup',
+                        'The specified authgroup has multiple peerusers.'
+                    )
+                # Note: we may have upgraded and found ourselves in the above situation,
+                # so we will also raise an alert if that is the case ... in addition to
+                # preventing it here.
+
+    @private
+    async def mutual_chap_peers(self):
+        """
+        Return a list of (peeruser, peersecret) tuples that are in use for Mutual CHAP discovery auth.
+        """
+        filters = [['authmethod', '=', 'CHAP_MUTUAL']]
+        options = {'select': ['authgroup']}
+        groups = await self.middleware.call('iscsi.discoveryauth.query', filters, options)
+        group_ids = [item['authgroup'] for item in groups]
+
+        filters = [['peeruser', '!=', ""], ['tag', 'in', group_ids]]
+        options = {'select': ['peeruser', 'peersecret']}
+        peers = await self.middleware.call('iscsi.auth.query', filters, options)
+        return [(peer['peeruser'], peer['peersecret']) for peer in peers]
+
+    @private
+    async def mutual_chap_peerusers(self):
+        """
+        Return a list of peerusers that are in use for Mutual CHAP discovery auth.
+        """
+        return [peer[0] for peer in await self.middleware.call('iscsi.discoveryauth.mutual_chap_peers')]
+
+    @private
+    async def recalc_mutual_chap_alert(self, orig_peerusers):
+        alert_name = 'ISCSIDiscoveryAuthMultipleMutualCHAP'
+        peerusers = await self.middleware.call('iscsi.discoveryauth.mutual_chap_peerusers')
+        if len(orig_peerusers) > 1:
+            # Alert was in place, do we need to update or remove it?
+            if len(peerusers) <= 1:
+                # Clear the existing alert
+                await self.middleware.call("alert.oneshot_delete", alert_name, {'peeruser': orig_peerusers[0]})
+            elif peerusers[0] != orig_peerusers[0]:
+                # Remove old event and replace with new one.
+                await self.middleware.call("alert.oneshot_delete", alert_name, {'peeruser': orig_peerusers[0]})
+                await self.middleware.call("alert.oneshot_create", alert_name, {'peeruser': peerusers[0]})
+        elif len(peerusers) > 1:
+            # Alert was not in place, add one.
+            await self.middleware.call("alert.oneshot_create", alert_name, {'peeruser': peerusers[0]})
+
+    @private
+    async def load_upgrade_alerts(self):
+        """
+        Load any events that may have been generated during an alembic migration.
+        """
+        for alert in UPGRADE_ALERTS:
+            try:
+                args = await self.middleware.call("keyvalue.get", alert)
+                await self.middleware.call("alert.oneshot_create", alert, args)
+                await self.middleware.call("keyvalue.delete", alert)
+            except KeyError:
+                pass
+
+    @private
+    async def clear_alerts(self):
+        alerts = [alert for alert in await self.middleware.call('alert.list') if alert['klass'].startswith('ISCSIDiscoveryAuth')]
+        for alert in alerts:
+            await self.middleware.call("alert.oneshot_delete", alert['klass'], alert['args'])
+
+
+async def __event_system_ready(middleware, event_type, args):
+    await middleware.call('iscsi.discoveryauth.load_upgrade_alerts')
+
+
+async def setup(middleware):
+    if await middleware.call('system.ready'):
+        await middleware.call('iscsi.discoveryauth.load_upgrade_alerts')
+    else:
+        middleware.event_subscribe('system.ready', __event_system_ready)

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -16,7 +16,7 @@ from assets.websocket.iscsi import (alua_enabled, initiator, initiator_portal,
                                     portal, read_capacity16, target,
                                     target_extent_associate, verify_capacity,
                                     verify_luns)
-from middlewared.service_exception import InstanceNotFound, ValidationError, ValidationErrors
+from middlewared.service_exception import CallError, InstanceNotFound, ValidationError, ValidationErrors
 from middlewared.test.integration.assets.iscsi import target_login_test
 from middlewared.test.integration.assets.pool import dataset, snapshot
 from middlewared.test.integration.utils import call, ssh
@@ -134,6 +134,15 @@ def iscsi_auth(tag, user, secret, peeruser=None, peersecret=None):
         yield auth_config
     finally:
         call('iscsi.auth.delete', auth_config['id'])
+
+
+@contextlib.contextmanager
+def iscsi_discovery_auth(authmethod, authgroup):
+    config = call('iscsi.discoveryauth.create', {'authmethod': authmethod, 'authgroup': authgroup})
+    try:
+        yield config
+    finally:
+        call('iscsi.discoveryauth.delete', config['id'])
 
 
 @contextlib.contextmanager
@@ -719,6 +728,57 @@ def test_06_mutual_chap(request):
                                 # Finally ensure we can connect with the right Mutual CHAP creds
                                 with iscsi_scsi_connection(truenas_server.ip, iqn, 0, user, secret, peer_user, peer_secret) as s:
                                     _verify_inquiry(s)
+
+
+def test_06_discovery_auth():
+    """
+    Test Discovery Auth
+    """
+    assert [] == call('iscsi.discoveryauth.query')
+
+    with pytest.raises(ValidationErrors) as ve:
+        call('iscsi.discoveryauth.create', {'authmethod': 'CHAP', 'authgroup': 100})
+    assert ve.value.errors == [
+        ValidationError(
+            'iscsi_discoveryauth_create.authgroup',
+            'The specified authgroup does not contain any entries.'
+        )]
+
+    with pytest.raises(ValidationErrors) as ve:
+        call('iscsi.discoveryauth.create', {'authmethod': 'None', 'authgroup': 0})
+    assert ve.value.errors == [
+        ValidationError(
+            'iscsi_discoveryauth_create.authmethod',
+            'Invalid choice: None',
+            errno.EINVAL
+        )]
+
+    randsec = ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=10))
+    with iscsi_auth(1, 'user1', 'sec1' + randsec) as auth_config:
+        with iscsi_discovery_auth('CHAP', 1) as item:
+            assert item['authmethod'] == 'CHAP'
+            assert item['authgroup'] == 1
+            with pytest.raises(ValidationErrors) as ve:
+                call('iscsi.discoveryauth.create', {'authmethod': 'CHAP', 'authgroup': 1})
+            assert ve.value.errors == [
+                ValidationError(
+                    'iscsi_discoveryauth_create.authgroup',
+                    'The specified authgroup is already in use.'
+                )]
+            # Now that the auth is in use, we should NOT be able to delete it
+            with pytest.raises(CallError) as e:
+                call('iscsi.auth.delete', auth_config['id'])
+            assert f'Authorized access of {auth_config["id"]} is being used by discovery auth(s): {item["id"]}' in str(e), e
+
+            with iscsi_auth(2, 'user2', 'sec2' + randsec, 'peeruser2', 'psec2' + randsec) as auth_config:
+                with iscsi_discovery_auth('CHAP_MUTUAL', 2) as item:
+                    with pytest.raises(ValidationErrors) as ve:
+                        call('iscsi.discoveryauth.create', {'authmethod': 'CHAP', 'authgroup': 2})
+                    assert ve.value.errors == [
+                        ValidationError(
+                            'iscsi_discoveryauth_create.authgroup',
+                            'The specified authgroup is already in use.'
+                        )]
 
 
 def test_07_report_luns(request):


### PR DESCRIPTION
In CORE _discovery authentication_ was tied to portals.  This is not the case for SCALE, where it is system-wide.

This PR covers the first step in modifying SCALE to reflect reality.  We will continue to re-use the Authorized Access groups which are also used in _target auth_.  Multiple groups can be specified for discovery auth & will be combined, with one caveat ... only a single `peeruser/peersecret` can be in use (for Mutual CHAP).  (Actually, this caveat is not new.)

Alerts will be generated both on migration and subsequently if multiple mutual CHAP peers are defined.  The `keyvalue` plugin used to communicate the various alerts generated on DB migration (as `middlewared` is not running at that point).

- Perform database migration
- Generate alerts from migration if appropriate
- Add new `iscsi.discoveryauth.*` APIs
- Stub out auth aspect of `iscsi.portal.*` APIs, for later removal

----
This is the 2nd generation of this PR, now being made against `stable/electriceel`.  (A earlier similar but abandoned PR was #14160)

Original PR: https://github.com/truenas/middleware/pull/14198
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130390