### PR TITLE
NAS-130755 / 24.10-RC.1 / Extend search for ip in websocket_interface (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1484,15 +1484,9 @@ class InterfaceService(CRUDService):
         if local_ip is None:
             return
 
-        interfaces = await self.middleware.call('interface.query')
-        for iface in interfaces:
-            for alias in iface['aliases']:
-                if alias['address'] == local_ip:
-                    return iface
-        for iface in interfaces:
-            for alias in iface['state']['aliases']:
-                if alias['address'] == local_ip:
-                    return iface
+        for iface in await self.middleware.call('interface.query'):
+            for _ in filter(lambda x: x['address'] == local_ip, iface['aliases'] + iface['state']['aliases']):
+                return iface
 
     @accepts()
     @returns(Dict(*[Str(i.value, enum=[i.value]) for i in XmitHashChoices]))

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1484,8 +1484,13 @@ class InterfaceService(CRUDService):
         if local_ip is None:
             return
 
-        for iface in await self.middleware.call('interface.query'):
+        interfaces = await self.middleware.call('interface.query')
+        for iface in interfaces:
             for alias in iface['aliases']:
+                if alias['address'] == local_ip:
+                    return iface
+        for iface in interfaces:
+            for alias in iface['state']['aliases']:
                 if alias['address'] == local_ip:
                     return iface
 


### PR DESCRIPTION
Recent addition of `test_websocket_interface` (in PR #14276) was failing frequently.

Apparently the VIP was not being handled well for HA systems.

Add search of `iface['state']['aliases']` if search of `iface['aliases']` does not yield a result.

Original PR: https://github.com/truenas/middleware/pull/14313
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130755