### PR TITLE
`service.stop` return values are swapped

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -269,11 +269,11 @@ class ServiceService(CRUDService):
             if service_object.deprecated:
                 await self.middleware.call('alert.oneshot_delete', 'DeprecatedService', service_object.name)
 
-            return False
+            return True
         else:
             self.logger.error("Service %r running after stop", service)
             await self.middleware.call('service.notify_running', service)
-            return True
+            return False
 
     @accepts(
         Str('service'),


### PR DESCRIPTION
The API documentation states: 'Will return `true` if service successfully stopped' but the opposite is true.