### PR TITLE
NAS-130995 / 24.10-RC.1 / Allow retrieving logs of apps in crashed state (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -18,6 +18,7 @@ from .ix_apps.metadata import update_app_metadata, update_app_metadata_for_porta
 from .ix_apps.path import get_installed_app_path, get_installed_app_version_path
 from .ix_apps.query import list_apps
 from .ix_apps.setup import setup_install_app_dir
+from .ix_apps.utils import AppState
 from .version_utils import get_latest_version_from_app_versions
 
 
@@ -33,7 +34,7 @@ class AppService(CRUDService):
         'app_entry',
         Str('name'),
         Str('id'),
-        Str('state', enum=['STOPPED', 'DEPLOYING', 'RUNNING']),
+        Str('state', enum=[state.value for state in AppState]),
         Bool('upgrade_available'),
         Str('human_version'),
         Str('version'),

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
@@ -1,7 +1,22 @@
+import enum
+
 from catalog_reader.library import RE_VERSION  # noqa
 from middlewared.plugins.apps_images.utils import normalize_reference  # noqa
 from middlewared.plugins.apps.schema_utils import CONTEXT_KEY_NAME  # noqa
 from middlewared.plugins.apps.utils import IX_APPS_MOUNT_PATH, PROJECT_PREFIX, run  # noqa
+
+
+class AppState(enum.Enum):
+    CRASHED = 'CRASHED'
+    DEPLOYING = 'DEPLOYING'
+    RUNNING = 'RUNNING'
+    STOPPED = 'STOPPED'
+
+
+class ContainerState(enum.Enum):
+    EXITED = 'exited'
+    RUNNING = 'running'
+    STARTING = 'starting'
 
 
 def get_app_name_from_project_name(project_name: str) -> str:

--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -3,6 +3,7 @@ from middlewared.service import private, Service
 
 from middlewared.utils.gpu import get_nvidia_gpus
 
+from .ix_apps.utils import ContainerState
 from .resources_utils import get_normalized_gpu_choices
 
 
@@ -43,7 +44,9 @@ class AppService(Service):
                 'id': c['id'],
             } for c in (
                 await self.middleware.call('app.get_instance', app_name)
-            )['active_workloads']['container_details'] if (options['alive_only'] is False or c['state'] == 'running')
+            )['active_workloads']['container_details'] if (
+                options['alive_only'] is False or ContainerState(c['state']) == ContainerState.RUNNING
+            )
         }
 
     @accepts(Str('app_name'), roles=['APPS_READ'])


### PR DESCRIPTION
## Context

Currently only those app's logs can be viewed which have containers which are either all running or at least one of them is in running or starting state. However this leads to the problem when an app has containers where all of them have crashed for any reason i.e bad configuration / app issues, unfortunately it is not possible to view logs for those apps yet.

A `CRASHED` state has been introduced which covers the case mentioned above where all the containers in the app if have crashed, that app is marked as `CRASHED` and we would still be able to view logs of such apps.

Original PR: https://github.com/truenas/middleware/pull/14419
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130995