### PR TITLE
NAS-131017 / 25.04 / Fix zpool.status regression

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -43,9 +43,9 @@ class ZPoolService(Service):
     def status_impl(self, pool_name, vdev_type, members, **kwargs):
         real_paths = kwargs.setdefault('real_paths', False)
         final = dict()
-        for member in filter(lambda x: x['vdev_type'] != 'file', members.values()):
+        for member in filter(lambda x: x.get('vdev_type') != 'file', members.values()):
             vdev_disks = self.resolve_block_paths(get_zfs_vdev_disks(member), real_paths)
-            if member['vdev_type'] == 'disk':
+            if member.get('vdev_type') in ('disk', 'dspare'):
                 disk = self.resolve_block_path(member['path'], real_paths)
                 final[disk] = get_normalized_disk_info(pool_name, member, 'stripe', vdev_type, vdev_disks)
             else:

--- a/src/middlewared/middlewared/plugins/zfs_/status_util.py
+++ b/src/middlewared/middlewared/plugins/zfs_/status_util.py
@@ -18,12 +18,14 @@ def get_normalized_disk_info(pool_name: str, disk: dict, vdev_name: str, vdev_ty
 
 
 def get_zfs_vdev_disks(vdev) -> list:
-    if vdev['state'] in ('UNAVAIL', 'OFFLINE'):
+    # We get this safely because of draid based vdevs
+    if vdev.get('state') in ('UNAVAIL', 'OFFLINE'):
         return []
 
-    if vdev['vdev_type'] == 'disk':
+    vdev_type = vdev.get('vdev_type')
+    if vdev_type == 'disk':
         return [vdev['path']]
-    elif vdev['vdev_type'] == 'file':
+    elif vdev_type == 'file':
         return []
     else:
         result = []

--- a/tests/api2/test_zpool_status.py
+++ b/tests/api2/test_zpool_status.py
@@ -10,10 +10,10 @@ POOL_NAME = 'test_format_pool'
 
 def get_disk_uuid_mapping(unused_disks):
     disk_uuid = {}
-    for uuid in os.listdir('/dev/disk/by-partuuid'):
-        resolved_path = call('zpool.resolve_block_path', os.path.join('/dev/disk/by-partuuid', uuid), True)
+    for disk_path in call('filesystem.listdir', '/dev/disk/by-partuuid'):
+        resolved_path = call('zpool.resolve_block_path', disk_path['path'], True)
         if resolved_path in unused_disks:
-            disk_uuid[resolved_path] = os.path.join('/dev/disk/by-partuuid', uuid)
+            disk_uuid[resolved_path] = disk_path['path']
     return disk_uuid
 
 


### PR DESCRIPTION
## Context

Integration test for `zpool.status` was failing earlier because we were not using `filesystem.listdir` to list disks and hence the relevant mapping could not be generated which eventually led to failure of the test.