### PR TITLE
NAS-131485 / 25.04 / Update default docker address pool (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-09-03_20-33_docker_addr_pool.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-09-03_20-33_docker_addr_pool.py
@@ -22,7 +22,7 @@ def upgrade():
                 'address_pools',
                 sa.TEXT(),
                 nullable=False,
-                server_default='[{"base": "172.30.0.0/16", "size": 27}, {"base": "172.31.0.0/16", "size": 27}]'
+                server_default='[{"base": "172.17.0.0/12", "size": 24}]'
             )
         )
 

--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-10-03_20-46_docker_address_pool.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-10-03_20-46_docker_address_pool.py
@@ -1,0 +1,35 @@
+"""
+Docker address pool default updated
+
+Revision ID: 92b98613c498
+Revises: c31881e67797
+Create Date: 2024-10-03 20:46:17.935672+00:00
+"""
+import json
+
+from alembic import op
+
+
+revision = '92b98613c498'
+down_revision = 'c31881e67797'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if docker_config := list(map(
+        dict, conn.execute('SELECT * FROM services_docker').fetchall()
+    )):
+        docker_config = docker_config[0]
+        address_pool_config = json.loads(docker_config['address_pools'])
+
+        if address_pool_config == [{'base': '172.30.0.0/16', 'size': 27}, {'base': '172.31.0.0/16', 'size': 27}]:
+            conn.execute("UPDATE services_docker SET address_pools = ? WHERE id = 1", [json.dumps(
+                [{"base": "172.17.0.0/12", "size": 24}]
+            )])
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/24.10/2024-10-03_20-46_docker_address_pool.py
+++ b/src/middlewared/middlewared/alembic/versions/24.10/2024-10-03_20-46_docker_address_pool.py
@@ -26,9 +26,9 @@ def upgrade():
         address_pool_config = json.loads(docker_config['address_pools'])
 
         if address_pool_config == [{'base': '172.30.0.0/16', 'size': 27}, {'base': '172.31.0.0/16', 'size': 27}]:
-            conn.execute("UPDATE services_docker SET address_pools = ? WHERE id = 1", [json.dumps(
+            conn.execute("UPDATE services_docker SET address_pools = ? WHERE id = ?", [json.dumps(
                 [{"base": "172.17.0.0/12", "size": 24}]
-            )])
+            ), docker_config['id']])
 
 
 def downgrade():

--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-10-04_00-45_merge.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-10-04_00-45_merge.py
@@ -1,0 +1,19 @@
+"""Merge
+
+Revision ID: 5fe28eada969
+Revises: f449b425ad89, 92b98613c498
+Create Date: 2024-10-04 00:45:59.547731+00:00
+"""
+
+revision = '5fe28eada969'
+down_revision = ('f449b425ad89', '92b98613c498')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -19,10 +19,7 @@ class DockerModel(sa.Model):
     pool = sa.Column(sa.String(255), default=None, nullable=True)
     enable_image_updates = sa.Column(sa.Boolean(), default=True)
     nvidia = sa.Column(sa.Boolean(), default=False)
-    address_pools = sa.Column(sa.JSON(list), default=[
-        {'base': '172.30.0.0/16', 'size': 27},
-        {'base': '172.31.0.0/16', 'size': 27}
-    ])
+    address_pools = sa.Column(sa.JSON(list), default=[{'base': '172.17.0.0/12', 'size': 24}])
 
 
 class DockerService(ConfigService):


### PR DESCRIPTION
This PR adds changes to update default docker address pool to use what docker uses but instead of having a size of `16` for each docker network, we use `24` so user can still get to consume at least 4096 docker networks this way.

Problem with earlier default was that users who were using apps in BETA and had 15 number of apps installed, each docker network was huge with a size of `16` which meant users could only create `15` apps with the default docker addr pool before it started consuming `192.168.0.0/16`. Then we made the change to use a smaller size per docker network and using base as `172.30/31.0.0/16` which was fine but the problem was users having 15 apps were already consuming this addr pool which resulted in docker exhausting all addr pools and refusing to start.

The current change defaults to using the default with what docker had but instead of having a very large network per docker network, we reduce the size to `24` so we can have more docker networks as it is unrealistic that we will have 65534 containers using a single docker network.

Original PR: https://github.com/truenas/middleware/pull/14616
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131485