### PR TITLE
NAS-132031 / 25.04 / Introduce job `read_roles` that will allow users to access jobs that …

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -15,7 +15,7 @@ import threading
 
 from middlewared.service_exception import CallError, ValidationError, ValidationErrors, adapt_exception
 from middlewared.pipe import Pipes
-from middlewared.utils.privilege import credential_is_limited_to_own_jobs
+from middlewared.utils.privilege import credential_is_limited_to_own_jobs, credential_has_full_admin
 from middlewared.utils.time_utils import utc_now
 
 
@@ -30,14 +30,8 @@ def send_job_event(middleware, event_type, job, fields):
 
 
 def should_send_job_event(job, wsclient):
-    if wsclient.authenticated_credentials and credential_is_limited_to_own_jobs(wsclient.authenticated_credentials):
-        if job.credentials is None:
-            return False
-
-        if not job.credentials.is_user_session:
-            return False
-
-        return job.credentials.user['username'] == wsclient.authenticated_credentials.user['username']
+    if wsclient.authenticated_credentials:
+        return job.credential_can_access(wsclient.authenticated_credentials, JobAccess.READ)
 
     return True
 
@@ -83,6 +77,11 @@ class JobSharedLock:
         return self.lock.release()
 
 
+class JobAccess(enum.Enum):
+    READ = "READ"
+    ABORT = "ABORT"
+
+
 class JobsQueue:
     def __init__(self, middleware):
         self.middleware = middleware
@@ -107,13 +106,13 @@ class JobsQueue:
     def all(self) -> dict[int, "Job"]:
         return self.deque.all()
 
-    def for_username(self, username):
+    def for_credential(self, credential, access: JobAccess):
+        if not credential_is_limited_to_own_jobs(credential):
+            return self.all()
+
         out = {}
         for jid, job in self.all().items():
-            if job.credentials is None or not job.credentials.is_user_session:
-                continue
-
-            if job.credentials.user['username'] != username:
+            if not job.credential_can_access(credential, access):
                 continue
 
             out[jid] = job
@@ -218,7 +217,7 @@ class JobsQueue:
         await self.deque.receive(self.middleware, job, logs)
 
 
-class JobsDeque(object):
+class JobsDeque:
     """
     A jobs deque to do not keep more than `maxlen` in memory
     with a `id` assigner.
@@ -335,6 +334,28 @@ class Job:
             return None
 
         return self.app.authenticated_credentials
+
+    def credential_can_access(self, credential, access: JobAccess):
+        return self.credential_access_error(credential, access) is None
+
+    def credential_access_error(self, credential, access: JobAccess):
+        if not credential_is_limited_to_own_jobs(credential):
+            return
+
+        if access == JobAccess.READ:
+            if credential.is_user_session and any(credential.has_role(role) for role in self.options['read_roles']):
+                return
+
+        if not credential.is_user_session or credential_has_full_admin(credential):
+            return
+
+        if self.credentials is None or not self.credentials.is_user_session:
+            return 'Only users with full administrative privileges can access internally ran jobs'
+
+        if self.credentials.user['username'] == credential.user['username']:
+            return
+
+        return 'Job is not owned by current session'
 
     def check_pipe(self, pipe):
         """

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -1036,7 +1036,8 @@ class CloudSyncService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin):
         ),
         roles=["CLOUD_SYNC_WRITE"],
     )
-    @job(lock=lambda args: "cloud_sync:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True)
+    @job(lock=lambda args: "cloud_sync:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True,
+         read_roles=["CLOUD_SYNC_READ"])
     async def sync(self, job, id_, options):
         """
         Run the cloud_sync job `id`, syncing the local data to remote.

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -471,7 +471,7 @@ class ReplicationService(CRUDService):
         Bool("really_run", default=True, hidden=True),
         roles=["REPLICATION_TASK_WRITE"],
     )
-    @job(logs=True)
+    @job(logs=True, read_roles=["REPLICATION_TASK_READ"])
     async def run(self, job, id_, really_run):
         """
         Run Replication Task of `id`.

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -84,7 +84,7 @@ def item_method(fn):
 
 def job(
     lock=None, lock_queue_size=5, logs=False, process=False, pipes=None, check_pipes=True, transient=False,
-    description=None, abortable=False
+    description=None, abortable=False, read_roles: list[str] | None = None,
 ):
     """
     Flag method as a long-running job. This must be the first decorator to be applied (meaning that it must be specified
@@ -162,6 +162,12 @@ def job(
     :param abortable: If `True` then the job can be aborted in the task manager UI. When the job is aborted,
         `asyncio.CancelledError` is raised inside the job method (meaning that only asynchronous job methods can be
         aborted). By default, jobs are not abortable.
+
+    :param read_roles: A list of roles that will allow a non-full-admin user to see this job in `core.get_jobs`
+        and download its logs even if the job was launched by another user or by the system.
+
+        By default, non-full-admin users already can see their own jobs and download their logs, so this only should
+        be used when the job is launched externally (i.e., using crontab).
     """
     def check_job(fn):
         fn._job = {
@@ -174,6 +180,7 @@ def job(
             'transient': transient,
             'description': description,
             'abortable': abortable,
+            'read_roles': read_roles or [],
         }
         return fn
     return check_job

--- a/tests/api2/test_job_logs.py
+++ b/tests/api2/test_job_logs.py
@@ -10,7 +10,8 @@ from middlewared.test.integration.utils import call, mock, url
 
 @pytest.fixture(scope="module")
 def c():
-    with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
+    with unprivileged_user_client(roles=["REPLICATION_TASK_READ"],
+                                  allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
         yield c
 
 
@@ -26,7 +27,7 @@ def test_job_download_logs(c):
 
         c.call("core.job_wait", jid, job=True)
 
-        path = c.call("core.job_download_logs", jid, 'logs.txt')
+        path = c.call("core.job_download_logs", jid, "logs.txt")
 
         r = requests.get(f"{url()}{path}")
         r.raise_for_status()
@@ -53,6 +54,28 @@ def test_job_download_logs_unprivileged_downloads_internal_logs(c):
             jid = call("test.test1")
 
             with pytest.raises(CallError) as ve:
-                c.call("core.job_download_logs", jid, 'logs.txt')
+                c.call("core.job_download_logs", jid, "logs.txt")
 
             assert ve.value.errno == errno.EPERM
+
+
+def test_job_download_logs_unprivileged_downloads_internal_logs_with_read_role(c):
+    with mock("test.test1", """
+        from middlewared.service import job
+
+        @job(logs=True, read_roles=["REPLICATION_TASK_READ"])
+        def mock(self, job, *args):
+            job.logs_fd.write(b'Job logs')
+    """):
+        jid = call("test.test1")
+
+        c.call("core.job_wait", jid, job=True)
+
+        path = c.call("core.job_download_logs", jid, "logs.txt")
+
+        r = requests.get(f"{url()}{path}")
+        r.raise_for_status()
+
+        assert r.headers["Content-Disposition"] == "attachment; filename=\"logs.txt\""
+        assert r.headers["Content-Type"] == "application/octet-stream"
+        assert r.text == "Job logs"


### PR DESCRIPTION
[NAS-132001: core.job_download_logs AttributeError crash](https://ixsystems.atlassian.net/browse/NAS-132001) occurred when a non-full-admin user attempted to download the logs of `replication.run`

This `replication.run` was called by an internal zettarepl scheduler and thus is an internally ran job. Non-full-admins can only download the logs of the jobs they started themselves.

Without this fix, an attempt of a non-full-admin user to download the logs of an automatically ran replication will show `Only users with full administrative privileges can download internal job logs`.

New `read_roles` parameter will allow certain users to view and download logs of certain jobs even if they were not launched by them. This will resolve this issue.