### PR TITLE
NAS-132157 / 25.04 / Robustize dmi_pci_slot_info

### DIFF
--- a/src/middlewared/middlewared/plugins/fc/utils.py
+++ b/src/middlewared/middlewared/plugins/fc/utils.py
@@ -68,7 +68,14 @@ def dmi_pci_slot_info():
         if mat := BUS_ADDRESS.search(line):
             bus_addr = mat.group(0)
             result[bus_addr] = designation
-    return result
+    # If any slots are missing a .0 function then fill it in
+    additional = {}
+    for bus_addr in result:
+        if not bus_addr.endswith('.0'):
+            new_addr = bus_addr.rsplit('.', 1)[0] + '.0'
+            if new_addr not in result:
+                additional[new_addr] = result[bus_addr]
+    return result | additional
 
 
 def filter_by_wwpns_hex_string(wwpn_naa, wwpn_b_naa):


### PR DESCRIPTION
Found a platform where the `dmidecode -t9` output included a `.1`, but not a `.0` bus address.

```
# dmidecode -t9
...
Handle 0x0047, DMI type 9, 17 bytes
System Slot Information
        Designation: CPU1 Slot2 PCI-E 3.0 X16
        Type: x16 PCI Express 3 x16
        Current Usage: In Use
        Length: Long
        ID: 2
        Characteristics:
                3.3 V is provided
                PME signal is supported
                SMBus signal is supported
        Bus Address: 0000:3b:00.4

Handle 0x0049, DMI type 9, 17 bytes
System Slot Information
        Designation: CPU1 Slot3 PCI-E 3.0 X8
        Type: x8 PCI Express 3 x8
        Current Usage: In Use
        Length: Short
        ID: 3
        Characteristics:
                3.3 V is provided
                PME signal is supported
                SMBus signal is supported
        Bus Address: 0000:18:00.1

Handle 0x004B, DMI type 9, 17 bytes
System Slot Information
        Designation: CPU2 Slot4 PCI-E 3.0 X16
        Type: x16 PCI Express 3 x16
        Current Usage: Available
        Length: Long
        ID: 4
        Characteristics:
                3.3 V is provided
                PME signal is supported
                SMBus signal is supported
        Bus Address: 0000:d7:00.0
```

This is despite the qlogic card clearly using .0 and .1
```
# lspci | grep -i Qlogic
18:00.0 Fibre Channel: QLogic Corp. ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter (rev 01)
18:00.1 Fibre Channel: QLogic Corp. ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter (rev 01)
```

Robustize the output from `dmi_pci_slot_info` by injecting the entry for .0 if necessary.