### PR TITLE
NAS-131186 / 24.10.0 / Add stop-alua to scst_util.sh and call before stopping middlewared (by bmeagherix)

### DIFF
--- a/debian/debian/ix-reboot.service
+++ b/debian/debian/ix-reboot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Exec TrueNAS shutdown tasks
+Description=Exec TrueNAS reboot tasks
 
 After=network.target middlewared.service
 
@@ -8,8 +8,6 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=true
 ExecStop=/usr/local/bin/scst_util.sh stop-alua
-ExecStop=midclt call core.event_send system.shutdown ADDED
-ExecStop=midclt call -job initshutdownscript.execute_init_tasks SHUTDOWN
 StandardOutput=null
 StandardError=null
 TimeoutStopSec=0

--- a/debian/debian/rules
+++ b/debian/debian/rules
@@ -16,6 +16,7 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-netif
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-postinit
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-preinit
+	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-reboot
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-reporting
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-shutdown
 	dh_installsystemd --no-start -r --no-restart-after-upgrade --name=ix-ssh-keys

--- a/src/freenas/usr/local/bin/scst_util.sh
+++ b/src/freenas/usr/local/bin/scst_util.sh
@@ -8,13 +8,32 @@ force_close() {
 	wait
 }
 
+stop_alua() {
+	shopt -s nullglob
+
+	# Disable iSCSI
+	if [ -f /sys/kernel/scst_tgt/targets/iscsi/enabled ]; then
+		echo 0 > /sys/kernel/scst_tgt/targets/iscsi/enabled
+	fi
+
+	# Turn off any cluster_mode in parallel
+	for cm in /sys/kernel/scst_tgt/devices/*/cluster_mode ; do
+		echo 0 > "$cm" &
+	done
+	wait
+}
+
 case "$1" in
     force-close)
         force_close
         rc=$?
         ;;
+    stop-alua)
+        stop_alua
+        rc=$?
+        ;;
     *)
-        echo "Usage: $0 {force-close}"
+        echo "Usage: $0 {force-close|stop-alua}"
         exit 2
         ;;
 esac

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -326,7 +326,7 @@ class FailoverEventsService(Service):
         elif event == 'BACKUP':
             return self.run_call('failover.events.vrrp_backup', fobj, ifname, event)
 
-    def fenced_start_loop(self, max_retries=3):
+    def fenced_start_loop(self, max_retries=4):
         # When active node is rebooted administratively from shell, the
         # fenced process will continue running on the node until systemd
         # finishes terminating services and actually reboots. Hence, we may


### PR DESCRIPTION
Turn off any ALUA `cluster_mode` _**_before_**_ stopping _middlewared_ on reboot or shutdown.

Original PR: https://github.com/truenas/middleware/pull/14520
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131186