### PR TITLE
NAS-131063 / 24.10-RC.1 / Make sure docker networking is not broken after interface sync (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/docker/networks.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/docker/networks.py
@@ -1,0 +1,13 @@
+from .casing import convert_case_for_dict_or_list
+from .utils import get_docker_client
+
+
+def list_networks() -> list[dict]:
+    networks = []
+    with get_docker_client() as client:
+        for network in client.networks.list(greedy=False):
+            attrs = network.attrs | {'short_id': network.short_id}
+            attrs['enable_ipv6'] = attrs.pop('EnableIPv6', False)
+            networks.append(convert_case_for_dict_or_list(attrs))
+
+    return networks

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,6 +1,6 @@
 from middlewared.plugins.apps.ix_apps.docker.networks import list_networks
 from middlewared.schema import Dict, Str
-from middlewared.service import CRUDService, filterable
+from middlewared.service import CRUDService, filterable, private
 from middlewared.utils import filter_list
 
 
@@ -42,3 +42,7 @@ class DockerNetworkService(CRUDService):
             })
 
         return filter_list(networks, filters, options)
+
+    @private
+    def interfaces_mapping(self):
+        return [f'br-{network["short_id"]}' for network in self.query()]

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,0 +1,28 @@
+from middlewared.schema import Dict, Str
+from middlewared.service import CRUDService, filterable
+from middlewared.utils import filter_list
+
+
+class DockerNetworkService(CRUDService):
+
+    class Config:
+        namespace = 'docker.network'
+        datastore_primary_key_type = 'string'
+        cli_namespace = 'docker.network'
+        role_prefix = 'DOCKER'
+
+    ENTRY = Dict(
+        'docker_network_entry',
+        Str('id', required=True),
+        Str('name', required=True),
+        Str('short_id', required=True),
+        additional_attrs=True,
+    )
+
+    @filterable
+    def query(self, app, filters, options):
+        """
+        Query all docker networks
+        """
+        if not self.middleware.call_sync('docker.state.validate', False):
+            return filter_list([], filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -14,9 +14,14 @@ class DockerNetworkService(CRUDService):
 
     ENTRY = Dict(
         'docker_network_entry',
-        Str('id', required=True),
-        Str('name', required=True),
-        Str('short_id', required=True),
+        Dict('ipam', additional_attrs=True, null=True),
+        Dict('labels', additional_attrs=True, null=True),
+        Str('created', required=True, null=True),
+        Str('driver', required=True, null=True),
+        Str('id', required=True, null=True),
+        Str('name', required=True, null=True),
+        Str('scope', required=True, null=True),
+        Str('short_id', required=True, null=True),
         additional_attrs=True,
     )
 
@@ -28,4 +33,12 @@ class DockerNetworkService(CRUDService):
         if not self.middleware.call_sync('docker.state.validate', False):
             return filter_list([], filters, options)
 
-        return filter_list(list_networks(), filters, options)
+        networks = []
+        for network in list_networks():
+            networks.append({
+                k: network.get(k) for k in (
+                    'ipam', 'labels', 'created', 'driver', 'id', 'name', 'scope', 'short_id',
+                )
+            })
+
+        return filter_list(networks, filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,3 +1,4 @@
+from middlewared.plugins.apps.ix_apps.docker.networks import list_networks
 from middlewared.schema import Dict, Str
 from middlewared.service import CRUDService, filterable
 from middlewared.utils import filter_list
@@ -20,9 +21,11 @@ class DockerNetworkService(CRUDService):
     )
 
     @filterable
-    def query(self, app, filters, options):
+    def query(self, filters, options):
         """
         Query all docker networks
         """
         if not self.middleware.call_sync('docker.state.validate', False):
             return filter_list([], filters, options)
+
+        return filter_list(list_networks(), filters, options)

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -45,4 +45,9 @@ class DockerNetworkService(CRUDService):
 
     @private
     def interfaces_mapping(self):
-        return [f'br-{network["short_id"]}' for network in self.query()]
+        try:
+            return [f'br-{network["short_id"]}' for network in self.query()]
+        except Exception as e:
+            # We don't want this to fail ever because this is used in interface.sync
+            self.logger.error('Failed to get docker interfaces mapping: %s', e)
+            return []

--- a/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
+++ b/src/middlewared/middlewared/plugins/interface/internal_ifaces.py
@@ -20,4 +20,4 @@ class InterfaceService(Service):
             # can be obtained from platform team.
             result.append('eno1')
 
-        return result
+        return result + await self.middleware.call('docker.network.interfaces_mapping')


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 401665dd420d5ec1bd88a0dba98cb4ead7a1c71c
    git cherry-pick -x d786298fab69faf928d58ba997c4f371ec493023
    git cherry-pick -x 12b4296aec9eb13bf7d7b8d35a92136a6caa19fb

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~5
    git cherry-pick -x d156c5f173b3a4dc96b4e054eae858fd09bd8f22

This PR adds changes to introduce a docker network crud from where we can retrieve configured docker networks and then we make sure that these interfaces are marked as internal because currently `interface.sync` is unconfiguring docker based interfaces which results in apps networking loss each time interfaces are synced.

Original PR: https://github.com/truenas/middleware/pull/14449
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131063