### PR TITLE
NAS-131178 / 24.10-RC.1 / Fix recursion in getting SID info (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1101,9 +1101,10 @@ class UserService(CRUDService):
             match user_obj['source']:
                 case 'LOCAL':
                     idmap_ctx = None
-                    db_entry = self.middleware.call_sync('user.query', [[
-                        'username', '=', user_obj['pw_name']
-                    ]], {'select': ['sid']})
+                    db_entry = self.middleware.call_sync('user.query', [
+                        ['username', '=', user_obj['pw_name']],
+                        ['local', '=', True]
+                    ], {'select': ['sid']})
                     if not db_entry:
                         self.logger.error(
                             '%s: local user exists on server but does not exist in the '
@@ -2120,9 +2121,10 @@ class GroupService(CRUDService):
             match grp_obj['source']:
                 case 'LOCAL':
                     idmap_ctx = None
-                    db_entry = self.middleware.call_sync('group.query', [[
-                        'group', '=', grp_obj['gr_name']
-                    ]], {'select': ['sid']})
+                    db_entry = self.middleware.call_sync('group.query', [
+                        ['group', '=', grp_obj['gr_name']],
+                        ['local', '=', True]
+                    ], {'select': ['sid']})
                     if not db_entry:
                         self.logger.error(
                             '%s: local group exists on server but does not exist in the '

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -421,8 +421,7 @@ class SMBService(ConfigService):
             await self.middleware.call("service.restart", "cifs", {"ha_propagate": False})
 
         # Ensure that winbind is running once we configure SMB service
-        if not await self.middleware.call('service.started', 'idmap'):
-            await self.middleware.call('service.start', 'idmap', {'ha_propagate': False})
+        await self.middleware.call('service.restart', 'idmap', {'ha_propagate': False})
 
         job.set_progress(100, 'Finished configuring SMB.')
 


### PR DESCRIPTION
Early in electric eel development, the SID values associated with local users and groups were changed to be deterministic based on their respective datastore table primary keys. A subsequent commit changed how this SID information was retrieved in user.get_user_obj and group.get_group_obj to ensure that we stopped relying on a winbind client connection (to robustize against edge case of user not having winbindd running). This SID information was obtained via user.query and group.query.

Unfortunately, the developer neglected to set an additional ['local', '=', True] filter for the query request (which limits to local users only), which resulted in call to directoryservices.cache.query when AD or LDAP is enabled. If the account is a local account then the cache lookup failure results in call back into user.get_user_obj or group.get_group_obj resulting in loop.

This commit correctly limits the lookup to local users and groups.

Original PR: https://github.com/truenas/middleware/pull/14514
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131178