### PR TITLE
NAS-130679 / 24.10-RC.1 / Fix edits for apps (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_utils.py
@@ -37,10 +37,10 @@ def construct_schema(
 ) -> dict:
     schema_name = f'app_{"update" if update else "create"}'
     attrs = list(itertools.chain.from_iterable(
-        get_schema(q, update, old_values) for q in item_version_details['schema']['questions']
+        get_schema(q, False, old_values) for q in item_version_details['schema']['questions']
     ))
     dict_obj = update_conditional_defaults(
-        Dict(schema_name, *attrs, update=update, additional_attrs=True), {
+        Dict(schema_name, *attrs, update=False, additional_attrs=True), {
             'schema': {'attrs': item_version_details['schema']['questions']}
         }
     )
@@ -48,7 +48,7 @@ def construct_schema(
     verrors = ValidationErrors()
     verrors.add_child('values', validate_schema(
         attrs, new_values, True, dict_kwargs={
-            'conditional_defaults': dict_obj.conditional_defaults, 'update': update,
+            'conditional_defaults': dict_obj.conditional_defaults, 'update': False,
         }
     ))
     return {


### PR DESCRIPTION
## Problem
When the `update` parameter is set to true, the Dict object is not updating values according to the schema, which is causing issues during app updates.

## Solution
Set `update` to false when constructing the schema during schema validation to ensure the values are updated correctly.

Original PR: https://github.com/truenas/middleware/pull/14293
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130679