### PR TITLE
NAS-132069 / 25.04 / Convert remaining auth plugin to api_method

### DIFF
--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -182,6 +182,7 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
     def dump(self):
         data = {
             "parent": dump_credentials(self.token.parent_credentials),
+            "username": None
         }
         if self.is_user_session:
             data["username"] = self.user["username"]
@@ -189,7 +190,7 @@ class TokenSessionManagerCredentials(SessionManagerCredentials):
         return data
 
 
-class TrueNasNodeSessionManagerCredentials(SessionManagerCredentials):
+class TruenasNodeSessionManagerCredentials(SessionManagerCredentials):
     def authorize(self, method, resource):
         return True
 

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -215,7 +215,7 @@ class AuthService(Service):
         super(AuthService, self).__init__(*args, **kwargs)
         self.session_manager.middleware = self.middleware
 
-    @filterable_api_method(item=AuthSessionEntry, private=False, roles=['AUTH_SESSIONS_READ'])
+    @filterable_api_method(item=AuthSessionEntry, roles=['AUTH_SESSIONS_READ'])
     @pass_app()
     def sessions(self, app, filters, options):
         """

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -10,7 +10,7 @@ import stat
 import time
 from functools import partial
 
-from middlewared.auth import TrueNasNodeSessionManagerCredentials
+from middlewared.auth import TruenasNodeSessionManagerCredentials
 from middlewared.schema import accepts, Bool, Dict, Int, List, NOT_PROVIDED, Str, returns, Patch
 from middlewared.service import (
     job, no_auth_required, no_authz_required, pass_app, private, CallError, ConfigService,
@@ -1028,7 +1028,7 @@ class FailoverService(ConfigService):
 async def ha_permission(middleware, app):
     try:
         if not app.authenticated and app.origin.is_ha_connection:
-            await AuthService.session_manager.login(app, TrueNasNodeSessionManagerCredentials())
+            await AuthService.session_manager.login(app, TruenasNodeSessionManagerCredentials())
     except AttributeError:
         pass
 

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -172,7 +172,7 @@ class NTPServerService(CRUDService):
         except Exception:
             return False
 
-    @filterable_api_method(item=NTPPeerEntry, roles=['READONLY_ADMIN'])
+    @filterable_api_method(item=NTPPeerEntry, roles=['READONLY_ADMIN'], private=True)
     def peers(self, filters, options):
         peers = []
 

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -20,7 +20,7 @@ class SMBService(Service):
         service = 'cifs'
         service_verb = 'restart'
 
-    @filterable_api_method
+    @filterable_api_method(private=True)
     def passdb_list(self, filters, options):
         """ query existing passdb users """
         try:

--- a/src/middlewared/middlewared/pytest/unit/utils/test_audit.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_audit.py
@@ -2,7 +2,7 @@ import pytest
 
 from middlewared.auth import (
     UserSessionManagerCredentials,
-    TrueNasNodeSessionManagerCredentials
+    TruenasNodeSessionManagerCredentials
 )
 
 from middlewared.utils.audit import audit_username_from_session
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 USER_SESSION = UserSessionManagerCredentials({'username': 'bob', 'privilege': {'allowlist': []}}, AA_LEVEL1)
 TOKEN_USER_SESSION = SimpleNamespace(root_credentials=USER_SESSION, is_user_session=True, user=USER_SESSION.user)
-NODE_SESSION = TrueNasNodeSessionManagerCredentials()
+NODE_SESSION = TruenasNodeSessionManagerCredentials()
 
 
 @pytest.mark.parametrize('cred,expected', [

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -51,7 +51,7 @@ def filterable_returns(schema):
     return filterable_internal
 
 
-def filterable_api_method(fn=None, /, *, roles=None, item=None, private=True):
+def filterable_api_method(fn=None, /, *, roles=None, item=None, private=False):
     def filterable_internal(fn):
         fn._filterable = True
         if hasattr(fn, 'wraps'):

--- a/src/middlewared/middlewared/test/integration/assets/keychain.py
+++ b/src/middlewared/middlewared/test/integration/assets/keychain.py
@@ -28,7 +28,7 @@ def localhost_ssh_credentials(**data):
         credentials = call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": str(uuid.uuid4()),
             "url": url,
-            "token": call("auth.generate_token"),
+            "token": call("auth.generate_token", 600, {}, False),
             "private_key": keypair["id"],
             **data,
         })

--- a/src/middlewared/middlewared/utils/audit.py
+++ b/src/middlewared/middlewared/utils/audit.py
@@ -1,6 +1,6 @@
 from middlewared.auth import (
     TokenSessionManagerCredentials,
-    TrueNasNodeSessionManagerCredentials
+    TruenasNodeSessionManagerCredentials
 )
 
 # Special values start with dot to ensure they cannot collide with local usernames
@@ -23,7 +23,7 @@ def audit_username_from_session(cred) -> str:
     if isinstance(cred, TokenSessionManagerCredentials):
         cred = cred.root_credentials
 
-    elif isinstance(cred, TrueNasNodeSessionManagerCredentials):
+    elif isinstance(cred, TruenasNodeSessionManagerCredentials):
         return NODE_SESSION
 
     return UNKNOWN_SESSION

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -1,5 +1,5 @@
 import enum
-from middlewared.auth import TrueNasNodeSessionManagerCredentials
+from middlewared.auth import TruenasNodeSessionManagerCredentials
 from middlewared.role import ROLES
 
 
@@ -28,7 +28,7 @@ def credential_has_full_admin(credential: object) -> bool:
     if credential.is_user_session and 'FULL_ADMIN' in credential.user['privilege']['roles']:
         return True
 
-    if isinstance(credential, TrueNasNodeSessionManagerCredentials):
+    if isinstance(credential, TruenasNodeSessionManagerCredentials):
         return True
 
     if credential.allowlist is None:

--- a/tests/api2/test_auth_token.py
+++ b/tests/api2/test_auth_token.py
@@ -73,7 +73,7 @@ def test_login_with_token_match_origin(unprivileged_user):
 
 def test_login_with_token_no_match_origin(unprivileged_user):
     token = ssh(
-        "sudo -u test midclt -u ws://localhost/api/current -U test -P test1234 call auth.generate_token 300"
+        "sudo -u test midclt -u ws://localhost/api/current -U test -P test1234 call auth.generate_token 300 '{}' false"
     ).strip()
 
     with client(auth=None) as c:

--- a/tests/api2/test_keychain_ssh.py
+++ b/tests/api2/test_keychain_ssh.py
@@ -27,7 +27,7 @@ def test_remote_ssh_semiautomatic_setup_invalid_homedir(credential):
         "home_create": False,
         "password": "test1234",
     }):
-        token = call("auth.generate_token")
+        token = call("auth.generate_token", 600, {}, False)
         with pytest.raises(CallError) as ve:
             call("keychaincredential.remote_ssh_semiautomatic_setup", {
                 "name": "localhost",
@@ -51,7 +51,7 @@ def test_remote_ssh_semiautomatic_setup_sets_user_attributes(credential):
             "smb": False,
             "shell": "/usr/sbin/nologin",
         }):
-            token = call("auth.generate_token")
+            token = call("auth.generate_token", 600, {}, False)
             connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
                 "name": "localhost",
                 "url": "http://localhost",
@@ -66,7 +66,7 @@ def test_remote_ssh_semiautomatic_setup_sets_user_attributes(credential):
 
 
 def test_ssl_certificate_error(credential):
-    token = call("auth.generate_token")
+    token = call("auth.generate_token", 600, {}, False)
     with pytest.raises(CallError) as ve:
         call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": "localhost",
@@ -80,7 +80,7 @@ def test_ssl_certificate_error(credential):
 
 
 def test_ignore_ssl_certificate_error(credential):
-    token = call("auth.generate_token")
+    token = call("auth.generate_token", 600, {}, False)
     connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
         "name": "localhost",
         "url": "https://localhost",

--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -11,7 +11,7 @@ def localhost_ssh_connection():
         "attributes": call("keychaincredential.generate_ssh_key_pair"),
     })
     try:
-        token = call("auth.generate_token")
+        token = call("auth.generate_token", 600, {}, False)
         connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": "localhost",
             "url": "http://localhost",


### PR DESCRIPTION
This is mostly boiler-plate code with exception of the following:

1. default for match_origin in auth.generate_token to True as a general improvement to product security.

2. TrueNasNodeSessionManagerCredentials class was renamed to TruenasNodeSessionManagerCredentials to ensure that generated credentials class name is TRUENAS_NODE rather than TRUE_NAS_NODE.

3. auth.generate_token was changed from not_auth_required with separate internal check for session being authenticated to no_authz_required.

4. api_method is extended to support no_authz_required and no_auth_required kwargs.