### PR TITLE
NAS-131942 / 25.04 / User proper validators for query-filters and query-options

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -1,18 +1,21 @@
-from typing import Any
 from typing_extensions import Annotated, Self
 
 from middlewared.api.base import BaseModel
-from middlewared.validators import QueryFilters as QueryFiltersValidator
-from middlewared.validators import QueryOptions as QueryOptionsValidator
+from middlewared.utils import filters
 
 from pydantic import AfterValidator, model_validator
 
 __all__ = ["QueryFilters", "QueryOptions", "QueryArgs"]
 
-qf_validator = QueryFiltersValidator()
-qo_validator = QueryOptionsValidator()
+filter_obj = filters()
 
-QueryFilters = Annotated[list, AfterValidator(qf_validator)]
+
+def validate_query_filters(qf: list) -> list:
+    filter_obj.validate_filters(qf)
+    return qf
+
+
+QueryFilters = Annotated[list, AfterValidator(validate_query_filters)]
 
 
 class QueryOptions(BaseModel):
@@ -31,7 +34,7 @@ class QueryOptions(BaseModel):
 
     @model_validator(mode='after')
     def validate_query_options(self) -> Self:
-        qo_validator(self.dict())
+        filter_obj.validate_options(self.dict())
         return self
 
 

--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -1,8 +1,18 @@
 from typing import Any
+from typing_extensions import Annotated, Self
 
 from middlewared.api.base import BaseModel
+from middlewared.validators import QueryFilters as QueryFiltersValidator
+from middlewared.validators import QueryOptions as QueryOptionsValidator
 
-__all__ = ["QueryOptions", "QueryArgs"]
+from pydantic import AfterValidator, model_validator
+
+__all__ = ["QueryFilters", "QueryOptions", "QueryArgs"]
+
+qf_validator = QueryFiltersValidator()
+qo_validator = QueryOptionsValidator()
+
+QueryFilters = Annotated[list, AfterValidator(qf_validator)]
 
 
 class QueryOptions(BaseModel):
@@ -12,14 +22,19 @@ class QueryOptions(BaseModel):
     prefix: str | None = None
     extra: dict = {}
     order_by: list[str] = []
-    select: list[str] = []
+    select: list[str | list] = []
     count: bool = False
     get: bool = False
     offset: int = 0
     limit: int = 0
     force_sql_filters: bool = False
 
+    @model_validator(mode='after')
+    def validate_query_options(self) -> Self:
+        qo_validator(self.dict())
+        return self
+
 
 class QueryArgs(BaseModel):
-    filters: list[Any] = []  # FIXME: Add validation here
+    filters: QueryFilters = []
     options: QueryOptions = QueryOptions()

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -216,9 +216,8 @@ class Port(Range):
 
 
 class QueryFilters(ValidatorBase):
-    def __call__(self, value: list) -> list:
+    def __call__(self, value):
         validate_filters(value)
-        return value
 
 
 class QueryOptions(ValidatorBase):

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -216,8 +216,9 @@ class Port(Range):
 
 
 class QueryFilters(ValidatorBase):
-    def __call__(self, value):
+    def __call__(self, value: list) -> list:
         validate_filters(value)
+        return value
 
 
 class QueryOptions(ValidatorBase):


### PR DESCRIPTION
The transition to new api_method made query-options too restrictive and did not implement validator for query-filters. This commit plumbs in our existing middleware validators into these models.