### PR TITLE
NAS-132712 / 25.04 / Fix alert text format for Mattermost.

### DIFF
--- a/src/middlewared/middlewared/alert/service/mattermost.py
+++ b/src/middlewared/middlewared/alert/service/mattermost.py
@@ -26,7 +26,7 @@ class MattermostAlertService(ThreadedAlertService):
                 "username": self.attributes["username"],
                 "channel": self.attributes["channel"],
                 "icon_url": self.attributes["icon_url"],
-                "text": self._format_alerts(alerts, gone_alerts, new_alerts),
+                "text": self._format_alerts(alerts, gone_alerts, new_alerts).replace("<il>","+ ").replace("<br>","\n").replace("<ul>","").replace("</ul>","").replace("</il>",""),
             }),
             timeout=INTERNET_TIMEOUT,
         )

--- a/src/middlewared/middlewared/alert/service/mattermost.py
+++ b/src/middlewared/middlewared/alert/service/mattermost.py
@@ -1,5 +1,7 @@
 import json
 import requests
+import html
+import html2text
 
 from middlewared.alert.base import ThreadedAlertService
 from middlewared.schema import Dict, Str
@@ -26,7 +28,7 @@ class MattermostAlertService(ThreadedAlertService):
                 "username": self.attributes["username"],
                 "channel": self.attributes["channel"],
                 "icon_url": self.attributes["icon_url"],
-                "text": self._format_alerts(alerts, gone_alerts, new_alerts).replace("<il>","+ ").replace("<br>","\n").replace("<ul>","").replace("</ul>","").replace("</il>",""),
+                "text": html.escape(html2text.html2text(self._format_alerts(alerts, gone_alerts, new_alerts))),
             }),
             timeout=INTERNET_TIMEOUT,
         )


### PR DESCRIPTION
Mattermost does not render html code sent in
messages. This edit removes/replaces html code from
the message text and adopts the markdown formatting
used by Mattermost.