### PR TITLE
NAS-131894 / 25.04 / prevent mistakes related to uids and gids in accounts plugin

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/group.py
+++ b/src/middlewared/middlewared/api/v25_04_0/group.py
@@ -43,8 +43,6 @@ class GroupCreate(GroupEntry):
 
     gid: LocalUID | None = None
     "If `null`, it is automatically filled with the next one available."
-    allow_duplicate_gid: bool = False
-    "Allows distinct group names to share the same gid."
 
 
 class GroupCreateArgs(BaseModel):
@@ -56,7 +54,7 @@ class GroupCreateResult(BaseModel):
 
 
 class GroupUpdate(GroupCreate, metaclass=ForUpdateMetaclass):
-    pass
+    gid: Excluded = excluded_field()
 
 
 class GroupUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -86,6 +86,7 @@ class UserCreate(UserEntry):
 
 
 class UserUpdate(UserCreate, metaclass=ForUpdateMetaclass):
+    uid: Excluded = excluded_field()
     group_create: Excluded = excluded_field()
 
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -669,7 +669,6 @@ def test_060_immutable_user_validation(request):
     to_validate = [
         {'group': 1},
         {'home': '/mnt/tank', 'home_create': True},
-        {'uid': 777777},
         {'smb': True},
         {'username': 'no_way_bad'},
     ]

--- a/tests/api2/test_account_duplicate_uid_gid.py
+++ b/tests/api2/test_account_duplicate_uid_gid.py
@@ -51,28 +51,6 @@ def test_create_duplicate_uid(uid_1234):
         ]
 
 
-def test_update_duplicate_uid(uid_1234):
-    with dataset(f"user2_homedir") as user2_homedir:
-        with user({
-            "username": "user2",
-            "full_name": "user2",
-            "group_create": True,
-            "groups": [],
-            "home": f"/mnt/{user2_homedir}",
-            "password": "test1234",
-        }) as user2:
-            with pytest.raises(ValidationErrors) as ve:
-                call("user.update", user2["id"], {"uid": 1234})
-
-            assert ve.value.errors == [
-                ValidationError('user_update.uid', 'Uid 1234 is already used (user user1 has it)', errno.EEXIST),
-            ]
-
-
-def test_update_no_duplicate_uid(uid_1234):
-    call("user.update", uid_1234["id"], {"uid": 1234})
-
-
 def test_create_duplicate_gid(gid_1234):
     with pytest.raises(ValidationErrors) as ve:
         with group({
@@ -84,19 +62,3 @@ def test_create_duplicate_gid(gid_1234):
     assert ve.value.errors == [
         ValidationError('group_create.gid', 'Gid 1234 is already used (group group1 has it)', errno.EEXIST),
     ]
-
-
-def test_update_duplicate_gid(gid_1234):
-    with group({
-        "name": "group2",
-    }) as group2:
-        with pytest.raises(ValidationErrors) as ve:
-            call("group.update", group2["id"], {"gid": 1234})
-
-        assert ve.value.errors == [
-            ValidationError('group_update.gid', 'Gid 1234 is already used (group group1 has it)', errno.EEXIST),
-        ]
-
-
-def test_update_no_duplicate_gid(gid_1234):
-    call("group.update", gid_1234["id"], {"gid": 1234})


### PR DESCRIPTION
After internal discussion the valid use-cases for allowing groups with duplicate gids are few and far between, but the risk of novice users accidentally exposing themselves to unexpected disclosure of information is not obscure. Hence, we are removing this quasi-feature from the v25.04 API before it's finalized. This same argument for allowing API consumers to change the uid for users and gid for groups can be made. In this case the functionality was never exposed via the webui.