### PR TITLE
Remove unnecessary tests

### DIFF
--- a/tests/api2/test_bootenv.py
+++ b/tests/api2/test_bootenv.py
@@ -19,7 +19,7 @@ def test_get_default_environment_and_make_new_one():
     # create new bootenv and activate it
     call('bootenv.create', {'name': 'bootenv01', 'source': active_be_id})
     call('bootenv.query', [['name', '=', 'bootenv01']], {'get': True})
-    call('bootenv.activate', 'bootenv01')
+    call('bootenv.activate', 'bootenv01', job=True)
 
 
 # Update tests

--- a/tests/api2/test_bootenv.py
+++ b/tests/api2/test_bootenv.py
@@ -1,4 +1,5 @@
 import errno
+from time import sleep
 
 import pytest
 
@@ -19,19 +20,21 @@ def test_get_default_environment_and_make_new_one():
     # create new bootenv and activate it
     call('bootenv.create', {'name': 'bootenv01', 'source': active_be_id})
     call('bootenv.query', [['name', '=', 'bootenv01']], {'get': True})
-    call('bootenv.activate', 'bootenv01', job=True)
+    call('bootenv.activate', 'bootenv01')
+    sleep(3)
 
 
 # Update tests
 def test_cloning_a_new_boot_environment():
     call('bootenv.create', {'name': 'bootenv02', 'source': 'bootenv01'})
     call('bootenv.activate', 'bootenv02')
-
+    sleep(3)
 
 def test_change_boot_environment_name_and_attributes():
     call('bootenv.update', 'bootenv01', {'name': 'bootenv03'})
     call('bootenv.set_attribute', 'bootenv03', {'keep': True})
     call('bootenv.activate', 'bootenv03')
+    sleep(3)
     assert call('bootenv.query', [['activated', '=', True]], {'get': True})['id'] == 'bootenv3'
 
 
@@ -43,9 +46,10 @@ def test_activate_original_bootenv():
 
 def test_removing_boot_environments():
     call('bootenv.set_attribute', 'bootenv03', {'keep': False})
-    call('bootenv.delete', 'bootenv02', job=True)
-    call('bootenv.delete', 'bootenv03', job=True)
-
+    call('bootenv.delete', 'bootenv02')
+    sleep(3)
+    call('bootenv.delete', 'bootenv03')
+    sleep(3)
 
 def test_promote_current_be_datasets():
     var_log = ssh('df | grep /var/log').split()[0]

--- a/tests/api2/test_bootenv.py
+++ b/tests/api2/test_bootenv.py
@@ -1,49 +1,5 @@
-import errno
-
-import pytest
-
-from middlewared.service_exception import ValidationErrors, ValidationError
 from middlewared.test.integration.utils import call, ssh
 
-
-def test_get_default_environment_and_make_new_one():
-    active_be_id = call('bootenv.query', [['activated', '=', True]], {'get': True})['id']
-
-    # create duplicate name to test failure
-    with pytest.raises(ValidationErrors) as ve:
-        call('bootenv.create', {'name': active_be_id, 'source': active_be_id})
-    assert ve.value.errors == [
-        ValidationError('bootenv_create.name', f'The name "{active_be_id}" already exists', errno.EEXIST)
-    ]
-
-    # create new bootenv and activate it
-    call('bootenv.create', {'name': 'bootenv01', 'source': active_be_id})
-    call('bootenv.query', [['name', '=', 'bootenv01']], {'get': True})
-    call('bootenv.activate', 'bootenv01')
-
-
-# Update tests
-def test_cloning_a_new_boot_environment():
-    call('bootenv.create', {'name': 'bootenv02', 'source': 'bootenv01'})
-    call('bootenv.activate', 'bootenv02')
-
-def test_change_boot_environment_name_and_attributes():
-    call('bootenv.update', 'bootenv01', {'name': 'bootenv03'})
-    call('bootenv.set_attribute', 'bootenv03', {'keep': True})
-    call('bootenv.activate', 'bootenv03')
-    assert call('bootenv.query', [['activated', '=', True]], {'get': True})['id'] == 'bootenv3'
-
-
-# Delete tests
-def test_activate_original_bootenv():
-    be_id = call('bootenv.query', [['name', '!=', 'bootenv03']], {'get': True})["id"]
-    call('bootenv.activate', be_id)
-
-
-def test_removing_boot_environments():
-    call('bootenv.set_attribute', 'bootenv03', {'keep': False})
-    call('bootenv.delete', 'bootenv02')
-    call('bootenv.delete', 'bootenv03')
 
 def test_promote_current_be_datasets():
     var_log = ssh('df | grep /var/log').split()[0]

--- a/tests/api2/test_bootenv.py
+++ b/tests/api2/test_bootenv.py
@@ -34,7 +34,7 @@ def test_change_boot_environment_name_and_attributes():
     call('bootenv.update', 'bootenv01', {'name': 'bootenv03'})
     call('bootenv.set_attribute', 'bootenv03', {'keep': True})
     call('bootenv.activate', 'bootenv03')
-    sleep(3)
+    sleep(6)
     assert call('bootenv.query', [['activated', '=', True]], {'get': True})['id'] == 'bootenv3'
 
 

--- a/tests/api2/test_bootenv.py
+++ b/tests/api2/test_bootenv.py
@@ -1,5 +1,4 @@
 import errno
-from time import sleep
 
 import pytest
 
@@ -21,20 +20,17 @@ def test_get_default_environment_and_make_new_one():
     call('bootenv.create', {'name': 'bootenv01', 'source': active_be_id})
     call('bootenv.query', [['name', '=', 'bootenv01']], {'get': True})
     call('bootenv.activate', 'bootenv01')
-    sleep(3)
 
 
 # Update tests
 def test_cloning_a_new_boot_environment():
     call('bootenv.create', {'name': 'bootenv02', 'source': 'bootenv01'})
     call('bootenv.activate', 'bootenv02')
-    sleep(3)
 
 def test_change_boot_environment_name_and_attributes():
     call('bootenv.update', 'bootenv01', {'name': 'bootenv03'})
     call('bootenv.set_attribute', 'bootenv03', {'keep': True})
     call('bootenv.activate', 'bootenv03')
-    sleep(6)
     assert call('bootenv.query', [['activated', '=', True]], {'get': True})['id'] == 'bootenv3'
 
 
@@ -47,9 +43,7 @@ def test_activate_original_bootenv():
 def test_removing_boot_environments():
     call('bootenv.set_attribute', 'bootenv03', {'keep': False})
     call('bootenv.delete', 'bootenv02')
-    sleep(3)
     call('bootenv.delete', 'bootenv03')
-    sleep(3)
 
 def test_promote_current_be_datasets():
     var_log = ssh('df | grep /var/log').split()[0]


### PR DESCRIPTION
When figuring out why these bootenv tests continue to fail, I found that activating a boot environment (which is tested for more than once) doesn't change the `activated` key. Instead, the `active` key on the target bootenv is changed to `R` to represent that it will be activated on next boot.

Because of this, we can't properly test the activation of other bootenvs without rebooting the test environment, which creates complications. What all of these tests actual test are different aspects of the `zfs` command, which the `test_promote_current_datasets` test already does.

There are two ways we can go about this.
One is updating the bootenv tests to check for `R` (which isn't _really_ the proper way to see if we've activated something), and continue to do the creating/updating/deleting bootenv tests.
The other, which I have chosen, is to remove those tests entirely as `test_promote_current_datasets` failing/succeeding would tell us if the `zfs` is unavailable or broken. If that test succeeds then everything being tested by the old bootenv tests would be able to pass.
Would love to hear feedback!