### PR TITLE
NAS-130624 / 24.10-RC.1 / Fix system.ready and ix-vendor.service (by yocalebo)

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -17,4 +17,4 @@ ExecStartPost=touch /var/run/middleware/ix-netif-complete
 StandardOutput=null
 
 [Install]
-WantedBy=multi-user.target ix-vendor.service
+WantedBy=multi-user.target

--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -17,4 +17,4 @@ ExecStartPost=touch /var/run/middleware/ix-netif-complete
 StandardOutput=null
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target ix-vendor.service

--- a/debian/debian/ix-vendor.service
+++ b/debian/debian/ix-vendor.service
@@ -7,5 +7,5 @@ After=ix-netif.service
 Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=30
-ExecStart=/usr/bin/vendor_service
+ExecStart=-/usr/bin/vendor_service
 StandardOutput=null

--- a/debian/debian/ix-vendor.service
+++ b/debian/debian/ix-vendor.service
@@ -7,5 +7,5 @@ After=ix-netif.service
 Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=30
-ExecStart=-/usr/bin/vendor_service
+ExecStart=/usr/bin/start_vendor_service
 StandardOutput=null

--- a/debian/debian/ix-vendor.service
+++ b/debian/debian/ix-vendor.service
@@ -1,6 +1,6 @@
 [Unit]
 # vendor_service.py must run after network routes are set up.
-After=ix-postinit.service
+After=ix-netif.service
 
 
 [Service]
@@ -9,6 +9,3 @@ RemainAfterExit=yes
 TimeoutStartSec=30
 ExecStart=/usr/bin/vendor_service
 StandardOutput=null
-
-[Install]
-WantedBy=multi-user.target

--- a/debian/debian/ix-vendor.service
+++ b/debian/debian/ix-vendor.service
@@ -1,11 +1,15 @@
 [Unit]
-# vendor_service.py must run after network routes are set up.
-After=ix-netif.service
-
+# Vendors can do a bunch of different things
+# so we want to run it as late as possible
+# in the boot process.
+After=ix-postinit.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 TimeoutStartSec=30
-ExecStart=/usr/bin/start_vendor_service
+ExecStart=-/usr/bin/start_vendor_service
 StandardOutput=null
+
+[Install]
+WantedBy=truenas.target

--- a/src/middlewared/middlewared/plugins/system_vendor/vendor.py
+++ b/src/middlewared/middlewared/plugins/system_vendor/vendor.py
@@ -11,6 +11,11 @@ from middlewared.service import Service
 SENTINEL_FILE_PATH = '/data/.vendor'
 
 
+def get_vendor() -> str | None:
+    with open(SENTINEL_FILE_PATH, 'r') as file:
+        return json.load(file).get('name') or None  # Don't return an empty string.
+
+
 class VendorService(Service):
 
     class Config:
@@ -20,8 +25,7 @@ class VendorService(Service):
     @api_method(VendorNameArgs, VendorNameResult, private=True)
     def name(self) -> str | None:
         try:
-            with open(SENTINEL_FILE_PATH, 'r') as file:
-                return json.load(file).get('name') or None  # Don't return an empty string.
+            return get_vendor()
         except FileNotFoundError:
             pass
         except json.JSONDecodeError:

--- a/src/middlewared/middlewared/scripts/vendor_service.py
+++ b/src/middlewared/middlewared/scripts/vendor_service.py
@@ -1,10 +1,9 @@
 import hashlib
 import subprocess
 import sys
-import time
 
+from middlewared.plugins.system_vendor.vendor import get_vendor
 from middlewared.utils.vendor import Vendors
-from truenas_api_client import Client
 
 
 def load_envvars(envvars_file: str):
@@ -12,9 +11,8 @@ def load_envvars(envvars_file: str):
         envvars = []
         with open(envvars_file, "r") as f:
             for line in f:
-                l = line.strip()
-                if l and not l.startswith("#"):
-                    envvars.append(l.split("=", 1))
+                if (line := line.strip()) and line[0] != "#":
+                    envvars.append(line.split("=", 1))
         return dict(envvars)
     except (OSError, ValueError):
         return dict()
@@ -73,10 +71,7 @@ def start_hexos_websocat():
 
 
 def main():
-    with Client() as c:
-        vendor_name = c.call("system.vendor.name")
-
-    if vendor_name == Vendors.HEXOS:
+    if get_vendor() == Vendors.HEXOS:
         start_hexos_websocat()
 
 

--- a/src/middlewared/setup.py
+++ b/src/middlewared/setup.py
@@ -55,6 +55,7 @@ setup(
             'sedhelper = middlewared.scripts.sedhelper:main',
             'wait_to_hang_and_dump_core = middlewared.scripts.wait_to_hang_and_dump_core:main',
             'wait_on_disks = middlewared.scripts.wait_on_disks:main',
+            'start_vendor_service = middlewared.scripts.vendor_service:main',
         ],
     },
 )


### PR DESCRIPTION
A few issues fixed here:

1. ix-vendor.service created a cyclical dependency which was causing a cascading set of failures. Most notably, `system.ready` endpoint would get stuck returning `False` because `system.state` was stuck in `BOOTING`.
2. the `vendor_service.py` script wasn't getting installed, so after fixing the service file, it failed because it couldn't find the executable.
3. remove the use of `Client()` in `vendor_service.py` by adding a `get_vendor()` function to `system_vendor/vendor.py`. This simplifies the script and makes it more resilient.
4. Add a `-` to the `ExecStart` stanza in `ix-vendor.service`. This is required because we use some weird legacy entrypoints stuff to create executable files for these scripts defined in `middlewared/setup.py`. Because of this, the actual executable (`start_vendor_service`) will exit uncleanly in the event of any failure, even though the actual script (`vendor_service.py`) has `try: finally: exit(0)`

Original PR: https://github.com/truenas/middleware/pull/14231
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130624