### PR TITLE
NAS-131456 / 24.10.1 / Update user-group memberships using datastore (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -270,7 +270,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
                 for connection in await self.query(
                     relationship.secondary.name.replace('_', '.', 1),
                     [[relationship_local_pk.name, 'in', pk_values]],
-                    {'relationships': False}
+                    {'relationships': False},
                 ):
                     child_id = connection[relationship_remote_pk.name]
 
@@ -282,6 +282,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
                     for child in await self.query(
                         relationship.target.name.replace('_', '.', 1),
                         [[remote_pk.name, 'in', all_children_ids]],
+                        {'relationships': False},
                     ):
                         all_children[child[remote_pk.name]] = child
 

--- a/src/middlewared/middlewared/test/integration/assets/account.py
+++ b/src/middlewared/middlewared/test/integration/assets/account.py
@@ -92,6 +92,7 @@ def unprivileged_user_client(roles=None, allowlist=None):
 def root_with_password_disabled():
     root_backup = call("datastore.query", "account.bsdusers", [["bsdusr_username", "=", "root"]], {"get": True})
     root_backup["bsdusr_group"] = root_backup["bsdusr_group"]["id"]
+    root_backup["bsdusr_groups"] = [g["id"] for g in root_backup["bsdusr_groups"]]
     root_id = root_backup.pop("id")
     # Connect before removing root password
     with client() as c:


### PR DESCRIPTION
It seems that the original code for updating user-group relationships (that was never touched since it was written in 2017) contains an error:

https://github.com/truenas/middleware/blob/master/src/middlewared/middlewared/plugins/account.py#L1367

`gms` is an array of `account.bsdgroupmembership` objects, so `gm["id"]` has a Row ID type for `account.bsdgroupmembership` table. `groups` is an array of Row IDs for `account.bsdgroup` table. `gm['id'] not in groups` check has no sense, it compares Row IDs of different tables.

This is probably the root cause of a rare bug where the following code

```
from truenas_api_client import Client


c = Client()

while True:
    user = c.call('user.query', [['username', '=', 'smbuser']], {'get': True})

    pk = c.call('user.update', user['id'], {'ssh_password_enabled': True})
    pk = c.call('user.update', user['id'], {'groups': [43, 40, 90]})
    user = c.call('user.get_instance', pk)
    assert set(user['groups']) == set([43, 40, 90])
```

very rarely fails with assertion failure, `user["groups"]` being

```
    "groups": [
      90,
      43,
      90
    ],
```

Our `datastore` plugin has the ability to manage many-to-many relationships table, let's use it.

Original PR: https://github.com/truenas/middleware/pull/14601
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131456