### PR TITLE
NAS-132420 / 25.04 / The conint function has been deprecated.

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
@@ -5,7 +5,7 @@ from lexicon.providers.ovh import ENDPOINTS
 from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
-    BaseModel, Excluded, excluded_field, single_argument_args, ForUpdateMetaclass, LongString, NonEmptyString,
+    BaseModel, single_argument_args, ForUpdateMetaclass, LongString, NonEmptyString,
 )
 
 
@@ -25,7 +25,7 @@ FilePathStr = Annotated[
 ]
 
 
-### Custom ACME DNS Authenticator Schemas
+# Custom ACME DNS Authenticator Schemas
 
 
 class ACMECustomDNSAuthenticatorReturns(BaseModel):
@@ -87,7 +87,7 @@ AuthType: TypeAlias = Annotated[
 ]
 
 
-## ACME DNS Authenticator
+# ACME DNS Authenticator
 
 
 class ACMEDNSAuthenticatorEntry(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/acme_dns_authenticator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Annotated, Literal, TypeAlias
 
 from lexicon.providers.ovh import ENDPOINTS
-from pydantic import BeforeValidator, ConfigDict, conint, Field, FilePath, PlainSerializer, Secret
+from pydantic import BeforeValidator, ConfigDict, Field, FilePath, PlainSerializer, Secret
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, single_argument_args, ForUpdateMetaclass, LongString, NonEmptyString,
@@ -72,8 +72,8 @@ class ShellSchema(BaseModel):
     authenticator: Literal['shell']
     script: FilePathStr = Field(..., description='Authentication Script')
     user: NonEmptyString = Field(description='Running user', default='nobody')
-    timeout: conint(ge=5) = Field(description='Script Timeout', default=60)
-    delay: conint(ge=10) = Field(description='Propagation delay', default=60)
+    timeout: Annotated[int, Field(ge=5, description='Script Timeout', default=60)]
+    delay: Annotated[int, Field(ge=10, description='Propagation delay', default=60)]
 
 
 @single_argument_args('attributes')

--- a/src/middlewared/middlewared/api/v25_04_0/docker.py
+++ b/src/middlewared/middlewared/api/v25_04_0/docker.py
@@ -1,7 +1,6 @@
-import typing
-from typing_extensions import Annotated
+from typing import Annotated, Literal
 
-from pydantic import conint, IPvAnyInterface, Field, field_validator
+from pydantic import IPvAnyInterface, Field, field_validator
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -10,7 +9,7 @@ from middlewared.api.base import (
 
 class AddressPool(BaseModel):
     base: IPvAnyInterface
-    size: conint(ge=1, le=32)
+    size: Annotated[int, Field(ge=1, le=32)]
 
     @field_validator('base')
     def check_prefixlen(cls, v):
@@ -44,7 +43,7 @@ class DockerStatusArgs(BaseModel):
 
 class StatusResult(BaseModel):
     description: str
-    status: typing.Literal['PENDING', 'RUNNING', 'STOPPED', 'INITIALIZING', 'STOPPING', 'UNCONFIGURED', 'FAILED']
+    status: Literal['PENDING', 'RUNNING', 'STOPPED', 'INITIALIZING', 'STOPPING', 'UNCONFIGURED', 'FAILED']
 
 
 class DockerStatusResult(BaseModel):
@@ -52,22 +51,22 @@ class DockerStatusResult(BaseModel):
 
 
 class NvidiaNormalStatus(BaseModel):
-    status: typing.Literal['ABSENT', 'NOT_INSTALLED', 'INSTALLED']
+    status: Literal['ABSENT', 'NOT_INSTALLED', 'INSTALLED']
 
 
 class NvidiaInstallingStatus(BaseModel):
-    status: typing.Literal['INSTALLING']
+    status: Literal['INSTALLING']
     progress: int
     description: str
 
 
 class NvidiaInstallErrorStatus(BaseModel):
-    status: typing.Literal['INSTALL_ERROR']
+    status: Literal['INSTALL_ERROR']
     error: str
 
 
 NvidiaStatus = Annotated[
-    typing.Union[NvidiaNormalStatus, NvidiaInstallingStatus, NvidiaInstallErrorStatus],
+    NvidiaNormalStatus | NvidiaInstallingStatus | NvidiaInstallErrorStatus,
     Field(discriminator='status'),
 ]
 

--- a/src/middlewared/middlewared/api/v25_04_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_04_0/pool.py
@@ -1,4 +1,6 @@
-from pydantic import conint, Field
+from typing import Annotated
+
+from pydantic import Field
 
 from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 
@@ -6,8 +8,8 @@ from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
 @single_argument_args('options')
 class DDTPruneArgs(BaseModel):
     pool_name: NonEmptyString
-    percentage: conint(ge=1, le=100) | None = Field(default=None)
-    days: conint(ge=1) | None = Field(default=None)
+    percentage: Annotated[int | None, Field(ge=1, le=100, default=None)]
+    days: Annotated[int | None, Field(ge=1, default=None)]
 
 
 class DDTPruneResult(BaseModel):


### PR DESCRIPTION
As pointed out in upstream documentation [here](https://docs.pydantic.dev/latest/api/types/#pydantic.types.conint--__tabbed_1_1), the `conint` function has been deprecated. This PR removes the usages of said function and uses the proper method based on the documentation. There is no change in functionality.