### PR TITLE
NAS-131618 / 25.04 / Fix KeyError on zpool.status call when a disk is being resilvered

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -50,13 +50,21 @@ class ZPoolService(Service):
                 final[disk] = get_normalized_disk_info(pool_name, member, 'stripe', vdev_type, vdev_disks)
             else:
                 for i in member['vdevs'].values():
-                    if i['vdev_type'] == 'spare':
+                    i_vdev_type = i['vdev_type']
+                    if i_vdev_type == 'spare':
                         i_vdevs = list(i['vdevs'].values())
                         if not i_vdevs:
                             # An edge case but just covering to be safe
                             continue
 
                         i = next((e for e in i_vdevs if e['class'] == 'spare'), i_vdevs[0])
+                    elif i_vdev_type == 'replacing':
+                        for d in i['vdevs'].values():
+                            if d['state'] == 'ONLINE':
+                                i = d
+                                break
+                        else:
+                            continue
 
                     disk = self.resolve_block_path(i['path'], real_paths)
                     final[disk] = get_normalized_disk_info(pool_name, i, member['name'], vdev_type, vdev_disks)


### PR DESCRIPTION
Our zpool.status endpoint does not account for the possibility of a disk being resilvered when it is called. In the case of disk replacement, `zpool status -jP --json-int` returns both the disk being replaced and the disk it is being replaced by. My change will return the new disk ("ONLINE") that is replacing the old one ("OFFLINE").