### PR TITLE
NAS-130694 / 24.10-RC.1 / Handle potential case when tos can be null (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/acme_protocol.py
+++ b/src/middlewared/middlewared/plugins/acme_protocol.py
@@ -171,7 +171,7 @@ class ACMERegistrationService(CRUDService):
             self._config.datastore,
             {
                 'uri': register.uri,
-                'tos': register.terms_of_service,
+                'tos': register.terms_of_service or '',
                 'new_account_uri': directory.newAccount,
                 'new_nonce_uri': directory.newNonce,
                 'new_order_uri': directory.newOrder,


### PR DESCRIPTION
This commit fixes a case where tos can be null which we get from an ACME provider. In the database we keep it as an empty string because this needs to go through the libraries we are using to generate an ACME certificate which can/cannot error out and unfortunately we don't have an ACME provider atm which gives a null tos to test a null case. Keeping it as an empty string in that case in database if tos received is null.

Original PR: https://github.com/truenas/middleware/pull/14484
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130694