### PR TITLE
NAS-130855 / 24.10-RC.1 / Fail pam authentication if service file missing (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -11,3 +11,4 @@ SKEL_PATH = '/etc/skel/'  # TODO evaluate whether this is still needed
 LEGACY_DEFAULT_HOME_PATH = '/nonexistent'
 DEFAULT_HOME_PATH = '/var/empty'
 DEFAULT_HOME_PATHS = (DEFAULT_HOME_PATH, LEGACY_DEFAULT_HOME_PATH)
+MIDDLEWARE_PAM_SERVICE = '/etc/pam.d/middleware'


### PR DESCRIPTION
If our dedicated middleware pam service file is for some reason missing we should try to regenerate it and if that fails then authentication should fail. The reason for this is that in the absence of the specified file libpam will fall through to the default PAM configuration, which could lead to unexpected behavior.

Original PR: https://github.com/truenas/middleware/pull/14368
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130855