### PR TITLE
NAS-131574 / 25.04 / Don't report crashed state when stopping an app

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/app_scale.py
+++ b/src/middlewared/middlewared/plugins/apps/app_scale.py
@@ -2,6 +2,8 @@ from middlewared.schema import accepts, Str, returns
 from middlewared.service import job, Service
 
 from .compose_utils import compose_action
+from .ix_apps.query import get_default_workload_values
+from .utils import get_app_stop_cache_key
 
 
 class AppService(Service):
@@ -18,11 +20,24 @@ class AppService(Service):
         Stop `app_name` app.
         """
         app_config = self.middleware.call_sync('app.get_instance', app_name)
-        job.set_progress(20, f'Stopping {app_name!r} app')
-        compose_action(
-            app_name, app_config['version'], 'down', remove_orphans=True, remove_images=False, remove_volumes=False,
-        )
-        job.set_progress(100, f'Stopped {app_name!r} app')
+        cache_key = get_app_stop_cache_key(app_name)
+        try:
+            self.middleware.call_sync('cache.put', cache_key, True)
+            self.middleware.send_event(
+                'app.query', 'CHANGED', id=app_name,
+                fields=app_config | {'state': 'STOPPING', 'active_workloads': get_default_workload_values()},
+            )
+            job.set_progress(20, f'Stopping {app_name!r} app')
+            compose_action(
+                app_name, app_config['version'], 'down', remove_orphans=True, remove_images=False, remove_volumes=False,
+            )
+            job.set_progress(100, f'Stopped {app_name!r} app')
+        finally:
+            self.middleware.send_event(
+                'app.query', 'CHANGED', id=app_name,
+                fields=app_config | {'state': 'STOPPED', 'active_workloads': get_default_workload_values()},
+            )
+            self.middleware.call_sync('cache.pop', cache_key)
 
     @accepts(Str('app_name'), roles=['APPS_WRITE'])
     @returns()

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
@@ -11,6 +11,7 @@ class AppState(enum.Enum):
     DEPLOYING = 'DEPLOYING'
     RUNNING = 'RUNNING'
     STOPPED = 'STOPPED'
+    STOPPING = 'STOPPING'
 
 
 class ContainerState(enum.Enum):

--- a/src/middlewared/middlewared/plugins/apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/utils.py
@@ -7,6 +7,10 @@ from middlewared.plugins.docker.state_utils import DatasetDefaults, IX_APPS_MOUN
 PROJECT_PREFIX = 'ix-'
 
 
+def get_app_stop_cache_key(app_name: str) -> str:
+    return f'app_stop_{app_name}'
+
+
 def run(*args, **kwargs) -> subprocess.CompletedProcess:
     shell = isinstance(args[0], str)
     if isinstance(args[0], list):


### PR DESCRIPTION
## Problem

Some apps when they are being stopped, we report `CRASHED` state for them. `CRASHED` state for us when we have containers available but they have exited.

## Solution

There isn't a clean way to address this as we are not getting relevant details from docker wrt this so we can determine that a container is in a stopping state and we then appropriately address the case - so what has been done is that we temporarily add a cache key to suppress events for that app when it is being stopped and send STOPPING/STOPPED event manually.