### PR TITLE
Remove filesystem.acl_is_trivial endpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -205,7 +205,7 @@ class FilesystemService(Service):
             'type': 'DIRECTORY',
             'size': stat.st_size,
             'mode': stat.st_mode,
-            'acl': False if self.acl_is_trivial(path) else True,
+            'acl': acl_is_present(os.listxattr(path)),
             'uid': stat.st_uid,
             'gid': stat.st_gid,
             'is_mountpoint': False,
@@ -477,7 +477,7 @@ class FilesystemService(Service):
         except KeyError:
             stat['group'] = None
 
-        stat['acl'] = False if self.acl_is_trivial(_path) else True
+        stat['acl'] = acl_is_present(os.listxattr(path))
 
         return stat
 
@@ -640,18 +640,6 @@ class FilesystemService(Service):
         for k in ['total_blocks', 'free_blocks', 'avail_blocks', 'total_bytes', 'free_bytes', 'avail_bytes']:
             result[f'{k}_str'] = str(result[k])
         return result
-
-    @accepts(Str('path'), roles=['FILESYSTEM_ATTRS_READ'])
-    @returns(Bool('paths_acl_is_trivial'))
-    def acl_is_trivial(self, path):
-        """
-        Returns True if the ACL can be fully expressed as a file mode without losing
-        any access rules.
-        """
-        if not os.path.exists(path):
-            raise CallError(f'Path not found [{path}].', errno.ENOENT)
-
-        return not acl_is_present(os.listxattr(path))
 
 
 class FileFollowTailEventSource(EventSource):

--- a/src/middlewared/middlewared/plugins/smb_/disable_acl_if_trivial.py
+++ b/src/middlewared/middlewared/plugins/smb_/disable_acl_if_trivial.py
@@ -22,7 +22,7 @@ class SMBService(Service):
                 continue
 
             try:
-                acl_is_trivial = await self.middleware.call("filesystem.acl_is_trivial", share["path"])
+                acl_is_trivial = not (await self.middleware.call("filesystem.stat", share["path"]))["acl"]
             except Exception:
                 self.middleware.logger.warning("Error running filesystem.acl_is_trivial for share %r", share["id"],
                                                exc_info=True)


### PR DESCRIPTION
This filesystem API endpoint was originally written for TrueNAS 11.3 when we first added a UI-based ACL editor. Since this time, better methods of presenting whether an ACL was present on filesystem were developed. For example, this information is returned in filesystem.stat output.