### PR TITLE
NAS-131337 / 25.04 / Make `_setup_periodic_tasks` thread-safe

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1058,7 +1058,8 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                         f"Setting up periodic task {method_name} to run every {method._periodic.interval} seconds"
                     )
 
-                    self.loop.call_later(
+                    self.loop.call_soon_threadsafe(
+                        self.loop.call_later,
                         delay,
                         functools.partial(
                             self.__call_periodic_task,


### PR DESCRIPTION
It is called from `notify_postinit` which is not an async function