### PR TITLE
NAS-131817 / 24.10.1 / fix slots 5,6,7,8 on hseries (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure2.py
@@ -117,7 +117,7 @@ class Enclosure2Service(Service):
             else:
                 try:
                     toggle_enclosure_slot_identifier(
-                        f'/sys/class/enclosure/{enc_info["pci"]}', origslot, data['status']
+                        f'/sys/class/enclosure/{enc_info["pci"]}', origslot, data['status'], False, enc_info['model']
                     )
                 except FileNotFoundError:
                     raise CallError(f'Slot: {data["slot"]!r} not found', errno.ENOENT)


### PR DESCRIPTION
Drive slots 5, 6, 7, 8 weren't being lit up because there is a kernel bug where sysfs is populating `slot` files with duplicate integers for more than 1 disk slot (i.e. `enclosure/**/dir1/slot == 4` and `enclosure/**/dir2/slot == 4`). This breaks the design of our enclosure drive mapping logic and so I've had to put in a quirk for this particular platform when drives are being lit up using our API. I've confirmed with QE team that with these fixes in, all drive light up exactly as intended.

Original PR: https://github.com/truenas/middleware/pull/14704
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131817