### PR TITLE
Implement TrueCloud snapshot and scripts config options

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud/crud.py
@@ -100,5 +100,5 @@ class CloudTaskServiceMixin:
         if app and not credential_has_full_admin(app.authenticated_credentials):
             for k in ["pre_script", "post_script"]:
                 if data[k]:
-                    verrors.add(f"{name}.{k}", "The ability to edit cloud sync pre and post scripts is limited to "
+                    verrors.add(f"{name}.{k}", "The ability to edit pre-scripts and post-scripts is limited to "
                                                "users who have full administrative credentials")

--- a/src/middlewared/middlewared/plugins/cloud/script.py
+++ b/src/middlewared/middlewared/plugins/cloud/script.py
@@ -25,7 +25,7 @@ def env_mapping(prefix: str, mapping: dict[str, Any]) -> dict[str, str]:
     return env
 
 
-async def run_script(job, env, hook, script_name):
+async def run_script(job, script_name, hook: str="", env={}):
     hook = hook.strip()
     if not hook:
         return

--- a/src/middlewared/middlewared/plugins/cloud/script.py
+++ b/src/middlewared/middlewared/plugins/cloud/script.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+import shlex
+import subprocess
+import tempfile
+from typing import Any
+
+from middlewared.service import CallError
+from middlewared.utils import Popen
+
+
+def env_mapping(prefix: str, mapping: dict[str, Any]) -> dict[str, str]:
+    """Return a mapping of environment variables with the given prefix."""
+    env = {}
+
+    for k, v in mapping.items():
+        var_name = (prefix + k).upper()
+
+        if isinstance(v, bool):
+            env[var_name] = str(int(v))
+
+        elif isinstance(v, (int, str)):
+            env[var_name] = str(v)
+
+    return env
+
+
+async def run_script(job, env, hook, script_name):
+    hook = hook.strip()
+    if not hook:
+        return
+
+    if hook.startswith("#!"):
+        shebang = shlex.split(hook.splitlines()[0][2:].strip())
+    else:
+        shebang = ["/bin/bash"]
+
+    # It is ok to do synchronous I/O here since we are operating in ramfs which will never block
+    with tempfile.NamedTemporaryFile("w+") as f:
+        os.chmod(f.name, 0o700)
+        f.write(hook)
+        f.flush()
+
+        proc = await Popen(
+            shebang + [f.name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=dict(os.environ, **env),
+        )
+        future = asyncio.ensure_future(_run_script_check(job, proc, script_name))
+        await proc.wait()
+        await asyncio.wait_for(future, None)
+        if proc.returncode != 0:
+            raise CallError(f"{script_name} failed with exit code {proc.returncode}")
+
+
+async def _run_script_check(job, proc, name):
+    while True:
+        read = await proc.stdout.readline()
+        if read == b"":
+            break
+        await job.logs_fd_write(f"[{name}] ".encode("utf-8") + read)

--- a/src/middlewared/middlewared/plugins/cloud/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud/snapshot.py
@@ -1,0 +1,52 @@
+import os
+
+from middlewared.utils.time_utils import utc_now
+
+
+def get_dataset_recursive(datasets, directory):
+    datasets = [
+        dict(dataset, prefixlen=len(
+            os.path.dirname(os.path.commonprefix(
+                [dataset["properties"]["mountpoint"]["value"] + "/", directory + "/"]))
+        ))
+        for dataset in datasets
+        if dataset["properties"]["mountpoint"]["value"] != "none"
+    ]
+
+    dataset = sorted(
+        [
+            dataset
+            for dataset in datasets
+            if (directory + "/").startswith(dataset["properties"]["mountpoint"]["value"] + "/")
+        ],
+        key=lambda dataset: dataset["prefixlen"],
+        reverse=True
+    )[0]
+
+    return dataset, any(
+        (ds["properties"]["mountpoint"]["value"] + "/").startswith(directory + "/")
+        for ds in datasets
+        if ds != dataset
+    )
+
+
+async def create_snapshot(middleware, path, name="cloud_task-onetime") -> tuple[str, str]:
+    """Create a ZFS snapshot given a dataset path; return its name and path."""
+    dataset, recursive = get_dataset_recursive(
+        await middleware.call("zfs.dataset.query", [["type", "=", "FILESYSTEM"]]),
+        path,
+    )
+    snapshot_name = f"{name}-{utc_now().strftime('%Y%m%d%H%M%S')}"
+
+    snapshot = await middleware.call("zfs.snapshot.create", {
+        "dataset": dataset["name"],
+        "name": snapshot_name,
+        "recursive": recursive
+    })["name"]
+
+    mountpoint = dataset["properties"]["mountpoint"]["value"]
+    path = os.path.normpath(os.path.join(
+        mountpoint, ".zfs", "snapshot", snapshot_name, os.path.relpath(path, mountpoint)
+    ))
+
+    return snapshot, path

--- a/src/middlewared/middlewared/plugins/cloud/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud/snapshot.py
@@ -38,11 +38,11 @@ async def create_snapshot(middleware, path, name="cloud_task-onetime") -> tuple[
     )
     snapshot_name = f"{name}-{utc_now().strftime('%Y%m%d%H%M%S')}"
 
-    snapshot = await middleware.call("zfs.snapshot.create", {
+    snapshot = (await middleware.call("zfs.snapshot.create", {
         "dataset": dataset["name"],
         "name": snapshot_name,
         "recursive": recursive
-    })["name"]
+    }))["name"]
 
     mountpoint = dataset["properties"]["mountpoint"]["value"]
     path = os.path.normpath(os.path.join(

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -3,6 +3,7 @@ import itertools
 
 from middlewared.plugins.cloud.path import check_local_path
 from middlewared.plugins.cloud_backup.restic import get_restic_config, run_restic
+from middlewared.plugins.cloud.script import env_mapping, run_script
 from middlewared.plugins.zfs_.utils import zvol_name_to_path, zvol_path_to_name
 from middlewared.schema import accepts, Bool, Dict, Int
 from middlewared.service import CallError, Service, item_method, job, private
@@ -68,7 +69,9 @@ async def restic(middleware, job, cloud_backup, dry_run):
 
         cmd = restic_config.cmd + ["--verbose", "backup"] + cmd
 
+        await run_script(job, "Pre-script", cloud_backup["pre_script"])
         await run_restic(job, cmd, restic_config.env, stdin, track_progress=True)
+        await run_script(job, "Post-script", cloud_backup["post_script"])
     finally:
         if stdin:
             try:

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -222,7 +222,7 @@ async def rclone(middleware, job, cloud_sync, dry_run):
             **cloud_sync["attributes"],
             "path": path
         })
-        await run_script(job, env, cloud_sync["pre_script"], "Pre-script")
+        await run_script(job, "Pre-script", cloud_sync["pre_script"], env)
 
         job.middleware.logger.trace("Running %r", args)
         proc = await Popen(
@@ -257,7 +257,7 @@ async def rclone(middleware, job, cloud_sync, dry_run):
                 message += f"rclone failed with exit code {proc.returncode}"
             raise CallError(message)
 
-        await run_script(job, env, cloud_sync["post_script"], "Post-script")
+        await run_script(job, "Post-script", cloud_sync["post_script"], env)
 
         refresh_credentials = REMOTES[cloud_sync["credentials"]["provider"]["type"]].refresh_credentials
         if refresh_credentials:

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -585,7 +585,7 @@ class ReplicationService(CRUDService):
             if data["netcat_active_side_port_min"] is not None and data["netcat_active_side_port_max"] is not None:
                 if data["netcat_active_side_port_min"] > data["netcat_active_side_port_max"]:
                     verrors.add("netcat_active_side_port_max",
-                                "Please specify value greater or equal than netcat_active_side_port_min")
+                                "Please specify value greater than or equal to netcat_active_side_port_min")
 
             if data["compression"] is not None:
                 verrors.add("compression", "Compression is not supported for SSH+netcat replication")

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -5,9 +5,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from middlewared.plugins.cloud_sync import (
-    get_dataset_recursive, FsLockManager, lsjson_error_excerpt, RcloneVerboseLogCutter
-)
+from middlewared.plugins.cloud_sync import FsLockManager, lsjson_error_excerpt, RcloneVerboseLogCutter
+from middlewared.plugins.cloud.snapshot import get_dataset_recursive
 
 
 def test__get_dataset_recursive_1():

--- a/src/middlewared/middlewared/schema/dict_schema.py
+++ b/src/middlewared/middlewared/schema/dict_schema.py
@@ -286,7 +286,7 @@ class Cron(Dict):
             verrors.add(self.name, 'Please ensure fields match cron syntax - ' + str(e))
 
         if value.get('begin') and value.get('end') and not (value.get('begin') <= value.get('end')):
-            verrors.add(self.name, 'Begin time should be less or equal than end time')
+            verrors.add(self.name, 'Begin time should be less than or equal to end time')
 
         if iter_ is not None and (value.get('begin') or value.get('end')):
             begin = value.get('begin') or time(0, 0)

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -195,8 +195,8 @@ class Range(ValidatorBase):
 
         error = {
             (True, True): f"between {self.min} and {self.max}",
-            (False, True): f"less or equal than {self.max}",
-            (True, False): f"greater or equal than {self.min}",
+            (False, True): f"less than or equal to {self.max}",
+            (True, False): f"greater than or equal to {self.min}",
             (False, False): "",
         }[self.min is not None, self.max is not None]
 


### PR DESCRIPTION
TrueCloud Backup tasks will have the option to take a temporary snapshot just before a sync job, just like Cloud Sync tasks. They will also support pre-scripts and post-scripts.

With the introduction of TrueCloud Backup scripts, the following environment variables for scripts are introduced:
- CLOUD_BACKUP_ID
- CLOUD_BACKUP_DESCRIPTION
- CLOUD_BACKUP_SNAPSHOT
- CLOUD_BACKUP_PASSWORD
- CLOUD_BACKUP_KEEP_LAST
- CLOUD_BACKUP_TRANSFER_SETTING
- CLOUD_BACKUP_TYPE
- CLOUD_BACKUP_ACCESS_KEY_ID
- CLOUD_BACKUP_SECRET_ACCESS_KEY
- CLOUD_BACKUP_FOLDER
- CLOUD_BACKUP_BUCKET
- CLOUD_BACKUP_FAST_LIST

Again, these are designed to mirror Cloud Sync.