### PR TITLE
NAS-130618 / 24.10-RC.1 / Set maximum size of message we will parse (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
@@ -1,0 +1,51 @@
+import pytest
+import json
+
+from aiohttp.http_websocket import WSCloseCode
+from middlewared.utils import limits
+
+
+def test__limit_unauthenticated_excetion():
+    data = 'x' * (limits.MsgSizeLimit.UNAUTHENTICATED + 1)
+    with pytest.raises(limits.MsgSizeError) as err:
+        limits.parse_message(False, data)
+
+    assert err.value.limit is limits.MsgSizeLimit.UNAUTHENTICATED
+    assert err.value.datalen == len(data)
+    assert err.value.ws_close_code is WSCloseCode.INVALID_TEXT
+    assert err.value.ws_errmsg == 'Anonymous connection max message length is 8 kB'
+
+
+def test__limit_authenticated_basic_exception():
+    data = json.dumps({'msg': 'method', 'method': 'canary', 'params': ['x' * (limits.MsgSizeLimit.AUTHENTICATED + 1)]})
+    with pytest.raises(limits.MsgSizeError) as err:
+        limits.parse_message(True, data)
+
+    assert err.value.limit is limits.MsgSizeLimit.AUTHENTICATED
+    assert err.value.datalen == len(data)
+    assert err.value.method_name == 'canary'
+    assert err.value.ws_close_code is WSCloseCode.MESSAGE_TOO_BIG
+    assert err.value.ws_errmsg == 'Max message length is 64 kB'
+
+
+def test__limit_authenticated_extended_exception():
+    data = json.dumps({'msg': 'method', 'method': 'canary', 'params': ['x' * (limits.MsgSizeLimit.EXTENDED + 1)]})
+    with pytest.raises(limits.MsgSizeError) as err:
+        limits.parse_message(True, data)
+
+    assert err.value.limit is limits.MsgSizeLimit.EXTENDED
+    assert err.value.datalen == len(data)
+    assert err.value.ws_close_code is WSCloseCode.MESSAGE_TOO_BIG
+    assert err.value.ws_errmsg == 'Max message length is 64 kB'
+
+
+def test__limit_unauthenticated_parse():
+    data = {'msg': 'method', 'method': 'canary', 'params': ['x' * 1000]}
+    parsed = limits.parse_message(False, json.dumps(data))
+    assert parsed == data
+
+
+def test__limit_authenticated_parse():
+    data = {'msg': 'method', 'method': 'canary', 'params': ['x' * 1000]}
+    parsed = limits.parse_message(True, json.dumps(data))
+    assert parsed == data

--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -1,0 +1,80 @@
+# This file provides constants and methods related to general middleware limits.
+# Currently tests are provided in ./src/middlewared/middlewared/pytest/unit/utils/test_limits.py
+
+import enum
+
+from aiohttp.http_websocket import WSCloseCode
+from truenas_api_client import json as ejson
+
+
+# WARNING: below methods must _not_ be audited. c.f. comment in parse_message() below
+MSG_SIZE_EXTENDED_METHODS = set((
+    'filesystem.file_receive',
+))
+
+
+class MsgSizeLimit(enum.IntEnum):
+    UNAUTHENTICATED = 8192  # maximum size of message processed from unauthenticated session
+    AUTHENTICATED = 65536  # maximum size of message processed from authentication session
+    EXTENDED = 2097152  # maximum size of message that sends a file
+
+
+class MsgSizeError(Exception):
+    def __init__(self, limit, datalen, method_name=None):
+        self.limit = limit
+        self.datalen = datalen
+        self.errmsg = f'Message length [{self.datalen}] exceeded maximum size of {self.limit}'
+        self.method_name = method_name or ''
+        if limit is MsgSizeLimit.UNAUTHENTICATED:
+            # This preserves legacy server behavior
+            self.ws_close_code = WSCloseCode.INVALID_TEXT
+            self.ws_errmsg = 'Anonymous connection max message length is 8 kB'
+        else:
+            self.ws_close_code = WSCloseCode.MESSAGE_TOO_BIG
+            self.ws_errmsg = 'Max message length is 64 kB'
+
+    def __str__(self):
+        return self.errmsg
+
+
+def parse_message(authenticated: bool, msg_data: str) -> dict:
+    """
+    Check given message to determine whether it exceeds size limits
+
+    WARNING: RFC5424 (syslog) specifies that SDATA of message should never
+    exceed 64 KiB. The default syslog-ng configuration will not parse messages
+    larger than this, hence, going above this value can potentially break
+    auditing (either locally or sending to remote syslog server).
+
+    The exception to this is for particular whitelisted methods (for example
+    filesystem.file_receive) that must process very large amounts of data and
+    are not audited
+
+    parameters:
+        authenticated - whether session is authenticated
+        msg_data - data sent by client
+
+    returns:
+        JSON loads output of msg_data (dictionary)
+
+    raises:
+        JSONDecodeError (subclass of ValueError)
+        MsgSizeError
+    """
+    datalen = len(msg_data)
+
+    if not authenticated and datalen > MsgSizeLimit.UNAUTHENTICATED.value:
+        raise MsgSizeError(MsgSizeLimit.UNAUTHENTICATED, datalen)
+
+    if datalen > MsgSizeLimit.EXTENDED.value:
+        raise MsgSizeError(MsgSizeLimit.EXTENDED, datalen)
+
+    message = ejson.loads(msg_data)
+
+    if (method := message.get('method')) in MSG_SIZE_EXTENDED_METHODS:
+        return message
+
+    if datalen > MsgSizeLimit.AUTHENTICATED:
+        raise MsgSizeError(MsgSizeLimit.AUTHENTICATED, datalen, method)
+
+    return message

--- a/tests/api2/test_large_message.py
+++ b/tests/api2/test_large_message.py
@@ -1,0 +1,47 @@
+import pytest
+
+from middlewared.service_exception import ValidationErrors
+from middlewared.test.integration.utils.client import client
+from truenas_api_client import ClientException
+
+
+MSG_TOO_BIG_ERR = 'Max message length is 64 kB'
+
+
+def test_large_message_default():
+    LARGE_PAYLOAD_1 = 'x' * 65537
+
+    with pytest.raises(ClientException) as ce:
+        with client() as c:
+            c.call('filesystem.mkdir', LARGE_PAYLOAD_1)
+
+    assert MSG_TOO_BIG_ERR in ce.value.error
+
+
+def test_large_message_extended():
+    LARGE_PAYLOAD_1 = 'x' * 65537
+    LARGE_PAYLOAD_2 = 'x' * 2097153
+
+    # NOTE: we are intentionally passing an invalid payload here
+    # to avoid writing unnecessary file to VM FS. If it fails with
+    # ValidationErrors instead of a ClientException then we know that
+    # the call passed through the size check.
+    with pytest.raises(ValidationErrors):
+        with client() as c:
+            c.call('filesystem.file_receive', LARGE_PAYLOAD_1)
+
+    with pytest.raises(ClientException) as ce:
+        with client() as c:
+            c.call('filesystem.file_receive', LARGE_PAYLOAD_2)
+
+    assert MSG_TOO_BIG_ERR in ce.value.error
+
+
+def test_large_message_unauthenticated():
+    LARGE_PAYLOAD = 'x' * 10000
+
+    with pytest.raises(ClientException) as ce:
+        with client(auth=None) as c:
+            c.call('filesystem.file_receive', LARGE_PAYLOAD)
+
+    assert 'Anonymous connection max message length' in ce.value.error


### PR DESCRIPTION
RFC5424 specifies that maximum size of SDATA for a syslog message as 64 KiB. Since these messages will in some circumstances be converted into audit entries and sent to remote syslog server we should set an upper bound on size of message we process (to prevent dropping audited messages). In principle there is no reason to ever be receiving giant messages.

Original PR: https://github.com/truenas/middleware/pull/14225
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130618