### PR TITLE
NAS-127511 / 25.04 / Fix zpool status for reporting used spare disks correctly

### DIFF
--- a/src/middlewared/middlewared/plugins/webui/enclosure.py
+++ b/src/middlewared/middlewared/plugins/webui/enclosure.py
@@ -37,7 +37,6 @@ class WebUIEnclosureService(Service):
             pool_info['vdev_disks'].append(info)
 
     def dashboard_impl(self):
-        disks_to_pools = dict()
         enclosures = self.middleware.call_sync('enclosure2.query')
         if enclosures:
             disk_deets = self.middleware.call_sync('device.get_disks')
@@ -56,7 +55,7 @@ class WebUIEnclosureService(Service):
                         # work with UI to remove unnecessary ones
                         self.map_disk_details(slot_info, disk_deets)
 
-                        if (pool_info := disks_to_pools['disks'].get(slot_info['dev'])):
+                        if pool_info := disks_to_pools['disks'].get(slot_info['dev']):
                             # now map zpool info
                             self.map_zpool_info(enc['id'], disk_slot, slot_info['dev'], pool_info)
 

--- a/src/middlewared/middlewared/plugins/zfs_/status_util.py
+++ b/src/middlewared/middlewared/plugins/zfs_/status_util.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+
+from middlewared.service import CallError, ValidationError
+
+
+def get_normalized_disk_info(pool_name: str, disk: dict, vdev_name: str, vdev_type: str, vdev_disks: list) -> dict:
+    return {
+        'pool_name': pool_name,
+        'disk_status': disk['state'],
+        'disk_read_errors': disk.get('read_errors', 0),
+        'disk_write_errors': disk.get('write_errors', 0),
+        'disk_checksum_errors': disk.get('checksum_errors', 0),
+        'vdev_name': vdev_name,
+        'vdev_type': vdev_type,
+        'vdev_disks': vdev_disks,
+    }
+
+
+def get_zfs_vdev_disks(vdev) -> list:
+    if vdev['state'] in ('UNAVAIL', 'OFFLINE'):
+        return []
+
+    if vdev['vdev_type'] == 'disk':
+        return [vdev['path']]
+    elif vdev['vdev_type'] == 'file':
+        return []
+    else:
+        result = []
+        for i in vdev.get('vdevs', {}).values():
+            result.extend(get_zfs_vdev_disks(i))
+        return result
+
+
+def get_zpool_status(pool_name: str | None = None) -> dict:
+    args = [pool_name] if pool_name else []
+    cp = subprocess.run(['zpool', 'status', '-jP', '--json-int'] + args, capture_output=True, check=False)
+    if cp.returncode:
+        if b'no such pool' in cp.stderr:
+            raise ValidationError('zpool.status', f'{pool_name!r} not found')
+
+        raise CallError(f'Failed to get zpool status: {cp.stderr.decode()}')
+
+    return json.loads(cp.stdout)['pools']

--- a/tests/api2/test_zpool_status.py
+++ b/tests/api2/test_zpool_status.py
@@ -1,0 +1,262 @@
+import os
+
+import pytest
+
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call, ssh
+
+POOL_NAME = 'test_format_pool'
+
+
+def get_disk_uuid_mapping(unused_disks):
+    disk_uuid = {}
+    for uuid in os.listdir('/dev/disk/by-partuuid'):
+        resolved_path = call('zpool.resolve_block_path', os.path.join('/dev/disk/by-partuuid', uuid), True)
+        if resolved_path in unused_disks:
+            disk_uuid[resolved_path] = os.path.join('/dev/disk/by-partuuid', uuid)
+    return disk_uuid
+
+
+def get_pool_status(unused_disks, real_paths=False, replaced=False):
+    disk_uuid_mapping = get_disk_uuid_mapping(unused_disks)
+    return {
+        'disks': {
+            f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'AVAIL' if not replaced else 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe' if not replaced else 'spare-0',
+                'vdev_type': 'spares' if not replaced else 'data',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                ] if not replaced else [
+                    f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                    f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                ]
+            },
+            f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe',
+                'vdev_type': 'logs',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}'
+                ]
+            },
+            f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe',
+                'vdev_type': 'dedup',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}'
+                ]
+            },
+            f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe',
+                'vdev_type': 'special',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}'
+                ]
+            },
+            f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe',
+                'vdev_type': 'l2cache',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}'
+                ]
+            },
+            f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
+                'pool_name': POOL_NAME,
+                'disk_status': 'ONLINE',
+                'disk_read_errors': 0,
+                'disk_write_errors': 0,
+                'disk_checksum_errors': 0,
+                'vdev_name': 'stripe' if not replaced else 'spare-0',
+                'vdev_type': 'data',
+                'vdev_disks': [
+                    f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}'
+                ] if not replaced else [
+                    f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                    f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                ]
+            }
+        },
+        POOL_NAME: {
+            'spares': {
+                f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'AVAIL' if not replaced else 'INUSE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'spares',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                    ]
+                }
+            },
+            'logs': {
+                f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'logs',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}'
+                    ]
+                }
+            },
+            'dedup': {
+                f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'dedup',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}'
+                    ]
+                }
+            },
+            'special': {
+                f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'special',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}'
+                    ]
+                }
+            },
+            'l2cache': {
+                f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'l2cache',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}'
+                    ]
+                }
+            },
+            'data': {
+                f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'stripe',
+                    'vdev_type': 'data',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}'
+                    ]
+                }
+            } if not replaced else {
+                f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'spare-0',
+                    'vdev_type': 'data',
+                    'vdev_disks': [
+                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                    ]
+                },
+                f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
+                    'pool_name': POOL_NAME,
+                    'disk_status': 'ONLINE',
+                    'disk_read_errors': 0,
+                    'disk_write_errors': 0,
+                    'disk_checksum_errors': 0,
+                    'vdev_name': 'spare-0',
+                    'vdev_type': 'data',
+                    'vdev_disks':  [
+                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                    ]
+                },
+            }
+        }
+    }
+
+
+@pytest.fixture(scope='module')
+def test_pool():
+    unused_disks = call('disk.get_unused')
+    if len(unused_disks) < 7:
+        pytest.skip('Insufficient number of disks to perform these tests')
+
+    with another_pool({
+        'name': POOL_NAME,
+        'topology': {
+            'cache': [{'type': 'STRIPE', 'disks': [unused_disks[0]['name']]}],
+            'data': [{'type': 'STRIPE', 'disks': [unused_disks[1]['name']]}],
+            'dedup': [{'type': 'STRIPE', 'disks': [unused_disks[2]['name']]}],
+            'log': [{'type': 'STRIPE', 'disks': [unused_disks[3]['name']]}],
+            'spares': [unused_disks[4]['name']],
+            'special': [{'type': 'STRIPE', 'disks': [unused_disks[5]['name']]}]
+        },
+        'allow_duplicate_serials': True,
+    }) as pool_info:
+        yield pool_info, unused_disks
+
+
+@pytest.mark.parametrize('real_path', [True, False])
+def test_zpool_status_format(test_pool, real_path):
+    assert call('zpool.status', {'name': POOL_NAME, 'real_paths': real_path}) == get_pool_status(
+        [disk['name'] for disk in test_pool[1]], real_path
+    )
+
+
+def test_replaced_disk_zpool_status_format(test_pool):
+    disk_mapping = get_disk_uuid_mapping([disk['name'] for disk in test_pool[1]])
+    data_disk = test_pool[1][1]['name']
+    spare_disk = test_pool[1][4]['name']
+    ssh(
+        f'zpool replace '
+        f'{test_pool[0]["name"]} '
+        f'{os.path.basename(disk_mapping[data_disk])} '
+        f'{os.path.basename(disk_mapping[spare_disk])}',
+    )
+    for real_path in (True, False):
+        assert call(
+            'zpool.status', {"name": POOL_NAME, "real_paths": real_path}
+        ) == get_pool_status(
+            [disk['name'] for disk in test_pool[1]], real_path, True
+        )


### PR DESCRIPTION
## Problem

`zpool.status` was not properly reporting path for disk properly when a spare had replaced a data disk.

## Solution

We are now using `zpool status` for retrieving serialized information about the zpool so we can properly account for disk path being reported for spare based disks and that is much better optimized for a system with large number of disks as compared to py-libzfs.