### PR TITLE
NAS-130011 / 24.10-RC.1 / Add drive bay light status (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/constants.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/constants.py
@@ -1,6 +1,8 @@
 SYSFS_SLOT_KEY = 'sysfs_slot'
 MAPPED_SLOT_KEY = 'mapped_slot'
 SUPPORTS_IDENTIFY_KEY = 'supports_identify_light'
+SUPPORTS_IDENTIFY_STATUS_KEY = 'supports_identify_light_status'
+DRIVE_BAY_LIGHT_STATUS = 'drive_bay_light_status'
 MINI_MODEL_BASE = 'MINI'
 MINIR_MODEL_BASE = f'{MINI_MODEL_BASE}R'
 HEAD_UNIT_DISK_SLOT_START_NUMBER = 1

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -2,23 +2,22 @@
 #
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
-
-from libsg3.ses import EnclosureDevice
+import errno
 
 from middlewared.schema import Dict, Int, Str, accepts
 from middlewared.service import Service, filterable
-from middlewared.service_exception import MatchNotFound, ValidationError
+from middlewared.service_exception import CallError, MatchNotFound, ValidationError
 from middlewared.utils import filter_list
 
 from .constants import SUPPORTS_IDENTIFY_KEY
-from .enums import JbofModels
+from .enums import ControllerModels, JbofModels
 from .fseries_drive_identify import set_slot_status as fseries_set_slot_status
-from .jbof_enclosures import map_jbof
-from .jbof_enclosures import set_slot_status as _jbof_set_slot_status
+from .jbof_enclosures import map_jbof, set_slot_status as _jbof_set_slot_status
 from .map2 import combine_enclosures
 from .nvme2 import map_nvme
 from .r30_drive_identify import set_slot_status as r30_set_slot_status
 from .ses_enclosures2 import get_ses_enclosures
+from .sysfs_disks import toggle_enclosure_slot_identifier
 
 
 class Enclosure2Service(Service):
@@ -77,14 +76,12 @@ class Enclosure2Service(Service):
         more flexbiility when we do get an enclosure that maps drives differently.
         (i.e. the ES102G2 is a prime example of this (enumerates drives at 1 instead of 0))
         """
-        sgdev = origslot = None
-        supports_identify = False
+        origslot, supports_identify = None, False
         for encslot, devinfo in filter(lambda x: x[0] == slot, enc_info['elements']['Array Device Slot'].items()):
-            sgdev = devinfo['original']['enclosure_sg']
             origslot = devinfo['original']['slot']
             supports_identify = devinfo[SUPPORTS_IDENTIFY_KEY]
 
-        return sgdev, origslot, supports_identify
+        return origslot, supports_identify
 
     @accepts(Dict(
         Str('enclosure_id', required=True),
@@ -105,49 +102,40 @@ class Enclosure2Service(Service):
         except MatchNotFound:
             raise ValidationError('enclosure2.set_slot_status', f'Enclosure with id: {data["enclosure_id"]} not found')
 
-        # Map the requested status to an underlying value.
-        # - OFF is an alias for CLEAR
-        # - ON means IDENT
-        if data['status'] in ['CLEAR', 'OFF']:
-            set_status = 'CLEAR'
-        elif data['status'] == 'ON':
-            set_status = 'IDENT'
-        else:
-            raise ValueError(f'{data["status"]}: unknown slot status')
-
         if enc_info['id'].endswith('_nvme_enclosure'):
             if enc_info['id'].startswith('r30'):
                 # an all nvme flash system so drive identification is handled
                 # in a completely different way than sata/scsi
-                return r30_set_slot_status(data['slot'], set_status)
+                return r30_set_slot_status(data['slot'], data['status'])
             elif enc_info['id'].startswith(('f60', 'f100', 'f130')):
-                return fseries_set_slot_status(data['slot'], set_status)
+                return fseries_set_slot_status(data['slot'], data['status'])
             else:
                 # mseries, and some rseries have mapped nvme enclosures but they
                 # don't support drive LED identification
                 return
         elif enc_info['model'] == JbofModels.ES24N.name:
-            return self.middleware.call_sync('enclosure2.jbof_set_slot_status', data['enclosure_id'], data['slot'], set_status)
+            return self.middleware.call_sync(
+                'enclosure2.jbof_set_slot_status', data['enclosure_id'], data['slot'], data['status']
+            )
 
-        sgdev, origslot, supported = self.get_original_disk_slot(data['slot'], enc_info)
-        if sgdev is None:
-            raise ValidationError('enclosure2.set_slot_status', 'Unable to find scsi generic device for enclosure')
-        elif origslot is None:
-            raise ValidationError('enclosure2.set_slot_status', f'Slot {data["slot"]} not found in enclosure')
-        elif not supported:
-            raise ValidationError('enclosure2.set_slot_status', f'Slot {data["slot"]} does not support identification')
-
-        if set_status == 'CLEAR':
-            actions = ('clear=ident', 'clear=fault')
+        if enc_info['pci'] is None:
+            raise ValidationError('enclosure2.set_slot_status', 'Unable to determine PCI address for enclosure')
         else:
-            actions = (f'set={set_status.lower()}',)
-
-        encdev = EnclosureDevice(sgdev)
-        try:
-            for action in actions:
-                encdev.set_control(str(origslot), action)
-        except OSError:
-            self.logger.warning(f'Failed to {data["status"]} slot {data["slot"]} on enclosure {enc_info["id"]}')
+            origslot, supported = self.get_original_disk_slot(data['slot'], enc_info)
+            if origslot is None:
+                raise ValidationError('enclosure2.set_slot_status', f'Slot {data["slot"]} not found in enclosure')
+            elif not supported:
+                raise ValidationError(
+                    'enclosure2.set_slot_status', f'Slot {data["slot"]} does not support identification'
+                )
+            else:
+                by_dirname = enc_info['model'] in (ControllerModels.H10.value, ControllerModels.H20.value)
+                try:
+                    toggle_enclosure_slot_identifier(
+                        f'/sys/class/enclosure/{enc_info["pci"]}', origslot, data['status'], by_dirname
+                    )
+                except FileNotFoundError:
+                    raise CallError(f'Slot: {data["slot"]!r} not found', errno.ENOENT)
 
     async def jbof_set_slot_status(self, ident, slot, status):
         return await _jbof_set_slot_status(ident, slot, status)

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -4,7 +4,6 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 import logging
-import re
 
 from middlewared.utils.scsi_generic import inquiry
 
@@ -27,9 +26,6 @@ from .sysfs_disks import map_disks_to_enclosure_slots
 from .slot_mappings import get_slot_info
 
 logger = logging.getLogger(__name__)
-
-SLOTNNN_RE = re.compile('^slot[0-9]{2,3}$')
-SLOT_NNN_COMMA_RE = re.compile('^SLOT [0-9]{2,3},')
 
 
 class Enclosure:
@@ -330,26 +326,12 @@ class Enclosure:
                 # is this a front, rear or internal slot?
                 parsed.update(disk_position_mapping.get(mapped_slot, dict()))
 
-                # Pick out the original slot number from the descriptor,
-                # for example 'slot00', 'slot01', ... etc
-                try:
-                    descriptor = element['descriptor'].strip()
-                    if SLOTNNN_RE.match(descriptor):
-                        origslot = int(descriptor[4:].lstrip('0') or '0')
-                    elif SLOT_NNN_COMMA_RE.match(descriptor):
-                        origslot = int(descriptor.split()[1].split(',')[0].lstrip('0') or 0)
-                    else:
-                        origslot = slot - 1
-                except KeyError:
-                    origslot = slot - 1
-                    descriptor = f'slot{origslot}'
-
                 parsed['original'] = {
                     'enclosure_id': self.encid,
                     'enclosure_sg': self.sg,
                     'enclosure_bsg': self.bsg,
-                    'descriptor': descriptor,
-                    'slot': origslot,
+                    'descriptor': f'slot{slot}',
+                    'slot': slot,
                 }
 
             final[element_type[0]].update({mapped_slot: parsed})

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -296,7 +296,9 @@ class Enclosure:
             }
             if element_type[0] == 'Array Device Slot' and self.disks_map:
                 try:
-                    parsed['dev'] = self.sysfs_map[self.disks_map[slot][SYSFS_SLOT_KEY]]['name']
+                    dinfo = self.disks_map[slot]
+                    sysfs_slot = dinfo[SYSFS_SLOT_KEY]
+                    parsed['dev'] = self.sysfs_map[sysfs_slot]['name']
                 except KeyError:
                     # this happens on some of the MINI platforms, for example,
                     # the MINI-3.0-XL+ because we map the 1st drive and only
@@ -306,16 +308,16 @@ class Enclosure:
                     continue
 
                 # does this enclosure slot support identification? (i.e. lighting up LED)
-                parsed[SUPPORTS_IDENTIFY_KEY] = self.disks_map[slot][SUPPORTS_IDENTIFY_KEY]
+                parsed[SUPPORTS_IDENTIFY_KEY] = dinfo[SUPPORTS_IDENTIFY_KEY]
 
                 # does this enclosure slot support reporting identification status?
                 # (i.e. whether the LED is currently lit up)
-                if self.disks_map[slot].get(SUPPORTS_IDENTIFY_STATUS_KEY, parsed[SUPPORTS_IDENTIFY_KEY]):
-                    parsed[DRIVE_BAY_LIGHT_STATUS] = self.disks_map[slot][SYSFS_SLOT_KEY]]['locate']
+                if dinfo.get(SUPPORTS_IDENTIFY_STATUS_KEY, parsed[SUPPORTS_IDENTIFY_KEY]):
+                    parsed[DRIVE_BAY_LIGHT_STATUS] = self.sysfs_map[sysfs_slot]['locate']
                 else:
                     parsed[DRIVE_BAY_LIGHT_STATUS] = None
 
-                mapped_slot = self.disks_map[slot][MAPPED_SLOT_KEY]
+                mapped_slot = dinfo[MAPPED_SLOT_KEY]
                 # is this a front, rear or internal slot?
                 parsed.update(disk_position_mapping.get(mapped_slot, dict()))
 
@@ -323,8 +325,8 @@ class Enclosure:
                     'enclosure_id': self.encid,
                     'enclosure_sg': self.sg,
                     'enclosure_bsg': self.bsg,
-                    'descriptor': f'slot{slot}',
-                    'slot': slot,
+                    'descriptor': f'slot{sysfs_slot}',
+                    'slot': sysfs_slot,
                 }
 
             final[element_type[0]].update({mapped_slot: parsed})

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -296,7 +296,7 @@ class Enclosure:
             }
             if element_type[0] == 'Array Device Slot' and self.disks_map:
                 try:
-                    parsed['dev'] = self.sysfs_map[self.disks_map[slot][SYSFS_SLOT_KEY]]
+                    parsed['dev'] = self.sysfs_map[self.disks_map[slot][SYSFS_SLOT_KEY]]['name']
                 except KeyError:
                     # this happens on some of the MINI platforms, for example,
                     # the MINI-3.0-XL+ because we map the 1st drive and only
@@ -310,15 +310,8 @@ class Enclosure:
 
                 # does this enclosure slot support reporting identification status?
                 # (i.e. whether the LED is currently lit up)
-                light_status = self.disks_map[slot].get(SUPPORTS_IDENTIFY_STATUS_KEY, parsed[SUPPORTS_IDENTIFY_KEY])
-                if light_status:
-                    # Per SES-4-r3 Table 84 — Array Device Slot status element
-                    # The IDENT bit is Bit #1 of Byte #2.  These have been flattened
-                    # above into value_raw.
-                    if value_raw & 0x0200:
-                        parsed[DRIVE_BAY_LIGHT_STATUS] = 'ON'
-                    else:
-                        parsed[DRIVE_BAY_LIGHT_STATUS] = 'OFF'
+                if self.disks_map[slot].get(SUPPORTS_IDENTIFY_STATUS_KEY, parsed[SUPPORTS_IDENTIFY_KEY]):
+                    parsed[DRIVE_BAY_LIGHT_STATUS] = self.disks_map[slot][SYSFS_SLOT_KEY]]['locate']
                 else:
                     parsed[DRIVE_BAY_LIGHT_STATUS] = None
 

--- a/src/middlewared/middlewared/plugins/enclosure_/fseries_drive_identify.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/fseries_drive_identify.py
@@ -31,7 +31,7 @@ def get_cmd(slot, status):
         clear_fault[-4] = '0x39'
         clear_fault[-1] = '0x00'
         final.append(clear_fault[:])
-    elif status in ('IDENT', 'IDENTIFY'):
+    elif status in ('ON', 'IDENT', 'IDENTIFY'):
         # turn blue led on
         ident = base[:]
         ident[-4] = '0x22'

--- a/src/middlewared/middlewared/plugins/enclosure_/fseries_drive_identify.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/fseries_drive_identify.py
@@ -19,7 +19,7 @@ def get_cmd(slot, status):
         None,  # ACTION
     ]
     final = []
-    if status == 'CLEAR':
+    if status in ('OFF', 'CLEAR'):
         # command to clear identify led (blue)
         clear_ident = base[:]
         clear_ident[-4] = '0x22'

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof/es24n.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof/es24n.py
@@ -60,6 +60,7 @@ def do_map_es24n(model, uuid, data):
         if v['serial'] and v['transport_protocol'] == 'rdma'
     }
     mapped = dict()
+    drive_bay_light_status = dict()
     for disk in all_disks['Members']:
         slot = disk.get('Id', '')
         if not slot or not slot.isdigit():
@@ -67,6 +68,19 @@ def do_map_es24n(model, uuid, data):
             continue
         else:
             slot = int(slot)
+
+        # Check the LocationIndicatorActive before other items as we want the value
+        # even if no disk is present.
+        match disk.get('LocationIndicatorActive'):
+            case True:
+                drive_bay_light_status[slot] = 'ON'
+            case False:
+                drive_bay_light_status[slot] = 'OFF'
+            case None:
+                drive_bay_light_status[slot] = None
+            case _:
+                LOGGER.error('Unexpected drive bay light status', exc_info=True)
+                drive_bay_light_status[slot] = None
 
         state = disk.get('Status', {}).get('State')
         if not state or state == 'Absent':
@@ -99,7 +113,7 @@ def do_map_es24n(model, uuid, data):
         elements[ElementType.VOLTAGE_SENSOR.value] = voltage
     # No Current Sensors reported
 
-    return fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements)
+    return fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements, drive_bay_light_status)
 
 
 async def is_this_an_es24n(rclient):

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof/es24n.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof/es24n.py
@@ -79,7 +79,7 @@ def do_map_es24n(model, uuid, data):
             case None:
                 drive_bay_light_status[slot] = None
             case _:
-                LOGGER.error('Unexpected drive bay light status', exc_info=True)
+                LOGGER.error('Unexpected drive bay light status')
                 drive_bay_light_status[slot] = None
 
         state = disk.get('Status', {}).get('State')

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof/utils.py
@@ -5,7 +5,9 @@ from middlewared.plugins.enclosure_.constants import (
     DISK_REAR_KEY,
     DISK_TOP_KEY,
     DISK_INTERNAL_KEY,
+    DRIVE_BAY_LIGHT_STATUS,
     SUPPORTS_IDENTIFY_KEY,
+    SUPPORTS_IDENTIFY_STATUS_KEY,
 )
 from middlewared.plugins.enclosure_.enums import (
     ElementStatus,
@@ -17,7 +19,7 @@ from middlewared.plugins.enclosure_.slot_mappings import get_jbof_slot_info
 LOGGER = getLogger(__name__)
 
 
-def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={}):
+def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={}, drive_bay_light_status={}):
     """This function takes the nvme devices that been mapped
     to their respective slots and then creates a "fake" enclosure
     device that matches (similarly) to what our real enclosure
@@ -76,6 +78,14 @@ def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={})
         drk = disks_map['versions']['DEFAULT']['model'][model][slot][DISK_REAR_KEY]
         dtk = disks_map['versions']['DEFAULT']['model'][model][slot][DISK_TOP_KEY]
         dik = disks_map['versions']['DEFAULT']['model'][model][slot][DISK_INTERNAL_KEY]
+
+        # light_status will follow light unless explicitedly overridden
+        light_status = disks_map['versions']['DEFAULT']['model'][model][slot].get(SUPPORTS_IDENTIFY_STATUS_KEY, light)
+        if light_status:
+            led = drive_bay_light_status.get(slot, None)
+        else:
+            led = None
+
         fake_enclosure['elements']['Array Device Slot'][mapped_slot] = {
             'descriptor': f'Disk #{slot}',
             'status': status,
@@ -87,6 +97,7 @@ def fake_jbof_enclosure(model, uuid, num_of_slots, mapped, ui_info, elements={})
             DISK_REAR_KEY: drk,
             DISK_TOP_KEY: dtk,
             DISK_INTERNAL_KEY: dik,
+            DRIVE_BAY_LIGHT_STATUS: led,
             'original': {
                 'enclosure_id': uuid,
                 'enclosure_sg': None,

--- a/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/jbof_enclosures.py
@@ -92,10 +92,9 @@ async def set_slot_status(ident, slot, status):
         _, uri = await get_enclosure_model(rclient)
     fulluri = f'{uri}/Drives/{slot}'
 
-    match status:
-        case 'CLEAR':
-            await rclient.post(fulluri, data={'LocationIndicatorActive': False})
-        case 'IDENT':
-            await rclient.post(fulluri, data={'LocationIndicatorActive': True})
-        case _:
-            raise ValueError('Unsupported slot status', status)
+    if status in ('CLEAR', 'OFF'):
+        await rclient.post(fulluri, data={'LocationIndicatorActive': False})
+    elif status in ('ON', 'IDENT', 'IDENTIFY'):
+        await rclient.post(fulluri, data={'LocationIndicatorActive': True})
+    else:
+        raise ValueError('Unsupported slot status', status)

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -13,7 +13,9 @@ from .constants import (
     DISK_REAR_KEY,
     DISK_TOP_KEY,
     DISK_INTERNAL_KEY,
-    SUPPORTS_IDENTIFY_KEY
+    DRIVE_BAY_LIGHT_STATUS,
+    SUPPORTS_IDENTIFY_KEY,
+    SUPPORTS_IDENTIFY_STATUS_KEY,
 )
 from .enums import ControllerModels
 from .slot_mappings import get_nvme_slot_info
@@ -82,6 +84,15 @@ def fake_nvme_enclosure(model, num_of_nvme_slots, mapped, ui_info=None):
         drk = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_REAR_KEY]
         dtk = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_TOP_KEY]
         dik = disks_map['versions']['DEFAULT']['id'][dmi][slot][DISK_INTERNAL_KEY]
+
+        # light_status will follow light unless we explicitedly override
+        light_status = disks_map['versions']['DEFAULT']['id'][dmi][slot].get(SUPPORTS_IDENTIFY_STATUS_KEY, light)
+        if light_status:
+            # Currently do not have an nvme platform that supports retrieving IDENT status
+            raise NotImplementedError
+        else:
+            led = None
+
         fake_enclosure['elements']['Array Device Slot'][mapped_slot] = {
             'descriptor': f'Disk #{slot}',
             'status': status,
@@ -89,6 +100,7 @@ def fake_nvme_enclosure(model, num_of_nvme_slots, mapped, ui_info=None):
             'value_raw': value_raw,
             'dev': device,
             SUPPORTS_IDENTIFY_KEY: light,
+            DRIVE_BAY_LIGHT_STATUS: led,
             DISK_FRONT_KEY: dfk,
             DISK_REAR_KEY: drk,
             DISK_TOP_KEY: dtk,

--- a/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
@@ -77,7 +77,7 @@ def set_slot_status(slot, status):
     clear_fault_cmd = f'{base} {led_status_mapping("FAULT")} {bay}'
     clear_rebui_cmd = f'{base} {led_status_mapping("REBUILD")} {bay}'
     cmds = [manual_mode_cmd, clear_ident_cmd, clear_fault_cmd, clear_rebui_cmd]
-    if status != 'CLEAR':
+    if status not in ('OFF', 'CLEAR'):
         cmds.append(f'{base} {status_map} {bay}')
 
     # always go back to auto mode (for now)

--- a/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
@@ -51,7 +51,7 @@ def led_status_mapping(status):
 
 def set_slot_status(slot, status):
     """
-    Unfortunately, there is on way to query current drive identification status.
+    Unfortunately, there is no way to query current drive identification status.
     Furthemore, switching SMBUS back into auto mode doesn't guarantee the LEDs
     will be automatically cleared so we need to clear them manually. Finally,
     it's unclear on whether or not we even need to transition from manual to auto

--- a/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/r30_drive_identify.py
@@ -40,6 +40,7 @@ def led_status_mapping(status):
     mapping = {
         'CLEAR': '0x00',  # turn off red led
         'IDENTIFY': '0x42',  # red and green led blink fast
+        'ON': '0x42',  # same as IDENTIFY
         'FAULT': '0x44',  # red led solid, green led still works as normal
         'REBUILD': '0x46',  # red led blink slow, green led still works as normal
     }

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -10,9 +10,14 @@ from .constants import (
     DISK_INTERNAL_KEY,
     SYSFS_SLOT_KEY,
     MAPPED_SLOT_KEY,
-    SUPPORTS_IDENTIFY_KEY
+    SUPPORTS_IDENTIFY_KEY,
+    SUPPORTS_IDENTIFY_STATUS_KEY
 )
 from .enums import ControllerModels, JbodModels, JbofModels
+
+# If SUPPORTS_IDENTIFY_STATUS_KEY is absent from a slot mapping then
+# its value will be the same as SUPPORTS_IDENTIFY_KEY for that slot.
+# (Usually, if IDENT is enabled, then its status can also be read.)
 
 
 def get_jbof_slot_info(model):
@@ -78,6 +83,7 @@ def get_nvme_slot_info(model):
                                 SYSFS_SLOT_KEY: i,
                                 MAPPED_SLOT_KEY: i,
                                 SUPPORTS_IDENTIFY_KEY: True,
+                                SUPPORTS_IDENTIFY_STATUS_KEY: False,
                                 DISK_FRONT_KEY: True,
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: False,
@@ -89,6 +95,7 @@ def get_nvme_slot_info(model):
                                 SYSFS_SLOT_KEY: i,
                                 MAPPED_SLOT_KEY: i,
                                 SUPPORTS_IDENTIFY_KEY: True,
+                                SUPPORTS_IDENTIFY_STATUS_KEY: False,
                                 DISK_FRONT_KEY: True,
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: False,
@@ -100,6 +107,7 @@ def get_nvme_slot_info(model):
                                 SYSFS_SLOT_KEY: i,
                                 MAPPED_SLOT_KEY: i,
                                 SUPPORTS_IDENTIFY_KEY: True,
+                                SUPPORTS_IDENTIFY_STATUS_KEY: False,
                                 DISK_FRONT_KEY: True,
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: False,
@@ -164,6 +172,7 @@ def get_nvme_slot_info(model):
                                 SYSFS_SLOT_KEY: i,
                                 MAPPED_SLOT_KEY: i,
                                 SUPPORTS_IDENTIFY_KEY: True,
+                                SUPPORTS_IDENTIFY_STATUS_KEY: False,
                                 DISK_FRONT_KEY: True if i <= 12 else False,
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: False,

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -55,16 +55,18 @@ def map_disks_to_enclosure_slots(pci):
                 continue
             else:
                 try:
-                    mapping[slot] = {
-                        'name': next((path / 'device/block').iterdir(), BaseDev).name,
-                        'locate': 'ON' if (path / 'locate').read_text().strip() == '1' else 'OFF',
-                    }
-                except (ValueError, FileNotFoundError):
+                    name = next((path / 'device/block').iterdir(), BaseDev).name,
+                except FileNotFoundError:
                     # no disk in this slot
-                    mapping[slot] = {
-                        'name': BaseDev.name,
-                        'locate': BaseDev.locate,
-                    }
+                    name = BaseDev.name
+                try:
+                    locate = 'ON' if (path / 'locate').read_text().strip() == '1' else 'OFF'
+                except ValueError:
+                    locate = BaseDev.locate
+                mapping[slot] = {
+                    'name': name,
+                    'locate': locate,
+                }
 
     return mapping
 

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -8,7 +8,7 @@ from os import scandir
 from pathlib import Path
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class BaseDev:
     name: str = None
     locate: str = None

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -55,7 +55,7 @@ def map_disks_to_enclosure_slots(pci):
                 continue
             else:
                 try:
-                    name = next((path / 'device/block').iterdir(), BaseDev).name,
+                    name = next((path / 'device/block').iterdir(), BaseDev).name
                 except FileNotFoundError:
                     # no disk in this slot
                     name = BaseDev.name

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -106,17 +106,12 @@ def toggle_enclosure_slot_identifier(sysfs_path, slot, action, by_dirname=False)
         else:
             raise FileNotFoundError(slot_errmsg)
 
-    fault = (pathobj / 'fault')
-    locate = (pathobj / 'locate')
     match action:
-        case 'CLEAR':
-            actions = ((fault, '0'), (locate, '0'),)
-        case 'FAULT':
-            actions = ((fault, '1'),)
-        case 'IDENTIFY':
-            actions = ((locate, '1'),)
+        case 'CLEAR' | 'OFF':
+            value = '0'
+        case 'ON':
+            value = '1'
         case _:
             raise ValueError(f'Invalid action ({action!r})')
 
-    for path, action in actions:
-        path.write_text(action)
+    (pathobj / 'locate').write_text(value)

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -61,7 +61,7 @@ def map_disks_to_enclosure_slots(pci):
                     name = BaseDev.name
                 try:
                     locate = 'ON' if (path / 'locate').read_text().strip() == '1' else 'OFF'
-                except ValueError:
+                except (ValueError, FileNotFoundError):
                     locate = BaseDev.locate
                 mapping[slot] = {
                     'name': name,


### PR DESCRIPTION
This PR adds initial support for `drive_bay_light_status` in `enclosure2.query` and `webui.enclosure.dashboard` APIs.

Support is added for JBOF and SES based enclosures.  Generally, being able to read light status follows whether it is possible to
set it (as indicated by `supports_identify_light` in slot mappings).  However, this can be overridden by adding a specific
`supports_identify_light_status` key/value to slot mappings - e.g. for platforms where it is possible to set the light status, but **not** to read it back again.

Other changes:
- As requested, change the `enclosure2.set_slot_status` API `status` parameter.  It will now accept the strings **"ON"**, **"OFF"** or **"CLEAR"**.
- For SES based enclosures the `original slot` value was incorrect, resulting in an off-by-one wrt which disk had its IDENT lit when requested.  Rectify by actually extracting the `slot` number from the `descriptor` string returned by the status method in `libsg3`.


Original PR: https://github.com/truenas/middleware/pull/14260
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130011