### PR TITLE
NAS-131950 / 25.04 / Fix dictionary key names based on field aliases

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/accept.py
+++ b/src/middlewared/middlewared/api/base/handler/accept.py
@@ -72,4 +72,9 @@ def validate_model(model: type[BaseModel], data: dict, *, exclude_unset=False, e
 
         raise verrors from None
 
-    return instance.model_dump(context={"expose_secrets": expose_secrets}, exclude_unset=exclude_unset, warnings=False)
+    return instance.model_dump(
+        context={"expose_secrets": expose_secrets},
+        exclude_unset=exclude_unset,
+        warnings=False,
+        by_alias=True
+    )


### PR DESCRIPTION
We want pydantic to dump by alias to maintain backwards-compatibility with old API schema and prevent introduction of new bugs.