### PR TITLE
NAS-132164 / 24.10.1 / Fix `ReadonlyRootfsManager` not really making rootfs writeable (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/utils/rootfs.py
+++ b/src/middlewared/middlewared/utils/rootfs.py
@@ -96,6 +96,12 @@ class ReadonlyRootfsManager:
                 check=True,
                 text=True,
             )
+            subprocess.run(
+                ["mount", "-o", f"{'ro' if readonly else 'rw'},remount", self.datasets[name].mountpoint],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
             self.datasets[name].readonly.current = readonly
 
         if state.get("usr") is False:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 23149f7357b7177fcf4197ca260dac15044eaf9d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bcf985a240fa9648088f484383179060fec895fc

As per @usaleem-ix's explanation

> There was an issue in ZFS, datasets mounted during boot did not have correct permissions because mount command from busybox was used in initramfs to  mount the datasets. this mount command does mount syscall directly into the kernel, bypassing the mount helper program also used by mount from util-linux package, that is available when boot is completed. https://ixsystems.atlassian.net/browse/NAS-127825
> This issue was fixed recently. Now on SCALE, we have datasets like usr, etc and others now mounted with correct permissions. We set readonly=on for /usr, same goes for root (/). We do this from fhs.py in scale-build. These options were not being enforced previously, but after the fix for NAS-127825 this test case broke.

Original PR: https://github.com/truenas/middleware/pull/14844
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132164