### PR TITLE
Set maximum size of websocket message we will parse

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1890,6 +1890,18 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                     )
                     break
 
+                elif len(msg.data) > 65536:
+                    # WARNING: RFC5424 (syslog) specifies that SDATA of message
+                    # should never exceed 64 KiB. The default syslog-ng configuration
+                    # will not parse messages larger than this, hence, going above this
+                    # value can potentially break auditing (either locally or sending to
+                    # remote syslog server).
+                    await ws.close(
+                        code=WSCloseCode.MESSAGE_TOO_BIG,
+                        message='Max message length is 64 kB'.encode('utf-8'),
+                    )
+                    break
+
                 try:
                     message = json.loads(msg.data)
                 except ValueError as f:


### PR DESCRIPTION
RFC5424 specifies that maximum size of SDATA for a syslog message as 64 KiB. Since these websocket messages will in some circumstances be converted into audit entries and sent to remote syslog server we should set an upper bound on size of websocket message we process. In principle there is no reason to ever be receiving giant websocket messages.