### PR TITLE
Convert `alertclasses.update` to new api style

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/alert.py
+++ b/src/middlewared/middlewared/api/v25_04_0/alert.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from pydantic import Field
 
-from middlewared.api.base import BaseModel, LongString
+from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LongString
 
 
 __all__ = [
@@ -45,12 +45,13 @@ class AlertCategory(BaseModel):
     classes: list[AlertCategoryClass]
 
 
-class AlertClassesUpdate(BaseModel):
-    classes: dict = {}
-
-
-class AlertClassesEntry(AlertClassesUpdate):
+class AlertClassesEntry(BaseModel):
     id: int
+    classes: dict
+
+
+class AlertClassesUpdate(AlertClassesEntry, metaclass=ForUpdateMetaclass):
+    id: Excluded = excluded_field()
 
 
 class AlertDismissArgs(BaseModel):
@@ -113,7 +114,7 @@ class AlertRestoreResult(BaseModel):
 
 
 class AlertClassesUpdateArgs(BaseModel):
-    alertclasses_update: AlertClassesUpdate = Field(default=AlertClassesUpdate())
+    data: AlertClassesUpdate
 
 
 class AlertClassesUpdateResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -33,9 +33,9 @@ from middlewared.api.current import (
     AlertDismissArgs, AlertDismissResult, AlertListArgs, AlertListResult, AlertListCategoriesArgs,
     AlertListCategoriesResult, AlertListPoliciesArgs, AlertListPoliciesResult, AlertRestoreArgs, AlertRestoreResult,
     AlertOneshotCreateArgs, AlertOneshotCreateResult, AlertOneshotDeleteArgs, AlertOneshotDeleteResult,
-    AlertServiceCreateArgs, AlertServiceCreateResult, AlertServiceUpdateArgs, AlertServiceUpdateResult,
-    AlertServiceDeleteArgs, AlertServiceDeleteResult, AlertServiceTestArgs, AlertServiceTestResult,
-    AlertServiceEntry,
+    AlertClassesEntry, AlertClassesUpdateArgs, AlertClassesUpdateResult, AlertServiceCreateArgs,
+    AlertServiceCreateResult, AlertServiceUpdateArgs, AlertServiceUpdateResult, AlertServiceDeleteArgs,
+    AlertServiceDeleteResult, AlertServiceTestArgs, AlertServiceTestResult, AlertServiceEntry,
 )
 from middlewared.schema import Bool, Dict, Int, Str
 from middlewared.service import (
@@ -1169,13 +1169,9 @@ class AlertClassesService(ConfigService):
     class Config:
         datastore = "system.alertclasses"
         cli_namespace = "system.alert.class"
-    
-    ENTRY = Dict(
-        "alertclasses_entry",
-        Int("id"),
-        Dict("classes", additional_attrs=True),
-    )
+        entry = AlertClassesEntry
 
+    @api_method(AlertClassesUpdateArgs, AlertClassesUpdateResult)
     async def do_update(self, data):
         """
         Update default Alert settings.


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/14615 incorrectly set the args and result models for `alertclasses.update`. After some experimentation, it seems like there is no way to perfectly match the current schema for "accepts" and "returns" without doing some ugly things with pydantic that don't fit nicely into how we have been implementing the new API style. This PR changes the schema for `alertclasses.update` without breaking the endpoint and preserves the syntax we have been using for the new API style.

<details>
<summary>Current schema</summary>

```json
    "accepts": [
      {
        "type": "object",
        "properties": {
          "classes": {
            "type": "object",
            "properties": {},
            "additionalProperties": true,
            "_name_": "classes",
            "title": "classes",
            "default": {},
            "_required_": false,
            "_attrs_order_": []
          }
        },
        "additionalProperties": false,
        "_name_": "alertclasses_update",
        "title": "alertclasses_update",
        "default": {},
        "_required_": false,
        "_attrs_order_": [
          "classes"
        ]
      }
    ],
    "returns": [
      {
        "type": "object",
        "properties": {
          "id": {
            "type": "integer",
            "_name_": "id",
            "title": "id",
            "_required_": false
          },
          "classes": {
            "type": "object",
            "properties": {},
            "additionalProperties": true,
            "_name_": "classes",
            "title": "classes",
            "default": {},
            "_required_": false,
            "_attrs_order_": []
          }
        },
        "additionalProperties": false,
        "_name_": "alertclasses_update_returns",
        "title": "alertclasses_update_returns",
        "default": {},
        "_required_": false,
        "_attrs_order_": [
          "id",
          "classes"
        ]
      }
    ]
```

</details>
<details>
<summary>New schema this PR produces</summary>

```json
    "accepts": [
      {
        "additionalProperties": false,
        "properties": {
          "classes": {
            "title": "classes",
            "type": "object",
            "_name_": "classes",
            "_required_": false
          }
        },
        "title": "data",
        "type": "object",
        "_name_": "data",
        "_required_": true,
        "_attrs_order_": [
          "classes"
        ]
      }
    ],
    "returns": [
      {
        "additionalProperties": false,
        "properties": {
          "id": {
            "title": "id",
            "type": "integer",
            "_name_": "id",
            "_required_": true
          },
          "classes": {
            "title": "classes",
            "type": "object",
            "_name_": "classes",
            "_required_": true
          }
        },
        "required": [
          "id",
          "classes"
        ],
        "title": "result",
        "type": "object",
        "_name_": "result",
        "_required_": true,
        "_attrs_order_": [
          "id",
          "classes"
        ]
      }
    ]
```

</details>