### PR TITLE
NAS-132268 / 13.3 / Do not use pickle module unnecessarily (#14945)

### DIFF
--- a/src/freenas/usr/local/libexec/collectd_alert.py
+++ b/src/freenas/usr/local/libexec/collectd_alert.py
@@ -25,7 +25,7 @@
 # SUCH DAMAGE.
 #
 
-import pickle as pickle
+import json
 import os
 import re
 import sys
@@ -46,9 +46,9 @@ def main():
 
     data = {}
     if os.path.exists(COLLECTD_FILE):
-        with open(COLLECTD_FILE, 'rb') as f:
+        with open(COLLECTD_FILE, 'r') as f:
             try:
-                data = pickle.loads(f.read())
+                data = json.load(f)
             except:
                 pass
 
@@ -67,8 +67,8 @@ def main():
     else:
         data[k] = v;
 
-    with open(COLLECTD_FILE, 'wb') as f:
-        f.write(pickle.dumps(data))
+    with open(COLLECTD_FILE, 'w') as f:
+        json.dump(data, f)
 
     lock.release()
 

--- a/src/middlewared/middlewared/alert/source/collectd.py
+++ b/src/middlewared/middlewared/alert/source/collectd.py
@@ -1,6 +1,6 @@
 from lockfile import LockFile, LockTimeout
 import os
-import pickle
+import json
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
 
@@ -40,9 +40,9 @@ class CollectdAlertSource(ThreadedAlertSource):
             except LockTimeout:
                 return
 
-        with open(COLLECTD_FILE, "rb") as f:
+        with open(COLLECTD_FILE, "r") as f:
             try:
-                data = pickle.loads(f.read())
+                data = json.load(f)
             except Exception:
                 data = {}
 

--- a/src/middlewared/middlewared/alert/source/vmware_login.py
+++ b/src/middlewared/middlewared/alert/source/vmware_login.py
@@ -1,10 +1,4 @@
-import pickle as pickle
-
-from lockfile import LockFile
-
-from middlewared.alert.base import AlertClass, OneShotAlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
-
-VMWARELOGIN_FAILS = "/var/tmp/.vmwarelogin_fails"
+from middlewared.alert.base import AlertClass, OneShotAlertClass, AlertCategory, AlertLevel, Alert
 
 
 class VMWareLoginFailedAlertClass(AlertClass, OneShotAlertClass):
@@ -23,28 +17,3 @@ class VMWareLoginFailedAlertClass(AlertClass, OneShotAlertClass):
             lambda alert: alert.args["hostname"] != hostname,
             alerts
         ))
-
-
-class LegacyVMWareLoginFailedAlertSource(ThreadedAlertSource):
-    def check_sync(self):
-        try:
-            with LockFile(VMWARELOGIN_FAILS):
-                with open(VMWARELOGIN_FAILS, "rb") as f:
-                    fails = pickle.load(f)
-        except Exception:
-            return
-
-        alerts = []
-        for oid, errmsg in list(fails.items()):
-            try:
-                vmware = self.middleware.call_sync("datastore.query", "storage.vmwareplugin", [["id", "=", oid]],
-                                                   {"get": True})
-            except IndexError:
-                continue
-
-            alerts.append(Alert(VMWareLoginFailedAlertClass, {
-                "hostname": vmware["hostname"],
-                "error": errmsg,
-            }))
-
-        return alerts

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -18,7 +18,6 @@ import errno
 import html
 import json
 import os
-import pickle
 import smtplib
 import socket
 import syslog
@@ -53,9 +52,9 @@ class MailQueue(object):
 
     def _get_queue(self):
         try:
-            with open(self.QUEUE_FILE, 'rb') as f:
-                self.queue = pickle.loads(f.read())
-        except (pickle.PickleError, EOFError):
+            with open(self.QUEUE_FILE, 'r') as f:
+                self.queue = json.load(f)
+        except Exception:
             self.queue = []
 
     def __enter__(self):
@@ -74,9 +73,9 @@ class MailQueue(object):
 
     def __exit__(self, typ, value, traceback):
 
-        with open(self.QUEUE_FILE, 'wb+') as f:
+        with open(self.QUEUE_FILE, 'w') as f:
             if self.queue:
-                f.write(pickle.dumps(self.queue))
+                json.dump(self.queue, f)
 
         self._lock.release()
         if typ is not None:


### PR DESCRIPTION
* dont use pickle in collectd_alert.py

* remove unused alert

* dont use pickle in mail.py

* dont use pickel in collectd.py alert

(cherry picked from commit 6ad8c1ce3082b22c0feca364ce52e645fd80d858)

A vulnerability involving python deserialization, CVE-2020-22083, was found and resolved.