### PR TITLE
NAS-131265 / 24.10.0 / Fix typo in cache refresh calls (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -227,7 +227,7 @@ class DirectoryServices(Service):
         # nsswitch.conf needs to be updated
         self.middleware.call_sync('etc.generate', 'nss')
         job.set_progress(10, 'Refreshing cache'),
-        cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh')
+        cache_refresh = self.middleware.call_sync('directoryservices.cache.refresh_impl')
         cache_refresh.wait_sync()
 
         job.set_progress(75, 'Restarting dependent services')

--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -275,7 +275,7 @@ class DSCache(Service):
 
     async def abort_refresh(self):
         cache_job = await self.middleware.call('core.get_jobs', [
-            ['method', '=', 'directoryservices.cache.refresh'],
+            ['method', '=', 'directoryservices.cache.refresh_impl'],
             ['state', '=', 'RUNNING']
         ])
         if cache_job:


### PR DESCRIPTION
This commit fixes some errors introduced while renaming private directory services cache methods.

Original PR: https://github.com/truenas/middleware/pull/14533
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131265