### PR TITLE
NAS-131446 / 25.04 / Fix enclosure alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -65,7 +65,7 @@ class EnclosureStatusAlertSource(AlertSource):
     async def check(self):
         good_enclosures, bad_elements = [], []
         for enc in await self.middleware.call("enclosure2.query"):
-            good_enclosures.append([enc["name"]])
+            good_enclosures.append([f"{enc['name']} (id: {enc['id']})")
             enc["elements"].pop("Array Device Slot")  # dont care about disk slots
             for element_type, element_values in enc["elements"].items():
                 for ele_value in element_values.values():


### PR DESCRIPTION
Starting in FT, most everyone has migrated over to using the new enclosure plugin. However, we still have some straggling code using the old enclosure logic. This updates the enclosure alert to use the new enclosure plugin.

Summary of what was done:
1. remove the legacy z-series hardware checks (this platform has been EOL for years and we no longer provide support on it at all)
2. update the logic to use the new enclosure plugin (NOTE: using a frozen dataclass since it's much more memory efficient and we're caching all bad elements on the class during runtime)
3. use a bit of type annotations and clarify variable names to make it more human readable
4. fix the formatting of the file while i'm here