### PR TITLE
use filterable_api_method in smb.sharesec and idmap

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -5,7 +5,9 @@ import datetime
 import wbclient
 
 from middlewared.schema import accepts, Bool, Dict, Int, Password, Patch, Ref, Str, LDAP_DN, OROperator
-from middlewared.service import CallError, CRUDService, job, private, ValidationErrors, filterable
+from middlewared.service import (
+    CallError, CRUDService, job, private, ValidationErrors, filterable, filterable_api_method
+)
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import SSL
 from middlewared.utils.directoryservices.constants import DSType as DirectoryServiceType
@@ -326,8 +328,7 @@ class IdmapDomainService(CRUDService):
         await self.middleware.call('zfs.snapshot.create', {'dataset': f'{sysdataset}/samba4',
                                                            'name': f'wbc-{ts}'})
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     def known_domains(self, query_filters, query_options):
         try:
             entries = [entry.domain_info() for entry in WBClient().all_domains()]
@@ -344,8 +345,7 @@ class IdmapDomainService(CRUDService):
 
         return filter_list(entries, query_filters, query_options)
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     def online_status(self, query_filters, query_options):
         try:
             all_info = self.known_domains()
@@ -1123,8 +1123,7 @@ class IdmapDomainService(CRUDService):
             'sid': sid
         }
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     async def builtins(self, filters, options):
         out = []
         idmap_backend = await self.middleware.call("smb.getparm", "idmap config * : backend", "GLOBAL")

--- a/src/middlewared/middlewared/plugins/smb_/sharesec.py
+++ b/src/middlewared/middlewared/plugins/smb_/sharesec.py
@@ -2,7 +2,7 @@ import os
 
 from base64 import b64encode, b64decode
 from middlewared.plugins.sysdataset import SYSDATASET_PATH
-from middlewared.service import filterable, periodic, private, CRUDService
+from middlewared.service import filterable_api_method, periodic, Service
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils import filter_list
 from middlewared.utils.security_descriptor import (
@@ -55,14 +55,13 @@ def dup_share_acl(src: str, dst: str) -> None:
     store_share_acl(dst, val)
 
 
-class ShareSec(CRUDService):
+class ShareSec(Service):
 
     class Config:
         namespace = 'smb.sharesec'
-        cli_namespace = 'sharing.smb.sharesec'
         private = True
 
-    @filterable
+    @filterable_api_method(private=True)
     def entries(self, filters, options):
         # TDB file contains INFO/version key that we don't want to return
         try:
@@ -142,7 +141,6 @@ class ShareSec(CRUDService):
             {'cifs_share_acl': share_sd_bytes}
         )
 
-    @private
     def flush_share_info(self):
         """
         Write stored share acls to share_info.tdb. This should only be called


### PR DESCRIPTION
As part of effort to remove places where private methods use legacy schema, this commit replaces @filterable with @filterable_api_method

* smb.sharesec
* idmap