### PR TITLE
NAS-131179 / 25.04 / fix drive identify on h-series

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -129,10 +129,9 @@ class Enclosure2Service(Service):
                     'enclosure2.set_slot_status', f'Slot {data["slot"]} does not support identification'
                 )
             else:
-                by_dirname = enc_info['model'] in (ControllerModels.H10.value, ControllerModels.H20.value)
                 try:
                     toggle_enclosure_slot_identifier(
-                        f'/sys/class/enclosure/{enc_info["pci"]}', origslot, data['status'], by_dirname
+                        f'/sys/class/enclosure/{enc_info["pci"]}', origslot, data['status']
                     )
                 except FileNotFoundError:
                     raise CallError(f'Slot: {data["slot"]!r} not found', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -37,7 +37,7 @@ class Enclosure:
         self._should_ignore_enclosure()
         self.sysfs_map, self.disks_map, self.elements = dict(), dict(), dict()
         if not self.should_ignore:
-            self.sysfs_map = map_disks_to_enclosure_slots(self.pci)
+            self.sysfs_map = map_disks_to_enclosure_slots(self)
             self.disks_map = self._get_array_device_mapping_info()
             self.elements = self._parse_elements(enc_stat['elements'])
 
@@ -301,7 +301,7 @@ class Enclosure:
                 try:
                     dinfo = self.disks_map[slot]
                     sysfs_slot = dinfo[SYSFS_SLOT_KEY]
-                    parsed['dev'] = self.sysfs_map[sysfs_slot]['name']
+                    parsed['dev'] = self.sysfs_map[sysfs_slot].name
                 except KeyError:
                     # this happens on some of the MINI platforms, for example,
                     # the MINI-3.0-XL+ because we map the 1st drive and only
@@ -316,7 +316,7 @@ class Enclosure:
                 # does this enclosure slot support reporting identification status?
                 # (i.e. whether the LED is currently lit up)
                 if dinfo.get(SUPPORTS_IDENTIFY_STATUS_KEY, parsed[SUPPORTS_IDENTIFY_KEY]):
-                    parsed[DRIVE_BAY_LIGHT_STATUS] = self.sysfs_map[sysfs_slot]['locate']
+                    parsed[DRIVE_BAY_LIGHT_STATUS] = self.sysfs_map[sysfs_slot].locate
                 else:
                     parsed[DRIVE_BAY_LIGHT_STATUS] = None
 

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -716,11 +716,11 @@ class Enclosure:
                 return 7
             elif self.is_mini_3_xl_plus:
                 return 10
-            elif any((self.is_xseries, self.is_r30, self.is_12_bay_jbod)):
+            elif any((self.is_hseries, self.is_xseries, self.is_r30, self.is_12_bay_jbod)):
                 return 12
             elif self.is_r20_series:
                 return 14
-            elif any((self.is_hseries, self.is_r10)):
+            elif self.is_r10:
                 return 16
             elif any((self.is_fseries, self.is_mseries, self.is_24_bay_jbod)):
                 return 24

--- a/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/sysfs_disks.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class BaseDev:
-    name: str = None
-    locate: str = None
+    name: str | None = None
+    locate: str | None = None
 
 
 def map_disks_to_enclosure_slots(enc) -> dict[int, BaseDev]:


### PR DESCRIPTION
The legacy enclosure plugin has this logic but it wasn't copied over to the new enclosure plugin. H-series has to be handled specially when enumerating drives via sysfs. Furthermore, the `front_slots` property was incorrectly reporting 16 front slots when h-series only has 12.