### PR TITLE
NAS-130813 / 25.04 / Fix internal callers for core.bulk

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -815,7 +815,14 @@ class CoreService(Service):
             job.set_progress(100 * i / len(params), progress_description)
 
             try:
-                msg = await self.middleware.call_with_audit(method, serviceobj, methodobj, p, app=app)
+                # Convention for the auditing backend is to only generate audit
+                # entries for external callers to methods. app is only None
+                # on internal calls to core.bulk.
+                if app:
+                    msg = await self.middleware.call_with_audit(method, serviceobj, methodobj, p, app=app)
+                else:
+                    msg = await self.middleware.call(method, *p)
+
                 status = {"result": msg, "error": None}
 
                 if isinstance(msg, Job):


### PR DESCRIPTION
Our convention for auditing is to not generate entries for purely internal calls to methods. This fixes an issue whereby the new apps implementation was calling internally into audited methods and crashing.