### PR TITLE
NAS-131159 / 24.10-RC.1 / Fix CPU stats in apps stats reporting (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/stats_util.py
+++ b/src/middlewared/middlewared/plugins/apps/stats_util.py
@@ -1,6 +1,7 @@
+from middlewared.utils.cpu import cpu_info
+
 from .ix_apps.metadata import get_collective_metadata
 from .ix_apps.utils import get_app_name_from_project_name
-
 
 NANO_SECOND = 1000000000
 
@@ -27,7 +28,7 @@ def normalize_projects_stats(all_projects_stats: dict, old_stats: dict, interval
         # 2. Normalize this delta over the given time interval by dividing by (interval * NANO_SECOND).
         # 3. Multiply by 100 to convert to percentage.
         cpu_delta = data['cpu_usage'] - old_stats[project]['cpu_usage']
-        normalized_data['cpu_usage'] = (cpu_delta / (interval * NANO_SECOND)) * 100
+        normalized_data['cpu_usage'] = (cpu_delta / (interval * NANO_SECOND * cpu_info()['core_count'])) * 100
 
         networks = []
         for net_name, network_data in data['networks'].items():


### PR DESCRIPTION
## Problem

When we have multiple containers in a compose file and they are using multiple cores of the system, our calculation of cpu usage stats will be inaccurate as it assumes a single core and percentage goes well above 100% depending on system cores and the ones being used. This compose file can be used to replicate the issue
```
version: "3"
services:
  cpu_stress_1:
    image: ubuntu:latest
    container_name: cpu_stress_1
    command: "bash -c 'apt-get update && apt-get install -y stress && stress --cpu 4'"
    deploy:
      resources:
        limits:
          cpus: "2"
        reservations:
          cpus: "1"
  
  cpu_stress_2:
    image: ubuntu:latest
    container_name: cpu_stress_2
    command: "bash -c 'apt-get update && apt-get install -y stress && stress --cpu 4'"
    deploy:
      resources:
        limits:
          cpus: "2"
        reservations:
          cpus: "1"
  
  cpu_stress_3:
    image: ubuntu:latest
    container_name: cpu_stress_3
    command: "bash -c 'apt-get update && apt-get install -y stress && stress --cpu 4'"
    deploy:
      resources:
        limits:
          cpus: "2"
        reservations:
          cpus: "1"
```

## Solution

When we are calculating percentage, we should account for the cores present in the system to properly report cpu usage for an app.

Original PR: https://github.com/truenas/middleware/pull/14503
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131159