### PR TITLE
NAS-131122 / 25.04 / dont test ntp peer if force is set to true

### DIFF
--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -230,15 +230,12 @@ class NTPServerService(CRUDService):
         verrors = ValidationErrors()
         maxpoll = data['maxpoll']
         minpoll = data['minpoll']
-        force = data.pop('force', False)
-        usable = True if await self.middleware.run_in_thread(
-            self.test_ntp_server, data['address']) else False
-
-        if not force and not usable:
-            verrors.add(f'{schema_name}.address',
-                        'Server could not be reached. Check "Force" to '
-                        'continue regardless.'
-                        )
+        if not data.pop('force', False):
+            if not await self.middleware.run_in_thread(self.test_ntp_server, data['address']):
+                verrors.add(
+                    f'{schema_name}.address',
+                    'Server could not be reached. Check "Force" to continue regardless.'
+                )
 
         if not maxpoll > minpoll:
             verrors.add(f'{schema_name}.maxpoll',


### PR DESCRIPTION
I'm working on removing REST calls from `test_500` and I've discovered a rather annoying behavior with the `system.ntpserver.create` endpoint. The problem is that we're _always_ testing whether or not the NTP peer that is being added is "reachable" disregarding the "force" flag. This means, no matter what, each NTP peer being added will wait up to 5 seconds before completing.

This changes it so that if the "force" flag is set to True it will not try to send ntp packets to the NTP peer.