### PR TITLE
NAS-130373 / 25.04 / Convert audit message_timestamp for sudo to UTC

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -19,7 +19,7 @@
 
     VALUES = textwrap.dedent('''
         "${TNAUDIT.aid}",
-        "${UNIXTIME}",
+        "${R_UNIXTIME}",
         "${TNAUDIT.time}",
         "${TNAUDIT.addr}",
         "${TNAUDIT.user}",
@@ -118,6 +118,7 @@ rewrite r_rewrite_sudo_common {
 };
 rewrite r_rewrite_sudo_accept {
   set("${sudo.accept.uuid}", value("TNAUDIT.aid"));
+  fix-time-zone("UTC");
   set('${S_YEAR}-${S_MONTH}-${S_DAY} ${S_HOUR}:${S_MIN}:${S_SEC}.$(substr "${sudo.accept.server_time.nanoseconds}" "0" "6")', value("TNAUDIT.time"));
   set("${sudo.accept.submithost}", value("TNAUDIT.addr"));
   set("${sudo.accept.submituser}", value("TNAUDIT.user"));

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -19,7 +19,7 @@
 
     VALUES = textwrap.dedent('''
         "${TNAUDIT.aid}",
-        "${R_UNIXTIME}",
+        "${C_UNIXTIME}",
         "${TNAUDIT.time}",
         "${TNAUDIT.addr}",
         "${TNAUDIT.user}",


### PR DESCRIPTION
The audit message_timestamp is supposed to be UTC.  This is not happing for sudo messages.  The message_timestamp for sudo is being output in local time.

This PR fixes that by changing the common setting to `C_UNIXTIME` and adding `fix-time-stamp("UTC") on the sudo rewrite.

This PR also adds a helper function to get audit entries and CI tests for MIDDLEWARE, SMB and SUDO timestamps.
