### PR TITLE
NAS-131825 / 25.04 / Use `datetime` type in the Alert model instead of `str`

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/alert.py
+++ b/src/middlewared/middlewared/api/v25_04_0/alert.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from pydantic import Field
@@ -20,8 +21,8 @@ class Alert(BaseModel):
     args: Any
     node: str
     key: LongString
-    datetime: str
-    last_occurrence: str
+    datetime_: datetime = Field(..., alias='datetime')
+    last_occurrence: datetime
     dismissed: bool
     mail: Any
     text: LongString


### PR DESCRIPTION
In https://github.com/truenas/middleware/pull/14615 I incorrectly typed `Alert.datetime` and `Alert.last_occurrence` as `str` instead of `datetime`. As it turns out, pydantic handles `datetime` similarly to how our old `Datetime` schema works https://docs.pydantic.dev/2.0/usage/types/datetime/#:~:text=datetime%20fields%20will,as%20Unix%20time.