### PR TITLE
NAS-131920 / 25.04 / Restore NOSUID to test_008_check_root_dataset_settings

### DIFF
--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -145,7 +145,7 @@ def test_008_check_root_dataset_settings(ws_client):
             # This is a run where root filesystem is unlocked. Don't obther checking remaining
             continue
 
-        for opt in filter(lambda x: x != 'NOSUID', fhs_entry['options']):
+        for opt in fhs_entry['options']:
             if opt not in fs['mount_opts'] and opt not in fs['super_opts']:
                 assert opt in fs['mount_opts'], f'{opt}: mount option not present for {mp}: {fs["mount_opts"]}'
 


### PR DESCRIPTION
Today PR #14737 "enabled the API test for mount options", but it failed to restore `NOSUID` which had been filtered out pending the ZFS fix in [NAS-127825](https://ixsystems.atlassian.net/browse/NAS-127825).

Passing CI here: [1437](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1437/)