### PR TITLE
NAS-131955 / 24.10.1 / Removing ES24N shelves left cruft in the database (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/rdma/interface/crud.py
+++ b/src/middlewared/middlewared/plugins/rdma/interface/crud.py
@@ -121,7 +121,7 @@ class RDMAInterfaceService(CRUDService):
         try:
             result = await self.middleware.call('rdma.interface.configure_interface', data['node'], data['ifname'], None)
             if not result:
-                self.logger.warn("Failed to delete active RDMA interface configuration")
+                self.logger.warning("Failed to delete active RDMA interface configuration")
         except Exception:
             self.logger.error('Failed to remove live RDMA configuration', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/rdma/interface/crud.py
+++ b/src/middlewared/middlewared/plugins/rdma/interface/crud.py
@@ -118,9 +118,12 @@ class RDMAInterfaceService(CRUDService):
         data = await self.get_instance(id_)
 
         # Attempt to remove the live configuration
-        result = await self.middleware.call('rdma.interface.configure_interface', data['node'], data['ifname'], None)
-        if not result:
-            self.logger.warn("Failed to delete active RDMA interface configuration")
+        try:
+            result = await self.middleware.call('rdma.interface.configure_interface', data['node'], data['ifname'], None)
+            if not result:
+                self.logger.warn("Failed to delete active RDMA interface configuration")
+        except Exception:
+            self.logger.error('Failed to remove live RDMA configuration', exc_info=True)
 
         # Now delete the entry
         return await self.middleware.call('datastore.delete', self._config.datastore, id_)

--- a/src/middlewared/middlewared/plugins/rdma/interface/crud.py
+++ b/src/middlewared/middlewared/plugins/rdma/interface/crud.py
@@ -123,7 +123,7 @@ class RDMAInterfaceService(CRUDService):
             if not result:
                 self.logger.warning("Failed to delete active RDMA interface configuration")
         except Exception:
-            self.logger.error('Failed to remove live RDMA configuration', exc_info=True)
+            self.logger.exception('Failed to remove live RDMA configuration')
 
         # Now delete the entry
         return await self.middleware.call('datastore.delete', self._config.datastore, id_)


### PR DESCRIPTION
Handle some exceptions so that we more fully tear down a JBOF, even if we can't currently communicate with it.

Original PR: https://github.com/truenas/middleware/pull/14863
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131955