### PR TITLE
NAS-132106 / 25.04 / Fix missing return value for acltemplate extend method

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl_template.py
@@ -53,6 +53,8 @@ class ACLTemplateService(CRUDService):
         for ace in data['acl']:
             ace['who'] = None
 
+        return data
+
     @private
     async def validate_acl(self, data, schema, verrors, template_id):
         await self._ensure_unique(verrors, schema, 'name', data['name'], template_id)


### PR DESCRIPTION
This error crept in while addressing various reviews and causes all acltemplate entries to be returned as None in query results.