### PR TITLE
NAS-132361 / 25.04 / Fix runtest.py when an absolute path is provided to --tests

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -313,7 +313,11 @@ def parse_test_name(test):
     return test
 
 def parse_test_name_prefix_dir(test_name):
-    return f"api2/{parse_test_name(test_name)}"
+    name = parse_test_name(test_name)
+    if name.startswith('/'):
+        return name
+    else:
+        return f"api2/{name}"
 
 if tests:
     pytest_command.extend(list(map(parse_test_name_prefix_dir, tests)))


### PR DESCRIPTION
A previous fix (#14880) did not take account of when an absolute path is provided to `--tests`.  Rectify.

With this the following all work:
```
~/truenas/middleware/tests$ ./runtest.py -v --ip scale3 --interface enp0s8 --password password --test test_mock_remote.py
~/truenas/middleware/tests$ ./runtest.py -v --ip scale3 --interface enp0s8 --password password --test api2/test_mock_remote.py
~/truenas/middleware/tests$ ./runtest.py -v --ip scale3 --interface enp0s8 --password password --tests test_mock_remote.py
~/truenas/middleware/tests$ ./runtest.py -v --ip scale3 --interface enp0s8 --password password --tests api2/test_mock_remote.py
~/truenas/middleware/tests$ ./runtest.py -v --ip scale3 --interface enp0s8 --password password --tests /home/brian/truenas/middleware/tests/api2/test_mock_remote.py
```

