### PR TITLE
NAS-130769 / 25.04 / Default to accept policy for forward chain

### DIFF
--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/bin/sh -c "iptables -P FORWARD ACCEPT"

--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -20,7 +20,7 @@ def render(service, middleware):
     base = {
         'data-root': data_root,
         'exec-opts': ['native.cgroupdriver=cgroupfs'],
-        'iptables': True,  # FIXME: VMs connectivity would be broken
+        'iptables': True,
         'storage-driver': 'overlay2',
     }
     isolated = middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']


### PR DESCRIPTION
## Context

Docker after starting changes the default policy of forward chain to `DROP` which results in networking for VMs getting broken, we switch it back to `ACCEPT` after docker has started to restore connectivity to VMs.