### PR TITLE
NAS-132202 / 24.10.1 / Mark app as having upgrade available if it's a custom app and there are image updates available (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -120,6 +120,12 @@ def list_apps(
             'image_updates_available': image_updates_available,
             **app_metadata | {'portals': normalize_portal_uris(app_metadata['portals'], host_ip)}
         }
+        if app_data['custom_app'] and image_updates_available:
+            # We want to mark custom apps as upgrade available if image updates are available
+            # so if user tries to upgrade, we will just be pulling a newer version of the image
+            # against the same docker tag
+            app_data['upgrade_available'] = True
+
         apps.append(app_data | get_config_of_app(app_data, collective_config, retrieve_config))
 
     if specific_app and specific_app in app_names:

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -137,6 +137,16 @@ class AppService(Service):
         if app['upgrade_available'] is False:
             raise CallError(f'No upgrade available for {app_name!r}')
 
+        if app['custom_app']:
+            return {
+                'latest_version': app['version'],
+                'latest_human_version': app['human_version'],
+                'upgrade_version': app['version'],
+                'upgrade_human_version': app['human_version'],
+                'changelog': 'Image updates are available for this app',
+                'available_versions_for_upgrade': [],
+            }
+
         versions_config = await self.get_versions(app, options)
         return {
             'latest_version': versions_config['latest_version']['version'],


### PR DESCRIPTION
This PR adds some changes so we now mark custom apps as having an upgrade available if there are image updates available for the custom app.

Original PR: https://github.com/truenas/middleware/pull/14856
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132202