### PR TITLE
NAS-131914 / 25.04 / Relax next mechanism requirement for OTP_TOKEN

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -98,6 +98,10 @@ class AuthLoginExArgs(BaseModel):
     login_data: AuthApiKeyPlain | AuthPasswordPlain | AuthTokenPlain | AuthOTPToken
 
 
+class AuthLoginExContinueArgs(BaseModel):
+    login_data: AuthOTPToken
+
+
 class AuthLoginExResult(BaseModel):
     result: AuthRespSuccess | AuthRespAuthErr | AuthRespExpired | AuthRespOTPRequired
 


### PR DESCRIPTION
If we have an in-progress authentication attempt, allow client to
abandon current stage in favor of restarting the authentication process.

In this case since we haven't generated a success or failure record
for the authentication attempt, log it as an OTP failure with a special
message that OTP validation was abandoned.

Add a new dedicated API endpoint to continue a login_ex request that
returned OTP_REQUIRED. This is named `auth.login_ex_continue` so that
we have potential to expand it in the future if we add support for
other login mechanisms that require conversation with client and
server.