### PR TITLE
NAS-130700 / 25.04 / Add support for remote controller audit query and download

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -201,8 +201,7 @@ class AuditService(ConfigService):
         verrors = ValidationErrors()
 
         # If HA, handle the possibility of remote controller requests
-        ctrlr_state = await self.middleware.call('failover.status')
-        if ctrlr_state != 'SINGLE' and data['remote_controller']:
+        if await self.middleware.call('failover.licensed') and data['remote_controller']:
             try:
                 if audit_query := self.middleware.call(
                     'failover.call_remote',

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -24,7 +24,6 @@ SQL_SAFE_FIELDS = (
     AuditEventParam.EVENT.value,
     AuditEventParam.SUCCESS.value,
 )
-AUDIT_CONTROLLER_SELECTIONS = ['MASTER', 'Active', 'BACKUP', 'Standby']
 
 
 AuditBase = declarative_base()

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -24,6 +24,8 @@ SQL_SAFE_FIELDS = (
     AuditEventParam.EVENT.value,
     AuditEventParam.SUCCESS.value,
 )
+AUDIT_CONTROLLER_SELECTIONS = ['MASTER', 'Active', 'BACKUP', 'Standby']
+
 
 AuditBase = declarative_base()
 

--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -123,14 +123,17 @@ def standby_user():
     user_id = None
     try:
         name = "StandbyUser" + PASSWD
-        user_id = call('failover.call_remote', 'user.create', [{
-            "username": name,
-            "full_name": name + " Deleteme",
-            "group": 100,
-            "smb": False,
-            "home_create": False,
-            "password": "testing"
-        }])
+        user_id = call(
+            'failover.call_remote', 'user.create', [{
+                "username": name,
+                "full_name": name + " Deleteme",
+                "group": 100,
+                "smb": False,
+                "home_create": False,
+                "password": "testing"
+            }],
+            {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2}
+        )
         yield name
     finally:
         if user_id is not None:
@@ -323,7 +326,11 @@ class TestAuditOps:
 class TestAuditOpsHA:
     def test_audit_ha_query(self, standby_user):
         name = standby_user
-        remote_user = call('failover.call_remote', 'user.query', [[["username", "=", name]]])
+        remote_user = call(
+            'failover.call_remote', 'user.query',
+            [[["username", "=", name]]],
+            {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2}
+        )
         assert remote_user != []
 
         # Handle delays in the audit database


### PR DESCRIPTION
### Problem
On HA systems each controller maintains an independent audit database.  Actions on a controller are reported only in the audit DB associated with that controller.

### Solution
Provide the capability to query and download the audit DB from the 'other' controller.
If no controller is specified the audit action is performed on the 'current' controller.
If the controller is specified the audit action will be performed on the requested controller.
The controller can be specified by any of the following names:  'BACKUP', 'Standby', 'MASTER', 'Active'.

Passing CI tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/631/