### PR TITLE
NAS-131953 / 24.10.1 / Fix apps for HA in EE

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -983,17 +983,6 @@ class FailoverEventsService(Service):
             return
 
         logger.info('Going to initialize apps plugin as %r pool is configured for apps', pool)
-        logger.info('Mounting relevant docker datasets')
-        try:
-            self.run_call('docker.fs_manage.mount')
-        except Exception:
-            self.middleware.call_sync('docker.state.set_status', Status.FAILED.value, 'Failed to mount docker datasets')
-            logger.error('Failed to mount docker datasets', exc_info=True)
-            return
-        else:
-            logger.info('Mounted docker datasets successfully')
-
-        logger.info('Starting docker service')
         try:
             self.run_call('docker.state.start_service')
         except Exception:


### PR DESCRIPTION
This commit fixes erroneous logging and apps functionality in HA on failover event for EE because a certain block code is not relevant for EE and that logic is already ingrained in docker start service endpoint.