### PR TITLE
NAS-130638 / 24.10-BETA.1 / add more default zfs props for apps internal dataset (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -27,7 +27,7 @@ class AppSchemaActions(Service):
         for create_ds in sorted(set(user_wants) - existing_datasets):
             await self.middleware.call(
                 'zfs.dataset.create', {
-                    'properties': user_wants[create_ds]['properties'] | DATASET_DEFAULTS,
+                    'properties': user_wants[create_ds]['properties'] | DATASET_DEFAULTS.to_dict(),
                     'name': create_ds, 'type': 'FILESYSTEM',
                 }
             )

--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -3,7 +3,7 @@ import os
 from middlewared.service import CallError, Service
 
 from .ix_apps.path import get_app_parent_volume_ds_name
-from .utils import DATASET_DEFAULTS
+from .utils import DatasetDefaults
 
 
 class AppSchemaActions(Service):
@@ -27,7 +27,7 @@ class AppSchemaActions(Service):
         for create_ds in sorted(set(user_wants) - existing_datasets):
             await self.middleware.call(
                 'zfs.dataset.create', {
-                    'properties': user_wants[create_ds]['properties'] | DATASET_DEFAULTS.to_dict(),
+                    'properties': user_wants[create_ds]['properties'] | DatasetDefaults.to_dict(),
                     'name': create_ds, 'type': 'FILESYSTEM',
                 }
             )

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from middlewared.plugins.docker.state_utils import DATASET_DEFAULTS, IX_APPS_MOUNT_PATH  # noqa
+from middlewared.plugins.docker.state_utils import DatasetDefaults, IX_APPS_MOUNT_PATH  # noqa
 
 
 PROJECT_PREFIX = 'ix-'

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -60,7 +60,7 @@ class DockerSetupService(Service):
         await self.middleware.call('docker.state.start_service')
 
     @private
-    def move_conflicting_dir(ds_name):
+    def move_conflicting_dir(self, ds_name):
         base_ds_name = os.path.basename(ds_name)
         from_path = os.path.join(IX_APPS_MOUNT_PATH, base_ds_name)
         if ds_name == "ix-apps":  # FIXME: we need to specify this globally

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -76,7 +76,7 @@ class DockerSetupService(Service):
     def create_update_docker_datasets_impl(self, docker_ds):
         expected_docker_datasets = docker_datasets(docker_ds)
         actual_docker_datasets = {
-            k['id']: v['properties'] for k, v in self.middleware.call_sync(
+            k['id']: k['properties'] for k in self.middleware.call_sync(
                 'zfs.dataset.query', [['id', 'in', expected_docker_datasets]], {
                     'extra': {
                         'properties': list(DatasetDefaults.update_only(skip_ds_name_check=True).keys()),
@@ -84,12 +84,12 @@ class DockerSetupService(Service):
                         'user_properties': False,
                     }
                 }
-            ).items()
+            )
         }
         for dataset_name in expected_docker_datasets:
             if existing_dataset := actual_docker_datasets.get(dataset_name):
                 update_props = DatasetDefaults.update_only(os.path.basename(dataset_name))
-                if any(val['value'] != update_props[name] for name, val in existing_dataset['properties'].items()):
+                if any(val['value'] != update_props[name] for name, val in existing_dataset.items()):
                     # if any of the zfs properties don't match what we expect we'll update all properties
                     self.middleware.call_sync(
                         'zfs.dataset.update', dataset_name, {

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -8,8 +8,7 @@ from datetime import datetime
 from middlewared.service import CallError, private, Service
 
 from .state_utils import (
-    DATASET_DEFAULTS, docker_datasets, docker_dataset_custom_props, docker_dataset_update_props, IX_APPS_MOUNT_PATH,
-    missing_required_datasets,
+    DATASET_DEFAULTS, docker_datasets, IX_APPS_MOUNT_PATH, IX_APPS_DIR_NAME, missing_required_datasets,
 )
 
 
@@ -61,41 +60,62 @@ class DockerSetupService(Service):
         await self.middleware.call('docker.state.start_service')
 
     @private
-    async def create_update_docker_datasets(self, docker_ds):
-        create_props_default = DATASET_DEFAULTS.to_dict()
-        for dataset_name in docker_datasets(docker_ds):
-            custom_props = docker_dataset_custom_props(dataset_name.split('/', 1)[-1])
-            # got custom properties, need to re-calculate
-            # the update and create props.
-            create_props = dict(create_props_default, **custom_props) if custom_props else create_props_default
-            update_props = docker_dataset_update_props(create_props)
+    def move_conflicting_dir(ds_name):
+        base_ds_name = os.path.basename(ds_name)
+        from_path = os.path.join(IX_APPS_MOUNT_PATH, base_ds_name)
+        if ds_name == "ix-apps":  # FIXME: we need to specify this globally
+            from_path = IX_APPS_MOUNT_PATH
 
-            dataset = await self.middleware.call(
-                'zfs.dataset.query', [['id', '=', dataset_name]], {
-                    'extra': {
-                        'properties': list(update_props),
-                        'retrieve_children': False,
-                        'user_properties': False,
-                    }
+        with contextlib.suppress(FileNotFoundError):
+            # can't stop someone from manually creating same name
+            # directories on disk so we'll just move them
+            shutil.move(from_path, f'{from_path}-{str(uuid.uuid4())[:4]}-{datetime.now().isoformat()}')
+
+    @private
+    def create_update_docker_datasets_impl(self, docker_ds):
+        create_props_default = DATASET_DEFAULTS.to_dict()
+        update_props_default = DATASET_DEFAULTS.update_only()
+        expect_dock_datasets = docker_datasets(docker_ds)
+        actual_dock_datasets = {k["id"]: v["properties"] for k, v in self.middleware.call_sync(
+            'zfs.dataset.query', [['id', 'in', expect_dock_datasets]], {
+                'extra': {
+                    'properties': list(update_props_default.keys()),
+                    'retrieve_children': False,
+                    'user_properties': False,
                 }
-            )
-            if not dataset:
-                base_ds_name = os.path.basename(dataset_name)
-                test_path = IX_APPS_MOUNT_PATH if base_ds_name == 'ix-apps' else os.path.join(
-                    IX_APPS_MOUNT_PATH, base_ds_name
-                )
-                with contextlib.suppress(FileNotFoundError):
-                    await self.middleware.run_in_thread(
-                        shutil.move, test_path, f'{test_path}-{str(uuid.uuid4())[:4]}-{datetime.now().isoformat()}',
-                    )
-                await self.middleware.call(
-                    'zfs.dataset.create', {
-                        'name': dataset_name, 'type': 'FILESYSTEM', 'properties': create_props,
-                    }
-                )
-            elif any(val['value'] != update_props[name] for name, val in dataset[0]['properties'].items()):
-                await self.middleware.call(
-                    'zfs.dataset.update', dataset_name, {
-                        'properties': {k: {'value': v} for k, v in update_props.items()}
-                    }
-                )
+            }
+        ).items()}
+        for dataset_name in expect_dock_datasets:
+            if existing_dataset := actual_dock_datasets.get(dataset_name):
+                for prop_name, prop_info in existing_dataset["properties"].items():
+                    if prop_info["value"] != update_props_default[prop_name]:
+                        # if any of the zfs properties dont match what we expect
+                        # we'll update all properties
+                        self.middleware.call_sync(
+                            'zfs.dataset.update', dataset_name, {
+                                'properties': {k: {'value': v} for k, v in update_props_default.items()}
+                            }
+                        )
+                        break
+
+            else:
+                self.move_conflicting_dir(dataset_name)
+                if dataset_name == "ix-apps":  # FIXME: we need to specify this globally
+                    create_props_default = create_props_default | {"mountpoint": f"/{IX_APPS_DIR_NAME}"}
+                self.middleware.call_sync('zfs.dataset.create', {
+                    'name': dataset_name, 'type': 'FILESYSTEM', 'properties': create_props_default,
+                })
+
+    @private
+    async def create_update_docker_datasets(self, docker_ds):
+        """The following logic applies:
+
+            1. create the docker datasets fresh (if they dont exist)
+            2. OR update the docker datasets zfs properties if they
+                don't match reality.
+
+            NOTE: this method needs to be optimized as much as possible
+            since this is called on docker state change for each docker
+            dataset
+        """
+        await self.middleware.run_in_thread(self.create_update_docker_datasets_impl, docker_ds)

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from middlewared.service import CallError, private, Service
 
 from .state_utils import (
-    DATASET_DEFAULTS, docker_datasets, IX_APPS_MOUNT_PATH, IX_APPS_DIR_NAME, missing_required_datasets,
+    DatasetDefaults, docker_datasets, IX_APPS_MOUNT_PATH, IX_APPS_DIR_NAME, missing_required_datasets,
 )
 
 
@@ -73,8 +73,8 @@ class DockerSetupService(Service):
 
     @private
     def create_update_docker_datasets_impl(self, docker_ds):
-        create_props_default = DATASET_DEFAULTS.to_dict()
-        update_props_default = DATASET_DEFAULTS.update_only()
+        create_props_default = DatasetDefaults.to_dict()
+        update_props_default = DatasetDefaults.update_only()
         expect_dock_datasets = docker_datasets(docker_ds)
         actual_dock_datasets = {k["id"]: v["properties"] for k, v in self.middleware.call_sync(
             'zfs.dataset.query', [['id', 'in', expect_dock_datasets]], {

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -74,7 +74,7 @@ class DockerSetupService(Service):
     @private
     def create_update_docker_datasets_impl(self, docker_ds):
         create_props_default = DatasetDefaults.to_dict()
-        update_props_default = DatasetDefaults.update_only()
+        update_props_default = DatasetDefaults.update_only(skip_ds_name_check=True)
         expected_docker_datasets = docker_datasets(docker_ds)
         actual_docker_datasets = {
             k['id']: v['properties'] for k, v in self.middleware.call_sync(

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -62,7 +62,7 @@ class DockerSetupService(Service):
 
     @private
     async def create_update_docker_datasets(self, docker_ds):
-        create_props_default = DATASET_DEFAULTS.copy()
+        create_props_default = DATASET_DEFAULTS.to_dict()
         for dataset_name in docker_datasets(docker_ds):
             custom_props = docker_dataset_custom_props(dataset_name.split('/', 1)[-1])
             # got custom properties, need to re-calculate

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -10,24 +10,39 @@ CATALOG_DATASET_NAME: str = 'truenas_catalog'
 IX_APPS_DIR_NAME = '.ix-apps'
 IX_APPS_MOUNT_PATH: str = os.path.join('/mnt', IX_APPS_DIR_NAME)
 
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class DatasetProp:
+    value: str
+    create_time_only: bool
+
+
 @dataclasses.dataclass(slots=True, frozen=True)
 class DATASET_DEFAULTS:
-    aclmode: str = 'discard'
-    acltype: str = 'posix'
-    atime: str = 'off'
-    casesensitivity: str = 'sensitive'
-    canmount: str = 'noauto'
-    dedup: str = 'off'
-    exec: str = 'on'
-    normalization: str = 'none'
-    overlay: str = 'on'
-    setuid: str = 'on'
-    snapdir: str = 'hidden'
-    xattr: str = 'sa'
+    aclmode: DatasetProp = DatasetProp('discard', False)
+    acltype: DatasetProp = DatasetProp('posix', False)
+    atime: DatasetProp = DatasetProp('off', False)
+    casesensitivity: DatasetProp = DatasetProp('sensitive', True)
+    canmount: DatasetProp = DatasetProp('noauto', False)
+    dedup: DatasetProp = DatasetProp('off', False)
+    exec: DatasetProp = DatasetProp('on', False)
+    normalization: DatasetProp = DatasetProp('none', True)
+    overlay: DatasetProp = DatasetProp('on', False)
+    setuid: DatasetProp = DatasetProp('on', False)
+    snapdir: DatasetProp = DatasetProp('hidden', False)
+    xattr: DatasetProp = DatasetProp('sa', False)
 
     @classmethod
     def to_dict(cls):
-        return dataclasses.asdict(cls())
+        return {k: v['value'] for k, v in dataclasses.asdict(cls())}
+
+    @classmethod
+    def create_time_only(cls):
+        return {k: v['value'] for k, v in dataclasses.asdict(cls()) if v['create_time_only']}
+
+    @classmethod
+    def update_only(cls):
+        return {k: v['value'] for k, v in dataclasses.asdict(cls()) if not v['create_time_only']}
 
 
 class Status(enum.Enum):

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import collections
 import enum
 import os
@@ -9,20 +10,24 @@ CATALOG_DATASET_NAME: str = 'truenas_catalog'
 IX_APPS_DIR_NAME = '.ix-apps'
 IX_APPS_MOUNT_PATH: str = os.path.join('/mnt', IX_APPS_DIR_NAME)
 
-DATASET_DEFAULTS: dict = {
-    'aclmode': 'discard',
-    'acltype': 'posix',
-    'atime': 'off',
-    'casesensitivity': 'sensitive',
-    'canmount': 'noauto',
-    'dedup': 'off',
-    'exec': 'on',
-    'normalization': 'none',
-    'overlay': 'on',
-    'setuid': 'on',
-    'snapdir': 'hidden',
-    'xattr': 'sa',
-}
+@dataclasses.dataclass(slots=True, frozen=True)
+class DATASET_DEFAULTS:
+    aclmode: str = 'discard'
+    acltype: str = 'posix'
+    atime: str = 'off'
+    casesensitivity: str = 'sensitive'
+    canmount: str = 'noauto'
+    dedup: str = 'off'
+    exec: str = 'on'
+    normalization: str = 'none'
+    overlay: str = 'on'
+    setuid: str = 'on'
+    snapdir: str = 'hidden'
+    xattr: str = 'sa'
+
+    @classmethod
+    def to_dict(cls):
+        return dataclasses.asdict(cls())
 
 
 class Status(enum.Enum):

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -12,11 +12,16 @@ IX_APPS_MOUNT_PATH: str = os.path.join('/mnt', IX_APPS_DIR_NAME)
 DATASET_DEFAULTS: dict = {
     'aclmode': 'discard',
     'acltype': 'posix',
-    'exec': 'on',
-    'setuid': 'on',
-    'casesensitivity': 'sensitive',
     'atime': 'off',
+    'casesensitivity': 'sensitive',
     'canmount': 'noauto',
+    'dedup': 'off',
+    'exec': 'on',
+    'normalization': 'none',
+    'overlay': 'on',
+    'setuid': 'on',
+    'snapdir': 'hidden',
+    'xattr': 'sa',
 }
 
 

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -18,7 +18,7 @@ class DatasetProp:
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
-class DATASET_DEFAULTS:
+class DatasetDefaults:
     aclmode: DatasetProp = DatasetProp('discard', False)
     acltype: DatasetProp = DatasetProp('posix', False)
     atime: DatasetProp = DatasetProp('off', False)

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -34,15 +34,15 @@ class DatasetDefaults:
 
     @classmethod
     def to_dict(cls):
-        return {k: v['value'] for k, v in dataclasses.asdict(cls())}
+        return {k: v['value'] for k, v in dataclasses.asdict(cls()).items()}
 
     @classmethod
     def create_time_only(cls):
-        return {k: v['value'] for k, v in dataclasses.asdict(cls()) if v['create_time_only']}
+        return {k: v['value'] for k, v in dataclasses.asdict(cls()).items() if v['create_time_only']}
 
     @classmethod
     def update_only(cls):
-        return {k: v['value'] for k, v in dataclasses.asdict(cls()) if not v['create_time_only']}
+        return {k: v['value'] for k, v in dataclasses.asdict(cls()).items() if not v['create_time_only']}
 
 
 class Status(enum.Enum):

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -2,7 +2,7 @@ import os.path
 import shutil
 
 from middlewared.plugins.apps.ix_apps.path import get_app_parent_volume_ds_name, get_installed_app_path
-from middlewared.plugins.docker.state_utils import DATASET_DEFAULTS
+from middlewared.plugins.docker.state_utils import DatasetDefaults
 from middlewared.schema import accepts, Bool, Dict, List, returns, Str
 from middlewared.service import CallError, job, Service
 
@@ -181,7 +181,7 @@ class K8stoDockerMigrationService(Service):
                     self.middleware.call_sync('zfs.snapshot.clone', {
                         'snapshot': snapshot,
                         'dataset_dst': destination_ds,
-                        'dataset_properties': DATASET_DEFAULTS.update_only(),
+                        'dataset_properties': DatasetDefaults.update_only(),
                     })
                     self.middleware.call_sync('zfs.dataset.promote', destination_ds)
                     self.middleware.call_sync('zfs.dataset.mount', destination_ds)

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -182,7 +182,7 @@ class K8stoDockerMigrationService(Service):
                         'snapshot': snapshot,
                         'dataset_dst': destination_ds,
                         'dataset_properties': {
-                            k: v for k, v in DATASET_DEFAULTS.items() if k not in ['casesensitivity']
+                            k: v for k, v in DATASET_DEFAULTS.to_dict().items() if k != 'casesensitivity'
                         },
                     })
                     self.middleware.call_sync('zfs.dataset.promote', destination_ds)

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -181,9 +181,7 @@ class K8stoDockerMigrationService(Service):
                     self.middleware.call_sync('zfs.snapshot.clone', {
                         'snapshot': snapshot,
                         'dataset_dst': destination_ds,
-                        'dataset_properties': {
-                            k: v for k, v in DATASET_DEFAULTS.to_dict().items() if k != 'casesensitivity'
-                        },
+                        'dataset_properties': DATASET_DEFAULTS.update_only(),
                     })
                     self.middleware.call_sync('zfs.dataset.promote', destination_ds)
                     self.middleware.call_sync('zfs.dataset.mount', destination_ds)

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -181,7 +181,7 @@ class K8stoDockerMigrationService(Service):
                     self.middleware.call_sync('zfs.snapshot.clone', {
                         'snapshot': snapshot,
                         'dataset_dst': destination_ds,
-                        'dataset_properties': DatasetDefaults.update_only(),
+                        'dataset_properties': DatasetDefaults.update_only(os.path.basename(destination_ds)),
                     })
                     self.middleware.call_sync('zfs.dataset.promote', destination_ds)
                     self.middleware.call_sync('zfs.dataset.mount', destination_ds)


### PR DESCRIPTION
1. add more default zfs properties to the internal apps dataset
2. convert the global mutable dictionary to an immutable dataclass to prevent the possibility of scrambling this object during runtime (the dataclass is also frozen so it's more memory efficient)
3. create a single thread to execute the disk I/O operations instead of a thread per move operation
4. lessen the amount of processes used in the process pool

Original PR: https://github.com/truenas/middleware/pull/14247
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130638