### PR TITLE
NAS-131795 / 25.04 / Improve error message for hostpath schema

### DIFF
--- a/src/middlewared/middlewared/schema/string_schema.py
+++ b/src/middlewared/middlewared/schema/string_schema.py
@@ -195,7 +195,11 @@ class HostPath(Path):
 
         if value:
             if not os.path.exists(value):
-                verrors.add(self.name, 'This path does not exist.', errno.ENOENT)
+                verrors.add(
+                    self.name,
+                    'Path does not exist (underlying dataset may be locked or the path is just missing).',
+                    errno.ENOENT
+                )
             else:
                 self.validate_internal(verrors, value)
 


### PR DESCRIPTION
This commit updates error message for hostpath schema so if path is missing, we outline that it could just be that the path does not exist or that the underlying dataset may be locked.