### PR TITLE
NAS-130676 / 25.04 /  Redesign root login alerts

### DIFF
--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -1,14 +1,104 @@
-from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
+from middlewared.alert.schedule import CrontabSchedule
+from middlewared.utils.audit import UNAUTHENTICATED
+from time import time
 
 
-class AdminSessionActiveAlertClass(AlertClass, SimpleOneShotAlertClass):
+class AdminSessionAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
-    title = "Active administrator session on TrueNAS server"
+    title = "Administrator account activity"
     text = (
-        "System administrator (root or truenas_admin) has one or more "
-        "active sessions on the TrueNAS server with the following session ids: %(sessions)s"
+        "The system administrator account was used to authenticate to the UI / API "
+        "%(count)d times in the last 24 hours:\n%(sessions)s"
     )
 
-    async def delete(self, alerts, query):
-        return []
+
+class APIFailedLoginAlertClass(AlertClass):
+    category = AlertCategory.SYSTEM
+    level = AlertLevel.WARNING
+    title = "API Login Failures"
+    text = (
+        "%(count)d API login failures in the last 24 hours:\n%(sessions)s"
+    )
+
+
+def audit_entry_to_msg(entry):
+    return (
+        f'(username={entry["username"]},'
+        f'session_id={entry["session"]},'
+        f'address={entry["address"]})'
+    )
+
+
+class AdminSessionAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=1)  # every 24 hours
+    run_on_backup_node = True
+    products = ('SCALE_ENTERPRISE',)
+
+    async def check(self):
+        now = int(time())
+        admin_logins = await self.middleware.call('audit.query', {
+            'services': ['MIDDLEWARE'],
+            'query-filters': [
+                ['message_timestamp', '>', now - 86400],
+                ['event', '=', 'AUTHENTICATION'],
+                ['username', 'in', ['root', 'admin', 'truenas_admin']],
+                ['success', '=', True]
+            ],
+            'query-options': {
+                'select': [
+                    'message_timestamp',
+                    'event',
+                    'session',
+                    'username',
+                    'address',
+                    'success'
+                ]
+            }
+        })
+        if not admin_logins:
+            return
+
+        audit_msg = ','.join([audit_entry_to_msg(entry) for entry in admin_logins])
+        return Alert(
+            AdminSessionAlertClass,
+            {'count': len(admin_logins), 'sessions': audit_msg},
+            key=None
+        )
+
+
+class APIFailedLoginAlertSource(AlertSource):
+    schedule = CrontabSchedule(hour=1)  # every 24 hours
+    run_on_backup_node = True
+
+    async def check(self):
+        now = int(time())
+        auth_failures = await self.middleware.call('audit.query', {
+            'services': ['MIDDLEWARE'],
+            'query-filters': [
+                ['message_timestamp', '>', now - 86400],
+                ['event', '=', 'AUTHENTICATION'],
+                ['username', '!=', UNAUTHENTICATED],
+                ['success', '=', False]
+            ],
+            'query-options': {
+                'select': [
+                    'message_timestamp',
+                    'event',
+                    'session',
+                    'username',
+                    'address',
+                    'success'
+                ]
+            }
+        })
+        if not auth_failures:
+            return
+
+        audit_msg = ','.join([audit_entry_to_msg(entry) for entry in auth_failures])
+        return Alert(
+            APIFailedLoginAlertClass,
+            {'count': len(auth_failures), 'sessions': audit_msg},
+            key=None
+        )

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -18,7 +18,6 @@ from middlewared.service import (
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils.origin import UnixSocketOrigin
-from middlewared.utils.privilege import credential_is_root_or_equivalent
 from middlewared.utils.crypto import generate_token
 from middlewared.utils.time_utils import utc_now
 
@@ -96,14 +95,6 @@ class SessionManager:
 
         self.middleware = None
 
-    def root_sessions(self):
-        root_sessions = []
-        for session_id, session in self.sessions.items():
-            if not is_internal_session(session) and credential_is_root_or_equivalent(session.credentials):
-                root_sessions.append(session_id)
-
-        return root_sessions
-
     async def login(self, app, credentials):
         if app.authenticated:
             self.sessions[app.session_id].credentials = credentials
@@ -120,13 +111,6 @@ class SessionManager:
         app.register_callback(RpcWebSocketAppEvent.CLOSE, self._app_on_close)
 
         if not is_internal_session(session):
-            if credential_is_root_or_equivalent(credentials):
-                await self.middleware.call(
-                    "alert.oneshot_create",
-                    "AdminSessionActive",
-                    {'sessions': ', '.join(self.root_sessions())}
-                )
-
             self.middleware.send_event("auth.sessions", "ADDED", fields=dict(id=app.session_id, **session.dump()))
             await self.middleware.log_audit_message(app, "AUTHENTICATION", {
                 "credentials": dump_credentials(credentials),
@@ -137,19 +121,9 @@ class SessionManager:
         session = self.sessions.pop(app.session_id, None)
 
         if session is not None:
-            was_root_session = credential_is_root_or_equivalent(session.credentials)
             session.credentials.logout()
 
             if not is_internal_session(session):
-                if was_root_session:
-                    await self.middleware.call("alert.oneshot_delete", "AdminSessionActive")
-                    if (root_sessions := self.root_sessions()):
-                        await self.middleware.call(
-                            "alert.oneshot_create",
-                            "AdminSessionActive",
-                            {'sessions': ', '.join(root_sessions)}
-                        )
-
                 self.middleware.send_event("auth.sessions", "REMOVED", fields=dict(id=app.session_id))
 
         app.authenticated = False

--- a/tests/api2/test_root_session_alert.py
+++ b/tests/api2/test_root_session_alert.py
@@ -1,48 +1,37 @@
 import pytest
 
+from middlewared.test.integration.assets.product import product_type
 from middlewared.test.integration.utils.client import client, truenas_server
 from middlewared.test.integration.utils import call
+from time import sleep
+
+
+@pytest.fixture(scope="function")
+def set_product_type(request):
+    # force SCALE_ENTERPRISE product type
+    with product_type():
+        yield
 
 
 def get_session_alert(call_fn, session_id):
-    alerts = call_fn('alert.list')
-    alert_msg = None
+    # sleep a little while to let auth event get logged
+    sleep(5)
 
-    for alert in alerts:
-        if alert['klass'] == 'AdminSessionActive':
-            if session_id and session_id not in alert['formatted']:
-                continue
+    alert = call_fn('alert.run_source', 'AdminSession')
+    assert alert
 
-            alert_msg = alert['formatted']
-            break
-
-    assert alert_msg is not None, str(alerts)
-    return alert_msg
+    assert session_id in alert[0]['args']['sessions'], str(alert[0]['args'])
 
 
 def check_session_alert(call_fn):
     session_id = call_fn('auth.sessions', [['current', '=', True]], {'get': True})['id']
-    session_alert = get_session_alert(call_fn, session_id)
-
-    return session_id
+    get_session_alert(call_fn, session_id)
 
 
-def test_root_session_alert():
-    # We have a persistent root session so we expect alert to be present
+def test_root_session(set_product_type):
+    # first check with our regular persistent session
     check_session_alert(call)
 
-
-def test_root_session_logout():
     with client(host_ip=truenas_server.ip) as c:
-        # ensure that client generates alert
-        session_id = check_session_alert(c.call)
-        c.call('auth.logout')
-
-    # Make sure our session properly closed
-    closed_session = call('auth.sessions', [['id', '=', session_id]])
-    assert not closed_session
-
-    # Make sure old session ID no longer in alert
-    session_alert = get_session_alert(call, None)
-
-    assert session_id not in session_alert
+        # check that we also pick up second alert
+        check_session_alert(c.call)


### PR DESCRIPTION
In lieu of generating one-shot alerts when root-level account authenticates, generate a daily summary report of session IDs and addresses for clients that authenticated to the UI / API as a root account and limit such behavior to SCALE_ENTERPRISE.

Also add new daily alert for failed login attempts to the UI / API.