### PR TITLE
NAS-130707 / 25.04 / Improve interface.websocket_local_ip and add tests

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1475,7 +1475,7 @@ class InterfaceService(CRUDService):
         """
         Returns the interface this websocket is connected to.
         """
-        local_ip = await self.websocket_local_ip(app=app)
+        local_ip = await self.websocket_local_ip(app)
         if local_ip is None:
             return
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -8,8 +8,9 @@ from os import scandir
 
 import middlewared.sqlalchemy as sa
 from middlewared.service import CallError, CRUDService, filterable, pass_app, private
-from middlewared.utils import filter_list, run
+from middlewared.utils import filter_list
 from middlewared.schema import accepts, Bool, Dict, Int, IPAddr, List, Patch, returns, Str, ValidationErrors
+from middlewared.utils.network_.procfs import read_proc_net
 from middlewared.utils.origin import TCPIPOrigin
 from middlewared.validators import Range
 from .interface.netif import netif
@@ -1452,34 +1453,20 @@ class InterfaceService(CRUDService):
     @returns(IPAddr(null=True))
     @pass_app()
     async def websocket_local_ip(self, app):
-        """
-        Returns the ip this websocket is connected to.
-        """
-        if app is None:
+        """Returns the local ip address for this websocket session."""
+        if any((
+            app is None,
+            not isinstance(app.origin, TCPIPOrigin)
+        )):
             return
 
-        if not isinstance(app.origin, TCPIPOrigin):
+        try:
+            info = await self.middleware.run_in_thread(read_proc_net, None, app.origin.port)
+        except Exception:
+            self.logger.error("Unexpected failure determining local websocket ip", exc_info=True)
             return
-
-        remote_port = app.origin.port
-
-        data = (await run(['lsof', '-Fn', f'-i:{remote_port}', '-n'], encoding='utf-8')).stdout
-        for line in iter(data.splitlines()):
-            # line we're interested in looks like "n127.0.0.1:x11->127.0.0.1:44812"
-            found = line.find('->')
-            if found < 0:
-                # -1 on failure
-                continue
-
-            if line.endswith(f':{remote_port}'):
-                base = line[1:].split('->')[0]
-                if '[' in base:
-                    # ipv6 line looks like this "[2001:aaaa:bbbb:cccc:dddd::100]:http"
-                    # only care about address in between the brackets
-                    return base.split('[', 1)[1].split(']')[0]
-                else:
-                    # ipv4 line looks like "192.168.1.103:http"
-                    return base.split(':')[0]
+        else:
+            return info.local_ip if info is not None else None
 
     @accepts()
     @returns(Str(null=True))
@@ -1488,7 +1475,10 @@ class InterfaceService(CRUDService):
         """
         Returns the interface this websocket is connected to.
         """
-        local_ip = await self.middleware.call('interface.websocket_local_ip', app=app)
+        local_ip = await self.websocket_local_ip(app=app)
+        if local_ip is None:
+            return
+
         for iface in await self.middleware.call('interface.query'):
             for alias in iface['aliases']:
                 if alias['address'] == local_ip:

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1910,7 +1910,7 @@ class InterfaceService(CRUDService):
                         list_of_ip.append(alias_dict)
 
         return list_of_ip
-    
+   
     @private
     def get_nic_names(self) -> set:
         """Get network interface names excluding internal interfaces"""

--- a/src/middlewared/middlewared/utils/network_/procfs.py
+++ b/src/middlewared/middlewared/utils/network_/procfs.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from socket import inet_ntoa, inet_ntop, AF_INET6
+from struct import pack
+
+__all__ = ('read_proc_net',)
+
+
+@dataclass(slots=True, frozen=True)
+class InetInfoEntry:
+    local_ip: str
+    local_port: int
+    remote_ip: str
+    remote_port: int
+
+
+def parse_address(hex_address, ipversion):
+    ip_hex, port_hex = hex_address.split(':')
+    if ipversion == '4':
+        ip = inet_ntoa(pack("<L", int(ip_hex, 16)))
+    else:
+        ip = inet_ntop(AF_INET6, bytes.fromhex(ip_hex))
+    port = int(port_hex, 16)
+    return ip, port
+
+
+def read_proc_net(local_port=None, remote_port=None) -> InetInfoEntry | list[InetInfoEntry]:
+    """Parse the /proc/net/{tcp/udp(6)} directories from
+    procfs and gather the local and remote ip/ports connected
+    to the system.
+    """
+    info = list()
+    port_specified = any((local_port is not None, remote_port is not None))
+    for prot in ('tcp', 'tcp6', 'udp', 'udp6'):
+        with open(f'/proc/net/{prot}', 'r') as f:
+            ipversion = '6' if prot[-1] == '6' else '4'
+            for _, line in filter(lambda x: x[0] > 1, enumerate(f, start=1)):
+                columns = line.split()
+                lip, lp = parse_address(columns[1], ipversion)
+                rip, rp = parse_address(columns[2], ipversion)
+                if port_specified:
+                    if any((
+                        local_port is not None and local_port == lp,
+                        remote_port is not None and remote_port == rp,
+                    )):
+                        return InetInfoEntry(lip, lp, rip, rp)
+                else:
+                    info.append(InetInfoEntry(lip, lp, rip, rp))
+    return info

--- a/src/middlewared/middlewared/utils/network_/procfs.py
+++ b/src/middlewared/middlewared/utils/network_/procfs.py
@@ -11,6 +11,7 @@ class InetInfoEntry:
     local_port: int
     remote_ip: str
     remote_port: int
+    protocol: str
 
 
 def parse_address(hex_address, ipversion):
@@ -42,7 +43,7 @@ def read_proc_net(local_port=None, remote_port=None) -> InetInfoEntry | list[Ine
                         local_port is not None and local_port == lp,
                         remote_port is not None and remote_port == rp,
                     )):
-                        return InetInfoEntry(lip, lp, rip, rp)
+                        return InetInfoEntry(lip, lp, rip, rp, prot)
                 else:
-                    info.append(InetInfoEntry(lip, lp, rip, rp))
+                    info.append(InetInfoEntry(lip, lp, rip, rp, prot))
     return info

--- a/tests/api2/test_websocket_interface.py
+++ b/tests/api2/test_websocket_interface.py
@@ -1,0 +1,8 @@
+from auto_config import interface
+from middlewared.test.integration.utils import call
+
+
+def test_websocket_interface():
+    """This tests to ensure we return the interface name
+    by which the websocket connection has been established."""
+    assert call("interface.websocket_interface")["id"] == interface

--- a/tests/api2/test_websocket_local_ip.py
+++ b/tests/api2/test_websocket_local_ip.py
@@ -1,0 +1,8 @@
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
+
+
+def test_websocket_local_ip():
+    """This tests to ensure we return the local IP address
+    of the TrueNAS system based on the websocket session."""
+    assert call("interface.websocket_local_ip") == truenas_server.ip


### PR DESCRIPTION
Testing an unrelated problem, I found that `app.query` was broken...which is a pretty significant issue. While that was broken, it brought me to the `interface.websocket_local_ip` endpoint. I discovered that we're calling fork+exec'ing in the main event loop to call `lsof` just to determine the IP address associated with the remote_port of the current websocket session. We can very easily gather this from procfs. While I was there I also improved `interface.websocket_interface`.

- fix interface.websocket_local_ip to not fork+exec
- add test for interface.websocket_local_ip
- add test for interface.websocket_interface