### PR TITLE
NAS-130598 / 24.10-RC.1 / Fix handling of call to session logout (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -317,7 +317,10 @@ class Application:
         # Run callbacks registered in plugins for on_close
         for method in self.__callbacks['on_close']:
             try:
-                method(self)
+                if asyncio.iscoroutinefunction(method):
+                    await method(self)
+                else:
+                    await self.middleware.run_in_thread(method, self)
             except Exception:
                 self.logger.error('Failed to run on_close callback.', exc_info=True)
 
@@ -329,7 +332,10 @@ class Application:
         # Run callbacks registered in plugins for on_message
         for method in self.__callbacks['on_message']:
             try:
-                method(self, message)
+                if asyncio.iscoroutinefunction(method):
+                    await method(self, message)
+                else:
+                    await self.middleware.run_in_thread(method, self, message)
             except Exception:
                 self.logger.error('Failed to run on_message callback.', exc_info=True)
 

--- a/tests/api2/test_root_session_alert.py
+++ b/tests/api2/test_root_session_alert.py
@@ -1,0 +1,46 @@
+import pytest
+
+from middlewared.test.integration.utils.client import client, truenas_server
+from middlewared.test.integration.utils import call
+
+
+def get_session_alert(call_fn):
+    alerts = call_fn('alert.list')
+    alert_msg = None
+
+    for alert in alerts:
+        if alert['klass'] == 'AdminSessionActive':
+            alert_msg = alert['formatted']
+            break
+
+    assert alert_msg is not None, str(alerts)
+    return alert_msg
+
+
+def check_session_alert(call_fn):
+    session_id = call_fn('auth.sessions', [['current', '=', True]], {'get': True})['id']
+    session_alert = get_session_alert(call_fn)
+
+    assert session_id in session_alert
+    return session_id
+
+
+def test_root_session_alert():
+    # We have a persistent root session so we expect alert to be present
+    check_session_alert(call)
+
+
+def test_root_session_logout():
+    with client(host_ip=truenas_server.ip) as c:
+        # ensure that client generates alert
+        session_id = check_session_alert(c.call)
+        c.call('auth.logout')
+
+    # Make sure our session properly closed
+    closed_session = call('auth.sessions', [['id', '=', session_id]])
+    assert not closed_session
+
+    # Make sure old session ID no longer in alert
+    session_alert = get_session_alert(call)
+
+    assert session_id not in session_alert


### PR DESCRIPTION
Since we are toggling alerts potentially when performing logout the session logout method needs to be converted properly into an async coroutine like session longin, and we need to make callers to the function properly await it.

Original PR: https://github.com/truenas/middleware/pull/14220
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130598