### PR TITLE
NAS-132612 / 25.04 / Remove stale locks before any TrueCloud Backup operation

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -32,16 +32,14 @@ class CloudBackupService(Service):
             text=True
         )
 
-        if self.is_initialized(cloud_backup):
+        if self.is_initialized(restic_config):
             return
 
         self.init(cloud_backup)
 
     @private
-    def is_initialized(self, cloud_backup):
+    def is_initialized(self, restic_config):
         self.middleware.call_sync("network.general.will_perform_activity", "cloud_backup")
-
-        restic_config = get_restic_config(cloud_backup)
 
         try:
             subprocess.run(

--- a/src/middlewared/middlewared/plugins/cloud_backup/init.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/init.py
@@ -25,6 +25,13 @@ class CloudBackupService(Service):
                                                          cloud_backup["credentials"]),
             }
 
+        restic_config = get_restic_config(cloud_backup)
+        subprocess.run(
+            restic_config.cmd + ["unlock"],
+            env=restic_config.env,
+            text=True
+        )
+
         if self.is_initialized(cloud_backup):
             return
 


### PR DESCRIPTION
When a TrueCloud Backup task backup is interrupted, either by a user abort or due to some other condition, a stale lock is left on the Storj repository which prevents any subsequent access to the repository. This change runs `restic unlock` before any repository access to ensure that stale locks are removed first.

Non-stale locks will not be removed since the `--remove-all` flag is not used.