### PR TITLE
NAS-131857 / 25.04 / Create new bucket on cloud_backup.init if it doesn't exist yet

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -54,11 +54,11 @@ class CloudTaskServiceMixin:
         if provider.buckets:
             schema.append(Str("bucket", required=True, empty=False))
 
-        schema.extend([
-            Str("folder", required=True),
-            *provider.task_schema,
-            *self._common_task_schema(provider),
-        ])
+        schema.append(Str("folder", required=True))
+
+        schema.extend(provider.task_schema)
+
+        schema.extend(self._common_task_schema(provider))
 
         attributes_verrors = validate_schema(schema, data["attributes"])
 

--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -52,10 +52,7 @@ class CloudTaskServiceMixin:
         schema = []
 
         if provider.buckets:
-            schema.extend([
-                Str("bucket", required=True, empty=False),
-                Bool("create_bucket", default=False),
-            ])
+            schema.append(Str("bucket", required=True, empty=False))
 
         schema.extend([
             Str("folder", required=True),

--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -52,13 +52,16 @@ class CloudTaskServiceMixin:
         schema = []
 
         if provider.buckets:
-            schema.append(Str("bucket", required=True, empty=False))
+            schema.extend([
+                Str("bucket", required=True, empty=False),
+                Bool("create_bucket", default=False),
+            ])
 
-        schema.append(Str("folder", required=True))
-
-        schema.extend(provider.task_schema)
-
-        schema.extend(self._common_task_schema(provider))
+        schema.extend([
+            Str("folder", required=True),
+            *provider.task_schema,
+            *self._common_task_schema(provider),
+        ])
 
         attributes_verrors = validate_schema(schema, data["attributes"])
 

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -65,7 +65,6 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
         Cron.convert_schedule_to_db_format(cloud_backup)
 
         cloud_backup.pop("job", None)
-        cloud_backup["attributes"].pop("create_bucket", None)
         cloud_backup.pop(self.locked_field, None)
 
         return cloud_backup

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -22,8 +22,10 @@ class CloudBackupService(Service):
         if isinstance(cred, int):
 
             attrs = cloud_backup["attributes"]
-            if attrs.get("create_bucket", False):
-                self.middleware.call("cloudsync.create_bucket", cred, attrs["bucket"])
+            if "bucket" in attrs:
+                existing_buckets = [b["Name"] for b in self.middleware.call("cloudsync.list_buckets", cred)]
+                if attrs["bucket"] not in existing_buckets:
+                    self.middleware.call("cloudsync.create_bucket", cred, attrs["bucket"])
 
             cloud_backup = {
                 **cloud_backup,

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -23,9 +23,9 @@ class CloudBackupService(Service):
 
             attrs = cloud_backup["attributes"]
             if "bucket" in attrs:
-                existing_buckets = [b["Name"] for b in self.middleware.call("cloudsync.list_buckets", cred)]
+                existing_buckets = [b["Name"] for b in self.middleware.call_sync("cloudsync.list_buckets", cred)]
                 if attrs["bucket"] not in existing_buckets:
-                    self.middleware.call("cloudsync.create_bucket", cred, attrs["bucket"])
+                    self.middleware.call_sync("cloudsync.create_bucket", cred, attrs["bucket"])
 
             cloud_backup = {
                 **cloud_backup,

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -18,11 +18,16 @@ class CloudBackupService(Service):
     def ensure_initialized(self, cloud_backup):
         self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
 
-        if isinstance(cloud_backup["credentials"], int):
+        cred = cloud_backup["credentials"]
+        if isinstance(cred, int):
+
+            attrs = cloud_backup["attributes"]
+            if attrs.get("create_bucket", False):
+                self.middleware.call("cloudsync.create_bucket", cred, attrs["bucket"])
+
             cloud_backup = {
                 **cloud_backup,
-                "credentials": self.middleware.call_sync("cloudsync.credentials.get_instance",
-                                                         cloud_backup["credentials"]),
+                "credentials": self.middleware.call_sync("cloudsync.credentials.get_instance", cred),
             }
 
         if self.is_initialized(cloud_backup):

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -10,8 +10,8 @@ from middlewared.utils import Popen
 
 @dataclass
 class ResticConfig:
-    cmd: [str]
-    env: {str: str}
+    cmd: list[str]
+    env: dict[str, str]
 
 
 def get_restic_config(cloud_backup):
@@ -63,15 +63,12 @@ async def run_restic(job, cmd, env, stdin=None):
 
 
 async def restic_check_progress(job, proc):
-    try:
-        while True:
-            read = (await proc.stdout.readline()).decode("utf-8", "ignore")
-            if read == "":
-                break
+    while True:
+        read = (await proc.stdout.readline()).decode("utf-8", "ignore")
+        if read == "":
+            break
 
-            await job.logs_fd_write(read.encode("utf-8", "ignore"))
+        await job.logs_fd_write(read.encode("utf-8", "ignore"))
 
-            job.internal_data.setdefault("messages", [])
-            job.internal_data["messages"] = job.internal_data["messages"][-4:] + [read]
-    finally:
-        pass
+        job.internal_data.setdefault("messages", [])
+        job.internal_data["messages"] = job.internal_data["messages"][-4:] + [read]


### PR DESCRIPTION
Our current implementation of `cloud_backup.create` has the soft requirement that the bucket should already exist. It is a soft requirement because it will create the bucket improperly and not raise an error if the bucket does not already exist. This forces the UI to call `cloudsync.create_bucket` before calling `cloud_backup.create`, but the bucket should never be created if the latter call fails.

With this change in `cloud_backup.init`, bucket creation will be handled properly if needed so that the UI no longer needs to call `cloudsync.create_bucket`.