### PR TITLE
NAS-131883 / 24.10.1 / Add python3-cryptography to list of dev packages (by sonicaj)

### DIFF
--- a/src/freenas/usr/bin/install-dev-tools
+++ b/src/freenas/usr/bin/install-dev-tools
@@ -15,6 +15,7 @@ PACKAGES=(
     # open-iscsi is used to test authorized networks for iscsi
     open-iscsi
     # Integration and unit test utils, python package management
+    python3-cryptography
     python3-pip
     python3-pyfakefs
     python3-pyotp


### PR DESCRIPTION
This commit adds python3-cryptography to list of deps which should be installed when dev-tools are being installed. TrueNAS already has this (and it pulls it from debian), however our test runners when they execute - they don't have this and it is required to run the integration tests.

Original PR: https://github.com/truenas/middleware/pull/14727
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131883