### PR TITLE
NAS-131973 / 25.04 / significantly speed up get_disk_names()

### DIFF
--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pyudev
@@ -62,7 +63,7 @@ def get_disk_names() -> list[str]:
     NOTE: The return of this method should match the keys retrieve when running `self.get_disks`.
     """
     disks = []
-    with open('/dev') as sdir:
+    with os.scandir('/dev') as sdir:
         for i in filter(lambda x: VALID_WHOLE_DISK.match(x.name), sdir):
             disks.append(i.name)
     return disks

--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -12,7 +12,7 @@ VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$')
 def safe_retrieval(prop, key, default, as_int=False):
     value = prop.get(key)
     if value is not None:
-        if type(value) is bytes:
+        if isinstance(value, bytes):
             value = value.strip().decode()
         else:
             value = value.strip()

--- a/src/middlewared/middlewared/utils/disks.py
+++ b/src/middlewared/middlewared/utils/disks.py
@@ -1,15 +1,15 @@
-import pathlib
 import re
-import typing
 
 import pyudev
 
 
 DISKS_TO_IGNORE = ('sr', 'md', 'dm-', 'loop', 'zd')
 RE_IS_PART = re.compile(r'p\d{1,3}$')
+# sda, vda, nvme0n1 but not sda1/vda1/nvme0n1p1
+VALID_WHOLE_DISK = re.compile(r'^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$')
 
 
-def safe_retrieval(prop, key, default, as_int=False) -> typing.Any:
+def safe_retrieval(prop, key, default, as_int=False):
     value = prop.get(key)
     if value is not None:
         if type(value) is bytes:
@@ -62,21 +62,9 @@ def get_disk_names() -> list[str]:
     NOTE: The return of this method should match the keys retrieve when running `self.get_disks`.
     """
     disks = []
-    try:
-        for disk in pathlib.Path('/sys/class/block').iterdir():
-            if disk.name.startswith(DISKS_TO_IGNORE):
-                continue
-            elif RE_IS_PART.search(disk.name):
-                # sdap1/nvme0n1p12/pmem0p1/etc
-                continue
-            elif disk.name[:2] in ('sd', 'vd') and disk.name[-1].isdigit():
-                # sda1/sda2/vda1/vda2/etc
-                continue
-            else:
-                disks.append(disk.name)
-    except FileNotFoundError:
-        pass
-
+    with open('/dev') as sdir:
+        for i in filter(lambda x: VALID_WHOLE_DISK.match(x.name), sdir):
+            disks.append(i.name)
     return disks
 
 


### PR DESCRIPTION
This significantly speeds up `get_disk_names`. Furthermore, it bypasses libudev. The udev cache is fickle and can be invalidated on a whim (even though the disk still exists).

Since this is such a critical part of our code, it's best to iterate `/dev` and pull out the valid disks. This is the exact same methodology used in `fenced` and that program has no room for failure.

This uses `scandir` instead of `iterdir`, the latter enumerating the entire contents of the directory into a list object before being returned to the caller (inefficient). We also use a filter, lambda expression since python3.12 (or 3.13) will inline these expressions further improving performance. Finally, fix a flake8 error while I'm here.