### PR TITLE
NAS-132694 / 25.04 / fix CatalogEntry definition

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/catalog.py
+++ b/src/middlewared/middlewared/api/v25_04_0/catalog.py
@@ -16,6 +16,7 @@ class CatalogEntry(BaseModel):
     id: NonEmptyString
     label: NonEmptyString = Field(pattern=r'^\w+[\w.-]*$')
     preferred_trains: list[NonEmptyString]
+    location: NonEmptyString
 
 
 @single_argument_args('catalog_update')


### PR DESCRIPTION
Few api tests are failing because it's missing a `location` attribute.
```
truenas_api_client.exc.ClientException: 1 validation error for CatalogConfigResult
result.location
  Extra inputs are not permitted [type=extra_forbidden, input_value='/mnt/.ix-apps/truenas_catalog', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden