### PR TITLE
NAS-132483 / 24.10.1 / There is no need to query all apps when clearing upgrade alerts for all apps (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/alert/source/applications.py
+++ b/src/middlewared/middlewared/alert/source/applications.py
@@ -56,7 +56,8 @@ class AppUpdateAlertClass(AlertClass, OneShotAlertClass):
         return Alert(AppUpdateAlertClass, args, _key=args['name'])
 
     async def delete(self, alerts, query):
+        # If query is None, it means we are deleting all alerts
         return list(filter(
-            lambda alert: alert.key != query,
+            lambda alert: alert.key != query and query is not None,
             alerts
         ))

--- a/src/middlewared/middlewared/plugins/apps/upgrade.py
+++ b/src/middlewared/middlewared/plugins/apps/upgrade.py
@@ -198,8 +198,7 @@ class AppService(Service):
 
     @private
     async def clear_upgrade_alerts_for_all(self):
-        for app in await self.middleware.call('app.query'):
-            await self.middleware.call('alert.oneshot_delete', 'AppUpdate', app['id'])
+        await self.middleware.call('alert.oneshot_delete', 'AppUpdate', None)
 
     @private
     async def check_upgrade_alerts(self):


### PR DESCRIPTION
This PR adds changes to not query all apps when deleting all upgrade alerts for apps, this is useful when pool is being unset or being changed and there is no need to actually query apps at this point (this can also be a cause of failure if user has malformed apps dataset which is another issue but at least he should be able to unset/switch pools).

Original PR: https://github.com/truenas/middleware/pull/14938
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132483