### PR TITLE
NAS-130625 / 24.10-BETA.1 / fix failover.mismatch_nics for h/f series appliances (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -5,7 +5,6 @@ import socket
 from collections import defaultdict
 from itertools import zip_longest
 from ipaddress import ip_address, ip_interface
-from os import scandir
 
 import middlewared.sqlalchemy as sa
 from middlewared.service import CallError, CRUDService, filterable, pass_app, private
@@ -1924,16 +1923,6 @@ class InterfaceService(CRUDService):
                         list_of_ip.append(alias_dict)
 
         return list_of_ip
-    
-    @private
-    def get_nic_names(self) -> set:
-        """Get network interface names excluding internal interfaces"""
-        res, ignore = set(), tuple(self.middleware.call_sync('interface.internal_interfaces'))
-        with scandir('/sys/class/net/') as nics:
-            for nic in filter(lambda x: x.is_symlink() and not x.name.startswith(ignore), nics):
-                res.add(nic.name)
-
-        return res
 
 
 async def configure_http_proxy(middleware, *args, **kwargs):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 8c99be0c1c40535c77d4e39c6878ff322a112ba5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x aba25629d8c2c46416ad56b62e3e6f503fe19487

As has been documented in past, these platforms auto-add a USB based NIC device when someone connects to the IPMI console. We accounted for this in `interface.query` however, we didn't account for this in `interface.get_nic_names`. Stepping back, however, we added `get_nic_names` because of the fact that `interface.query` was abnormally expensive on HA systems. In a completely unrelated situation, I found that we were fork+exec'ing for each interface _ONLY_ on HA systems. I fixed that problem here: https://github.com/truenas/middleware/pull/14177

Because of those changes, interface.query is significantly faster on HA. This means we can get rid of `interface.get_nic_names` and use the `interface.query` endpoint.

Original PR: https://github.com/truenas/middleware/pull/14283
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130625

Original PR: https://github.com/truenas/middleware/pull/14285
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130625