### PR TITLE
NAS-131398 / 25.04 / Add reason to call to system.reboot in ALUA test

### DIFF
--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -582,7 +582,7 @@ class TestFixtureConfiguredALUA:
         if newnode != fix_orig_active_node:
             if self.VERBOSE:
                 print(f'Restoring {fix_orig_active_node} as MASTER')
-            call('system.reboot')
+            call('system.reboot', 'iSCSI ALUA test')
             newnode2 = self.wait_for_new_master(newnode)
             assert newnode2 == fix_orig_active_node
             self.wait_for_backup()


### PR DESCRIPTION
Recent PR (#14546) added a required `reason` parameter to `system.reboot`.

The call location in this PR was missed in that PR: add a reason.