### PR TITLE
NAS-132351 / 25.04 / Fix disk device serial migration

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-10-29_12-43_vm_zvol_serial.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-10-29_12-43_vm_zvol_serial.py
@@ -12,6 +12,8 @@ from string import ascii_letters, digits, punctuation
 
 from alembic import op
 
+from middlewared.plugins.pwenc import encrypt, decrypt
+
 
 revision = 'a4ce4939b908'
 down_revision = 'dd6e581235b2'
@@ -39,9 +41,9 @@ def generate_string(string_size=8, punctuation_chars=False, extra_chars=None):
 def upgrade():
     conn = op.get_bind()
     for device in conn.execute("SELECT * FROM vm_device WHERE dtype IN ('DISK', 'RAW')").fetchall():
-        attributes = json.loads(device['attributes'])
+        attributes = json.loads(decrypt(device['attributes']))
         attributes['serial'] = generate_string(string_size=8)
-        conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (json.dumps(attributes), device['id']))
+        conn.execute("UPDATE vm_device SET attributes = ? WHERE id = ?", (encrypt(json.dumps(attributes)), device['id']))
 
 
 def downgrade():


### PR DESCRIPTION
## Problem

A migration was added to make VM devices attributes field to be encrypted in EE and backported to FT. However now on FT when migrations are executed, EE migrations run first which makes the field encrypted and then when a migration runs which touches the `vm_device` table, that fails to execute properly as the field is encrypted now.


## Solution

Make sure we treat `attributes` column as encrypted when running the relevant migration in FT.