### PR TITLE
NAS-132501 / 25.04 / Allow share administrators to view the available RDMA capabilities.

### DIFF
--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -126,7 +126,7 @@ class RDMAService(Service):
             v['name'] = ':'.join(sorted(names))
         return list(grouper.values())
 
-    @api_method(RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult)
+    @api_method(RdmaCapableProtocolsArgs, RdmaCapableProtocolsResult, roles=['SHARING_ADMIN'])
     async def capable_protocols(self):
         result = []
         is_ent = await self.middleware.call('system.is_enterprise')


### PR DESCRIPTION
Users with SHARING_ADMIN role should be able to view and modify NFS services. 
Viewing the available RDMA capabilities should be included.

This PR allows users with the SHARIN_ADMIN role to view RDMA capabilities.