### PR TITLE
NAS-131063 / 25.04 / Make sure docker networking is not broken after interface sync

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/docker/networks.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/docker/networks.py
@@ -1,0 +1,13 @@
+from .casing import convert_case_for_dict_or_list
+from .utils import get_docker_client
+
+
+def list_networks() -> list[dict]:
+    networks = []
+    with get_docker_client() as client:
+        for network in client.networks.list(greedy=False):
+            attrs = network.attrs | {'short_id': network.short_id}
+            attrs['enable_ipv6'] = attrs.pop('EnableIPv6', False)
+            networks.append(convert_case_for_dict_or_list(attrs))
+
+    return networks

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,6 +1,6 @@
 from middlewared.plugins.apps.ix_apps.docker.networks import list_networks
 from middlewared.schema import Dict, Str
-from middlewared.service import CRUDService, filterable
+from middlewared.service import CRUDService, filterable, private
 from middlewared.utils import filter_list
 
 
@@ -42,3 +42,7 @@ class DockerNetworkService(CRUDService):
             })
 
         return filter_list(networks, filters, options)
+
+    @private
+    def interfaces_mapping(self):
+        return [f'br-{network["short_id"]}' for network in self.query()]

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,0 +1,28 @@
+from middlewared.schema import Dict, Str
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+
+class DockerNetworkService(CRUDService):
+
+    class Config:
+        namespace = 'docker.network'
+        datastore_primary_key_type = 'string'
+        cli_namespace = 'docker.network'
+        role_prefix = 'DOCKER'
+
+    ENTRY = Dict(
+        'docker_network_entry',
+        Str('id', required=True),
+        Str('name', required=True),
+        Str('short_id', required=True),
+        additional_attrs=True,
+    )
+
+    @filterable
+    def query(self, app, filters, options):
+        """
+        Query all docker networks
+        """
+        if not self.middleware.call_sync('docker.state.validate', False):
+            return filter_list([], filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -14,9 +14,14 @@ class DockerNetworkService(CRUDService):
 
     ENTRY = Dict(
         'docker_network_entry',
-        Str('id', required=True),
-        Str('name', required=True),
-        Str('short_id', required=True),
+        Dict('ipam', additional_attrs=True, null=True),
+        Dict('labels', additional_attrs=True, null=True),
+        Str('created', required=True, null=True),
+        Str('driver', required=True, null=True),
+        Str('id', required=True, null=True),
+        Str('name', required=True, null=True),
+        Str('scope', required=True, null=True),
+        Str('short_id', required=True, null=True),
         additional_attrs=True,
     )
 
@@ -28,4 +33,12 @@ class DockerNetworkService(CRUDService):
         if not self.middleware.call_sync('docker.state.validate', False):
             return filter_list([], filters, options)
 
-        return filter_list(list_networks(), filters, options)
+        networks = []
+        for network in list_networks():
+            networks.append({
+                k: network.get(k) for k in (
+                    'ipam', 'labels', 'created', 'driver', 'id', 'name', 'scope', 'short_id',
+                )
+            })
+
+        return filter_list(networks, filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.apps.ix_apps.docker.networks import list_networks
 from middlewared.schema import Dict, Str
 from middlewared.service import CRUDService, filterable
 from middlewared.utils import filter_list
@@ -20,9 +21,11 @@ class DockerNetworkService(CRUDService):
     )
 
     @filterable
-    def query(self, app, filters, options):
+    def query(self, filters, options):
         """
         Query all docker networks
         """
         if not self.middleware.call_sync('docker.state.validate', False):
             return filter_list([], filters, options)
+
+        return filter_list(list_networks(), filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -45,4 +45,9 @@ class DockerNetworkService(CRUDService):
 
     @private
     def interfaces_mapping(self):
-        return [f'br-{network["short_id"]}' for network in self.query()]
+        try:
+            return [f'br-{network["short_id"]}' for network in self.query()]
+        except Exception as e:
+            # We don't want this to fail ever because this is used in interface.sync
+            self.logger.error('Failed to get docker interfaces mapping: %s', e)
+            return []

--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -20,4 +20,4 @@ class InterfaceService(Service):
             # can be obtained from platform team.
             result.append('eno1')
 
-        return result
+        return result + await self.middleware.call('docker.network.interfaces_mapping')

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import ipaddress
+import itertools
 from collections import defaultdict
 from itertools import zip_longest
 from ipaddress import ip_address, ip_interface
@@ -1703,7 +1704,11 @@ class InterfaceService(CRUDService):
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
-        internal_interfaces = tuple(await self.middleware.call('interface.internal_interfaces'))
+        internal_interfaces = tuple(itertools.chain(*[
+            await self.middleware.call(endpoint) for endpoint in (
+                'interface.internal_interfaces', 'docker.network.interfaces_mapping'
+            )
+        ]))
         dhclient_aws = []
         for name, iface in await self.middleware.run_in_thread(lambda: list(netif.list_interfaces().items())):
             # Skip internal interfaces

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import ipaddress
-import itertools
 from collections import defaultdict
 from itertools import zip_longest
 from ipaddress import ip_address, ip_interface
@@ -1704,11 +1703,7 @@ class InterfaceService(CRUDService):
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
 
-        internal_interfaces = tuple(itertools.chain(*[
-            await self.middleware.call(endpoint) for endpoint in (
-                'interface.internal_interfaces', 'docker.network.interfaces_mapping'
-            )
-        ]))
+        internal_interfaces = tuple(await self.middleware.call('interface.internal_interfaces'))
         dhclient_aws = []
         for name, iface in await self.middleware.run_in_thread(lambda: list(netif.list_interfaces().items())):
             # Skip internal interfaces


### PR DESCRIPTION
This PR adds changes to introduce a docker network crud from where we can retrieve configured docker networks and then we make sure that these interfaces are marked as internal because currently `interface.sync` is unconfiguring docker based interfaces which results in apps networking loss each time interfaces are synced.