### PR TITLE
NAS-131944 / 25.04 / Convert rdma to new api method.

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -11,9 +11,10 @@ from .failover_reboot import *  # noqa
 from .group import *  # noqa
 from .keychain import *  # noqa
 from .privilege import *  # noqa
+from .rdma import *  # noqa
 from .smartctl import * # noqa
 from .system_reboot import *  # noqa
 from .system_lifecycle import *  # noqa
 from .user import *  # noqa
 from .vendor import *  # noqa
-from .virt import *  #noqa
+from .virt import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -1,0 +1,35 @@
+from middlewared.api.base import BaseModel
+
+__all__ = ["RdmaCapableServicesArgs", "RdmaCapableServicesResult"]
+
+
+class RdmaCapableServicesArgs(BaseModel):
+    pass
+
+
+class RdmaCapableServicesResult(BaseModel):
+    result: list[str]
+
+# class NvmeSelfTest(BaseModel):
+#     num: int
+#     description: str
+#     status: str
+#     status_verbose: str
+#     power_on_hours: int
+#     power_on_hours_ago: int
+#     failing_lba: int | None = None
+#     nsid: int | None = None
+#     seg: int | None = None
+#     sct: int | None = 0x0
+#     code: int | None = 0x0
+
+
+# class ScsiSelfTest(BaseModel):
+#     num: int
+#     description: str
+#     status: str
+#     status_verbose: str
+#     power_on_hours_ago: int
+#     segment_number: int | None = None
+#     lifetime: int | None = None
+#     lba_of_first_error: int | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -1,6 +1,36 @@
-from middlewared.api.base import BaseModel
+from middlewared.api.base import BaseModel, single_argument_result
+from typing import Literal
 
-__all__ = ["RdmaCapableServicesArgs", "RdmaCapableServicesResult"]
+__all__ = [
+    "RdmaLinkConfigArgs", "RdmaLinkConfigResult",
+    "RdmaCardConfigArgs", "RdmaCardConfigResult",
+    "RdmaCapableServicesArgs", "RdmaCapableServicesResult"
+]
+
+
+class RdmaLinkConfigArgs(BaseModel):
+    all: bool = False
+
+
+class RdmaLinkConfig(BaseModel):
+    rdma: str
+    netdev: str
+
+
+class RdmaLinkConfigResult(BaseModel):
+    result: list[RdmaLinkConfig]
+
+
+class RdmaCardConfigArgs(BaseModel):
+    pass
+
+
+@single_argument_result
+class RdmaCardConfigResult(BaseModel):
+    serial: str
+    product: str
+    part_number: str
+    links: list[RdmaLinkConfig]
 
 
 class RdmaCapableServicesArgs(BaseModel):
@@ -8,28 +38,4 @@ class RdmaCapableServicesArgs(BaseModel):
 
 
 class RdmaCapableServicesResult(BaseModel):
-    result: list[str]
-
-# class NvmeSelfTest(BaseModel):
-#     num: int
-#     description: str
-#     status: str
-#     status_verbose: str
-#     power_on_hours: int
-#     power_on_hours_ago: int
-#     failing_lba: int | None = None
-#     nsid: int | None = None
-#     seg: int | None = None
-#     sct: int | None = 0x0
-#     code: int | None = 0x0
-
-
-# class ScsiSelfTest(BaseModel):
-#     num: int
-#     description: str
-#     status: str
-#     status_verbose: str
-#     power_on_hours_ago: int
-#     segment_number: int | None = None
-#     lifetime: int | None = None
-#     lba_of_first_error: int | None = None
+    result: list[Literal["NFS"]]

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -3,6 +3,10 @@ import subprocess
 from pathlib import Path
 from .constants import RDMAprotocols
 
+from middlewared.api import api_method
+from middlewared.api.current import (
+    RdmaCapableServicesArgs, RdmaCapableServicesResult
+)
 from middlewared.schema import Bool, Dict, List, Ref, Str, accepts, returns
 from middlewared.service import Service, private
 from middlewared.service_exception import CallError
@@ -135,7 +139,7 @@ class RDMAService(Service):
             v['name'] = ':'.join(sorted(names))
         return list(grouper.values())
 
-    @private
+    @api_method(RdmaCapableServicesArgs, RdmaCapableServicesResult)
     async def capable_services(self):
         result = []
         is_ent = await self.middleware.call('system.is_enterprise')

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -5,9 +5,10 @@ from .constants import RDMAprotocols
 
 from middlewared.api import api_method
 from middlewared.api.current import (
+    RdmaLinkConfigArgs, RdmaLinkConfigResult,
+    RdmaCardConfigArgs, RdmaCardConfigResult,
     RdmaCapableServicesArgs, RdmaCapableServicesResult
 )
-from middlewared.schema import Bool, Dict, List, Ref, Str, accepts, returns
 from middlewared.service import Service, private
 from middlewared.service_exception import CallError
 from middlewared.utils.functools_ import cache
@@ -44,14 +45,7 @@ class RDMAService(Service):
                 result['part'] = sline[len(PART_NUMBER_PREFIX):]
         return result
 
-    @private
-    @accepts(Bool('all', default=False))
-    @returns(List(items=[Dict(
-        'rdma_link_config',
-        Str('rdma', required=True),
-        Str('netdev', required=True),
-        register=True
-    )]))
+    @api_method(RdmaLinkConfigArgs, RdmaLinkConfigResult, private=True)
     async def get_link_choices(self, all):
         """Return a list containing dictionaries with keys 'rdma' and 'netdev'.
 
@@ -87,14 +81,7 @@ class RDMAService(Service):
                 result.append({'rdma': link['ifname'], 'netdev': link['netdev']})
         return result
 
-    @accepts()
-    @returns(List(items=[Dict(
-        'rdma_card_config',
-        Str('serial'),
-        Str('product'),
-        Str('part_number'),
-        List('links', items=[Ref('rdma_link_config')])
-    )], register=True))
+    @api_method(RdmaCardConfigArgs, RdmaCardConfigResult)
     @cache
     def get_card_choices(self):
         """Return a list containing details about each RDMA card.  Dual cards


### PR DESCRIPTION
To support the rdma configuration setting in the UI the newish `rdma.capable_services` routine is required as a public method.  As such, we need to convert it from private to public.

_As part of that change_, the entire `rdma.py` service module was converted to the new api method.

Also fixed a couple flake8 issues.