### PR TITLE
Fix test_try_to_create_invalid_encrypted_dataset

### DIFF
--- a/tests/api2/test_pool_dataset_encryption.py
+++ b/tests/api2/test_pool_dataset_encryption.py
@@ -127,7 +127,7 @@ class TestNormalPool:
                 'encryption_options': {'pbkdf2iters': 0},
                 'inherit_encryption': False
             },
-            'Should be greater or equal than 100000'
+            'Should be greater than or equal to 100000'
         ),
         (
             {


### PR DESCRIPTION
Failing since https://github.com/truenas/middleware/pull/14918 was merged.

https://github.com/truenas/middleware/pull/14953 applies this fix in 24.10.