### PR TITLE
NAS-130670 / 24.10-BETA.1 / Add community train to preferred trains by default (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/migration/0011_catalog_community_train.py
+++ b/src/middlewared/middlewared/migration/0011_catalog_community_train.py
@@ -1,0 +1,12 @@
+from middlewared.plugins.catalog.utils import COMMUNITY_TRAIN, OFFICIAL_LABEL
+
+
+async def migrate(middleware):
+    config = await middleware.call('catalog.config')
+    if COMMUNITY_TRAIN not in config['preferred_trains']:
+        await middleware.call(
+            'datastore.update', 'services.catalog', OFFICIAL_LABEL, {
+                'preferred_trains': [COMMUNITY_TRAIN] + config['preferred_trains'],
+            },
+        )
+    await middleware.call('catalog.update_train_for_enterprise')

--- a/src/middlewared/middlewared/plugins/catalog/utils.py
+++ b/src/middlewared/middlewared/plugins/catalog/utils.py
@@ -3,6 +3,7 @@ import os
 from middlewared.utils import MIDDLEWARE_RUN_DIR
 
 
+COMMUNITY_TRAIN = 'community'
 OFFICIAL_ENTERPRISE_TRAIN = 'enterprise'
 OFFICIAL_LABEL = 'TRUENAS'
 OFFICIAL_CATALOG_REPO = 'https://github.com/truenas/apps'


### PR DESCRIPTION
This commit adds changes to add community train to preferred trains by default. Also it makes sure that enterprise users have correct trains setup.

Original PR: https://github.com/truenas/middleware/pull/14251
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130670