### PR TITLE
NAS-131749 / 25.04 / update test for xattr=on changes

### DIFF
--- a/src/middlewared/middlewared/test/integration/utils/docker.py
+++ b/src/middlewared/middlewared/test/integration/utils/docker.py
@@ -18,7 +18,7 @@ DOCKER_DATASET_PROPS = {
     'overlay': 'on',
     'setuid': 'on',
     'snapdir': 'hidden',
-    'xattr': 'sa',
+    'xattr': 'on',
 }
 
 

--- a/tests/api2/test_006_pool_and_sysds.py
+++ b/tests/api2/test_006_pool_and_sysds.py
@@ -239,7 +239,7 @@ def test__check_root_level_dataset_properties():
     ds = call('pool.dataset.get_instance', pool_name)
     assert ds['acltype']['value'] == 'POSIX'
     assert ds['aclmode']['value'] == 'DISCARD'
-    assert ds['xattr']['value'] == 'SA'
+    assert ds['xattr']['value'] == 'ON'
     assert ds['deduplication']['value'] == 'OFF'
     assert ds['casesensitivity']['value'] == 'SENSITIVE'
     assert ds['compression']['value'] == 'LZ4'


### PR DESCRIPTION
In OpenZFS 2.3 the meaning of xattr=on changed from dir to sa which means that "ON" is now the expected value for the top-level dataset of a new zpool.