### PR TITLE
NAS-131305 / 25.04 / fix MINI 3.0 X (vers 1.0) drive mapping

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -8,6 +8,7 @@ import re
 
 from pyudev import Context, Devices, DeviceNotFoundAtPathError
 
+from ixhardware import parse_dmi
 from .constants import (
     DISK_FRONT_KEY,
     DISK_REAR_KEY,
@@ -251,8 +252,9 @@ def map_r30_or_fseries(model, ctx):
     return fake_nvme_enclosure(model, num_of_nvme_slots, mapped, ui_info)
 
 
-def map_nvme(dmi):
-    model = dmi.removeprefix('TRUENAS-').removesuffix('-S').removesuffix('-HA')
+def map_nvme():
+    model = parse_dmi().system_product_name.removeprefix('TRUENAS-')
+    model = model.removesuffix('-S').removesuffix('-HA')
     ctx = Context()
     if model in (
         ControllerModels.R50.value,

--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
@@ -15,14 +15,14 @@ def get_ses_enclosure_status(bsg_path):
         logger.error('Error querying enclosure status for %r', bsg_path, exc_info=True)
 
 
-def get_ses_enclosures(dmi, asdict=True):
+def get_ses_enclosures(asdict=True):
     rv = list()
     with suppress(FileNotFoundError):
         for i in Path('/sys/class/enclosure').iterdir():
             bsg = f'/dev/bsg/{i.name}'
             if (status := get_ses_enclosure_status(bsg)):
                 sg = next((i / 'device/scsi_generic').iterdir())
-                enc = Enclosure(bsg, f'/dev/{sg.name}', dmi, status)
+                enc = Enclosure(bsg, f'/dev/{sg.name}', status)
                 if asdict:
                     rv.append(enc.asdict())
                 else:

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -534,9 +534,8 @@ def get_slot_info(enc):
         }
     elif enc.model == ControllerModels.MINI3X.value:
         return {
-            'any_version': True,
+            'any_version': False,
             'versions': {
-                # NOTE: 1.0 "version" has same mapping?? (CORE is the same)
                 'DEFAULT': {
                     'id': {
                         '3000000000000001': {
@@ -547,6 +546,21 @@ def get_slot_info(enc):
                             1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
                             2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
                             4: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False}
+                        }
+                    }
+                },
+                '1.0': {
+                    'id': {
+                        '3000000000000002': {
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: False},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: False},
+                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: False},
+                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: False}
+                        },
+                        '3000000000000001': {
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
+                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False}
                         }
                     }
                 }

--- a/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
+++ b/src/middlewared/middlewared/plugins/failover_/detect_enclosure.py
@@ -87,7 +87,7 @@ class EnclosureDetectionService(Service):
             # down this path.
             return HARDWARE, NODE
 
-        for enc in get_ses_enclosures(product, False):
+        for enc in get_ses_enclosures(False):
             if enc.is_mseries:
                 HARDWARE = 'ECHOWARP'
                 if enc.product == '4024Sp':


### PR DESCRIPTION
We do not have a MINI 3.0 X version 1.0 internally to test these changes on, however, we do have a non-version 1.0 which is essentially the same device just cabled so slightly differently.

I have added the mapping based on physically identifying drives on the non-version 1.0 and working backwards from there. Most of the changes here are related to 2 changes:
1. updating docstrings to reflect reality
2. removing the need to pass the `dmi` object around. Instead I use our dedicated `ixhardware` module (which does the exact same thing but provides me the ability to access the `system_version` buffer which is needed for the mini 3.0 x version 1.0 platform.

I have tested these changes on (with no regressions):
1. m60 with 12x ES102's connected
3. mini 3.0 x (NON version 1.0)
4. random hardware that we don't sell