### PR TITLE
NAS-131685 / 25.04 / Remove xattr from available dataset properties

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -294,10 +294,10 @@ class PoolDatasetService(CRUDService):
             to_check = {'acltype': None, 'aclmode': None}
 
             if mode == 'UPDATE':
-                # Prevent users from changing acltype or xattr settings underneath an active SMB share
+                # Prevent users from changing acltype settings underneath an active SMB share
                 # If this dataset hosts an SMB share, then prompt the user to first delete the share,
                 # make the dataset change, the recreate the share.
-                keys = ('acltype', 'xattr')
+                keys = ('acltype',)
                 if any([data.get(key) for key in keys]):
                     ds_attachments = await self.middleware.call('pool.dataset.attachments', data['name'])
                     if smb_attachments := [share for share in ds_attachments if share['type'] == "SMB Share"]:
@@ -473,7 +473,6 @@ class PoolDatasetService(CRUDService):
         Inheritable(Str('aclmode', enum=['PASSTHROUGH', 'RESTRICTED', 'DISCARD']), has_default=False),
         Inheritable(Str('acltype', enum=['OFF', 'NFSV4', 'POSIX']), has_default=False),
         Str('share_type', default='GENERIC', enum=['GENERIC', 'MULTIPROTOCOL', 'NFS', 'SMB', 'APPS']),
-        Inheritable(Str('xattr', default='SA', enum=['ON', 'SA'])),
         Ref('encryption_options'),
         Bool('encryption', default=False),
         Bool('inherit_encryption', default=True),
@@ -743,7 +742,6 @@ class PoolDatasetService(CRUDService):
             ('sync', None, str.lower, True),
             ('volblocksize', None, None, False),
             ('volsize', None, lambda x: str(x), False),
-            ('xattr', None, str.lower, True),
             ('special_small_block_size', 'special_small_blocks', None, True),
         ):
             if i not in data or (inheritable and data[i] == 'INHERIT'):

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -134,8 +134,6 @@ class ZFSDatasetService(CRUDService):
 
         # it's important that we set xattr=sa for various
         # performance reasons related to ea handling
-        # pool.dataset.create already sets this by default
-        # so mirror the behavior here
         if data['type'] == 'FILESYSTEM' and 'xattr' not in params:
             params['xattr'] = 'sa'
 

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -280,11 +280,11 @@ def test_008_test_prevent_smb_dataset_update(request):
             with smb_share(path, 'SMB_SHARE_2'):
 
                 # Confirm we ignore requests that don't involve changes
-                for setting in [{"xattr": "SA"}, {"acltype": "POSIX"}]:
+                for setting in [{"acltype": "POSIX"}]:
                     call('pool.dataset.update', ds, setting)
 
                 # Confirm we block requests that involve changes
-                for setting in [{"xattr": "ON"}, {"acltype": "OFF"}]:
+                for setting in [{"acltype": "OFF"}]:
                     attrib = list(setting.keys())[0]
                     with pytest.raises(ValidationErrors) as ve:
                         call('pool.dataset.update', ds, setting)


### PR DESCRIPTION
The xattr parameter was initially exposed to end-users to allow option to set what was at the time a new-ish ZFS feature to store xattrs in sa instead of xattr directory. Since this time we've changed the default and there is no longer a reason to allow setting the legacy DIR mode. This allows us to be agnostic as to upstream OpenZFS changes regarding the defaults for the xattr property and meaning of "on".