### PR TITLE
NAS-132681 / 24.10.2 / Reload iscsitarget on iscsi.auth.delete (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -125,9 +125,12 @@ class iSCSITargetAuthCredentialService(CRUDService):
             if usages['in_use']:
                 raise CallError(usages['usages'])
 
-        return await self.middleware.call(
+        result = await self.middleware.call(
             'datastore.delete', self._config.datastore, id_
         )
+        await self._service_change('iscsitarget', 'reload')
+
+        return result
 
     @private
     async def is_in_use_by_portals_targets(self, id_):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 932bfbc35d9c4efce59f01f938c7e04a8943329f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 510930b97aaadde14979666542ec75aee9f5b689

Was doing reload on `iscsi.auth.create` and `iscsi.auth.update`, but not on `iscsi.auth.delete`.  Rectify.

Original PR: https://github.com/truenas/middleware/pull/15006
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132681