### PR TITLE
NAS-131318 / 24.10.0 / Get rid of `unable to open cache: unable to locate cache directory: neither $XDG_CACHE_HOME nor $HOME are defined` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -21,7 +21,7 @@ def get_restic_config(cloud_backup):
 
     url, env = remote.get_restic_config(cloud_backup)
 
-    cmd = ["restic", "-r", f"{remote.rclone_type}:{url}/{remote_path}"]
+    cmd = ["restic", "--no-cache", "-r", f"{remote.rclone_type}:{url}/{remote_path}"]
 
     env["RESTIC_PASSWORD"] = cloud_backup["password"]
 

--- a/tests/api2/test_cloud_backup.py
+++ b/tests/api2/test_cloud_backup.py
@@ -72,6 +72,7 @@ def test_cloud_backup(cloud_backup_task):
     run_task(cloud_backup_task.task)
 
     logs = ssh("cat " + call("cloud_backup.get_instance", cloud_backup_task.task["id"])["job"]["logs_path"])
+    assert "unable to open cache:" not in logs
     assert "Files:           1 new,     0 changed,     0 unmodified" in logs
 
     snapshots = call("cloud_backup.list_snapshots", cloud_backup_task.task["id"])


### PR DESCRIPTION
This cache was neither used previously nor necessary (we don't retrieve same files from the backup constantly)

Original PR: https://github.com/truenas/middleware/pull/14562
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131318