### PR TITLE
NAS-131695 / 25.04 / Change libvirt default uid/gid

### DIFF
--- a/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
+++ b/src/middlewared/middlewared/migration/0010_nvram_attr_vms.py
@@ -1,12 +1,12 @@
 import os
 import shutil
 
-from middlewared.plugins.vm.utils import SYSTEM_NVRAM_FOLDER_PATH, get_vm_nvram_file_name
+from middlewared.plugins.vm.utils import (
+    get_vm_nvram_file_name, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID, SYSTEM_NVRAM_FOLDER_PATH,
+)
 
 
 DEFAULT_NVRAM_FOLDER_PATH = '/var/lib/libvirt/qemu/nvram'
-LIBVIRT_QEMU_UID = 64055
-LIBVIRT_QEMU_GID = 64055
 
 
 def migrate(middleware):

--- a/src/middlewared/middlewared/migration/0012_libvirt_uid_gid.py
+++ b/src/middlewared/middlewared/migration/0012_libvirt_uid_gid.py
@@ -1,0 +1,15 @@
+import os
+
+from middlewared.plugins.vm.utils import LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID
+
+
+def migrate(middleware):
+    for device in middleware.call_sync('vm.device.query', [['dtype', 'in', ['CDROM', 'RAW']]]):
+        path = device['attributes'].get('path')
+        try:
+            os.chown(path, LIBVIRT_QEMU_UID, LIBVIRT_QEMU_GID)
+        except (FileNotFoundError, TypeError):
+            middleware.logger.error(
+                'Unable to chown %s VM device\'s path of %r VM as %r path cannot be located',
+                device['dtype'], device['vm'], path,
+            )

--- a/src/middlewared/middlewared/plugins/vm/utils.py
+++ b/src/middlewared/middlewared/plugins/vm/utils.py
@@ -3,6 +3,8 @@ from xml.etree import ElementTree as etree
 
 ACTIVE_STATES = ['RUNNING', 'SUSPENDED']
 SYSTEM_NVRAM_FOLDER_PATH = '/data/subsystems/vm/nvram'
+LIBVIRT_QEMU_UID = 986
+LIBVIRT_QEMU_GID = 986
 LIBVIRT_URI = 'qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock'
 LIBVIRT_USER = 'libvirt-qemu'
 NGINX_PREFIX = '/vm/display'


### PR DESCRIPTION
## Context

After talking with Andrew, we decided to change libvirt's default uid/gid as it has a high potential for a clash with the default uid/gid in place. A uid/gid has been chosen for libvirt which is under 1000 and reduces a potential clash with a user configured uid/gid.