### PR TITLE
NAS-132599 / 25.04 / Increase ES24n import timeout

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -402,8 +402,6 @@ class FailoverEventsService(Service):
                 jbof_job.wait_sync(timeout=60)
             except TimeoutError:
                 logger.error('Timed out attaching JBOFs.')
-            except Exception:
-                logger.error('Unexpected error', exc_info=True)
             else:
                 logger.info('Done bring up of NVMe/RoCE')
         except Exception:

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -389,7 +389,7 @@ class FailoverEventsService(Service):
         try:
             # Request fenced_reload just in case the job does not complete in time
             jbof_job = self.run_call('jbof.configure_job', True)
-            jbof_job.wait_sync(timeout=10)
+            jbof_job.wait_sync(timeout=60)
             if jbof_job.error:
                 logger.error(f'Error attaching JBOFs: {jbof_job.error}')
             elif jbof_job.result['failed']:
@@ -397,7 +397,15 @@ class FailoverEventsService(Service):
             else:
                 logger.info(jbof_job.result['message'])
         except TimeoutError:
-            logger.error('Timed out attaching JBOFs - will continue in background')
+            logger.error('Timed out attaching JBOFs.  Retrying')
+            try:
+                jbof_job.wait_sync(timeout=60)
+            except TimeoutError:
+                logger.error('Timed out attaching JBOFs.')
+            except Exception:
+                logger.error('Unexpected error', exc_info=True)
+            else:
+                logger.info('Done bring up of NVMe/RoCE')
         except Exception:
             logger.error('Unexpected error', exc_info=True)
         else:

--- a/src/middlewared/middlewared/plugins/jbof/crud.py
+++ b/src/middlewared/middlewared/plugins/jbof/crud.py
@@ -852,6 +852,7 @@ class JBOFService(CRUDService):
                                        interface['prefixlen'],
                                        interface['mtu'])
             jbof_ips.append(jbof_static_ip_from_initiator_ip(interface['address']))
+            self.logger.debug(f'Configured {interface["address"]} for NVMe/RoCE')
 
         # Next do the NVMe connect
         # Include some retry code, but expect it won't get used.


### PR DESCRIPTION
Found that `vrrp_master` could fail to import pools that were based on ES24n.  Increase timeout dramatically to avoid this.