### PR TITLE
NAS-131570 / 25.04 / Fix pool deletion with active NFS shares.

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -5,7 +5,6 @@ import itertools
 import os
 import shutil
 
-from middlewared.common.attachment import LockableFSAttachmentDelegate
 from middlewared.common.listen import SystemServiceListenMultipleDelegate
 from middlewared.schema import accepts, Bool, Dict, Dir, Int, IPAddr, List, Patch, returns, Str
 from middlewared.async_validators import check_path_resides_within_volume, validate_port
@@ -18,6 +17,9 @@ from middlewared.plugins.nfs_.utils import get_domain, leftmost_has_wildcards, g
 from middlewared.plugins.system_dataset.utils import SYSDATASET_PATH
 
 NFS_RDMA_DEFAULT_PORT = 20049
+
+# Support the nfsv4recoverydir procfs entry.  This may deprecate.
+NFSV4_RECOVERY_DIR_PROCFS_PATH = '/proc/fs/nfsd/nfsv4recoverydir'
 
 
 class NFSServicePathInfo(enum.Enum):
@@ -128,6 +130,28 @@ class NFSService(SystemServiceService):
             return name
 
     @private
+    def update_procfs_v4recoverydir(self):
+        '''
+        The proc file /proc/fs/nfsd/nfsv4recoverydir is part of the legacy NFS client management.
+        It's usefulness is debatable and by default it reports a path that TrueNAS does not use.
+        While this entry exists TrueNAS will attempt to make it consistent with actual.
+        NOTE: NFS will function correctly even if this is reporting an inconsistent value.
+        '''
+        procfs_path = NFSV4_RECOVERY_DIR_PROCFS_PATH
+        try:
+            with open(procfs_path, 'r+') as fp:
+                fp.write(f'{NFSServicePathInfo.V4RECOVERYDIR.path()}\n')
+        except FileNotFoundError:
+            # This usually happens after a reboot
+            self.logger.info("%r: Missing or has been removed", procfs_path)
+        except Exception as e:
+            # errno=EBUSY usually happens on a system dataset move
+            if e.errno != errno.EBUSY:
+                self.logger.info("Unable to update %r: %r", procfs_path, str(e))
+        else:
+            self.logger.debug("%r: updated with %r", procfs_path, NFSServicePathInfo.V4RECOVERYDIR.path())
+
+    @private
     def setup_directories(self):
         '''
         We are moving the NFS state directory from /var/lib/nfs to
@@ -163,16 +187,6 @@ class NFSService(SystemServiceService):
                 os.chown(path, uid, gid)
             except Exception:
                 self.logger.error('Unexpected failure initializing %r', path, exc_info=True)
-
-        procfs_path = '/proc/fs/nfsd/nfsv4recoverydir'
-        try:
-            with open(procfs_path, 'r+') as fp:
-                fp.write(f'{NFSServicePathInfo.V4RECOVERYDIR.path()}\n')
-        except FileNotFoundError:
-            # When this is removed from the kernel we will have a gentle reminder
-            self.logger.info("%r: Proc file has been removed", procfs_path)
-        except Exception:
-            self.logger.error("Unexpected failure updating %r", procfs_path, exc_info=True)
 
     @private
     async def nfs_extend(self, nfs):
@@ -950,22 +964,10 @@ async def pool_post_import(middleware, pool):
             break
 
 
-class NFSFSAttachmentDelegate(LockableFSAttachmentDelegate):
-    name = 'nfs'
-    title = 'NFS Share'
-    service = 'nfs'
-    service_class = SharingNFSService
-    resource_name = 'path'
-
-    async def restart_reload_services(self, attachments):
-        await self._service_change('nfs', 'reload')
-
-
 async def setup(middleware):
     await middleware.call(
         'interface.register_listen_delegate',
         SystemServiceListenMultipleDelegate(middleware, 'nfs', 'bindip'),
     )
-    await middleware.call('pool.dataset.register_attachment_delegate', NFSFSAttachmentDelegate(middleware))
 
     middleware.register_hook('pool.post_import', pool_post_import, sync=True)

--- a/src/middlewared/middlewared/plugins/nfs_/fs_attachment_delegate.py
+++ b/src/middlewared/middlewared/plugins/nfs_/fs_attachment_delegate.py
@@ -1,0 +1,18 @@
+from middlewared.common.attachment import LockableFSAttachmentDelegate
+
+from middlewared.plugins.nfs import SharingNFSService
+
+
+class NFSFSAttachmentDelegate(LockableFSAttachmentDelegate):
+    name = 'nfs'
+    title = 'NFS Share'
+    service = 'nfs'
+    service_class = SharingNFSService
+    resource_name = 'path'
+
+    async def restart_reload_services(self, attachments):
+        await self._service_change('nfs', 'reload')
+
+
+async def setup(middleware):
+    await middleware.call('pool.dataset.register_attachment_delegate', NFSFSAttachmentDelegate(middleware))

--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -29,7 +29,15 @@ class NFSService(SimpleService):
         else:
             await self.middleware.call('alert.oneshot_delete', 'NFSblockedByExportsDir')
 
+    async def before_start(self):
+        # If available, make sure the procfs nfsv4recoverydir entry has the correct info.
+        # Usually the update should be done _before_ nfsd is running.
+        # Sometimes, after a reboot, the proc entry may not exist and that's ok.
+        await self.middleware.call('nfs.update_procfs_v4recoverydir')
+
     async def after_start(self):
+        # This is to cover the case where the proc entry did not exist
+        await self.middleware.call('nfs.update_procfs_v4recoverydir')
         await self._systemd_unit("rpc-statd", "start")
 
     async def stop(self):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -716,6 +716,8 @@ class SystemDatasetService(ConfigService):
             # a file descriptor underneath /var/log will no longer need to be
             # stopped/restarted to allow the system dataset to migrate
             restart = ['netdata']
+            if self.middleware.call_sync('service.started', 'nfs'):
+                restart.append('nfs')
             if self.middleware.call_sync('service.started', 'cifs'):
                 restart.insert(0, 'cifs')
             if self.middleware.call_sync('service.started', 'open-vm-tools'):

--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -56,6 +56,8 @@ def another_pool(data=None, topology=None):
         except ValidationErrors as e:
             if not any(error.errcode == errno.ENOENT for error in e.errors):
                 raise
+        except InstanceNotFound:
+            pass
 
 
 @contextlib.contextmanager

--- a/src/middlewared/middlewared/test/integration/utils/failover.py
+++ b/src/middlewared/middlewared/test/integration/utils/failover.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import sys
+from time import sleep
 
 try:
     apifolder = os.getcwd()
@@ -25,3 +26,46 @@ def disable_failover():
     finally:
         if ha:
             call("failover.update", {"disabled": False, "master": True})
+
+
+def wait_for_standby():
+    '''
+    NOTE:
+       1) This routine is for dual-controller (ha) only
+       2) This is nearly identical to 'wait_for_standby' in test_006_pool_and_sysds
+
+    This routine will wait for the standby controller to return from a reboot.
+    '''
+    if ha:
+        sleep(5)
+
+        sleep_time = 1
+        max_wait_time = 300
+        rebooted = False
+        waited_time = 0
+
+        while waited_time < max_wait_time and not rebooted:
+            if call('failover.remote_connected'):
+                rebooted = True
+            else:
+                waited_time += sleep_time
+                sleep(sleep_time)
+
+        assert rebooted, f'Standby did not connect after {max_wait_time} seconds'
+
+        waited_time = 0  # need to reset this
+        is_backup = False
+        while waited_time < max_wait_time and not is_backup:
+            try:
+                is_backup = call('failover.call_remote', 'failover.status') == 'BACKUP'
+            except Exception:
+                pass
+
+            if not is_backup:
+                waited_time += sleep_time
+                sleep(sleep_time)
+
+        assert is_backup, f'Standby node did not become BACKUP after {max_wait_time} seconds'
+        pass
+    else:
+        pass

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -13,12 +13,14 @@ from middlewared.service_exception import (
 from middlewared.test.integration.assets.account import group as create_group
 from middlewared.test.integration.assets.account import user as create_user
 from middlewared.test.integration.assets.filesystem import directory
+from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call, mock, ssh
 from middlewared.test.integration.utils.string import random_string
 from middlewared.test.integration.utils.client import truenas_server
+from middlewared.test.integration.utils.failover import wait_for_standby
 from middlewared.test.integration.utils.system import reset_systemd_svcs as reset_svcs
 
-from auto_config import hostname, password, pool_name, user
+from auto_config import hostname, password, pool_name, user, ha
 from protocols import SSH_NFS, nfs_share
 
 MOUNTPOINT = f"/tmp/nfs-{hostname}"
@@ -318,31 +320,68 @@ def run_missing_usrgrp_mapping_test(data: list[str], usrgrp, tmp_path, share, us
 
 
 @contextlib.contextmanager
-def nfs_dataset(name, options=None, acl=None, mode=None):
+def manage_start_nfs():
+    """ The exit state is managed by init_nfs """
+    try:
+        yield set_nfs_service_state('start')
+    finally:
+        set_nfs_service_state('stop')
+
+
+def move_systemdataset(new_pool_name):
+    ''' Move the system dataset to the requested pool '''
+    try:
+        call('systemdataset.update', {'pool': new_pool_name}, job=True)
+    except Exception as e:
+        raise e
+    else:
+        if ha:
+            wait_for_standby()
+
+    return call('systemdataset.config')
+
+
+@contextlib.contextmanager
+def system_dataset(new_pool_name):
+    '''
+    Temporarily move the system dataset to the new_pool_name
+    '''
+    orig_sysds = call('systemdataset.config')
+    try:
+        sysds = move_systemdataset(new_pool_name)
+        yield sysds
+    finally:
+        move_systemdataset(orig_sysds['pool'])
+
+
+@contextlib.contextmanager
+def nfs_dataset(name, options=None, acl=None, mode=None, pool=None):
     """
     NOTE: This is _nearly_ the same as the 'dataset' test asset. The difference
           is the retry loop.
     TODO: Enhance the 'dataset' test asset to include a retry loop
     """
     assert "/" not in name
-    dataset = f"{pool_name}/{name}"
+    _pool_name = pool if pool else pool_name
+
+    _dataset = f"{_pool_name}/{name}"
 
     try:
-        call("pool.dataset.create", {"name": dataset, **(options or {})})
+        call("pool.dataset.create", {"name": _dataset, **(options or {})})
 
         if acl is None:
-            call("filesystem.setperm", {'path': f"/mnt/{dataset}", "mode": mode or "777"}, job=True)
+            call("filesystem.setperm", {'path': f"/mnt/{_dataset}", "mode": mode or "777"}, job=True)
         else:
-            call("filesystem.setacl", {'path': f"/mnt/{dataset}", "dacl": acl}, job=True)
+            call("filesystem.setacl", {'path': f"/mnt/{_dataset}", "dacl": acl}, job=True)
 
-        yield dataset
+        yield _dataset
 
     finally:
         # dataset may be busy
         sleep(2)
         for _ in range(6):
             try:
-                call("pool.dataset.delete", dataset)
+                call("pool.dataset.delete", _dataset)
                 # Success
                 break
             except InstanceNotFound:
@@ -476,7 +515,9 @@ class TestNFSops:
         assert start_nfs is True
 
         # Make sure the conf file has the expected settings
-        nfs_state_dir = '/var/db/system/nfs'
+        sysds_path = call('systemdataset.sysdataset_path')
+        assert sysds_path == '/var/db/system'
+        nfs_state_dir = os.path.join(sysds_path, 'nfs')
         s = parse_server_config()
         assert s['exportd']['state-directory-path'] == nfs_state_dir, str(s)
         assert s['nfsdcld']['storagedir'] == os.path.join(nfs_state_dir, 'nfsdcld'), str(s)
@@ -484,9 +525,23 @@ class TestNFSops:
         assert s['nfsdcld']['storagedir'] == os.path.join(nfs_state_dir, 'nfsdcld'), str(s)
         assert s['mountd']['state-directory-path'] == nfs_state_dir, str(s)
         assert s['statd']['state-directory-path'] == nfs_state_dir, str(s)
+
         # Confirm we have the mount point in the system dataset
+        sysds = call('systemdataset.config')
+        bootds = call('systemdataset.get_system_dataset_spec', sysds['pool'], sysds['uuid'])
+        bootds_nfs = list([d for d in bootds if 'nfs' in d.get('name')])[0]
+        assert bootds_nfs['name'] == sysds['pool'] + "/.system/nfs"
+
+        # Confirm the required entries are present
+        required_nfs_entries = set(["nfsdcld", "nfsdcltrack", "sm", "sm.bak", "state", "v4recovery"])
+        current_nfs_entries = set(list(ssh(f'ls {nfs_state_dir}').splitlines()))
+        assert required_nfs_entries.issubset(current_nfs_entries)
+
+        # Confirm proc entry reports expected value
+        recovery_dir = ssh('cat /proc/fs/nfsd/nfsv4recoverydir')
+        assert recovery_dir == os.path.join(nfs_state_dir, 'v4recovery'), \
+            f"Expected {nfs_state_dir + '/v4recovery'} but found {recovery_dir}"
         # ----------------------------------------------------------------------
-        # NOTE: Update test_001_ssh.py: test_002_first_boot_checks.
         # NOTE: Test fresh-install and upgrade.
         # ----------------------------------------------------------------------
 
@@ -1676,6 +1731,22 @@ class TestNFSops:
 
             s = parse_server_config()
             assert s['mountd']['manage-gids'] == expected, str(s)
+
+
+def test_pool_delete_with_attached_share():
+    '''
+    Confirm we can delete a pool with the system dataset and a dataset with active NFS shares
+    '''
+    with another_pool() as new_pool:
+        # Move the system dataset to this pool
+        with system_dataset(new_pool['name']):
+            # Add some additional NFS stuff to make it interesting
+            with nfs_dataset("deleteme", pool=new_pool['name']) as ds:
+                with nfs_share(f"/mnt/{ds}"):
+                    with manage_start_nfs():
+                        # Delete the pool and confirm it's gone
+                        call("pool.export", new_pool["id"], {"destroy": True}, job=True)
+                        assert call("pool.query", [["name", "=", f"{new_pool['name']}"]]) == []
 
 
 def test_threadpool_mode():

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -537,8 +537,10 @@ class TestNFSops:
         current_nfs_entries = set(list(ssh(f'ls {nfs_state_dir}').splitlines()))
         assert required_nfs_entries.issubset(current_nfs_entries)
 
-        # Confirm proc entry reports expected value
-        recovery_dir = ssh('cat /proc/fs/nfsd/nfsv4recoverydir')
+        # Confirm proc entry reports expected value after nfs restart
+        call('service.restart', 'nfs')
+        sleep(1)
+        recovery_dir = ssh('cat /proc/fs/nfsd/nfsv4recoverydir').strip()
         assert recovery_dir == os.path.join(nfs_state_dir, 'v4recovery'), \
             f"Expected {nfs_state_dir + '/v4recovery'} but found {recovery_dir}"
         # ----------------------------------------------------------------------

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -2,12 +2,11 @@ import contextlib
 
 from functions import DELETE, POST
 
-from .ftp_proto import ftp_connect, ftps_connect, ftp_connection, ftps_connection
-from .iscsi_proto import (initiator_name_supported, iscsi_scsi_connect,
-                          iscsi_scsi_connection)
+from .ftp_proto import ftp_connect, ftps_connect, ftp_connection, ftps_connection  # noqa
+from .iscsi_proto import initiator_name_supported, iscsi_scsi_connect, iscsi_scsi_connection  # noqa
 from .iSNSP.client import iSNSPClient
-from .ms_rpc import MS_RPC
-from .nfs_proto import SSH_NFS
+from .ms_rpc import MS_RPC  # noqa
+from .nfs_proto import SSH_NFS  # noqa
 from .smb_proto import SMB
 
 


### PR DESCRIPTION
Deleting a pool that holds the system dataset while NFS is active can cause a failure to delete the pool.

The fix for this is to temporarily stop NFS during the system dataset move operation.

This PR also includes:
- CI test for the pool delete condition (main topic)
- Better management of `/proc/fs/nfsd/nfsv4recoverydir` and a CI test
- Adding `wait_for_standby` routine in failover test utils
- Added `# noqa` to a few lines to avoid flake8 complaints


Passing HA CI NFS tests can be found [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1452/).
Passing standalone CI NFS tests can be found [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1453/)