### PR TITLE
NAS-132530 / 25.04 / Fix API for rdma.get_card_choices

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -1,4 +1,4 @@
-from middlewared.api.base import BaseModel, single_argument_result
+from middlewared.api.base import BaseModel
 from typing import Literal
 
 __all__ = [
@@ -25,12 +25,16 @@ class RdmaCardConfigArgs(BaseModel):
     pass
 
 
-@single_argument_result
-class RdmaCardConfigResult(BaseModel):
+class RdmaCardConfig(BaseModel):
+    name: str
     serial: str
     product: str
     part_number: str
     links: list[RdmaLinkConfig]
+
+
+class RdmaCardConfigResult(BaseModel):
+    result: list[RdmaCardConfig]
 
 
 class RdmaCapableProtocolsArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -87,7 +87,7 @@ class RDMAService(Service):
         """Return a list containing details about each RDMA card.  Dual cards
         will contain two RDMA links."""
         self.logger.info('Fetching RDMA card choices')
-        links = self.middleware.call_sync('rdma.get_link_choices')
+        links = self.middleware.call_sync('rdma.get_link_choices', True)
         grouper = {}
         for link in links:
             rdma = link["rdma"]


### PR DESCRIPTION
1. Ensure we get **all** link choices.
2. We are returning a **list** of cards

(Currently, this API will just be used for `ixdiagnose`.)