### PR TITLE
NAS-130489 / 25.04 / Add support for discovery auth

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -226,6 +226,7 @@ class EtcService(Service):
                 {'method': 'failover.status'},
                 {'method': 'fc.capable'},
                 {'method': 'fcport.query'},
+                {'method': 'iscsi.auth.query'},
                 {'method': 'iscsi.global.alua_enabled'},
                 {'method': 'iscsi.global.config'},
                 {'method': 'iscsi.target.query'},


### PR DESCRIPTION
Add support for discovery auth:
- Write the `iscsi.auth` user/secret as the `IncomingUser` in _/etc/scst.conf_
- Write a single peeruser/peersecret as the `OutgoingUser` if Mutual CHAP discovery auth has been specified.
- Further, in HA systems write the `internal_portal` so that discovery auth does **not** apply to HA "internal" targets.

----
CI build with no regressions [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1926/) or [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1943/).
New CI tests will be added as part of NAS-130509 (PR #15010)