### PR TITLE
NAS-132314 / 24.10.1 / add hardware.virtualization plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware/virt_detection.py
+++ b/src/middlewared/middlewared/plugins/hardware/virt_detection.py
@@ -1,0 +1,19 @@
+import subprocess
+
+from middlewared.service import Service
+from middlewared.utils.functools_ import cache
+
+
+class HardwareVirtualization(Service):
+    class Config:
+        namespace = "hardware.virtualization"
+        private = True
+
+    @cache
+    def variant(self) -> str:
+        rv = subprocess.run(["systemd-detect-virt"], capture_output=True)
+        return rv.stdout.decode().strip()
+
+    def is_virtualized(self) -> bool:
+        """Detect if the TrueNAS system is virtualized"""
+        return self.variant() != 'none'


### PR DESCRIPTION
This is a private plugin that uses an upstream provided tool to detect if we're virtualized. This will be used, mostly, in the debug capturing process but also for a future commit (or any for that matter) that depends on determining if we're virtualized.

Original PR: https://github.com/truenas/middleware/pull/14886
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132314