### PR TITLE
NAS-131704 / 25.04 / Make sure docker datasets are mounted if address pools are changed only

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -116,6 +116,10 @@ class DockerService(ConfigService):
                 await self.middleware.call('docker.setup.status_change')
             elif config['pool'] and config['address_pools'] != old_config['address_pools']:
                 job.set_progress(60, 'Starting docker')
+                catalog_sync_job = await self.middleware.call('docker.fs_manage.mount')
+                if catalog_sync_job:
+                    await catalog_sync_job.wait()
+
                 await self.middleware.call('service.start', 'docker')
 
             if not old_config['nvidia'] and config['nvidia']:

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -58,6 +58,16 @@ def test_apps_are_running():
     assert call('docker.status')['status'] == 'RUNNING'
 
 
+@pytest.mark.dependency(depends=['docker_setup'])
+def test_apps_dataset_after_address_pool_update():
+    docker_config = call('docker.update', {'address_pools': [{'base': '172.17.0.0/12', 'size': 27}]}, job=True)
+    assert docker_config['address_pools'] == [{'base': '172.17.0.0/12', 'size': 27}]
+    assert call('filesystem.statfs', IX_APPS_MOUNT_PATH)['source'] == docker_config['dataset']
+    assert call('docker.status')['status'] == 'RUNNING'
+
+
 def test_unset_docker_pool(docker_pool):
-    docker_config = call('docker.update', {'pool': None}, job=True)
+    docker_config = call(
+        'docker.update', {'pool': None, 'address_pools': [{'base': '172.17.0.0/12', 'size': 24}]}, job=True
+    )
     assert docker_config['pool'] is None, docker_config


### PR DESCRIPTION
This PR fixes a case which is only valid for FT that when address pool property is changed, we are not mounting docker datasets again. An integration test has been added to this end as well to make sure we catch such cases sooner.