### PR TITLE
NAS-131772 / 25.04 / Fix entire `core.get_jobs` crashing if one job fails to dump its result

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -609,11 +609,16 @@ class Job:
                 'extra': extra,
             }
 
+        result_encoding_error = None
         if self.state == State.SUCCESS:
             if raw_result:
                 result = self.result
             else:
-                result = self.middleware.dump_result(self.method, self.result, False)
+                try:
+                    result = self.middleware.dump_result(self.method, self.result, False)
+                except Exception as e:
+                    result = None
+                    result_encoding_error = repr(e)
         else:
             result = None
 
@@ -628,6 +633,7 @@ class Job:
             'logs_excerpt': self.logs_excerpt,
             'progress': self.progress,
             'result': result,
+            'result_encoding_error': result_encoding_error,
             'error': self.error,
             'exception': self.exception,
             'exc_info': exc_info,


### PR DESCRIPTION
This is especially painful in debug: if a job returns an invalid result, we lose the results of all other jobs.