### PR TITLE
NAS-131330 / 24.10.0 / Better error handling for bad storj bucket name (by creatorcary)

### DIFF
--- a/tests/api2/test_cloud_sync_storj.py
+++ b/tests/api2/test_cloud_sync_storj.py
@@ -1,27 +1,14 @@
-import os
-import sys
-
 import pytest
 
+from config import (
+    STORJ_IX_AWS_ACCESS_KEY_ID,
+    STORJ_IX_AWS_SECRET_ACCESS_KEY,
+    STORJ_IX_BUCKET,
+)
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.assets.cloud_sync import credential, task, run_task
 from middlewared.test.integration.assets.pool import dataset
 
-apifolder = os.getcwd()
-sys.path.append(apifolder)
-
-pytestmark = pytest.mark.skip(reason='See IT ticket IT-9829')
-try:
-    from config import (
-        STORJ_IX_AWS_ACCESS_KEY_ID,
-        STORJ_IX_AWS_SECRET_ACCESS_KEY,
-        STORJ_IX_BUCKET,
-    )
-except ImportError:
-    pytestmark = pytest.mark.skip(reason='Storj credential are missing in config.py')
-    STORJ_IX_AWS_ACCESS_KEY_ID = None
-    STORJ_IX_AWS_SECRET_ACCESS_KEY = None
-    STORJ_IX_BUCKET = None
 
 CREDENTIAL = {
     "provider": "STORJ_IX",

--- a/tests/api2/test_cloud_sync_storj.py
+++ b/tests/api2/test_cloud_sync_storj.py
@@ -50,7 +50,7 @@ def test_storj_list_buckets(storj_credential):
 def storj_sync(storj_credential):
     """Reset the remote bucket to only contain a single empty folder."""
     with dataset("test_storj_sync") as ds:
-        assert ssh(f"mkdir /mnt/{ds}/{DIR_NAME}")
+        ssh(f"mkdir /mnt/{ds}/{DIR_NAME}")
         with task({
             "direction": "PUSH",
             "transfer_mode": "SYNC",

--- a/tests/api2/test_cloud_sync_storj.py
+++ b/tests/api2/test_cloud_sync_storj.py
@@ -21,7 +21,7 @@ TASK_ATTRIBUTES = {
     "bucket": STORJ_IX_BUCKET,
     "folder": "",
 }
-DIR_NAME = "a"
+FILENAME = "a"
 
 
 def test_storj_verify():
@@ -48,9 +48,9 @@ def test_storj_list_buckets(storj_credential):
 
 @pytest.fixture(scope="module")
 def storj_sync(storj_credential):
-    """Reset the remote bucket to only contain a single empty folder."""
+    """Reset the remote bucket to only contain a single empty file."""
     with dataset("test_storj_sync") as ds:
-        ssh(f"mkdir /mnt/{ds}/{DIR_NAME}")
+        ssh(f"touch /mnt/{ds}/{FILENAME}")
         with task({
             "direction": "PUSH",
             "transfer_mode": "SYNC",
@@ -67,7 +67,7 @@ def test_storj_list_directory(storj_credential, storj_sync):
         "attributes": TASK_ATTRIBUTES,
     })
     assert len(result) == 1
-    assert result[0]["Name"] == DIR_NAME
+    assert result[0]["Name"] == FILENAME
 
 
 def test_storj_pull(storj_credential, storj_sync):
@@ -81,4 +81,4 @@ def test_storj_pull(storj_credential, storj_sync):
         }) as t:
             run_task(t)
 
-            assert ssh(f"ls /mnt/{ds}") == DIR_NAME + "\n"
+            assert ssh(f"ls /mnt/{ds}") == FILENAME + "\n"


### PR DESCRIPTION
Currently the returned `CallError` is "An error occurred (InvalidBucketName) when calling the CreateBucket operation: The specified bucket is not valid." To save the user some research, we can clarify this message to the `ValidationError` "Bucket name can only contain lowercase letters, numbers, and hyphens" which is verbatim in the [storj documentation](https://storj.dev/support/object-browser#:~:text=The%20bucket%20name%20can%20only%20contain%20lowercase%20letters%2C%20numbers%2C%20and%20hyphens.) or "The bucket name must be between 3-63 characters in length and cannot contain uppercase."

[s3 bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) (we do not enforce them all!)

We should ask UI to render these errors as red validation text as per the submitted ticket.

![validation_bucke+](https://github.com/user-attachments/assets/d78e8fff-f97d-42d6-8fd6-c8a6a969736a)
![validation_BUCKET](https://github.com/user-attachments/assets/d248a14f-a300-4b6c-bce9-cb648f46745e)


Original PR: https://github.com/truenas/middleware/pull/14569
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131330