### PR TITLE
NAS-131470 / 25.04 / No longer need to check wrt CORE in SCALE codebase

### DIFF
--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -198,11 +198,6 @@ class SystemService(Service):
         """
         Returns whether the `feature` is enabled or not
         """
-        is_core = (await self.middleware.call('system.product_type')) == 'CORE'
-        if name == 'FIBRECHANNEL' and is_core:
-            return False
-        elif is_core:
-            return True
         license_ = await self.middleware.call('system.license')
         if license_ and name in license_['features']:
             return True


### PR DESCRIPTION
Remove some obsolete code in `system.feature_enabled`.  No longer need to check for CORE in SCALE codebase.  (Wasteful)