### PR TITLE
NAS-130967 / 25.04 / Provide cpu topology extensions to VM if requested (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-08-30_22-13_cpu_topology_extension.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-08-30_22-13_cpu_topology_extension.py
@@ -1,0 +1,26 @@
+"""
+Providing cpu topology extension to VMs
+
+Revision ID: d24d6760fda4
+Revises: 7b13df980355
+Create Date: 2024-08-30 22:13:09.525439+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'd24d6760fda4'
+down_revision = '7b13df980355'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vm_vm', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('enable_cpu_topology_extension', sa.Boolean(), nullable=False, server_default='0')
+        )
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-09-02_16-54_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-09-02_16-54_merge.py
@@ -1,0 +1,19 @@
+"""Merge
+
+Revision ID: 991d17a5b3a2
+Revises: d4d5d52be239, 7b13df980355
+Create Date: 2024-09-02 16:54:59.547731+00:00
+"""
+
+revision = '991d17a5b3a2'
+down_revision = ('d4d5d52be239', 'd24d6760fda4')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/domain_xml.py
@@ -75,6 +75,8 @@ def cpu_xml(vm_data, context):
     features = []
     if vm_data['cpu_mode'] == 'HOST-PASSTHROUGH':
         features.append(create_element('cache', mode='passthrough'))
+        if vm_data['enable_cpu_topology_extension']:
+            features.append(create_element('feature', policy='require', name='topoext'))
 
     cpu_nodes = [
         create_element(

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -57,6 +57,7 @@ class VMModel(sa.Model):
     command_line_args = sa.Column(sa.Text(), default='', nullable=False)
     bootloader_ovmf = sa.Column(sa.String(1024), default='OVMF_CODE.fd')
     trusted_platform_module = sa.Column(sa.Boolean(), default=False)
+    enable_cpu_topology_extension = sa.Column(sa.Boolean(), default=False)
 
 
 @functools.cache
@@ -145,6 +146,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         Int('threads', default=1),
         Str('cpuset', default=None, null=True, validators=[NumericSet()]),
         Str('nodeset', default=None, null=True, validators=[NumericSet()]),
+        Bool('enable_cpu_topology_extension', default=False),
         Bool('pin_vcpus', default=False),
         Bool('suspend_on_snapshot', default=False),
         Bool('trusted_platform_module', default=False),

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_libvirt_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_libvirt_xml.py
@@ -36,6 +36,7 @@ def test_command_line_xml(vm_data, expected_xml):
         'cpuset': None,
         'pin_vcpus': False,
         'nodeset': None,
+        'enable_cpu_topology_extension': False
     }, {'cpu_model_choices': {}}, [
         '<cpu mode="custom"><topology sockets="1" cores="2" threads="3" /></cpu>',
         '<vcpu>6</vcpu>',
@@ -49,10 +50,26 @@ def test_command_line_xml(vm_data, expected_xml):
         'cpuset': None,
         'pin_vcpus': False,
         'nodeset': None,
+        'enable_cpu_topology_extension': False
     }, {'cpu_model_choices': {}}, [
         '<cpu mode="host-passthrough"><topology sockets="1" cores="2" threads="3" /><cache mode="passthrough" /></cpu>',
         '<vcpu>6</vcpu>',
     ]),
+    ({
+         'cpu_mode': 'HOST-PASSTHROUGH',
+         'vcpus': 1,
+         'cores': 2,
+         'threads': 3,
+         'cpu_model': None,
+         'cpuset': None,
+         'pin_vcpus': False,
+         'nodeset': None,
+         'enable_cpu_topology_extension': True
+     }, {'cpu_model_choices': {}}, [
+         '<cpu mode="host-passthrough"><topology sockets="1" cores="2" threads="3" />'
+         '<cache mode="passthrough" /><feature policy="require" name="topoext" /></cpu>',
+         '<vcpu>6</vcpu>',
+     ]),
     ({
         'cpu_mode': 'CUSTOM',
         'vcpus': 1,
@@ -62,6 +79,7 @@ def test_command_line_xml(vm_data, expected_xml):
         'cpuset': None,
         'pin_vcpus': False,
         'nodeset': None,
+        'enable_cpu_topology_extension': False
     }, {'cpu_model_choices': {'pentium': 'pentium', 'pentium2': 'pentium2'}}, [
         '<cpu mode="custom"><topology sockets="1" cores="2" threads="3" />'
         '<model fallback="forbid">pentium</model></cpu>',
@@ -76,6 +94,7 @@ def test_command_line_xml(vm_data, expected_xml):
         'cpuset': '1-2,4-6',
         'pin_vcpus': True,
         'nodeset': None,
+        'enable_cpu_topology_extension': False,
     }, {'cpu_model_choices': {}}, [
         '<cpu mode="custom"><topology sockets="1" cores="2" threads="3" /></cpu>',
         '<vcpu cpuset="1-2,4-6">6</vcpu>',
@@ -91,6 +110,7 @@ def test_command_line_xml(vm_data, expected_xml):
         'cpuset': None,
         'pin_vcpus': False,
         'nodeset': '1-2,4-6',
+        'enable_cpu_topology_extension': False
     }, {'cpu_model_choices': {}}, [
         '<cpu mode="custom"><topology sockets="1" cores="2" threads="3" /></cpu>',
         '<vcpu>6</vcpu>',


### PR DESCRIPTION
**Problem:**  
Users with AMD CPUs who have SMT (Simultaneous Multithreading) enabled are currently unable to passthrough their CPUs with SMT cores to guest VMs. This is because, by default, SMT support is disabled in libvirtd and requires specific features to be enabled.

**Solution:**  
Add a new field in the VMs configuration that allows users to enable SMT passthrough for their CPUs. When this field is enabled, the relevant features will be added to the CPU XML configuration, ensuring that SMT-enabled CPUs can be properly passed through to the guest if host passthrough is also enabled.

Original PR: https://github.com/truenas/middleware/pull/14392
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130967