### PR TITLE
NAS-131351 / 25.04 / Add basic docker configuration integration tests

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -73,7 +73,6 @@ class DockerStateService(Service):
                 await self.set_status(Status.RUNNING.value)
             else:
                 await self.set_status(Status.FAILED.value)
-            await self.middleware.call('catalog.sync')
 
     async def validate(self, raise_error=True):
         # When `raise_error` is unset, we return boolean true if there was no issue with the state

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -13,7 +13,6 @@ class DockerService(SimpleService):
     async def before_start(self):
         await self.middleware.call('docker.state.set_status', Status.INITIALIZING.value)
         await self.middleware.call('docker.state.before_start_check')
-        await self.middleware.call('catalog.sync')
         for key, value in (
             ('vm.panic_on_oom', 0),
             ('vm.overcommit_memory', 1),

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -45,7 +45,6 @@ class DockerService(SimpleService):
     async def after_start(self):
         await self.middleware.call('docker.state.set_status', Status.RUNNING.value)
         self.middleware.create_task(self.middleware.call('docker.events.setup'))
-        await self.middleware.call('catalog.sync')
         if (await self.middleware.call('docker.config'))['enable_image_updates']:
             self.middleware.create_task(self.middleware.call('app.image.op.check_update'))
 
@@ -54,4 +53,3 @@ class DockerService(SimpleService):
 
     async def after_stop(self):
         await self.middleware.call('docker.state.set_status', Status.STOPPED.value)
-        await self.middleware.call('catalog.sync')

--- a/src/middlewared/middlewared/test/integration/utils/docker.py
+++ b/src/middlewared/middlewared/test/integration/utils/docker.py
@@ -1,0 +1,29 @@
+import os
+
+
+IX_APPS_DIR_NAME = '.ix-apps'
+IX_APPS_MOUNT_PATH: str = os.path.join('/mnt', IX_APPS_DIR_NAME)
+
+DOCKER_DATASET_PROPS = {
+    'aclmode': 'discard',
+    'acltype': 'posix',
+    'atime': 'off',
+    'casesensitivity': 'sensitive',
+    'canmount': 'noauto',
+    'dedup': 'off',
+    'encryption': 'off',
+    'exec': 'on',
+    'normalization': 'none',
+    'overlay': 'on',
+    'setuid': 'on',
+    'snapdir': 'hidden',
+    'xattr': 'sa',
+}
+
+
+def dataset_props(ds_name: str) -> dict:
+    return DOCKER_DATASET_PROPS | {
+        'mountpoint': IX_APPS_MOUNT_PATH if ds_name.endswith('/ix-apps') else os.path.join(
+            IX_APPS_MOUNT_PATH, ds_name.split('/', 2)[-1]
+        ),
+    }

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -2,7 +2,7 @@ import pytest
 
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call
-from middlewared.test.integration.utils.docker import dataset_props
+from middlewared.test.integration.utils.docker import dataset_props, IX_APPS_MOUNT_PATH
 
 
 @pytest.fixture(scope='module')
@@ -30,6 +30,12 @@ def test_docker_datasets_properties():
                 invalid_props[to_check_prop] = current_props[to_check_prop]['value']
 
         assert invalid_props == {}, f'{ds_name} has invalid properties: {invalid_props}'
+
+
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_correct_docker_dataset_is_mounted():
+    docker_config = call('docker.config')
+    assert call('filesystem.statfs', IX_APPS_MOUNT_PATH)['source'] == docker_config['dataset']
 
 
 @pytest.mark.dependency(depends=['docker_setup'])

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -53,6 +53,11 @@ def test_apps_being_reported():
     assert call('app.available', [], {'count': True}) != 0
 
 
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_apps_are_running():
+    assert call('docker.status')['status'] == 'RUNNING'
+
+
 def test_unset_docker_pool(docker_pool):
     docker_config = call('docker.update', {'pool': None}, job=True)
     assert docker_config['pool'] is None, docker_config

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -1,7 +1,8 @@
 import pytest
 
-from middlewared.test.integration.utils import call
 from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.utils.docker import dataset_props
 
 
 @pytest.fixture(scope='module')
@@ -10,9 +11,25 @@ def docker_pool():
         yield pool['name']
 
 
+@pytest.mark.dependency(name='docker_setup')
 def test_docker_setup(docker_pool):
     docker_config = call('docker.update', {'pool': docker_pool}, job=True)
     assert docker_config['pool'] == docker_pool, docker_config
+
+
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_docker_datasets_properties():
+    docker_config = call('docker.config')
+    datasets = {
+        ds['name']: ds['properties'] for ds in call('zfs.dataset.query', [['id', '^', docker_config['dataset']]])
+    }
+    for ds_name, current_props in datasets.items():
+        invalid_props = {}
+        for to_check_prop, to_check_prop_value in dataset_props(ds_name).items():
+            if current_props[to_check_prop]['value'] != to_check_prop_value:
+                invalid_props[to_check_prop] = current_props[to_check_prop]['value']
+
+        assert invalid_props == {}, f'{ds_name} has invalid properties: {invalid_props}'
 
 
 def test_unset_docker_pool(docker_pool):

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -1,0 +1,20 @@
+import pytest
+
+from middlewared.test.integration.utils import call
+from middlewared.test.integration.assets.pool import another_pool
+
+
+@pytest.fixture(scope='module')
+def docker_pool():
+    with another_pool() as pool:
+        yield pool['name']
+
+
+def test_docker_setup(docker_pool):
+    docker_config = call('docker.update', {'pool': docker_pool}, job=True)
+    assert docker_config['pool'] == docker_pool, docker_config
+
+
+def test_unset_docker_pool(docker_pool):
+    docker_config = call('docker.update', {'pool': None}, job=True)
+    assert docker_config['pool'] is None, docker_config

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -32,6 +32,21 @@ def test_docker_datasets_properties():
         assert invalid_props == {}, f'{ds_name} has invalid properties: {invalid_props}'
 
 
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_catalog_synced_properly():
+    assert call('catalog.synced') is True
+
+
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_catalog_sync_location():
+    assert call('catalog.config')['location'] == '/mnt/.ix-apps/truenas_catalog'
+
+
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_apps_being_reported():
+    assert call('app.available', [], {'count': True}) != 0
+
+
 def test_unset_docker_pool(docker_pool):
     docker_config = call('docker.update', {'pool': None}, job=True)
     assert docker_config['pool'] is None, docker_config


### PR DESCRIPTION
This PR adds basic docker configuration tests where we setup docker and make sure all the required datasets have required properties in place. While at it, some optimization has also been done to reduce number of `catalog.sync` calls going on because they were just redundant.