### PR TITLE
NAS-131400 / 24.10.0 / Bump docker service start timeout to 120 secs (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -39,7 +39,7 @@ class DockerService(SimpleService):
     async def start(self):
         try:
             await super().start()
-            timeout = 40
+            timeout = 120  # We have this at 120 because HDDs are notorious and docker can take more time there
             # First time when docker is started, it takes a bit more time to initialise itself properly
             # and we need to have sleep here so that after start is called post_start is not dismissed
             while timeout > 0:


### PR DESCRIPTION
This commit adds changes to bump docker start timeout to 120 secs because docker on HDDs can take some time to initialize, even this is not fool proof but after discussing with Caleb we have decided to bump this for now.

Original PR: https://github.com/truenas/middleware/pull/14583
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131400