### PR TITLE
NAS-130768 / 25.04 / Improve passdb handling

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -712,6 +712,10 @@ class SMBService(ConfigService):
 
         if old['netbiosname_local'] != new_config['netbiosname_local']:
             await self.middleware.call('smb.set_system_sid')
+            # we need to update domain field in passdb.tdb
+            pdb_job = await self.middleware.call('smb.synchronize_passdb')
+            await pdb_job.wait()
+
             await self.middleware.call('idmap.gencache.flush')
             srv = (await self.middleware.call("network.configuration.config"))["service_announcement"]
             await self.middleware.call("network.configuration.toggle_announcement", srv)

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -104,6 +104,10 @@ class SMBPath(enum.Enum):
     def is_dir(self):
         return self.value[2]
 
+    @property
+    def path(self):
+        return self.value[0]
+
 
 class SMBSharePreset(enum.Enum):
     NO_PRESET = {"verbose_name": "No presets", "params": {

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -1,12 +1,17 @@
-from middlewared.service import filterable, Service, job, private
-from middlewared.service_exception import CallError, MatchNotFound
-from middlewared.utils import run, filter_list
-from middlewared.utils.sid import db_id_to_rid
-from middlewared.plugins.idmap_.idmap_constants import IDType
-from middlewared.plugins.smb import SMBCmd, SMBPath
-
 import os
-import time
+
+from middlewared.api.current import UserEntry
+from middlewared.service import filterable, Service, job, private
+from middlewared.utils.sid import get_domain_rid
+from .util_passdb import (
+    delete_passdb_entry,
+    insert_passdb_entries,
+    query_passdb_entries,
+    update_passdb_entry,
+    user_entry_to_passdb_entry,
+    PassdbMustReinit,
+    PASSDB_PATH
+)
 
 
 class SMBService(Service):
@@ -16,228 +21,71 @@ class SMBService(Service):
         service_verb = 'restart'
 
     @private
-    async def smbpasswd_dump(self):
-        out = {}
-        p = await run([SMBCmd.PDBEDIT.value, '-d', '0', '-Lw'], check=False)
-        if p.returncode != 0:
-            raise CallError(f'Failed to dump passdb file: {p.stderr.decode()}')
-
-        for entry in p.stdout.decode().splitlines():
-            out.update({
-                entry.split(":")[0]: entry
-            })
-
-        return out
-
-    @private
     @filterable
-    async def passdb_list_full(self, filters, options):
-        pdbentries = []
-        pdb = await run([SMBCmd.PDBEDIT.value, '-Lv', '-d', '0'], check=False)
-        if pdb.returncode != 0:
-            raise CallError(f'Failed to list passdb output: {pdb.stderr.decode()}')
-
-        for p in (pdb.stdout.decode()).split('---------------'):
-            pdbentry = {}
-            for entry in p.splitlines():
-                parm = entry.split(':')
-                if len(parm) != 2:
-                    continue
-
-                pdbentry.update({parm[0].rstrip(): parm[1].lstrip() if parm[1] else ''})
-
-            if pdbentry:
-                pdbentries.append(pdbentry)
-
-        return filter_list(pdbentries, filters, options)
+    def passdb_list(self, filters, options):
+        """ query existing passdb users """
+        try:
+            return query_passdb_entries(filters or [], options or {})
+        except PassdbMustReinit as err:
+            self.logger.warning(err.errmsg)
+            self.synchronize_passdb(True).wait_sync(raise_error=True)
+            return query_passdb_entries(filters or [], options or {})
 
     @private
-    async def passdb_list(self, verbose=False):
-        """
-        passdb entries for local SAM database. This will be populated with
-        local users in an AD environment. Immediately return in ldap enviornment.
-        """
-        if verbose:
-            return await self.passdb_list_full()
+    def update_passdb_user(self, user: UserEntry):
+        server_name = self.middleware.call_sync('smb.config')['netbiosname_local']
 
-        pdbentries = []
-        pdb = await run([SMBCmd.PDBEDIT.value, '-L', '-d', '0'], check=False)
-        if pdb.returncode != 0:
-            raise CallError(f'Failed to list passdb output: {pdb.stderr.decode()}')
+        existing_entry = self.passdb_list([['username', '=', user['username']]])
+        passdb_entry = user_entry_to_passdb_entry(
+            server_name,
+            user,
+            existing_entry[0] if existing_entry else None
+        )
 
-        for p in (pdb.stdout.decode()).splitlines():
-            entry = p.split(':')
-            try:
-                pdbentries.append({
-                    'username': entry[0],
-                    'full_name': entry[2],
-                    'uid': entry[1],
-                })
-            except Exception as e:
-                self.logger.debug('Failed to parse passdb entry [%s]: %s', p, e)
-
-        return pdbentries
+        update_passdb_entry(passdb_entry)
 
     @private
-    async def update_passdb_user(self, user):
-        if user['smbhash'] == user['pdb']:
-            return
+    def remove_passdb_user(self, username, sid):
+        delete_passdb_entry(username, get_domain_rid(sid))
 
-        smbpasswd_string = user['smbhash'].split(":")
-        username = user['username']
-        if len(smbpasswd_string) != 7:
-            self.logger.warning("SMB hash for user [%s] is invalid. Authentication for SMB "
-                                "sessions for this user will fail until this is repaired. "
-                                "This may indicate that configuration was restored without a secret "
-                                "seed, and may be repaired by resetting the user password.", username)
-            return
+    @private
+    @job(lock="passdb_sync", lock_queue_size=1)
+    def synchronize_passdb(self, job, force=False):
+        """ Sync user configuration from our user table with Samba's passdb.tdb file
 
-        if user['pdb'] is None:
-            cmd = [SMBCmd.PDBEDIT.value, '-d', '0', '-a', username]
-            rid = db_id_to_rid(IDType.USER, user['id'])
-            cmd.extend(['-U', str(rid)])
+        Params:
+            force - force resync by deleting the existing passdb.tdb file
 
-            cmd.append('-t')
-
-            pdbcreate = await run(
-                cmd, input=" \n \n".encode(), check=False,
-            )
-            if pdbcreate.returncode != 0:
-                raise CallError(f'{username}: failed to create passdb user: {pdbcreate.stderr.decode()}')
-
-            setntpass = await run(
-                [SMBCmd.PDBEDIT.value, '-d', '0', '--set-nt-hash', smbpasswd_string[3], username], check=False,
-            )
-            if setntpass.returncode != 0:
-                raise CallError(f'Failed to set NT password for {username}: {setntpass.stderr.decode()}')
-
-            if user['locked']:
-                disableacct = await run([SMBCmd.SMBPASSWD.value, '-d', username], check=False)
-                if disableacct.returncode != 0:
-                    raise CallError(f'Failed to disable {username}: {disableacct.stderr.decode()}')
-
-            # Remove any potential negative cache entries
+        Raises:
+            PassdbMustReinit - the synchronize job must be rerun with force command
+            RuntimeError - TDB library error
+        """
+        server_name = self.middleware.call_sync('smb.config')['netbiosname_local']
+        if force:
             try:
-                await self.middleware.call('idmap.gencache.del_idmap_cache_entry', {
-                    'entry_type': 'UID2SID',
-                    'entry': user['uid']
-                })
-            except MatchNotFound:
+                os.unlink(PASSDB_PATH)
+            except FileNotFoundError:
                 pass
 
-            return
+        pdb_entries = {entry['user_rid']: entry for entry in query_passdb_entries([], {})}
+        to_update = []
 
-        """
-        If an invalid global auxiliary parameter is present
-        in the smb.conf, then pdbedit will write error messages
-        to stdout (two for each invalid parameter, separated by \n).
-        The last line of output in this case will be the passdb entry
-        in smbpasswd format (-Lw). This is the reason why we pre-emptively
-        splitlines() and use last element of resulting list for our checks.
-        """
-        entry = user['pdb'].split(":")
+        for entry in self.middleware.call_sync('user.query', [("smb", "=", True), ('local', '=', True)]):
+            existing_entry = pdb_entries.pop(get_domain_rid(entry['sid']), None)
+            to_update.append(user_entry_to_passdb_entry(server_name, entry, existing_entry))
 
-        if smbpasswd_string[3] != entry[3]:
-            setntpass = await run([SMBCmd.PDBEDIT.value, '-d', '0', '--set-nt-hash', smbpasswd_string[3], username], check=False)
-            if setntpass.returncode != 0:
-                raise CallError(f'Failed to set NT password for {username}: {setntpass.stderr.decode()}')
-        if user['locked'] and 'D' not in entry[4]:
-            disableacct = await run([SMBCmd.SMBPASSWD.value, '-d', username], check=False)
-            if disableacct.returncode != 0:
-                raise CallError(f'Failed to disable {username}: {disableacct.stderr.decode()}')
-        elif not user['locked'] and 'D' in entry[4]:
-            enableacct = await run([SMBCmd.SMBPASSWD.value, '-e', username], check=False)
-            if enableacct.returncode != 0:
-                raise CallError(f'Failed to enable {username}: {enableacct.stderr.decode()}')
+            if existing_entry and existing_entry['username'] != entry['username']:
+                # username changed. Since it's part of key for one of tdb entries we have to nuke it.
+                delete_passdb_entry(existing_entry['username'], existing_entry['user_rid'])
 
-    @private
-    async def remove_passdb_user(self, username):
-        deluser = await run([SMBCmd.PDBEDIT.value, '-d', '0', '-x', username], check=False)
-        if deluser.returncode != 0:
-            raise CallError(f'Failed to delete user [{username}]: {deluser.stderr.decode()}')
+        # inserting over existing entries replaces them
+        # this is performed with a transaction lock in place and so
+        # we don't have to worry about rollback in case of failure
+        insert_passdb_entries(to_update)
 
-    @private
-    async def passdb_reinit(self, conf_users):
-        """
-        This method gets called if we need to rebuild passdb.tdb from scratch.
-        Back up problematic version first to preserve collateral in case of regression.
-        `conf_users` contains results of `user.query`. Since users will receive new
-        SID values, we will need to flush samba's cache to ensure consistency.
-        """
-        private_dir = SMBPath.PASSDB_DIR.platform()
-        ts = int(time.time())
-        old_path = f'{private_dir}/passdb.tdb'
-        new_path = f'{private_dir}/passdb.{ts}.old'
-        self.logger.debug("Backing up original passdb to [%s]", new_path)
-        try:
-            os.rename(old_path, new_path)
-        except FileNotFoundError:
-            pass
-        except Exception:
-            self.logger.debug('Failed to move %s to %s', old_path, new_path, exc_info=True)
+        for entry in pdb_entries.values():
+            # we popped off keys as we matched them to existing DB users.
+            # any remaining shouldn't be in the passdb file
 
-        for u in conf_users:
-            await self.middleware.call('smb.update_passdb_user', u | {'pdb': None})
-
-        net = await run([SMBCmd.NET.value, 'cache', 'flush'], check=False)
-        if net.returncode != 0:
-            self.logger.warning("Samba gencache flush failed with error: %s", net.stderr.decode())
-
-    @private
-    async def passdb_sync_impl(self, conf_users):
-        server_name = (await self.middleware.call('smb.config'))['netbiosname_local']
-        try:
-            invalid_entries = await self.passdb_list_full([['Domain', 'C!=', server_name]])
-        except Exception:
-            self.logger.warning("Failed to generate full passdb list, reinitializing", exc_info=True)
-            return await self.passdb_reinit(conf_users)
-
-        if invalid_entries:
-            self.logger.warning(
-                "Reinitializing passdb file due to invalid domain for the following users: %s",
-                ", ".join([u["Unix username"] for u in invalid_entries])
-            )
-            return await self.passdb_reinit(conf_users)
-
-        pdb_users = await self.smbpasswd_dump()
-        for u in conf_users:
-            pdb_entry = pdb_users.pop(u['username'], None)
-            u.update({"pdb": pdb_entry})
-            await self.middleware.call('smb.update_passdb_user', u)
-
-        for entry in pdb_users.keys():
-            self.logger.debug('Synchronizing passdb with config file: deleting user [%s] from passdb.tdb', entry)
-            try:
-                await self.remove_passdb_user(entry)
-            except Exception:
-                self.logger.warning("Failed to remove passdb user. This may indicate a corrupted passdb. Regenerating.", exc_info=True)
-                await self.passdb_reinit(conf_users)
-                break
-
-    @private
-    @job(lock="passdb_sync")
-    async def synchronize_passdb(self, job, bypass_sentinel_check=False):
-        """
-        Create any missing entries in the passdb.tdb.
-        Replace NT hashes of users if they do not match what is the the config file.
-        Synchronize the "disabled" state of users
-        Delete any entries in the passdb_tdb file that don't exist in the config file.
-        This method may cause temporary service disruption for SMB.
-        """
-        ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
-
-        passdb_backend = await self.middleware.call('smb.getparm',
-                                                    'passdb backend',
-                                                    'global')
-
-        if not passdb_backend.startswith('tdbsam'):
-            return
-
-        if not bypass_sentinel_check and not await self.middleware.call('smb.is_configured'):
-            raise CallError(
-                "SMB server configuration is not complete. "
-                "This may indicate system dataset setup failure."
-            )
-
-        conf_users = await self.middleware.call('user.query', [("smb", "=", True), ('local', '=', True)])
-        await self.passdb_sync_impl(conf_users)
+            self.logger.debug('%s: removing user from SMB user database', entry['username'])
+            delete_passdb_entry(entry['username'], entry['user_rid'])

--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -1,0 +1,545 @@
+# Utilities that wrap around samba's passdb.tdb file
+#
+# test coverage provided by src/middlewared/middlewared/pytest/unit/utils/test_passdb.py
+# sample tdb contents (via tdbdump)
+#
+# {
+# key(19) = "INFO/minor_version\00"
+# data(4) = "\00\00\00\00"
+# }
+# {
+# key(13) = "RID_00004e66\00"
+# data(8) = "smbuser\00"
+# }
+# {
+# key(9) = "NEXT_RID\00"
+# data(4) = "\E9\03\00\00"
+# }
+# {
+# key(13) = "USER_smbuser\00"
+# data(202) = "\00\00\00\00\7F\A9T|\7F\A9T|\00\00\00\00z\91\C4f\00\00\00\00\7F\A9T|\08\00\00\00smbuser\00\0F\00\00\00TESTMJPYWOO8AG\00\01\00\00\00\00\08\00\00\00smbuser\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\00\01\00\00\00\00\01\00\00\00\00\01\00\00\00\00fN\00\00\01\02\00\00\00\00\00\00\10\00\00\00\B3\F3O\F0\FB\B7r\A1\A7\08\10\CB\B32\07@\00\00\00\00\10\00\00\00\A8\00\15\00\00\00 \00\00\00\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\FF\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\EC\04\00\00"  # noqa
+# }
+# {
+# key(13) = "INFO/version\00"
+# data(4) = "\04\00\00\00"
+# }
+
+import enum
+import os
+
+from base64 import b64decode, b64encode
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from middlewared.plugins.idmap_.idmap_constants import IDType
+from middlewared.service_exception import MatchNotFound
+from middlewared.utils import filter_list
+from middlewared.utils.sid import db_id_to_rid
+from middlewared.utils.tdb import (
+    get_tdb_handle,
+    TDBBatchAction,
+    TDBBatchOperation,
+    TDBDataType,
+    TDBHandle,
+    TDBOptions,
+    TDBPathType,
+)
+from struct import pack, unpack
+from time import time
+from .constants import SMBPath
+
+# Major and minor versions must be written to the passdb.tdb file
+# Major version identifies version of struct samu.
+MINOR_VERSION_KEY = 'INFO/minor_version'
+MINOR_VERSION_VAL = b64encode(pack('<I', 0))
+MAJOR_VERSION_KEY = 'INFO/version'
+MAJOR_VERSION_VAL = b64encode(pack('<I', 4))
+
+# The following constants are taken from default values
+# generated in samu_new() in source3/passdb/passdb.c
+DEFAULT_HOURS_LEN = 21
+PACKED_HOURS = pack(f'<{"B" * DEFAULT_HOURS_LEN}', *[0xff] * DEFAULT_HOURS_LEN)
+UNKNOWN_6 = 0x000004ec  # unknown value in samba struct samu
+
+USER_PREFIX = 'USER_'
+RID_PREFIX = 'RID_'
+
+PASSDB_TDB_OPTIONS = TDBOptions(TDBPathType.CUSTOM, TDBDataType.BYTES)
+PASSDB_PATH = f'{SMBPath.PASSDB_DIR.path}/passdb.tdb'
+PASSDB_TIME_T_MAX = 2085923199  # observed in recent samba versions. Should be output of get_time_t_max()
+
+
+class PassdbMustReinit(Exception):
+    def __init__(self, reason):
+        self.errmsg = reason
+
+
+class UserAccountControl(enum.IntFlag):
+    """
+    from librpc/idl/samr.idl and MS-SAMR 2.2.1.12
+
+    account control (acct_ctrl / acct_flags) bits
+    entries in enum are only ones that may possibly be relevant for local accounts
+    We may expand as-needed to include more documented flags.
+    """
+    DISABLED = 0x00000001  # User account disabled
+    NORMAL_ACCOUNT = 0x00000010  # Normal user account
+    DONT_EXPIRE_PASSWORD = 0x00000200  # User password does not expire
+    AUTO_LOCKED = 0x00000400  # Account auto locked
+    PASSWORD_EXPIRED = 0x00020000  # Password expired
+
+
+@dataclass(frozen=True)
+class PDBTimes:
+    logon: int
+    logoff: int
+    kickoff: int
+    bad_password: int
+    pass_last_set: int
+    pass_can_change: int
+    pass_must_change: int
+
+
+@dataclass(frozen=True)
+class PDBEntry:
+    """
+    Derived from SAMU_BUFFER_FORMAT_V3
+
+    NOTE: buffer format v3 and v4 are identical
+    These are extracted from on-disk passdb.tdb entry
+    Some fields from the passdb are omitted because we will never allow
+    changing values (for example unknown_6, lanman password)
+    """
+    username: str  # Unix username
+    nt_username: str  # Windows username
+    domain: str  # Windows domain name (netbios name of TrueNAS)
+    full_name: str  # user's full name
+    comment: str
+    home_dir: str  # home directory
+    dir_drive: str  # home directroy drive string
+    logon_script: str
+    profile_path: str
+    user_rid: int
+    group_rid: int  # Samba's pdbedit defaults to 513 (domain users)
+    acct_desc: str  # User description string
+    acct_ctrl: int
+    nt_pw: str  # NT password hash
+    logon_count: int
+    bad_pw_count: int
+    times: PDBTimes
+
+
+def _add_version_info():
+    """ add version info to new file """
+    with get_tdb_handle(PASSDB_PATH, PASSDB_TDB_OPTIONS) as hdl:
+        hdl.store(MINOR_VERSION_KEY, MINOR_VERSION_VAL)
+        hdl.store(MAJOR_VERSION_KEY, MAJOR_VERSION_VAL)
+
+
+def _unpack_samba_pascal_string(entry_bytes: bytes, raw: bool = False) -> tuple[str, bytes]:
+    """
+    samba pascal strings have length of string as uint precedening string data
+    This method unpacks from entry_bytes and returns tuple of string value and
+    remainaing bytes of data.
+    """
+
+    entry_len = unpack('<I', entry_bytes[0:4])[0]
+    entry_bytes = entry_bytes[4:]
+    if raw:
+        entry = unpack(f'<{entry_len}s', entry_bytes[0: entry_len])[0]
+    else:
+        # the length encoded in pascal string includes null-termination
+        # strip off extra NULL and decode prior to return
+        entry = unpack(f'<{entry_len}s', entry_bytes[0: entry_len])[0][:-1].decode()
+
+    return (entry, entry_bytes[entry_len:])
+
+
+def _pack_samba_pascal_string(entry: str | bytes) -> bytes:
+    """ pack given string / bytes into format expected in TDB file """
+    if isinstance(entry, str):
+        entry = entry.encode() + b'\x00'
+
+    entry_len = pack('<I', len(entry))
+    return entry_len + entry
+
+
+def _unpack_pdb_bytes(entry_bytes: bytes) -> PDBEntry:
+    """ This method unpacks a SAMU_BUFFER_FORMAT_V3 into PDBEntry object """
+    # first seven entries are various timestamps encoded as signed 32 bit int
+    times = PDBTimes(*unpack('<iiiiiii', entry_bytes[0:28]))
+    entry_bytes = entry_bytes[28:]
+
+    # next are a series of pascal strings
+    username, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    domain, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    nt_username, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    full_name, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    homedir, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    dir_drive, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    logon_script, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    profile_path, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    acct_desc, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    workstations, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    comment, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+    munged_dial, entry_bytes = _unpack_samba_pascal_string(entry_bytes)
+
+    # next are rid values
+    user_rid, group_rid = unpack('<II', entry_bytes[0:8])
+    entry_bytes = entry_bytes[8:]
+
+    lm_pw, entry_bytes = _unpack_samba_pascal_string(entry_bytes, True)
+    nt_pw, entry_bytes = _unpack_samba_pascal_string(entry_bytes, True)
+    nt_pw_history, entry_bytes = _unpack_samba_pascal_string(entry_bytes, True)
+
+    acct_ctrl, logon_divs, hours_len = unpack('<iHi', entry_bytes[0:10])
+    entry_bytes = entry_bytes[10:]
+
+    hours, entry_bytes = _unpack_samba_pascal_string(entry_bytes, True)
+
+    bad_pw_cnt, logon_cnt = unpack('<HH', entry_bytes[0:4])
+
+    return PDBEntry(
+        username=username,
+        nt_username=nt_username,
+        domain=domain,
+        full_name=full_name,
+        comment=comment,
+        home_dir=homedir,
+        dir_drive=dir_drive,
+        logon_script=logon_script,
+        profile_path=profile_path,
+        acct_desc=acct_desc,
+        acct_ctrl=acct_ctrl,
+        nt_pw=nt_pw.hex().upper(),
+        user_rid=user_rid,
+        group_rid=group_rid,
+        logon_count=logon_cnt,
+        bad_pw_count=bad_pw_cnt,
+        times=times
+    )
+
+
+def _pack_pdb_entry(entry: PDBEntry) -> bytes:
+    """
+    Pack information in PDBEntry into bytes for TDB insertion
+
+    Some values are defaulted to empty strings because we do not
+    provide a mechanism for setting / maintaining them from middleware
+    or explicitly do not support the associated feature (such as lanman password)
+    """
+    data = pack(
+        '<iiiiiii',
+        entry.times.logon,
+        entry.times.logoff,
+        entry.times.kickoff,
+        entry.times.bad_password,
+        entry.times.pass_last_set,
+        entry.times.pass_can_change,
+        entry.times.pass_must_change,
+    )
+
+    data += _pack_samba_pascal_string(entry.username)
+    data += _pack_samba_pascal_string(entry.domain)
+    data += _pack_samba_pascal_string(entry.nt_username)
+    data += _pack_samba_pascal_string(entry.full_name)
+    data += _pack_samba_pascal_string(entry.home_dir)
+    data += _pack_samba_pascal_string(entry.dir_drive)
+    data += _pack_samba_pascal_string(entry.logon_script)
+    data += _pack_samba_pascal_string(entry.profile_path)
+    data += _pack_samba_pascal_string(entry.acct_desc)
+    data += _pack_samba_pascal_string('')  # workstations
+    data += _pack_samba_pascal_string(entry.comment)
+    data += _pack_samba_pascal_string('')  # munged dial
+
+    data += pack('<II', entry.user_rid, entry.group_rid)
+    data += _pack_samba_pascal_string('')  # lanman password
+    data += _pack_samba_pascal_string(bytes.fromhex(entry.nt_pw))
+    data += _pack_samba_pascal_string('')  # NT password history
+    data += pack('<IHi', entry.acct_ctrl, 168, DEFAULT_HOURS_LEN)
+    data += _pack_samba_pascal_string(PACKED_HOURS)
+    data += pack('<HHi', entry.bad_pw_count, entry.logon_count, UNKNOWN_6)
+
+    return data
+
+
+def _parse_passdb_entry(hdl: TDBHandle, tdb_key: str, tdb_val: str) -> PDBEntry:
+    """
+    Retrieve SAMU data based on passdb RID entry and parse bytes into a PDBEntry
+    object.
+
+
+    """
+    key = f'{USER_PREFIX}{b64decode(tdb_val)[:-1].decode()}'
+    try:
+        if (pdb_bytes := hdl.get(f'{USER_PREFIX}{b64decode(tdb_val)[:-1].decode()}')) is None:
+            # malformed passdb entry. Shouldn't happen we'll return None to force
+            # rewrite
+            raise PassdbMustReinit(f'{key}: passdb.tdb lacks expected key')
+    except MatchNotFound:
+        raise PassdbMustReinit(f'{key}: passdb.tdb lacks expected key') from None
+
+    return _unpack_pdb_bytes(b64decode(pdb_bytes))
+
+
+def passdb_entries(as_dict: bool = False) -> Iterable[PDBEntry, dict]:
+    """ Iterate the passdb.tdb file
+
+    Each SMB user contains two TDB entries. One that maps a RID value to the username
+    and the other maps the username to a samu buffer. These are both written simultaneously
+    under a transaction lock and so we should never be in a situation where they are
+    inconsistent; however if we are unable to look up a USER entry based on the username
+    in the RID entry, a PassdbMustReinit exception will be raised so that caller knows
+    that the file should be rewritten.
+
+    Params:
+       as_dict - return as dictionary
+
+    Returns:
+       SMBGroupMap or SMBGroupMembership
+
+    Raises:
+       PassdbMustReinit - internal inconsistencies in passdb file
+    """
+    if not os.path.exists(PASSDB_PATH):
+        _add_version_info()
+
+    with get_tdb_handle(PASSDB_PATH, PASSDB_TDB_OPTIONS) as hdl:
+        for entry in hdl.entries():
+            if not entry['key'].startswith(RID_PREFIX):
+                continue
+
+            parsed = _parse_passdb_entry(hdl, entry['key'], entry['value'])
+            yield asdict(parsed) if as_dict else parsed
+
+
+def query_passdb_entries(filters: list, options: dict) -> list[dict]:
+    """ Query passdb entries with default query-filters and query-options
+
+    This provides a convenient query API for passdb entries. Wraps around
+    passdb_entries() and same failure scenarios apply.
+
+    Params:
+        filters - standard query-filters
+        options - standard query-options
+
+    Returns:
+        filterable returns with asdict() output of PDBEntry objects
+
+    Raises:
+       PassdbMustReinit - internal inconsistencies in passdb file
+    """
+    try:
+        return filter_list(passdb_entries(as_dict=True), filters, options)
+    except FileNotFoundError:
+        return []
+
+
+def insert_passdb_entries(entries: list[PDBEntry]) -> None:
+    """ Insert multiple groupmap entries under a transaction lock
+
+    Each PDBEntry requires two TDB insertions and so the entire list
+    is submitted under a TDB transaction lock, which means that in case
+    of failure changes are rolled back to the state prior to insertion.
+
+    Entries that already exist will be overwritten.
+
+    Params:
+        entries - list of PDBEntry objects to be inserted
+
+    Raises:
+        TypeError - list item isn't PDBEntry object
+        RuntimeError - TDB library error
+    """
+
+    if not os.path.exists(PASSDB_PATH):
+        _add_version_info()
+
+    batch_ops = []
+
+    for entry in entries:
+        if not isinstance(entry, PDBEntry):
+            raise TypeError(f'{type(entry)}: not a PDBEntry')
+
+        samu_data = _pack_pdb_entry(entry)
+        batch_ops.extend([
+            TDBBatchOperation(
+                action=TDBBatchAction.SET,
+                key=f'{USER_PREFIX}{entry.username}',
+                value=b64encode(samu_data)
+            ),
+            TDBBatchOperation(
+                action=TDBBatchAction.SET,
+                key=f'{RID_PREFIX}{entry.user_rid:08x}',
+                value=b64encode(entry.username.encode() + b'\x00')
+            )
+        ])
+
+    if len(batch_ops) == 0:
+        # nothing to do, avoid taking lock
+        return
+
+    with get_tdb_handle(PASSDB_PATH, PASSDB_TDB_OPTIONS) as hdl:
+        hdl.batch_op(batch_ops)
+
+
+def delete_passdb_entry(username: str, rid: int) -> None:
+    """ Delete a passdb entry under a transaction lock """
+    if not os.path.exists(PASSDB_PATH):
+        # passdb.tdb doesn't exist so nothing to do
+        return
+
+    with get_tdb_handle(PASSDB_PATH, PASSDB_TDB_OPTIONS) as hdl:
+        # Do this under transaction lock to force atomicity of changes
+        try:
+            hdl.batch_op([
+                TDBBatchOperation(
+                    action=TDBBatchAction.DEL,
+                    key=f'{USER_PREFIX}{username}'
+                ),
+                TDBBatchOperation(
+                    action=TDBBatchAction.DEL,
+                    key=f'{RID_PREFIX}{rid:08x}'
+                )
+            ])
+        except RuntimeError:
+            # entries do not exist
+            pass
+
+
+def update_passdb_entry(entry: PDBEntry) -> None:
+    """ Update an existing passdb entry or insert a new one
+
+    This method attempts to update an existing passdb entry with info in PDBEntry
+    object. If any operations related to update fail then rollback to original
+    status of TDB file is performed.
+
+    If entry does not exist, then new one is inserted.
+
+    Params:
+        entry - PDBEntry object with samu data for user
+
+    Raises:
+        TypeError - not a PDBEntry
+        RuntimeError - TDB library error
+    """
+    if not isinstance(entry, PDBEntry):
+        raise TypeError(f'{type(entry)}: expected PDBEntry type.')
+
+    if not os.path.exists(PASSDB_PATH):
+        _add_version_info()
+
+    with get_tdb_handle(PASSDB_PATH, PASSDB_TDB_OPTIONS) as hdl:
+        batch_ops = []
+        try:
+            current_username = b64decode(hdl.get(f'{RID_PREFIX}{entry.user_rid:08x}'))[:-1].decode()
+        except MatchNotFound:
+            pass
+        else:
+            if current_username != entry.username:
+                # name has changed. Make sure we clean up old entry under transaction
+                # lock
+                batch_ops.append(
+                    TDBBatchOperation(
+                        action=TDBBatchAction.DEL,
+                        key=f'{USER_PREFIX}{current_username}'
+                    ),
+                )
+
+        samu_data = _pack_pdb_entry(entry)
+        batch_ops.extend([
+            TDBBatchOperation(
+                action=TDBBatchAction.SET,
+                key=f'{USER_PREFIX}{entry.username}',
+                value=b64encode(samu_data)
+            ),
+            TDBBatchOperation(
+                action=TDBBatchAction.SET,
+                key=f'{RID_PREFIX}{entry.user_rid:08x}',
+                value=b64encode(entry.username.encode() + b'\x00')
+            )
+        ])
+        hdl.batch_op(batch_ops)
+
+
+def user_entry_to_uac_flags(user_entry) -> UserAccountControl:
+    """ helper function to convert user entry account flags to MS-SAMU User Account Control flags """
+    flags_out = UserAccountControl.NORMAL_ACCOUNT
+
+    if user_entry['locked']:
+        flags_out |= UserAccountControl.AUTO_LOCKED
+
+    if user_entry['password_disabled']:
+        flags_out |= UserAccountControl.DISABLED
+
+    return flags_out
+
+
+def user_smbhash_to_nt_pw(username, smbhash) -> str:
+    """ helper function to get the NT hash from `smbhash` data """
+    if not smbhash:
+        raise ValueError(f'{username}: no SMB hash available for user')
+
+    if ':' in smbhash:
+        # we may have a legacy entry in smbpasswd format
+        smbhash = smbhash.split(':')[3]
+
+    return smbhash
+
+
+def user_entry_to_passdb_entry(
+    netbiosname: str,
+    user_entry: dict,
+    existing_entry: dict = None
+) -> PDBEntry:
+    """ Create an updated PDBEntry based on user-provided specifications
+
+    This helper function creates a PDBEntry for later use in passdb insertion call. The
+    intended use is for cases where struct SAMU encodes information that we may wish to
+    preserve but are unable to due to not having corresponding fields in our middleware
+    user entries.
+    """
+    if not user_entry['smb']:
+        raise ValueError(f'{user_entry["username"]}: not an SMB user')
+
+    if not user_entry['smbhash']:
+        raise ValueError(f'{user_entry["username"]}: SMB hash not available')
+
+    pdb_times = PDBTimes(
+        logon=0,
+        logoff=PASSDB_TIME_T_MAX,
+        kickoff=PASSDB_TIME_T_MAX,
+        bad_password=0,
+        pass_last_set=int(time()),
+        pass_can_change=0,
+        pass_must_change=PASSDB_TIME_T_MAX
+    )
+
+    pdb_dict = {
+        'username': user_entry['username'],
+        'nt_username': '',
+        'domain': netbiosname.upper(),
+        'full_name': user_entry['full_name'],
+        'comment': '',
+        'home_dir': '',
+        'dir_drive': '',
+        'logon_script': '',
+        'profile_path': '',
+        'user_rid': db_id_to_rid(IDType.USER, user_entry['id']),
+        'group_rid': 513,  # samba default -- domain users rid
+        'acct_desc': '',
+        'acct_ctrl': user_entry_to_uac_flags(user_entry),
+        'nt_pw': user_smbhash_to_nt_pw(user_entry['username'], user_entry['smbhash']),
+        'logon_count': 0,
+        'bad_pw_count': 0,
+        'times': pdb_times
+    }
+
+    if existing_entry:
+        # preserve existing times:
+        pdb_dict['times'] = PDBTimes(**existing_entry['times'])
+
+        # preserve counters
+        pdb_dict['logon_count'] = existing_entry['logon_count']
+        pdb_dict['bad_pw_count'] = existing_entry['bad_pw_count']
+
+    return PDBEntry(**pdb_dict)

--- a/src/middlewared/middlewared/pytest/unit/utils/test_passdb.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_passdb.py
@@ -1,0 +1,217 @@
+import os
+import pytest
+import secrets
+import string
+import subprocess
+
+from dataclasses import asdict
+from middlewared.plugins.smb_ import util_passdb
+from middlewared.utils.crypto import generate_nt_hash
+from time import sleep, time
+
+PDB_DOMAIN = 'CANARY'
+PDB_DOM_SID = 'S-1-5-21-710078819-430336432-4106732522'
+PDB_DICT_DEFAULTS = {
+    'username': None,
+    'nt_username': '',
+    'domain': PDB_DOMAIN,
+    'full_name': None,
+    'comment': '',
+    'home_dir': '',
+    'dir_drive': '',
+    'logon_script': '',
+    'profile_path': '',
+    'user_rid': None,
+    'group_rid': 513,  # samba default -- domain users rid
+    'acct_desc': '',
+    'acct_ctrl': util_passdb.UserAccountControl.NORMAL_ACCOUNT,
+    'nt_pw': None,
+    'logon_count': 0,
+    'bad_pw_count': 0,
+    'times': None
+}
+
+SAMPLE_USER = {
+    'id': 75,
+    'uid': 3000,
+    'username': 'pdbuser',
+    'unixhash': '$6$rounds=656000$oYArtLuJhcfrwkkX$uUcNk1VdH7jHWZLd6HXT1svD3MXtS578sBx2oDrag3ZTxVFm41y1mIvpCHcR1/dcGiTiT/lhIyVD8m1QHgovq0',  # noqa
+    'smbhash': '05BC65787F63B56CF6D47F16E32E3ABF',
+    'home': '/var/empty',
+    'shell': '/usr/sbin/nologin',
+    'full_name': 'pdbuser_name',
+    'builtin': False,
+    'smb': True,
+    'password_disabled': False,
+    'ssh_password_enabled': False,
+    'locked': False,
+    'sudo_commands': [],
+    'sudo_commands_nopasswd': [],
+    'email': None,
+    'group': {
+        'id': 107,
+        'bsdgrp_gid': 3000,
+        'bsdgrp_group': 'pdbuser',
+        'bsdgrp_builtin': False,
+        'bsdgrp_sudo_commands': [],
+        'bsdgrp_sudo_commands_nopasswd': [],
+        'bsdgrp_smb': False
+    },
+    'groups': [
+        90
+    ],
+    'sshpubkey': None,
+    'immutable': False,
+    'twofactor_auth_configured': False,
+    'local': True,
+    'id_type_both': False,
+    'sid': 'S-1-5-21-710078819-430336432-4106732522-20075',
+    'roles': []
+}
+
+PDB_DOMAIN = 'CANARY'
+NORMAL_ACCOUNT = util_passdb.UserAccountControl.NORMAL_ACCOUNT
+LOCKED_ACCOUNT = NORMAL_ACCOUNT | util_passdb.UserAccountControl.AUTO_LOCKED
+DISABLED_ACCOUNT = NORMAL_ACCOUNT | util_passdb.UserAccountControl.DISABLED
+EXPIRED_ACCOUNT = NORMAL_ACCOUNT | util_passdb.UserAccountControl.PASSWORD_EXPIRED
+
+
+@pytest.fixture(scope='module')
+def passdb_dir():
+    os.makedirs(util_passdb.SMBPath.PASSDB_DIR.path, mode=0o700, exist_ok=True)
+    os.makedirs(util_passdb.SMBPath.PRIVATEDIR.path, mode=0o700, exist_ok=True)
+
+    # valid smb.conf is required for pdbedit command
+    with open('/etc/smb4.conf', 'w') as f:
+        f.write('[global]\n')
+        f.flush()
+
+
+@pytest.fixture(scope='function')
+def pdb_times():
+    yield util_passdb.PDBTimes(
+        logon=0,
+        logoff=util_passdb.PASSDB_TIME_T_MAX,
+        kickoff=util_passdb.PASSDB_TIME_T_MAX,
+        bad_password=0,
+        pass_last_set=int(time()),
+        pass_can_change=0,
+        pass_must_change=util_passdb.PASSDB_TIME_T_MAX
+    )
+
+
+@pytest.fixture(scope='function')
+def pdb_user(pdb_times):
+    payload = PDB_DICT_DEFAULTS | {
+        'username': SAMPLE_USER['username'],
+        'full_name': SAMPLE_USER['full_name'],
+        'user_rid': 20075,
+        'times': pdb_times,
+        'nt_pw': SAMPLE_USER['smbhash']
+    }
+
+    yield util_passdb.PDBEntry(**payload)
+
+
+def check_pdbedit(usernames):
+    """
+    validate that standard Samba tools see same users. This can fail if for
+    instance we fail to insert major / minor versions into passdb.tdb because
+    samba will interpret it as containing struct samu version 0.
+    """
+    expected = set(usernames)
+    found = []
+    pdbedit = subprocess.run(['pdbedit', '-L'], capture_output=True)
+    assert pdbedit.returncode == 0, pdbedit.stderr.decode()
+    for entry in pdbedit.stdout.decode().strip().splitlines():
+        found.append(entry.split(':')[0])
+
+    assert len(found) == len(usernames), f'expected: {usernames}, found: {found}'
+
+    found = set(found)
+    missing = expected - found
+    assert missing == set(), str(missing)
+
+    extra = found - expected
+    assert extra == set(), str(extra)
+
+
+@pytest.mark.parametrize('pdbentrydict', [
+    PDB_DICT_DEFAULTS | {'username': 'user1', 'full_name': 'user1', 'user_rid': 20071},
+    PDB_DICT_DEFAULTS | {'username': 'user2', 'full_name': 'user2', 'user_rid': 20072, 'acct_ctrl': LOCKED_ACCOUNT},
+    PDB_DICT_DEFAULTS | {'username': 'user3', 'full_name': 'user3', 'user_rid': 20073, 'acct_ctrl': DISABLED_ACCOUNT},
+    PDB_DICT_DEFAULTS | {'username': 'user4', 'full_name': 'user4', 'user_rid': 20074, 'acct_ctrl': EXPIRED_ACCOUNT},
+])
+def test__insert_query_delete(pdbentrydict, passdb_dir, pdb_times):
+    """ Add user, verify it shows in our query, verify that it shows in pdbedit, then delete it """
+
+    # generate NT hash from randomized password
+    nt_hash = generate_nt_hash(''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(10)))
+    payload = pdbentrydict | {'times': pdb_times, 'nt_pw': nt_hash}
+
+    entry = util_passdb.PDBEntry(**payload)
+
+    util_passdb.insert_passdb_entries([entry])
+
+    try:
+        contents = util_passdb.query_passdb_entries([], {})
+        assert len(contents) == 1
+        check_pdbedit([entry.username])
+    finally:
+        util_passdb.delete_passdb_entry(payload['username'], payload['user_rid'])
+
+    assert asdict(entry) == contents[0]
+
+    contents = util_passdb.query_passdb_entries([], {})
+    assert len(contents) == 0, str(contents)
+
+
+def test__smbhash_parser():
+    """
+    The `smbhash` field in samba has changed from being a smbpasswd string to simply
+    containing the NT hash for user. This test ensures that we properly extract NT hash
+    from both entry types.
+    """
+    smb_hash_legacy = "smbuser:3000:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:05BC65787F63B56CF6D47F16E32E3ABF:[U         ]:LCT-66C7190E:"  # noqa
+    nt_hash = "05BC65787F63B56CF6D47F16E32E3ABF"
+
+    assert util_passdb.user_smbhash_to_nt_pw('smbuser', smb_hash_legacy) == nt_hash
+    assert util_passdb.user_smbhash_to_nt_pw('smbuser', nt_hash) == nt_hash
+
+
+@pytest.mark.parametrize('user_data,expected', [
+    ({'locked': False, 'password_disabled': False}, util_passdb.UserAccountControl.NORMAL_ACCOUNT),
+    ({'locked': True, 'password_disabled': False}, LOCKED_ACCOUNT),
+    ({'locked': False, 'password_disabled': True}, DISABLED_ACCOUNT),
+    ({'locked': True, 'password_disabled': True}, DISABLED_ACCOUNT | LOCKED_ACCOUNT),
+])
+def test__uac_flags_parser(user_data, expected):
+    """
+    This test validates mapping of account status parameters from our user table entries to
+    MS-SAMU user account control flags
+    """
+    assert util_passdb.user_entry_to_uac_flags(user_data) == expected
+
+
+@pytest.mark.parametrize('changes', [
+    {'locked': True, 'full_name': 'bob'},
+    {'smbhash': generate_nt_hash('Cats')},
+])
+def test__pdb_update(pdb_user, changes):
+    """
+    This test validates the helper function that generates updated PDBEntry based on user
+    specified data. For example, if there is an existing entry we should preserve its
+    timestamps.
+    """
+    sleep(1)
+    now = int(time())
+    user_entry = SAMPLE_USER | changes
+
+    new_entry = util_passdb.user_entry_to_passdb_entry(PDB_DOMAIN, user_entry, asdict(pdb_user))
+
+    # validate that timestamps were preserved
+    assert now != new_entry.times.pass_last_set
+    assert pdb_user.times == new_entry.times
+    assert new_entry.nt_pw == user_entry['smbhash']
+    assert new_entry.domain == PDB_DOMAIN
+    assert util_passdb.user_entry_to_uac_flags(user_entry) == new_entry.acct_ctrl

--- a/src/middlewared/middlewared/utils/tdb.py
+++ b/src/middlewared/middlewared/utils/tdb.py
@@ -292,7 +292,7 @@ class TDBHandle:
                 tdb_flags = tdb.DEFAULT
                 open_flags = os.O_RDWR
                 open_mode = 0o600
-            case 'group_mapping.tdb' | 'group_mapping_rejects.tdb':
+            case 'group_mapping.tdb' | 'group_mapping_rejects.tdb' | 'passdb.tdb':
                 tdb_flags = tdb.DEFAULT
                 open_flags = os.O_RDWR
                 self.keys_null_terminated = True


### PR DESCRIPTION
This commit adds utility functions to pack / unpack samba's passdb.tdb file. This allows us to remove subprocess calls to manipulate our SMB entries and provides a clean mechanism for maintaining more robust account details in the future when we expand our user database objects. In ad-hoc testing this resulted in about a 2x speed improvement for user account CRUD operations.