### PR TITLE
NAS-130861 / 24.10-RC.1 / Define custom address pool capacity for docker (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -22,6 +22,16 @@ def render(service, middleware):
         'exec-opts': ['native.cgroupdriver=cgroupfs'],
         'iptables': True,
         'storage-driver': 'overlay2',
+        'default-address-pools': [
+            {
+                'base': '172.30.0.0/16',
+                'size': 27
+            },
+            {
+                'base': '172.31.0.0/16',
+                'size': 27
+            },
+        ],
     }
     isolated = middleware.call_sync('system.advanced.config')['isolated_gpu_pci_ids']
     for gpu in filter(lambda x: x not in isolated, get_nvidia_gpus()):


### PR DESCRIPTION
This commit defines custom address pools to optimize Docker network creation capacity. The pools are set to 172.30.0.0/16 and 172.31.0.0/16 with a /27 subnet size, allowing for up to 4096 Docker networks, each with 32 IP addresses. This change significantly increases the number of available Docker networks, which is crucial for adding large number of apps which are meant to run simultaneously because by default behaviour the capacity would roughly be at 32 networks meaning roughly 32 apps.

Original PR: https://github.com/truenas/middleware/pull/14370
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130861