### PR TITLE
NAS-131826 / 24.10.1 / Enforce old password for non-FULL_ADMIN users (by yocalebo)

### DIFF
--- a/tests/api2/test_password_reset.py
+++ b/tests/api2/test_password_reset.py
@@ -96,6 +96,15 @@ def test_restricted_user_set_password():
                         'new_password': 'CANARY',
                     })
 
+                with pytest.raises(ValidationErrors) as ve:
+                    # Providing invalid old password for a limited user
+                    # should raise an error
+                    c2.call('user.set_password', {
+                        'username': TEST_USERNAME_2,
+                        'old_password': 'ANOTHER CANARY',
+                        'new_password': 'CANARY',
+                    })
+
             call("user.update", u['id'], {'password_disabled': True})
             with pytest.raises(ValidationErrors) as ve:
                 # This should fail because we've disabled password auth


### PR DESCRIPTION
When a non-full_admin user is authenticated to our API, that user must provide (and it be validated correctly) the current password if they so choose to change their password. This is also required by STIG SRG-OS-000373-GPOS-00158. A test has been added to validate this functionality.

Passing tests are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1376/testReport/api2/test_password_reset/)

Original PR: https://github.com/truenas/middleware/pull/14701
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131826