### PR TITLE
NAS-131037 / 25.04 / Be more selective about file metdata in listdir

### DIFF
--- a/src/middlewared/middlewared/utils/filesystem/directory.py
+++ b/src/middlewared/middlewared/utils/filesystem/directory.py
@@ -36,6 +36,9 @@ class DirectoryRequestMask(enum.IntFlag):
     XATTR - list of extended attributes (requires listxattr call)
 
     ZFS_ATTRS - include ZFS attributes (requires fcntl call per file)
+
+    NOTE: this changes to this should also be reflected in API test
+    `test_listdir_request_mask.py`
     """
     ACL = enum.auto()
     CTLDIR = enum.auto()
@@ -245,9 +248,9 @@ class DirectoryIterator():
                     attr_mask = fget_zfs_file_attributes(fd)
                     zfs_attrs = zfs_attributes_dump(attr_mask)
                 except OSError as e:
-                    # non-ZFS filesystems will fail with ENOTTY
+                    # non-ZFS filesystems will fail with ENOTTY or EINVAL
                     # In this case we set `None` to indicate non-ZFS
-                    if e.errno != errno.ENOTTY:
+                    if e.errno not in (errno.ENOTTY, errno.EINVAL):
                         raise e from None
 
                     zfs_attrs = None

--- a/tests/api2/test_listdir_request_mask.py
+++ b/tests/api2/test_listdir_request_mask.py
@@ -1,0 +1,31 @@
+import enum
+import pytest
+
+from middlewared.test.integration.utils import call
+
+
+class DirectoryRequestMask(enum.IntFlag):
+    ACL = enum.auto()
+    CTLDIR = enum.auto()
+    REALPATH = enum.auto()
+    XATTRS = enum.auto()
+    ZFS_ATTRS = enum.auto()
+
+
+@pytest.mark.parametrize('select_key,request_mask', [
+    ('realpath', DirectoryRequestMask.REALPATH.value),
+    ('acl', DirectoryRequestMask.ACL.value),
+    ('zfs_attrs', DirectoryRequestMask.ZFS_ATTRS.value),
+    ('is_ctldir', DirectoryRequestMask.CTLDIR.value),
+    ('xattrs', DirectoryRequestMask.XATTRS.value),
+    (['xattrs', 'user_xattrs'], DirectoryRequestMask.XATTRS.value),
+    ([], None),
+    ('name', 0)
+])
+def test__select_to_request_mask(select_key, request_mask):
+    if select_key == []:
+        val = call('filesystem.listdir_request_mask', [])
+        assert val is None
+    else:
+        val = call('filesystem.listdir_request_mask', [select_key])
+        assert val == request_mask


### PR DESCRIPTION
The directory iterator we use is configurable about what file metdata to retrieve. This can in some situations significantly improve performance of generating directory listing.

This commit modifies the request mask we pass to the iterator based on the user-provided filter-options.