### PR TITLE
NAS-131091 / 25.04 / Enable NFS over RDMA

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-10-04_18-09_add_nfs_rdma.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-10-04_18-09_add_nfs_rdma.py
@@ -1,0 +1,25 @@
+"""Add NFS RDMA configuration setting
+
+Revision ID: 85e5d349cdb1
+Revises: 5fe28eada969
+Create Date: 2024-10-04 18:09:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '85e5d349cdb1'
+down_revision = '5fe28eada969'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_nfs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('nfs_srv_rdma', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.d/local.conf.mako
@@ -13,6 +13,10 @@
     # the number of mountd be 1/4 the number of nfsd.
     num_mountd = max(num_nfsd // 4, 1)
     manage_gids = 'y' if config["userd_manage_gids"] else 'n'
+
+    # RDMA Notes: 
+    #    * The INET default NFS RDMA (nfsrdma) port is 20049
+    #    * Including 'insecure' appears to not be requried on the share settings
 %>
 [nfsd]
 syslog = 1
@@ -30,6 +34,10 @@ vers4 = n
 % endif
 % if config['bindip']:
 host = ${','.join(config['bindip'])}
+% endif
+% if config['rdma']:
+rdma = y
+rdma-port = 20049
 % endif
 
 [exportd]

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -100,7 +100,7 @@ class NFSService(SystemServiceService):
         Bool('userd_manage_gids', required=True),
         Bool('keytab_has_nfs_spn', required=True),
         Bool('managed_nfsd', default=True),
-        Bool('rdma', default=False, required=True),
+        Bool('rdma', default=False),
     )
 
     @private

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -403,9 +403,7 @@ class NFSService(SystemServiceService):
             verrors.add("nfs_update.v4_domain", "This option does not apply to NFSv3")
 
         if new["rdma"]:
-            self.logger.debug(f"[MCG DEBUG] rdma setting is {new['rdma']}")
             available_rdma_services = await self.middleware.call('rdma.capable_services')
-            self.logger.debug(f"[MCG DEBUG] available_rdma_services = {available_rdma_services}")
             if "NFS" not in available_rdma_services:
                 verrors.add(
                     "nfs_update.rdma",


### PR DESCRIPTION
This PR allows a TrueNAS SCALE Enterprise server  with an RDMA NIC to be configured to support NFS over RDMA.

Enabling RDMA is restricted to Enterprise licensed servers with an RDMA capable NIC installed.

- Extend the NFS configuration database with an NFS 'rdma' configuration setting. 
- Update the NFS config mako to include RDMA configuration when requested. 
- Update the NFS plugin to support the new 'rdma' setting. 
- Update the 'Port' validator to include an optional exclude list. Update the CI port test.

More testing and tests will follow.