### PR TITLE
NAS-131573 / 25.04 / Default to accept policy for IPv6 forward chain

### DIFF
--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=/bin/sh -c "iptables -P FORWARD ACCEPT"
+ExecStartPost=/bin/sh -c "iptables -P FORWARD ACCEPT && ip6tables -P FORWARD ACCEPT"


### PR DESCRIPTION
This PR restores IPv6 connectivity in VMs when enabling Docker. 
It's basically the same as the following PR, but for IPv6:
- https://github.com/truenas/middleware/pull/14338 by @Qubad786

The fix was confirmed working on TrueNAS Scale 24.10-RC.1 and 24.10-RC.2 systems.
The PR targets master / 25.04, but it should also really be backported to 24.10.

---

JIRA URL: https://ixsystems.atlassian.net/browse/NAS-131573
See both of my recent comments in the JIRA ticket for more details on the underlying issue: [comment 1](https://ixsystems.atlassian.net/browse/NAS-131573?focusedCommentId=279491), [comment 2](https://ixsystems.atlassian.net/browse/NAS-131573?focusedCommentId=279494).

This is the Moby GitHub issue tracking the underlying bug:
- https://github.com/moby/moby/issues/48365

---

Like mentioned in the JIRA ticket above, an alternative approach would be to add `"ip6tables":false` [here](https://github.com/truenas/middleware/blob/47e941879f54dba70b443c9e00f54f5740bfa656/src/middlewared/middlewared/etc_files/docker/daemon.json.py#L20-L26) to restore the behavior of previous Docker versions which do not modify the default policy to `DROP` for IPv6.
However, the "workaround" is already in place for IPv4, so I'd also use the same method for IPv6.