### PR TITLE
NAS-131763 / 24.10.0 / Improve app status reporting (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -1,4 +1,5 @@
 import os
+from collections import defaultdict
 from dataclasses import dataclass
 from pkg_resources import parse_version
 
@@ -199,6 +200,10 @@ def translate_resources_to_desired_workflow(app_resources: dict) -> dict:
                     state = ContainerState.STARTING.value
             else:
                 state = ContainerState.RUNNING.value
+        elif container['State']['Status'].lower() == 'created':
+            state = ContainerState.CREATED.value
+        elif container['State']['Status'] == 'exited' and container['State']['ExitCode'] != 0:
+            state = ContainerState.CRASHED.value
         else:
             state = 'exited'
 

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -94,11 +94,11 @@ def list_apps(
 
         if workload_stats[ContainerState.CRASHED.value]:
             state = AppState.CRASHED
-        elif workload_stats[ContainerState.CREATED.value]:
+        elif workload_stats[ContainerState.CREATED.value] or workload_stats[ContainerState.STARTING.value]:
             state = AppState.DEPLOYING
-        elif 0 < workloads_len == (
-            workload_stats[ContainerState.RUNNING.value] + workload_stats[ContainerState.EXITED.value]
-        ):
+        elif 0 < workloads_len == sum(
+            workload_stats[k.value] for k in (ContainerState.RUNNING, ContainerState.EXITED)
+        ) and workload_stats[ContainerState.RUNNING.value]:
             state = AppState.RUNNING
 
         state = state.value

--- a/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/utils.py
@@ -15,6 +15,8 @@ class AppState(enum.Enum):
 
 
 class ContainerState(enum.Enum):
+    CRASHED = 'crashed'
+    CREATED = 'created'
     EXITED = 'exited'
     RUNNING = 'running'
     STARTING = 'starting'


### PR DESCRIPTION
This PR aims to improve how we report in what state the app is in right now. Before we get to what we are doing in this PR, some context here - so when we have a compose file which has multiple dependencies, the services dependent on the service running right now won't start unless the service they depend on finishes gracefully - in this case docker does create containers for these services which are waiting to start but does not actually start them.

What was happening with our earlier logic was that when we started an app - we reported it as deploying -> crashed -> deploying -> running (for some apps), this happened because there were some dependencies involved and when 1 dependency finished executing, there wasn't another container running atm and we marked it as crashed which is obviously not true.

So what we have done now is, that we account for 2 more container states i.e crashed/created. Crashed is that a container exited but with a non-zero exit code and created is that it is up and waiting for the service it is dependent on to finish it's execution so this one can start. Using these 2 new states, we see if we have any crashed container - we mark that app as failed and then if we have any container in created status or in starting status (healthcheck not green which we say is starting) we mark it as deploying and finally if exited containers (containers which exited with 0 exit code) plus running containers is the total number of containers we have, then we mark it as running.

Original PR: https://github.com/truenas/middleware/pull/14668
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131763