### PR TITLE
NAS-131893 / 25.04 / lazy-initialize pam context

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -202,7 +202,7 @@ class AuthenticationContext:
     to handle any required PAM conversations.
     """
     pam_lock: threading.Lock = threading.Lock()
-    pam_hdl: pam.PamAuthenticator = pam.pam()
+    pam_hdl: pam.PamAuthenticator | None = None
     next_mech: AuthMech | None = None
     auth_data: dict | None = None
 

--- a/src/middlewared/middlewared/plugins/auth_/authenticate.py
+++ b/src/middlewared/middlewared/plugins/auth_/authenticate.py
@@ -106,6 +106,9 @@ class AuthService(Service):
                 return {'code': pam.PAM_ABORT, 'reason': 'Failed to generate PAM service file'}
 
         with auth_ctx.pam_lock:
+            if not auth_ctx.pam_hdl:
+                auth_ctx.pam_hdl = pam.pam()
+
             p = auth_ctx.pam_hdl
             p.authenticate(username, password, service=os.path.basename(pam_service))
             pam_resp = {'code': p.code, 'reason': p.reason}


### PR DESCRIPTION
During the upgrade process we import middleware in a chroot environment which breaks setup of the AuthenticationContext dataclass since the ctype symbol lookup for pam_start fails.

This commit makes it so that we don't initialize a pam context for App instances until endpoint auth.libpam_authenticate is called.