### PR TITLE
NAS-131616 / 25.04 / Fix `UserWarning: Field name "schema" in "DNSAuthenticatorSchemaEntry"...` on login

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/acme_protocol.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_protocol.py
@@ -50,7 +50,7 @@ class DNSAuthenticatorAttributeSchema(BaseModel):
 
 class DNSAuthenticatorSchemaEntry(BaseModel):
     key: str
-    schema: list[DNSAuthenticatorAttributeSchema]
+    schema_: list[DNSAuthenticatorAttributeSchema] = Field(..., alias='schema')
 
 
 ###################   Arguments   ###################


### PR DESCRIPTION
The new api style definition in `acme_protocol.py` (see https://github.com/truenas/middleware/pull/14600) caused a pydantic warning due to the model I defined having an attribute named `schema` which conflicts with an attribute of pydantic's `BaseModel` class.

The fix here is the same as it would be for any field having a reserved keyword name which is to define the name as an alias using `Field`.