### PR TITLE
NAS-131296 / 24.10.0 / fix modify time for HA debug archives (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system/debug.py
+++ b/src/middlewared/middlewared/plugins/system/debug.py
@@ -4,6 +4,7 @@ import os
 import requests
 import shutil
 import tarfile
+import time
 
 from middlewared.schema import accepts, returns
 from middlewared.service import CallError, job, private, Service
@@ -136,6 +137,10 @@ class SystemService(Service):
 
                 tarinfo = tarfile.TarInfo(f'{remote_hostname}.txz')
                 tarinfo.size = standby_debug.tell()
+                # need to set a valid modify time because `standby_debug`
+                # is an io.BytesIO object which doesn't have any type of
+                # file metadata on it.
+                tarinfo.mtime = time.time()
                 standby_debug.seek(0)
                 tar.addfile(tarinfo, fileobj=standby_debug)
 


### PR DESCRIPTION
The standby debug is downloaded via REST over the heartbeat and put into an io.BytesIO object. This bytes object doesn't store file metadata like mtime. To remedy the situation, simply update the mtime attribute after we add it to a TarInfo object before writing it to the parent archive. Without these changes, the mtime is empty which gets interpreted in many different ways depending on the OS that is interpreting the archive file.

This has been a _long_ standing issue.

Original PR: https://github.com/truenas/middleware/pull/14549
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131296