### PR TITLE
NAS-132572 / 24.10.1 / Safely extract user config (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -12,6 +12,7 @@ from middlewared.schema import accepts, Bool, Dict, returns
 from middlewared.service import CallError, Service, job, private
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 from middlewared.utils.db import FREENAS_DATABASE
+from samba import safe_tarfile
 
 CONFIG_FILES = {
     'pwenc_secret': PWENC_FILE_SECRET,
@@ -111,7 +112,18 @@ class ConfigService(Service):
     def upload_impl(self, file_or_tar, is_tar_file=False):
         with tempfile.TemporaryDirectory() as temp_dir:
             if is_tar_file:
-                with tarfile.open(file_or_tar, 'r') as tar:
+                # FIXME: following uses Samba's safe_tarfile to try to ameliorate CVE-2007-4559.
+                #
+                # When we have debian python version with tarfile extraction fix, replace samba safe_tarfile
+                # with appropriate parameters to avoid dir traversal issues.
+                #
+                # https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extraction_filter
+                # https://peps.python.org/pep-0706/
+                #
+                # e.g.
+                # with tarfile.open(file_or_tar, 'r') as tar:
+                #    tar.extractall(temp_dir, filter='tar')
+                with safe_tarfile.open(file_or_tar, 'r') as tar:
                     tar.extractall(temp_dir)
             else:
                 # if it's just the db then copy it to the same

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -28,6 +28,12 @@ TRUENAS_ADMIN_KEYS_UPLOADED = '/data/truenas_admin_authorized_keys_uploaded'
 ROOT_KEYS_UPLOADED = '/data/root_authorized_keys_uploaded'
 DATABASE_NAME = os.path.basename(FREENAS_DATABASE)
 
+try:
+    tarfile.tar_filter
+    TARFILE_HAS_FILTER = True
+except AttributeError:
+    TARFILE_HAS_FILTER = False
+
 
 class ConfigService(Service):
 
@@ -123,8 +129,16 @@ class ConfigService(Service):
                 # e.g.
                 # with tarfile.open(file_or_tar, 'r') as tar:
                 #    tar.extractall(temp_dir, filter='tar')
-                with safe_tarfile.open(file_or_tar, 'r') as tar:
-                    tar.extractall(temp_dir)
+                if TARFILE_HAS_FILTER:
+                    self.logger.error(
+                        'tarfile version now properly supports filter kwarg. Mitigation '
+                        'may be removed.'
+                    )
+                    with tarfile.open(file_or_tar, 'r') as tar:
+                        tar.extractall(temp_dir, filter='tar')
+                else:
+                    with safe_tarfile.open(file_or_tar, 'r') as tar:
+                        tar.extractall(temp_dir)
             else:
                 # if it's just the db then copy it to the same
                 # temp directory to keep the logic simple(ish).


### PR DESCRIPTION
Since user is providing this file and method already replacing our configuration in many ways, the original usage doesn't pose a security risk. This change provides protection against a broken config file rewriting files outside the temporary directory used for extraction and causing undefined system behavior.

This commit uses Samba's safe_tarfile wrapper to extract the file with note to replace once we have a python version from upstream debian that supports the newer tarfile feature.

Original PR: https://github.com/truenas/middleware/pull/14969
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132572