### PR TITLE
NAS-131232 / 25.04 / Fix SMB share ACL sync log spam

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -185,7 +185,7 @@ class ShareSec(CRUDService):
             if not (share_acl := filter_list(entries, [['key', '=', f'SECDESC/{share_name.lower()}']])):
                 continue
 
-            if share_acl[0] != s['share_acl']:
+            if share_acl[0]['value'] != s['share_acl']:
                 self.logger.debug('Updating stored copy of SMB share ACL on %s', share_name)
                 await self.middleware.call(
                     'datastore.update',


### PR DESCRIPTION
A faulty check for changed SMB share ACL was triggering datastore write on every check interval.