### PR TITLE
NAS-130883 / 24.10-RC.1 / Make sure vm.query does not fail (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -4,6 +4,7 @@ import logging
 from middlewared.service import accepts, Service
 from middlewared.schema import Str, Dict, Int
 from middlewared.utils.cpu import cpu_info
+from middlewared.utils.zfs import query_imported_fast_impl
 
 from .netdata import ClientConnectError, Netdata
 from .utils import calculate_disk_space_for_netdata, get_metrics_approximation, TIER_0_POINT_SIZE, TIER_1_POINT_SIZE
@@ -52,8 +53,8 @@ class NetdataService(Service):
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
-            self.middleware.call_sync('zfs.pool.query', [], {'count': True}),
-            self.middleware.call_sync('vm.query', [], {'count': True}),
+            len(query_imported_fast_impl()),
+            self.middleware.call_sync('datastore.query', 'vm.vm', [], {'count': True}),
             len(glob.glob('/sys/fs/cgroup/**/*.service')),
         )
 

--- a/src/middlewared/middlewared/plugins/vm/connection.py
+++ b/src/middlewared/middlewared/plugins/vm/connection.py
@@ -65,7 +65,10 @@ class LibvirtConnectionMixin:
         if not self._is_libvirt_connection_alive():
             raise CallError('Failed to connect to libvirt')
 
-    def _check_setup_connection(self):
+    def _safely_check_setup_connection(self, timeout: int = 10):
         if not self._is_connection_alive():
-            self.middleware.call_sync('vm.setup_libvirt_connection', 10)
+            self.middleware.call_sync('vm.setup_libvirt_connection', timeout)
+
+    def _check_setup_connection(self):
+        self._safely_check_setup_connection()
         self._check_connection_alive()

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -101,9 +101,11 @@ class VMService(CRUDService, VMSupervisorMixin):
         status = {}
         kvm_supported = self._is_kvm_supported()
         if rows and kvm_supported:
-            self._check_setup_connection()
+            self._safely_check_setup_connection(5)
+
+        libvirt_running = self._is_connection_alive()
         for row in rows:
-            status[row['id']] = self.status_impl(row) if kvm_supported else get_default_status()
+            status[row['id']] = self.status_impl(row) if libvirt_running else get_default_status()
 
         return {
             'status': status,


### PR DESCRIPTION
## Problem

While diagnosing another problem with libvirt, i saw we were not able to calculate netdata disk space because `vm.query` was failing there as libvirt was misbehaving (that's still being investigated).

## Solution

Make sure `vm.query` does not fail if libvirt is not running.

Original PR: https://github.com/truenas/middleware/pull/14382
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130883