### PR TITLE
Do not validate the results of method calls made by a full administrator through the legacy WebSocket API

### DIFF
--- a/tests/api2/test_legacy_websocket.py
+++ b/tests/api2/test_legacy_websocket.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+
+from truenas_api_client import Client
+
+from middlewared.test.integration.assets.api_key import api_key
+from middlewared.test.integration.assets.cloud_sync import credential
+from middlewared.test.integration.utils import call, mock, password, websocket_url
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def c():
+    with Client(websocket_url() + "/websocket") as c:
+        c.call("auth.login_ex", {
+            "mechanism": "PASSWORD_PLAIN",
+            "username": "root",
+            "password": password(),
+        })
+        yield c
+
+
+def test_adapts_cloud_credentials(c):
+    with credential({
+        "provider": {
+            "type": "FTP",
+            "host": "localhost",
+            "port": 21,
+            "user": "test",
+            "pass": "",
+        },
+    }) as cred:
+        result = c.call("cloudsync.credentials.get_instance", cred["id"])
+        assert result["provider"] == "FTP"
+
+
+def test_does_not_perform_output_validation_for_full_admin(c):
+    with api_key():
+        key = call("api_key.query")[0]
+        with mock("api_key.item_extend", return_value={**key, "invalid_field": 1}):
+            c.call("api_key.get_instance", key["id"])


### PR DESCRIPTION
That's the intended behavior. It was broken recently by the new code that adapts the result to 24.10 schemas if they exist. Validation of the method call result should be performed lazily in that case.