### PR TITLE
NAS-131090

### DIFF
--- a/src/middlewared/middlewared/api/base/types/__init__.py
+++ b/src/middlewared/middlewared/api/base/types/__init__.py
@@ -1,2 +1,3 @@
 from .base import *  # noqa
+from .fc import *  # noqa
 from .user import *  # noqa

--- a/src/middlewared/middlewared/api/base/types/fc.py
+++ b/src/middlewared/middlewared/api/base/types/fc.py
@@ -1,0 +1,14 @@
+from pydantic import StringConstraints
+from typing_extensions import Annotated
+
+__all__ = ["FibreChannelHostAlias", "FibreChannelPortAlias", "WWPN"]
+
+# Port alias will have a optional "/<number>" postfix vs host alias, where number > 0
+FC_HOST_ALIAS_PATTERN = r"^[a-zA-Z0-9,\-_:]+$"
+FC_PORT_ALIAS_PATTERN = r"^[a-zA-Z0-9,\-_:]+(/[1-9][0-9]*)?$"
+NAA_PATTERN = r"^naa.[0-9a-fA-F]{16}$"
+
+
+FibreChannelHostAlias = Annotated[str, StringConstraints(min_length=1, max_length=32, pattern=FC_HOST_ALIAS_PATTERN)]
+FibreChannelPortAlias = Annotated[str, StringConstraints(min_length=1, max_length=40, pattern=FC_PORT_ALIAS_PATTERN)]
+WWPN = Annotated[str, StringConstraints(pattern=NAA_PATTERN)]

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -8,6 +8,7 @@ from .common import *  # noqa
 from .core import *  # noqa
 from .disk import *  # noqa
 from .failover_reboot import *  # noqa
+from .fc_host import *  # noqa
 from .group import *  # noqa
 from .keychain import *  # noqa
 from .privilege import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -9,6 +9,7 @@ from .core import *  # noqa
 from .disk import *  # noqa
 from .failover_reboot import *  # noqa
 from .fc_host import *  # noqa
+from .fcport import *  # noqa
 from .group import *  # noqa
 from .keychain import *  # noqa
 from .privilege import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/fc_host.py
+++ b/src/middlewared/middlewared/api/v25_04_0/fc_host.py
@@ -1,0 +1,44 @@
+from typing import Literal
+
+from middlewared.api.base import WWPN, BaseModel, Excluded, FibreChannelHostAlias, ForUpdateMetaclass, excluded_field
+
+
+class FCHostEntry(BaseModel):
+    id: int
+    alias: FibreChannelHostAlias
+    wwpn: WWPN | None = None
+    wwpn_b: WWPN | None = None
+    npiv: int = 0
+
+
+class FCHostCreate(FCHostEntry):
+    id: Excluded = excluded_field()
+
+
+class FCHostCreateArgs(BaseModel):
+    fc_host_create: FCHostCreate
+
+
+class FCHostCreateResult(BaseModel):
+    result: FCHostEntry
+
+
+class FCHostUpdate(FCHostCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class FCHostUpdateArgs(BaseModel):
+    id: int
+    fc_host_update: FCHostUpdate
+
+
+class FCHostUpdateResult(BaseModel):
+    result: FCHostEntry
+
+
+class FCHostDeleteArgs(BaseModel):
+    id: int
+
+
+class FCHostDeleteResult(BaseModel):
+    result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/fcport.py
+++ b/src/middlewared/middlewared/api/v25_04_0/fcport.py
@@ -1,0 +1,46 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel, Excluded, FibreChannelPortAlias, ForUpdateMetaclass, WWPN, excluded_field
+
+
+class FCPortEntry(BaseModel):
+    id: int
+    port: FibreChannelPortAlias
+    wwpn: WWPN | None
+    wwpn_b: WWPN | None
+    target_id: int
+
+
+class FCPortCreate(FCPortEntry):
+    id: Excluded = excluded_field()
+    wwpn: Excluded = excluded_field()
+    wwpn_b: Excluded = excluded_field()
+
+
+class FCPortCreateArgs(BaseModel):
+    fc_Port_create: FCPortCreate
+
+
+class FCPortCreateResult(BaseModel):
+    result: FCPortEntry
+
+
+class FCPortUpdate(FCPortCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class FCPortUpdateArgs(BaseModel):
+    id: int
+    fc_Port_update: FCPortUpdate
+
+
+class FCPortUpdateResult(BaseModel):
+    result: FCPortEntry
+
+
+class FCPortDeleteArgs(BaseModel):
+    id: int
+
+
+class FCPortDeleteResult(BaseModel):
+    result: Literal[True]

--- a/src/middlewared/middlewared/etc_files/scst.env.mako
+++ b/src/middlewared/middlewared/etc_files/scst.env.mako
@@ -1,4 +1,4 @@
 <%
-    global_config = middleware.call_sync('iscsi.global.config')
+    global_config = render_ctx['iscsi.global.config']
 %>\
 ISCSID_OPTIONS="-p ${global_config['listen_port']}"

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -219,10 +219,22 @@ class EtcService(Service):
         'ssl': [
             {'type': 'py', 'path': 'generate_ssl_certs'},
         ],
-        'scst': [
-            {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import', 'mode': 0o600},
-            {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import', 'mode': 0o744},
-        ],
+        'scst': {
+            'ctx': [
+                {'method': 'failover.licensed'},
+                {'method': 'failover.node'},
+                {'method': 'failover.status'},
+                {'method': 'fc.capable'},
+                {'method': 'fcport.query'},
+                {'method': 'iscsi.global.alua_enabled'},
+                {'method': 'iscsi.global.config'},
+                {'method': 'iscsi.target.query'},
+            ],
+            'entries': [
+                {'type': 'mako', 'path': 'scst.conf', 'checkpoint': 'pool_import', 'mode': 0o600},
+                {'type': 'mako', 'path': 'scst.env', 'checkpoint': 'pool_import', 'mode': 0o744},
+            ]
+        },
         'scst_targets': [
             {'type': 'mako', 'path': 'initiators.allow', 'checkpoint': 'pool_import'},
             {'type': 'mako', 'path': 'initiators.deny', 'checkpoint': 'pool_import'},
@@ -293,7 +305,7 @@ class EtcService(Service):
         'snmpd': [
             {'type': 'mako', 'path': 'snmp/snmpd.conf',
                 'local_path': 'local/snmpd.conf', 'owner': 'root', 'group': 'Debian-snmp', 'mode': 0o640
-            },
+             },
         ],
         'syslogd': {
             'ctx': [

--- a/src/middlewared/middlewared/plugins/fc/fc.py
+++ b/src/middlewared/middlewared/plugins/fc/fc.py
@@ -1,0 +1,153 @@
+import os.path
+import re
+import subprocess
+from functools import cache
+from pathlib import Path
+
+from middlewared.service import Service
+from middlewared.service_exception import CallError
+from .utils import dmi_pci_slot_info, wwn_as_colon_hex
+
+FIBRE_CHANNEL_SEARCH_STRING = 'Fibre Channel'
+QLA2XXX_KERNEL_MODULE = 'qla2xxx_scst'
+FIBRE_CHANNEL_VENDOR = 'QLogic'
+FC_HOST_PAT = re.compile('/sys/devices/(.*)/(?P<host>host.*)/fc_host/(?P=host)')
+
+
+class FCService(Service):
+
+    class Config:
+        private = True
+
+    async def capable(self):
+        """
+        Returns True if the system is licensed for FIBRECHANNEL and contains
+        one or more Fibre Channel cards.  False otherwise.
+        """
+        if await self.middleware.call('system.is_enterprise'):
+            if await self.middleware.call('system.feature_enabled', 'FIBRECHANNEL'):
+                if await self.middleware.call('fc.hba_present'):
+                    return True
+        return False
+
+    @cache
+    def hba_present(self):
+        """
+        Return True if a Qlogic Fibre Channel card is present.  False otherwise.
+        """
+        lspci_cmd = ['lspci']
+        ret = subprocess.run(lspci_cmd, capture_output=True)
+        if ret.returncode:
+            error = ret.stderr.decode() if ret.stderr else ret.stdout.decode()
+            if not error:
+                error = 'No error message reported'
+            self.logger.debug('Failed to execute command: lspci with error: %r', error)
+            raise CallError(f'Failed to determine serial number/product: {error}')
+        for line in ret.stdout.decode().split('\n'):
+            if FIBRE_CHANNEL_SEARCH_STRING not in line:
+                continue
+            if FIBRE_CHANNEL_VENDOR not in line:
+                continue
+            # We matched!
+            return True
+        return False
+
+    @cache
+    def fc_hosts(self):
+        result = []
+        if self.middleware.call_sync('fc.capable'):
+            self.__load_kernel_module()
+            slots = dmi_pci_slot_info()
+            with os.scandir('/sys/class/fc_host') as scan:
+                for i in filter(lambda x: x.is_symlink() and x.name.startswith('host'), scan):
+                    # Ensure realpath looks something like
+                    # '/sys/devices/pci0000:b2/0000:b2:00.0/0000:b3:00.0/host14/fc_host/host14'
+                    if srp := FC_HOST_PAT.search(os.path.realpath(i.path)):
+                        addr = srp[1]
+                        path = Path(i.path)
+                        # node_name and port_name must be transported as string to avoid JSON breakage
+                        entry = {
+                            'name': i.name,
+                            'path': i.path,
+                            'node_name': (path / 'node_name').read_text().strip(),
+                            'port_name': (path / 'port_name').read_text().strip(),
+                            'addr': addr,
+                        }
+                        # Maybe also get slot information from DMI (dmidecode)
+                        # First pull out the piece of PCI address that is also included
+                        # in dmidecode output.
+                        laddr = addr.split('/')[-1]
+                        if laddr in slots:
+                            _, function = laddr.rsplit('.', 1)
+                            entry['slot'] = f'{slots[laddr]} / PCI Function {function}'
+                        else:
+                            # The DMI information typically includes function 0
+                            # We'll want to also match the slot if we're a different
+                            # function.
+                            if '.' in laddr:
+                                laddr, function = laddr.rsplit('.', 1)
+                                zeroaddr = f'{laddr}.0'
+                                if zeroaddr in slots:
+                                    entry['slot'] = f'{slots[zeroaddr]} / PCI Function {function}'
+                        result.append(entry)
+        return result
+
+    @cache
+    def fc_host_wwpn_choices(self):
+        result = []
+        for fc in (self.middleware.call_sync('fc.fc_hosts')):
+            port_name = fc['port_name']
+            # Replace the leading '0x' with 'naa.'
+            wwpn = f'naa.{port_name[2:]}'
+            result.append(wwpn)
+        return result
+
+    def __load_kernel_module(self):
+        if not os.path.isdir(f'/sys/module/{QLA2XXX_KERNEL_MODULE}'):
+            self.logger.info('Loading kernel module %r', QLA2XXX_KERNEL_MODULE)
+            try:
+                subprocess.run(["modprobe", QLA2XXX_KERNEL_MODULE])
+            except subprocess.CalledProcessError as e:
+                self.logger.error('Failed to load kernel module. Error %r', e)
+
+    async def load_kernel_module(self):
+        """
+        Load the Fibre Channel HBA kernel module.
+        """
+        if await self.middleware.call('fc.capable'):
+            await self.middleware.run_in_thread(self.__load_kernel_module)
+
+    async def ports(self):
+        """
+        Return a list of port nicknames
+        (Should we make it a dict with wwpn from each node?, and a flag to see whether virtual)
+        """
+        return []
+
+    async def nickname_to_wwpn(self, nickname):
+        # TODO:
+        # 1. Hard code for now (DB table in future?)
+        # 2. Currently we do not handle NPIV.  Rectify this.
+        match nickname:
+            case 'fc0':
+                addr = '/sys/devices/pci0000:b2/0000:b2:00.0/0000:b3:00.0'
+            case 'fc1':
+                addr = '/sys/devices/pci0000:b2/0000:b2:00.0/0000:b3:00.1'
+            case _:
+                return None
+
+        try:
+            return wwn_as_colon_hex((await self.middleware.call('fc.fc_hosts'))[addr]['port_name'])
+        except KeyError:
+            return None
+
+
+# async def __event_system_ready(middleware, event_type, args):
+#     await middleware.call('fc.load_kernel_module')
+#
+#
+# async def setup(middleware):
+#     if await middleware.call('system.ready'):
+#         await middleware.call('fc.load_kernel_module')
+#     else:
+#         middleware.event_subscribe('system.ready', __event_system_ready)

--- a/src/middlewared/middlewared/plugins/fc/fc.py
+++ b/src/middlewared/middlewared/plugins/fc/fc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from middlewared.service import Service
 from middlewared.service_exception import CallError
-from .utils import dmi_pci_slot_info, wwn_as_colon_hex
+from .utils import dmi_pci_slot_info
 
 FIBRE_CHANNEL_SEARCH_STRING = 'Fibre Channel'
 QLA2XXX_KERNEL_MODULE = 'qla2xxx_scst'
@@ -123,23 +123,6 @@ class FCService(Service):
         (Should we make it a dict with wwpn from each node?, and a flag to see whether virtual)
         """
         return []
-
-    async def nickname_to_wwpn(self, nickname):
-        # TODO:
-        # 1. Hard code for now (DB table in future?)
-        # 2. Currently we do not handle NPIV.  Rectify this.
-        match nickname:
-            case 'fc0':
-                addr = '/sys/devices/pci0000:b2/0000:b2:00.0/0000:b3:00.0'
-            case 'fc1':
-                addr = '/sys/devices/pci0000:b2/0000:b2:00.0/0000:b3:00.1'
-            case _:
-                return None
-
-        try:
-            return wwn_as_colon_hex((await self.middleware.call('fc.fc_hosts'))[addr]['port_name'])
-        except KeyError:
-            return None
 
 
 # async def __event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/fc/fc_host.py
+++ b/src/middlewared/middlewared/plugins/fc/fc_host.py
@@ -1,0 +1,270 @@
+from collections import defaultdict
+from typing import Literal
+
+import middlewared.sqlalchemy as sa
+from middlewared.api import api_method
+from middlewared.api.current import (FCHostCreateArgs, FCHostCreateResult, FCHostDeleteArgs, FCHostDeleteResult,
+                                     FCHostEntry, FCHostUpdateArgs, FCHostUpdateResult)
+from middlewared.plugins.failover_.remote import NETWORK_ERRORS
+from middlewared.service import CallError, CRUDService, ValidationErrors, private
+from .utils import str_to_naa
+
+
+class FCHostModel(sa.Model):
+    __tablename__ = 'services_fc_host'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    fc_host_alias = sa.Column(sa.String(32), unique=True)
+    fc_host_wwpn = sa.Column(sa.String(20), nullable=True, unique=True)
+    fc_host_wwpn_b = sa.Column(sa.String(20), nullable=True, unique=True)
+    fc_host_npiv = sa.Column(sa.Integer())
+
+
+class FCHostService(CRUDService):
+
+    class Config:
+        namespace = "fc.fc_host"
+        datastore = "services.fc_host"
+        datastore_prefix = 'fc_host_'
+        cli_namespace = "sharing.fc.fc_host"
+        entry = FCHostEntry
+        role_prefix = 'SHARING_ISCSI_TARGET'
+
+    @api_method(FCHostCreateArgs, FCHostCreateResult, audit='Create FC host', audit_extended=lambda data: data['alias'])
+    async def do_create(self, data: dict) -> dict:
+        """
+        Creates FC host.
+
+        `alias` is a user-readable name for FC host.
+        `wwpn` is the WWPN in naa format (Controller A if HA)
+        `wwpn_b` is the WWPN in naa format (Controller B, only applicable for HA)
+        `npiv` is the number of NPIV hosts to create for this FC host.
+        """
+        await self._validate("fc_host_create", data)
+
+        pk = await self.middleware.call(
+            'datastore.insert', self._config.datastore, data,
+            {'prefix': self._config.datastore_prefix})
+
+        return await self.get_instance(pk)
+
+    @api_method(FCHostUpdateArgs, FCHostUpdateResult, audit='Update FC host', audit_callback=True)
+    async def do_update(self, audit_callback: callable, id_: int, data: dict) -> dict:
+        """
+        Update FC host `id`.
+
+        `alias` is a user-readable name for FC host port.
+        `wwpn` is the WWPN in naa format (Controller A if HA)
+        `wwpn_b` is the WWPN in naa format (Controller B, only applicable for HA)
+        `npiv` is the number of NPIV hosts to create for this FC host.
+        """
+        old = await self.get_instance(id_)
+        audit_callback(old['alias'])
+        new = old.copy()
+        new.update(data)
+
+        await self._validate("fc_host_update", new, id_)
+
+        await self.middleware.call(
+            "datastore.update",
+            self._config.datastore,
+            id_,
+            new,
+            {'prefix': self._config.datastore_prefix}
+        )
+
+        return await self.get_instance(id_)
+
+    @api_method(FCHostDeleteArgs, FCHostDeleteResult, audit='Delete FC host', audit_callback=True)
+    async def do_delete(self, audit_callback: callable, id_: int) -> Literal[True]:
+        """
+        Delete FC host `id`.
+        """
+        alias = (await self.get_instance(id_))['alias']
+        audit_callback(alias)
+
+        response = await self.middleware.call(
+            "datastore.delete",
+            self._config.datastore,
+            id_
+        )
+
+        return response
+
+    async def _get_remote_fc_host_wwpn_choices(self):
+        try:
+            return await self.middleware.call('failover.call_remote', 'fc.fc_host_wwpn_choices')
+        except CallError as e:
+            if e.errno in NETWORK_ERRORS + (CallError.ENOMETHOD,):
+                # swallow error, but don't present any choices
+                return []
+            else:
+                raise
+
+    async def _validate(self, schema_name: str, data: dict, id_: int = None):
+        verrors = ValidationErrors()
+
+        wwpn = data.get('wwpn')
+        wwpn_b = data.get('wwpn_b')
+
+        if await self.middleware.call('failover.licensed'):
+            # If failover is licensed then we allow both wwpn and wwpn_b to be set,
+            # but restricted to the available wwpns on each node
+            for key in ['alias', 'wwpn', 'wwpn_b']:
+                if data[key] is not None:
+                    await self._ensure_unique(verrors, schema_name, key, data[key], id_)
+            if wwpn is not None or wwpn_b is not None:
+                node = await self.middleware.call('failover.node')
+                match node:
+                    case 'A':
+                        node_a_choices = await self.middleware.call('fc.fc_host_wwpn_choices')
+                        node_b_choices = await self._get_remote_fc_host_wwpn_choices()
+                    case 'B':
+                        node_a_choices = await self._get_remote_fc_host_wwpn_choices()
+                        node_b_choices = await self.middleware.call('fc.fc_host_wwpn_choices')
+                    case _:
+                        raise CallError('Cannot configure FC until HA is configured')
+                if wwpn and wwpn not in node_a_choices:
+                    verrors.add(
+                        f'{schema_name}.wwpn',
+                        f'Invalid wwpn ({wwpn}) supplied, should be one of: {",".join(node_a_choices)}'
+                    )
+                if wwpn_b and wwpn_b not in node_b_choices:
+                    verrors.add(
+                        f'{schema_name}.wwpn_b',
+                        f'Invalid wwpn ({wwpn_b}) supplied, should be one of: {",".join(node_b_choices)}'
+                    )
+        else:
+            for key in ['alias', 'wwpn']:
+                if data[key] is not None:
+                    await self._ensure_unique(verrors, schema_name, key, data[key], id_)
+            if wwpn_b is not None:
+                verrors.add(
+                    f'{schema_name}.wwpn_b',
+                    'May not specify a wwpn for a failover node if not HA'
+                )
+            if wwpn is not None:
+                choices = await self.middleware.call('fc.fc_host_wwpn_choices')
+                if wwpn not in choices:
+                    verrors.add(
+                        f'{schema_name}.wwpn',
+                        f'Invalid wwpn ({wwpn}) supplied, should be one of: {",".join(choices)}'
+                    )
+
+        verrors.check()
+
+    async def _next_alias(self):
+        """
+        Return the next unused fc_host alias e.g. "fc0"
+        """
+        existing = [host['alias'] for host in await self.middleware.call('fc.fc_host.query', [], {'select': ['alias']})]
+        count = 0
+        while count < 100:
+            name = f'fc{count}'
+            if name not in existing:
+                return name
+            count += 1
+
+    async def _get_remote_fc_hosts(self):
+        try:
+            return await self.middleware.call('failover.call_remote', 'fc.fc_hosts')
+        except CallError as e:
+            if e.errno in NETWORK_ERRORS + (CallError.ENOMETHOD,):
+                # swallow error, but don't present any choices
+                return []
+            else:
+                raise
+
+    @private
+    async def wire(self, overwrite=False):
+        """
+        Wire up fc_host pairings, using the 'slot' field from fc.fc_hosts
+        to determine which pairs go together.
+
+        Need to handle the case where the other controller is currently
+        down and is therefore unable to give its current config.
+        """
+        if not await self.middleware.call('fc.capable'):
+            return False
+        if await self.middleware.call('failover.licensed'):
+            # HA
+            if await self.middleware.call('failover.status') != 'MASTER':
+                self.logger.error('Cannot wire fc_host if not ACTIVE node')
+                return False
+            node = await self.middleware.call('failover.node')
+            slot_2_fc_host_wwpn = defaultdict(dict)
+            match node:
+                case 'A':
+                    node_a_fc_hosts = await self.middleware.call('fc.fc_hosts')
+                    node_b_fc_hosts = await self._get_remote_fc_hosts()
+                case 'B':
+                    node_a_fc_hosts = await self._get_remote_fc_hosts()
+                    node_b_fc_hosts = await self.middleware.call('fc.fc_hosts')
+                case _:
+                    raise CallError('Cannot configure FC until HA is configured')
+            # Match pairs by slow (includes PCI function)
+            for fc_host in node_a_fc_hosts:
+                slot_2_fc_host_wwpn[fc_host['slot']]['A'] = str_to_naa(fc_host.get('port_name'))
+            for fc_host in node_b_fc_hosts:
+                slot_2_fc_host_wwpn[fc_host['slot']]['B'] = str_to_naa(fc_host.get('port_name'))
+            # Iterate over each slot and make sure the corresponding fc_host entry is preent
+            sorted_slots = sorted(list(slot_2_fc_host_wwpn.keys()))
+            result = True
+            for slot in sorted_slots:
+                wwpn = slot_2_fc_host_wwpn[slot].get('A')
+                wwpn_b = slot_2_fc_host_wwpn[slot].get('B')
+                if wwpn and wwpn_b:
+                    existing = await self.middleware.call('fc.fc_host.query', [
+                        ['OR', [['wwpn', '=', wwpn], ['wwpn_b', '=', wwpn_b]]]
+                    ])
+                elif wwpn:
+                    existing = await self.middleware.call('fc.fc_host.query', [['wwpn', '=', wwpn]])
+                elif wwpn_b:
+                    existing = await self.middleware.call('fc.fc_host.query', [['wwpn', '=', wwpn_b]])
+                else:
+                    existing = []
+                if not existing:
+                    # Insert new record
+                    new_fc_host = {
+                        'alias': await self._next_alias(),
+                        'wwpn': wwpn,
+                        'wwpn_b': wwpn_b,
+                        'npiv': 0
+                    }
+                    await self.middleware.call('fc.fc_host.create', new_fc_host)
+                else:
+                    # Maybe update record
+                    if len(existing) == 1:
+                        existing = existing[0]
+                        update_fc_host = {}
+                        if existing['wwpn'] != wwpn:
+                            if existing['wwpn'] is None or overwrite:
+                                update_fc_host['wwpn'] = wwpn
+                            else:
+                                result = False
+                        if existing['wwpn_b'] != wwpn_b:
+                            if existing['wwpn_b'] is None or overwrite:
+                                update_fc_host['wwpn_b'] = wwpn_b
+                            else:
+                                result = False
+                        if update_fc_host:
+                            await self.middleware.call('fc.fc_host.update', existing['id'], update_fc_host)
+                    else:
+                        # Should not occur
+                        self.logger.error('Slot "%r" has %d entries: %r', slot, len(existing), existing)
+                        result = False
+            return result
+        else:
+            # Not HA - just wire up all fc_hosts in wwpn
+            fc_hosts = sorted(await self.middleware.call('fc.fc_hosts'), key=lambda d: d['slot'])
+            for fchost in fc_hosts:
+                if naa := str_to_naa(fchost.get('port_name')):
+                    existing = await self.middleware.call('fc.fc_host.query', [['wwpn', '=', naa]])
+                    if not existing:
+                        new_fc_host = {
+                            'alias': await self._next_alias(),
+                            'wwpn': naa,
+                            'npiv': 0
+                        }
+                        await self.middleware.call('fc.fc_host.create', new_fc_host)
+            return True

--- a/src/middlewared/middlewared/plugins/fc/utils.py
+++ b/src/middlewared/middlewared/plugins/fc/utils.py
@@ -1,0 +1,60 @@
+import re
+from subprocess import run
+
+DESIGNATION = re.compile(r'(?<=Designation: ).*')
+BUS_ADDRESS = re.compile(r'(?<=Bus Address: ).*')
+HEX_COLON = re.compile(r'^([0-9a-fA-F][0-9a-fA-F]:)+[0-9a-fA-F][0-9a-fA-F]$')
+
+
+def wwn_as_colon_hex(hexstr):
+    """
+    Given a hex string '0xaabbccdd' (or 'naa.aabbccdd') return 'aa:bb:cc:dd'.
+    """
+    if isinstance(hexstr, str):
+        if hexstr.startswith('0x'):
+            # range(2,) to skip the leading 0x
+            return ':'.join(hexstr[i:i + 2] for i in range(2, len(hexstr), 2))
+        if hexstr.startswith('naa.'):
+            # range(4,) to skip the leading naa.
+            return ':'.join(hexstr[i:i + 2] for i in range(4, len(hexstr), 2))
+
+
+def colon_hex_as_naa(hexstr):
+    """
+    Given a colon hex string 'aa:bb:cc:dd'  return 'naa.aabbccdd'.
+    """
+    return 'naa.' + ''.join(hexstr.split(':'))
+
+
+def str_to_naa(string):
+    if string is None:
+        return None
+    if string.startswith('0x'):
+        return 'naa.' + string[2:]
+    if HEX_COLON.match(string):
+        return 'naa.' + ''.join(string.split(':')).lower()
+    if string.startswith('naa.'):
+        return string
+
+
+def wwpn_to_vport(wwpn, chan):
+    if wwpn is None:
+        return None
+    # Similar to some code in isp_default_wwn (CORE os)
+    seed = wwpn
+    seed ^= 0x0100000000000000
+    seed ^= ((chan + 1) & 0xf) << 56
+    seed ^= (((chan + 1) >> 4) & 0xf) << 52
+    return seed
+
+
+def dmi_pci_slot_info():
+    result = {}
+    output = run(['dmidecode', '-t9'], capture_output=True, encoding='utf8').stdout
+    for line in output.splitlines():
+        if mat := DESIGNATION.search(line):
+            designation = mat.group(0)
+        if mat := BUS_ADDRESS.search(line):
+            bus_addr = mat.group(0)
+            result[bus_addr] = designation
+    return result

--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -1,9 +1,207 @@
+from typing import Literal
+
 import middlewared.sqlalchemy as sa
+from middlewared.api import api_method
+from middlewared.api.current import (FCPortCreateArgs, FCPortCreateResult, FCPortDeleteArgs, FCPortDeleteResult,
+                                     FCPortEntry, FCPortUpdateArgs, FCPortUpdateResult)
+from middlewared.service import CRUDService, ValidationErrors, private
+from middlewared.service_exception import MatchNotFound
+from .fc.utils import wwpn_to_vport
+
+
+VPORT_SEP_CHAR = '/'
 
 
 class FCPortModel(sa.Model):
     __tablename__ = 'services_fibrechanneltotarget'
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    fc_port = sa.Column(sa.String(10))
+    fc_port = sa.Column(sa.String(40))
     fc_target_id = sa.Column(sa.ForeignKey('services_iscsitarget.id'), nullable=True, index=True)
+
+
+class FCPortService(CRUDService):
+
+    class Config:
+        namespace = "fcport"
+        datastore = "services.fibrechanneltotarget"
+        datastore_prefix = 'fc_'
+        datastore_extend = 'fcport.extend'
+        cli_namespace = "sharing.fc_port"
+        entry = FCPortEntry
+        role_prefix = 'SHARING_ISCSI_TARGET'
+
+    @api_method(FCPortCreateArgs, FCPortCreateResult, audit='Create FC port mapping', audit_extended=lambda data: data['alias'])
+    async def do_create(self, data: dict) -> dict:
+        """
+        Creates mapping between a FC port and a target.
+
+        `name` is a user-readable name for key.
+        """
+        await self._validate("fcport_create", data)
+
+        await self.compress(data)
+
+        pk = await self.middleware.call(
+            'datastore.insert', self._config.datastore, data,
+            {'prefix': self._config.datastore_prefix})
+
+        await self.update_scst()
+
+        return await self.get_instance(pk)
+
+    @api_method(FCPortUpdateArgs, FCPortUpdateResult, audit='Update FC port mapping', audit_callback=True)
+    async def do_update(self, audit_callback: callable, id_: int, data: dict) -> dict:
+        """
+        Update FC port mapping `id`.
+        """
+        old = await self.get_instance(id_)
+        audit_callback(old['port'])
+        new = old.copy()
+        new.update(data)
+
+        await self._validate("fcport_update", new, id_)
+
+        await self.compress(new)
+
+        await self.middleware.call(
+            "datastore.update",
+            self._config.datastore,
+            id_,
+            new,
+            {'prefix': self._config.datastore_prefix}
+        )
+
+        await self.update_scst()
+
+        return await self.get_instance(id_)
+
+    @api_method(FCPortDeleteArgs, FCPortDeleteResult, audit='Delete FC port mapping', audit_callback=True)
+    async def do_delete(self, audit_callback: callable, id_: int) -> Literal[True]:
+        """
+        Delete FC port mapping `id`.
+        """
+        alias = (await self.get_instance(id_))['port']
+        audit_callback(alias)
+
+        response = await self.middleware.call(
+            "datastore.delete",
+            self._config.datastore,
+            id_
+        )
+
+        await self.update_scst()
+
+        return response
+
+    async def _validate(self, schema_name: str, data: dict, id_: int = None):
+        verrors = ValidationErrors()
+
+        # Make sure we don't reuse either port or target_id
+        for key in ['port', 'target_id']:
+            await self._ensure_unique(verrors, schema_name, key, data[key], id_)
+
+        # Make sure that the port base is a valid fc_host alias
+        fc_hosts = {host['alias']: host for host in await self.middleware.call('fc.fc_host.query')}
+        port = data.get('port')
+        if port:
+            if VPORT_SEP_CHAR in port:
+                # NPIV - Get the base FC Host
+                fc_host_alias, chan = port.rsplit(VPORT_SEP_CHAR, 1)
+            else:
+                fc_host_alias = port
+                chan = None
+            if fc_host_alias in fc_hosts:
+                # Valid base, may need to check NPIV chan
+                if chan is not None:
+                    if chan.isdigit():
+                        npiv_setting = fc_hosts[fc_host_alias]['npiv']
+                        if int(chan) > npiv_setting:
+                            verrors.add(
+                                f'{schema_name}.port',
+                                f'Invalid FC port ({port}) supplied, chan {chan} is greater than NPIV setting {npiv_setting}'
+                            )
+                        elif int(chan) == 0:
+                            verrors.add(
+                                f'{schema_name}.port',
+                                f'Invalid FC port ({port}) supplied, chan {chan} must be greater than 0 and less than NPIV setting {npiv_setting}'
+                            )
+                    else:
+                        verrors.add(
+                            f'{schema_name}.port',
+                            f'Invalid FC port ({port}) supplied, digits only after "{VPORT_SEP_CHAR}"'
+                        )
+            else:
+                verrors.add(
+                    f'{schema_name}.port',
+                    f'Invalid FC port ({port}) supplied, should be one of: {",".join(fc_hosts.keys())}'
+                )
+        else:
+            verrors.add(
+                f'{schema_name}.port',
+                f'No FC port supplied, should be based on one of: {",".join(fc_hosts.keys())}'
+            )
+
+        # Test the target supplied
+        target_id = data.get('target_id')
+        if target_id is not None:
+            try:
+                target = await self.middleware.call('iscsi.target.query', [['id', '=', target_id]], {'get': True})
+            except MatchNotFound:
+                verrors.add(
+                    f'{schema_name}.target_id',
+                    f'No target exists with the specified id {target_id}'
+                )
+            else:
+                target_mode = target['mode']
+                if target_mode not in ['FC', 'BOTH']:
+                    target_name = target['name']
+                    verrors.add(
+                        f'{schema_name}.target_id',
+                        f'Specified target "{target_name}" ({target_id}) does not have a "mode" ({target_mode}) that permits FC access'
+                    )
+
+        verrors.check()
+
+    @private
+    async def compress(self, data):
+        for key in ['wwpn', 'wwpn_b']:
+            if key in data:
+                data.pop(key)
+        return data
+
+    @private
+    async def extend(self, data):
+        data['wwpn'] = None
+        data['wwpn_b'] = None
+        # We want to retrieve the WWPN associated with the port name
+        if VPORT_SEP_CHAR in data['port']:
+            # NPIV - Get the base FC Host
+            fc_host_alias, chan = data['port'].rsplit(VPORT_SEP_CHAR, 1)
+        else:
+            fc_host_alias = data['port']
+            chan = None
+        try:
+            fc_host_pair = await self.middleware.call('fc.fc_host.query', [['alias', '=', fc_host_alias]], {'get': True})
+        except MatchNotFound:
+            pass
+        else:
+            if chan:
+                # NPIV
+                data['wwpn'] = wwpn_to_vport(fc_host_pair.get('wwpn'), int(chan))
+                data['wwpn_b'] = wwpn_to_vport(fc_host_pair.get('wwpn_b'), int(chan))
+            else:
+                # Non-NPIV
+                data['wwpn'] = fc_host_pair.get('wwpn')
+                data['wwpn_b'] = fc_host_pair.get('wwpn_b')
+        return data
+
+    @private
+    async def update_scst(self):
+        # First process the local (MASTER) config
+        await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
+
+        # Then process the BACKUP config if we are HA and ALUA is enabled.
+        if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
+            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('iscsi.alua.wait_for_alua_settled')

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -193,9 +193,8 @@ class ISCSIGlobalService(SystemServiceService):
         if not await self.middleware.call('failover.licensed'):
             return False
 
-        # TODO: FIBRECHANNEL not currently supported in SCALE
-        # license_ = await self.middleware.call('system.license')
-        # if license_ is not None and 'FIBRECHANNEL' in license_['features']:
-        #     return True
+        # If FIBRECHANNEL is licensed then allow ALUA
+        if await self.middleware.call('system.feature_enabled', 'FIBRECHANNEL'):
+            return True
 
         return (await self.middleware.call('iscsi.global.config'))['alua']


### PR DESCRIPTION
### Add support for Fibre Channel targets

#### Overview
SCST includes support for Fibre Channel targets using QLA2xxx HBAs.  This PR includes the middleware changes necessary to utilize the mechanism.

- ALUA is supported, using the same HA internal iSCSI targets as are used for iSCSI ALUA support,
- NPIV will be supported (not yet ready, hence WIP)

#### API summary
In CORE an `fcport` CRUD interface was available to perform the target to FC port mapping.  A similar CRUD API is presented here.

However, in CORE we could _reliably_ pair the ports on each node in a HA system simply by using the same moniker (e.g. `isp0`).  Since this is not quite true in SCALE we instead will have a DB table / API to wire the ports together based upon the slot information obtained from `dmidecode`.  The auto-wiring will use a default moniker of `fc0`, etc ... so that any migration from SCALE will be _forced_ to manually check that the A/B controllers port pairing are as expected.  The upshot of all of this is that another `fc.fc_host` API is implemented.

The `fc.fc_host` API will also include the NPIV setting for the FC Host port, which in CORE was a `System Tunable`.