### PR TITLE
NAS-132460 / 25.04 / fix api_key.update schema

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -31,7 +31,7 @@ class ApiKeyEntry(BaseModel):
 
 
 class ApiKeyEntryWithKey(ApiKeyEntry):
-    key: Secret[str | None]
+    key: Secret[str]
 
 
 class ApiKeyCreate(ApiKeyEntry):
@@ -62,7 +62,7 @@ class ApiKeyUpdateArgs(BaseModel):
 
 
 class ApiKeyUpdateResult(BaseModel):
-    result: ApiKeyEntryWithKey
+    result: ApiKeyEntryWithKey | ApiKeyEntry
 
 
 class ApiKeyDeleteArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -31,7 +31,7 @@ class ApiKeyEntry(BaseModel):
 
 
 class ApiKeyEntryWithKey(ApiKeyEntry):
-    key: Secret[str]
+    key: Secret[str | None]
 
 
 class ApiKeyCreate(ApiKeyEntry):

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -256,7 +256,7 @@ class ApiKeyService(CRUDService):
         )
 
         if not key:
-            return new
+            return new | {'key': None}
 
         self.middleware.call_sync('etc.generate', 'pam_middleware')
         self.middleware.call_sync('api_key.check_status')

--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -256,7 +256,7 @@ class ApiKeyService(CRUDService):
         )
 
         if not key:
-            return new | {'key': None}
+            return new
 
         self.middleware.call_sync('etc.generate', 'pam_middleware')
         self.middleware.call_sync('api_key.check_status')

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -240,7 +240,7 @@ def test_api_key_crud_restricted_admin_own_keys(sharing_admin_user):
             updated = c.call('api_key.update', key_info['id'], {
                 'name': 'test_restricted_admin_key_new'
             })
-            assert updated['key'] is None
+            assert 'key' not in updated
             updated = c.call('api_key.update', key_info['id'], {'reset': True})
             assert updated['key'] is not '********'
         finally:

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -237,9 +237,12 @@ def test_api_key_crud_restricted_admin_own_keys(sharing_admin_user):
         })
 
         try:
-            c.call('api_key.update', key_info['id'], {
+            updated = c.call('api_key.update', key_info['id'], {
                 'name': 'test_restricted_admin_key_new'
             })
+            assert updated['key'] is None
+            updated = c.call('api_key.update', key_info['id'], {'reset': True})
+            assert updated['key'] is not '********'
         finally:
             c.call('api_key.delete', key_info['id'])
 


### PR DESCRIPTION
* always include `key` in update response. This will be set to None if the key is not being reset

* allow None as a key type in entry with key.