### PR TITLE
NAS-131086 / 25.04 / Fix app deletion edge case

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -337,13 +337,13 @@ class AppService(CRUDService):
             app_name, app_config['version'], 'down', remove_orphans=True,
             remove_volumes=True, remove_images=options['remove_images'],
         )
-        try:
-            job.set_progress(80, 'Cleaning up resources')
-            shutil.rmtree(get_installed_app_path(app_name))
-            if options['remove_ix_volumes'] and (apps_volume_ds := self.get_app_volume_ds(app_name)):
-                self.middleware.call_sync('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
-        finally:
-            self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)
+        # Remove app from metadata first as if someone tries to query filesystem info of the app
+        # where the app resources have been nuked from filesystem, it will error out
+        self.middleware.call_sync('app.metadata.generate', [app_name]).wait_sync(raise_error=True)
+        job.set_progress(80, 'Cleaning up resources')
+        shutil.rmtree(get_installed_app_path(app_name))
+        if options['remove_ix_volumes'] and (apps_volume_ds := self.get_app_volume_ds(app_name)):
+            self.middleware.call_sync('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
 
         if options.get('send_event', True):
             self.middleware.send_event('app.query', 'REMOVED', id=app_name)

--- a/src/middlewared/middlewared/plugins/apps/metadata.py
+++ b/src/middlewared/middlewared/plugins/apps/metadata.py
@@ -15,11 +15,12 @@ class AppMetadataService(Service):
         private = True
 
     @job(lock='app_metadata_generate', lock_queue_size=1)
-    def generate(self, job):
+    def generate(self, job, blacklisted_apps=None):
         config = {}
         metadata = {}
+        blacklisted_apps = blacklisted_apps or []
         with os.scandir(get_app_parent_config_path()) as scan:
-            for entry in filter(lambda e: e.is_dir(), scan):
+            for entry in filter(lambda e: e.name not in blacklisted_apps and e.is_dir(), scan):
                 if not (app_metadata := get_app_metadata(entry.name)):
                     # The app is malformed or something is seriously wrong with it
                     continue


### PR DESCRIPTION
## Problem

When an app is in the progress of being deleted, UI is querying apps trying to retrieve app schema as well which we don't keep collectively cached and that errors out as this can/cannot happen that app folder has been removed but metadata has not been updated yet.

## Solution

Before removing app from filesystem, remove app from collective metadata which is used to generate list of installed apps and then remove the app's related content from filesystem.