### PR TITLE
NAS-131911 / 25.04 / Allow removing ix-volumes of apps which were migrated from k8s

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -191,11 +191,12 @@ class ZFSDatasetService(CRUDService):
     def do_delete(self, id_, options):
         force = options['force']
         recursive = options['recursive']
+        recursively_remove_dependents = options['recursively_remove_dependents']
 
         args = []
         if force:
             args += ['-f']
-        if options['recursively_remove_dependents']:
+        if recursively_remove_dependents:
             args += ['-R']
         elif recursive:
             args += ['-r']

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -185,6 +185,7 @@ class ZFSDatasetService(CRUDService):
             'options',
             Bool('force', default=False),
             Bool('recursive', default=False),
+            Bool('recursively_remove_dependents', default=False),
         )
     )
     def do_delete(self, id_, options):
@@ -194,7 +195,9 @@ class ZFSDatasetService(CRUDService):
         args = []
         if force:
             args += ['-f']
-        if recursive:
+        if options['recursively_remove_dependents']:
+            args += ['-R']
+        elif recursive:
             args += ['-r']
 
         # If dataset is mounted and has receive_resume_token, we should destroy it or ZFS will say


### PR DESCRIPTION
This PR adds changes to allow removing ix-volumes of apps which were migrated over from k8s. When we migrated apps from k8s and they had ix-volumes, what we did was that we created a clone and promoted the clone under the new ix-apps dataset. So in order to delete these ix-volumes, we want to properly make sure all dependents are removed.