### PR TITLE
NAS-132031 / 24.10.1 / Introduce job `read_roles` that will allow users to access jobs that … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -1036,7 +1036,8 @@ class CloudSyncService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin):
         ),
         roles=["CLOUD_SYNC_WRITE"],
     )
-    @job(lock=lambda args: "cloud_sync:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True)
+    @job(lock=lambda args: "cloud_sync:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True,
+         read_roles=["CLOUD_SYNC_READ"])
     async def sync(self, job, id_, options):
         """
         Run the cloud_sync job `id`, syncing the local data to remote.

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -471,7 +471,7 @@ class ReplicationService(CRUDService):
         Bool("really_run", default=True, hidden=True),
         roles=["REPLICATION_TASK_WRITE"],
     )
-    @job(logs=True)
+    @job(logs=True, read_roles=["REPLICATION_TASK_READ"])
     async def run(self, job, id_, really_run):
         """
         Run Replication Task of `id`.

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -17,14 +17,13 @@ import middlewared.main
 
 from middlewared.api.base.jsonschema import get_json_schema
 from middlewared.common.environ import environ_update
-from middlewared.job import Job
+from middlewared.job import Job, JobAccess
 from middlewared.pipe import Pipes
 from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, returns, Str
 from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.settings import conf
 from middlewared.utils import BOOTREADY, filter_list, MIDDLEWARE_RUN_DIR
 from middlewared.utils.debug import get_frame_details, get_threads_stacks
-from middlewared.utils.privilege import credential_has_full_admin, credential_is_limited_to_own_jobs
 from middlewared.validators import IpAddress, Range
 
 from .compound_service import CompoundService
@@ -136,33 +135,22 @@ class CoreService(Service):
                 'frames': frames,
             }
 
-    def _job_by_app_and_id(self, app, job_id):
+    def _job_by_app_and_id(self, app, job_id, access):
         if app is None:
             try:
                 return self.middleware.jobs[job_id]
             except KeyError:
                 raise CallError('Job does not exist', errno.ENOENT)
         else:
-            return self.__job_by_credential_and_id(app.authenticated_credentials, job_id)
+            return self.__job_by_credential_and_id(app.authenticated_credentials, job_id, access)
 
-    def __job_by_credential_and_id(self, credential, job_id):
-        if not credential_is_limited_to_own_jobs(credential):
-            return self.middleware.jobs[job_id]
-
-        if not credential.is_user_session or credential_has_full_admin(credential):
-            return self.middleware.jobs[job_id]
-
+    def __job_by_credential_and_id(self, credential, job_id, access):
         job = self.middleware.jobs[job_id]
 
-        if job.credentials is None:
-            raise CallError(
-                'Only users with full administrative privileges can access internally ran jobs', errno.EPERM,
-            )
+        if (error := job.credential_access_error(credential, access)) is not None:
+            raise CallError(error, errno.EPERM)
 
-        if job.credentials.user['username'] == credential.user['username']:
-            return job
-
-        raise CallError(f'{job_id}: job is not owned by current session.', errno.EPERM)
+        return job
 
     @no_authz_required
     @filterable
@@ -225,9 +213,8 @@ class CoreService(Service):
 
         raw_result_default = False if app else True
 
-        if app and credential_is_limited_to_own_jobs(app.authenticated_credentials):
-            username = app.authenticated_credentials.user['username']
-            jobs = list(self.middleware.jobs.for_username(username).values())
+        if app:
+            jobs = list(self.middleware.jobs.for_credential(app.authenticated_credentials, JobAccess.READ).values())
         else:
             jobs = list(self.middleware.jobs.all().values())
 
@@ -247,7 +234,7 @@ class CoreService(Service):
         Please see `core.download` method documentation for explanation on `filename` and `buffered` arguments,
         and return value.
         """
-        job = self._job_by_app_and_id(app, id_)
+        job = self._job_by_app_and_id(app, id_, JobAccess.READ)
 
         if job.logs_path is None:
             raise CallError('This job has no logs')
@@ -258,7 +245,7 @@ class CoreService(Service):
     @accepts(Int('id'))
     @job()
     async def job_wait(self, job, id_):
-        target_job = self.__job_by_credential_and_id(job.credentials, id_)
+        target_job = self.__job_by_credential_and_id(job.credentials, id_, JobAccess.READ)
 
         return await job.wrap(target_job)
 
@@ -300,7 +287,7 @@ class CoreService(Service):
     @accepts(Int('id'))
     @pass_app(rest=True)
     def job_abort(self, app, id_):
-        job = self._job_by_app_and_id(app, id_)
+        job = self._job_by_app_and_id(app, id_, JobAccess.ABORT)
         return job.abort()
 
     def _should_list_service(self, name, service, target):

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -58,7 +58,7 @@ def item_method(fn):
 
 def job(
     lock=None, lock_queue_size=5, logs=False, process=False, pipes=None, check_pipes=True, transient=False,
-    description=None, abortable=False
+    description=None, abortable=False, read_roles: list[str] | None = None,
 ):
     """
     Flag method as a long-running job. This must be the first decorator to be applied (meaning that it must be specified
@@ -136,6 +136,12 @@ def job(
     :param abortable: If `True` then the job can be aborted in the task manager UI. When the job is aborted,
         `asyncio.CancelledError` is raised inside the job method (meaning that only asynchronous job methods can be
         aborted). By default, jobs are not abortable.
+
+    :param read_roles: A list of roles that will allow a non-full-admin user to see this job in `core.get_jobs`
+        and download its logs even if the job was launched by another user or by the system.
+
+        By default, non-full-admin users already can see their own jobs and download their logs, so this only should
+        be used when the job is launched externally (i.e., using crontab).
     """
     def check_job(fn):
         fn._job = {
@@ -148,6 +154,7 @@ def job(
             'transient': transient,
             'description': description,
             'abortable': abortable,
+            'read_roles': read_roles or [],
         }
         return fn
     return check_job

--- a/tests/api2/test_job_logs.py
+++ b/tests/api2/test_job_logs.py
@@ -10,7 +10,8 @@ from middlewared.test.integration.utils import call, mock, url
 
 @pytest.fixture(scope="module")
 def c():
-    with unprivileged_user_client(allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
+    with unprivileged_user_client(roles=["REPLICATION_TASK_READ"],
+                                  allowlist=[{"method": "CALL", "resource": "test.test1"}]) as c:
         yield c
 
 
@@ -26,7 +27,7 @@ def test_job_download_logs(c):
 
         c.call("core.job_wait", jid, job=True)
 
-        path = c.call("core.job_download_logs", jid, 'logs.txt')
+        path = c.call("core.job_download_logs", jid, "logs.txt")
 
         r = requests.get(f"{url()}{path}")
         r.raise_for_status()
@@ -53,6 +54,28 @@ def test_job_download_logs_unprivileged_downloads_internal_logs(c):
             jid = call("test.test1")
 
             with pytest.raises(CallError) as ve:
-                c.call("core.job_download_logs", jid, 'logs.txt')
+                c.call("core.job_download_logs", jid, "logs.txt")
 
             assert ve.value.errno == errno.EPERM
+
+
+def test_job_download_logs_unprivileged_downloads_internal_logs_with_read_role(c):
+    with mock("test.test1", """
+        from middlewared.service import job
+
+        @job(logs=True, read_roles=["REPLICATION_TASK_READ"])
+        def mock(self, job, *args):
+            job.logs_fd.write(b'Job logs')
+    """):
+        jid = call("test.test1")
+
+        c.call("core.job_wait", jid, job=True)
+
+        path = c.call("core.job_download_logs", jid, "logs.txt")
+
+        r = requests.get(f"{url()}{path}")
+        r.raise_for_status()
+
+        assert r.headers["Content-Disposition"] == "attachment; filename=\"logs.txt\""
+        assert r.headers["Content-Type"] == "application/octet-stream"
+        assert r.text == "Job logs"


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b2b54218fbc50bc5f6c1f8bb6e41e3994370aa56

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a2945013442c1744e15d621962cf7f5f55a97891

[NAS-132001: core.job_download_logs AttributeError crash](https://ixsystems.atlassian.net/browse/NAS-132001) occurred when a non-full-admin user attempted to download the logs of `replication.run`

This `replication.run` was called by an internal zettarepl scheduler and thus is an internally ran job. Non-full-admins can only download the logs of the jobs they started themselves.

Without this fix, an attempt of a non-full-admin user to download the logs of an automatically ran replication will show `Only users with full administrative privileges can download internal job logs`.

New `read_roles` parameter will allow certain users to view and download logs of certain jobs even if they were not launched by them. This will resolve this issue.

Original PR: https://github.com/truenas/middleware/pull/14814
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132031