### PR TITLE
NAS-132402 / 25.04 / Refactor dtype key in VM device attrs

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-11-10_12-23_vm_device_dtype.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-11-10_12-23_vm_device_dtype.py
@@ -1,0 +1,37 @@
+"""
+Normalize vm_device attributes with dtype
+
+Revision ID: 0972c1f572b8
+Revises: f077d0ae123d
+Create Date: 2024-11-10 12:23:04.993358+00:00
+"""
+import json
+
+from alembic import op
+
+from middlewared.plugins.pwenc import encrypt, decrypt
+
+
+revision = '0972c1f572b8'
+down_revision = 'f077d0ae123d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    for vm_device_config in conn.execute("SELECT * FROM vm_device").fetchall():
+        vm_device_config = dict(vm_device_config)
+        attributes = json.loads(decrypt(vm_device_config['attributes']))
+        attributes['dtype'] = vm_device_config['dtype']
+        conn.execute(
+            "UPDATE vm_device SET attributes = ? WHERE id = ?",
+            (encrypt(json.dumps(attributes)), vm_device_config['id'])
+        )
+
+    with op.batch_alter_table('vm_device', schema=None) as batch_op:
+        batch_op.drop_column('dtype')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/interface/link_address.py
+++ b/src/middlewared/middlewared/plugins/interface/link_address.py
@@ -197,7 +197,9 @@ class InterfaceRenamer:
                     "datastore.update", "network.vlan", vlan["id"], {"vlan_pint": new_name}, {"ha_sync": False},
                 )
 
-        for vm_device in await self.middleware.call("datastore.query", "vm.device", [["dtype", "=", "NIC"]]):
+        # We use vm.device.query because attributes.dtype filter won't work with datastore plugin as attributes
+        # column is not serialized at the point datastore plugin applies filters
+        for vm_device in await self.middleware.call("vm.device.query", [["attributes.dtype", "=", "NIC"]]):
             if new_name := self.mapping.get(vm_device["attributes"].get("nic_attach")):
                 self.middleware.logger.info("Changing VM NIC device %r from %r to %r", vm_device["id"],
                                             vm_device["attributes"]["nic_attach"], new_name)

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -318,8 +318,8 @@ class PoolDatasetService(Service):
             results['rsync'].append(task)
 
         # vm
-        for vm in self.middleware.call_sync('datastore.query', 'vm.device', [['dtype', 'in', ['RAW', 'DISK']]]):
-            if vm['dtype'] == 'DISK':
+        for vm in self.middleware.call_sync('vm.device.query', [['attributes.dtype', 'in', ['RAW', 'DISK']]]):
+            if vm['attributes']['dtype'] == 'DISK':
                 # disk type is always a zvol
                 vm['zvol'] = zvol_path_to_name(vm['attributes']['path'])
             else:

--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -45,7 +45,7 @@ class PoolDatasetService(Service):
         result = []
         for vm in await self.middleware.call('vm.query', [('autostart', '=', True)]):
             for device in vm['devices']:
-                if device['dtype'] not in ('DISK', 'RAW'):
+                if device['attributes']['dtype'] not in ('DISK', 'RAW'):
                     continue
 
                 path = device['attributes'].get('path')

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -407,7 +407,7 @@ class UsageService(Service):
             nics = disks = 0
             display_list = []
             for d in v['devices']:
-                dtype = d['dtype']
+                dtype = d['attributes']['dtype']
                 if dtype == 'NIC':
                     nics += 1
                 elif dtype == 'DISK':

--- a/src/middlewared/middlewared/plugins/vm/attachments.py
+++ b/src/middlewared/middlewared/plugins/vm/attachments.py
@@ -13,7 +13,7 @@ async def determine_recursive_search(recursive, device, child_datasets):
     # TODO: Add unit tests for this please
     if recursive:
         return True
-    elif device['dtype'] == 'DISK':
+    elif device['attributes']['dtype'] == 'DISK':
         return False
 
     # What we want to do here is make sure that any raw files or cdrom files are not living in the child
@@ -45,7 +45,7 @@ class VMService(Service):
         to_ignore_vms = await self.get_vms_to_ignore_for_querying_attachments(True, [['suspend_on_snapshot', '=', False]])
         for device in await self.middleware.call(
             'vm.device.query', [
-                ['dtype', 'in', ('DISK', 'RAW', 'CDROM')],
+                ['attributes.dtype', 'in', ('DISK', 'RAW', 'CDROM')],
                 ['vm', 'nin', to_ignore_vms],
             ]
         ):
@@ -82,7 +82,7 @@ class VMFSAttachmentDelegate(FSAttachmentDelegate):
         vms_attached = []
         ignored_vms = await self.middleware.call('vm.get_vms_to_ignore_for_querying_attachments', enabled)
         for device in await self.middleware.call('datastore.query', 'vm.device'):
-            if (device['dtype'] not in ('DISK', 'RAW', 'CDROM')) or device['vm']['id'] in ignored_vms:
+            if (device['attributes']['dtype'] not in ('DISK', 'RAW', 'CDROM')) or device['vm']['id'] in ignored_vms:
                 continue
 
             disk = device['attributes'].get('path')
@@ -133,7 +133,7 @@ class VMPortDelegate(PortDelegate):
     async def get_ports(self):
         ports = []
         vms = {vm['id']: vm['name'] for vm in await self.middleware.call('vm.query')}
-        for device in await self.middleware.call('vm.device.query', [['dtype', '=', 'DISPLAY']]):
+        for device in await self.middleware.call('vm.device.query', [['attributes.dtype', '=', 'DISPLAY']]):
             ports.append({
                 'description': f'{vms[device["vm"]]!r} VM',
                 'ports': [

--- a/src/middlewared/middlewared/plugins/vm/clone.py
+++ b/src/middlewared/middlewared/plugins/vm/clone.py
@@ -105,20 +105,21 @@ class VMService(Service):
             for item in devices:
                 item.pop('id', None)
                 item['vm'] = new_vm['id']
-                if item['dtype'] == 'NIC':
+                item_dtype = item['attributes']['dtype']
+                if item_dtype == 'NIC':
                     if 'mac' in item['attributes']:
                         del item['attributes']['mac']
-                if item['dtype'] == 'DISPLAY':
+                if item_dtype == 'DISPLAY':
                     if 'port' in item['attributes']:
                         dev_dict = await self.middleware.call('vm.port_wizard')
                         item['attributes']['port'] = dev_dict['port']
                         item['attributes']['web_port'] = dev_dict['web']
-                if item['dtype'] == 'DISK':
+                if item_dtype == 'DISK':
                     zvol = zvol_path_to_name(item['attributes']['path'])
                     item['attributes']['path'] = zvol_name_to_path(
                         await self.__clone_zvol(vm['name'], zvol, created_snaps, created_clones)
                     )
-                if item['dtype'] == 'RAW':
+                if item_dtype == 'RAW':
                     self.logger.warning('RAW disks must be copied manually. Skipping...')
                     continue
 
@@ -148,7 +149,7 @@ class VMService(Service):
     async def validate(self, vm):
         verrors = ValidationErrors()
         for index, device in enumerate(vm['devices']):
-            if device['dtype'] == 'DISPLAY' and not device['attributes'].get('password'):
+            if device['attributes']['dtype'] == 'DISPLAY' and not device['attributes'].get('password'):
                 verrors.add(
                     f'vm.devices.{index}.attributes.password',
                     'Password must be configured for display device in order to clone the VM.'

--- a/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/cdrom.py
@@ -1,7 +1,7 @@
 import os
 
 from middlewared.plugins.boot import BOOT_POOL_NAME
-from middlewared.schema import Dict, File
+from middlewared.schema import Dict, File, Str
 from middlewared.service import CallError
 from middlewared.utils.zfs import query_imported_fast_impl
 from middlewared.validators import check_path_resides_within_volume_sync, Match
@@ -22,6 +22,7 @@ class CDROM(Device):
                 ),
             ], empty=False
         ),
+        Str('dtype', enum=['CDROM'], required=True),
     )
 
     def identity(self):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -20,6 +20,7 @@ class DISPLAY(Device):
 
     schema = Dict(
         'attributes',
+        Str('dtype', enum=['DISPLAY'], required=True),
         Str('resolution', enum=RESOLUTION_ENUM, default='1024x768'),
         Int('port', default=None, null=True, validators=[Range(min_=5900, max_=65535)]),
         Int('web_port', default=None, null=True, validators=[Range(min_=5900, max_=65535)]),

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -17,6 +17,7 @@ class NIC(Device):
         Str('type', enum=['E1000', 'VIRTIO'], default='E1000'),
         Str('nic_attach', default=None, null=True),
         Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
+        Str('dtype', enum=['NIC'], required=True),
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/middlewared/middlewared/plugins/vm/devices/pci.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/pci.py
@@ -25,7 +25,7 @@ class PCIBase(Device):
 
     def pre_start_vm_device_setup(self, context):
         if self.in_use_by_vm(context['vms'], context['vm_devices']):
-            raise CallError(f'{self.data["dtype"]} device is already being used by another active VM')
+            raise CallError(f'{self.data["attributes"]["dtype"]} device is already being used by another active VM')
 
 
 class PCI(PCIBase):
@@ -33,10 +33,11 @@ class PCI(PCIBase):
     schema = Dict(
         'attributes',
         Str('pptdev', required=True, empty=False),
+        Str('dtype', enum=['PCI'], required=True),
     )
 
     def vm_device_filters(self):
-        return [['attributes.pptdev', '=', self.passthru_device()], ['dtype', '=', 'PCI']]
+        return [['attributes.pptdev', '=', self.passthru_device()], ['attributes.dtype', '=', 'PCI']]
 
     def detach_device(self):
         cp = subprocess.Popen(

--- a/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/storage_devices.py
@@ -94,6 +94,7 @@ class RAW(StorageDevice):
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Str('iotype', enum=IOTYPE_CHOICES, default='THREADS'),
         Str('serial'),
+        Str('dtype', enum=['RAW'], required=True),
     )
 
     def create_source_element(self):
@@ -136,6 +137,7 @@ class DISK(StorageDevice):
         Int('physical_sectorsize', enum=[None, 512, 4096], default=None, null=True),
         Str('iotype', enum=IOTYPE_CHOICES, default='THREADS'),
         Str('serial'),
+        Str('dtype', enum=['DISK'], required=True),
     )
 
     def create_source_element(self):

--- a/src/middlewared/middlewared/plugins/vm/devices/usb.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/usb.py
@@ -30,6 +30,7 @@ class USB(PCIBase):
         ),
         Str('controller_type', empty=False, default='nec-xhci', enum=USB_CONTROLLER_CHOICES),
         Str('device', empty=False, null=True, default=None),
+        Str('dtype', enum=['USB'], required=True),
     )
 
     @property

--- a/src/middlewared/middlewared/plugins/vm/vm_display_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_display_info.py
@@ -34,7 +34,9 @@ class VMService(Service):
     async def all_used_display_device_ports(self, additional_filters=None):
         all_ports = [6000]
         additional_filters = additional_filters or []
-        for device in await self.middleware.call('vm.device.query', [['dtype', '=', 'DISPLAY']] + additional_filters):
+        for device in await self.middleware.call(
+            'vm.device.query', [['attributes.dtype', '=', 'DISPLAY']] + additional_filters
+        ):
             all_ports.extend([device['attributes']['port'], device['attributes']['web_port']])
         return all_ports
 
@@ -54,7 +56,6 @@ class VMService(Service):
             Dict(
                 'vmdevice',
                 Int('id'),
-                Str('dtype'),
                 DISPLAY.schema,
                 Int('order'),
                 Int('vm'),
@@ -67,7 +68,9 @@ class VMService(Service):
         `attributes.password_configured` will be set to `true`.
         """
         devices = []
-        for device in await self.middleware.call('vm.device.query', [['vm', '=', id_], ['dtype', '=', 'DISPLAY']]):
+        for device in await self.middleware.call(
+            'vm.device.query', [['vm', '=', id_], ['attributes.dtype', '=', 'DISPLAY']]
+        ):
             device['attributes']['password_configured'] = bool(device['attributes'].get('password'))
             devices.append(device)
         return devices
@@ -117,7 +120,7 @@ class VMService(Service):
     @private
     async def get_display_devices_ui_info(self):
         devices = []
-        for device in await self.middleware.call('vm.device.query', [['dtype', '=', 'DISPLAY']]):
+        for device in await self.middleware.call('vm.device.query', [['attributes.dtype', '=', 'DISPLAY']]):
             devices.append(DISPLAY(device, middleware=self.middleware).get_webui_info())
         return devices
 

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -45,7 +45,7 @@ class VMService(Service, VMSupervisorMixin):
 
         if await self.middleware.call('system.is_ha_capable'):
             for device in vm['devices']:
-                if device['dtype'] in ('PCI', 'USB'):
+                if device['attributes']['dtype'] in ('PCI', 'USB'):
                     raise CallError(
                         'Please remove PCI/USB devices from VM before starting it in HA capable machines as '
                         'they are not supported.'

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -130,7 +130,7 @@ class VMService(CRUDService, VMSupervisorMixin):
             [('vm', '=', vm['id'])],
             {'force_sql_filters': True},
         )
-        vm['display_available'] = any(device['dtype'] == 'DISPLAY' for device in vm['devices'])
+        vm['display_available'] = any(device['attributes']['dtype'] == 'DISPLAY' for device in vm['devices'])
         vm['status'] = context['status'][vm['id']]
         return vm
 
@@ -430,7 +430,7 @@ class VMService(CRUDService, VMSupervisorMixin):
 
             if data['zvols']:
                 devices = await self.middleware.call('vm.device.query', [
-                    ('vm', '=', id_), ('dtype', '=', 'DISK')
+                    ('vm', '=', id_), ('attributes.dtype', '=', 'DISK')
                 ])
 
                 for zvol in devices:

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_attachments.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_attachments.py
@@ -4,10 +4,10 @@ from middlewared.plugins.vm.attachments import determine_recursive_search
 
 
 @pytest.mark.parametrize('recursive,device,child_datasets,result', [
-    (True, {'attributes': {'path': '/mnt/tank/somefile'}, 'dtype': 'CDROM'}, ['tank/child'], True),
-    (False, {'attributes': {'path': '/dev/zvol/tank/somezvol'}, 'dtype': 'DISK'}, ['tank/child'], False),
-    (False, {'attributes': {'path': '/mnt/tank/child/file'}, 'dtype': 'RAW'}, ['tank/child'], False),
-    (False, {'attributes': {'path': '/mnt/tank/file'}, 'dtype': 'RAW'}, ['tank/child'], True),
+    (True, {'attributes': {'path': '/mnt/tank/somefile', 'dtype': 'CDROM'}}, ['tank/child'], True),
+    (False, {'attributes': {'path': '/dev/zvol/tank/somezvol', 'dtype': 'DISK'}}, ['tank/child'], False),
+    (False, {'attributes': {'path': '/mnt/tank/child/file', 'dtype': 'RAW'}}, ['tank/child'], False),
+    (False, {'attributes': {'path': '/mnt/tank/file', 'dtype': 'RAW'}}, ['tank/child'], True),
 ])
 @pytest.mark.asyncio
 async def test_determining_recursive_search(recursive, device, child_datasets, result):

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_validation.py
@@ -16,9 +16,9 @@ AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
                 'type': 'VIRTIO',
                 'mac': '00:a0:99:7e:bb:8a',
                 'nic_attach': 'br0',
-                'trust_guest_rx_filters': False
+                'trust_guest_rx_filters': False,
+                'dtype': 'NIC',
             },
-            'dtype': 'NIC',
         },
         ''
     ),
@@ -28,9 +28,9 @@ AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
                 'type': 'VIRTIO',
                 'mac': '00:a0:99:7e:bb:8a',
                 'nic_attach': 'br2',
+                'dtype': 'NIC',
                 'trust_guest_rx_filters': False
             },
-            'dtype': 'NIC',
         },
         '[EINVAL] attributes.nic_attach: Not a valid choice.'
     ),
@@ -40,9 +40,9 @@ AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
                 'type': 'VIRTIO',
                 'mac': 'ff:a0:99:7e:bb:8a',
                 'nic_attach': 'br0',
+                'dtype': 'NIC',
                 'trust_guest_rx_filters': False
             },
-            'dtype': 'NIC',
         },
         '[EINVAL] attributes.mac: MAC address must not start with `ff`'
     ),
@@ -52,9 +52,9 @@ AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
                 'type': 'VIRTIO',
                 'mac': 'ff:a0:99:7e:bb:8a',
                 'nic_attach': 'br0',
+                'dtype': 'NIC',
                 'trust_guest_rx_filters': True
             },
-            'dtype': 'NIC',
         },
         '[EINVAL] attributes.trust_guest_rx_filters: This can only be set when "nic_attach" is not a bridge device'
     ),
@@ -64,9 +64,9 @@ AVAILABLE_NIC_INTERFACES = ['br0', 'eth0']
                 'type': 'E1000',
                 'mac': 'ff:a0:99:7e:bb:8a',
                 'nic_attach': 'eth0',
+                'dtype': 'NIC',
                 'trust_guest_rx_filters': True
             },
-            'dtype': 'NIC',
         },
         '[EINVAL] attributes.trust_guest_rx_filters: This can only be set when "type" of NIC device is "VIRTIO"'
     ),

--- a/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/vm/test_vm_devices_xml.py
@@ -22,8 +22,7 @@ def test_basic_devices_xml(vm_data, expected_xml):
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
     ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
-        'attributes': {'path': '/mnt/tank/disk.iso'},
-        'dtype': 'CDROM',
+        'attributes': {'path': '/mnt/tank/disk.iso', 'dtype': 'CDROM'},
     }]}, '<devices><disk type="file" device="cdrom"><driver name="qemu" type="raw" />'
          '<source file="/mnt/tank/disk.iso" /><target dev="sda" bus="sata" /><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -40,8 +39,8 @@ def test_cdrom_xml(vm_data, expected_xml):
 
 @pytest.mark.parametrize('vm_data,expected_xml', [
     ({'ensure_display_device': False, 'trusted_platform_module': False, 'min_memory': None, 'devices': [{
-        'dtype': 'DISPLAY',
         'attributes': {
+            'dtype': 'DISPLAY',
             'bind': '0.0.0.0',
             'password': '',
             'web': True,
@@ -72,9 +71,9 @@ def test_display_xml(vm_data, expected_xml):
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
             'nic_attach': 'br0',
-            'trust_guest_rx_filters': False
+            'trust_guest_rx_filters': False,
+            'dtype': 'NIC',
         },
-        'dtype': 'NIC',
     }]}, '<devices><interface type="bridge"><source bridge="br0" /><model type="virtio" />'
          '<mac address="00:a0:99:7e:bb:8a" /></interface>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -84,9 +83,9 @@ def test_display_xml(vm_data, expected_xml):
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
             'nic_attach': 'ens3',
-            'trust_guest_rx_filters': False
+            'trust_guest_rx_filters': False,
+            'dtype': 'NIC',
         },
-        'dtype': 'NIC',
     }]}, '<devices><interface type="direct" trustGuestRxFilters="no"><source dev="ens3" mode="bridge" />'
          '<model type="virtio" /><mac address="00:a0:99:7e:bb:8a" /></interface>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -96,9 +95,9 @@ def test_display_xml(vm_data, expected_xml):
             'type': 'VIRTIO',
             'mac': '00:a0:99:7e:bb:8a',
             'nic_attach': 'ens3',
-            'trust_guest_rx_filters': True
+            'trust_guest_rx_filters': True,
+            'dtype': 'NIC',
         },
-        'dtype': 'NIC',
     }]}, '<devices><interface type="direct" trustGuestRxFilters="yes"><source dev="ens3" mode="bridge" />'
          '<model type="virtio" /><mac address="00:a0:99:7e:bb:8a" /></interface>'
          f'{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -125,9 +124,9 @@ def test_nic_xml(vm_data, expected_xml):
             'logical_sectorsize': None,
             'physical_sectorsize': None,
             'iotype': 'THREADS',
-            'serial': 'test-serial'
+            'serial': 'test-serial',
+            'dtype': 'DISK',
         },
-        'dtype': 'DISK',
     }]}, '<devices><disk type="block" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source dev="/dev/zvol/pool/boot_1" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -150,9 +149,9 @@ def test_disk_xml(vm_data, expected_xml):
             'logical_sectorsize': None,
             'physical_sectorsize': None,
             'iotype': 'THREADS',
-            'serial': 'test-serial'
+            'serial': 'test-serial',
+            'dtype': 'RAW',
         },
-        'dtype': 'RAW',
     }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          f'</disk>{GUEST_CHANEL}<serial type="pty" /></devices>'
@@ -164,9 +163,9 @@ def test_disk_xml(vm_data, expected_xml):
             'logical_sectorsize': 512,
             'physical_sectorsize': 512,
             'iotype': 'THREADS',
-            'serial': 'test-serial'
+            'serial': 'test-serial',
+            'dtype': 'RAW',
         },
-        'dtype': 'RAW',
     }]}, '<devices><disk type="file" device="disk"><driver name="qemu" type="raw" cache="none" io="threads" discard="unmap" />'
          '<source file="/mnt/tank/somefile" /><target bus="sata" dev="sda" /><serial>test-serial</serial><boot order="1" />'
          '<blockio logical_block_size="512" physical_block_size="512" /></disk>'


### PR DESCRIPTION
## Context

In order to remove `accepts` from VM plugin, we need to move `dtype` key to inside of `vm_device.attributes` as that is how the new api style models will work with VM devices. However this change is extensive/involved and has been done separately before the actual removal of accepts decorator from VM plugin so that it is easier to review/manage the changes where accepts decorator is removed.