### PR TITLE
NAS-131121 / 25.04 / fix skipif logic in test_005

### DIFF
--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -127,7 +127,7 @@ def test_003_recheck_ipvx(request):
     assert int(call("tunable.get_sysctl", f"net.ipv6.conf.{interface}.autoconf")) == 0
 
 
-@pytest.mark.skipif(ha, reason="Test valid on HA systems only")
+@pytest.mark.skipif(not ha, reason="Test valid on HA systems only")
 def test_004_remove_critical_failover_group(request):
     with pytest.raises(ValidationErrors) as ve:
         call(


### PR DESCRIPTION
I'm still seeing this test fail on non HA systems and it's because I decorated the method with invalid logic. This fixes the decorator so that this test is, for real this time, skipped on _non_ HA systems.