### PR TITLE
NAS-131115 / 24.10.0 / Fix null data points in UPS stats (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -253,12 +253,18 @@ class DiskTempPlugin(GraphBase):
 class UPSBase(GraphBase):
 
     UPS_IDENTIFIER = None
+    skip_zero_values_in_aggregation = True
 
     async def export_multiple_identifiers(
         self, query_params: dict, identifiers: list, aggregate: bool = True
     ) -> typing.List[dict]:
         self.UPS_IDENTIFIER = (await self.middleware.call('ups.config'))['identifier']
         return await super().export_multiple_identifiers(query_params, identifiers, aggregate)
+
+    def query_parameters(self) -> dict:
+        return super().query_parameters() | {
+            'group': 'median'
+        }
 
 
 class UPSChargePlugin(UPSBase):
@@ -333,7 +339,6 @@ class UPSTemperaturePlugin(UPSBase):
 
     title = 'UPS Temperature'
     vertical_label = 'Celsius'
-    skip_zero_values_in_aggregation = True
     uses_identifiers = False
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:


### PR DESCRIPTION
### Problem
When the UPS service is started after a long period, null values distort the mean calculation because they are included in the average. Furthermore, for datasets larger than 3000 points, Netdata reduces the number of points by creating 3000 groups and calculating the average for each group to get single datapoint. Null values affect the accuracy of these group calculations as well.

### Solution
Skip all zero values when calculating the mean and use the median to represent a single data point in a group if Netdata has more than 3000 data points. This will ensure more accurate aggregation.

Original PR: https://github.com/truenas/middleware/pull/14572
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131115