### PR TITLE
NAS-131547 / 25.04 / Appropriately handle resilvering case with zpool status report

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -57,6 +57,11 @@ class ZPoolService(Service):
                             continue
 
                         i = next((e for e in i_vdevs if e['class'] == 'spare'), i_vdevs[0])
+                    elif i['vdev_type'] == 'replacing':
+                        for j in filter(lambda entry: entry.get('path'), list(i['vdevs'].values())):
+                            disk = self.resolve_block_path(j['path'], real_paths)
+                            final[disk] = get_normalized_disk_info(pool_name, j, member['name'], vdev_type, vdev_disks)
+                        continue
 
                     disk = self.resolve_block_path(i['path'], real_paths)
                     final[disk] = get_normalized_disk_info(pool_name, i, member['name'], vdev_type, vdev_disks)


### PR DESCRIPTION
## Problem

The current `zpool status` is incorrectly handling the "replacing" vdev type, which appears only during an ongoing resilvering process. This is causing a "path not found" key error, as it treats the replacing vdev as a regular vdev.

## Solution

Updated `zpool status` to properly handle and manage the "replacing" vdev type during resilvering, preventing key errors.