### PR TITLE
NAS-131799 / 24.10.0 / Make sure apps are migrated in HA (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -959,6 +959,10 @@ class FailoverEventsService(Service):
         return self.FAILOVER_RESULT
 
     def start_apps(self):
+        self.start_apps_impl()
+        self.middleware.create_task(self.middleware.call('k8s_to_docker.trigger_migration'))
+
+    def start_apps_impl(self):
         pool = self.run_call('docker.config')['pool']
         if not pool:
             self.middleware.call_sync('docker.state.set_status', Status.UNCONFIGURED.value)


### PR DESCRIPTION
## Problem

App migrations are not being executed on HA-capable machines, which prevents chart releases from Dragonfish (DF) or older versions from being migrated to new apps in Electric Eel (EE).

## Solution

Enable app migrations to run on the active node during failover, allowing for successful app migration on HA systems.

Original PR: https://github.com/truenas/middleware/pull/14698
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131799