### PR TITLE
NAS-131293 / 25.04 / fix regression in alerts

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -712,14 +712,14 @@ class AlertService(Service):
         try:
             try:
                 for alert in await self.middleware.call("failover.call_remote", "alert.run_source", [name]):
-                    other_node_alerts.append([
+                    other_node_alerts.append(
                         Alert(**dict(
                             {k: v for k, v in alert.items() if k in keys},
                             klass=AlertClass.class_by_name[alert["klass"]],
                             _source=alert["source"],
                             _key=alert["key"]
                         ))
-                    ])
+                    )
             except CallError as e:
                 if e.errno not in NETWORK_ERRORS + (CallError.EALERTCHECKERUNAVAILABLE,):
                     raise


### PR DESCRIPTION
A subtle typo is causing this crash on HA. It's happening because I'm appending a list to a list.
```
[2024/09/18 10:25:58] (ERROR) middlewared.job.run():504 - Job <bound method AlertService.process_alerts of <middlewared.plugins.alert.AlertService object at 0x7f2ac1ecd7d0>> failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 489, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 534, in __run_body
    rv = await self.method(*args)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/alert.py", line 494, in process_alerts
    await self.__run_alerts()
  File "/usr/lib/python3/dist-packages/middlewared/plugins/alert.py", line 774, in __run_alerts
    oalert.node = fi.other_node
    ^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'node'
```