### PR TITLE
NAS-132077 / 25.04 / Make sure helm secret is safely serialized when listing k8s backups

### DIFF
--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/secrets_utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/secrets_utils.py
@@ -50,7 +50,7 @@ def get_secret_contents(secret_path: str, helm_secret: bool = False) -> dict:
 
     contents = {}
     for k, v in secret['data'].items():
-        with contextlib.suppress(binascii.Error, gzip.BadGzipFile, KeyError):
+        with contextlib.suppress(binascii.Error, gzip.BadGzipFile, KeyError, UnicodeDecodeError):
             if helm_secret:
                 v = json.loads(gzip.decompress(b64decode(b64decode(v))).decode())
                 for pop_k in ('manifest', 'info', 'version', 'namespace'):


### PR DESCRIPTION
This commit makes sure when we are listing secrets of an app from k8s era, we safely handle `UnicodeDecodeError` which can come when a secret potentially gets corrupted (we did this in DF and earlier already when we used to list apps). Such a secret in this case is missed and we get the next secret available for the app.