### PR TITLE
NAS-132141 / 24.10.1 / Change default for token match-origin

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -307,7 +307,7 @@ class AuthService(Service):
     @accepts(
         Int('ttl', default=600, null=True),
         Dict('attrs', additional_attrs=True),
-        Bool('match_origin', default=False),
+        Bool('match_origin', default=True),
     )
     @returns(Str('token'))
     @pass_app(rest=True)

--- a/src/middlewared/middlewared/test/integration/assets/keychain.py
+++ b/src/middlewared/middlewared/test/integration/assets/keychain.py
@@ -28,7 +28,7 @@ def localhost_ssh_credentials(**data):
         credentials = call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": str(uuid.uuid4()),
             "url": url,
-            "token": call("auth.generate_token"),
+            "token": call("auth.generate_token", 600, {}, False),
             "private_key": keypair["id"],
             **data,
         })

--- a/tests/api2/test_auth_token.py
+++ b/tests/api2/test_auth_token.py
@@ -83,7 +83,7 @@ def test_login_with_token_match_origin(unprivileged_user):
 
 def test_login_with_token_no_match_origin(unprivileged_user):
     token = ssh(
-        "sudo -u test midclt -u ws://localhost/websocket -U test -P test1234 call auth.generate_token 300"
+        "sudo -u test midclt -u ws://localhost/websocket -U test -P test1234 call auth.generate_token 300 '{}' false"
     ).strip()
 
     with client(auth=None) as c:

--- a/tests/api2/test_keychain_ssh.py
+++ b/tests/api2/test_keychain_ssh.py
@@ -27,7 +27,7 @@ def test_remote_ssh_semiautomatic_setup_invalid_homedir(credential):
         "home_create": False,
         "password": "test1234",
     }):
-        token = call("auth.generate_token")
+        token = call("auth.generate_token", 600, {}, False)
         with pytest.raises(CallError) as ve:
             call("keychaincredential.remote_ssh_semiautomatic_setup", {
                 "name": "localhost",
@@ -51,7 +51,7 @@ def test_remote_ssh_semiautomatic_setup_sets_user_attributes(credential):
             "smb": False,
             "shell": "/usr/sbin/nologin",
         }):
-            token = call("auth.generate_token")
+            token = call("auth.generate_token", 600, {}, False)
             connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
                 "name": "localhost",
                 "url": "http://localhost",
@@ -66,7 +66,7 @@ def test_remote_ssh_semiautomatic_setup_sets_user_attributes(credential):
 
 
 def test_ssl_certificate_error(credential):
-    token = call("auth.generate_token")
+    token = call("auth.generate_token", 600, {}, False)
     with pytest.raises(CallError) as ve:
         call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": "localhost",
@@ -80,7 +80,7 @@ def test_ssl_certificate_error(credential):
 
 
 def test_ignore_ssl_certificate_error(credential):
-    token = call("auth.generate_token")
+    token = call("auth.generate_token", 600, {}, False)
     connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
         "name": "localhost",
         "url": "https://localhost",

--- a/tests/api2/test_replication_utils.py
+++ b/tests/api2/test_replication_utils.py
@@ -11,7 +11,7 @@ def localhost_ssh_connection():
         "attributes": call("keychaincredential.generate_ssh_key_pair"),
     })
     try:
-        token = call("auth.generate_token")
+        token = call("auth.generate_token", 600, {}, False)
         connection = call("keychaincredential.remote_ssh_semiautomatic_setup", {
             "name": "localhost",
             "url": "http://localhost",


### PR DESCRIPTION
The UI team does not use this feature for semi-automatic replication setup and so it's safe for us to match origin for tokens by default.