### PR TITLE
NAS-131911 / 24.10.1 / Allow removing ix-volumes of apps which were migrated from k8s (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -333,12 +333,19 @@ class AppService(CRUDService):
             'options',
             Bool('remove_images', default=True),
             Bool('remove_ix_volumes', default=False),
+            Bool('force_remove_ix_volumes', default=False),
         )
     )
     @job(lock=lambda args: f'app_delete_{args[0]}')
     def do_delete(self, job, app_name, options):
         """
         Delete `app_name` app.
+
+        `force_remove_ix_volumes` should be set when the ix-volumes were created by the system for apps which were
+        migrated from k8s to docker and the user wants to remove them. This is to prevent accidental deletion of
+        the original ix-volumes which were created in dragonfish and before for kubernetes based apps. When this
+        is set, it will result in the deletion of ix-volumes from both docker based apps and k8s based apps and should
+        be carefully set.
         """
         app_config = self.get_instance__sync(app_name)
         return self.delete_internal(job, app_name, app_config, options)
@@ -356,7 +363,11 @@ class AppService(CRUDService):
         job.set_progress(80, 'Cleaning up resources')
         shutil.rmtree(get_installed_app_path(app_name))
         if options['remove_ix_volumes'] and (apps_volume_ds := self.get_app_volume_ds(app_name)):
-            self.middleware.call_sync('zfs.dataset.delete', apps_volume_ds, {'recursive': True})
+            self.middleware.call_sync(
+                'zfs.dataset.delete', apps_volume_ds, {
+                    'recursively_remove_dependents' if options.get('force_remove_ix_volumes') else 'recursive': True,
+                }
+            )
 
         if options.get('send_event', True):
             self.middleware.send_event('app.query', 'REMOVED', id=app_name)

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -191,11 +191,12 @@ class ZFSDatasetService(CRUDService):
     def do_delete(self, id_, options):
         force = options['force']
         recursive = options['recursive']
+        recursively_remove_dependents = options['recursively_remove_dependents']
 
         args = []
         if force:
             args += ['-f']
-        if options['recursively_remove_dependents']:
+        if recursively_remove_dependents:
             args += ['-R']
         elif recursive:
             args += ['-r']

--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -185,6 +185,7 @@ class ZFSDatasetService(CRUDService):
             'options',
             Bool('force', default=False),
             Bool('recursive', default=False),
+            Bool('recursively_remove_dependents', default=False),
         )
     )
     def do_delete(self, id_, options):
@@ -194,7 +195,9 @@ class ZFSDatasetService(CRUDService):
         args = []
         if force:
             args += ['-f']
-        if recursive:
+        if options['recursively_remove_dependents']:
+            args += ['-R']
+        elif recursive:
             args += ['-r']
 
         # If dataset is mounted and has receive_resume_token, we should destroy it or ZFS will say


### PR DESCRIPTION
This PR adds changes to allow removing ix-volumes of apps which were migrated over from k8s. When we migrated apps from k8s and they had ix-volumes, what we did was that we created a clone and promoted the clone under the new ix-apps dataset. So in order to delete these ix-volumes, we want to properly make sure all dependents are removed.

Original PR: https://github.com/truenas/middleware/pull/14810
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131911