### PR TITLE
NAS-132268 / 13.0 / fix mail.queue regression

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -59,6 +59,8 @@ from . import logger
 if osc.IS_LINUX:
     from systemd.daemon import notify as systemd_notify
 
+RUNDIR = '/var/run/middlewared'
+
 
 class Application(object):
 
@@ -1727,6 +1729,12 @@ def main():
     if args.pidfile:
         with open(pidpath, "w") as _pidfile:
             _pidfile.write(f"{str(os.getpid())}\n")
+
+    try:
+        os.makedirs(RUNDIR, exist_ok=True)
+        os.chmod(RUNDIR, 0o700)
+    except Exception:
+        pass
 
     Middleware(
         loop_debug=args.loop_debug,


### PR DESCRIPTION
Previous commit a67d4cadb67f6a7ee35e660a5150d0527dc78693 introduced a regression in the `mail.queue` deserialization because we're writing non-json serializable data. Revert the json changes and instead, create a directory (/var/run/middlewared) and chmod to 700 and put the mail file in that directory.