### PR TITLE
NAS-132626 / 24.10.1 / call proactive_support_allowed() (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -9,6 +9,7 @@ import aiohttp
 import async_timeout
 import requests
 
+from licenselib.utils import proactive_support_allowed
 from middlewared.pipe import Pipes
 from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
 from middlewared.schema import accepts, Bool, Dict, Int, List, Password, returns, Str
@@ -118,7 +119,7 @@ class SupportService(ConfigService):
         if license_ is None:
             return False
 
-        return license_['contract_type'] in ['SILVER', 'GOLD']
+        return proactive_support_allowed(license_['contract_type'])
 
     @accepts(roles=['SUPPORT_READ'])
     @returns(Bool('proactive_support_is_available_and_enabled'))


### PR DESCRIPTION
A new contract type was added here: https://github.com/truenas/licenselib/pull/3. Put the proactive logic inside the license library (which seems more appropriate anyways). The PR that adds this new function is: https://github.com/truenas/licenselib/pull/6

Original PR: https://github.com/truenas/middleware/pull/14988
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132626