### PR TITLE
NAS-131431 / 25.04 / use load_disks_impl in fenced unit test

### DIFF
--- a/tests/unit/test_fenced.py
+++ b/tests/unit/test_fenced.py
@@ -1,7 +1,7 @@
 import pytest
 
 from fenced.main import parse_ed
-from fenced.utils import load_disks_from_sys_block
+from fenced.utils import load_disks_impl
 
 
 @pytest.mark.parametrize(
@@ -21,10 +21,10 @@ def test_parse_ed(exclude, expected):
 
 
 @pytest.mark.parametrize("exclude", [tuple(), ("sda"), ("sda,sdb")])
-def test_load_disks_from_sys_block(exclude):
+def test_load_disks(exclude):
     """We need to make sure that fenced always enumerates
     a list of disks."""
-    disks = load_disks_from_sys_block(exclude)
+    disks = load_disks_impl(exclude)
     assert disks
     for disk in exclude:
         assert disk not in disks


### PR DESCRIPTION
Use the load_disks_impl function in the fenced unit test. This function is the entry point for loading disks.