### PR TITLE
NAS-132307 / 25.04 / remove accepts from CacheService plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -1,81 +1,58 @@
-from middlewared.schema import Any, Str, Int, accepts
-from middlewared.service import Service, private
-
 from collections import namedtuple
-import time
+from collections.abc import Callable
+from time import monotonic
+from typing import Any
+
+from middlewared.service import Service
 
 
 class CacheService(Service):
-
     class Config:
         private = True
 
     def __init__(self, *args, **kwargs):
         super(CacheService, self).__init__(*args, **kwargs)
         self.__cache = {}
-        self.kv_tuple = namedtuple('Cache', ['value', 'timeout'])
+        self.kv_tuple = namedtuple("Cache", ["value", "timeout"])
 
-    @accepts(Str('key'))
-    def has_key(self, key):
-        """
-        Check if given `key` is in cache.
-        """
+    def has_key(self, key: str):
+        """Check if given `key` is in cache."""
         return key in self.__cache
 
-    @accepts(Str('key'))
-    def get(self, key):
+    def get(self, key: str):
         """
         Get `key` from cache.
 
         Raises:
             KeyError: not found in the cache
         """
-
         if self.__cache[key].timeout > 0:
             self.get_timeout(key)
-
         return self.__cache[key].value
 
-    @accepts(Str('key'), Any('value'), Int('timeout', default=0))
-    def put(self, key, value, timeout):
-        """
-        Put `key` of `value` in the cache.
-        """
-
+    def put(self, key: str, value: Any, timeout: int = 0):
+        """Put `key` of `value` in the cache."""
         if timeout != 0:
-            timeout = time.monotonic() + timeout
+            timeout = monotonic() + timeout
+        self.__cache[key] = self.kv_tuple(value=value, timeout=timeout)
 
-        v = self.kv_tuple(value=value, timeout=timeout)
-        self.__cache[key] = v
+    def pop(self, key: str):
+        """Removes and returns `key` from cache."""
+        try:
+            self.__cache.pop(key, None).value
+        except AttributeError:
+            pass
 
-    @accepts(Str('key'))
-    def pop(self, key):
-        """
-        Removes and returns `key` from cache.
-        """
-        cache = self.__cache.pop(key, None)
-
-        if cache is not None:
-            cache = cache.value
-
-        return cache
-
-    @private
-    def get_timeout(self, key):
-        """
-        Check if 'key' has expired
-        """
-        now = time.monotonic()
+    def get_timeout(self, key: str):
+        """Check if 'key' has expired"""
+        now = monotonic()
         value, timeout = self.__cache[key]
-
         if now >= timeout:
             # Bust the cache
             del self.__cache[key]
+            raise KeyError(f"{key} has expired")
 
-            raise KeyError(f'{key} has expired')
-
-    @private
-    def get_or_put(self, key, timeout, method):
+    def get_or_put(self, key: str, timeout: int, method: Callable):
         try:
             return self.get(key)
         except KeyError:

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -39,7 +39,7 @@ class CacheService(Service):
     def pop(self, key: str):
         """Removes and returns `key` from cache."""
         try:
-            self.__cache.pop(key, None).value
+            return self.__cache.pop(key, None).value
         except AttributeError:
             pass
 

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -38,10 +38,10 @@ class CacheService(Service):
 
     def pop(self, key: str):
         """Removes and returns `key` from cache."""
-        try:
-            return self.__cache.pop(key, None).value
-        except AttributeError:
-            pass
+        cache = self.__cache.pop(key, None)
+        if cache is not None:
+            cache = cache.value
+        return cache
 
     def get_timeout(self, key: str):
         """Check if 'key' has expired"""


### PR DESCRIPTION
Our `api_method` decorator was designed (primarily) for public facing endpoints. However, for a private service like the `CacheService`, there is no reason to go through the boilerplate of adding all the arguments/returns. It's much easier and better (imo) to simply keep it marked private and remove the `@accepts` decorator. I've used builtin annotations to keep some semblance of what argument types are being passed to each method. This was easiest path forward without breaking backwards compatibility. There should be no change in functionality.