### PR TITLE
NAS-131305 / 24.10.0 / fix MINI 3.0 X (vers 1.0) drive mapping (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -7,6 +7,7 @@ import logging
 
 from middlewared.utils.scsi_generic import inquiry
 
+from ixhardware import parse_dmi
 from .constants import (
     MINI_MODEL_BASE,
     MINIR_MODEL_BASE,
@@ -29,8 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 class Enclosure:
-    def __init__(self, bsg, sg, dmi, enc_stat):
-        self.bsg, self.sg, self.pci, self.dmi = bsg, sg, bsg.removeprefix('/dev/bsg/'), dmi
+    def __init__(self, bsg, sg, enc_stat):
+        self.dmi = parse_dmi()
+        self.bsg, self.sg, self.pci, = bsg, sg, bsg.removeprefix('/dev/bsg/')
         self.encid, self.status = enc_stat['id'], list(enc_stat['status'])
         self.vendor, self.product, self.revision, self.encname = self._get_vendor_product_revision_and_encname()
         self._get_model_and_controller()
@@ -48,7 +50,7 @@ class Enclosure:
             'name': self.encname,  # vendor, product and revision joined by whitespace
             'model': self.model,  # M60, F100, MINI-R, etc
             'controller': self.controller,  # if True, represents the "head-unit"
-            'dmi': self.dmi,  # comes from system.dmidecode_info[system-product-name]
+            'dmi': self.dmi.system_product_name,
             'status': self.status,  # the overall status reported by the enclosure
             'id': self.encid,
             'vendor': self.vendor,  # t10 vendor from INQUIRY
@@ -118,7 +120,8 @@ class Enclosure:
         2. We check the t10 vendor and product strings returned from the enclosure
             using a standard inquiry command
         """
-        model = self.dmi.removeprefix('TRUENAS-').removeprefix('FREENAS-')
+        spn = self.dmi.system_product_name
+        model = spn.removeprefix('TRUENAS-').removeprefix('FREENAS-')
         model = model.removesuffix('-HA').removesuffix('-S')
         try:
             dmi_model = ControllerModels[model]
@@ -134,7 +137,7 @@ class Enclosure:
             except ValueError:
                 # this shouldn't ever happen because the instantiator of this class
                 # checks DMI before we even get here but better safe than sorry
-                logger.warning('Unexpected model: %r from dmi: %r', model, self.dmi)
+                logger.warning('Unexpected model: %r from dmi: %r', model, spn)
                 self.model = ''
                 self.controller = False
                 return
@@ -231,7 +234,7 @@ class Enclosure:
         vers_key = 'DEFAULT'
         if not mapped_info['any_version']:
             for key, vers in mapped_info['versions'].items():
-                if self.revision == key:
+                if self.dmi.system_version == key:
                     vers_key = vers
                     break
 

--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -8,6 +8,7 @@ import re
 
 from pyudev import Context, Devices, DeviceNotFoundAtPathError
 
+from ixhardware import parse_dmi
 from .constants import (
     DISK_FRONT_KEY,
     DISK_REAR_KEY,
@@ -251,8 +252,9 @@ def map_r30_or_fseries(model, ctx):
     return fake_nvme_enclosure(model, num_of_nvme_slots, mapped, ui_info)
 
 
-def map_nvme(dmi):
-    model = dmi.removeprefix('TRUENAS-').removesuffix('-S').removesuffix('-HA')
+def map_nvme():
+    model = parse_dmi().system_product_name.removeprefix('TRUENAS-')
+    model = model.removesuffix('-S').removesuffix('-HA')
     ctx = Context()
     if model in (
         ControllerModels.R50.value,

--- a/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/ses_enclosures2.py
@@ -15,13 +15,13 @@ def get_ses_enclosure_status(bsg_path):
         logger.error('Error querying enclosure status for %r', bsg_path, exc_info=True)
 
 
-def get_ses_enclosures(dmi):
+def get_ses_enclosures():
     rv = list()
     with suppress(FileNotFoundError):
         for i in Path('/sys/class/enclosure').iterdir():
             bsg = f'/dev/bsg/{i.name}'
             if (status := get_ses_enclosure_status(bsg)):
                 sg = next((i / 'device/scsi_generic').iterdir())
-                rv.append(Enclosure(bsg, f'/dev/{sg.name}', dmi, status).asdict())
+                rv.append(Enclosure(bsg, f'/dev/{sg.name}', status).asdict())
 
     return rv

--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -534,9 +534,8 @@ def get_slot_info(enc):
         }
     elif enc.model == ControllerModels.MINI3X.value:
         return {
-            'any_version': True,
+            'any_version': False,
             'versions': {
-                # NOTE: 1.0 "version" has same mapping?? (CORE is the same)
                 'DEFAULT': {
                     'id': {
                         '3000000000000001': {
@@ -547,6 +546,21 @@ def get_slot_info(enc):
                             1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
                             2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
                             4: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False}
+                        }
+                    }
+                },
+                '1.0': {
+                    'id': {
+                        '3000000000000002': {
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: False},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: False},
+                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: False},
+                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: False}
+                        },
+                        '3000000000000001': {
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
+                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False}
                         }
                     }
                 }


### PR DESCRIPTION
We do not have a MINI 3.0 X version 1.0 internally to test these changes on, however, we do have a non-version 1.0 which is essentially the same device just cabled so slightly differently.

I have added the mapping based on physically identifying drives on the non-version 1.0 and working backwards from there. Most of the changes here are related to 2 changes:
1. updating docstrings to reflect reality
2. removing the need to pass the `dmi` object around. Instead I use our dedicated `ixhardware` module (which does the exact same thing but provides me the ability to access the `system_version` buffer which is needed for the mini 3.0 x version 1.0 platform.

I have tested these changes on (with no regressions):
1. m60 with 12x ES102's connected
3. mini 3.0 x (NON version 1.0)
4. random hardware that we don't sell

Original PR: https://github.com/truenas/middleware/pull/14657
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131305