### PR TITLE
NAS-131350 / 25.04 / Fix failing build

### DIFF
--- a/src/freenas/debian/preinst
+++ b/src/freenas/debian/preinst
@@ -11,7 +11,8 @@ for file in \
     /etc/logrotate.d/netdata \
     /usr/lib/tmpfiles.d/nut-server.conf \
     /usr/lib/tmpfiles.d/nut-client.conf \
-    /usr/lib/tmpfiles.d/nut-common.tmpfiles
+    /usr/lib/tmpfiles.d/nut-common.tmpfiles \
+    /usr/share/misc/enterprise-numbers.txt
 do
     dpkg-divert --add --package truenas-files --rename --divert "/var/trash/$(echo "$file" | sed "s/\//_/g")" "$file"
 done


### PR DESCRIPTION
This commit adds changes to move IANA numbers to trash as outlined by https://github.com/truenas/middleware/pull/13868/files because they are now coming from ipmitool we have in debian, however they have a decent diff from the URI we are pulling from and the comment there outlines it needs to be a version after 1.18.9-4 but we are still at the same version. So with this change, we remove the enterprise-numbers.txt file coming from ipmitool and keep on pulling our own instead.