### PR TITLE
NAS-132115 / 24.10.0.1 / fix HA logic bug (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -296,10 +296,10 @@ class FailoverEventsService(Service):
 
             # If there is a state change on a non-critical interface then
             # ignore the event and return
-            ignore = [i for i in fobj['non_crit_interfaces'] if i in ifname]
-            if ignore:
-                logger.warning('Ignoring state change on non-critical interface "%s".', ifname)
-                raise IgnoreFailoverEvent()
+            for i in fobj['non_crit_interfaces']:
+                if i == ifname:
+                    logger.warning('Ignoring state change on non-critical interface "%s".', ifname)
+                    raise IgnoreFailoverEvent()
 
             needs_imported = False
             for pool in self.run_call('pool.query', [('name', 'in', [i['name'] for i in fobj['volumes']])]):


### PR DESCRIPTION
This fixes a bug in our HA logic whereby we're mistakenly ignoring interfaces that are marked critical for failover (treating them as non-critical for failover).

The explanation is simple and I'm surprised we're only now seeing this issue. I check to see if the left operand is `in` the right operand. This means left operand strings with a value of `ens4` will evaluate to true if the right side of the operand is of string `ens4d1`.

The solution is to make sure the left and right operands are equivalent.

Original PR: https://github.com/truenas/middleware/pull/14820
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132115

Original PR: https://github.com/truenas/middleware/pull/14825
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132115