### PR TITLE
NAS-131910 / 25.04 / Fix non-fulladmin user getting `datetime_` instead of `datetime` on `alert.list`

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import enum
 import json
 import logging
-import typing
+from typing import Any, TypeAlias
 
 import html2text
 
@@ -10,12 +10,11 @@ from middlewared.alert.schedule import IntervalSchedule
 from middlewared.utils import ProductName, ProductType
 from middlewared.utils.lang import undefined
 
-__all__ = ["UnavailableException",
-           "AlertClass", "OneShotAlertClass", "SimpleOneShotAlertClass", "DismissableAlertClass",
-           "AlertCategory", "AlertLevel", "Alert",
-           "AlertSource", "ThreadedAlertSource",
-           "AlertService", "ThreadedAlertService", "ProThreadedAlertService",
-           "format_alerts", "ellipsis"]
+__all__ = [
+    "UnavailableException", "AlertClass", "OneShotAlertClass", "SimpleOneShotAlertClass", "DismissableAlertClass",
+    "AlertCategory", "AlertLevel", "Alert", "AlertSource", "ThreadedAlertSource", "AlertService",
+    "ThreadedAlertService", "ProThreadedAlertService", "format_alerts", "ellipsis"
+]
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +213,7 @@ class AlertLevel(enum.Enum):
     EMERGENCY = 7
 
 
-DateTimeType: typing.TypeAlias = datetime
+DateTimeType: TypeAlias = datetime
 
 
 class Alert:
@@ -250,13 +249,13 @@ class Alert:
     """
 
     klass: type[AlertClass]
-    args: typing.Union[dict[str, typing.Any], list]
-    key: typing.Any
+    args: dict[str, Any] | list
+    key: Any
     datetime: DateTimeType
     last_occurrence: DateTimeType
-    node: typing.Optional[str]
+    node: str | None
     dismissed: bool
-    mail: typing.Optional[dict]
+    mail: dict | None
 
     def __init__(self, klass, args=None, key=undefined, datetime=None, last_occurrence=None, node=None, dismissed=None,
                  mail=None, _uuid=None, _source=None, _key=None, _text=None):

--- a/src/middlewared/middlewared/api/base/handler/result.py
+++ b/src/middlewared/middlewared/api/base/handler/result.py
@@ -5,4 +5,8 @@ def serialize_result(model, result, expose_secrets):
     if expose_secrets:
         return result
 
-    return model(result=result).model_dump(context={"expose_secrets": expose_secrets}, warnings=False)["result"]
+    return model(result=result).model_dump(
+        context={"expose_secrets": expose_secrets},
+        warnings=False,
+        by_alias=True,
+    )["result"]

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+
+from middlewared.api.base import BaseModel
+
+
+def test_dump_by_alias():
+    class AliasModel(BaseModel):
+        field1_: int = Field(..., alias='field1')
+        field2: str
+        field3_: bool = Field(alias='field3', default=False)
+
+    class AliasModelResult(BaseModel):
+        result: AliasModel
+
+    result = {'field1': 1, 'field2': 'two'}
+    result_model = AliasModelResult(result=result)
+
+    assert result_model.model_dump()['result'] == {'field1_': 1, 'field2': 'two', 'field3_': False}
+    assert result_model.model_dump(by_alias=True)['result'] == {'field1': 1, 'field2': 'two', 'field3': False}

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,6 +1,7 @@
 from pydantic import Field
 
 from middlewared.api.base import BaseModel
+from middlewared.api.base.handler.result import serialize_result
 
 
 def test_dump_by_alias():
@@ -13,7 +14,6 @@ def test_dump_by_alias():
         result: AliasModel
 
     result = {'field1': 1, 'field2': 'two'}
-    result_model = AliasModelResult(result=result)
+    dump = serialize_result(AliasModelResult, result, False)
 
-    assert result_model.model_dump()['result'] == {'field1_': 1, 'field2': 'two', 'field3_': False}
-    assert result_model.model_dump(by_alias=True)['result'] == {'field1': 1, 'field2': 'two', 'field3': False}
+    assert dump == {'field1': 1, 'field2': 'two', 'field3': False}


### PR DESCRIPTION
This fix https://github.com/truenas/middleware/pull/14712 introduced the new problem of non-full_admin users receiving `datetime_` instead of `datetime` on `alert.list`. This revealed the broader issue of our new-style API call results not respecting field aliases in serialization.

I've also cleaned up the type annotations in alert.py. 