### PR TITLE
NAS-131422 / 25.04 / Choose qla2xxx_scst kernel module for FC target

### DIFF
--- a/src/freenas/etc/modprobe.d/blacklist-qla2xxx.conf
+++ b/src/freenas/etc/modprobe.d/blacklist-qla2xxx.conf
@@ -1,0 +1,1 @@
+blacklist qla2xxx

--- a/src/freenas/etc/modprobe.d/qla2xxx_scst.conf
+++ b/src/freenas/etc/modprobe.d/qla2xxx_scst.conf
@@ -1,0 +1,1 @@
+options qla2xxx_scst qlini_mode=disabled


### PR DESCRIPTION
We will use the SCST provided `qla2xxx_scst` kernel module for Fibre Channel target, rather than the upstream kernel `qla2xxx` module.  Further, do **not** use it in initiator mode.