### PR TITLE
NAS-131208 / 25.04 / Improvements to mounting/umounting docker datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -1,0 +1,31 @@
+from middlewared.service import Service
+
+from .state_utils import Status
+
+
+class DockerFilesystemManageService(Service):
+
+    class Config:
+        namespace = 'docker.fs_manage'
+        private = True
+
+    async def common_func(self, mount):
+        if docker_ds := (await self.middleware.call('docker.config'))['dataset']:
+            try:
+                if mount:
+                    await self.middleware.call('zfs.dataset.mount', docker_ds, {'recursive': True, 'force_mount': True})
+                else:
+                    await self.middleware.call('zfs.dataset.umount', docker_ds, {'force': True})
+                await self.middleware.call('catalog.sync')
+            except Exception as e:
+                await self.middleware.call(
+                    'docker.state.set_status', Status.FAILED.value,
+                    f'Failed to {"mount" if mount else "umount"} {docker_ds!r}: {e}',
+                )
+                raise
+
+    async def mount(self):
+        await self.common_func(True)
+
+    async def umount(self):
+        await self.common_func(False)

--- a/src/middlewared/middlewared/plugins/docker/fs_manage.py
+++ b/src/middlewared/middlewared/plugins/docker/fs_manage.py
@@ -32,7 +32,7 @@ class DockerFilesystemManageService(Service):
     async def umount(self):
         await self.common_func(False)
 
-    async def ix_apps_is_mounted(self):
+    async def ix_apps_is_mounted(self, dataset_to_check=None):
         """
         This will tell us if some dataset is mounted on /mnt/.ix-apps or not.
         """
@@ -43,4 +43,10 @@ class DockerFilesystemManageService(Service):
                 return False
             raise
 
-        return False if fs_details['source'].startswith('boot-pool/') else True
+        if fs_details['source'].startswith('boot-pool/'):
+            return False
+
+        if dataset_to_check:
+            return fs_details['source'] == dataset_to_check
+
+        return True

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -54,6 +54,10 @@ class DockerSetupService(Service):
         # This is problematic for bridge interfaces which can or cannot come up in time
         await self.validate_interfaces()
 
+        # Make sure correct ix-apps dataset is mounted
+        if not await self.middleware.call('docker.fs_manage.ix_apps_is_mounted', config['dataset']):
+            raise CallError(f'{config["dataset"]!r} dataset is not mounted on {IX_APPS_MOUNT_PATH!r}')
+
     @private
     async def validate_interfaces(self):
         default_iface, success = await self.middleware.run_in_thread(wait_for_default_interface_link_state_up)

--- a/src/middlewared/middlewared/plugins/docker/state_setup.py
+++ b/src/middlewared/middlewared/plugins/docker/state_setup.py
@@ -70,6 +70,8 @@ class DockerSetupService(Service):
             return
 
         await self.create_update_docker_datasets(config['dataset'])
+        # Docker dataset would not be mounted at this point, so we will explicitly mount them now
+        await self.middleware.call('docker.fs_manage.mount')
         await self.middleware.call('docker.state.start_service')
         self.middleware.create_task(self.middleware.call('docker.state.periodic_check'))
 

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -13,7 +13,6 @@ class DockerService(SimpleService):
     async def before_start(self):
         await self.middleware.call('docker.state.set_status', Status.INITIALIZING.value)
         await self.middleware.call('docker.state.before_start_check')
-        await self.middleware.call('docker.fs_manage.mount')
         await self.middleware.call('catalog.sync')
         for key, value in (
             ('vm.panic_on_oom', 0),
@@ -54,6 +53,5 @@ class DockerService(SimpleService):
         await self.middleware.call('docker.state.set_status', Status.STOPPING.value)
 
     async def after_stop(self):
-        await self.middleware.call('docker.fs_manage.umount')
         await self.middleware.call('docker.state.set_status', Status.STOPPED.value)
         await self.middleware.call('catalog.sync')

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -10,25 +10,10 @@ class DockerService(SimpleService):
     etc = ['docker']
     systemd_unit = 'docker'
 
-    async def mount_umount_ix_apps(self, mount):
-        if docker_ds := (await self.middleware.call('docker.config'))['dataset']:
-            try:
-                if mount:
-                    await self.middleware.call('zfs.dataset.mount', docker_ds, {'recursive': True, 'force_mount': True})
-                else:
-                    await self.middleware.call('zfs.dataset.umount', docker_ds, {'force': True})
-                await self.middleware.call('catalog.sync')
-            except Exception as e:
-                await self.middleware.call(
-                    'docker.state.set_status', Status.FAILED.value,
-                    f'Failed to {"mount" if mount else "umount"} {docker_ds!r}: {e}',
-                )
-                raise
-
     async def before_start(self):
         await self.middleware.call('docker.state.set_status', Status.INITIALIZING.value)
         await self.middleware.call('docker.state.before_start_check')
-        await self.mount_umount_ix_apps(True)
+        await self.middleware.call('docker.fs_manage.mount')
         await self.middleware.call('catalog.sync')
         for key, value in (
             ('vm.panic_on_oom', 0),
@@ -69,6 +54,6 @@ class DockerService(SimpleService):
         await self.middleware.call('docker.state.set_status', Status.STOPPING.value)
 
     async def after_stop(self):
-        await self.mount_umount_ix_apps(False)
+        await self.middleware.call('docker.fs_manage.umount')
         await self.middleware.call('docker.state.set_status', Status.STOPPED.value)
         await self.middleware.call('catalog.sync')

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -8,6 +8,11 @@ from middlewared.utils.mount import getmntinfo
 from middlewared.utils.path import is_child
 
 
+def handle_ds_not_found(error_code: int, ds_name: str):
+    if error_code == libzfs.Error.NOENT.value:
+        raise CallError(f'Dataset {ds_name!r} not found', errno.ENOENT)
+
+
 class ZFSDatasetService(Service):
 
     class Config:
@@ -69,6 +74,7 @@ class ZFSDatasetService(Service):
                     dataset.mount()
         except libzfs.ZFSException as e:
             self.logger.error('Failed to mount dataset', exc_info=True)
+            handle_ds_not_found(e, name)
             raise CallError(f'Failed to mount dataset: {e}')
 
     @accepts(Str('name'), Dict('options', Bool('force', default=False)))
@@ -79,6 +85,7 @@ class ZFSDatasetService(Service):
                 dataset.umount(force=options['force'])
         except libzfs.ZFSException as e:
             self.logger.error('Failed to umount dataset', exc_info=True)
+            handle_ds_not_found(e, name)
             raise CallError(f'Failed to umount dataset: {e}')
 
     @accepts(
@@ -96,6 +103,7 @@ class ZFSDatasetService(Service):
                 dataset.rename(options['new_name'], recursive=options['recursive'])
         except libzfs.ZFSException as e:
             self.logger.error('Failed to rename dataset', exc_info=True)
+            handle_ds_not_found(e, name)
             raise CallError(f'Failed to rename dataset: {e}')
 
     def promote(self, name):
@@ -105,6 +113,7 @@ class ZFSDatasetService(Service):
                 dataset.promote()
         except libzfs.ZFSException as e:
             self.logger.error('Failed to promote dataset', exc_info=True)
+            handle_ds_not_found(e, name)
             raise CallError(f'Failed to promote dataset: {e}')
 
     def inherit(self, name, prop, recursive=False):
@@ -116,6 +125,8 @@ class ZFSDatasetService(Service):
                     raise CallError(f'Property {prop!r} not found.', errno.ENOENT)
                 zprop.inherit(recursive=recursive)
         except libzfs.ZFSException as e:
+            handle_ds_not_found(e, name)
+
             if prop != 'mountpoint':
                 raise CallError(str(e))
 

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -74,7 +74,7 @@ class ZFSDatasetService(Service):
                     dataset.mount()
         except libzfs.ZFSException as e:
             self.logger.error('Failed to mount dataset', exc_info=True)
-            handle_ds_not_found(e, name)
+            handle_ds_not_found(e.code, name)
             raise CallError(f'Failed to mount dataset: {e}')
 
     @accepts(Str('name'), Dict('options', Bool('force', default=False)))
@@ -85,7 +85,7 @@ class ZFSDatasetService(Service):
                 dataset.umount(force=options['force'])
         except libzfs.ZFSException as e:
             self.logger.error('Failed to umount dataset', exc_info=True)
-            handle_ds_not_found(e, name)
+            handle_ds_not_found(e.code, name)
             raise CallError(f'Failed to umount dataset: {e}')
 
     @accepts(
@@ -103,7 +103,7 @@ class ZFSDatasetService(Service):
                 dataset.rename(options['new_name'], recursive=options['recursive'])
         except libzfs.ZFSException as e:
             self.logger.error('Failed to rename dataset', exc_info=True)
-            handle_ds_not_found(e, name)
+            handle_ds_not_found(e.code, name)
             raise CallError(f'Failed to rename dataset: {e}')
 
     def promote(self, name):
@@ -113,7 +113,7 @@ class ZFSDatasetService(Service):
                 dataset.promote()
         except libzfs.ZFSException as e:
             self.logger.error('Failed to promote dataset', exc_info=True)
-            handle_ds_not_found(e, name)
+            handle_ds_not_found(e.code, name)
             raise CallError(f'Failed to promote dataset: {e}')
 
     def inherit(self, name, prop, recursive=False):
@@ -125,7 +125,7 @@ class ZFSDatasetService(Service):
                     raise CallError(f'Property {prop!r} not found.', errno.ENOENT)
                 zprop.inherit(recursive=recursive)
         except libzfs.ZFSException as e:
-            handle_ds_not_found(e, name)
+            handle_ds_not_found(e.code, name)
 
             if prop != 'mountpoint':
                 raise CallError(str(e))


### PR DESCRIPTION
This PR adds changes to improve docker datasets mount/umount behavior. Earlier we used to mount/umount on docker service start/stop but that was excessive after discussion with Caleb and the finalized workflow was:

1. Mount on system boot if docker is configured
2. Umount/mount only if docker pool is changed
