### PR TITLE
NAS-132002 / 25.04 / Make sure apps are correctly handled with root dataset being encrypted in FT

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/attachments.py
+++ b/src/middlewared/middlewared/plugins/docker/attachments.py
@@ -45,7 +45,7 @@ class DockerFSAttachmentDelegate(FSAttachmentDelegate):
         if not attachments:
             return
         try:
-            await self.middleware.call('docker.state.start_service')
+            await self.middleware.call('docker.state.start_service', True)
         except Exception:
             self.middleware.logger.error('Failed to start docker')
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -962,19 +962,8 @@ class FailoverEventsService(Service):
             return
 
         logger.info('Going to initialize apps plugin as %r pool is configured for apps', pool)
-        logger.info('Mounting relevant docker datasets')
         try:
-            self.run_call('docker.fs_manage.mount')
-        except Exception:
-            self.middleware.call_sync('docker.state.set_status', Status.FAILED.value, 'Failed to mount docker datasets')
-            logger.error('Failed to mount docker datasets', exc_info=True)
-            return
-        else:
-            logger.info('Mounted docker datasets successfully')
-
-        logger.info('Starting docker service')
-        try:
-            self.run_call('docker.state.start_service')
+            self.run_call('docker.state.start_service', True)
         except Exception:
             logger.error('Failed to start docker service', exc_info=True)
         else:

--- a/src/middlewared/middlewared/test/integration/assets/docker.py
+++ b/src/middlewared/middlewared/test/integration/assets/docker.py
@@ -1,0 +1,16 @@
+import contextlib
+
+from middlewared.test.integration.utils import call
+
+
+@contextlib.contextmanager
+def docker(pool: dict):
+    docker_config = call('docker.update', {'pool': pool['name']}, job=True)
+    assert docker_config['pool'] == pool['name'], docker_config
+    try:
+        yield docker_config
+    finally:
+        docker_config = call(
+            'docker.update', {'pool': None, 'address_pools': [{'base': '172.17.0.0/12', 'size': 24}]}, job=True
+        )
+        assert docker_config['pool'] is None, docker_config

--- a/tests/api2/test_apps.py
+++ b/tests/api2/test_apps.py
@@ -2,6 +2,7 @@ import pytest
 
 from middlewared.test.integration.utils import call, client
 from middlewared.test.integration.assets.apps import app
+from middlewared.test.integration.assets.docker import docker
 from middlewared.test.integration.assets.pool import another_pool
 from truenas_api_client import ValidationErrors
 
@@ -138,13 +139,8 @@ services:
 @pytest.fixture(scope='module')
 def docker_pool():
     with another_pool() as pool:
-        docker_config = call('docker.update', {'pool': pool['name']}, job=True)
-        assert docker_config['pool'] == pool['name'], docker_config
-        try:
+        with docker(pool) as docker_config:
             yield docker_config
-        finally:
-            docker_config = call('docker.update', {'pool': None}, job=True)
-            assert docker_config['pool'] is None, docker_config
 
 
 def test_create_catalog_app(docker_pool):

--- a/tests/api2/test_docker_setup.py
+++ b/tests/api2/test_docker_setup.py
@@ -1,5 +1,6 @@
 import pytest
 
+from middlewared.test.integration.assets.docker import docker
 from middlewared.test.integration.assets.pool import another_pool
 from middlewared.test.integration.utils import call
 from middlewared.test.integration.utils.docker import dataset_props, IX_APPS_MOUNT_PATH
@@ -8,17 +9,11 @@ from middlewared.test.integration.utils.docker import dataset_props, IX_APPS_MOU
 @pytest.fixture(scope='module')
 def docker_pool():
     with another_pool() as pool:
-        yield pool['name']
+        with docker(pool) as docker_config:
+            yield docker_config
 
 
-@pytest.mark.dependency(name='docker_setup')
-def test_docker_setup(docker_pool):
-    docker_config = call('docker.update', {'pool': docker_pool}, job=True)
-    assert docker_config['pool'] == docker_pool, docker_config
-
-
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_docker_datasets_properties():
+def test_docker_datasets_properties(docker_pool):
     docker_config = call('docker.config')
     datasets = {
         ds['name']: ds['properties'] for ds in call('zfs.dataset.query', [['id', '^', docker_config['dataset']]])
@@ -32,42 +27,29 @@ def test_docker_datasets_properties():
         assert invalid_props == {}, f'{ds_name} has invalid properties: {invalid_props}'
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_correct_docker_dataset_is_mounted():
+def test_correct_docker_dataset_is_mounted(docker_pool):
     docker_config = call('docker.config')
     assert call('filesystem.statfs', IX_APPS_MOUNT_PATH)['source'] == docker_config['dataset']
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_catalog_synced_properly():
+def test_catalog_synced_properly(docker_pool):
     assert call('catalog.synced') is True
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_catalog_sync_location():
+def test_catalog_sync_location(docker_pool):
     assert call('catalog.config')['location'] == '/mnt/.ix-apps/truenas_catalog'
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_apps_being_reported():
+def test_apps_being_reported(docker_pool):
     assert call('app.available', [], {'count': True}) != 0
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_apps_are_running():
+def test_apps_are_running(docker_pool):
     assert call('docker.status')['status'] == 'RUNNING'
 
 
-@pytest.mark.dependency(depends=['docker_setup'])
-def test_apps_dataset_after_address_pool_update():
+def test_apps_dataset_after_address_pool_update(docker_pool):
     docker_config = call('docker.update', {'address_pools': [{'base': '172.17.0.0/12', 'size': 27}]}, job=True)
     assert docker_config['address_pools'] == [{'base': '172.17.0.0/12', 'size': 27}]
     assert call('filesystem.statfs', IX_APPS_MOUNT_PATH)['source'] == docker_config['dataset']
     assert call('docker.status')['status'] == 'RUNNING'
-
-
-def test_unset_docker_pool(docker_pool):
-    docker_config = call(
-        'docker.update', {'pool': None, 'address_pools': [{'base': '172.17.0.0/12', 'size': 24}]}, job=True
-    )
-    assert docker_config['pool'] is None, docker_config


### PR DESCRIPTION
This PR fixes an issue in FT where we are differently handling applications dataset being mounted/umounted - which in it's current state resulted in the apps dataset to be mounted even if root dataset was locked (as apps dataset is un-encrypted). While i am here, i have also fixed docker integration test to properly make use of fixture and added integration test to handle the encryption case as well.