### PR TITLE
NAS-132629 / 24.10.1 / Increase the timeout wrt ES24n import in import_on_boot (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -434,7 +434,7 @@ class PoolService(Service):
             self.logger.info('Start bring up of NVMe/RoCE')
             try:
                 jbof_job = self.middleware.call_sync('jbof.configure_job')
-                jbof_job.wait_sync(timeout=10)
+                jbof_job.wait_sync(timeout=60)
                 if jbof_job.error:
                     self.logger.error(f'Error attaching JBOFs: {jbof_job.error}')
                 elif jbof_job.result['failed']:
@@ -442,7 +442,19 @@ class PoolService(Service):
                 else:
                     self.logger.info(jbof_job.result['message'])
             except TimeoutError:
-                self.logger.error('Timed out attaching JBOFs - will continue in background')
+                self.logger.error('Timed out attaching JBOFs.  Waiting again.')
+                try:
+                    jbof_job.wait_sync(timeout=60)
+                    if jbof_job.error:
+                        self.logger.error(f'Error attaching JBOFs: {jbof_job.error}')
+                    elif jbof_job.result['failed']:
+                        self.logger.error(f'Failed to attach JBOFs:{jbof_job.result["message"]}')
+                    else:
+                        self.logger.info(jbof_job.result['message'])
+                except TimeoutError:
+                    self.logger.error('Timed out attaching JBOFs - will continue in background.')
+                else:
+                    self.logger.info('Done bring up of NVMe/RoCE')
             except Exception:
                 self.logger.error('Unexpected error', exc_info=True)
 


### PR DESCRIPTION
Increase the timeout associated with a non-HA ES24n import substantially.

A similar change was recently made for HA in PR #14975

Original PR: https://github.com/truenas/middleware/pull/14986
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132629