### PR TITLE
NAS-130749 / 24.10-BETA.1 / Properly retrieve create time props when making apps related datasets (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/schema_action_context.py
+++ b/src/middlewared/middlewared/plugins/apps/schema_action_context.py
@@ -27,7 +27,7 @@ class AppSchemaActions(Service):
         for create_ds in sorted(set(user_wants) - existing_datasets):
             await self.middleware.call(
                 'zfs.dataset.create', {
-                    'properties': user_wants[create_ds]['properties'] | DatasetDefaults.create_time_only(),
+                    'properties': user_wants[create_ds]['properties'] | DatasetDefaults.create_time_props(),
                     'name': create_ds, 'type': 'FILESYSTEM',
                 }
             )

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -99,7 +99,7 @@ class DockerSetupService(Service):
             else:
                 self.move_conflicting_dir(dataset_name)
                 self.middleware.call_sync('zfs.dataset.create', {
-                    'name': dataset_name, 'type': 'FILESYSTEM', 'properties': DatasetDefaults.create_time_only(
+                    'name': dataset_name, 'type': 'FILESYSTEM', 'properties': DatasetDefaults.create_time_props(
                         os.path.basename(dataset_name)
                     ),
                 })

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -37,10 +37,6 @@ class DatasetDefaults:
     xattr: DatasetProp = DatasetProp('sa', False)
 
     @classmethod
-    def to_dict(cls):
-        return {k: v['value'] for k, v in dataclasses.asdict(cls()).items()}
-
-    @classmethod
     def create_time_only(cls, ds_name: str | None = None):
         return {
             k: v['value'] for k, v in dataclasses.asdict(cls()).items()

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -44,7 +44,7 @@ class DatasetDefaults:
     def create_time_only(cls, ds_name: str | None = None):
         return {
             k: v['value'] for k, v in dataclasses.asdict(cls()).items()
-            if v['create_time_only'] and v['ds_name'] in (ds_name, None)
+            if v['ds_name'] in (ds_name, None)
         }
 
     @classmethod

--- a/src/middlewared/middlewared/plugins/docker/state_utils.py
+++ b/src/middlewared/middlewared/plugins/docker/state_utils.py
@@ -37,7 +37,7 @@ class DatasetDefaults:
     xattr: DatasetProp = DatasetProp('sa', False)
 
     @classmethod
-    def create_time_only(cls, ds_name: str | None = None):
+    def create_time_props(cls, ds_name: str | None = None):
         return {
             k: v['value'] for k, v in dataclasses.asdict(cls()).items()
             if v['ds_name'] in (ds_name, None)


### PR DESCRIPTION
This commit adds changes to properly retrieve create time props when making apps related datasets. Basically what happens is that on create time we are not considering update time props, they should be configured when we create the dataset and not on a subsequent call which will trigger state management to run again.

Essentially which are update only props are also create time props and should be applied when we actually create the dataset.

Original PR: https://github.com/truenas/middleware/pull/14303
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130749