### PR TITLE
fix boot.environment.destroy caller

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/install.py
+++ b/src/middlewared/middlewared/plugins/update_/install.py
@@ -105,7 +105,7 @@ class UpdateService(Service):
         ):
             space_left_before_prune = space_left
             logger.info("Pruning %r", be["id"])
-            self.middleware.call_sync("boot.environment.destroy", be["id"])
+            self.middleware.call_sync("boot.environment.destroy", {"id": be["id"]})
 
             be_size = be["used_bytes"]
             for i in range(10):


### PR DESCRIPTION
The `boot.environment` namespace is not a CRUD plugin and so, therefore, to keep the new API boilerplate to a minimum, it was designed so that it took a single positional argument (of type dictionary). However, there is a caller that isn't passing the properly formatted argument to it so it's crashing. Traceback looks like
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install.py", line 26, in install_scale
    self.middleware.call_sync("update.ensure_free_space", boot_pool_name, manifest["size"])
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1758, in call_sync
    return methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install.py", line 108, in ensure_free_space
    self.middleware.call_sync("boot.environment.destroy", be["id"])
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1758, in call_sync
    return methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/decorator.py", line 74, in wrapped
    args = list(args[:args_index]) + accept_params(accepts, args[args_index:])
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/handler/accept.py", line 23, in accept_params
    dump = validate_model(model, args_as_dict, exclude_unset=exclude_unset, expose_secrets=expose_secrets)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/handler/accept.py", line 80, in validate_model
    raise verrors from None
middlewared.service_exception.ValidationErrors: [EINVAL] boot_environment_destroy: Input should be a valid dictionary or instance of BootEnvironmentDestroyArgs