### PR TITLE
NAS-131365 / 25.04 / Better error message for bad storj bucket name

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/storjix.py
+++ b/src/middlewared/middlewared/rclone/remote/storjix.py
@@ -45,6 +45,8 @@ class StorjIxRcloneRemote(BaseRcloneRemote):
                 s3_client.create_bucket(Bucket=name)
             except s3_client.exceptions.BucketAlreadyExists as e:
                 raise CallError(str(e), errno=errno.EEXIST)
+            except Exception as e:
+                raise CallError("Bucket name can only contain lowercase letters, numbers, and hyphens", errno.EINVAL, str(e))
 
         return await self.middleware.run_in_thread(create_bucket_sync)
 

--- a/src/middlewared/middlewared/rclone/remote/storjix.py
+++ b/src/middlewared/middlewared/rclone/remote/storjix.py
@@ -45,8 +45,11 @@ class StorjIxRcloneRemote(BaseRcloneRemote):
                 s3_client.create_bucket(Bucket=name)
             except s3_client.exceptions.BucketAlreadyExists as e:
                 raise CallError(str(e), errno=errno.EEXIST)
-            except Exception as e:
-                raise CallError("Bucket name can only contain lowercase letters, numbers, and hyphens", errno.EINVAL, str(e))
+            except botocore.exceptions.ClientError as e:
+                if "InvalidBucketName" in e.args[0]:
+                    raise CallError("Bucket name can only contain lowercase letters, numbers, and hyphens.",
+                                    errno.EINVAL, str(e))
+                raise
 
         return await self.middleware.run_in_thread(create_bucket_sync)
 


### PR DESCRIPTION
Currently the returned error message is "An error occurred (InvalidBucketName) when calling the CreateBucket operation: The specified bucket is not valid." To save the user some research, we can clarify this message to "Bucket name can only contain lowercase letters, numbers, and hyphens" which is verbatim in the [storj documentation](https://storj.dev/support/object-browser#:~:text=The%20bucket%20name%20can%20only%20contain%20lowercase%20letters%2C%20numbers%2C%20and%20hyphens.).

![bad_bucket_name_alert](https://github.com/user-attachments/assets/03fbd633-f9ea-431e-a48d-047a3fbef265)
 