### PR TITLE
NAS-130595 / 25.04 / add `ix-vendor` to service list

### DIFF
--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -20,6 +20,7 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-shutdown
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-ssh-keys
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-syncdisks
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-vendor
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-wait-on-disks
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-zfs
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=snmp-agent


### PR DESCRIPTION
`ix-vendor` was never added to this list and was therefore not included in the build.