### PR TITLE
NAS-130708 / 24.10-BETA.1 / Clear pool status alert cache when I/O errors occur on the pool (by themylogin) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -159,6 +159,13 @@ async def zfs_events(middleware, data):
             return
         middleware.send_event('pool.query', 'CHANGED', id=pool['id'], fields=pool)
     elif event_id in (
+        'ereport.fs.zfs.checksum',
+        'ereport.fs.zfs.io',
+        'ereport.fs.zfs.data',
+        'ereport.fs.zfs.vdev.clear',
+    ):
+        await middleware.call('cache.pop', 'VolumeStatusAlerts')
+    elif event_id in (
         'sysevent.fs.zfs.config_sync',
         'sysevent.fs.zfs.pool_destroy',
         'sysevent.fs.zfs.pool_import',


### PR DESCRIPTION
These errors, if corrected, do not degrade vdev and don't cause `sysevent.fs.zfs.config_sync`.

Not able to add an integration test since causing these errors with `zinject` irreversibly makes the system barely usable.

Original PR: https://github.com/truenas/middleware/pull/14297
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130708

Original PR: https://github.com/truenas/middleware/pull/14298
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130708