### PR TITLE
NAS-132192 / 25.04 / Fix incorrect translation of LDAP basedn to realm

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/ipa.py
+++ b/src/middlewared/middlewared/utils/directoryservices/ipa.py
@@ -79,3 +79,15 @@ def write_ipa_default_config(
 
 def write_ipa_cacert(cacert_bytes):
     return _write_ipa_file(IPAPath.CACERT, cacert_bytes)
+
+
+def ldap_dn_to_realm(ldap_dn: str) -> str:
+    """Extract a hypothetical kerberos realm from DC components of LDAP DN."""
+    realm_parts = []
+    for component in ldap_dn.split(','):
+        if not (parts := component.split('dc=')):
+            continue
+
+        realm_parts.append(parts[1].strip())
+
+    return '.'.join(realm_parts)

--- a/tests/unit/test_directory_services.py
+++ b/tests/unit/test_directory_services.py
@@ -1,0 +1,11 @@
+import pytest
+
+from middlewared.utils.directoryservices.ipa import ldap_dn_to_realm
+
+
+@pytest.mark.parametrize('ldap_dn,realm', [
+    ('dc=company,dc=com', 'company.com'),
+    ('dc=tn,dc=ixsystems,dc=net', 'tn.ixsystems.net'),
+])
+def test_dn_to_realm(ldap_dn, realm):
+    assert ldap_dn_to_realm(ldap_dn) == realm


### PR DESCRIPTION
This commit fixes a parsing bug that slipped into the translation of LDAP config into IPA config for electric eel. We had to layer IPA config on LDAP config due to time crunch for the release.