### PR TITLE
NAS-132267 / 25.04 / Convert iscsi.extent.* to new api

### DIFF
--- a/src/middlewared/middlewared/api/base/types/iscsi.py
+++ b/src/middlewared/middlewared/api/base/types/iscsi.py
@@ -1,5 +1,8 @@
 from typing import Literal, TypeAlias
 
-__all__ = ["IscsiAuthType"]
+__all__ = ["IscsiAuthType", "IscsiExtentBlockSize", "IscsiExtentRPM", "IscsiExtentType"]
 
 IscsiAuthType: TypeAlias = Literal['NONE', 'CHAP', 'CHAP_MUTUAL']
+IscsiExtentType: TypeAlias = Literal['DISK', 'FILE']
+IscsiExtentBlockSize: TypeAlias = Literal[512, 1024, 2048, 4096]
+IscsiExtentRPM: TypeAlias = Literal['UNKNOWN', 'SSD', '5400', '7200', '10000', '15000']

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -17,6 +17,7 @@ from .fcport import *  # noqa
 from .filesystem import *  # noqa
 from .group import *  # noqa
 from .iscsi_auth import *  # noqa
+from .iscsi_extent import *  # noqa
 from .keychain import *  # noqa
 from .privilege import *  # noqa
 from .rdma import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
@@ -1,0 +1,82 @@
+from typing import Literal
+
+from annotated_types import Ge, Le
+from pydantic import StringConstraints
+from typing_extensions import Annotated
+
+from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, IscsiExtentBlockSize, IscsiExtentRPM,
+                                  IscsiExtentType, NonEmptyString, excluded_field)
+
+__all__ = [
+    "IscsiExtentEntry",
+    "IscsiExtentCreateArgs",
+    "IscsiExtentCreateResult",
+    "IscsiExtentUpdateArgs",
+    "IscsiExtentUpdateResult",
+    "IscsiExtentDeleteArgs",
+    "IscsiExtentDeleteResult",
+    "IscsiExtentDiskChoicesArgs",
+    "IscsiExtentDiskChoicesResult",
+]
+
+
+class IscsiExtentEntry(BaseModel):
+    id: int
+    name: Annotated[NonEmptyString, StringConstraints(max_length=64)]
+    type: IscsiExtentType = 'DISK'
+    disk: str = None
+    serial: str = None
+    path: str = None
+    filesize: int = 0
+    blocksize: IscsiExtentBlockSize = 512
+    pblocksize: bool = False
+    avail_threshold: Annotated[int, Ge(1), Le(99)] | None = None
+    comment: str = ''
+    insecure_tpc: bool = True
+    xen: bool = False
+    rpm: IscsiExtentRPM = 'SSD'
+    ro: bool = False
+    enabled: bool = True
+
+
+class IscsiExtentCreate(IscsiExtentEntry):
+    id: Excluded = excluded_field()
+
+
+class IscsiExtentCreateArgs(BaseModel):
+    iscsi_extent_create: IscsiExtentCreate
+
+
+class IscsiExtentCreateResult(BaseModel):
+    result: IscsiExtentEntry
+
+
+class IscsiExtentUpdate(IscsiExtentCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class IscsiExtentUpdateArgs(BaseModel):
+    id: int
+    iscsi_extent_update: IscsiExtentUpdate
+
+
+class IscsiExtentUpdateResult(BaseModel):
+    result: IscsiExtentEntry
+
+
+class IscsiExtentDeleteArgs(BaseModel):
+    id: int
+    remove: bool = False
+    force: bool = False
+
+
+class IscsiExtentDeleteResult(BaseModel):
+    result: Literal[True]
+
+
+class IscsiExtentDiskChoicesArgs(BaseModel):
+    pass
+
+
+class IscsiExtentDiskChoicesResult(BaseModel):
+    result: dict[str, str]

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -4,18 +4,17 @@ import pathlib
 import secrets
 import subprocess
 import uuid
-
-import middlewared.sqlalchemy as sa
-
-from middlewared.async_validators import check_path_resides_within_volume
-from middlewared.plugins.zfs_.utils import zvol_path_to_name
-from middlewared.schema import accepts, Bool, Dict, Int, Patch, Str
-from middlewared.service import CallError, private, SharingService, ValidationErrors
-from middlewared.utils.size import format_size
-from middlewared.validators import Range
 from collections import defaultdict
 
-from .utils import MAX_EXTENT_NAME_LEN
+import middlewared.sqlalchemy as sa
+from middlewared.api import api_method
+from middlewared.api.current import (IscsiExtentCreateArgs, IscsiExtentCreateResult, IscsiExtentDeleteArgs,
+                                     IscsiExtentDeleteResult, IscsiExtentDiskChoicesArgs, IscsiExtentDiskChoicesResult,
+                                     IscsiExtentEntry, IscsiExtentUpdateArgs, IscsiExtentUpdateResult)
+from middlewared.async_validators import check_path_resides_within_volume
+from middlewared.plugins.zfs_.utils import zvol_path_to_name
+from middlewared.service import CallError, private, SharingService, ValidationErrors
+from middlewared.utils.size import format_size
 
 
 class iSCSITargetExtentModel(sa.Model):
@@ -51,6 +50,7 @@ class iSCSITargetExtentService(SharingService):
         datastore_extend = 'iscsi.extent.extend'
         cli_namespace = 'sharing.iscsi.extent'
         role_prefix = 'SHARING_ISCSI_EXTENT'
+        entry = IscsiExtentEntry
 
     @private
     async def sharing_task_determine_locked(self, data, locked_datasets):
@@ -68,26 +68,7 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.middleware.call('pool.dataset.path_in_locked_datasets', path, locked_datasets)
 
-    @accepts(Dict(
-        'iscsi_extent_create',
-        Str('name', required=True, max_length=MAX_EXTENT_NAME_LEN),
-        Str('type', enum=['DISK', 'FILE'], default='DISK'),
-        Str('disk', default=None, null=True),
-        Str('serial', default=None, null=True),
-        Str('path', default=None, null=True),
-        Int('filesize', default=0),
-        Int('blocksize', enum=[512, 1024, 2048, 4096], default=512),
-        Bool('pblocksize'),
-        Int('avail_threshold', validators=[Range(min_=1, max_=99)], null=True),
-        Str('comment'),
-        Bool('insecure_tpc', default=True),
-        Bool('xen'),
-        Str('rpm', enum=['UNKNOWN', 'SSD', '5400', '7200', '10000', '15000'],
-            default='SSD'),
-        Bool('ro', default=False),
-        Bool('enabled', default=True),
-        register=True
-    ), audit='Create iSCSI extent', audit_extended=lambda data: data["name"])
+    @api_method(IscsiExtentCreateArgs, IscsiExtentCreateResult, audit='Create iSCSI extent', audit_extended=lambda data: data['name'])
     async def do_create(self, data):
         """
         Create an iSCSI Extent.
@@ -123,16 +104,7 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.get_instance(data['id'])
 
-    @accepts(
-        Int('id'),
-        Patch(
-            'iscsi_extent_create',
-            'iscsi_extent_update',
-            ('attr', {'update': True})
-        ),
-        audit='Update iSCSI extent',
-        audit_callback=True,
-    )
+    @api_method(IscsiExtentUpdateArgs, IscsiExtentUpdateResult, audit='Update iSCSI extent', audit_callback=True)
     async def do_update(self, audit_callback, id_, data):
         """
         Update iSCSI Extent of `id`.
@@ -166,13 +138,7 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.get_instance(id_)
 
-    @accepts(
-        Int('id'),
-        Bool('remove', default=False),
-        Bool('force', default=False),
-        audit='Delete iSCSI extent',
-        audit_callback=True,
-    )
+    @api_method(IscsiExtentDeleteArgs, IscsiExtentDeleteResult, audit='Delete iSCSI extent', audit_callback=True)
     async def do_delete(self, audit_callback, id_, remove, force):
         """
         Delete iSCSI Extent of `id`.
@@ -413,7 +379,7 @@ class iSCSITargetExtentService(SharingService):
         else:
             return naa
 
-    @accepts()
+    @api_method(IscsiExtentDiskChoicesArgs, IscsiExtentDiskChoicesResult)
     async def disk_choices(self):
         """
         Return a dict of available zvols that can be used

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -68,7 +68,12 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.middleware.call('pool.dataset.path_in_locked_datasets', path, locked_datasets)
 
-    @api_method(IscsiExtentCreateArgs, IscsiExtentCreateResult, audit='Create iSCSI extent', audit_extended=lambda data: data['name'])
+    @api_method(
+        IscsiExtentCreateArgs,
+        IscsiExtentCreateResult,
+        audit='Create iSCSI extent',
+        audit_extended=lambda data: data['name']
+    )
     async def do_create(self, data):
         """
         Create an iSCSI Extent.
@@ -104,7 +109,12 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.get_instance(data['id'])
 
-    @api_method(IscsiExtentUpdateArgs, IscsiExtentUpdateResult, audit='Update iSCSI extent', audit_callback=True)
+    @api_method(
+        IscsiExtentUpdateArgs,
+        IscsiExtentUpdateResult,
+        audit='Update iSCSI extent',
+        audit_callback=True
+    )
     async def do_update(self, audit_callback, id_, data):
         """
         Update iSCSI Extent of `id`.
@@ -138,7 +148,12 @@ class iSCSITargetExtentService(SharingService):
 
         return await self.get_instance(id_)
 
-    @api_method(IscsiExtentDeleteArgs, IscsiExtentDeleteResult, audit='Delete iSCSI extent', audit_callback=True)
+    @api_method(
+        IscsiExtentDeleteArgs,
+        IscsiExtentDeleteResult,
+        audit='Delete iSCSI extent',
+        audit_callback=True
+    )
     async def do_delete(self, audit_callback, id_, remove, force):
         """
         Delete iSCSI Extent of `id`.


### PR DESCRIPTION
Converts the `iscsi.extent` endpoints to the new api paradigm.

----
Clear CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1714/):