### PR TITLE
NAS-130860 / 25.04 / Have upgrade alerts for apps

### DIFF
--- a/src/middlewared/middlewared/alert/source/applications.py
+++ b/src/middlewared/middlewared/alert/source/applications.py
@@ -29,7 +29,7 @@ class ApplicationsStartFailedAlertClass(AlertClass, OneShotAlertClass):
         return []
 
 
-class ChartReleaseUpdateAlertClass(AlertClass, OneShotAlertClass):
+class AppUpdateAlertClass(AlertClass, OneShotAlertClass):
     deleted_automatically = False
 
     category = AlertCategory.APPLICATIONS
@@ -38,7 +38,7 @@ class ChartReleaseUpdateAlertClass(AlertClass, OneShotAlertClass):
     text = 'An update is available for "%(name)s" application.'
 
     async def create(self, args):
-        return Alert(ChartReleaseUpdateAlertClass, args, _key=args['name'])
+        return Alert(AppUpdateAlertClass, args, _key=args['name'])
 
     async def delete(self, alerts, query):
         return list(filter(

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -347,6 +347,8 @@ class AppService(CRUDService):
 
         if options.get('send_event', True):
             self.middleware.send_event('app.query', 'REMOVED', id=app_name)
+
+        self.middleware.call_sync('alert.oneshot_delete', 'AppUpdate', app_name)
         job.set_progress(100, f'Deleted {app_name!r} app')
         return True
 

--- a/src/middlewared/middlewared/plugins/catalog/sync.py
+++ b/src/middlewared/middlewared/plugins/catalog/sync.py
@@ -47,6 +47,7 @@ class CatalogService(Service):
             await self.middleware.call('alert.oneshot_delete', 'CatalogSyncFailed', OFFICIAL_LABEL)
             job.set_progress(100, f'Synced {OFFICIAL_LABEL!r} catalog')
             self.SYNCED = True
+            self.middleware.create_task(self.middleware.call('app.check_upgrade_alerts'))
 
     @private
     def update_git_repository(self, location, repository, branch):

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -1,4 +1,4 @@
-from middlewared.service import CallError, periodic, Service
+from middlewared.service import CallError, periodic, Service, private
 
 from .state_utils import APPS_STATUS, Status, STATUS_DESCRIPTIONS
 
@@ -98,7 +98,6 @@ class DockerStateService(Service):
         docker_config = await self.middleware.call('docker.config')
         if docker_config['enable_image_updates']:
             self.middleware.create_task(self.middleware.call('app.image.op.check_update'))
-        # TODO: Add app upgrade alerts
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -71,6 +71,7 @@ class DockerSetupService(Service):
 
         await self.create_update_docker_datasets(config['dataset'])
         await self.middleware.call('docker.state.start_service')
+        self.middleware.create_task(self.middleware.call('docker.state.periodic_check'))
 
     @private
     def move_conflicting_dir(self, ds_name):

--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -83,6 +83,10 @@ class DockerService(ConfigService):
             )
 
         if old_config != config:
+            if config['pool'] != old_config['pool']:
+                # We want to clear upgrade alerts for apps at this point
+                await self.middleware.call('app.clear_upgrade_alerts_for_all')
+
             if any(config[k] != old_config[k] for k in ('pool', 'address_pools')):
                 job.set_progress(20, 'Stopping Docker service')
                 try:


### PR DESCRIPTION
## Context

We are missing out on a notification mechanism for apps when they have upgrades available and this is accounted for in these changes by having an upgrade alert be generated when a new version of the app is available. While working on this, another issue was observed that docker image cache was not being updated on docker pool state changes which has been fixed as well.