### PR TITLE
NAS-131778 / 25.04 / handle edge-case crash for nvdimm alert

### DIFF
--- a/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
+++ b/src/middlewared/middlewared/alert/source/mseries_nvdimm_and_bios.py
@@ -154,6 +154,9 @@ class NVDIMMAndBIOSAlertSource(ThreadedAlertSource):
                 alerts.append(Alert(OldBiosVersionAlertClass))
 
             for nvdimm in self.middleware.call_sync('mseries.nvdimm.info'):
-                self.produce_alerts(nvdimm, alerts, old_bios)
+                try:
+                    self.produce_alerts(nvdimm, alerts, old_bios)
+                except Exception:
+                    self.middleware.logger.exception('Unexpected failure processing NVDIMM alerts')
 
         return alerts


### PR DESCRIPTION
Don't pollute the webUI with tracebacks for an edge-case crash. Catch the exception and log it instead.