### PR TITLE
NAS-132067 / 25.04 / fix ES24 enclosure detection

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -179,7 +179,7 @@ class Enclosure:
             case 'CELESTIC_X2012' | 'CELESTIC_X2012-MT':
                 self.model = JbodModels.ES12.value
                 self.controller = False
-            case 'ECStream_4024J' | 'iX_4024J':
+            case x if x.startswith(('ECStream_4024J', 'iX_4024J')):
                 self.model = JbodModels.ES24.value
                 self.controller = False
             case 'ECStream_2024Jp' | 'ECStream_2024Js' | 'iX_2024Jp' | 'iX_2024Js':


### PR DESCRIPTION
The original regex code for this platform is as follows: `re.compile(r"(ECStream|iX) 4024J")` which basically means contains those patterns. This was misinterpreted in the new enclosure plugin. The new enclosure plugin is more strict with its firmware string checks and looks for an exact match of those patterns. This is invalid because the ES24 firmware string (that's what these patterns are matching on) actually end with `s` or `p`. To resolve this we'll use `startswith` operation on the firmware string. After these changes, it was confirmed to fix ES24 enclosure detection.