### PR TITLE
NAS-131842 / 25.04 / Only allow upgrading an app if it is not in stopped state

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -32,6 +32,9 @@ class AppService(Service):
         Upgrade `app_name` app to `app_version`.
         """
         app = self.middleware.call_sync('app.get_instance', app_name)
+        if app['state'] == 'STOPPED':
+            raise CallError('In order to upgrade an app, it must not be in stopped state')
+
         if app['upgrade_available'] is False:
             raise CallError(f'No upgrade available for {app_name!r}')
 


### PR DESCRIPTION
This commit adds changes to not allow upgrading an app if it is in stopped state, after discussing with Stavros we believe that is the best way to move forward as to actually be able to ensure that an app gets properly migrated over to the newer version, ideally it should be in a state other then stopped (deploying/running/crashed etc).