### PR TITLE
NAS-130866 / 24.10-RC.1 / UPS shutdown event handling was failing to shutdown STANDBY node (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -315,7 +315,7 @@ class UPSService(SystemServiceService):
                     if await self.middleware.call('failover.status') == 'MASTER':
                         syslog.syslog(syslog.LOG_NOTICE, 'upssched-cmd "issuing shutdown" for passive node')
                         try:
-                            await self.middleware.call('failover.call_remote', 'ups.upssched_event', 'shutdown')
+                            await self.middleware.call('failover.call_remote', 'ups.upssched_event', ['shutdown'])
                         except Exception as e:
                             syslog.syslog(syslog.LOG_ERR, f'failed shutting down passive node with error {e}')
 


### PR DESCRIPTION
The parameters to `failover.call_remote` were missing `[]`.

Original PR: https://github.com/truenas/middleware/pull/14371
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130866