### PR TITLE
NAS-131723 / 25.04 / Add exclusion support for TrueCloud backup tasks

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -64,8 +64,7 @@ async def restic_backup(middleware, job, cloud_backup, dry_run):
         if dry_run:
             cmd.append("-n")
 
-        for excl in cloud_backup["exclude"]:
-            cmd.extend(["--exclude", excl])
+        cmd.extend(["--exclude=" + excl for excl in cloud_backup["exclude"]])
 
         restic_config = get_restic_config(cloud_backup)
 

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -9,7 +9,7 @@ from middlewared.service import CallError, Service, item_method, job, private
 from middlewared.utils.time_utils import utc_now
 
 
-async def restic(middleware, job, cloud_backup, dry_run):
+async def restic_backup(middleware, job, cloud_backup, dry_run):
     await middleware.call("network.general.will_perform_activity", "cloud_backup")
 
     snapshot = None
@@ -63,6 +63,9 @@ async def restic(middleware, job, cloud_backup, dry_run):
 
         if dry_run:
             cmd.append("-n")
+
+        for excl in cloud_backup["exclude"]:
+            cmd.extend(["--exclude", excl])
 
         restic_config = get_restic_config(cloud_backup)
 
@@ -122,7 +125,7 @@ class CloudBackupService(Service):
         try:
             await self.middleware.call("cloud_backup.ensure_initialized", cloud_backup)
 
-            await restic(self.middleware, job, cloud_backup, options["dry_run"])
+            await restic_backup(self.middleware, job, cloud_backup, options["dry_run"])
 
             job.set_progress(100, "Cleaning up")
             restic_config = get_restic_config(cloud_backup)


### PR DESCRIPTION
Patterns can be given when creating a TrueCloud Backup task that will exclude matching directories and files from the backup.

https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files