### PR TITLE
NAS-131785 / 25.04 / Make sure serial is specified for all VM disk devices

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-10-29_12-43_vm_zvol_serial.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-10-29_12-43_vm_zvol_serial.py
@@ -1,0 +1,48 @@
+"""
+Add serial to VM zvol disk devices
+
+Revision ID: a4ce4939b908
+Revises: dd6e581235b2
+Create Date: 2024-10-29 12:43:45.960915+00:00
+
+"""
+import json
+from secrets import choice
+from string import ascii_letters, digits, punctuation
+
+from alembic import op
+
+
+revision = 'a4ce4939b908'
+down_revision = 'dd6e581235b2'
+branch_labels = None
+depends_on = None
+
+
+def generate_string(string_size=8, punctuation_chars=False, extra_chars=None):
+    """
+    Generate a cryptographically secure random string of size `string_size`.
+    If `punctuation_chars` is True, then punctuation characters will be added to the string.
+    Otherwise, only ASCII (upper and lower) and digits (0-9) are used to generate the string.
+    """
+    initial_string = ascii_letters + digits
+    if punctuation_chars:
+        initial_string += punctuation
+    if extra_chars is not None and isinstance(extra_chars, str):
+        initial_string += extra_chars
+
+    # remove any duplicates since extra_chars is user-provided
+    initial_string = ''.join(set(initial_string))
+    return ''.join(choice(initial_string) for i in range(string_size))
+
+
+def upgrade():
+    conn = op.get_bind()
+    for device in conn.execute("SELECT * FROM vm_device WHERE dtype IN ('DISK', 'RAW')").fetchall():
+        attributes = json.loads(device['attributes'])
+        attributes['serial'] = generate_string(string_size=8)
+        conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (json.dumps(attributes), device['id']))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -125,10 +125,11 @@ def test_nic_xml(vm_data, expected_xml):
             'logical_sectorsize': None,
             'physical_sectorsize': None,
             'iotype': 'THREADS',
+            'serial': 'test-serial'
         },
         'dtype': 'DISK',
     }]}, '<devices><disk type="block" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
-         '<source dev="/dev/zvol/pool/boot_1" /><target bus="sata" dev="sda" /><boot order="1" />'
+         '<source dev="/dev/zvol/pool/boot_1" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
 ])
@@ -149,10 +150,11 @@ def test_disk_xml(vm_data, expected_xml):
             'logical_sectorsize': None,
             'physical_sectorsize': None,
             'iotype': 'THREADS',
+            'serial': 'test-serial'
         },
         'dtype': 'RAW',
     }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
-         '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><boot order="1" />'
+         '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),
     ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
@@ -162,10 +164,11 @@ def test_disk_xml(vm_data, expected_xml):
             'logical_sectorsize': 512,
             'physical_sectorsize': 512,
             'iotype': 'THREADS',
+            'serial': 'test-serial'
         },
         'dtype': 'RAW',
     }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
-         '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><boot order="1" />'
+         '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          '<blockio logical_block_size="512" physical_block_size="512" /></disk>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
     ),


### PR DESCRIPTION
## Problem

When disk devices are created in VMs, they don't have a serial present. Some types of disks may have an autogenerated one from libvirt but then we can potentially get persistence issues wrt serials and for some types, libvirt doesn't even add auto-generated ones.

## Solution

Generate a random serial number and assign it to VM disks making sure the serial persists across the device lifecycle.