### PR TITLE
NAS-132684 / 24.10.1 / Handle case where netbiosalias is omitted from AD payload (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -71,7 +71,7 @@ class ActiveDirectoryService(ConfigService):
         Str('createcomputer'),
         NetbiosName('netbiosname'),
         NetbiosName('netbiosname_b'),
-        List('netbiosalias', items=[NetbiosName('alias')]),
+        List('netbiosalias', items=[NetbiosName('alias')], default=None),
         Bool('enable'),
         register=True
     )
@@ -122,6 +122,11 @@ class ActiveDirectoryService(ConfigService):
     @private
     async def update_netbios_data(self, old, new):
         must_update = False
+
+        # None here as opposed to empty list indicates to preserve current value
+        if new['netbiosalias'] is None:
+            new['netbiosalias'] = old['netbiosalias']
+
         for key in ['netbiosname', 'netbiosalias']:
             # netbios names are case-insensitive
             if key in new and old[key] != new[key]:


### PR DESCRIPTION
When netbiosalias is set in SMB configuration and omitted from the payload in the AD form, it gets populated as an empty list causing a ValidationError to be raised (because we don't allow changing netbios configuration while AD is enabled). Unfortunately, some howto guides online have recommended users to set the netbiosname and netbios alias to the same value, and as is the way of such things this advice is both unnecessary and detremental. This means that users who followed such guides are now unable to modify their AD configuration through the webui (which no longer sets the netbiosalias by default).

Set the default for netbiosalias to None in the AD plugin so that it does not default to an empty list. None is treated as a special value indicating that the existing netbios aliases should be preserved.

Original PR: https://github.com/truenas/middleware/pull/15012
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132684