### PR TITLE
NAS-132383 / 25.04 / fix str length error on EULA

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/truenas.py
+++ b/src/middlewared/middlewared/api/v25_04_0/truenas.py
@@ -1,4 +1,4 @@
-from middlewared.api.base import BaseModel
+from middlewared.api.base import BaseModel, LongString
 
 
 __all__ = [
@@ -42,7 +42,7 @@ class TrueNASGetEULAArgs(BaseModel):
 
 
 class TrueNASGetEULAResult(BaseModel):
-    result: str | None
+    result: LongString | None
 
 
 class TrueNASIsEULAAcceptedArgs(BaseModel):


### PR DESCRIPTION
On a freshly installed nightly image on first login, the EULA is shown to the end-user. However, it's showing a traceback
```
Error: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 215, in call_method
    result = lam._adapt_result(result)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/legacy_api_method.py", line 75, in _adapt_result
    return self.adapter.adapt(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/handler/version.py", line 100, in adapt
    value = validate_model(current_version_model, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/handler/accept.py", line 80, in validate_model
    raise verrors from None
middlewared.service_exception.ValidationErrors: [EINVAL] result: String should have at most 1024 characters
```
This fixes said traceback.