### PR TITLE
NAS-130785 / 24.10-RC.1 / fix interface.websocket_local_ip

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1460,9 +1460,12 @@ class InterfaceService(CRUDService):
         if sock.family not in (socket.AF_INET, socket.AF_INET6):
             return
 
-        remote_port = (
-            app.request.headers.get('X-Real-Remote-Port') or app.request.transport.get_extra_info('peername')[1]
-        )
+        try:
+            # this comes from nginx reverse proxy and is a string
+            remote_port = int(app.request.headers['X-Real-Remote-Port'])
+        except (ValueError, KeyError):
+            remote_port = app.request.transport.get_extra_info('peername')[1]
+
         if not remote_port:
             return
 


### PR DESCRIPTION
This is a subtle, but painful regression in EE. If we manage to get the remote port via the `X-Real-Remote-Port` header, it will be a string. We need to cast this to an `int` before passing it to `read_proc_net` or it won't work. Note, the logic for casting this to an int is the same as the `get_remote_addr_port` in `utils/nginx.py`.

NOTE: this does not affect master because we properly cast these to an int in the `TCPIPOrigin` class.