### PR TITLE
NAS-132431 / 24.10.1 / Fix random false positives in OTP tests (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
+++ b/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
@@ -1,6 +1,9 @@
 import contextlib
-import pyotp
+from datetime import datetime
+import time
 import typing
+
+import pyotp
 
 from middlewared.test.integration.utils import call
 
@@ -18,6 +21,12 @@ def get_user_secret(user_id: int, get: typing.Optional[bool] = True) -> typing.U
 
 
 def get_2fa_totp_token(users_config: dict) -> str:
+    second = datetime.now().second
+    if second >= 55 or second < 5:
+        # We allow 5 seconds time difference between NAS and test client, and OTP expiry interval is 60 seconds.
+        # So tokens generated within 5 seconds of :00 are not safe to use
+        time.sleep(10)
+
     return pyotp.TOTP(
         users_config['secret'],
         interval=users_config['interval'],

--- a/tests/api2/test_twofactor_auth.py
+++ b/tests/api2/test_twofactor_auth.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import contextlib
+from datetime import datetime, timezone
 import errno
 import os
 import sys
@@ -25,6 +26,13 @@ USERS_2FA_CONF = {
     TEST_USERNAME: {'interval': 30, 'otp_digits': 6},
     TEST_USERNAME_2: {'interval': 40, 'otp_digits': 7}
 }
+
+@pytest.fixture(scope='module', autouse=True)
+def ensure_small_time_difference():
+    nas_time = call('system.info')['datetime']
+    local_time = datetime.now(timezone.utc)
+    if abs((nas_time - local_time).total_seconds()) > 5:
+        raise Exception(f'Time difference between NAS ({nas_time!r}) and test client ({local_time}) is too large')
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 402fb58d5aca8db6e0f011addfd4624d85b5df3c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 85571ecd40790f6c2c55e2cc34b5fc9e945e3f58



Original PR: https://github.com/truenas/middleware/pull/14914
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132431