### PR TITLE
NAS-131183 / 24.04.2.2 / fix HA inaccessible alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
+++ b/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
@@ -30,6 +30,9 @@ class FailoverRemoteSystemInaccessibleAlertSource(AlertSource):
         self.incident_id = None
 
     async def check(self):
+        if not await self.middleware.call('failover.licensed'):
+            return []
+
         try:
             await self.middleware.call('failover.call_remote', 'core.ping', [], {'timeout': 2})
         except Exception:


### PR DESCRIPTION
`failover_related = True` isn't working by design. It's only by pure chance that our failover related alerts are all checking failover.licensed endpoint before running. Since this is being backported to 24.04.2.2, I'm keeping the changes as minimal as possible. I will, however, be pushing another PR to fix the `faliover_related` attribute more thoroughly.

Original PR: https://github.com/truenas/middleware/pull/14521
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131183