### PR TITLE
NAS-130748 / 13.3 / Prevent permission denied error for non-root csh/tcsh over ssh

### DIFF
--- a/src/freenas/etc/csh.login.template
+++ b/src/freenas/etc/csh.login.template
@@ -19,6 +19,6 @@ if ( "$USER" == "root" ) then
     if ( -f /usr/local/sbin/hactl) then
         /usr/local/sbin/hactl status -q
     endif
+    cat /root/.warning
 endif
 
-cat /root/.warning


### PR DESCRIPTION
The .warning file is in root's home directory and thus cannot be read by non-root users on login.

This solution puts it in the earlier block that checks for user root.

Another solution would be to move the warning file out of root's home directory.

Re-submitting to correct branch.