### PR TITLE
NAS-132270 / 25.04 / Improve fcport.status when ALUA is disabled

### DIFF
--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -173,7 +173,15 @@ class FCPortService(CRUDService):
                             sessions.append(entry.name)
             except FileNotFoundError:
                 # In HA when ALUA is disabled this path will not exist
-                pass
+                result[p['port']] = {
+                    'port_type': 'Unknown',
+                    'port_state': 'Offline',
+                    'speed': 'Unknown',
+                    'physical': False,
+                    key: naa,
+                    'sessions': [],
+                }
+                continue
             # Take some data directly from fc.fc_hosts
             result[p['port']] = {
                 'port_type': naa_to_fc_host[naa]['port_type'],


### PR DESCRIPTION
This change will avoid a `KeyError` for NPIV configurations when ALUA is disabled.