### PR TITLE
NAS-132266 / 25.04 / Allow filesystem.setperm to not have mode specified

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -62,8 +62,19 @@ class FilesystemChownResult(BaseModel):
 
 @single_argument_args('filesystem_setperm')
 class FilesystemSetPermArgs(FilesystemPermChownBase):
-    mode: UnixPerm
+    mode: UnixPerm | None = None
     options: FilesystemSetpermOptions = Field(default=FilesystemSetpermOptions())
+
+    @model_validator(mode='after')
+    def payload_is_actionable(self) -> Self:
+        """ User should be changing something. Either stripping ACL or setting mode """
+        if self.mode is None and self.options.stripacl is False:
+            raise ValueError(
+                'Payload must either explicitly specify permissions or '
+                'contain the stripacl option.'
+            )
+
+        return self
 
 
 class FilesystemSetPermResult(BaseModel):

--- a/tests/api2/test_filesystem_setperm_strip_acl.py
+++ b/tests/api2/test_filesystem_setperm_strip_acl.py
@@ -1,0 +1,29 @@
+import os
+
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+
+def test__strip_acl_setperm():
+    """ verify ACL can be stripped on single file by explicity specifying strip """
+    with dataset('stripacl_test', {'share_type': 'SMB'}) as ds:
+        mp = os.path.join('/mnt', ds)
+
+        dir_path = os.path.join(mp, 'thedir')
+        assert call('filesystem.stat', mp)['acl']
+
+        call('filesystem.mkdir', {'path': dir_path, 'options': {'raise_chmod_error': False}})
+        assert call('filesystem.stat', dir_path)['acl']
+
+        # nonrecursive
+        call('filesystem.setperm', {'path': mp, 'options': {'stripacl': True}}, job=True)
+
+        # target for setperm should not have ACL anymore
+        assert not call('filesystem.stat', mp)['acl']
+
+        # but directory should
+        assert call('filesystem.stat', dir_path)['acl']
+
+        # recursive
+        call('filesystem.setperm', {'path': mp, 'options': {'stripacl': True, 'recursive': True}}, job=True)
+        assert not call('filesystem.stat', dir_path)['acl']


### PR DESCRIPTION
The UI team uses the combination of no mode with stripacl to strip ACLs from paths.