### PR TITLE
NAS-131370 / 25.04 / Fix post mount actions execution on system dataset setup

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -579,7 +579,8 @@ class SystemDatasetService(ConfigService):
                 os.chmod(mountpoint, mode_perms)
 
             mounted = True
-            self.__post_mount_actions(ds_config['name'], ds_config.get('post_mount_actions', []))
+            if path == SYSDATASET_PATH:
+                self.__post_mount_actions(ds_config['name'], ds_config.get('post_mount_actions', []))
 
         if mounted and path == SYSDATASET_PATH:
             fsid = os.statvfs(SYSDATASET_PATH).f_fsid

--- a/tests/api2/test_system_dataset.py
+++ b/tests/api2/test_system_dataset.py
@@ -77,3 +77,11 @@ def test_system_dataset_mountpoints():
         assert ds_stats["uid"] == system_dataset_spec["chown_config"]["uid"]
         assert ds_stats["gid"] == system_dataset_spec["chown_config"]["gid"]
         assert ds_stats["mode"] & 0o777 == system_dataset_spec["chown_config"]["mode"]
+
+
+def test_netdata_post_mount_action():
+    # We rely on this to make sure system dataset post mount actions are working as intended
+    ds_stats = call("filesystem.stat", "/var/db/system/netdata/ix_state")
+    assert ds_stats["uid"] == 999, ds_stats
+    assert ds_stats["gid"] == 997, ds_stats
+    assert ds_stats["mode"] & 0o777 == 0o755, ds_stats


### PR DESCRIPTION
## Problem

When system dataset is being migrated, if we have a pool from where it i being migrated - we are temporarily mounting it to another location before it is mounted at it's rightful place so we can copy over data.
However during this transition, we have post mount actions being executed which is not alright and can trigger different failures which in the case i ended up finding this was an issue related to netdata setup not being properly executed.

## Solution

Ensure all post mount actions only when the system dataset is mounted at it's rightful place i.e `/var/db/system`. Additionally, permissions for ix-state directory in netdata are corrected if any exception occurs on the first time system tries to setup netdata.