### PR TITLE
NAS-130788 / 24.10-RC.1 / Allow retrieving logs of apps in deploying state (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/logs.py
+++ b/src/middlewared/middlewared/plugins/apps/logs.py
@@ -38,7 +38,7 @@ class AppContainerLogsFollowTailEventSource(EventSource):
 
     def validate_log_args(self, app_name, container_id):
         app = self.middleware.call_sync('app.get_instance', app_name)
-        if app['state'] != 'RUNNING':
+        if app['state'] not in ('RUNNING', 'DEPLOYING'):
             raise CallError(f'App "{app_name}" is not running')
 
         if not any(c['id'] == container_id for c in app['active_workloads']['container_details']):


### PR DESCRIPTION
## Context

Middleware should allow to retrieve logs of apps which are in deploying state.

Original PR: https://github.com/truenas/middleware/pull/14334
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130788