### PR TITLE
NAS-132473 / 25.04 / Refactor realtime CPU stats

### DIFF
--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -119,3 +119,9 @@
 
 [plugin:cgroups]
         enable by default cgroups names matching = !*udev* *
+
+[plugin:proc:/proc/stat]
+    per cpu core utilization = no
+    context switches = no
+    processes started = no
+    processes running = no

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -76,7 +76,6 @@ class RealtimeEventSource(EventSource):
 
     def run_sync(self):
         interval = self.arg['interval']
-        cores = self.middleware.call_sync('system.info')['cores']
         disk_mapping = get_disks_with_identifiers()
 
         while not self._cancel_sync.is_set():
@@ -105,7 +104,7 @@ class RealtimeEventSource(EventSource):
                     'zfs': get_arc_stats(netdata_metrics),  # ZFS ARC Size
                     'memory': get_memory_info(netdata_metrics),
                     'virtual_memory': psutil.virtual_memory()._asdict(),
-                    'cpu': get_cpu_stats(netdata_metrics, cores),
+                    'cpu': get_cpu_stats(netdata_metrics),
                     'disks': get_disk_stats(netdata_metrics, disks, disk_mapping),
                     'interfaces': get_interface_stats(
                         netdata_metrics, [

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/cpu.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/cpu.py
@@ -1,37 +1,14 @@
 from .utils import safely_retrieve_dimension
 
 
-def get_cpu_core_stats(netdata_metrics: dict, core_number: int = None, chart_name: str = None) -> dict:
-    chart = f'cpu.cpu{core_number}' if core_number is not None else chart_name
-    data = {
-        'user': safely_retrieve_dimension(netdata_metrics, chart, 'user', 0),
-        'nice': safely_retrieve_dimension(netdata_metrics, chart, 'nice', 0),
-        'system': safely_retrieve_dimension(netdata_metrics, chart, 'system', 0),
-        'idle': safely_retrieve_dimension(netdata_metrics, chart, 'idle', 0),
-        'iowait': safely_retrieve_dimension(netdata_metrics, chart, 'iowait', 0),
-        'irq': safely_retrieve_dimension(netdata_metrics, chart, 'irq', 0),
-        'softirq': safely_retrieve_dimension(netdata_metrics, chart, 'softirq', 0),
-        'steal': safely_retrieve_dimension(netdata_metrics, chart, 'steal', 0),
-        'guest': safely_retrieve_dimension(netdata_metrics, chart, 'guest', 0),
-        'guest_nice': safely_retrieve_dimension(netdata_metrics, chart, 'guest_nice', 0),
-        'usage': 0,
-    }
-    if cp_total := sum(data.values()):
-        # usage is the sum of all but idle and iowait
-        data['usage'] = ((cp_total - data['idle'] - data['iowait']) / cp_total) * 100
+def calculate_usage(cpu_stats: dict) -> float:
+    cp_total = sum(cpu_stats.values())
+    return ((cp_total - cpu_stats['idle'] - cpu_stats['iowait']) / cp_total) * 100 if cp_total else 0
 
+
+def get_cpu_stats(netdata_metrics: dict) -> dict:
+    metric_name = 'system.cpu'
+    fields = ['user', 'nice', 'system', 'idle', 'iowait', 'irq', 'softirq', 'steal', 'guest', 'guest_nice']
+    data = {field: safely_retrieve_dimension(netdata_metrics, metric_name, field, 0) for field in fields}
+    data['usage'] = calculate_usage(data)
     return data
-
-
-def get_all_cores_stats(netdata_metrics: dict, cores: int) -> dict:
-    data = {}
-    for core_num in range(cores):
-        data[str(core_num)] = get_cpu_core_stats(netdata_metrics, core_num)
-    return data
-
-
-def get_cpu_stats(netdata_metrics: dict, cores: int) -> dict:
-    return {
-        **({str(core_num): get_cpu_core_stats(netdata_metrics, core_num) for core_num in range(cores)}),
-        'average': get_cpu_core_stats(netdata_metrics, chart_name='system.cpu'),
-    }

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -60,9 +60,7 @@ def get_metrics_approximation(
     data = {
         1: {
             'system.cpu': 10,
-            'cpu.cpu': 10 * core_count,
             'cpu.cpu0_cpuidle': 4 * core_count,
-            'cpu.cpufreq': core_count,
             'system.intr': 1,
             'system.ctxt': 1,
             'system.forks': 1,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 770, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 9257, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 1105, 60: 10}),
+    (4, 2, 1, 2, 10, 2, {1: 748, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 8905, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 929, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
@@ -19,14 +19,14 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 444),
-        (4, 2, 1, 2, 10, 1, 7, 4, 60, 27),
-        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 3107),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 431),
+        (4, 2, 1, 2, 10, 1, 7, 4, 60, 26),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2991),
         (1600, 32, 4, 10, 1, 4, 4, 4, 900, 13),
-        (10, 16, 2, 2, 12, 1, 3, 1, 1, 249),
-        (10, 16, 2, 2, 10, 3, 3, 4, 60, 18),
-        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13929),
-        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 61),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 205),
+        (10, 16, 2, 2, 10, 3, 3, 4, 60, 15),
+        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13407),
+        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 58),
     ],
 )
 def test_netdata_disk_space_approximation(

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -57,104 +57,6 @@ NETDATA_ALL_METRICS = {
             }
         }
     },
-    'cpu.cpu0': {
-        'name': 'cpu.cpu0',
-        'family': 'utilization',
-        'context': 'cpu.cpu',
-        'units': 'percentage',
-        'last_updated': 1691150349,
-        'dimensions': {
-            'guest_nice': {
-                'name': 'guest_nice',
-                'value': 0.2575124
-            },
-            'guest': {
-                'name': 'guest',
-                'value': 0.2575124
-            },
-            'steal': {
-                'name': 'steal',
-                'value': 0.2575124
-            },
-            'softirq': {
-                'name': 'softirq',
-                'value': 0.2375124
-            },
-            'irq': {
-                'name': 'irq',
-                'value': 0.2075124
-            },
-            'user': {
-                'name': 'user',
-                'value': 0.3275124
-            },
-            'system': {
-                'name': 'system',
-                'value': 0.3275124
-            },
-            'nice': {
-                'name': 'nice',
-                'value': 26.75124
-            },
-            'iowait': {
-                'name': 'iowait',
-                'value': 2.75124
-            },
-            'idle': {
-                'name': 'idle',
-                'value': 49.0049751
-            }
-        }
-    },
-    'cpu.cpu1': {
-        'name': 'cpu.cpu1',
-        'family': 'utilization',
-        'context': 'cpu.cpu',
-        'units': 'percentage',
-        'last_updated': 1691150349,
-        'dimensions': {
-            'guest_nice': {
-                'name': 'guest_nice',
-                'value': 0.2575124
-            },
-            'guest': {
-                'name': 'guest',
-                'value': 0.2575124
-            },
-            'steal': {
-                'name': 'steal',
-                'value': 0.2575124
-            },
-            'softirq': {
-                'name': 'softirq',
-                'value': 0.2375124
-            },
-            'irq': {
-                'name': 'irq',
-                'value': 0.2075124
-            },
-            'user': {
-                'name': 'user',
-                'value': 0.3275124
-            },
-            'system': {
-                'name': 'system',
-                'value': 0.3275124
-            },
-            'nice': {
-                'name': 'nice',
-                'value': 26.75124
-            },
-            'iowait': {
-                'name': 'iowait',
-                'value': 2.75124
-            },
-            'idle': {
-                'name': 'idle',
-                'value': 49.0049751
-            }
-        }
-    },
     'system.ram': {
         'name': 'system.ram',
         'family': 'ram',
@@ -905,21 +807,14 @@ def test_arc_stats():
 
 
 def test_cpu_stats():
-    cpu_stats = get_cpu_stats(NETDATA_ALL_METRICS, 2)
-    cpu_stat = {'system.cpu': cpu_stats['average'], 'cpu.cpu0': cpu_stats['0'], 'cpu.cpu1': cpu_stats['1']}
-    for chart_name, metrics in cpu_stat.items():
-        total_sum = sum(metrics.values()) - metrics['usage']
-        assert metrics['user'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'user', 0)
-        assert metrics['nice'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'nice', 0)
-        assert metrics['system'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'system', 0)
-        assert metrics['idle'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'idle', 0)
-        assert metrics['iowait'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'iowait', 0)
-        assert metrics['irq'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'irq', 0)
-        assert metrics['softirq'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'softirq', 0)
-        assert metrics['steal'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'steal', 0)
-        assert metrics['guest'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'guest', 0)
-        assert metrics['guest_nice'] == safely_retrieve_dimension(NETDATA_ALL_METRICS, chart_name, 'guest_nice', 0)
-        assert metrics['usage'] == ((total_sum - metrics['idle'] - metrics['iowait']) / total_sum) * 100
+    cpu_stat = get_cpu_stats(NETDATA_ALL_METRICS)
+    total_sum = 0
+    for metric, value in cpu_stat.items():
+        if metric == 'usage':
+            assert value == ((total_sum - cpu_stat['idle'] - cpu_stat['iowait']) / total_sum) * 100
+        else:
+            assert value == safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.cpu', metric, 0)
+            total_sum += value
 
 
 def test_disk_stats():


### PR DESCRIPTION
## Context

We have been getting per core CPU stats with netdata which is unnecessary and may not be uniform across all systems. With FT we have made a breaking change to streamline that process and only retrieve collective CPU stats giving us 3 benefits:

1. Streamlining stats for any machine
2. Avoiding doing excessive computation each interval in reporting realtime
3. Reducing disk space as we have reduced the data points we want netdata to collect