### PR TITLE
NAS-127825 / 24.10.1 / Enable the API test for mount options (by usaleem-ix)

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -145,14 +145,9 @@ def test_008_check_root_dataset_settings(ws_client):
             # This is a run where root filesystem is unlocked. Don't obther checking remaining
             continue
 
-        # FIXME: c.f. NAS-127825
-        # Certain mount opts are broken. OS team is aware but fix is complicated
-        # so we skip these checks for now.
-        """
         for opt in filter(lambda x: x != 'NOSUID', fhs_entry['options']):
-            if opt not in fs['mount_opts']:
+            if opt not in fs['mount_opts'] and opt not in fs['super_opts']:
                 assert opt in fs['mount_opts'], f'{opt}: mount option not present for {mp}: {fs["mount_opts"]}'
-        """
 
 
 def test_009_check_listening_ports():


### PR DESCRIPTION
The test needed to be updated slightly, since some options like `RW,XATTR,NOACL,CASESENSISTIVE` are present in `super_opts` instead of `mount_opts`.

```
{
"mount_id": 28,
"parent_id": 27,
"device_id": {
  "major": 0,
  "minor": 25,
  "dev_t": 25
},
"root": "/",
"mountpoint": "/audit",
"mount_opts": [
  "RW",
  "NOSUID",
  "NODEV",
  "NOEXEC",
  "NOATIME"
],
"fs_type": "zfs",
"mount_source": "boot-pool/ROOT/25.04.0-MASTER-20241018-005230/audit",
"super_opts": [
  "RW",
  "XATTR",
  "NOACL",
  "CASESENSITIVE"
]
},
```
Related ZFS PRs[[1](https://github.com/truenas/zfs/pull/257)][[2](https://github.com/truenas/zfs/pull/257)] are merged in TrueNAS ZFS.

[Updated API test run](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1413/#showFailuresLink) was successful.


Original PR: https://github.com/truenas/middleware/pull/14737
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127825