### PR TITLE
Fix `refresh` method call in directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -227,7 +227,7 @@ class DirectoryServices(Service):
         # nsswitch.conf needs to be updated
         self.middleware.call_sync('etc.generate', 'nss')
         job.set_progress(10, 'Refreshing cache'),
-        cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh')
+        cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh_impl')
         cache_refresh.wait_sync()
 
         job.set_progress(75, 'Restarting dependent services')

--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -275,7 +275,7 @@ class DSCache(Service):
 
     async def abort_refresh(self):
         cache_job = await self.middleware.call('core.get_jobs', [
-            ['method', '=', 'directoryservices.cache.refresh'],
+            ['method', '=', 'directoryservices.cache.refresh_impl'],
             ['state', '=', 'RUNNING']
         ])
         if cache_job:


### PR DESCRIPTION
It looks like https://github.com/truenas/middleware/pull/13924 renamed the `directoryservices.cache.refresh` method.
However, it wasn't actually renamed in all the places where it's called, so here: https://github.com/truenas/middleware/blob/8e3f19794b47fdee4f9b0fd314abbdbf3a4efa87/src/middlewared/middlewared/plugins/directoryservices.py#L230
and here:
https://github.com/truenas/middleware/blob/8e3f19794b47fdee4f9b0fd314abbdbf3a4efa87/src/middlewared/middlewared/plugins/directoryservices_/cache.py#L278

This breaks directory services on 24.10 and later.
I've briefly tested the changes from this PR on a ElectricEel-24.10-BETA.1 system and an Active Directory setup with Windows Server 2022 now seems to work again. Please double check that these changes are fine though.

If this change is used, it should not only be backported the final 24.10.0 `stable/electriceel` release, but IMO also to the upcoming 24.10-RC.1, since directory services break without this. 

I've not created a JIRA ticket for the issue yet, since it looks like they're automatically created for PRs (sometimes?)—although they're always locked down. Let me know if you still want a ticket for the actual underlying issue.
Traceback from the actual issue is below:

<details><summary>Traceback of the issue (unmodified 24.10-BETA.1 system) (click to open)</summary>
<p>

```python
Error: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/utils/service/call.py", line 30, in _method_lookup
    methodobj = getattr(serviceobj, method_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DSCache' object has no attribute 'refresh'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 469, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 513, in __run_body
    rv = await self.middleware.run_in_thread(self.method, *args)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1356, in run_in_thread
    return await self.run_in_executor(io_thread_pool_executor, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1353, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/directoryservices.py", line 228, in setup
    cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh')
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1615, in call_sync
    serviceobj, methodobj = self._method_lookup(name)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/service/call.py", line 32, in _method_lookup
    raise MethodNotFoundError(method_name, service)
middlewared.utils.service.call.MethodNotFoundError: [ENOMETHOD] Method 'refresh' not found in 'directoryservices.cache'


```

</p>
</details> 

--- 

(A similar issue with active directory being broken by a typo/refactor already happened a couple of years back on a stable release. Of course, this is a beta release, so I don’t expect anything, but it might be worth adding tests or manually test with directory services configured, at least before releasing a stable version.)