### PR TITLE
NAS-131019 / 25.04 / Have separate logging file for logging app lifecycle issues

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -39,6 +39,7 @@ logging.getLogger('docker.utils.config').setLevel(logging.ERROR)
 logging.getLogger('docker.auth').setLevel(logging.ERROR)
 logging.TRACE = 6
 
+APP_LIFECYCLE_LOGFILE = '/var/log/app_lifecycle.log'
 APP_MIGRATION_LOGFILE = '/var/log/app_migrations.log'
 DOCKER_IMAGE_LOGFILE = '/var/log/docker_image.log'
 FAILOVER_LOGFILE = '/var/log/failover.log'
@@ -83,6 +84,7 @@ class Logger:
         else:
             for name, filename, log_format in [
                 (None, LOGFILE, self.log_format),
+                ('app_lifecycle', APP_LIFECYCLE_LOGFILE, self.log_format),
                 ('app_migrations', APP_MIGRATION_LOGFILE, self.log_format),
                 ('docker_image', DOCKER_IMAGE_LOGFILE, self.log_format),
                 ('failover', FAILOVER_LOGFILE, self.log_format),

--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -1,10 +1,14 @@
 import itertools
+import logging
 import typing
 
 from middlewared.service_exception import CallError
 
 from .ix_apps.lifecycle import get_rendered_templates_of_app
 from .utils import PROJECT_PREFIX, run
+
+
+logger = logging.getLogger('app_lifecycle')
 
 
 def compose_action(
@@ -49,4 +53,7 @@ def compose_action(
     # TODO: We will likely have a configurable timeout on this end
     cp = run(['docker', 'compose'] + compose_files + args, timeout=1200)
     if cp.returncode != 0:
-        raise CallError(f'Failed {action!r} action for {app_name!r} app: {cp.stderr}')
+        logger.error('Failed %r action for %r app: %s', action, app_name, cp.stderr)
+        raise CallError(
+            f'Failed {action!r} action for {app_name!r} app, please check /var/log/app_lifecycle.log for more details'
+        )


### PR DESCRIPTION
This PR adds changes to introduce a separate logging file for app lifecycle related issues as raising them in compose related jobs means that they will get logged to middlewared.log and this can then result into it becoming quite noisy.