### PR TITLE
NAS-131750 / 25.04 / Add middleware backend support for SMB fast copy

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -148,9 +148,10 @@ class SMBService(ConfigService):
         smb_config = self.middleware.call_sync('smb.config')
         smb_shares = self.middleware.call_sync('sharing.smb.query')
         bind_ip_choices = self.middleware.call_sync('smb.bindip_choices')
+        is_enterprise = self.middleware.call_sync('system.is_enterprise')
 
         return generate_smb_conf_dict(
-            ds_type, ds_config, smb_config, smb_shares, bind_ip_choices, idmap_config
+            ds_type, ds_config, smb_config, smb_shares, bind_ip_choices, idmap_config, is_enterprise
         )
 
     @private
@@ -1200,7 +1201,9 @@ class SharingSMBService(SharingService):
             'socket options',
             'include',
             'wide links',
-            'insecure wide links'
+            'insecure wide links',
+            'zfs_core:zfs_block_cloning',
+            'zfs_core:zfs_integrity_streams',
         ]
         freebsd_vfs_objects = [
             'noacl',

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -15,7 +15,8 @@ def generate_smb_conf_dict(
     smb_service_config: dict,
     smb_shares: list,
     smb_bind_choices: dict,
-    idmap_settings: list
+    idmap_settings: list,
+    is_enterprise: bool = False
 ):
     guest_enabled = any(filter_list(smb_shares, [['guestok', '=', True]]))
     fsrvp_enabled = any(filter_list(smb_shares, [['fsrvp', '=', True]]))
@@ -303,7 +304,11 @@ def generate_smb_conf_dict(
         param, value = entry.split('=', 1)
         smbconf[param.strip()] = value.strip()
 
+    # The following parameters must come after processing includes in order to
+    # prevent auxiliary parameters from overriding them
     smbconf.update({
+        'zfs_core:zfs_integrity_streams': is_enterprise,
+        'zfs_core:zfs_block_cloning': is_enterprise,
         'registry shares': True,
         'include': 'registry',
     })

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_smb.py
@@ -234,6 +234,17 @@ def test__base_smb():
     assert conf['server smb encrypt'] == 'default'
     assert conf['directory mask'] == '0775'
     assert conf['create mask'] == '0664'
+    assert conf['zfs_core:zfs_integrity_streams'] is False
+    assert conf['zfs_core:zfs_block_cloning'] is False
+
+
+def test__base_smb_enterprise():
+    conf = generate_smb_conf_dict(
+        None, None, BASE_SMB_CONFIG, [],
+        BIND_IP_CHOICES, BASE_IDMAP, True
+    )
+    assert conf['zfs_core:zfs_integrity_streams'] is True
+    assert conf['zfs_core:zfs_block_cloning'] is True
 
 
 def test__syslog():


### PR DESCRIPTION
Enable SMB parameters required for support of VEEAM fast copy if TrueNAS is enterprise-licensed. SMB protocol functional tests will be added in followup commit.