### PR TITLE
NAS-130824 / 24.10-RC.1 / fix edge-case crash in enclosure_class.py (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -380,7 +380,7 @@ class Enclosure:
         Args:
         Returns: bool
         """
-        return all((self.controller, self.model[0] == 'R'))
+        return all((self.controller, self.model and self.model[0] == 'R'))
 
     @property
     def is_r10(self):
@@ -457,7 +457,7 @@ class Enclosure:
         Args:
         Returns: bool
         """
-        return all((self.controller, self.model[0] == 'F'))
+        return all((self.controller, self.model and self.model[0] == 'F'))
 
     @property
     def is_hseries(self):
@@ -466,7 +466,7 @@ class Enclosure:
         Args:
         Returns: bool
         """
-        return all((self.controller, self.model[0] == 'H'))
+        return all((self.controller, self.model and self.model[0] == 'H'))
 
     @property
     def is_mseries(self):
@@ -476,7 +476,7 @@ class Enclosure:
         Returns: bool
         """
         return all((
-            self.controller, not self.is_mini, self.model[0] == 'M'
+            self.controller, not self.is_mini, self.model and self.model[0] == 'M'
         ))
 
     @property
@@ -487,7 +487,7 @@ class Enclosure:
         Returns: bool
         """
         return all((
-            self.controller, self.model[0] == 'X'
+            self.controller, self.model and self.model[0] == 'X'
         ))
 
     @property


### PR DESCRIPTION
Performance team saw a strange crash in the new enclosure because they have 1x ES60 returning a product string that is unexpected. This crashed because `self.model` was set to an empty string so accessing the 0th index, failed. This adds another conditional to make sure we have `self.model` attribute populated before accessing the 0th index.

Original PR: https://github.com/truenas/middleware/pull/14352
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130824