### PR TITLE
NAS-131232 / 24.10.0 / Fix SMB share ACL sync log spam (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -184,7 +184,7 @@ class ShareSec(CRUDService):
             if not (share_acl := filter_list(entries, [['key', '=', f'SECDESC/{share_name.lower()}']])):
                 continue
 
-            if share_acl[0] != s['share_acl']:
+            if share_acl[0]['value'] != s['share_acl']:
                 self.logger.debug('Updating stored copy of SMB share ACL on %s', share_name)
                 await self.middleware.call(
                     'datastore.update',


### PR DESCRIPTION
A faulty check for changed SMB share ACL was triggering datastore write on every check interval.

Original PR: https://github.com/truenas/middleware/pull/14527
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131232