### PR TITLE
NAS-130706 / 25.04 / Add timestamp fix to sudo reject path

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -127,6 +127,7 @@ rewrite r_rewrite_sudo_accept {
 };
 rewrite r_rewrite_sudo_reject {
   set("${sudo.reject.uuid}", value("TNAUDIT.aid"));
+  fix-time-zone("UTC");
   set('${S_YEAR}-${S_MONTH}-${S_DAY} ${S_HOUR}:${S_MIN}:${S_SEC}.$(substr "${sudo.reject.server_time.nanoseconds}" "0" "6")', value("TNAUDIT.time"));
   set("${sudo.reject.submithost}", value("TNAUDIT.addr"));
   set("${sudo.reject.submituser}", value("TNAUDIT.user"));

--- a/tests/api2/test_audit_sudo.py
+++ b/tests/api2/test_audit_sudo.py
@@ -119,13 +119,14 @@ class SudoTests:
         # Now create an event and do some basic checking
         self.sudo_command('ls /etc')
         assert count + 1 == wait_for_events(self.USER, count + 1)
-        accept = assert_accept(user_sudo_events(self.USER)[-1])
+        event = user_sudo_events(self.USER)[-1]
+        accept = assert_accept(event)
         assert accept['submituser'] == self.USER
         assert accept['command'] == LS_COMMAND
         assert accept['runuser'] == 'root'
         assert accept['runargv'].split(',') == ['ls', '/etc']
         # NAS-130373
-        assert_timestamp(user_sudo_events(self.USER)[-1], accept)
+        assert_timestamp(event, accept)
 
         # One more completely unique command
         magic = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(20))
@@ -183,14 +184,15 @@ class SudoTests:
             self.sudo_command('ls /etc')
         assert 'is not allowed to execute ' in str(ve), str(ve)
         assert count + 1 == wait_for_events(self.USER, count + 1)
-        reject = assert_reject(user_sudo_events(self.USER)[-1])
+        event = user_sudo_events(self.USER)[-1]
+        reject = assert_reject(event)
         assert reject['submituser'] == self.USER
         assert reject['command'] == LS_COMMAND
         assert reject['runuser'] == 'root'
         assert reject['runargv'].split(',') == ['ls', '/etc']
         assert reject['reason'] == 'command not allowed'
         # NAS-130373
-        assert_timestamp(user_sudo_events(self.USER)[-1], reject)
+        assert_timestamp(event, reject)
 
 
 class SudoNoPasswd:

--- a/tests/api2/test_audit_sudo.py
+++ b/tests/api2/test_audit_sudo.py
@@ -62,12 +62,12 @@ def assert_reject(event):
     return event['event_data']['sudo']['reject']
 
 
-def assert_timestamp(event):
+def assert_timestamp(event, event_data):
     """
     NAS-130373:  message_timestamp should be UTC
     """
     assert type(event) is dict
-    submit_time = event['event_data']['sudo']['accept']['submit_time']['seconds']
+    submit_time = event_data['submit_time']['seconds']
     msg_ts = event['message_timestamp']
     utc_ts = get_utc()
 
@@ -125,7 +125,7 @@ class SudoTests:
         assert accept['runuser'] == 'root'
         assert accept['runargv'].split(',') == ['ls', '/etc']
         # NAS-130373
-        assert_timestamp(user_sudo_events(self.USER)[-1])
+        assert_timestamp(user_sudo_events(self.USER)[-1], accept)
 
         # One more completely unique command
         magic = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(20))
@@ -189,6 +189,8 @@ class SudoTests:
         assert reject['runuser'] == 'root'
         assert reject['runargv'].split(',') == ['ls', '/etc']
         assert reject['reason'] == 'command not allowed'
+        # NAS-130373
+        assert_timestamp(user_sudo_events(self.USER)[-1], reject)
 
 
 class SudoNoPasswd:


### PR DESCRIPTION
The 'reject' path is missing the UTC timestamp fix.   Add fix-time-zone("UTC") to sudo 'reject' processing path.
See [NAS-130373](https://github.com/truenas/middleware/pull/14261) for additional information.