### PR TITLE
NAS-132462 / 25.04 / Fix schema annotations for new boot.environment plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/boot_/environments.py
+++ b/src/middlewared/middlewared/plugins/boot_/environments.py
@@ -142,14 +142,14 @@ class BootEnvironmentService(Service):
             )
         else:
             run_zectl_cmd(["activate", data["id"]])
-            return self.query([["id", "=", data["id"]]])
+            return self.query([["id", "=", data["id"]]], {"get": True})
 
     @api_method(BootEnvironmentCloneArgs, BootEnvironmentCloneResult)
     def clone(self, data):
         be = self.validate_be("boot.environment.clone", data["id"])
         self.validate_be("boot.environment.clone", data["target"], should_exist=False)
         run_zectl_cmd(["create", "-r", "-e", be["dataset"], data["target"]])
-        return self.query([["id", "=", data["target"]]])
+        return self.query([["id", "=", data["target"]]], {"get": True})
 
     @api_method(BootEnvironmentDestroyArgs, BootEnvironmentDestroyResult)
     def destroy(self, data):
@@ -169,7 +169,7 @@ class BootEnvironmentService(Service):
                 "properties": {"zectl:keep": {"value": str(data["value"])}},
             },
         )
-        return self.query([["id", "=", data["id"]]])
+        return self.query([["id", "=", data["id"]]], {"get": True})
 
 
 async def setup(middleware):

--- a/tests/api2/test_boot_environments.py
+++ b/tests/api2/test_boot_environments.py
@@ -36,6 +36,8 @@ def simulate_can_activate_is_false(be_ds):
 
 
 def validate_activated_be(be_name, activate_string="R"):
+    """Validate the boot environment shows that it is activated
+    according to OS perspective."""
     for line in ssh("zectl list -H").splitlines():
         values = line.split()
         be, activated = values[0], values[1]
@@ -73,91 +75,50 @@ def test_failure_conditions_for_activate(orig_be):
 
 
 def test_clone_activate_keep_and_destroy(orig_be):
+    """Perform various boot environment operations via the API
+    and verify functionality works as expected.
     """
-    1. clone the active BE via api
-    2. verify the cloned BE shows up in API
-    3. verify the cloned BE exists on OS
-    4. test activating non-functional BE fails
-    5. activate the cloned BE via api
-    6. verify the cloned BE shows activated in the API
-    7. verify the cloned BE is activated on OS
-    8. activate original BE
-    9. verify the original BE is activated on OS
-    10. mark a BE to be kept
-    11. verify the BE is marked kept via the api
-    12. verify the BE is marked kept on OS
-    13. mark BE as to be NOT kept
-    14. verify the BE is marked as not kept via the api
-    15. verify the BE is marked not kept on OS
-    16. destroy the cloned BE via api
-    17. destroy the cloned BE is destroyed via the api
-    18. verify the cloned BE is destroyed on OS
-    """
-    # step 1
-    call("boot.environment.clone", {"id": orig_be["id"], "target": TEMP_BE_NAME})
+    tmp = call("boot.environment.clone", {"id": orig_be["id"], "target": TEMP_BE_NAME})
+    assert tmp["id"] == TEMP_BE_NAME
 
-    # step 2
-    tmp = be_query(TEMP_BE_NAME)
-
-    # step 3
     rv = ssh("zectl list -H").strip()
     assert TEMP_BE_NAME in rv, rv
 
-    # step 4
     with simulate_can_activate_is_false(tmp["dataset"]):
         with pytest.raises(ValidationError) as ve:
             call("boot.environment.activate", {"id": tmp["id"]})
     assert ve.value.attribute == "boot.environment.activate"
     assert ve.value.errmsg == f"{tmp['id']!r} can not be activated"
 
-    # step 5
-    call("boot.environment.activate", {"id": TEMP_BE_NAME})
+    rv = call("boot.environment.activate", {"id": TEMP_BE_NAME})
+    assert rv["id"] == TEMP_BE_NAME
+    assert rv["activated"] is True
 
-    # step 6
-    rv = be_query(TEMP_BE_NAME)
-    assert rv["activated"], rv
-
-    # step 7
     validate_activated_be(TEMP_BE_NAME)
 
-    # step 8
-    call("boot.environment.activate", {"id": orig_be["id"]})
-    rv = be_query(orig_be["id"])
-    assert rv["activated"], rv
+    rv = call("boot.environment.activate", {"id": orig_be["id"]})
+    assert rv["activated"] is True
 
-    # step 9
     validate_activated_be(orig_be["id"], activate_string="NR")
 
-    # step 10
-    call("boot.environment.keep", {"id": orig_be["id"], "value": True})
+    rv = call("boot.environment.keep", {"id": orig_be["id"], "value": True})
+    assert rv["keep"] is True
 
-    # step 11
-    rv = be_query(orig_be["id"])
-    assert rv["keep"] is True, rv
-
-    # step 12
     values = get_zfs_property(orig_be["dataset"], "zectl:keep")
     assert values[2] == "True"
 
-    # step 13
-    call("boot.environment.keep", {"id": orig_be["id"], "value": False})
+    rv = call("boot.environment.keep", {"id": orig_be["id"], "value": False})
+    assert rv["keep"] is False
 
-    # step 14
-    rv = be_query(orig_be["id"])
-    assert rv["keep"] is False, rv
-
-    # step 15
     values = get_zfs_property(orig_be["dataset"], "zectl:keep")
     assert values[2] == "False"
 
-    # step 16
-    call("boot.environment.destroy", {"id": TEMP_BE_NAME})
+    rv = call("boot.environment.destroy", {"id": TEMP_BE_NAME})
+    assert rv is None
 
-    # step 17
-    rv = be_query(TEMP_BE_NAME, get=False)
-    assert not rv, rv
+    rv = call("boot.environment.query", [["id", "=", TEMP_BE_NAME]])
+    assert rv == [], rv
 
-    # step 18
     rv = ssh("zectl list -H").strip()
     assert TEMP_BE_NAME not in rv, rv
 


### PR DESCRIPTION
UI received the following traceback on certain endpoints
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/truenas_api_client/legacy.py", line 416, in call
    return self.wait(c, callback=callback, job=job, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/truenas_api_client/legacy.py", line 435, in wait
    raise ValidationErrors(c.extra)
truenas_api_client.exc.ValidationErrors: [EINVAL] result: Input should be a valid dictionary or instance of BootEnvironmentEntry
```
This is because the result annotation didn't match what was being returned. This fixes said issue and also updates the test to be more explicit about the returned objects.