### PR TITLE
NAS-131807 / 24.10.1 / fix r40 picture loading in UI (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -656,7 +656,6 @@ class Enclosure:
         Returns: bool
         """
         return any((
-            self.is_r40,
             self.is_r50_series,
             self.is_60_bay_jbod,
             self.is_102_bay_jbod
@@ -670,7 +669,7 @@ class Enclosure:
         Returns: int
         """
         if self.top_loaded:
-            if self.is_r40 or self.is_r50_series:
+            if self.is_r50_series:
                 return 48
             elif self.is_60_bay_jbod:
                 return 60
@@ -691,6 +690,7 @@ class Enclosure:
         return any((
             self.is_xseries,
             self.is_r30,
+            self.is_r40,
             self.is_12_bay_jbod,
             self.is_r20_series,
             self.is_hseries,


### PR DESCRIPTION
The picture in the UI isn't loading properly because the UI has more strict checks on their side for determining what model picture they use. The r40 is front loaded and not top loaded.

Original PR: https://github.com/truenas/middleware/pull/14705
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131807