### PR TITLE
NAS-131161 / 25.04 / Properly filter for local admins emails

### DIFF
--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -492,11 +492,11 @@ class MailService(ConfigService):
 
     @private
     async def local_administrators_emails(self):
-        return list(set(
-            user["email"]
-            for user in await self.middleware.call("privilege.local_administrators")
-            if user["email"]
-        ))
+        return list(set(user["email"] for user in await self.middleware.call("user.query", [
+            ["roles", "rin", "FULL_ADMIN"],
+            ["local", "=", True],
+            ["email", "!=", None]
+        ])))
 
     @private
     async def local_administrator_email(self):

--- a/tests/api2/test_mail_admins.py
+++ b/tests/api2/test_mail_admins.py
@@ -1,0 +1,37 @@
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.utils import call
+
+MAILUSER = 'wilbur'
+MAILADDR = 'wilbur.spam@ixsystems.com'
+NONMAIL_USER = 'wilburette'
+NONMAIL_ADDR = 'wilburette.spam@ixsystems.com'
+PASSWD = 'abcd1234'
+
+
+@pytest.fixture(scope='module')
+def full_admin_user():
+    ba_id = call('group.query', [['gid', '=', 544]], {'get': True})['id']
+    with user({
+        'username': NONMAIL_USER,
+        'full_name': NONMAIL_USER,
+        'group_create': True,
+        'email': NONMAIL_ADDR,
+        'password': PASSWD
+    }, get_instance=False):
+        with user({
+            'username': MAILUSER,
+            'full_name': MAILUSER,
+            'group_create': False,
+            'email': MAILADDR,
+            'group': ba_id,
+            'password': PASSWD
+        }, get_instance=True) as u:
+            yield u
+
+
+def test_mail_administrators(full_admin_user):
+    emails = call('mail.local_administrators_emails')
+    assert MAILADDR in emails
+    assert NONMAIL_ADDR not in emails


### PR DESCRIPTION
Originally the mail.local_administrators only returned users who were members of the default builtin local administrators privilege by virtue of auxiliary group membership. This commit makes the logic more generic. Since the method was originally written we expanded user.query output to include information about the user's roles and so we can select all users with FULL_ADMIN privileges (which may be granted by non-default privilege sets).