### PR TITLE
NAS-131748 / 25.04 / Make sure isolated gpu roles test don't timeout

### DIFF
--- a/tests/api2/test_system_settings_roles.py
+++ b/tests/api2/test_system_settings_roles.py
@@ -11,8 +11,8 @@ from middlewared.test.integration.assets.roles import common_checks
     ('READONLY_ADMIN', 'system.advanced.update', [{}], False, False, False),
     ('SYSTEM_ADVANCED_WRITE', 'system.advanced.update', [{}], True, False, False),
     ('SYSTEM_ADVANCED_READ', 'system.advanced.sed_global_password', [], True, False, False),
-    ('READONLY_ADMIN', 'system.advanced.update_gpu_pci_ids', [[]], False, False, False),
-    ('SYSTEM_ADVANCED_WRITE', 'system.advanced.update_gpu_pci_ids', [], True, False, True),
+    ('READONLY_ADMIN', 'system.advanced.update_gpu_pci_ids', [None], False, True, False),
+    ('SYSTEM_ADVANCED_WRITE', 'system.advanced.update_gpu_pci_ids', [None], True, True, True),
     ('SYSTEM_GENERAL_READ', 'system.general.local_url', [], True, False, False),
 ])
 def test_system_settings_read_and_write_role(


### PR DESCRIPTION
## Problem

We have an integration test to test role of `system.advanced.update_gpu_pci_ids` which basically when called updates initramfs as well and this potentially times out in our CI pipeline.

## Solution

There is no actual need to call the endpoint when we can check the roles without actually getting the endpoint to work. The common utility we have in place already handles this nicely where the role is asserted without actually getting the endpoint to execute because role based exceptions should be raised before the method is actually executed.
