### PR TITLE
NAS-132377 / 24.10.1 / fix MINI-3.0-X vers 1.0 enclosure page (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_class.py
@@ -233,8 +233,8 @@ class Enclosure:
         # different revisions
         vers_key = 'DEFAULT'
         if not mapped_info['any_version']:
-            for key, vers in mapped_info['versions'].items():
-                if self.dmi.system_version == key:
+            for vers in mapped_info['versions']:
+                if self.dmi.system_version == vers:
                     vers_key = vers
                     break
 


### PR DESCRIPTION
We don't have this platform internally, we have the legacy (the pre 1.0 version model) and so it's impossible to test this otherwise. However, we have a user in the field that has this model that is hitting this error message
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure_/ses_enclosures2.py", line 25, in get_ses_enclosures
    rv.append(Enclosure(bsg, f'/dev/{sg.name}', status).asdict())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure_/enclosure_class.py", line 43, in __init__
    self.disks_map = self._get_array_device_mapping_info()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/enclosure_/enclosure_class.py", line 255, in _get_array_device_mapping_info
    for mapkey, mapslots in mapped_info['versions'][vers_key].items():
                            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: unhashable type: 'dict'
```
This is happening because the for loop when determining what disk slot mapping we should use is incorrectly assigning the `vers_key` variable to a dictionary instead of a string.

Original PR: https://github.com/truenas/middleware/pull/14913
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132377