### PR TITLE
Fix fcport validate

### DIFF
--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -71,6 +71,8 @@ class FCPortService(CRUDService):
         """
         old = await self.get_instance(id_)
         audit_callback(old['port'])
+        # Reflatten target_id
+        old['target_id'] = old.pop('target')['id']
         new = old.copy()
         new.update(data)
 
@@ -236,10 +238,10 @@ class FCPortService(CRUDService):
 
     async def _validate(self, schema_name: str, data: dict, id_: int = None):
         verrors = ValidationErrors()
-
-        # Make sure we don't reuse either port or target_id
-        for key in ['port', 'target_id']:
-            await self._ensure_unique(verrors, schema_name, key, data[key], id_)
+        # Make sure we don't reuse either port or target_id.  Need to special case
+        # map "target_id" to "target.id" because of how query is nesting target.
+        await self._ensure_unique(verrors, schema_name, 'port', data['port'], id_)
+        await self._ensure_unique(verrors, schema_name, 'target_id', data['target_id'], id_, 'target.id')
 
         # Make sure that the port base is a valid fc_host alias
         fc_hosts = {host['alias']: host for host in await self.middleware.call('fc.fc_host.query')}

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -306,8 +306,10 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
             raise InstanceNotFound(f'{self._config.verbose_name} {id_} does not exist')
         return instance[0]
 
-    async def _ensure_unique(self, verrors, schema_name, field_name, value, id_=None):
-        f = [(field_name, '=', value)]
+    async def _ensure_unique(self, verrors, schema_name, field_name, value, id_=None, query_field_name=None):
+        if query_field_name is None:
+            query_field_name = field_name
+        f = [(query_field_name, '=', value)]
         if id_ is not None:
             f.append(('id', '!=', id_))
         instance = await self.middleware.call(f'{self._config.namespace}.query', f)


### PR DESCRIPTION
When a CRUD query call is dealing with a `ForeignKey`, it "expands" (for want of a better word) the result, so that even though the DB contains e.g. '`target_id`', a query will result in a '`target`' dict (which will include an '`id`' field).  It appears that this replacement also impacts query.
```
# midclt call fcport.query '[["target_id", "=", 2]]' '{"count": true}'
0
# midclt call fcport.query '[["target.id", "=", 2]]' '{"count": true}'
1
```

Therefore:
- Add an **optional** `query_field_name` parameter to `CRUDService._ensure_unique`
- In `fcport._validate` use this parameter to replace `target_id` with `target.id`

Also add a _bunch_ of CI tests to check all of this.
