### PR TITLE
NAS-131171 / 24.10.0 / fix disk.wipe (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/wipe.py
+++ b/src/middlewared/middlewared/plugins/disk_/wipe.py
@@ -76,9 +76,9 @@ class DiskService(Service):
             # no reason to write more than 1MB at a time
             # or kernel will break them into smaller chunks
             if mode in ('QUICK', 'FULL'):
-                to_write = bytearray(CHUNK).zfill(0)
+                to_write = b'0' * CHUNK
             else:
-                to_write = bytearray(os.urandom(CHUNK))
+                to_write = os.urandom(CHUNK)
 
             # seek back to the beginning of the disk
             os.lseek(f.fileno(), 0, os.SEEK_SET)


### PR DESCRIPTION
This fixes disk.wipe to actually zero the first and last 32MB of the disk being wiped. We have seen a few reports of users on SCALE where libblkid is reporting partition information on disks that should _not_ be there. There is a separate libblkid bug related to ZFS and the OS team is working on that separately, however, this was trivially reproducible by writing another filesystems label "magic string" and then running `disk.wipe` on it preventing that file system label from being removed. This boils down to the API in python interpreting and doing something with null characters instead of 0's. The fix is quite simple really and I've improved the `disk.wipe` test to ensure this does not get missed in the future. Tests are passing.

Original PR: https://github.com/truenas/middleware/pull/14742
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131171