### PR TITLE
NAS-132681 / 25.04 / Reload iscsitarget on iscsi.auth.delete

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -119,6 +119,7 @@ class iSCSITargetAuthCredentialService(CRUDService):
         )
         if orig_peerusers:
             await self.middleware.call('iscsi.auth.recalc_mutual_chap_alert', orig_peerusers)
+        await self._service_change('iscsitarget', 'reload')
 
         return result
 


### PR DESCRIPTION
Was doing reload on `iscsi.auth.create` and `iscsi.auth.update`, but not on `iscsi.auth.delete`.  Rectify.