### PR TITLE
NAS-131467 / 25.04 / remove call to enclosure.list_ses_enclosures

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
@@ -15,13 +15,17 @@ def get_ses_enclosure_status(bsg_path):
         logger.error('Error querying enclosure status for %r', bsg_path, exc_info=True)
 
 
-def get_ses_enclosures(dmi):
+def get_ses_enclosures(dmi, asdict=True):
     rv = list()
     with suppress(FileNotFoundError):
         for i in Path('/sys/class/enclosure').iterdir():
             bsg = f'/dev/bsg/{i.name}'
             if (status := get_ses_enclosure_status(bsg)):
                 sg = next((i / 'device/scsi_generic').iterdir())
-                rv.append(Enclosure(bsg, f'/dev/{sg.name}', dmi, status).asdict())
+                enc = Enclosure(bsg, f'/dev/{sg.name}', dmi, status)
+                if asdict:
+                    rv.append(enc.asdict())
+                else:
+                    rv.append(enc)
 
     return rv


### PR DESCRIPTION
Remove the call to the legacy endpoint in the failover enclosure detection plugin. This makes changes so we can use the `Enclosure` class that already takes care of doing a bunch of identification. This allows us to use properties like `is_mseries` or `is_xseries` accordingly. Tested on both m60 and x20 with no regressions.