### PR TITLE
NAS-130796 / 25.04 / Do not allow iSCSI extents to use zvols on boot-pool

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -329,6 +329,10 @@ class BootService(Service):
         if properties:
             await self.middleware.call('zfs.pool.update', BOOT_POOL_NAME, {'properties': properties})
 
+    @private
+    async def is_boot_pool_path(self, path):
+        return path.startswith(f'/dev/zvol/{await self.middleware.call("boot.pool_name")}/')
+
 
 async def on_config_upload(middleware, path):
     await middleware.call('boot.update_initramfs', {'database': path})

--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -331,7 +331,7 @@ class BootService(Service):
 
     @private
     async def is_boot_pool_path(self, path):
-        return path.startswith(f'/dev/zvol/{await self.middleware.call("boot.pool_name")}/')
+        return path.startswith(f'/dev/zvol/{await self.pool_name()}/')
 
 
 async def on_config_upload(middleware, path):

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -335,6 +335,9 @@ class iSCSITargetExtentService(SharingService):
             if not os.path.exists(device):
                 verrors.add(f'{schema_name}.disk', f'Device {device!r} for volume {zvol_name!r} does not exist')
 
+            if self.middleware.call_sync('boot.is_boot_pool_path', device):
+                verrors.add(f'{schema_name}.disk', 'Disk residing in boot pool cannot be consumed and is not supported')
+
             if '@' in zvol_name and not data['ro']:
                 verrors.add(f'{schema_name}.ro', 'Must be set when disk is a ZFS Snapshot')
 


### PR DESCRIPTION
This PR was 100% inspired by PR #14180

Add private API `boot.is_boot_pool_path` and call to prevent an iSCSI extent from being based on a ZVOL on the boot-pool.