### PR TITLE
NAS-131044 / 25.04 / Add an endpoint for UI to retrieve available space for ix-apps

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/resources.py
+++ b/src/middlewared/middlewared/plugins/apps/resources.py
@@ -120,7 +120,7 @@ class AppService(Service):
         Returns space available in bytes in the configured apps pool which apps can consume
         """
         await self.middleware.call('docker.state.validate')
-        return (await self.middleware.call('filesystem.statfs', IX_APPS_MOUNT_PATH))['free_bytes']
+        return (await self.middleware.call('filesystem.statfs', IX_APPS_MOUNT_PATH))['avail_bytes']
 
     @accepts(roles=['APPS_READ'])
     @returns(Dict('gpu_choices', additional_attrs=True))


### PR DESCRIPTION
This commit adds changes to add an endpoint which UI can consume to retrieve available space in ix-apps dataset so it can show to a user when he wants to install an app that by default X space is available in ix-apps dataset.