### PR TITLE
NAS-130882 / 24.10-RC.1 / Add tests to verify roles for apps (by sonicaj)

### DIFF
--- a/tests/api2/test_apps_images_roles.py
+++ b/tests/api2/test_apps_images_roles.py
@@ -1,0 +1,16 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+@pytest.mark.parametrize('method, role, valid_role, valid_role_exception', (
+    ('app.image.query', 'APPS_READ', True, False),
+    ('app.image.query', 'APPS_WRITE', True, False),
+    ('app.image.query', 'DOCKER_READ', False, False),
+    ('app.image.pull', 'APPS_READ', False, False),
+    ('app.image.pull', 'APPS_WRITE', True, False),
+    ('app.image.delete', 'APPS_READ', False, False),
+    ('app.image.delete', 'APPS_WRITE', True, True),
+))
+def test_apps_roles(unprivileged_user_fixture, method, role, valid_role, valid_role_exception):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=valid_role_exception)

--- a/tests/api2/test_apps_roles.py
+++ b/tests/api2/test_apps_roles.py
@@ -1,0 +1,23 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+@pytest.mark.parametrize('method, role, valid_role, valid_role_exception', (
+    ('app.query', 'APPS_READ', True, False),
+    ('app.query', 'APPS_WRITE', True, False),
+    ('app.query', 'DOCKER_READ', False, False),
+    ('app.config', 'APPS_READ', True, True),
+    ('app.config', 'APPS_WRITE', True, True),
+    ('app.config', 'DOCKER_READ', False, False),
+    ('app.update', 'APPS_READ', False, False),
+    ('app.update', 'APPS_WRITE', True, True),
+    ('app.create', 'APPS_READ', False, False),
+    ('app.create', 'APPS_WRITE', True, True),
+    ('app.delete', 'APPS_READ', False, False),
+    ('app.delete', 'APPS_WRITE', True, True),
+    ('app.convert_to_custom', 'APPS_READ', False, False),
+    ('app.convert_to_custom', 'APPS_WRITE', True, True),
+))
+def test_apps_roles(unprivileged_user_fixture, method, role, valid_role, valid_role_exception):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=valid_role_exception)

--- a/tests/api2/test_catalog_roles.py
+++ b/tests/api2/test_catalog_roles.py
@@ -1,0 +1,32 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+@pytest.mark.parametrize('method, role, valid_role, valid_role_exception', (
+    ('catalog.get_app_details', 'CATALOG_READ', True, True),
+    ('catalog.get_app_details', 'CATALOG_WRITE', True, True),
+    ('catalog.get_app_details', 'DOCKER_READ', False, False),
+    ('app.latest', 'CATALOG_READ', True, False),
+    ('app.latest', 'CATALOG_WRITE', True, False),
+    ('app.latest', 'APPS_WRITE', True, False),
+    ('app.available', 'CATALOG_READ', True, False),
+    ('app.available', 'CATALOG_WRITE', True, False),
+    ('app.available', 'APPS_WRITE', True, False),
+    ('app.categories', 'CATALOG_READ', True, False),
+    ('app.categories', 'CATALOG_WRITE', True, False),
+    ('app.categories', 'APPS_WRITE', True, False),
+    ('app.similar', 'CATALOG_READ', True, True),
+    ('app.similar', 'CATALOG_WRITE', True, True),
+    ('app.similar', 'APPS_WRITE', True, True),
+    ('catalog.apps', 'CATALOG_READ', True, False),
+    ('catalog.apps', 'CATALOG_WRITE', True, False),
+    ('catalog.apps', 'DOCKER_READ', False, False),
+    ('catalog.sync', 'CATALOG_READ', False, False),
+    ('catalog.sync', 'CATALOG_WRITE', True, False),
+    ('catalog.update', 'CATALOG_READ', False, True),
+    ('catalog.update', 'CATALOG_WRITE', True, True),
+
+))
+def test_apps_roles(unprivileged_user_fixture, method, role, valid_role, valid_role_exception):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=valid_role_exception)

--- a/tests/api2/test_docker_roles.py
+++ b/tests/api2/test_docker_roles.py
@@ -1,0 +1,20 @@
+import pytest
+
+from middlewared.test.integration.assets.roles import common_checks
+
+
+@pytest.mark.parametrize('method, role, valid_role, valid_role_exception', (
+    ('docker.status', 'DOCKER_READ', True, False),
+    ('docker.status', 'DOCKER_WRITE', True, False),
+    ('docker.status', 'CATALOG_READ', False, False),
+    ('docker.config', 'DOCKER_READ', True, False),
+    ('docker.config', 'DOCKER_WRITE', True, False),
+    ('docker.config', 'CATALOG_READ', False, False),
+    ('docker.lacks_nvidia_drivers', 'DOCKER_READ', True, False),
+    ('docker.lacks_nvidia_drivers', 'DOCKER_WRITE', True, False),
+    ('docker.lacks_nvidia_drivers', 'CATALOG_READ', False, False),
+    ('docker.update', 'DOCKER_READ', False, False),
+    ('docker.update', 'DOCKER_WRITE', True, True),
+))
+def test_apps_roles(unprivileged_user_fixture, method, role, valid_role, valid_role_exception):
+    common_checks(unprivileged_user_fixture, method, role, valid_role, valid_role_exception=valid_role_exception)


### PR DESCRIPTION
This commit adds an integration tests to validate roles for apps plugin.

Original PR: https://github.com/truenas/middleware/pull/14380
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130882