### PR TITLE
NAS-130966 / 24.10.0 / Make sure we delete any app volume mount datasets created on app install failure (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -261,8 +261,10 @@ class AppService(CRUDService):
         shutil.rmtree(get_installed_app_path(app_name), ignore_errors=True)
 
         if apps_volume_ds and remove_ds:
-            with contextlib.suppress(Exception):
+            try:
                 self.middleware.call_sync('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
+            except Exception:
+                self.logger.error('Failed to remove %r app volume dataset', apps_volume_ds, exc_info=True)
 
         self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)
         self.middleware.send_event('app.query', 'REMOVED', id=app_name)

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -240,10 +240,13 @@ class AppService(CRUDService):
                 compose_action(app_name, version, 'up', force_recreate=True, remove_orphans=True)
         except Exception as e:
             job.set_progress(80, f'Failure occurred while installing {app_name!r}, cleaning up')
+            apps_volume_ds = self.get_app_volume_ds(app_name)
             for method, args, kwargs in (
                 (compose_action, (app_name, version, 'down'), {'remove_orphans': True}),
                 (shutil.rmtree, (get_installed_app_path(app_name),), {}),
-            ):
+            ) + (
+                self.middleware.call_sync, ('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
+            ) if apps_volume_ds else ():
                 with contextlib.suppress(Exception):
                     method(*args, **kwargs)
 

--- a/src/middlewared/middlewared/plugins/apps/custom_app.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app.py
@@ -84,14 +84,9 @@ class AppCustomService(Service):
                 'Failure occurred while '
                 f'{"converting" if app_being_converted else "installing"} {app_name!r}, cleaning up'
             )
-            for method, args, kwargs in (
-                (compose_action, (app_name, version, 'down'), {'remove_orphans': True}),
-                (shutil.rmtree, (get_installed_app_path(app_name),), {}),
-            ):
-                with contextlib.suppress(Exception):
-                    method(*args, **kwargs)
 
-            self.middleware.send_event('app.query', 'REMOVED', id=app_name)
+            self.middleware.call_sync('app.remove_failed_resources', app_name, version)
+
             raise e from None
         else:
             self.middleware.call_sync('app.metadata.generate').wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/path.py
@@ -11,6 +11,10 @@ def get_collective_metadata_path() -> str:
     return os.path.join(IX_APPS_MOUNT_PATH, 'metadata.yaml')
 
 
+def get_app_parent_volume_ds(docker_ds: str, app_name: str) -> str:
+    return os.path.join(docker_ds, 'app_mounts', app_name)
+
+
 def get_app_parent_config_path() -> str:
     return os.path.join(IX_APPS_MOUNT_PATH, 'app_configs')
 


### PR DESCRIPTION
This PR adds changes to remove any app volume mount datasets created during installation in the event installation process failed for whatever reason. We are picky on this end and make sure we only remove them if the app volume dataset didn't exist before as when a user deletes an app, it's optional for him/her to remove the app volume mounts datasets and we don't want them nuked if a user installs an app with the same name and app install fails for whatever reason.

Original PR: https://github.com/truenas/middleware/pull/14544
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130966