### PR TITLE
NAS-132140 / 25.04 / Remove auth.two_factor_auth endpoint

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -22,10 +22,6 @@ class AuthLegacyUsernamePassword(BaseModel):
     password: Secret[str]
 
 
-class AuthLegacyTwoFactorArgs(AuthLegacyUsernamePassword):
-    pass
-
-
 class AuthLegacyPasswordLoginArgs(AuthLegacyUsernamePassword):
     otp_token: Secret[str | None] = None
 

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -9,7 +9,7 @@ from middlewared.api import api_method
 from middlewared.api.base.server.ws_handler.rpc import RpcWebSocketAppEvent
 from middlewared.api.current import (
     AuthLegacyPasswordLoginArgs, AuthLegacyApiKeyLoginArgs, AuthLegacyTokenLoginArgs,
-    AuthLegacyTwoFactorArgs, AuthLegacyResult,
+    AuthLegacyResult,
     AuthLoginExArgs, AuthLoginExContinueArgs, AuthLoginExResult,
     AuthMeArgs, AuthMeResult,
     AuthMechChoicesArgs, AuthMechChoicesResult,
@@ -368,16 +368,6 @@ class AuthService(Service):
         return {
             'username': root_credentials.user['username'],
         }
-
-    @api_method(AuthLegacyTwoFactorArgs, AuthLegacyResult, authentication_required=False)
-    async def two_factor_auth(self, username, password):
-        """
-        Returns true if two-factor authorization is required for authorizing user's login.
-        """
-        user_authenticated = await self.middleware.call('auth.authenticate_plain', username, password)
-        return user_authenticated and (
-            await self.middleware.call('auth.twofactor.config')
-        )['enabled'] and '2FA' in user_authenticated['account_attributes']
 
     @cli_private
     @api_method(AuthLegacyPasswordLoginArgs, AuthLegacyResult, authentication_required=False)


### PR DESCRIPTION
This endpoint is now redundant. All known consumers have switched to using `auth.login_ex` for two-factor authentication.