### PR TITLE
NAS-129366 / 24.10.1 / Try to fix SED unlock issues on HA SCALE (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -542,7 +542,9 @@ class FailoverEventsService(Service):
         if maybe_unlocked:
             logger.info('Done unlocking all SED disks (if any)')
             try:
+                logger.info('Retasting disks on standby node')
                 self.run_call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
+                logger.info('Done retasting disks on standby node')
             except Exception:
                 logger.exception('Unexpected failure retasting disks on standby node')
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -959,6 +959,11 @@ class FailoverEventsService(Service):
         self.run_call('service.start', 'keepalived', self.HA_PROPAGATE)
         logger.info('Unpausing failover event processing')
         self.run_call('vrrpthread.unpause_events')
+
+        logger.info('Retasting disks (if required)')
+        self.run_call('disk.retaste')
+        logger.info ('Done retasting disks (if required)')
+
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -530,15 +530,21 @@ class FailoverEventsService(Service):
 
         # unlock SED disks
         logger.info('Unlocking all SED disks (if any)')
+        maybe_unlocked = False
         try:
-            self.run_call('disk.sed_unlock_all', True)
+            maybe_unlocked = self.run_call('disk.sed_unlock_all', True)
         except Exception as e:
             # failing here doesn't mean the zpool won't import
             # we could have failed on only 1 disk so log an
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
-        else:
+
+        if maybe_unlocked:
             logger.info('Done unlocking all SED disks (if any)')
+            try:
+                self.run_call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
+            except Exception:
+                logger.exception('Unexpected failure retasting disks on standby node')
 
         # setup the zpool cachefile  TODO: see comment below about cachefile usage
         # self.run_call('failover.zpool.cachefile.setup', 'MASTER')


### PR DESCRIPTION
A couple issues have been found internally surrounding SED drives and how we unlock them. This is SCALE specific and so after consultation with the OS team, we're trying to implement changes which fix these problems.

1. On MASTER failover event, notify the standby controller to retaste the disks after we unlock any SED drives
2. On BACKUP failover event, retaste the disks to ensure we're "up to date" with partition information
3. Change the `disk.retaste` job to only queue up 1 job (including the currently running job)
4. stop using `libudev` in the `disk.retaste` endpoint since the udev database can be in flux by the time we query it. Instead we'll use device node names in `/dev`.

Original PR: https://github.com/truenas/middleware/pull/14690
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129366