### PR TITLE
NAS-130863 / 24.10-RC.1 / Properly try waiting for default interface to come up before consuming in apps (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -58,7 +58,7 @@ class DockerSetupService(Service):
     async def validate_interfaces(self):
         default_iface, success = wait_for_default_interface_link_state_up()
         if default_iface is None:
-            raise CallError('Unable to determine default interface.')
+            raise CallError('Unable to determine default interface')
         elif not success:
             raise CallError(f'Default interface {default_iface!r} is not in active state')
 

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -56,7 +56,7 @@ class DockerSetupService(Service):
 
     @private
     async def validate_interfaces(self):
-        default_iface, success = wait_for_default_interface_link_state_up()
+        default_iface, success = await self.middleware.run_in_thread(wait_for_default_interface_link_state_up)
         if default_iface is None:
             raise CallError('Unable to determine default interface')
         elif not success:

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -50,6 +50,13 @@ class DockerSetupService(Service):
                 errno=CallError.EDATASETISLOCKED,
             )
 
+        # What we want to validate now is that the interface on default route is up and running
+        # This is problematic for bridge interfaces which can or cannot come up in time
+
+    @private
+    async def validate_interfaces(self):
+        pass
+
     @private
     async def status_change(self):
         config = await self.middleware.call('docker.config')

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/trigger_migration.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/trigger_migration.py
@@ -28,6 +28,13 @@ class K8stoDockerMigrationService(Service):
         if not k8s_pool:
             return
 
+        # We would like to wait for interfaces like bridge to come up before we proceed with migration
+        # because they are notorious and can take some time to actually come up and if they are the default
+        # interface, then migration is bound to fail as catalog won't sync because of no network
+        # connectivity and us not able to see if an app is available in newer catalog. If the default interface
+        # is not up, then we will fail the migration here and early
+        await self.middleware.call('docker.state.validate_interfaces')
+
         list_backup_job = await self.middleware.call('k8s_to_docker.list_backups', k8s_pool)
         await list_backup_job.wait()
         if list_backup_job.error or list_backup_job.result['error']:

--- a/src/middlewared/middlewared/utils/interface.py
+++ b/src/middlewared/middlewared/utils/interface.py
@@ -1,4 +1,9 @@
 import contextlib
+import os
+import time
+
+
+IFACE_LINK_STATE_MAX_WAIT: int = 60
 
 
 def get_default_interface() -> str | None:
@@ -10,3 +15,18 @@ def get_default_interface() -> str | None:
     for entry in filter(lambda i: len(i) == 11, data):
         if entry[1] == '00000000' and entry[1] == entry[7]:
             return entry[0]
+
+
+def wait_on_interface_link_state_up(interface: str) -> bool:
+    sleep_interval = 1
+    time_waited = 0
+    while time_waited < IFACE_LINK_STATE_MAX_WAIT:
+        with contextlib.suppress(FileNotFoundError):
+            with open(os.path.join('/sys/class/net', interface, 'operstate'), 'r') as f:
+                if f.read().strip().lower() == 'up':
+                    return True
+
+        time.sleep(sleep_interval)
+        time_waited += sleep_interval
+
+    return False

--- a/src/middlewared/middlewared/utils/interface.py
+++ b/src/middlewared/middlewared/utils/interface.py
@@ -4,17 +4,17 @@ import time
 
 
 IFACE_LINK_STATE_MAX_WAIT: int = 60
+RTF_GATEWAY: int = 0x0002
+RTF_UP: int = 0x0001
 
 
 def get_default_interface() -> str | None:
-    data = []
     with contextlib.suppress(FileNotFoundError):
         with open('/proc/net/route', 'r') as f:
-            data = [line.split() for line in f.readlines()]
-
-    for entry in filter(lambda i: len(i) == 11, data):
-        if entry[1] == '00000000' and entry[1] == entry[7]:
-            return entry[0]
+            for entry in filter(lambda i: len(i) == 11, map(str.split, f.readlines()[1:])):
+                with contextlib.suppress(ValueError):
+                    if int(entry[3], 16) == (RTF_UP | RTF_GATEWAY):
+                        return entry[0].strip()
 
 
 def wait_on_interface_link_state_up(interface: str) -> bool:

--- a/src/middlewared/middlewared/utils/interface.py
+++ b/src/middlewared/middlewared/utils/interface.py
@@ -30,3 +30,11 @@ def wait_on_interface_link_state_up(interface: str) -> bool:
         time_waited += sleep_interval
 
     return False
+
+
+def wait_for_default_interface_link_state_up() -> tuple[str | None, bool]:
+    default_interface = get_default_interface()
+    if default_interface is None:
+        return default_interface, False
+
+    return default_interface, wait_on_interface_link_state_up(default_interface)

--- a/src/middlewared/middlewared/utils/interface.py
+++ b/src/middlewared/middlewared/utils/interface.py
@@ -1,0 +1,12 @@
+import contextlib
+
+
+def get_default_interface() -> str | None:
+    data = []
+    with contextlib.suppress(FileNotFoundError):
+        with open('/proc/net/route', 'r') as f:
+            data = [line.split() for line in f.readlines()]
+
+    for entry in filter(lambda i: len(i) == 11, data):
+        if entry[1] == '00000000' and entry[1] == entry[7]:
+            return entry[0]


### PR DESCRIPTION
This PR adds changes to try and wait for default interface to come up before trying to consume networking in apps, this is especially problematic for bridge interfaces as they can take some time to come in ready state.

Original PR: https://github.com/truenas/middleware/pull/14431
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130863