### PR TITLE
NAS-132347 / 25.04 / Fix Fibre Channel ALUA

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -99,7 +99,8 @@
         # Physical devices are added to the config automatically.  We want to
         # identify any that are not being used and select a rel_tgt_id in the
         # 10K range for them.
-        physical_naa = {str_to_naa(entry['port_name']) for entry in middleware.call_sync('fc.fc_hosts', [['physical', '=', True]], {'select': ['port_name']})}
+        ports_in_use = middleware.call_sync('fc.fc_hosts', [['physical', '=', True]], {'select': ['port_name']})
+        physical_naa = {str_to_naa(entry['port_name']) for entry in ports_in_use}
         used_physical_naa = set()
         for entry in render_ctx['fcport.query']:
             if '/' not in entry['port']:

--- a/src/middlewared/middlewared/plugins/iscsi_/alua.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/alua.py
@@ -343,6 +343,7 @@ class iSCSITargetAluaService(Service):
                     return
                 else:
                     job.set_progress(25, 'Logged in HA targets')
+                    self.logger.debug('Logged in HA targets')
 
                 # Now that we've logged in the HA targets, regenerate the config so that the
                 # dev_disk DEVICEs are present (we cleared _standby_write_empty_config above).
@@ -353,6 +354,7 @@ class iSCSITargetAluaService(Service):
                 # Sanity check that all the targets surfaced up thru SCST okay.
                 devices = list(itertools.chain.from_iterable([x for x in after_iqns.values() if x is not None]))
                 if await self.middleware.call('iscsi.scst.check_cluster_mode_paths_present', devices):
+                    self.logger.debug(f'cluster_mode surfaced for {devices}')
                     break
 
                 self.logger.debug('Detected missing cluster_mode.  Retrying.')
@@ -505,9 +507,10 @@ class iSCSITargetAluaService(Service):
             # it will now offer the targets to the world.
             await self.middleware.call('service.reload', 'iscsitarget')
             job.set_progress(100, 'Reloaded iscsitarget service')
+            self.logger.debug(f'Fixed cluster_mode for {len(devices)} extents (reloaded)')
         else:
             job.set_progress(100, 'Fixed cluster_mode')
-        self.logger.debug(f'Fixed cluster_mode for {len(devices)} extents')
+            self.logger.debug(f'Fixed cluster_mode for {len(devices)} extents')
 
     async def wait_cluster_mode(self, target_id, extent_id):
         """After we add a target/extent mapping we wish to wait for the ALUA state to settle."""

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -124,11 +124,17 @@ class iSCSITargetService(Service):
         else:
             return False
 
-    def delete_lun(self, iqn, lun):
+    def delete_iscsi_lun(self, iqn, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'del {lun}\n')
 
-    def replace_lun(self, iqn, extent, lun):
+    def replace_iscsi_lun(self, iqn, extent, lun):
         pathlib.Path(f'{SCST_BASE}/targets/iscsi/{iqn}/ini_groups/security_group/luns/mgmt').write_text(f'replace {extent} {lun}\n')
+
+    def delete_fc_lun(self, wwpn, lun):
+        pathlib.Path(f'{SCST_BASE}/targets/qla2x00t/{wwpn}/luns/mgmt').write_text(f'del {lun}\n')
+
+    def replace_fc_lun(self, wwpn, extent, lun):
+        pathlib.Path(f'{SCST_BASE}/targets/qla2x00t/{wwpn}/luns/mgmt').write_text(f'replace {extent} {lun}\n')
 
     def set_node_optimized(self, node):
         """Update which node is reported as being the active/optimized path."""


### PR DESCRIPTION
Avoid some fragility when toggling ALUA on.

Found that needed to **skip** the NPIV target in `scst.conf` when `standby_write_empty_config` was true, and add them afterwards.  Avoids a `scstadmin` load error on the (required) subsequent service reload.

Also, **always** write physical port targets to `scst.conf` as these will otherwise be auto-added by SCST - with a potentially clashing `rel_tgt_id`.  CI tests needed to be updated to take account of this change.

Finally, implemented some changes wrt ALUA failover.  Previously all targets were iSCSI, whereas now `iscsi.alua.become_active` and `iscsi.alua.removed_target_extent` need to take slightly different actions depending on the target mode.  This also necessitated some minor (private) API changes in `iscsi.scst`.