### PR TITLE
NAS-132492 / 25.04 / Fix VM integration test

### DIFF
--- a/tests/api2/test_account_privilege_role_private_fields.py
+++ b/tests/api2/test_account_privilege_role_private_fields.py
@@ -118,9 +118,9 @@ def vm_device():
             "vm.device",
             {
                 "id": 7,
-                "dtype": "DISPLAY",
                 "vm": 5,
                 "attributes": {
+                    "dtype": "DISPLAY",
                     "bind": "127.0.0.1",
                     "port": 1,
                     "web_port": 1,

--- a/tests/api2/test_pool_dataset_unlock_restart_vms.py
+++ b/tests/api2/test_pool_dataset_unlock_restart_vms.py
@@ -26,9 +26,9 @@ def test_restart_vm_on_dataset_unlock(zvol):
         call("pool.dataset.lock", ds, job=True)
 
         if zvol:
-            device = {"dtype": "DISK", "attributes": {"path": f"/dev/zvol/{ds}"}}
+            device = {"attributes": {"path": f"/dev/zvol/{ds}", "dtype": "DISK"}}
         else:
-            device = {"dtype": "RAW", "attributes": {"path": f"/mnt/{ds}/child"}}
+            device = {"attributes": {"path": f"/mnt/{ds}/child", "dtype": "RAW"}}
 
         with mock("vm.query", return_value=[{"id": 1, "devices": [device]}]):
             with mock("vm.status", return_value={"state": "RUNNING"}):


### PR DESCRIPTION
## Context

With recent `dtype` changes in vm devices, some integration tests were left out which needed to be updated and have been updated.