### PR TITLE
NAS-130968 / 24.10-RC.1 / Do not attempt to start libvirt on shutdown (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -100,11 +100,12 @@ class VMService(CRUDService, VMSupervisorMixin):
     @private
     def extend_context(self, rows, extra):
         status = {}
+        shutting_down = self.middleware.call_sync('system.state') == 'SHUTTING_DOWN'
         kvm_supported = self._is_kvm_supported()
-        if rows and kvm_supported:
+        if shutting_down is False and rows and kvm_supported:
             self._safely_check_setup_connection(5)
 
-        libvirt_running = self._is_connection_alive()
+        libvirt_running = shutting_down is False and self._is_connection_alive()
         for row in rows:
             status[row['id']] = self.status_impl(row) if libvirt_running else get_default_status()
 


### PR DESCRIPTION

**Problem:**  
During the shutdown process, `vm.query` attempts to establish a connection with libvirtd, which is already stopped by that time. This results in an attempt to start libvirtd, which fails because systemd does not permit services to start during shutdown.

**Solution:**  
Modify `vm.query` to prevent it from trying to establish a connection with libvirtd during the system's shutdown process, avoiding the issue entirely.

Original PR: https://github.com/truenas/middleware/pull/14393
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130968