### PR TITLE
NAS-131085 / 24.10-RC.1 / Fix app migration (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/trigger_migration.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/trigger_migration.py
@@ -33,7 +33,7 @@ class K8stoDockerMigrationService(Service):
         # interface, then migration is bound to fail as catalog won't sync because of no network
         # connectivity and us not able to see if an app is available in newer catalog. If the default interface
         # is not up, then we will fail the migration here and early
-        await self.middleware.call('docker.state.validate_interfaces')
+        await self.middleware.call('docker.setup.validate_interfaces')
 
         list_backup_job = await self.middleware.call('k8s_to_docker.list_backups', k8s_pool)
         await list_backup_job.wait()


### PR DESCRIPTION
## Context

Automatic migration was failing due to a typo which has been fixed.

Original PR: https://github.com/truenas/middleware/pull/14468
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131085