### PR TITLE
NAS-131163 / 24.10-RC.1 / Fix negative value reported for cpu app stats (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/stats_util.py
+++ b/src/middlewared/middlewared/plugins/apps/stats_util.py
@@ -28,7 +28,14 @@ def normalize_projects_stats(all_projects_stats: dict, old_stats: dict, interval
         # 2. Normalize this delta over the given time interval by dividing by (interval * NANO_SECOND).
         # 3. Multiply by 100 to convert to percentage.
         cpu_delta = data['cpu_usage'] - old_stats[project]['cpu_usage']
-        normalized_data['cpu_usage'] = (cpu_delta / (interval * NANO_SECOND * cpu_info()['core_count'])) * 100
+        if cpu_delta >= 0:
+            normalized_data['cpu_usage'] = (cpu_delta / (interval * NANO_SECOND * cpu_info()['core_count'])) * 100
+        else:
+            # This will happen when there were multiple containers and an app is being stopped
+            # and old stats contain cpu usage times of multiple containers and current stats
+            # only contains the stats of the containers which are still running which means collectively
+            # current cpu usage time will be obviously low then what old stats contain
+            normalized_data['cpu_usage'] = 0
 
         networks = []
         for net_name, network_data in data['networks'].items():


### PR DESCRIPTION
## Problem

While looking at the cpu stats logic, there is another edge case possibility where we might report cpu usage percentage as negative. This would happen when old stats have multiple containers running - the stats we get are cpu usage time in nanoseconds and that are aggregated for all containers in a single compose file.
Now when the app is being stopped for example, what can happen is that old stats has accumulative cpu usage time of 3 containers and currently there is only 1 container running - which means we will only have cpu usage time in nanoseconds of 1 container and that would be less then what we had in old stats and computing delta here would be negative.

## Solution

If cpu delta is negative, we should just report cpu usage as 0 in that case as we can't reliably compute cpu usage anymore and not report a negative percentage.

Original PR: https://github.com/truenas/middleware/pull/14506
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131163