### PR TITLE
NAS-131249 / 25.04 / Add middleware hooks to configure dedup_table* fields

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -18,6 +18,7 @@ from .filesystem import *  # noqa
 from .group import *  # noqa
 from .iscsi_auth import *  # noqa
 from .keychain import *  # noqa
+from .pool import *  # noqa
 from .privilege import *  # noqa
 from .rdma import *  # noqa
 from .rdma_interface import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool.py
@@ -1,0 +1,22 @@
+from pydantic import conint, Field
+
+from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
+
+
+@single_argument_args('options')
+class DDTPruneArgs(BaseModel):
+    pool_name: NonEmptyString
+    percentage: conint(ge=1, le=100) | None = Field(default=None)
+    days: conint(ge=1) | None = Field(default=None)
+
+
+class DDTPruneResult(BaseModel):
+    result: None
+
+
+class DDTPrefetchArgs(BaseModel):
+    pool_name: NonEmptyString
+
+
+class DDTPrefetchResult(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -676,6 +676,9 @@ class FailoverEventsService(Service):
         self.run_call('directoryservices.setup')
         logger.info('Done starting background job for directoryservices.setup')
 
+        logger.info('Starting background job for prefetching DDT for zpools')
+        self.middleware.create_task(self.middleware.call('zfs.pool.ddt_prefetch_pools'))
+
         logger.info('Allowing network traffic.')
         fw_accept_job = self.run_call('failover.firewall.accept_all')
         fw_accept_job.wait_sync()

--- a/src/middlewared/middlewared/plugins/pool_/dedup.py
+++ b/src/middlewared/middlewared/plugins/pool_/dedup.py
@@ -1,0 +1,42 @@
+from middlewared.api import api_method
+from middlewared.api.current import DDTPrefetchArgs, DDTPrefetchResult, DDTPruneArgs, DDTPruneResult
+from middlewared.service import job, Service
+
+
+class PoolService(Service):
+
+    class Config:
+        cli_namespace = 'storage.pool'
+
+    @api_method(DDTPruneArgs, DDTPruneResult)
+    @job(lock=lambda args: f'ddt_prune_{args[0]["pool_name"]}')
+    async def ddt_prune(self, job, options):
+        """
+        Prune DDT entries in pool `pool_name` based on the specified options.
+
+        `percentage` is the percentage of DDT entries to prune.
+
+        `days` is the number of days to prune DDT entries.
+        """
+        return await self.middleware.call('zfs.pool.ddt_prune', options)
+
+    @api_method(DDTPrefetchArgs, DDTPrefetchResult)
+    @job(lock=lambda args: f'ddt_prefetch_{args[0]}')
+    async def ddt_prefetch(self, job, pool_name):
+        """
+        Prefetch DDT entries in pool `pool_name`.
+        """
+        return await self.middleware.call('zfs.pool.ddt_prefetch', pool_name)
+
+
+async def pool_post_import(middleware, pool):
+    if pool:
+        middleware.logger.info('Prefetching ddt table of %r pool', pool['name'])
+        middleware.create_task(middleware.call('zfs.pool.ddt_prefetch', pool['name']))
+    else:
+        # This is to handle the case when pools are imported on boot time when pool attr is none
+        middleware.create_task(middleware.call('zfs.pool.ddt_prefetch_pools'))
+
+
+async def setup(middleware):
+    middleware.register_hook('pool.post_import', pool_post_import)

--- a/tests/api2/test_dedup_pool_table_quota.py
+++ b/tests/api2/test_dedup_pool_table_quota.py
@@ -1,0 +1,121 @@
+import pytest
+
+from truenas_api_client.exc import ValidationErrors
+
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call
+
+
+def dedup_pool_payload(dedup_table_quota: str | None, dedup_table_quota_value: int | None) -> dict:
+    unused_disks = call('disk.get_unused')
+    if len(unused_disks) < 2:
+        pytest.skip('Insufficient number of disks to perform this test')
+
+    return {
+        'deduplication': 'ON',
+        'topology': {
+            'data': [{
+                'type': 'STRIPE',
+                'disks': [unused_disks[0]['name']]
+            }],
+            'dedup': [{
+                'type': 'STRIPE',
+                'disks': [unused_disks[1]['name']]
+            }],
+        },
+        'dedup_table_quota': dedup_table_quota,
+        'dedup_table_quota_value': dedup_table_quota_value,
+        'allow_duplicate_serials': True,
+    }
+
+
+@pytest.fixture(scope='module')
+def dedup_pool():
+    with another_pool(dedup_pool_payload('CUSTOM', 2048)) as pool:
+        yield pool
+
+
+@pytest.mark.parametrize(
+    'dedup_table_quota,dedup_table_quota_value,error_msg,error_attr', [
+        (
+            None,
+            1024,
+            'You must set Deduplication Table Quota to CUSTOM to specify a value.',
+            'pool_create.dedup_table_quota'
+        ),
+        (
+            'AUTO',
+            1024,
+            'You must set Deduplication Table Quota to CUSTOM to specify a value.',
+            'pool_create.dedup_table_quota'
+        ),
+        (
+            'CUSTOM',
+            None,
+            'This field is required when Deduplication Table Quota is set to CUSTOM.',
+            'pool_create.dedup_table_quota_value'
+        ),
+    ]
+)
+def test_dedup_table_quota_create_validation(dedup_table_quota, dedup_table_quota_value, error_msg, error_attr):
+    with pytest.raises(ValidationErrors) as ve:
+        with another_pool(dedup_pool_payload(dedup_table_quota, dedup_table_quota_value)):
+            pass
+
+    assert ve.value.errors[0].attribute == error_attr
+    assert ve.value.errors[0].errmsg == error_msg
+
+
+def test_dedup_table_quota_value_on_create(dedup_pool):
+    assert call('pool.get_instance', dedup_pool['id'])['dedup_table_quota'] == '2048'
+
+
+@pytest.mark.parametrize(
+    'dedup_table_quota,dedup_table_quota_value,expected_value,error_msg,error_attr', [
+        (None, None, '0', '', ''),
+        (
+            None,
+            1024,
+            '',
+            'You must set Deduplication Table Quota to CUSTOM to specify a value.',
+            'pool_update.dedup_table_quota'
+        ),
+        ('AUTO', None, 'auto', '', ''),
+        (
+            'AUTO',
+            1024,
+            '',
+            'You must set Deduplication Table Quota to CUSTOM to specify a value.',
+            'pool_update.dedup_table_quota'
+        ),
+        ('CUSTOM', 1024, '1024', '', ''),
+        (
+            'CUSTOM',
+            None,
+            '',
+            'This field is required when Deduplication Table Quota is set to CUSTOM.',
+            'pool_update.dedup_table_quota_value'
+        ),
+    ]
+)
+def test_dedup_table_quota_update(
+    dedup_pool, dedup_table_quota, dedup_table_quota_value, expected_value, error_msg, error_attr
+):
+    if error_msg:
+        with pytest.raises(ValidationErrors) as ve:
+            call(
+                'pool.update', dedup_pool['id'], {
+                    'dedup_table_quota': dedup_table_quota,
+                    'dedup_table_quota_value': dedup_table_quota_value,
+                    'allow_duplicate_serials': True,
+                }, job=True)
+        assert ve.value.errors[0].attribute == error_attr
+        assert ve.value.errors[0].errmsg == error_msg
+    else:
+        call(
+            'pool.update', dedup_pool['id'], {
+                'dedup_table_quota': dedup_table_quota,
+                'dedup_table_quota_value': dedup_table_quota_value,
+                'allow_duplicate_serials': True
+            }, job=True)
+        assert call('pool.get_instance', dedup_pool['id'])['dedup_table_quota'] == expected_value


### PR DESCRIPTION
## Context

It was requested that we expose ability to prefetch/prune ddt entries and relevant changes have been added to accommodate that. Also it was requested that we preferably prefetch after pool has been imported and those changes have been accommodated as well on both pool import and failover.