### PR TITLE
NAS-131457 / 25.04 / remove enclosure.sync_zpool

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1159,7 +1159,6 @@ async def hook_setup_ha(middleware, *args, **kwargs):
 
 
 async def hook_pool_export(middleware, pool=None, *args, **kwargs):
-    await middleware.call('enclosure.sync_zpool', pool)
     await middleware.call('failover.remove_encryption_keys', {'pools': [pool]})
 
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -122,16 +122,6 @@ class FailoverEventsService(Service):
                     svc, data['timeout']
                 )
 
-    async def background(self):
-        """
-        Some methods can be backgrounded on a failover
-        event since they can take quite some time to
-        finish. So background them to not hold up the
-        entire failover event.
-        """
-        logger.info('Syncing enclosure')
-        self.middleware.create_task(self.middleware.call('enclosure.sync_zpool'))
-
     async def refresh_failover_status(self, jobid, event):
         # this is called in a background task so we need to make sure that
         # we wait on the current failover job to complete before we try
@@ -695,13 +685,6 @@ class FailoverEventsService(Service):
         logger.info('Syncing disks')
         self.run_call('disk.sync_all', {'zfs_guid': True})
         logger.info('Done syncing disks')
-
-        # background any methods that can take awhile to
-        # run but shouldn't hold up the entire failover
-        # event
-        logger.info('Starting failover background jobs')
-        self.run_call('failover.events.background')
-        logger.info('Done starting failover background jobs')
 
         if handle_alua:
             try:


### PR DESCRIPTION
This method is unnecessary. It's clearing identify/fault lights on ALL disks based on certain zpool events and/or on failover event. That's a POLA violation since the user explicitly turns on these lights. They shouldn't automatically get turned off based on certain events. (We've already discussed a similar POLA violation surrounding this logic in UI awhile ago. So this brings us in line with how our UI behaves as well.)