### PR TITLE
NAS-131570 / 24.10.1 / Fix pool deletion with active NFS shares. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/fs_attachment_delegate.py
+++ b/src/middlewared/middlewared/plugins/nfs_/fs_attachment_delegate.py
@@ -1,0 +1,18 @@
+from middlewared.common.attachment import LockableFSAttachmentDelegate
+
+from middlewared.plugins.nfs import SharingNFSService
+
+
+class NFSFSAttachmentDelegate(LockableFSAttachmentDelegate):
+    name = 'nfs'
+    title = 'NFS Share'
+    service = 'nfs'
+    service_class = SharingNFSService
+    resource_name = 'path'
+
+    async def restart_reload_services(self, attachments):
+        await self._service_change('nfs', 'reload')
+
+
+async def setup(middleware):
+    await middleware.call('pool.dataset.register_attachment_delegate', NFSFSAttachmentDelegate(middleware))

--- a/src/middlewared/middlewared/plugins/service_/services/nfs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/nfs.py
@@ -29,7 +29,15 @@ class NFSService(SimpleService):
         else:
             await self.middleware.call('alert.oneshot_delete', 'NFSblockedByExportsDir')
 
+    async def before_start(self):
+        # If available, make sure the procfs nfsv4recoverydir entry has the correct info.
+        # Usually the update should be done _before_ nfsd is running.
+        # Sometimes, after a reboot, the proc entry may not exist and that's ok.
+        await self.middleware.call('nfs.update_procfs_v4recoverydir')
+
     async def after_start(self):
+        # This is to cover the case where the proc entry did not exist
+        await self.middleware.call('nfs.update_procfs_v4recoverydir')
         await self._systemd_unit("rpc-statd", "start")
 
     async def stop(self):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -714,6 +714,8 @@ class SystemDatasetService(ConfigService):
             # a file descriptor underneath /var/log will no longer need to be
             # stopped/restarted to allow the system dataset to migrate
             restart = ['netdata']
+            if self.middleware.call_sync('service.started', 'nfs'):
+                restart.append('nfs')
             if self.middleware.call_sync('service.started', 'cifs'):
                 restart.insert(0, 'cifs')
             if self.middleware.call_sync('service.started', 'open-vm-tools'):

--- a/src/middlewared/middlewared/test/integration/assets/pool.py
+++ b/src/middlewared/middlewared/test/integration/assets/pool.py
@@ -56,6 +56,8 @@ def another_pool(data=None, topology=None):
         except ValidationErrors as e:
             if not any(error.errcode == errno.ENOENT for error in e.errors):
                 raise
+        except InstanceNotFound:
+            pass
 
 
 @contextlib.contextmanager

--- a/src/middlewared/middlewared/test/integration/utils/failover.py
+++ b/src/middlewared/middlewared/test/integration/utils/failover.py
@@ -1,0 +1,71 @@
+import contextlib
+import os
+import sys
+from time import sleep
+
+try:
+    apifolder = os.getcwd()
+    sys.path.append(apifolder)
+    from auto_config import ha, hostname
+except ImportError:
+    ha = False
+    hostname = None
+
+from .call import call
+
+__all__ = ["disable_failover"]
+
+
+@contextlib.contextmanager
+def disable_failover():
+    if ha:
+        call("failover.update", {"disabled": True, "master": True})
+
+    try:
+        yield
+    finally:
+        if ha:
+            call("failover.update", {"disabled": False, "master": True})
+
+
+def wait_for_standby():
+    '''
+    NOTE:
+       1) This routine is for dual-controller (ha) only
+       2) This is nearly identical to 'wait_for_standby' in test_006_pool_and_sysds
+
+    This routine will wait for the standby controller to return from a reboot.
+    '''
+    if ha:
+        sleep(5)
+
+        sleep_time = 1
+        max_wait_time = 300
+        rebooted = False
+        waited_time = 0
+
+        while waited_time < max_wait_time and not rebooted:
+            if call('failover.remote_connected'):
+                rebooted = True
+            else:
+                waited_time += sleep_time
+                sleep(sleep_time)
+
+        assert rebooted, f'Standby did not connect after {max_wait_time} seconds'
+
+        waited_time = 0  # need to reset this
+        is_backup = False
+        while waited_time < max_wait_time and not is_backup:
+            try:
+                is_backup = call('failover.call_remote', 'failover.status') == 'BACKUP'
+            except Exception:
+                pass
+
+            if not is_backup:
+                waited_time += sleep_time
+                sleep(sleep_time)
+
+        assert is_backup, f'Standby node did not become BACKUP after {max_wait_time} seconds'
+        pass
+    else:
+        pass

--- a/tests/protocols/__init__.py
+++ b/tests/protocols/__init__.py
@@ -2,12 +2,11 @@ import contextlib
 
 from functions import DELETE, POST
 
-from .ftp_proto import ftp_connect, ftps_connect, ftp_connection, ftps_connection
-from .iscsi_proto import (initiator_name_supported, iscsi_scsi_connect,
-                          iscsi_scsi_connection)
+from .ftp_proto import ftp_connect, ftps_connect, ftp_connection, ftps_connection  # noqa
+from .iscsi_proto import initiator_name_supported, iscsi_scsi_connect, iscsi_scsi_connection  # noqa
 from .iSNSP.client import iSNSPClient
-from .ms_rpc import MS_RPC
-from .nfs_proto import SSH_NFS
+from .ms_rpc import MS_RPC  # noqa
+from .nfs_proto import SSH_NFS  # noqa
 from .smb_proto import SMB
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 00b3d399b4463d30a92190ac82173c01d294ed55
    git cherry-pick -x 412cf97770a84309e907d365d8fbb7d7d4bb1117

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x c1c8ab37e9b5f22c3f15301111708e1b982f9267

Deleting a pool that holds the system dataset while NFS is active can cause a failure to delete the pool.

The fix for this is to temporarily stop NFS during the system dataset move operation.

This PR also includes:
- CI test for the pool delete condition (main topic)
- Better management of `/proc/fs/nfsd/nfsv4recoverydir` and a CI test
- Adding `wait_for_standby` routine in failover test utils
- Added `# noqa` to a few lines to avoid flake8 complaints


Passing HA CI NFS tests can be found [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1452/).
Passing standalone CI NFS tests can be found [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1453/)

Original PR: https://github.com/truenas/middleware/pull/14692
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131570