### PR TITLE
NAS-131379 / 25.04 / Add recovery step for case where we fail to ping_dc

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
@@ -108,6 +108,11 @@ class ADHealthMixin:
                 self._recover_secrets()
             case ADHealthCheckFailReason.AD_SECRET_ENTRY_MISSING:
                 self._recover_secrets()
+            case ADHealthCheckFailReason.AD_NETLOGON_FAILURE:
+                # It's possible that our smb.conf has incorrect
+                # information in it. We'll try to regenerate the config
+                # file and the restart winbindd for good measure
+                self.middleware.call_sync('etc.generate', 'smb')
             case ADHealthCheckFailReason.WINBIND_STOPPED:
                 # pick up winbind restart below
                 pass


### PR DESCRIPTION
It is theoretically possible that the smb.conf file is not properly configured for AD causing health check to ping_dc to fail. This commit adds a potential recovery step where we regenerate the smb.conf and restart winbindd.