### PR TITLE
NAS-131832 / 24.10.1 / Better validate VM NIC mac address (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -104,3 +104,7 @@ class NIC(Device):
                 'attributes.trust_guest_rx_filters',
                 'This can only be set when "type" of NIC device is "VIRTIO"'
             )
+
+        mac_address = device['attributes'].get('mac')
+        if mac_address and mac_address.lower().startswith('ff'):
+            verrors.add('attributes.mac', 'MAC address must not start with `ff`')

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_validation.py
@@ -1,0 +1,83 @@
+import pytest
+
+from middlewared.plugins.vm.devices import NIC
+from middlewared.pytest.unit.middleware import Middleware
+
+from middlewared.service_exception import ValidationErrors
+
+
+AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
+
+
+@pytest.mark.parametrize('device_data,expected_error', [
+    (
+        {
+            'attributes': {
+                'type': 'VIRTIO',
+                'mac': '00:a0:99:7e:bb:8a',
+                'nic_attach': 'br0',
+                'trust_guest_rx_filters': False
+            },
+            'dtype': 'NIC',
+        },
+        ''
+    ),
+    (
+        {
+            'attributes': {
+                'type': 'VIRTIO',
+                'mac': '00:a0:99:7e:bb:8a',
+                'nic_attach': 'br2',
+                'trust_guest_rx_filters': False
+            },
+            'dtype': 'NIC',
+        },
+        '[EINVAL] attributes.nic_attach: Not a valid choice.'
+    ),
+    (
+        {
+            'attributes': {
+                'type': 'VIRTIO',
+                'mac': 'ff:a0:99:7e:bb:8a',
+                'nic_attach': 'br0',
+                'trust_guest_rx_filters': False
+            },
+            'dtype': 'NIC',
+        },
+        '[EINVAL] attributes.mac: MAC address must not start with `ff`'
+    ),
+    (
+        {
+            'attributes': {
+                'type': 'VIRTIO',
+                'mac': 'ff:a0:99:7e:bb:8a',
+                'nic_attach': 'br0',
+                'trust_guest_rx_filters': True
+            },
+            'dtype': 'NIC',
+        },
+        '[EINVAL] attributes.trust_guest_rx_filters: This can only be set when "nic_attach" is not a bridge device'
+    ),
+    (
+        {
+            'attributes': {
+                'type': 'E1000',
+                'mac': 'ff:a0:99:7e:bb:8a',
+                'nic_attach': 'eth0',
+                'trust_guest_rx_filters': True
+            },
+            'dtype': 'NIC',
+        },
+        '[EINVAL] attributes.trust_guest_rx_filters: This can only be set when "type" of NIC device is "VIRTIO"'
+    ),
+])
+def test_nic_device_validation(device_data, expected_error):
+    m = Middleware()
+    m['vm.device.nic_attach_choices'] = lambda *arg: AVAILABLE_NIC_INTERFACES
+    if expected_error:
+        with pytest.raises(ValidationErrors) as ve:
+            NIC(device_data, m).validate(device_data)
+
+        assert str(ve.value.errors[0]) == expected_error
+    else:
+        assert NIC(device_data, m).validate(device_data) is None


### PR DESCRIPTION
## Problem
Libvirt does not allow NIC MAC addresses to start with `ff`, which causes VMs to break until a reboot is performed.

## Solution
Add validation to the NIC configuration to prevent MAC addresses from starting with `ff` for VMs.

Original PR: https://github.com/truenas/middleware/pull/14778
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131832