### PR TITLE
NAS-131804 / 24.10.1 / Show progress on cloud_backup.sync and restore (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -1,7 +1,10 @@
 import asyncio
 from dataclasses import dataclass
+from datetime import timedelta
+import json
 import subprocess
 
+from middlewared.job import JobProgressBuffer
 from middlewared.plugins.cloud.path import get_remote_path
 from middlewared.plugins.cloud.remotes import REMOTES
 from middlewared.service import CallError
@@ -21,14 +24,14 @@ def get_restic_config(cloud_backup):
 
     url, env = remote.get_restic_config(cloud_backup)
 
-    cmd = ["restic", "--no-cache", "-r", f"{remote.rclone_type}:{url}/{remote_path}"]
+    cmd = ["restic", "--no-cache", "--json", "-r", f"{remote.rclone_type}:{url}/{remote_path}"]
 
     env["RESTIC_PASSWORD"] = cloud_backup["password"]
 
     return ResticConfig(cmd, env)
 
 
-async def run_restic(job, cmd, env, stdin=None):
+async def run_restic(job, cmd, env, stdin=None, track_progress=False):
     job.middleware.logger.debug("Running %r", cmd)
     proc = await Popen(
         cmd,
@@ -37,24 +40,23 @@ async def run_restic(job, cmd, env, stdin=None):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
-    check_progress = asyncio.ensure_future(restic_check_progress(job, proc))
+    check_progress = asyncio.ensure_future(restic_check_progress(job, proc, track_progress))
     cancelled_error = None
     try:
+        await proc.wait()
+    except asyncio.CancelledError as e:
+        cancelled_error = e
         try:
-            await proc.wait()
-        except asyncio.CancelledError as e:
-            cancelled_error = e
-            try:
-                await job.middleware.call("service.terminate_process", proc.pid)
-            except CallError as e:
-                job.middleware.logger.warning(f"Error terminating restic on cloud backup abort: {e!r}")
+            await job.middleware.call("service.terminate_process", proc.pid)
+        except CallError as e:
+            job.middleware.logger.warning(f"Error terminating restic on cloud backup abort: {e!r}")
     finally:
         await asyncio.wait_for(check_progress, None)
 
     if cancelled_error is not None:
         raise cancelled_error
     if proc.returncode != 0:
-        message = "".join(job.internal_data.get("messages", []))
+        message = "\n".join(job.internal_data.get("messages", []))
         if message and proc.returncode != 1:
             if not message.endswith("\n"):
                 message += "\n"
@@ -62,16 +64,60 @@ async def run_restic(job, cmd, env, stdin=None):
         raise CallError(message)
 
 
-async def restic_check_progress(job, proc):
-    try:
-        while True:
-            read = (await proc.stdout.readline()).decode("utf-8", "ignore")
-            if read == "":
-                break
+async def restic_check_progress(job, proc, track_progress=False):
+    """Record progress of restic backup, restore, and forget commands.
 
-            await job.logs_fd_write(read.encode("utf-8", "ignore"))
+    `track_progress` cannot be set when running "restic forget".
 
-            job.internal_data.setdefault("messages", [])
-            job.internal_data["messages"] = job.internal_data["messages"][-4:] + [read]
-    finally:
-        pass
+    Relevant documentation: https://restic.readthedocs.io/en/stable/075_scripting.html#json-output
+
+    """
+    if not track_progress:
+        read = await proc.stdout.read()
+        await job.logs_fd_write(read)
+        return
+
+    # backup or restore
+    job.internal_data.setdefault("messages", [])
+    progress_buffer = JobProgressBuffer(job)
+    time_delta = ""
+    action = ""
+    while True:
+        read = (await proc.stdout.readline()).decode("utf-8", "ignore")
+        if read == "":
+            break
+
+        read = json.loads(read)
+        msg_type = read["message_type"]
+        if msg_type == "status":
+            if (remaining := read.get("seconds_remaining")) is not None:
+                time_delta = str(timedelta(seconds=remaining))
+
+            progress_buffer.set_progress(
+                read["percent_done"] * 100,
+                (f"{time_delta} remaining\n" if time_delta else "") + action
+            )
+            continue
+
+        await job.logs_fd_write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
+
+        match msg_type:
+            case "verbose_status":
+                action = " ".join([read[key] for key in ("item", "action") if key in read])
+                msg = action
+
+            case "summary":
+                continue
+
+            case "error":
+                action = read["error.message"]
+                msg = "".join([
+                    "Error",
+                    f" in {item}" if (item := read.get("item")) else "",
+                    f" while {during}" if (during := read.get("during")) else "",
+                    ": ",
+                    action
+                ])
+
+        job.internal_data["messages"] = job.internal_data["messages"][-4:] + [msg]
+        progress_buffer.set_progress(description=(f"{time_delta} remaining\n" if time_delta else "") + action)

--- a/src/middlewared/middlewared/plugins/cloud_backup/restore.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restore.py
@@ -48,4 +48,5 @@ class CloudBackupService(Service):
             job,
             restic_config.cmd + cmd,
             restic_config.env,
+            track_progress=True,
         )

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -65,7 +65,7 @@ async def restic(middleware, job, cloud_backup, dry_run):
 
         cmd = restic_config.cmd + ["--verbose", "backup"] + cmd
 
-        await run_restic(job, cmd, restic_config.env, stdin)
+        await run_restic(job, cmd, restic_config.env, stdin, track_progress=True)
     finally:
         if stdin:
             try:
@@ -131,6 +131,8 @@ class CloudBackupService(Service):
 
             if "id" in cloud_backup:
                 await self.middleware.call("alert.oneshot_delete", "CloudBackupTaskFailed", cloud_backup["id"])
+            
+            job.set_progress(description="Done")
         except Exception:
             if "id" in cloud_backup:
                 await self.middleware.call("alert.oneshot_create", "CloudBackupTaskFailed", {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4751f4dfa968b9ba42a4aef90153c6d98c53cbbc
    git cherry-pick -x 4f412bfd3779ca75f21f93b02ea27ba7d2cecbff
    git cherry-pick -x 228cd2c2bbc12b2aaa2ca66fc9eddce689c487a6
    git cherry-pick -x dc40c11aa7ed9344b00a6a58f7c948fd6f16472c
    git cherry-pick -x 0ed403a58f2f02e47424fd120269fab31188ae0d
    git cherry-pick -x 6b5d518c31826f754c0e1caa18a7cc657903f1c0
    git cherry-pick -x b47c435a28f42ce8eda91a7a3cec47af1eb352b9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 49990e396e018e81839c9661de9dd1e8dcc08bca

Our TrueCloud Backup Tasks use restic to back up local data. The procedure we use to capture restic's output does not capture progress updates. By setting the `--json` flag we can receive continual status updates as JSON objects while the command runs. This allows us to monitor things like the percentage of completion, time remaining, and the status of files being accessed (new/updated/removed etc.) on `cloud_backup.sync` and `cloud_backup.restore`.

Tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1571/

https://github.com/user-attachments/assets/c5cf870d-f4c8-49ad-9362-556047b1a9e5


Original PR: https://github.com/truenas/middleware/pull/14782
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131804