### PR TITLE
NAS-132303 / 25.04 / remove strftime call in boot.environment.query

### DIFF
--- a/src/middlewared/middlewared/plugins/boot_/environments.py
+++ b/src/middlewared/middlewared/plugins/boot_/environments.py
@@ -119,7 +119,7 @@ class BootEnvironmentService(Service):
                     "activated": activated_be == ds_name,
                     "created": datetime.datetime.utcfromtimestamp(
                         props["creation"]["value"]
-                    ).strftime("%Y-%m-%d %H:%M"),
+                    ),
                     "used_bytes": props["used"]["value"],
                     "used": format_size(props["used"]["value"]),
                     "keep": props["zectl:keep"]["value"] == "True",


### PR DESCRIPTION
This is changing the datetime object into a string which doesn't match the schema annotation.