### PR TITLE
NAS-131056 / 25.04 / Remove deprecated v4_v3owner NFS configuration setting

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-09-12_23-57_remove_nfs_v4_v3owner.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-09-12_23-57_remove_nfs_v4_v3owner.py
@@ -1,0 +1,26 @@
+"""Remove deprecated v4_v3owner NFS configuration option
+
+
+Revision ID: 6dedf12c1035
+Revises: 7b618b9ca77d
+Create Date: 2024-09-12 23:57:43.814512+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6dedf12c1035'
+down_revision = '7b618b9ca77d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_nfs', schema=None) as batch_op:
+        batch_op.drop_column('nfs_srv_v4_v3owner')
+
+
+def downgrade():
+    pass

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -61,7 +61,6 @@ class NFS_CONFIG:
     default_config = {
         "allow_nonroot": False,
         "protocols": ["NFSV3", "NFSV4"],
-        "v4_v3owner": False,
         "v4_krb": False,
         "v4_domain": "",
         "bindip": [],


### PR DESCRIPTION
The NFS configuration setting, `v4_v3owner` has always been an inactive and non-functional setting in SCALE.  It has been marked as deprecated in previous releases.

This PR removes the unused and non-functional v4_v3owner NFS configuration setting.
This PR includes an alembic migration and updates the NFS CI tests.