### PR TITLE
NAS-129366 / 24.04.2.4 / Try to fix SED unlock issues on HA SCALE (by yocalebo) (by bugclerk) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/retaste.py
+++ b/src/middlewared/middlewared/plugins/disk_/retaste.py
@@ -2,16 +2,15 @@ import fcntl
 import logging
 import multiprocessing
 import os
+import re
 
-from pyudev import Context
-
-from middlewared.plugins.device_.device_info import (RE_NVME_PRIV,
-                                                     is_iscsi_device)
-from middlewared.plugins.disk_.enums import DISKS_TO_IGNORE
 from middlewared.schema import List, Str
 from middlewared.service import Service, accepts, job
 
 logger = logging.getLogger(__name__)
+
+SD_PATTERN = re.compile(r"^sd[a-z]+$")
+NVME_PATTERN = re.compile(r"^nvme\d+n\d+$")
 
 
 def taste_it(disk, errors):
@@ -35,12 +34,10 @@ def taste_it(disk, errors):
 def retaste_disks_impl(disks: set = None):
     if disks is None:
         disks = set()
-        for disk in Context().list_devices(subsystem='block', DEVTYPE='disk'):
-            if disk.sys_name.startswith(DISKS_TO_IGNORE) or RE_NVME_PRIV.match(disk.sys_name):
-                continue
-            if is_iscsi_device(disk):
-                continue
-            disks.add(f'/dev/{disk.sys_name}')
+        with os.scandir('/dev') as sdir:
+            for i in sdir:
+                if SD_PATTERN.match(i.name) or NVME_PATTERN.match(i.name):
+                    disks.add(i.path)
 
     with multiprocessing.Manager() as m:
         errors = m.dict()
@@ -60,7 +57,7 @@ def retaste_disks_impl(disks: set = None):
 class DiskService(Service):
 
     @accepts(List('disks', required=False, default=None, items=[Str('name', required=True)]))
-    @job(lock='disk_retaste')
+    @job(lock='disk_retaste', lock_queue_size=1)
     def retaste(self, job, disks):
         if disks:
             # remove duplicates and prefix '/dev' (i.e. /dev/sda, /dev/sdb, etc)

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -541,7 +541,9 @@ class FailoverEventsService(Service):
         if maybe_unlocked:
             logger.info('Done unlocking all SED disks (if any)')
             try:
+                logger.info('Retasting disks on standby node')
                 self.run_call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
+                logger.info('Done retasting disks on standby node')
             except Exception:
                 logger.exception('Unexpected failure retasting disks on standby node')
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -529,15 +529,21 @@ class FailoverEventsService(Service):
 
         # unlock SED disks
         logger.info('Unlocking all SED disks (if any)')
+        maybe_unlocked = False
         try:
-            self.run_call('disk.sed_unlock_all', True)
+            maybe_unlocked = self.run_call('disk.sed_unlock_all', True)
         except Exception as e:
             # failing here doesn't mean the zpool won't import
             # we could have failed on only 1 disk so log an
             # error and move on
             logger.error('Failed to unlock SED disk(s) with error: %r', e)
-        else:
+
+        if maybe_unlocked:
             logger.info('Done unlocking all SED disks (if any)')
+            try:
+                self.run_call('failover.call_remote', 'disk.retaste', [], {'raise_connect_error': False})
+            except Exception:
+                logger.exception('Unexpected failure retasting disks on standby node')
 
         # setup the zpool cachefile  TODO: see comment below about cachefile usage
         # self.run_call('failover.zpool.cachefile.setup', 'MASTER')

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -955,6 +955,11 @@ class FailoverEventsService(Service):
         self.run_call('service.start', 'keepalived', self.HA_PROPAGATE)
         logger.info('Unpausing failover event processing')
         self.run_call('vrrpthread.unpause_events')
+
+        logger.info('Retasting disks (if required)')
+        self.run_call('disk.retaste')
+        logger.info ('Done retasting disks (if required)')
+
         logger.info('Successfully became the BACKUP node.')
         self.FAILOVER_RESULT = 'SUCCESS'
 


### PR DESCRIPTION
A couple issues have been found internally surrounding SED drives and how we unlock them. This is SCALE specific and so after consultation with the OS team, we're trying to implement changes which fix these problems.

1. On MASTER failover event, notify the standby controller to retaste the disks after we unlock any SED drives
2. On BACKUP failover event, retaste the disks to ensure we're "up to date" with partition information
3. Change the `disk.retaste` job to only queue up 1 job (including the currently running job)
4. stop using `libudev` in the `disk.retaste` endpoint since the udev database can be in flux by the time we query it. Instead we'll use device node names in `/dev`.

Original PR: https://github.com/truenas/middleware/pull/14690
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129366

Original PR: https://github.com/truenas/middleware/pull/14691
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129366

Original PR: https://github.com/truenas/middleware/pull/14831
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129366