### PR TITLE
NAS-131797 / 25.04 / Properly capture IP on which a port is bound to in apps port delegate

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/port_attachments.py
+++ b/src/middlewared/middlewared/plugins/apps/port_attachments.py
@@ -16,7 +16,7 @@ class AppPortDelegate(PortDelegate):
             app_ports = []
             for port_entry in app['active_workloads']['used_ports']:
                 for host_port in port_entry['host_ports']:
-                    app_ports.append(('0.0.0.0', host_port['host_port']))
+                    app_ports.append((host_port['host_ip'], host_port['host_port']))
 
             ports.append({
                 'description': f'{app["id"]!r} application',


### PR DESCRIPTION
This PR fixes a problem where when adding application ports to the port attachment delegate, we currently use the IP `0.0.0.0` instead of the specific IP to which the port is bound. This causes issues for users who have created a custom app and bound a port to a specific IP, as they are unable to bind the same port to a different IP.