### PR TITLE
Add hybrid mode to UPS

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nut/upssched.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nut/upssched.conf.mako
@@ -21,4 +21,8 @@ AT ONBATT   * START-TIMER SHUTDOWN ${ups_config['shutdowntimer']}
 AT ONLINE   * CANCEL-TIMER SHUTDOWN
 % elif shutdown.lower() == 'lowbatt':
 AT LOWBATT  * EXECUTE SHUTDOWN
+% elif shutdown.lower() == 'hybrid':
+AT ONBATT   * START-TIMER SHUTDOWN ${ups_config['shutdowntimer']}
+AT ONLINE   * CANCEL-TIMER SHUTDOWN
+AT LOWBATT  * EXECUTE SHUTDOWN
 % endif

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -71,7 +71,7 @@ class UPSService(SystemServiceService):
         Str('optionsupsd', max_length=None, required=True),
         Str('port', required=True),
         Str('remotehost', required=True),
-        Str('shutdown', enum=['LOWBATT', 'BATT'], required=True),
+        Str('shutdown', enum=['LOWBATT', 'BATT', 'HYBRID'], required=True),
         Str('shutdowncmd', null=True, required=True),
         Str('complete_identifier', required=True),
     )


### PR DESCRIPTION
Implements this feature request: https://forums.truenas.com/t/ups-server-additional-shutdown-mode/11257

Hybrid mode:
When UPS is on battery Shutdown Timer is started. If low battery is reached shutdown is executed immediately. 

WebUI pull request: https://github.com/truenas/webui/pull/10549