### PR TITLE
NAS-132476 / 25.04 / fix validator for remote usernames

### DIFF
--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -1,6 +1,7 @@
 import string
 
 from annotated_types import Ge, Le
+from pydantic import Field
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Annotated
 
@@ -52,12 +53,6 @@ def validate_local_username(val: str) -> str:
     return validate_username(val)
 
 
-def validate_remote_username(val: str) -> str:
-    # Restrictions on names returned by nss_winbind are more lax than we place
-    # on our local usernames. \\ is used as a separator for domain and username
-    return validate_username(val, DEFAULT_VALID_CHARS + '\\', None, None)
-
-
 def validate_sid(value: str) -> str:
     value = value.strip()
     value = value.upper()
@@ -70,7 +65,7 @@ def validate_sid(value: str) -> str:
 
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
-RemoteUsername = Annotated[str, AfterValidator(validate_remote_username)]
+RemoteUsername = Annotated[str, Field(str, Field(min_length=1)]
 LocalUID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
 LocalGID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -65,7 +65,7 @@ def validate_sid(value: str) -> str:
 
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
-RemoteUsername = Annotated[str, Field(str, Field(min_length=1)]
+RemoteUsername = Annotated[str, Field(str, Field(min_length=1))]
 LocalUID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
 LocalGID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -65,7 +65,7 @@ def validate_sid(value: str) -> str:
 
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
-RemoteUsername = Annotated[str, Field(str, Field(min_length=1))]
+RemoteUsername = Annotated[str, Field(min_length=1)]
 LocalUID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
 LocalGID = Annotated[int, Ge(0), Le(TRUENAS_IDMAP_DEFAULT_LOW - 1)]


### PR DESCRIPTION
AD usernames may actually contain large portion of UTF character set.

Example:

```
root@testMYW4RQDK8Q[~]# getent passwd ACME\\Блин
ACME\блин:*:100011617:100000514::/var/empty:/bin/sh
```

This means our validation for names where they may be remote must be very relaxed. To simplify matters I'm simply requiring a minimum length of 1 character. We can tighten up if required in the future.