### PR TITLE
NAS-131875 / 24.10.0 / fix R40 webUI behavior (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -723,6 +723,8 @@ class Enclosure:
                 return 16
             elif any((self.is_fseries, self.is_mseries, self.is_24_bay_jbod)):
                 return 24
+            elif self.is_rseries:
+                return 48
             else:
                 return 0
         return 0


### PR DESCRIPTION
I learned this is the only front loaded, 48 bay system we sell. Update the property so the UI allows the enclosure page to be responsive. Otherwise, it's broken subtly.

Original PR: https://github.com/truenas/middleware/pull/14715
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131875