### PR TITLE
NAS-131410 / 24.10.2 / add H30 to enclosure plugin (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/enums.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enums.py
@@ -22,6 +22,7 @@ class ControllerModels(Enum):
     F130 = 'F130'  # all nvme flash
     H10 = 'H10'
     H20 = 'H20'
+    H30 = 'H30'
     M30 = 'M30'
     M40 = 'M40'
     M50 = 'M50'


### PR DESCRIPTION
The H30 is exactly the same as H10/H20 so all of the detection logic is in place. Simply need to add the model to the enum and everything else will just work.

Original PR: https://github.com/truenas/middleware/pull/14587
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131410