### PR TITLE
Rename rdma.capable_services to rdma.capable_protocols.

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -4,7 +4,7 @@ from typing import Literal
 __all__ = [
     "RdmaLinkConfigArgs", "RdmaLinkConfigResult",
     "RdmaCardConfigArgs", "RdmaCardConfigResult",
-    "RdmaCapableServicesArgs", "RdmaCapableServicesResult"
+    "RdmaCapableProtocolsArgs", "RdmaCapableProtocolsResult"
 ]
 
 
@@ -33,9 +33,9 @@ class RdmaCardConfigResult(BaseModel):
     links: list[RdmaLinkConfig]
 
 
-class RdmaCapableServicesArgs(BaseModel):
+class RdmaCapableProtocolsArgs(BaseModel):
     pass
 
 
-class RdmaCapableServicesResult(BaseModel):
+class RdmaCapableProtocolsResult(BaseModel):
     result: list[Literal["NFS"]]

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -417,8 +417,8 @@ class NFSService(SystemServiceService):
             verrors.add("nfs_update.v4_domain", "This option does not apply to NFSv3")
 
         if new["rdma"]:
-            available_rdma_services = await self.middleware.call('rdma.capable_services')
-            if "NFS" not in available_rdma_services:
+            available_rdma_protocols = await self.middleware.call('rdma.capable_protocols')
+            if 'NFS' not in available_rdma_protocols:
                 verrors.add(
                     "nfs_update.rdma",
                     "This platform cannot support NFS over RDMA or is missing an RDMA capable NIC."

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -7,7 +7,7 @@ from middlewared.api import api_method
 from middlewared.api.current import (
     RdmaLinkConfigArgs, RdmaLinkConfigResult,
     RdmaCardConfigArgs, RdmaCardConfigResult,
-    RdmaCapableServicesArgs, RdmaCapableServicesResult
+    RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult
 )
 from middlewared.service import Service, private
 from middlewared.service_exception import CallError
@@ -126,8 +126,8 @@ class RDMAService(Service):
             v['name'] = ':'.join(sorted(names))
         return list(grouper.values())
 
-    @api_method(RdmaCapableServicesArgs, RdmaCapableServicesResult)
-    async def capable_services(self):
+    @api_method(RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult)
+    async def capable_protocols(self):
         result = []
         is_ent = await self.middleware.call('system.is_enterprise')
         if is_ent and 'MINI' not in await self.middleware.call('truenas.get_chassis_hardware'):


### PR DESCRIPTION
The name for method `rdma.capable_services` is misleading in that what is returned is not related to `services`.  The return lists the supported 'protocols'.  Currently, this is only 'NFS'.

Changed the name of the method to `rdma.capable_protocols`.  The returns are unchanged.

Added a CI test.