### PR TITLE
NAS-130709 / 25.04 / Fix LDAP status on failover

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
@@ -29,11 +29,8 @@ class IPAHealthMixin:
                 self._recover_ipa_config()
             case IPAHealthCheckFailReason.IPA_NO_CACERT | IPAHealthCheckFailReason.IPA_CACERT_PERM:
                 self._recover_ipa_config()
-            case IPAHealthCheckFailReason.LDAP_BIND_FAILED:
+            case IPAHealthCheckFailReason.LDAP_BIND_FAILED | IPAHealthCheckFailReason.SSSD_STOPPED:
                 self._recover_ldap_config()
-            case IPAHealthCheckFailReason.SSSD_STOPPED:
-                # pick up with sssd restart below
-                pass
             case _:
                 # not recoverable
                 raise error from None

--- a/src/middlewared/middlewared/plugins/directoryservices_/ldap_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ldap_health_mixin.py
@@ -15,11 +15,8 @@ class LDAPHealthMixin:
         our health check.
         """
         match error.reason:
-            case LDAPHealthCheckFailReason.LDAP_BIND_FAILED:
+            case LDAPHealthCheckFailReason.LDAP_BIND_FAILED | LDAPHealthCheckFailReason.SSSD_STOPPED:
                 self._recover_ldap_config()
-            case LDAPHealthCheckFailReason.SSSD_STOPPED:
-                # pick up with sssd restart below
-                pass
             case _:
                 # not recoverable
                 raise error from None

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -382,21 +382,12 @@ class SMBService(ConfigService):
         job.set_progress(30, 'Setting up server SID.')
         await self.middleware.call('smb.set_system_sid')
 
-        """
-        If the ldap passdb backend is being used, then the remote LDAP server
-        will provide the SMB users and groups. We skip these steps to avoid having
-        samba potentially try to write our local users and groups to the remote
-        LDAP server.
-
-        """
-        passdb_backend = await self.middleware.call('smb.getparm', 'passdb backend', 'global')
-        if passdb_backend.startswith("tdbsam"):
-            job.set_progress(40, 'Synchronizing passdb and groupmap.')
-            await self.middleware.call('etc.generate', 'user')
-            pdb_job = await self.middleware.call("smb.synchronize_passdb", True)
-            grp_job = await self.middleware.call("smb.synchronize_group_mappings", True)
-            await pdb_job.wait()
-            await grp_job.wait()
+        job.set_progress(40, 'Synchronizing passdb and groupmap.')
+        await self.middleware.call('etc.generate', 'user')
+        pdb_job = await self.middleware.call("smb.synchronize_passdb", True)
+        grp_job = await self.middleware.call("smb.synchronize_group_mappings", True)
+        await pdb_job.wait()
+        await grp_job.wait()
 
         """
         The following steps ensure that we cleanly import our SMB shares


### PR DESCRIPTION
This fix addresses a few minor issues with directory services state recovery.

1. Rather than simply failing directoryservices.setup if unhealthy, we should take recovery steps

2. If for some reason SSSD fails to start triggering a health check failure we should go through etc.generate steps to make sure we have all required files written before trying to start it again.

3. Always generate the nsswitch.conf after setting up directory services. This avoids possibilty of having SSSD / winbind running without them being present in nsswitch.conf on failover.