### PR TITLE
NAS-132186 / 25.04 / Fix proxy test

### DIFF
--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -16,9 +16,9 @@ INS2_NAME = 'void'
 INS2_OS = 'Void Linux'
 INS2_IMAGE = 'voidlinux/musl'
 
-INS3_NAME = 'centos'
-INS3_OS = 'CentOS'
-INS3_IMAGE = 'centos/9-Stream'
+INS3_NAME = 'ubuntu'
+INS3_OS = 'Ubuntu'
+INS3_IMAGE = 'ubuntu/oracular/default'
 
 
 def clean():
@@ -141,7 +141,6 @@ def test_virt_instance_device_add():
 
 
 def test_virt_instance_proxy():
-    ssh(f'incus exec {INS3_NAME} -- yum install -y nmap-ncat')
     ssh(f'incus exec -T {INS3_NAME} -- bash -c "nohup nc -l 0.0.0.0 80 > /tmp/nc 2>&1 &"')
     ssh('echo "foo" | nc -w 1 localhost 8005 || true')
     rv = ssh(f'incus exec {INS3_NAME} -- cat /tmp/nc')


### PR DESCRIPTION
I dont have a great explanation why, probably nmap-ncat behaves differently and maybe a race condition (I couldn't reproduce locally), but with ubuntu and built-in nc we dont seem to have that problem:

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1707/#showFailuresLink