### PR TITLE
NAS-132605 / 25.04 / params property is optional in JSON-RPC spec

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -274,7 +274,7 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
             app.send_error(id_, JSONRPCError.METHOD_NOT_FOUND.value, "Method does not exist")
             return
 
-        asyncio.ensure_future(self.process_method_call(app, id_, method, message["params"]))
+        asyncio.ensure_future(self.process_method_call(app, id_, method, message.get("params", [])))
 
     async def process_method_call(self, app: RpcWebSocketApp, id_: Any, method: Method, params: list):
         try:


### PR DESCRIPTION
According to https://www.jsonrpc.org/specification#request_object, the `params` object may be omitted. 
```
params
    A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted.
```
We're crashing with the below traceback
```
[2024/11/19 07:16:10] (ERROR) middlewared.process():251 - Unhandled exception in JSON-RPC message handler
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py", line 249, in process
    await self.process_message(app, message)
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py", line 277, in process_message
    asyncio.ensure_future(self.process_method_call(app, id_, method, message["params"]))
                                                                     ~~~~~~~^^^^^^^^^^
KeyError: 'params'
```