### PR TITLE
NAS-131582 / 25.04 / Replace usage of hard-coded strings for the product type

### DIFF
--- a/src/freenas/usr/local/libexec/disable-rootfs-protection
+++ b/src/freenas/usr/local/libexec/disable-rootfs-protection
@@ -9,6 +9,8 @@ from truenas_api_client import Client
 from pathlib import Path
 from subprocess import run
 
+from middlewared.plugins.system.product import ProductType
+
 
 ZFS_CMD = '/usr/sbin/zfs'
 TO_CHMOD = ['apt', 'dpkg']
@@ -91,11 +93,11 @@ if __name__ == '__main__':
     # environment.
     if rv.stdout.decode().strip() != 'on' and not args.force:
         with Client() as c:
-            if c.call('system.product_type') == 'SCALE_ENTERPRISE':
+            if c.call('system.product_type') == ProductType.SCALE_ENTERPRISE:
                 print((
-                  'Root filesystem protections may not be administratively disabled '
-                  'on Enterprise-licensed TrueNAS products. Circumventing this '
-                  'restriction is considered an unsupported configuration.'
+                    'Root filesystem protections may not be administratively disabled '
+                    'on Enterprise-licensed TrueNAS products. Circumventing this '
+                    'restriction is considered an unsupported configuration.'
                 ))
                 sys.exit(1)
     try:

--- a/src/freenas/usr/local/libexec/disable-rootfs-protection
+++ b/src/freenas/usr/local/libexec/disable-rootfs-protection
@@ -9,7 +9,7 @@ from truenas_api_client import Client
 from pathlib import Path
 from subprocess import run
 
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 ZFS_CMD = '/usr/sbin/zfs'

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -7,7 +7,7 @@ import typing
 import html2text
 
 from middlewared.alert.schedule import IntervalSchedule
-from middlewared.plugins.system.product import PRODUCT_NAME
+from middlewared.plugins.system.product import ProductType, PRODUCT_NAME
 from middlewared.utils.lang import undefined
 
 __all__ = ["UnavailableException",
@@ -72,7 +72,7 @@ class AlertClass(metaclass=AlertClassMeta):
     text = None
 
     exclude_from_list = False
-    products = ("CORE", "ENTERPRISE", "SCALE", "SCALE_ENTERPRISE")
+    products = ("CORE", "ENTERPRISE", ProductType.SCALE, ProductType.SCALE_ENTERPRISE)
     proactive_support = False
     proactive_support_notify_gone = False
 
@@ -311,7 +311,7 @@ class AlertSource:
 
     schedule = IntervalSchedule(timedelta())
 
-    products = ("CORE", "ENTERPRISE", "SCALE", "SCALE_ENTERPRISE")
+    products = ("CORE", "ENTERPRISE", ProductType.SCALE, ProductType.SCALE_ENTERPRISE)
     failover_related = False
     run_on_backup_node = True
 

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -7,7 +7,7 @@ import typing
 import html2text
 
 from middlewared.alert.schedule import IntervalSchedule
-from middlewared.plugins.system.product import ProductType, PRODUCT_NAME
+from middlewared.utils import ProductName, ProductType
 from middlewared.utils.lang import undefined
 
 __all__ = ["UnavailableException",
@@ -376,7 +376,7 @@ class AlertService:
         else:
             node_map = None
 
-        html = format_alerts(PRODUCT_NAME, hostname, node_map, alerts, gone_alerts, new_alerts)
+        html = format_alerts(ProductName.PRODUCT_NAME, hostname, node_map, alerts, gone_alerts, new_alerts)
 
         if self.html:
             return html
@@ -397,7 +397,7 @@ class ThreadedAlertService(AlertService):
             node_map = self.middleware.call_sync("alert.node_map")
         else:
             node_map = None
-        return format_alerts(PRODUCT_NAME, hostname, node_map, alerts, gone_alerts, new_alerts)
+        return format_alerts(ProductName.PRODUCT_NAME, hostname, node_map, alerts, gone_alerts, new_alerts)
 
 
 class ProThreadedAlertService(ThreadedAlertService):

--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -1,5 +1,6 @@
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 from middlewared.alert.schedule import CrontabSchedule
+from middlewared.plugins.system.product import ProductType
 from middlewared.utils.audit import UNAUTHENTICATED
 from time import time
 
@@ -38,7 +39,7 @@ def audit_entry_to_msg(entry):
 class AdminSessionAlertSource(AlertSource):
     schedule = CrontabSchedule(hour=1)  # every 24 hours
     run_on_backup_node = True
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     async def check(self):
         now = int(time())

--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -1,6 +1,6 @@
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 from middlewared.alert.schedule import CrontabSchedule
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.utils.audit import UNAUTHENTICATED
 from time import time
 

--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -3,6 +3,7 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 from dataclasses import dataclass
+from middlewared.plugins.system.product import ProductType
 
 from middlewared.alert.base import (
     AlertClass,
@@ -30,7 +31,7 @@ class EnclosureUnhealthyAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Enclosure Status Is Not Healthy"
     text = 'Enclosure (%s): Element "%s" is reporting a status of "%s" with a value of "%s". (raw value "%s")'
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class EnclosureHealthyAlertClass(AlertClass):
@@ -38,11 +39,11 @@ class EnclosureHealthyAlertClass(AlertClass):
     level = AlertLevel.INFO
     title = "Enclosure Status Is Healthy"
     text = "Enclosure (%s) is healthy."
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class EnclosureStatusAlertSource(AlertSource):
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
     bad = ("critical", "noncritical", "unknown", "unrecoverable")

--- a/src/middlewared/middlewared/alert/source/enclosure_status.py
+++ b/src/middlewared/middlewared/alert/source/enclosure_status.py
@@ -3,7 +3,7 @@
 # Licensed under the terms of the TrueNAS Enterprise License Agreement
 # See the file LICENSE.IX for complete terms and conditions
 from dataclasses import dataclass
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 from middlewared.alert.base import (
     AlertClass,

--- a/src/middlewared/middlewared/alert/source/failover.py
+++ b/src/middlewared/middlewared/alert/source/failover.py
@@ -6,6 +6,7 @@
 import errno
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, UnavailableException
+from middlewared.plugins.system.product import ProductType
 from middlewared.service_exception import CallError
 
 
@@ -14,7 +15,7 @@ class FailoverInterfaceNotFoundAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Failover Internal Interface Not Found'
     text = 'Failover internal interface not found. Contact support.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class TrueNASVersionsMismatchAlertClass(AlertClass):
@@ -22,7 +23,7 @@ class TrueNASVersionsMismatchAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'TrueNAS Software Versions Must Match Between Storage Controllers'
     text = 'TrueNAS software versions must match between storage controllers.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverStatusCheckFailedAlertClass(AlertClass):
@@ -30,7 +31,7 @@ class FailoverStatusCheckFailedAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Failed to Check Failover Status with the Other Controller'
     text = 'Failed to check failover status with the other controller: %s.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverFailedAlertClass(AlertClass):
@@ -38,7 +39,7 @@ class FailoverFailedAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Failover Failed'
     text = 'Failover failed. Check /var/log/failover.log on both controllers.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class VRRPStatesDoNotAgreeAlertClass(AlertClass):
@@ -46,11 +47,11 @@ class VRRPStatesDoNotAgreeAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Controllers VRRP States Do Not Agree'
     text = 'Controllers VRRP states do not agree: %(error)s.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover.py
+++ b/src/middlewared/middlewared/alert/source/failover.py
@@ -6,7 +6,7 @@
 import errno
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, UnavailableException
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.service_exception import CallError
 
 

--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -4,6 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.plugins.system.product import ProductType
 
 TITLE = 'Disks Missing On '
 TEXT = 'Disks with serial %(serials)s present on '
@@ -14,7 +15,7 @@ class DisksAreNotPresentOnStandbyNodeAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = TITLE + 'Standby Storage Controller'
     text = TEXT + 'active storage controller but missing on standby storage controller.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class DisksAreNotPresentOnActiveNodeAlertClass(AlertClass):
@@ -22,11 +23,11 @@ class DisksAreNotPresentOnActiveNodeAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = TITLE + 'Active Storage Controller'
     text = TEXT + 'standby storage controller but missing on active storage controller.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverDisksAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_disks.py
+++ b/src/middlewared/middlewared/alert/source/failover_disks.py
@@ -4,7 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 TITLE = 'Disks Missing On '
 TEXT = 'Disks with serial %(serials)s present on '

--- a/src/middlewared/middlewared/alert/source/failover_interfaces.py
+++ b/src/middlewared/middlewared/alert/source/failover_interfaces.py
@@ -4,6 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
+from middlewared.plugins.system.product import ProductType
 
 
 class NoCriticalFailoverInterfaceFoundAlertClass(AlertClass):
@@ -11,11 +12,11 @@ class NoCriticalFailoverInterfaceFoundAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'At Least 1 Network Interface Is Required To Be Marked Critical For Failover'
     text = 'At least 1 network interface is required to be marked critical for failover.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverCriticalAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_interfaces.py
+++ b/src/middlewared/middlewared/alert/source/failover_interfaces.py
@@ -4,7 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class NoCriticalFailoverInterfaceFoundAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/failover_nics.py
+++ b/src/middlewared/middlewared/alert/source/failover_nics.py
@@ -4,6 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.plugins.system.product import ProductType
 
 TITLE = 'Missing Network Interface On '
 TEXT = 'Network interfaces %(interfaces)s present on '
@@ -14,7 +15,7 @@ class NetworkCardsMismatchOnStandbyNodeAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = TITLE + 'Standby Storage Controller'
     text = TEXT + 'active storage controller but missing on standby storage controller.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NetworkCardsMismatchOnActiveNodeAlertClass(AlertClass):
@@ -22,11 +23,11 @@ class NetworkCardsMismatchOnActiveNodeAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = TITLE + 'Active Storage Controller'
     text = TEXT + 'standby storage controller but missing on active storage controller.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverNetworkCardsAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_nics.py
+++ b/src/middlewared/middlewared/alert/source/failover_nics.py
@@ -4,7 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 TITLE = 'Missing Network Interface On '
 TEXT = 'Network interfaces %(interfaces)s present on '

--- a/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
+++ b/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
@@ -6,6 +6,7 @@
 import time
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, UnavailableException
+from middlewared.plugins.system.product import ProductType
 from middlewared.utils.crypto import generate_token
 
 
@@ -14,13 +15,13 @@ class FailoverRemoteSystemInaccessibleAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Other Controller is Inaccessible'
     text = 'Other TrueNAS controller is inaccessible. Contact support. Incident ID: %s.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
     proactive_support_notify_gone = True
 
 
 class FailoverRemoteSystemInaccessibleAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     failover_related = True
     run_on_backup_node = False
 

--- a/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
+++ b/src/middlewared/middlewared/alert/source/failover_remote_inaccessible.py
@@ -6,7 +6,7 @@
 import time
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, UnavailableException
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.utils.crypto import generate_token
 
 

--- a/src/middlewared/middlewared/alert/source/failover_sync.py
+++ b/src/middlewared/middlewared/alert/source/failover_sync.py
@@ -6,7 +6,7 @@
 from middlewared.alert.base import (
     Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel, OneShotAlertClass
 )
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class FailoverSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):

--- a/src/middlewared/middlewared/alert/source/failover_sync.py
+++ b/src/middlewared/middlewared/alert/source/failover_sync.py
@@ -6,6 +6,7 @@
 from middlewared.alert.base import (
     Alert, AlertClass, SimpleOneShotAlertClass, AlertCategory, AlertLevel, OneShotAlertClass
 )
+from middlewared.plugins.system.product import ProductType
 
 
 class FailoverSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
@@ -17,7 +18,7 @@ class FailoverSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
         "the standby storage controller but failed. Use Sync to Peer on the "
         "System/Failover page to try and perform a manual sync."
     )
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     async def create(self, args):
         return Alert(FailoverSyncFailedAlertClass, {'mins': args['mins']})
@@ -36,7 +37,7 @@ class FailoverKeysSyncFailedAlertClass(AlertClass, SimpleOneShotAlertClass):
         "The automatic synchronization of encryption passphrases with the standby "
         "controller has failed. Please go to System > Failover and manually sync to peer."
     )
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class FailoverKMIPKeysSyncFailedAlertClass(AlertClass, OneShotAlertClass):
@@ -49,7 +50,7 @@ class FailoverKMIPKeysSyncFailedAlertClass(AlertClass, OneShotAlertClass):
         "The automatic synchronization of KMIP keys with the standby "
         "controller has failed due to %(error)s. Please go to System > Failover and manually sync to peer."
     )
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     async def create(self, args):
         return Alert(FailoverKMIPKeysSyncFailedAlertClass, args)

--- a/src/middlewared/middlewared/alert/source/jbof.py
+++ b/src/middlewared/middlewared/alert/source/jbof.py
@@ -8,6 +8,7 @@ import datetime
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource, SimpleOneShotAlertClass
 from middlewared.alert.schedule import IntervalSchedule
 from middlewared.plugins.enclosure_.enums import ElementStatus, ElementType
+from middlewared.plugins.system.product import ProductType
 
 
 class JBOFTearDownFailureAlertClass(AlertClass, SimpleOneShotAlertClass):
@@ -25,7 +26,7 @@ class JBOFRedfishCommAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Failed to Communicate with JBOF'
     text = 'JBOF: "%(desc)s" (%(ip1)s/%(ip2)s) Failed to communicate with redfish interface.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class JBOFInvalidDataAlertClass(AlertClass):
@@ -33,7 +34,7 @@ class JBOFInvalidDataAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'JBOF has invalid data'
     text = 'JBOF: "%(desc)s" (%(ip1)s/%(ip2)s) does not provide valid data for: %(keys)s'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class JBOFElementWarningAlertClass(AlertClass):
@@ -41,7 +42,7 @@ class JBOFElementWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'JBOF element non-critical'
     text = 'JBOF: "%(desc)s" (%(ip1)s/%(ip2)s) %(etype)s %(key)s is noncritical: %(value)s'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class JBOFElementCriticalAlertClass(AlertClass):
@@ -49,11 +50,11 @@ class JBOFElementCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'JBOF element critical'
     text = 'JBOF: "%(desc)s" (%(ip1)s/%(ip2)s) %(etype)s %(key)s is critical: %(value)s'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class JBOFAlertSource(AlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     run_on_backup_node = False
     schedule = IntervalSchedule(datetime.timedelta(minutes=5))
 

--- a/src/middlewared/middlewared/alert/source/jbof.py
+++ b/src/middlewared/middlewared/alert/source/jbof.py
@@ -8,7 +8,7 @@ import datetime
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource, SimpleOneShotAlertClass
 from middlewared.alert.schedule import IntervalSchedule
 from middlewared.plugins.enclosure_.enums import ElementStatus, ElementType
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class JBOFTearDownFailureAlertClass(AlertClass, SimpleOneShotAlertClass):

--- a/src/middlewared/middlewared/alert/source/legacy_mini_bmc.py
+++ b/src/middlewared/middlewared/alert/source/legacy_mini_bmc.py
@@ -1,5 +1,5 @@
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 URL = "https://www.truenas.com/docs/hardware/legacyhardware/miniseries/freenas-minis-2nd-gen/freenasminibmcwatchdog/"
 

--- a/src/middlewared/middlewared/alert/source/legacy_mini_bmc.py
+++ b/src/middlewared/middlewared/alert/source/legacy_mini_bmc.py
@@ -1,4 +1,5 @@
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
+from middlewared.plugins.system.product import ProductType
 
 URL = "https://www.truenas.com/docs/hardware/legacyhardware/miniseries/freenas-minis-2nd-gen/freenasminibmcwatchdog/"
 
@@ -12,11 +13,11 @@ class TrueNASMiniBMCAlertClass(AlertClass):
         f"<a href=\"{URL}\" target=\"_blank\">"
         "ASRock Rack C2750D4I BMC Watchdog Issue</a> for details."
     )
-    products = ("SCALE",)
+    products = (ProductType.SCALE,)
 
 
 class TrueNASMiniBMCAlertSource(AlertSource):
-    products = ("SCALE",)
+    products = (ProductType.SCALE,)
 
     async def check(self):
         dmi = await self.middleware.call("system.dmidecode_info")

--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -9,6 +9,7 @@ import textwrap
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
+from middlewared.plugins.system.product import ProductType
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
@@ -17,7 +18,7 @@ class LicenseAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "TrueNAS License Issue"
     text = "%s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class LicenseIsExpiringAlertClass(AlertClass):
@@ -25,7 +26,7 @@ class LicenseIsExpiringAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "TrueNAS License Is Expiring"
     text = "%s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class LicenseHasExpiredAlertClass(AlertClass):
@@ -33,11 +34,11 @@ class LicenseHasExpiredAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "TrueNAS License Has Expired"
     text = "%s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class LicenseStatusAlertSource(ThreadedAlertSource):
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
     run_on_backup_node = False
     schedule = IntervalSchedule(timedelta(hours=24))
 

--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -9,7 +9,7 @@ import textwrap
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 

--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -5,7 +5,7 @@
 
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 from middlewared.alert.schedule import CrontabSchedule
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.utils.size import format_size
 
 

--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -5,6 +5,7 @@
 
 from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 from middlewared.alert.schedule import CrontabSchedule
+from middlewared.plugins.system.product import ProductType
 from middlewared.utils.size import format_size
 
 
@@ -13,7 +14,7 @@ class MemoryErrorsAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'Uncorrected Memory Errors Detected'
     text = '%(count)d total uncorrected errors detected for %(loc)s.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 
@@ -22,7 +23,7 @@ class MemorySizeMismatchAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'Memory Size Mismatch Detected'
     text = 'Memory size on this controller %(r1)s doesn\'t match other controller %(r2)s'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -7,6 +7,7 @@ import datetime
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
+from middlewared.plugins.system.product import ProductType
 
 WEBUI_SUPPORT_FORM = (
     'Please contact iXsystems Support using the "File Ticket" button in the System Settings->General->Support form'
@@ -18,7 +19,7 @@ class NVDIMMAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'There Is An Issue With NVDIMM'
     text = 'NVDIMM: "%(dev)s" is reporting "%(value)s" with status "%(status)s".'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NVDIMMESLifetimeWarningAlertClass(AlertClass):
@@ -26,7 +27,7 @@ class NVDIMMESLifetimeWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'NVDIMM Energy Source Lifetime Is Less Than 20%'
     text = 'NVDIMM Energy Source Remaining Lifetime for %(dev)s is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NVDIMMESLifetimeCriticalAlertClass(AlertClass):
@@ -34,7 +35,7 @@ class NVDIMMESLifetimeCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'NVDIMM Energy Source Lifetime Is Less Than 10%'
     text = 'NVDIMM Energy Source Remaining Lifetime for %(dev)s is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NVDIMMMemoryModLifetimeWarningAlertClass(AlertClass):
@@ -42,7 +43,7 @@ class NVDIMMMemoryModLifetimeWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'NVDIMM Memory Module Lifetime Is Less Than 20%'
     text = 'NVDIMM Memory Module Remaining Lifetime for %(dev)s is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NVDIMMMemoryModLifetimeCriticalAlertClass(AlertClass):
@@ -50,7 +51,7 @@ class NVDIMMMemoryModLifetimeCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'NVDIMM Memory Module Lifetime Is Less Than 10%'
     text = 'NVDIMM Memory Module Remaining Lifetime for %(dev)s is %(value)d%%.'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
@@ -58,7 +59,7 @@ class NVDIMMInvalidFirmwareVersionAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = 'Invalid NVDIMM Firmware Version'
     text = f'NVDIMM: "%(dev)s" is running invalid firmware. {WEBUI_SUPPORT_FORM}'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 
@@ -70,7 +71,7 @@ class NVDIMMRecommendedFirmwareVersionAlertClass(AlertClass):
         'NVDIMM: "%(dev)s" is running firmware version "%(rv)s" which can be upgraded to '
         f'"%(uv)s". {WEBUI_SUPPORT_FORM}'
     )
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 
@@ -79,13 +80,13 @@ class OldBiosVersionAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = 'Old BIOS Version'
     text = f'This system is running an old BIOS version. {WEBUI_SUPPORT_FORM}'
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 
 class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
     schedule = IntervalSchedule(datetime.timedelta(minutes=5))
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     def produce_alerts(self, nvdimm, alerts, old_bios):
         persistency_restored = 0x4

--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -7,7 +7,7 @@ import datetime
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 from middlewared.alert.schedule import IntervalSchedule
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 WEBUI_SUPPORT_FORM = (
     'Please contact iXsystems Support using the "File Ticket" button in the System Settings->General->Support form'

--- a/src/middlewared/middlewared/alert/source/proactive_support.py
+++ b/src/middlewared/middlewared/alert/source/proactive_support.py
@@ -4,7 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class ProactiveSupportAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/proactive_support.py
+++ b/src/middlewared/middlewared/alert/source/proactive_support.py
@@ -4,6 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.plugins.system.product import ProductType
 
 
 class ProactiveSupportAlertClass(AlertClass):
@@ -11,11 +12,11 @@ class ProactiveSupportAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "Proactive Support Is Not Configured"
     text = "%s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class ProactiveSupportAlertSource(AlertSource):
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
     run_on_backup_node = False
 
     async def check(self):

--- a/src/middlewared/middlewared/alert/source/sata_dom_wear.py
+++ b/src/middlewared/middlewared/alert/source/sata_dom_wear.py
@@ -6,6 +6,7 @@
 from datetime import timedelta
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, IntervalSchedule
+from middlewared.plugins.system.product import ProductType
 
 
 class SATADOMWearWarningAlertClass(AlertClass):
@@ -13,7 +14,7 @@ class SATADOMWearWarningAlertClass(AlertClass):
     level = AlertLevel.WARNING
     title = "SATA DOM Lifetime: Less Than 20% Left"
     text = "%(lifetime)d%% of lifetime left on SATA DOM %(disk)s."
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class SATADOMWearCriticalAlertClass(AlertClass):
@@ -21,12 +22,12 @@ class SATADOMWearCriticalAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "SATA DOM Lifetime: Less Than 10% Left"
     text = "%(lifetime)d%% of lifetime left on SATA DOM %(disk)s."
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class SATADOMWearAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(hours=1))
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     async def check(self):
         dmi = await self.middleware.call("system.dmidecode_info")

--- a/src/middlewared/middlewared/alert/source/sata_dom_wear.py
+++ b/src/middlewared/middlewared/alert/source/sata_dom_wear.py
@@ -6,7 +6,7 @@
 from datetime import timedelta
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource, IntervalSchedule
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class SATADOMWearWarningAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/sensors.py
+++ b/src/middlewared/middlewared/alert/source/sensors.py
@@ -4,6 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
+from middlewared.plugins.system.product import ProductType
 
 
 class SensorAlertClass(AlertClass):
@@ -11,7 +12,7 @@ class SensorAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Sensor Value Is Outside of Working Range"
     text = "Sensor %(name)s is %(relative)s %(level)s value: %(value)s %(event)s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class PowerSupplyAlertClass(AlertClass):
@@ -19,7 +20,7 @@ class PowerSupplyAlertClass(AlertClass):
     level = AlertLevel.CRITICAL
     title = "Power Supply Error"
     text = "%(psu)s is %(state)s showing: %(errors)s"
-    products = ("SCALE_ENTERPRISE",)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
 
 class SensorsAlertSource(AlertSource):

--- a/src/middlewared/middlewared/alert/source/sensors.py
+++ b/src/middlewared/middlewared/alert/source/sensors.py
@@ -4,7 +4,7 @@
 # See the file LICENSE.IX for complete terms and conditions
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, AlertSource, Alert
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class SensorAlertClass(AlertClass):

--- a/src/middlewared/middlewared/alert/source/usb_storage.py
+++ b/src/middlewared/middlewared/alert/source/usb_storage.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+from middlewared.plugins.system.product import ProductType
 
 
 class USBStorageAlertClass(AlertClass):
@@ -14,12 +15,12 @@ class USBStorageAlertClass(AlertClass):
     title = 'A USB Storage Device Has Been Connected to This System'
     text = ('A USB storage device %r has been connected to this system. Please remove that USB device to '
             'prevent problems with system boot or HA failover.')
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
     proactive_support = True
 
 
 class USBStorageAlertSource(ThreadedAlertSource):
-    products = ('SCALE_ENTERPRISE',)
+    products = (ProductType.SCALE_ENTERPRISE,)
 
     def check_sync(self):
         alerts = []

--- a/src/middlewared/middlewared/alert/source/usb_storage.py
+++ b/src/middlewared/middlewared/alert/source/usb_storage.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 
 
 class USBStorageAlertClass(AlertClass):

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -4,7 +4,7 @@ import pyotp
 from middlewared.api import api_method
 from middlewared.api.current import *
 from middlewared.service import CallError, no_authz_required, pass_app, private, Service
-from middlewared.plugins.system.product import PRODUCT_NAME
+from middlewared.utils import ProductName
 from middlewared.utils.privilege import app_credential_full_admin_or_user
 
 
@@ -17,7 +17,7 @@ class UserService(Service):
             digits=user_twofactor_config['otp_digits'],
         ).provisioning_uri(
             f'{username}-{await self.middleware.call("system.hostname")}'
-            f'@{PRODUCT_NAME}',
+            f'@{ProductName.PRODUCT_NAME}',
             'iXsystems'
         )
 

--- a/src/middlewared/middlewared/plugins/catalog/update.py
+++ b/src/middlewared/middlewared/plugins/catalog/update.py
@@ -3,6 +3,7 @@ import os
 import middlewared.sqlalchemy as sa
 
 from middlewared.plugins.docker.state_utils import catalog_ds_path, CATALOG_DATASET_NAME
+from middlewared.plugins.system.product import ProductType
 from middlewared.schema import accepts, Dict, List, returns, Str
 from middlewared.service import ConfigService, private, ValidationErrors
 from middlewared.validators import Match
@@ -30,18 +31,18 @@ class CatalogService(ConfigService):
         role_prefix = 'CATALOG'
 
     ENTRY = Dict(
-            'catalog_create',
-            List('preferred_trains'),
-            Str('id'),
-            Str(
-                'label', required=True, validators=[Match(
-                    r'^\w+[\w.-]*$',
-                    explanation='Label must start with an alphanumeric character and can include dots and dashes.'
-                )],
-                max_length=60,
-            ),
-            register=True,
-        )
+        'catalog_create',
+        List('preferred_trains'),
+        Str('id'),
+        Str(
+            'label', required=True, validators=[Match(
+                r'^\w+[\w.-]*$',
+                explanation='Label must start with an alphanumeric character and can include dots and dashes.'
+            )],
+            max_length=60,
+        ),
+        register=True,
+    )
 
     @private
     def extend(self, data, context):
@@ -92,7 +93,7 @@ class CatalogService(ConfigService):
                 'At least 1 preferred train must be specified.'
             )
         if (
-            await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE' and
+            await self.middleware.call('system.product_type') == ProductType.SCALE_ENTERPRISE and
             OFFICIAL_ENTERPRISE_TRAIN not in data['preferred_trains']
         ):
             verrors.add(
@@ -122,7 +123,7 @@ class CatalogService(ConfigService):
     @private
     async def update_train_for_enterprise(self):
         catalog = await self.middleware.call('catalog.config')
-        if await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE':
+        if await self.middleware.call('system.product_type') == ProductType.SCALE_ENTERPRISE:
             preferred_trains = []
             # Logic coming from here
             # https://github.com/truenas/middleware/blob/e7f2b29b6ff8fadcc9fdd8d7f104cbbf5172fc5a/src/middlewared

--- a/src/middlewared/middlewared/plugins/catalog/update.py
+++ b/src/middlewared/middlewared/plugins/catalog/update.py
@@ -3,9 +3,9 @@ import os
 import middlewared.sqlalchemy as sa
 
 from middlewared.plugins.docker.state_utils import catalog_ds_path, CATALOG_DATASET_NAME
-from middlewared.plugins.system.product import ProductType
 from middlewared.schema import accepts, Dict, List, returns, Str
 from middlewared.service import ConfigService, private, ValidationErrors
+from middlewared.utils import ProductType
 from middlewared.validators import Match
 
 from .utils import OFFICIAL_ENTERPRISE_TRAIN, OFFICIAL_LABEL, TMP_IX_APPS_CATALOGS

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 from sqlalchemy.exc import IntegrityError
 
-from middlewared.plugins.system.product import ProductType
+from middlewared.utils import ProductType
 from middlewared.schema import accepts, Bool, Datetime, Dict, Int, Patch, Str
 from middlewared.service import filterable, private, CallError, CRUDService, ValidationError
 import middlewared.sqlalchemy as sa

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from sqlalchemy.exc import IntegrityError
 
+from middlewared.plugins.system.product import ProductType
 from middlewared.schema import accepts, Bool, Datetime, Dict, Int, Patch, Str
 from middlewared.service import filterable, private, CallError, CRUDService, ValidationError
 import middlewared.sqlalchemy as sa
@@ -465,7 +466,7 @@ class DiskService(CRUDService):
         This runs on boot to properly configure all power management options
         (Advanced Power Management and IDLE) for all disks.
         """
-        if await self.middleware.call('system.product_type') != 'SCALE_ENTERPRISE':
+        if await self.middleware.call('system.product_type') != ProductType.SCALE_ENTERPRISE:
             for disk in await self.middleware.call('disk.query'):
                 await self.middleware.call('disk.power_management', disk['name'], disk)
 

--- a/src/middlewared/middlewared/plugins/failover_/fenced.py
+++ b/src/middlewared/middlewared/plugins/failover_/fenced.py
@@ -9,6 +9,7 @@ import contextlib
 import os
 import signal
 
+from middlewared.plugins.system.product import ProductType
 from middlewared.service import Service, CallError
 from middlewared.utils import MIDDLEWARE_RUN_DIR
 from middlewared.utils.cgroups import move_to_root_cgroups
@@ -115,7 +116,7 @@ class FencedService(Service):
 
 async def hook_pool_event(middleware, *args, **kwargs):
     # only run this on SCALE Enterprise
-    if await middleware.call('system.product_type') != 'SCALE_ENTERPRISE':
+    if await middleware.call('system.product_type') != ProductType.SCALE_ENTERPRISE:
         return
 
     # HA licensed systems call fenced on their own

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -1,8 +1,7 @@
 from middlewared.schema import accepts, Bool, Dict, Int, List, Password, Patch, Ref, returns, Str
 from middlewared.service import CallError, ConfigService, ValidationErrors, job, periodic, private
 import middlewared.sqlalchemy as sa
-from middlewared.plugins.system.product import PRODUCT_NAME
-from middlewared.utils import BRAND
+from middlewared.utils import ProductName, BRAND
 from middlewared.utils.mako import get_template
 from middlewared.validators import Email
 
@@ -247,7 +246,7 @@ class MailService(ConfigService):
         """
         gc = self.middleware.call_sync('datastore.config', 'network.globalconfiguration')
         hostname = f'{gc["gc_hostname"]}.{gc["gc_domain"]}'
-        message['subject'] = f'{PRODUCT_NAME} {hostname}: {message["subject"]}'
+        message['subject'] = f'{ProductName.PRODUCT_NAME} {hostname}: {message["subject"]}'
         add_html = True
         if 'html' in message and message['html'] is None:
             message.pop('html')

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -20,7 +20,7 @@ LICENSE_FILE_MODE = 0o600
 PRODUCT_NAME = 'TrueNAS'
 
 
-class ProductType():
+class ProductType:
     SCALE = 'SCALE'
     SCALE_ENTERPRISE = 'SCALE_ENTERPRISE'
 

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -11,18 +11,13 @@ from licenselib.license import ContractType, Features, License
 from middlewared.plugins.truenas import EULA_PENDING_PATH
 from middlewared.schema import accepts, Bool, returns, Str
 from middlewared.service import no_authz_required, private, Service, ValidationError
-from middlewared.utils import sw_info
+from middlewared.utils import ProductType, sw_info
 from middlewared.utils.license import LICENSE_ADDHW_MAPPING
 
 
 LICENSE_FILE = '/data/license'
 LICENSE_FILE_MODE = 0o600
 PRODUCT_NAME = 'TrueNAS'
-
-
-class ProductType:
-    SCALE = 'SCALE'
-    SCALE_ENTERPRISE = 'SCALE_ENTERPRISE'
 
 
 class SystemService(Service):

--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -20,6 +20,11 @@ LICENSE_FILE_MODE = 0o600
 PRODUCT_NAME = 'TrueNAS'
 
 
+class ProductType():
+    SCALE = 'SCALE'
+    SCALE_ENTERPRISE = 'SCALE_ENTERPRISE'
+
+
 class SystemService(Service):
 
     PRODUCT_TYPE = None
@@ -36,19 +41,19 @@ class SystemService(Service):
         if SystemService.PRODUCT_TYPE is None:
             if await self.is_ha_capable():
                 # HA capable hardware
-                SystemService.PRODUCT_TYPE = 'SCALE_ENTERPRISE'
+                SystemService.PRODUCT_TYPE = ProductType.SCALE_ENTERPRISE
             else:
                 if license_ := await self.middleware.call('system.license'):
                     if license_['model'].lower().startswith('freenas'):
                         # legacy freenas certified
-                        SystemService.PRODUCT_TYPE = 'SCALE'
+                        SystemService.PRODUCT_TYPE = ProductType.SCALE
                     else:
                         # the license has been issued for a "certified" line
                         # of hardware which is considered enterprise
-                        SystemService.PRODUCT_TYPE = 'SCALE_ENTERPRISE'
+                        SystemService.PRODUCT_TYPE = ProductType.SCALE_ENTERPRISE
                 else:
                     # no license
-                    SystemService.PRODUCT_TYPE = 'SCALE'
+                    SystemService.PRODUCT_TYPE = ProductType.SCALE
 
         return SystemService.PRODUCT_TYPE
 
@@ -58,7 +63,7 @@ class SystemService(Service):
 
     @private
     async def is_enterprise(self):
-        return await self.middleware.call('system.product_type') == 'SCALE_ENTERPRISE'
+        return await self.middleware.call('system.product_type') == ProductType.SCALE_ENTERPRISE
 
     @no_authz_required
     @accepts()

--- a/src/middlewared/middlewared/test/integration/assets/product.py
+++ b/src/middlewared/middlewared/test/integration/assets/product.py
@@ -1,10 +1,9 @@
 import contextlib
 
-from middlewared.plugins.system.product import ProductType
 from middlewared.test.integration.utils import mock
 
 
 @contextlib.contextmanager
-def product_type(product_type=ProductType.SCALE_ENTERPRISE):
+def product_type(product_type='SCALE_ENTERPRISE'):
     with mock('system.product_type', return_value=product_type):
         yield

--- a/src/middlewared/middlewared/test/integration/assets/product.py
+++ b/src/middlewared/middlewared/test/integration/assets/product.py
@@ -1,9 +1,10 @@
 import contextlib
 
-from middlewared.test.integration.utils import call, mock
+from middlewared.plugins.system.product import ProductType
+from middlewared.test.integration.utils import mock
 
 
 @contextlib.contextmanager
-def product_type(product_type='SCALE_ENTERPRISE'):
+def product_type(product_type=ProductType.SCALE_ENTERPRISE):
     with mock('system.product_type', return_value=product_type):
         yield

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 import json
 from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 
 from middlewared.service_exception import MatchNotFound
@@ -15,12 +16,25 @@ from .lang import undefined
 from .prctl import die_with_parent
 from .threading import io_thread_pool_executor
 
+
+# Define Product Strings
+@dataclass(slots=True, frozen=True)
+class ProductType:
+    SCALE: str = 'SCALE'
+    SCALE_ENTERPRISE: str = 'SCALE_ENTERPRISE'
+
+
+@dataclass(slots=True, frozen=True)
+class ProductName:
+    PRODUCT_NAME: str = 'TrueNAS'
+
+
 MID_PID = None
 MIDDLEWARE_RUN_DIR = '/var/run/middleware'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 MANIFEST_FILE = '/data/manifest.json'
-BRAND = 'TrueNAS'
-PRODUCT = 'SCALE_ENTERPRISE'
+BRAND = ProductName.PRODUCT_NAME
+PRODUCT = ProductType.SCALE
 BRAND_PRODUCT = f'{BRAND}-{PRODUCT}'
 NULLS_FIRST = 'nulls_first:'
 NULLS_LAST = 'nulls_last:'

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -10,6 +10,7 @@ import json
 from collections import namedtuple
 from datetime import datetime
 
+from middlewared.plugins.system.product import ProductType
 from middlewared.service_exception import MatchNotFound
 from .lang import undefined
 from .prctl import die_with_parent
@@ -20,7 +21,7 @@ MIDDLEWARE_RUN_DIR = '/var/run/middleware'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 MANIFEST_FILE = '/data/manifest.json'
 BRAND = 'TrueNAS'
-PRODUCT = 'SCALE'
+PRODUCT = ProductType.SCALE_ENTERPRISE
 BRAND_PRODUCT = f'{BRAND}-{PRODUCT}'
 NULLS_FIRST = 'nulls_first:'
 NULLS_LAST = 'nulls_last:'

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -10,7 +10,6 @@ import json
 from collections import namedtuple
 from datetime import datetime
 
-from middlewared.plugins.system.product import ProductType
 from middlewared.service_exception import MatchNotFound
 from .lang import undefined
 from .prctl import die_with_parent
@@ -21,7 +20,7 @@ MIDDLEWARE_RUN_DIR = '/var/run/middleware'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 MANIFEST_FILE = '/data/manifest.json'
 BRAND = 'TrueNAS'
-PRODUCT = ProductType.SCALE_ENTERPRISE
+PRODUCT = 'SCALE_ENTERPRISE'
 BRAND_PRODUCT = f'{BRAND}-{PRODUCT}'
 NULLS_FIRST = 'nulls_first:'
 NULLS_LAST = 'nulls_last:'


### PR DESCRIPTION
### Problem
--------------------
The product types, 'SCALE' and 'SCALE_ENTERPRISE' are not defined anywhere.  We test for the product type in many places, each time using a hard-coded string. 
This presents two problems:  Increased possibility of typos and missing a single source of truth for the product type identifier.

### Solution
-------------------
Add a product type class, 'ProductType' to `system/product.py`.
Replace the hard-coded strings with the class variables.
Note: The enum class was not used solely because it required appending `.value` to the name.

Also fixed various minor flake8 issues.
