### PR TITLE
NAS-130755 / 25.04 / Extend search for ip in websocket_interface

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1474,15 +1474,9 @@ class InterfaceService(CRUDService):
         if local_ip is None:
             return
 
-        interfaces = await self.middleware.call('interface.query')
-        for iface in interfaces:
-            for alias in iface['aliases']:
-                if alias['address'] == local_ip:
-                    return iface
-        for iface in interfaces:
-            for alias in iface['state']['aliases']:
-                if alias['address'] == local_ip:
-                    return iface
+        for iface in await self.middleware.call('interface.query'):
+            for _ in filter(lambda x: x['address'] == local_ip, iface['aliases'] + iface['state']['aliases']):
+                return iface
 
     @accepts()
     @returns(Dict(*[Str(i.value, enum=[i.value]) for i in XmitHashChoices]))

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -4,7 +4,6 @@ import ipaddress
 from collections import defaultdict
 from itertools import zip_longest
 from ipaddress import ip_address, ip_interface
-from os import scandir
 
 import middlewared.sqlalchemy as sa
 from middlewared.service import CallError, CRUDService, filterable, pass_app, private
@@ -1475,8 +1474,13 @@ class InterfaceService(CRUDService):
         if local_ip is None:
             return
 
-        for iface in await self.middleware.call('interface.query'):
+        interfaces = await self.middleware.call('interface.query')
+        for iface in interfaces:
             for alias in iface['aliases']:
+                if alias['address'] == local_ip:
+                    return iface
+        for iface in interfaces:
+            for alias in iface['state']['aliases']:
                 if alias['address'] == local_ip:
                     return iface
 


### PR DESCRIPTION
Recent addition of `test_websocket_interface` (in PR #14276) was failing frequently.

Apparently the VIP was not being handled well for HA systems.

Add search of `iface['state']['aliases']` if search of `iface['aliases']` does not yield a result.