### PR TITLE
NAS-130625 / 25.04 / fix failover.mismatch_nics for h/f series appliances

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1907,16 +1907,6 @@ class InterfaceService(CRUDService):
                         list_of_ip.append(alias_dict)
 
         return list_of_ip
-   
-    @private
-    def get_nic_names(self) -> set:
-        """Get network interface names excluding internal interfaces"""
-        res, ignore = set(), tuple(self.middleware.call_sync('interface.internal_interfaces'))
-        with scandir('/sys/class/net/') as nics:
-            for nic in filter(lambda x: x.is_symlink() and not x.name.startswith(ignore), nics):
-                res.add(nic.name)
-
-        return res
 
 
 async def configure_http_proxy(middleware, *args, **kwargs):


### PR DESCRIPTION
As has been documented in past, these platforms auto-add a USB based NIC device when someone connects to the IPMI console. We accounted for this in `interface.query` however, we didn't account for this in `interface.get_nic_names`. Stepping back, however, we added `get_nic_names` because of the fact that `interface.query` was abnormally expensive on HA systems. In a completely unrelated situation, I found that we were fork+exec'ing for each interface _ONLY_ on HA systems. I fixed that problem here: https://github.com/truenas/middleware/pull/14177

Because of those changes, interface.query is significantly faster on HA. This means we can get rid of `interface.get_nic_names` and use the `interface.query` endpoint.