### PR TITLE
NAS-130653 / 25.04 / Updated debug generate lock queue size

### DIFF
--- a/src/middlewared/middlewared/plugins/system/debug.py
+++ b/src/middlewared/middlewared/plugins/system/debug.py
@@ -18,7 +18,7 @@ from .utils import DEBUG_MAX_SIZE, get_debug_execution_dir
 class SystemService(Service):
 
     @private
-    @job(lock='system.debug_generate')
+    @job(lock='system.debug_generate', lock_queue_size=1)
     def debug_generate(self, job):
         """
         Generate system debug file.

--- a/src/middlewared/middlewared/plugins/system/debug.py
+++ b/src/middlewared/middlewared/plugins/system/debug.py
@@ -64,7 +64,7 @@ class SystemService(Service):
 
     @accepts(roles=['READONLY_ADMIN'])
     @returns()
-    @job(lock='system.debug', pipes=['output'])
+    @job(lock='system.debug', lock_queue_size=0, pipes=['output'])
     def debug(self, job):
         """
         Download a debug file.

--- a/src/middlewared/middlewared/plugins/test/rest.py
+++ b/src/middlewared/middlewared/plugins/test/rest.py
@@ -45,3 +45,10 @@ class RestTestService(Service):
         time.sleep(2)
         job.pipes.output.w.write(json.dumps(arg).encode("utf-8"))
         job.pipes.output.w.close()
+
+    @accepts(Any("arg"))
+    @job(lock="test_download_slow_pipe_with_lock", lock_queue_size=0, pipes=["output"])
+    def test_download_slow_pipe_with_lock(self, job, arg):
+        time.sleep(5)
+        job.pipes.output.w.write(json.dumps(arg).encode("utf-8"))
+        job.pipes.output.w.close()

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -94,6 +94,9 @@ def job(
         If lock queue size is exceeded then the new job is discarded and the `id` of the last job in the queue is
         returned.
 
+        If lock queue size is zero, then launching a job when another job with the same lock is running will raise an
+        `EBUSY` error.
+
         Default value is `5`. `None` would mean that lock queue is infinite.
 
     :param logs: If `True` then `job.logs_fd` object will be available. It is an unbuffered file opened in binary mode;

--- a/src/middlewared/middlewared/service_exception.py
+++ b/src/middlewared/middlewared/service_exception.py
@@ -14,7 +14,7 @@ class CallException(ErrnoMixin, Exception):
 
 
 class CallError(CallException):
-    def __init__(self, errmsg: str, errno: int=errno.EFAULT, extra=None):
+    def __init__(self, errmsg: str, errno: int = errno.EFAULT, extra=None):
         self.errmsg = errmsg
         self.errno = errno
         self.extra = extra
@@ -30,7 +30,7 @@ class ValidationError(CallException):
     attribute of a middleware method is invalid/not allowed.
     """
 
-    def __init__(self, attribute, errmsg, errno: int=errno.EINVAL):
+    def __init__(self, attribute, errmsg, errno: int = errno.EINVAL):
         self.attribute = attribute
         self.errmsg = errmsg
         self.errno = errno
@@ -53,11 +53,11 @@ class ValidationErrors(CallException):
     CallException with a collection of ValidationError
     """
 
-    def __init__(self, errors: typing.List[ValidationError]=None):
+    def __init__(self, errors: typing.List[ValidationError] = None):
         self.errors = errors or []
         super().__init__(self.errors)
 
-    def add(self, attribute, errmsg: str, errno: int=errno.EINVAL):
+    def add(self, attribute, errmsg: str, errno: int = errno.EINVAL):
         self.errors.append(ValidationError(attribute, errmsg, errno))
 
     def add_validation_error(self, validation_error: ValidationError):

--- a/tests/api2/test_rest_api_download.py
+++ b/tests/api2/test_rest_api_download.py
@@ -6,7 +6,7 @@ import requests
 
 from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.account import unprivileged_user
-from middlewared.test.integration.utils import client, session, url
+from middlewared.test.integration.utils import call, client, session, url
 
 
 @pytest.mark.parametrize("method", ["test_download_pipe", "test_download_unchecked_pipe"])
@@ -77,6 +77,14 @@ def test_buffered_download_from_slow_download_endpoint(buffered, sleep, result):
     assert r.headers["Content-Disposition"] == "attachment; filename=\"file.bin\""
     assert r.headers["Content-Type"] == "application/octet-stream"
     assert r.text == result
+
+
+def test_download_duplicate_job():
+    call("core.download", "resttest.test_download_slow_pipe_with_lock", [{"key": "value"}], "file.bin")
+    with pytest.raises(CallError) as ve:
+        call("core.download", "resttest.test_download_slow_pipe_with_lock", [{"key": "value"}], "file.bin")
+
+    assert ve.value.errno == errno.EBUSY
 
 
 def test_download_authorization_ok():


### PR DESCRIPTION
Adding this limit stops people from spamming debug generation, as most of the time just one job is required. 