### PR TITLE
NAS-132001 / 24.10.1 / Fix `__job_by_credential_and_id` crashing for non-full-admins and internally ran jobs (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -156,7 +156,7 @@ class CoreService(Service):
 
         if job.credentials is None:
             raise CallError(
-                'Only users with full administrative privileges can download internal job logs', errno.EPERM,
+                'Only users with full administrative privileges can access internally ran jobs', errno.EPERM,
             )
 
         if job.credentials.user['username'] == credential.user['username']:

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -154,6 +154,11 @@ class CoreService(Service):
 
         job = self.middleware.jobs[job_id]
 
+        if job.credentials is None:
+            raise CallError(
+                'Only users with full administrative privileges can download internal job logs', errno.EPERM,
+            )
+
         if job.credentials.user['username'] == credential.user['username']:
             return job
 

--- a/tests/api2/test_job_logs.py
+++ b/tests/api2/test_job_logs.py
@@ -1,10 +1,20 @@
+import errno
+
+import pytest
 import requests
 
+from middlewared.service_exception import CallError
 from middlewared.test.integration.assets.account import unprivileged_user_client
-from middlewared.test.integration.utils import mock, url
+from middlewared.test.integration.utils import call, mock, url
 
 
-def test_job_download_logs():
+@pytest.fixture(scope="module")
+def c():
+    with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
+        yield c
+
+
+def test_job_download_logs(c):
     with mock("test.test1", """    
         from middlewared.service import job
 
@@ -12,16 +22,37 @@ def test_job_download_logs():
         def mock(self, job, *args):
             job.logs_fd.write(b'Job logs')
     """):
-        with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
-            jid = c.call("test.test1")
+        jid = c.call("test.test1")
 
-            c.call("core.job_wait", jid, job=True)
+        c.call("core.job_wait", jid, job=True)
 
-            path = c.call("core.job_download_logs", jid, 'logs.txt')
+        path = c.call("core.job_download_logs", jid, 'logs.txt')
 
-            r = requests.get(f"{url()}{path}")
-            r.raise_for_status()
+        r = requests.get(f"{url()}{path}")
+        r.raise_for_status()
 
-            assert r.headers["Content-Disposition"] == "attachment; filename=\"logs.txt\""
-            assert r.headers["Content-Type"] == "application/octet-stream"
-            assert r.text == "Job logs"
+        assert r.headers["Content-Disposition"] == "attachment; filename=\"logs.txt\""
+        assert r.headers["Content-Type"] == "application/octet-stream"
+        assert r.text == "Job logs"
+
+
+def test_job_download_logs_unprivileged_downloads_internal_logs(c):
+    with mock("test.test1", """
+        def mock(self, *args):
+            job = self.middleware.call_sync("test.test2")
+            job.wait_sync(raise_error=True)
+            return job.id
+    """):
+        with mock("test.test2", """
+            from middlewared.service import job
+
+            @job(logs=True)
+            def mock(self, job, *args):
+                job.logs_fd.write(b'Job logs')
+        """):
+            jid = call("test.test1")
+
+            with pytest.raises(CallError) as ve:
+                c.call("core.job_download_logs", jid, 'logs.txt')
+
+            assert ve.value.errno == errno.EPERM


### PR DESCRIPTION
@yocalebo please note that this only fixes half of the real issue. I created a new ticket for you to review and determine fix version https://ixsystems.atlassian.net/browse/NAS-132031

Original PR: https://github.com/truenas/middleware/pull/14790
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132001