### PR TITLE
NAS-130695 / 24.10-RC.1 / properly hide internal docker dataset (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -166,7 +166,7 @@ class PoolDatasetService(CRUDService):
             ['pool', '!=', await self.middleware.call('boot.pool_name')],
             ['id', 'rnin', '/.system'],
             ['id', 'rnin', '/ix-applications/'],
-            ['id', 'rnin', '/ix-apps/'],
+            ['id', 'rnin', '/ix-apps'],
         ]
 
     @private

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -3,7 +3,7 @@ import errno
 import os
 
 import middlewared.sqlalchemy as sa
-
+from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
 from middlewared.plugins.zfs_.exceptions import ZFSSetPropertyError
 from middlewared.plugins.zfs_.validation_utils import validate_dataset_name
 from middlewared.schema import (
@@ -163,7 +163,7 @@ class PoolDatasetService(CRUDService):
     async def internal_datasets_filters(self):
         # We get filters here which ensure that we don't match an internal dataset
         return [
-            ['pool', '!=', await self.middleware.call('boot.pool_name')],
+            ['pool', 'nin', BOOT_POOL_NAME_VALID],
             ['id', 'rnin', '/.system'],
             ['id', 'rnin', '/ix-applications/'],
             ['id', 'rnin', '/ix-apps'],


### PR DESCRIPTION
Fix 1 issue:
- properly hide the `ix-apps` dataset (this is an internal dataset) from public facing API

Improve 1 other:
- no reason to call boot.pool_name each time someone calls `pool.dataset.query`. This information is static so we can use the BOOT_POOL_NAME_VALID array to accomplish the same task and save us a `self.middleware.call` call.

Original PR: https://github.com/truenas/middleware/pull/14266
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130695