### PR TITLE
NAS-132216 / 25.04 / Allow deletion of a custom app which has invalid compose file

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -165,6 +165,7 @@ def get_default_workload_values() -> dict:
         'container_details': [],  # This would contain service name and image in use
         'volumes': [],  # This would be docker volumes
         'images': [],
+        'networks': [],
     }
 
 
@@ -235,5 +236,6 @@ def translate_resources_to_desired_workflow(app_resources: dict) -> dict:
     workloads.update({
         'images': list(images),
         'volumes': [v.__dict__ for v in volumes],
+        'networks': app_resources['networks'],
     })
     return workloads


### PR DESCRIPTION
This PR adds changes to account for the case where a custom app might have invalid compose file in place and deletion of that app fails. We only allow it if there are no active resources belonging to that custom app and user has explicitly requested to move forward.