### PR TITLE
NAS-131826 / 25.04 / Enforce old password for non-FULL_ADMIN users

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -3,6 +3,7 @@ import errno
 import glob
 import json
 import os
+import pam
 import shlex
 import shutil
 import stat
@@ -1478,20 +1479,21 @@ class UserService(CRUDService):
                     f'{username}: user is not local to the TrueNAS server.'
                 )
 
-        if data['old_password'] is None and not is_full_admin:
-            verrors.add(
-                'user.set_password.old_password',
-                'FULL_ADMIN role is required in order to bypass check for current password.'
-            )
-
-        if data['old_password'] is not None and not await self.middleware.call(
-            'auth.libpam_authenticate',
-            username, data['old_password']
-        ):
-            verrors.add(
-                'user.set_password.old_password',
-                f'{username}: failed to validate password.'
-            )
+        if not is_full_admin:
+            if data['old_password'] is None:
+                verrors.add(
+                    'user.set_password.old_password',
+                    'FULL_ADMIN role is required in order to bypass check for current password.'
+                )
+            else:
+                pam_resp = await self.middleware.call(
+                    'auth.libpam_authenticate', username, data['old_password']
+                )
+                if pam_resp['code'] != pam.PAM_SUCCESS:
+                    verrors.add(
+                        'user.set_password.old_password',
+                        f'{username}: failed to validate password.'
+                    )
 
         verrors.check()
 

--- a/tests/api2/test_password_reset.py
+++ b/tests/api2/test_password_reset.py
@@ -96,6 +96,15 @@ def test_restricted_user_set_password():
                         'new_password': 'CANARY',
                     })
 
+                with pytest.raises(ValidationErrors) as ve:
+                    # Providing invalid old password for a limited user
+                    # should raise an error
+                    c2.call('user.set_password', {
+                        'username': TEST_USERNAME_2,
+                        'old_password': 'ANOTHER CANARY',
+                        'new_password': 'CANARY',
+                    })
+
             call("user.update", u['id'], {'password_disabled': True})
             with pytest.raises(ValidationErrors) as ve:
                 # This should fail because we've disabled password auth


### PR DESCRIPTION
When a non-full_admin user is authenticated to our API, that user must provide (and it be validated correctly) the current password if they so choose to change their password. This is also required by STIG SRG-OS-000373-GPOS-00158. A test has been added to validate this functionality.

Passing tests are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1376/testReport/api2/test_password_reset/)