### PR TITLE
NAS-132164 / 25.04 / Fix `ReadonlyRootfsManager` not really making rootfs writeable

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -209,22 +209,6 @@ class BootService(Service):
         )
         return interval
 
-    @asynccontextmanager
-    async def __toggle_rootfs_readwrite(self):
-        mnt = await self.middleware.call('filesystem.mount_info', [['mountpoint', '=', '/']], {'get': True})
-        if 'RO' in mnt['super_opts']:
-            try:
-                await self.middleware.call('zfs.dataset.update', mnt['mount_source'], {
-                    "properties": {"readonly": {"parsed": False}}
-                })
-                yield
-            finally:
-                await self.middleware.call('zfs.dataset.update', mnt['mount_source'], {
-                    "properties": {"readonly": {"parsed": True}}
-                })
-        else:
-            yield
-
     @accepts(Dict(
         'options',
         Str('database', default=None, null=True),
@@ -235,19 +219,18 @@ class BootService(Service):
         """
         Returns true if initramfs was updated and false otherwise.
         """
-        async with self.__toggle_rootfs_readwrite():
-            args = ['/']
-            if options['database']:
-                args.extend(['-d', options['database']])
-            if options['force']:
-                args.extend(['-f'])
+        args = ['/']
+        if options['database']:
+            args.extend(['-d', options['database']])
+        if options['force']:
+            args.extend(['-f'])
 
-            cp = await run(
-                '/usr/local/bin/truenas-initrd.py', *args,
-                encoding='utf8', errors='ignore', check=False
-            )
-            if cp.returncode > 1:
-                raise CallError(f'Failed to update initramfs: {cp.stderr}')
+        cp = await run(
+            '/usr/local/bin/truenas-initrd.py', *args,
+            encoding='utf8', errors='ignore', check=False
+        )
+        if cp.returncode > 1:
+            raise CallError(f'Failed to update initramfs: {cp.stdout} {cp.stderr}')
 
         return cp.returncode == 1
 

--- a/src/middlewared/middlewared/utils/rootfs.py
+++ b/src/middlewared/middlewared/utils/rootfs.py
@@ -96,6 +96,12 @@ class ReadonlyRootfsManager:
                 check=True,
                 text=True,
             )
+            subprocess.run(
+                ["mount", "-o", f"{'ro' if readonly else 'rw'},remount", self.datasets[name].mountpoint],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
             self.datasets[name].readonly.current = readonly
 
         if state.get("usr") is False:


### PR DESCRIPTION
As per @usaleem-ix's explanation

> There was an issue in ZFS, datasets mounted during boot did not have correct permissions because mount command from busybox was used in initramfs to  mount the datasets. this mount command does mount syscall directly into the kernel, bypassing the mount helper program also used by mount from util-linux package, that is available when boot is completed. https://ixsystems.atlassian.net/browse/NAS-127825
> This issue was fixed recently. Now on SCALE, we have datasets like usr, etc and others now mounted with correct permissions. We set readonly=on for /usr, same goes for root (/). We do this from fhs.py in scale-build. These options were not being enforced previously, but after the fix for NAS-127825 this test case broke.