### PR TITLE
NAS-130814 / 24.10-RC.1 / Add timeout to iscsi.target.logout_iqn (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -458,13 +458,13 @@ class iSCSITargetService(CRUDService):
                 raise OSError(cp.returncode, os.strerror(cp.returncode), err)
 
     @private
-    async def logout_iqn(self, ip, iqn, no_wait=False):
+    async def logout_iqn(self, ip, iqn, no_wait=False, timeout=30):
         cmd = ['iscsiadm', '-m', 'node', '-p', ip, '-T', iqn, '--logout']
         if no_wait:
             cmd.append('--no_wait')
         err = f'LOGOUT: {ip!r} {iqn!r}'
         try:
-            cp = await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8')
+            cp = await run(cmd, stderr=subprocess.STDOUT, encoding='utf-8', timeout=timeout)
         except Exception as e:
             err += f' ERROR: {str(e)}'
             raise UnexpectedFailure(err)


### PR DESCRIPTION
Add a (long) default timeout to `iscsi.target.logout_iqn`.  This will avoid non-terminating calls to `iscsi.target.logout_ha_targets`.

CI test run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/313/).

Original PR: https://github.com/truenas/middleware/pull/14355
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130814