### PR TITLE
NAS-131916 / 25.04 / Fix sending `failover.reboot.info`

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -181,7 +181,7 @@ async def reboot_info(middleware, *args, **kwargs):
 
 
 def remote_reboot_info(middleware, *args, **kwargs):
-    middleware.call_sync('failover.reboot.send_event', background=True)
+    asyncio.run_coroutine_threadsafe(middleware.call('failover.reboot.send_event'), loop=middleware.loop)
 
 
 async def setup(middleware):


### PR DESCRIPTION
This method is used in both async and non-async contexts. The original implementation causes the following exception when used from the async context
```
[2024/10/24 06:15:41] (ERROR) middlewared.wrap():1773 - Unhandled exception in event handler
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1771, in wrap
    await handler(self, event_type, kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/failover_/reboot.py", line 184, in remote_reboot_info
    middleware.call_sync('failover.reboot.send_event', background=True)
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1656, in call_sync
    raise RuntimeError('You cannot use call_sync from main thread')
RuntimeError: You cannot use call_sync from main thread
```
Since we don't need to wait for the result of the method execution anyway, we can just do `run_coroutine_threadsafe` to be context-agnostic.