### PR TITLE
NAS-131717 / 25.04 / fix r50 series nvme enclosure maps

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -190,7 +190,7 @@ def get_nvme_slot_info(model):
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: True,
                                 DISK_INTERNAL_KEY: False
-                            } for i, j in zip(range(1, 4), range(25, 28))
+                            } for i, j in zip(range(1, 4), range(49, 52))
                         },
                         'r50b_nvme_enclosure': {
                             i: {
@@ -201,7 +201,7 @@ def get_nvme_slot_info(model):
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: True,
                                 DISK_INTERNAL_KEY: False
-                            } for i, j in zip(range(1, 3), range(25, 27))
+                            } for i, j in zip(range(1, 3), range(49, 51))
                         },
                         'r50bm_nvme_enclosure': {
                             i: {
@@ -212,7 +212,7 @@ def get_nvme_slot_info(model):
                                 DISK_TOP_KEY: False,
                                 DISK_REAR_KEY: True,
                                 DISK_INTERNAL_KEY: False
-                            } for i, j in zip(range(1, 5), range(25, 29))
+                            } for i, j in zip(range(1, 5), range(49, 53))
                         },
                     }
                 }


### PR DESCRIPTION
Worked with platform team on an internal R50BM that was experiencing enclosure problems. Found that I had copy and pasted the rear nvme drive bay logic from the M30 which doesn't apply to the R50 series. The m-series have 24 front drive bays and 4 rear nvmes while the R50 series has 48 top loaded drives plus 2,3 and 4 rear nvme drives. This fixes the typo and I confirmed fixes the issue that was being experienced.