### PR TITLE
NAS-132424 / 25.04 / Add description to devices

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt.py
@@ -86,6 +86,7 @@ class VirtInstanceImageChoicesResult(BaseModel):
 
 class Device(BaseModel):
     name: Optional[NonEmptyString] = None
+    description: Optional[NonEmptyString] = None
     readonly: bool = False
 
 


### PR DESCRIPTION
We can probably improve performance / save cpu cycles if we make description optional in the API call and add context to not call choices multiple times, but might not be worth it. Just let me know.