### PR TITLE
NAS-131697 / 24.10.0 / Fix domain join with multiple DCs (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
@@ -26,8 +26,9 @@ class ADJoinMixin:
 
         self.middleware.call_sync('service.stop', 'idmap')
         self.middleware.call_sync('service.start', 'idmap', {'silent': False})
-        self.middleware.call_sync('kerberos.start')
+        # Wait for winbind to come online to provide some time for sysvol replication
         self._ad_wait_wbclient()
+        self.middleware.call_sync('kerberos.start')
 
     def _ad_wait_wbclient(self) -> None:
         waited = 0


### PR DESCRIPTION
During multi-dc testing in preparation to cutover to new CI domain it was observed that delayed sysvol replication after a fresh join could cause our post-join setup step in which we regenerate the krb5.conf and perform kinit with the AD machine account keytab could fail due to us talking to a DC that had not received updated account information yet. This commit changes the order of operations when we activate AD so that we first wait for winbindd to mark the domain as ONLINE before we try to set up kerberos.

Original PR: https://github.com/truenas/middleware/pull/14643
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131697