### PR TITLE
NAS-130434 / 24.04.2.1 / drop ntb0 MTU to 64000 (by yocalebo) (by bugclerk)

### DIFF
--- a/src/freenas/etc/systemd/network/10-persistent-net.link
+++ b/src/freenas/etc/systemd/network/10-persistent-net.link
@@ -1,5 +1,15 @@
 [Match]
 Driver=ntb_netdev
 
+
 [Link]
 Name=ntb0
+# TODO: at time of writing, ntb on SCALE has pathological
+# behavior related TCP/IP Window size calculation whereby
+# the receiving side clamps the window size to 0 causing
+# recalculation which, ultimately, ends with behavior
+# described in https://en.wikipedia.org/wiki/Silly_window_syndrome
+# The work-around is to drop MTU size a bit which fixes
+# the scenario altogether. When we discover why this is
+# happening, we should remove the MTUBytes line.
+MTUBytes=64000


### PR DESCRIPTION
At time of writing, ntb on SCALE has pathological behavior related TCP/IP Window size calculation whereby the receiving side clamps the window size to 0 causing recalculation which, ultimately, ends with behavior described in https://en.wikipedia.org/wiki/Silly_window_syndrome. The work-around is to drop MTU size a bit which fixes the scenario altogether. When we discover why this is happening, we should remove the MTUBytes line in this file.

Original PR: https://github.com/truenas/middleware/pull/14136
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130434

Original PR: https://github.com/truenas/middleware/pull/14137
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130434