### PR TITLE
Improve auditing of token auth failures

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1879,15 +1879,13 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                     )
                     break
 
-                datalen = len(msg.data)
-
                 try:
                     message = parse_message(connection.authenticated, msg.data)
                 except MsgSizeError as err:
                     if err.limit is not MsgSizeLimit.UNAUTHENTICATED:
                         origin = connection.origin.repr() if connection.origin else None
                         if connection.authenticated_credentials:
-                            creds =  connection.authenticated_credentials.dump()
+                            creds = connection.authenticated_credentials.dump()
                         else:
                             creds = None
 

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -23,7 +23,7 @@ from middlewared.utils.crypto import generate_token
 from middlewared.utils.time_utils import utc_now
 
 
-class TokenError(exception):
+class TokenError(Exception):
     pass
 
 

--- a/src/middlewared/middlewared/utils/audit.py
+++ b/src/middlewared/middlewared/utils/audit.py
@@ -10,6 +10,7 @@ API_KEY_PREFIX = '.API_KEY:'
 NODE_SESSION = '.TRUENAS_NODE'
 UNAUTHENTICATED = '.UNAUTHENTICATED'
 UNKNOWN_SESSION = '.UNKNOWN'
+TOKEN_EXPIRED = '.TOKEN_EXPIRED'  # used for expired tokens in auth.py
 
 
 def audit_username_from_session(cred) -> str:


### PR DESCRIPTION
This commit makes our audit messages more precise about the reason authentication with token failed and refines the filter for what constitutes an authentication failure for our auth failures alert.