### PR TITLE
NAS-130890 / 24.10-RC.1 / Fix UPS events (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -26,7 +26,7 @@ from middlewared.alert.base import (
     ProThreadedAlertService,
 )
 from middlewared.alert.base import UnavailableException, AlertService as _AlertService
-from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, Patch, returns, Ref, Str
+from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, OROperator, Patch, returns, Ref, Str
 from middlewared.service import (
     ConfigService, CRUDService, Service, ValidationErrors,
     job, periodic, private,
@@ -930,59 +930,28 @@ class AlertService(Service):
         await self.middleware.call("alert.send_alerts")
 
     @private
-    @accepts(Str("klass"), Any("query", null=True, default=None))
+    @accepts(
+        OROperator(
+            Str("klass"),
+            List('klass', items=[Str('klassname')], default=None),
+        ),
+        Any("query", null=True, default=None))
     @job(lock="process_alerts", transient=True)
     async def oneshot_delete(self, job, klass, query):
         """
-        Deletes one-shot alerts of specified `klass`, passing `query` to `klass.delete` method.
+        Deletes one-shot alerts of specified `klass` or klasses, passing `query`
+        to `klass.delete` method.
 
         It's not an error if no alerts matching delete `query` exist.
 
-        :param klass: one-shot alert class name (without the `AlertClass` suffix).
+        :param klass: either one-shot alert class name (without the `AlertClass` suffix), or list thereof.
         :param query: `query` that will be passed to `klass.delete` method.
         """
 
-        try:
-            klass = AlertClass.class_by_name[klass]
-        except KeyError:
-            raise CallError(f"Invalid alert source: {klass!r}")
-
-        if not issubclass(klass, OneShotAlertClass):
-            raise CallError(f"Alert class {klass!r} is not a one-shot alert source")
-
-        related_alerts, unrelated_alerts = bisect(lambda a: (a.node, a.klass) == (self.node, klass),
-                                                  self.alerts)
-        left_alerts = await klass(self.middleware).delete(related_alerts, query)
-        deleted = False
-        for deleted_alert in related_alerts:
-            if deleted_alert not in left_alerts:
-                self.alerts.remove(deleted_alert)
-                deleted = True
-
-        if deleted:
-            # We need to flush alerts to the database immediately after deleting oneshot alerts.
-            # Some oneshot alerts can only de deleted programmatically (i.e. cloud sync oneshot alerts are deleted
-            # when deleting cloud sync task). If we delete a cloud sync task and then reboot the system abruptly,
-            # the alerts won't be flushed to the database and on next boot an alert for nonexisting cloud sync task
-            # will appear, and it won't be deletable.
-            await self.middleware.call("alert.flush_alerts")
-
-            await self.middleware.call("alert.send_alerts")
-
-    @private
-    @accepts(
-        List('klasses', items=[Str('klass')], required=True),
-        Any("query", null=True, default=None))
-    @job(lock="process_alerts", transient=True)
-    async def oneshot_bulk_delete(self, job, klasses, query):
-        """
-        Deletes one-shot alerts of specified `klasses`, passing `query` to `klass.delete` method.
-
-        It's not an error if no alerts matching delete `query` exist.
-
-        :param klasses: list of one-shot alert class names (without the `AlertClass` suffix).
-        :param query: `query` that will be passed to `klass.delete` method.
-        """
+        if isinstance(klass, list):
+            klasses = klass
+        else:
+            klasses = [klass]
 
         deleted = False
         for klassname in klasses:

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -274,7 +274,7 @@ class UPSService(SystemServiceService):
     @private
     async def dismiss_alerts(self):
         alerts = list((await self.alerts_mapping()).values())
-        await self.middleware.call('alert.oneshot_bulk_delete', alerts)
+        await self.middleware.call('alert.oneshot_delete', alerts)
 
     @private
     @accepts(

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -273,8 +273,8 @@ class UPSService(SystemServiceService):
 
     @private
     async def dismiss_alerts(self):
-        for alert in (await self.alerts_mapping()).values():
-            await self.middleware.call('alert.oneshot_delete', alert)
+        alerts = list((await self.alerts_mapping()).values())
+        await self.middleware.call('alert.oneshot_bulk_delete', alerts)
 
     @private
     @accepts(

--- a/tests/api2/test_530_ups.py
+++ b/tests/api2/test_530_ups.py
@@ -226,10 +226,11 @@ def test__ups_onbatt_to_online(ups_running, dummy_ups_driver_configured):
 
 def test__ups_online_to_onbatt_lowbattery(ups_running, dummy_ups_driver_configured):
     assert 'UPSOnBattery' not in [alert['klass'] for alert in call('alert.list')]
-    write_fake_data({'battery.charge': 10, 'ups.status': 'OB LB'})
+    write_fake_data({'battery.charge': 90, 'ups.status': 'OB'})
     alert = wait_for_alert('UPSOnBattery')
     assert alert
-    assert 'battery.charge: 10' in alert['formatted'], alert
+    assert 'battery.charge: 90' in alert['formatted'], alert
+    write_fake_data({'battery.charge': 10, 'ups.status': 'OB LB'})
     alert = wait_for_alert('UPSBatteryLow')
     assert alert
     assert 'battery.charge: 10' in alert['formatted'], alert


### PR DESCRIPTION
A recent change (PR #14319) changed the default `lock_queue_size` from `None` to `5`.

However, `ups.dismiss_alerts` was calling `alert.oneshot_delete` 6 times.  Further, shortly afterwards it was calling `alert.oneshot_create` which uses the same lock.  **Depending upon timing**, this _could_ result in the `alert.oneshot_create` not running.

Rectify(/avoid) by adding a `alert.oneshot_bulk_delete`, so that `ups.dismiss_alerts` only needs to make a single call.  (This has the added benefit of being slightly more efficient.)

(Choosing backport-24.10-RC.1 because the above mentioned PR was also backported there.)

Original PR: https://github.com/truenas/middleware/pull/14391
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130890