### PR TITLE
NAS-130197 / 25.04 / Add NFS and FTP statistics to usage reporting

### DIFF
--- a/src/middlewared/middlewared/plugins/ftp_/status.py
+++ b/src/middlewared/middlewared/plugins/ftp_/status.py
@@ -13,7 +13,7 @@ class FTPService(Service):
         ftp = 21
 
         try:
-            proc_data = self.middleware.call(read_proc_net)
+            proc_data = read_proc_net()
             ftp_proclist = list(filter(lambda x: x.local_port == ftp and x.remote_port != 0, proc_data))
         except Exception:
             num_conn = 0

--- a/src/middlewared/middlewared/plugins/ftp_/status.py
+++ b/src/middlewared/middlewared/plugins/ftp_/status.py
@@ -1,0 +1,25 @@
+from middlewared.service import Service, private
+from middlewared.schema import Int, returns
+from middlewared.utils.network_.procfs import read_proc_net
+
+
+class FTPService(Service):
+
+    @private
+    @returns(Int('number_of_connections'))
+    def connection_count(self):
+        ''' Return the number of active connections '''
+        # FTP listening port is 21
+        ftp = 21
+
+        try:
+            proc_data = self.middleware.call(read_proc_net)
+            ftp_proclist = list(filter(lambda x: x.local_port == ftp and x.remote_port != 0, proc_data))
+        except Exception:
+            num_conn = 0
+        else:
+            num_conn = len(ftp_proclist)
+            # NOTE: This count includes multiple 'connections' from a single client.
+            #       If we want to report number of 'clients', we process the filtered list with:
+            #       set_clients = set([':'.join(i.split()[4].split(':')[:-1]) for i in ftp_conn])
+        return num_conn

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -341,10 +341,10 @@ class UsageService(Service):
             }
         }
 
-    def gather_ftp(self, context_unused):
+    async def gather_ftp(self, context_unused):
         """ Gather number of FTP connection info """
-        ftp_config = self.middleware.call('ftp.config')
-        num_conn = self.middleware.call('ftp.connection_count')
+        ftp_config = await self.middleware.call('ftp.config')
+        num_conn = await self.middleware.call('ftp.connection_count')
 
         return {
             'FTP': {

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -9,6 +9,7 @@ import aiohttp
 
 from middlewared.service import Service
 from middlewared.utils.mount import getmntinfo
+# from middlewared.utils.network_.procfs import read_proc_net
 from middlewared.utils.time_utils import utc_now
 
 
@@ -328,6 +329,29 @@ class UsageService(Service):
 
     async def gather_services(self, context):
         return {'services': context['services']}
+
+    async def gather_nfs(self, context_unused):
+        num_clients = await self.middleware.call('nfs.client_count')
+        nfs_config = await self.middleware.call('nfs.config')
+        return {
+            'NFS': {
+                'enabled_protocols': nfs_config['protocols'],
+                'kerberos': nfs_config['v4_krb_enabled'],
+                'num_clients': num_clients,
+            }
+        }
+
+    def gather_ftp(self, context_unused):
+        """ Gather number of FTP connection info """
+        ftp_config = self.middleware.call('ftp.config')
+        num_conn = self.middleware.call('ftp.connection_count')
+
+        return {
+            'FTP': {
+                'connections_allowed': ftp_config['clients'] * ftp_config['ipconnections'],
+                'num_connections': num_conn
+            }
+        }
 
     async def gather_sharing(self, context):
         sharing_list = []

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -9,7 +9,6 @@ import aiohttp
 
 from middlewared.service import Service
 from middlewared.utils.mount import getmntinfo
-# from middlewared.utils.network_.procfs import read_proc_net
 from middlewared.utils.time_utils import utc_now
 
 

--- a/src/middlewared/middlewared/test/integration/assets/ftp.py
+++ b/src/middlewared/middlewared/test/integration/assets/ftp.py
@@ -7,8 +7,9 @@ from middlewared.test.integration.utils import call, ssh
 
 
 @contextlib.contextmanager
-def ftp_server(config):
-    call("ftp.update", config)
+def ftp_server(config=None):
+    if config is not None:
+        call("ftp.update", config)
     call("service.start", "ftp")
 
     try:

--- a/src/middlewared/middlewared/test/integration/assets/nfs.py
+++ b/src/middlewared/middlewared/test/integration/assets/nfs.py
@@ -7,11 +7,11 @@ from time import sleep
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["nfs_share", "nfs_start"]
+__all__ = ["nfs_share", "nfs_server"]
 
 
 @contextlib.contextmanager
-def nfs_start():
+def nfs_server():
     try:
         res = call('service.start', 'nfs', {'silent': False})
         sleep(1)

--- a/src/middlewared/middlewared/test/integration/assets/nfs.py
+++ b/src/middlewared/middlewared/test/integration/assets/nfs.py
@@ -3,10 +3,21 @@ import contextlib
 import logging
 
 from middlewared.test.integration.utils import call
+from time import sleep
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["nfs_share"]
+__all__ = ["nfs_share", "nfs_start"]
+
+
+@contextlib.contextmanager
+def nfs_start():
+    try:
+        res = call('service.start', 'nfs', {'silent': False})
+        sleep(1)
+        yield res
+    finally:
+        call('service.stop', 'nfs', {'silent': False})
 
 
 @contextlib.contextmanager

--- a/tests/api2/test_usage_reporting.py
+++ b/tests/api2/test_usage_reporting.py
@@ -1,0 +1,81 @@
+import pytest
+from itertools import chain
+from middlewared.test.integration.assets.nfs import nfs_start
+from middlewared.test.integration.assets.pool import dataset as nfs_dataset
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.client import truenas_server
+from protocols import ftp_connection, SSH_NFS, nfs_share
+
+from auto_config import password, pool_name, user
+
+
+class GatherTypes:
+    expected = {
+        'total_capacity': ['total_capacity'],
+        'backup_data': ['data_backup_stats', 'data_without_backup_size'],
+        'applications': ['apps', 'catalog_items', 'docker_images'],
+        'filesystem_usage': ['datasets', 'zvols'],
+        'ha_stats': ['ha_licensed'],
+        'directory_service_stats': ['directory_services'],
+        'cloud_services': ['cloud_services'],
+        'hardware': ['hardware'],
+        'network': ['network'],
+        'system_version': ['platform', 'version'],
+        'system': ['system_hash', 'usage_version', 'system'],
+        'pools': ['pools', 'total_raw_capacity'],
+        'services': ['services'],
+        'nfs': ['NFS'],
+        'ftp': ['FTP'],
+        'sharing': ['shares'],
+        'vms': ['vms'],
+        'nspawn_containers': ['nspawn_containers'],
+        # Add new gather type here
+    }
+
+
+@pytest.fixture(scope="module")
+def get_usage_sample():
+    sample = call('usage.gather')
+    yield sample
+
+
+def test_gather_types(get_usage_sample):
+    """ Confirm we find the expected types. Fail if this test needs updating """
+    sample = get_usage_sample
+    expected = list(chain.from_iterable(GatherTypes.expected.values()))
+
+    # If there is a mismatch it probably means this test module needs to be updated
+    assert set(expected).symmetric_difference(sample) == set(), "Expected empty set. "\
+        f"Missing an entry in the output ({len(sample)} entries) or test needs updating ({len(expected)} entries)"
+
+
+def test_nfs_reporting(get_usage_sample):
+    """ Confirm we are correctly reporting the number of connections """
+    # Initial state should have NFSv[3,4] and no connections
+    assert set(get_usage_sample['NFS']['enabled_protocols']) == set(["NFSV3", "NFSV4"])
+    assert get_usage_sample['NFS']['num_clients'] == 0
+
+    # Establish two connections
+    nfs_path = f'/mnt/{pool_name}/test_nfs'
+    with nfs_dataset("test_nfs"):
+        with nfs_share(nfs_path):
+            with nfs_start():
+                with SSH_NFS(truenas_server.ip, nfs_path,
+                             user=user, password=password, ip=truenas_server.ip):
+                    usage_sample = call('usage.gather')
+                    assert usage_sample['NFS']['num_clients'] == 1
+
+
+def test_ftp_reporting(get_usage_sample):
+    """ Confirm we are correctly reporting the number of connections """
+    # Initial state should have no connections
+    assert get_usage_sample['FTP']['num_connections'] == 0
+
+    # Establish two connections
+    with ftp_connection(truenas_server.ip):
+        with ftp_connection(truenas_server.ip):
+            usage_sample = call('usage.gather')
+            assert usage_sample['FTP']['num_connections'] == 2
+
+
+# Possible TODO:  Add validation of the entries

--- a/tests/api2/test_usage_reporting.py
+++ b/tests/api2/test_usage_reporting.py
@@ -1,6 +1,7 @@
 import pytest
 from itertools import chain
-from middlewared.test.integration.assets.nfs import nfs_start
+from middlewared.test.integration.assets.nfs import nfs_server
+from middlewared.test.integration.assets.ftp import ftp_server
 from middlewared.test.integration.assets.pool import dataset as nfs_dataset
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.utils.client import truenas_server
@@ -59,7 +60,7 @@ def test_nfs_reporting(get_usage_sample):
     nfs_path = f'/mnt/{pool_name}/test_nfs'
     with nfs_dataset("test_nfs"):
         with nfs_share(nfs_path):
-            with nfs_start():
+            with nfs_server():
                 with SSH_NFS(truenas_server.ip, nfs_path,
                              user=user, password=password, ip=truenas_server.ip):
                     usage_sample = call('usage.gather')
@@ -72,10 +73,11 @@ def test_ftp_reporting(get_usage_sample):
     assert get_usage_sample['FTP']['num_connections'] == 0
 
     # Establish two connections
-    with ftp_connection(truenas_server.ip):
+    with ftp_server():
         with ftp_connection(truenas_server.ip):
-            usage_sample = call('usage.gather')
-            assert usage_sample['FTP']['num_connections'] == 2
+            with ftp_connection(truenas_server.ip):
+                usage_sample = call('usage.gather')
+                assert usage_sample['FTP']['num_connections'] == 2
 
 
 # Possible TODO:  Add validation of the entries


### PR DESCRIPTION
Add NFS and FTP usage statistics

- NFS
-- Enabled protocols, krb5 enabled, number of clients
- FTP
-- Number of connections

Added a simple CI test for the usage reporting
Added `connection_count` as an NFS service function.
Added `nfs_server` test asset and made the `config` parameter optional in the `ftp_server` test asset.

Test results are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/269/).