### PR TITLE
NAS-130530 / 24.10.0 / Do not allow VMs to consume zvols on boot-pool (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -335,6 +335,8 @@ class iSCSITargetExtentService(SharingService):
             if not os.path.exists(device):
                 verrors.add(f'{schema_name}.disk', f'Device {device!r} for volume {zvol_name!r} does not exist')
 
+            self.middleware.call_sync('iscsi.extent.validate_zvol_path', verrors, f'{schema_name}.disk', device)
+
             if '@' in zvol_name and not data['ro']:
                 verrors.add(f'{schema_name}.ro', 'Must be set when disk is a ZFS Snapshot')
 

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -2,6 +2,7 @@ import errno
 import os
 
 from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
+from middlewared.plugins.zfs_.validation_utils import check_zvol_in_boot_pool_using_path
 from middlewared.schema import Bool, Dict, Int, Str
 from middlewared.validators import Match
 
@@ -162,6 +163,8 @@ class DISK(StorageDevice):
                 verrors.add('attributes.path', 'Disk path is required.')
             elif not path.startswith('/dev/zvol/'):
                 verrors.add('attributes.path', 'Disk path must start with "/dev/zvol/"')
+            elif check_zvol_in_boot_pool_using_path(path):
+                verrors.add('attributes.path', 'Disk residing in boot pool cannot be consumed and is not supported')
             else:
                 zvol = self.middleware.call_sync(
                     'zfs.dataset.query', [['id', '=', zvol_path_to_name(path)]], {'extra': {'properties': []}}

--- a/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/validation_utils.py
@@ -1,5 +1,16 @@
 import libzfs
 
+from .utils import zvol_name_to_path
+
+
+def check_zvol_in_boot_pool_using_name(zvol_name: str) -> bool:
+    return check_zvol_in_boot_pool_using_path(zvol_name_to_path(zvol_name))
+
+
+def check_zvol_in_boot_pool_using_path(zvol_path: str) -> bool:
+    from middlewared.plugins.boot import BOOT_POOL_NAME
+    return zvol_path.startswith(f'/dev/zvol/{BOOT_POOL_NAME}/')
+
 
 def validate_pool_name(name: str) -> bool:
     return libzfs.validate_pool_name(name)


### PR DESCRIPTION
## Problem

There have been users who have created zvols with `zfs create` and then consumed them in VMs where the zvols resided in boot-pool.

## Solution

Enhance validation to not allow users to specify zvols which reside on boot-pool.

Original PR: https://github.com/truenas/middleware/pull/14180
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130530