### PR TITLE
NAS-131874 / 24.10.1 / fix xseries drive mapping (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -658,22 +658,7 @@ def get_slot_info(enc):
                 }
             }
         }
-    elif enc.is_xseries:
-        return {
-            'any_version': True,
-            'versions': {
-                'DEFAULT': {
-                    'model': {
-                        enc.model: {
-                            i: {SYSFS_SLOT_KEY: i, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
-                            for i in range(0, 12)
-                        },
-                    }
-                }
-            }
-        }
-    # JBODs
-    elif enc.model == JbodModels.ES12.value:
+    elif enc.model == JbodModels.ES12.value or enc.is_xseries:
         return {
             'any_version': True,
             'versions': {


### PR DESCRIPTION
The x-series platform is the same chassis as the ES12. During another round of testing, found the drive slots were off ever so slightly. This fixes the problem.

Original PR: https://github.com/truenas/middleware/pull/14714
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131874