### PR TITLE
NAS-132177 / 24.10.0.1 / fix disk.sync_all edge-case crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure.py
+++ b/src/middlewared/middlewared/plugins/enclosure.py
@@ -545,7 +545,8 @@ class Enclosure(object):
                     disk
                 )
 
-            self.append(info)
+            if info:
+                self.append(info)
 
         return mapping
 


### PR DESCRIPTION
I was made aware of an internal system that had been upgraded to 24.10.0 and disks weren't showing up. After investigation I found that `disk.sync_all` was crashing with this error:
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure.py", line 367, in __init__
    enclosure = Enclosure(num, data, stat, product_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure.py", line 415, in __init__
    self._parse(data)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure.py", line 426, in _parse
    self.map_disks_to_enclosure_slots(is_hseries)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure.py", line 549, in map_disks_to_enclosure_slots
    self.append(info)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure.py", line 620, in append
    if element.name not in self.__elementsbyname:
       ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
```
This is happening because this internal system is connected to an EOL piece of hardware that we haven't sold in many, many years. The error is an edge-case so we'll fix it because `disk.sync_all` hasn't been converted to using the new enclosure code.

Original PR: https://github.com/truenas/middleware/pull/14847
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132177