### PR TITLE
NAS-132676 / 25.04 / Only redact secrets when the method return value is passed to the user

### DIFF
--- a/src/middlewared/middlewared/api/base/handler/accept.py
+++ b/src/middlewared/middlewared/api/base/handler/accept.py
@@ -15,7 +15,7 @@ def accept_params(model: type[BaseModel], args: list, *, exclude_unset=False, ex
     :param model: `BaseModel` that defines method args.
     :param args: a list of method args.
     :param exclude_unset: if true, will not append default parameters to the list.
-    :param expose_secrets: if false, will replace `Private` parameters with a placeholder.
+    :param expose_secrets: if false, will replace `Secret` parameters with a placeholder.
     :return: a validated list of method args.
     """
     args_as_dict = model_dict_from_list(model, args)
@@ -60,7 +60,7 @@ def validate_model(model: type[BaseModel], data: dict, *, exclude_unset=False, e
     :param model: `BaseModel` subclass.
     :param data: provided data.
     :param exclude_unset: if true, will not add default values.
-    :param expose_secrets: if false, will replace `Private` fields with a placeholder.
+    :param expose_secrets: if false, will replace `Secret` fields with a placeholder.
     :return: validated data.
     """
     try:
@@ -83,5 +83,5 @@ def validate_model(model: type[BaseModel], data: dict, *, exclude_unset=False, e
         context={"expose_secrets": expose_secrets},
         exclude_unset=exclude_unset,
         warnings=False,
-        by_alias=True
+        by_alias=True,
     )

--- a/src/middlewared/middlewared/api/base/handler/dump_params.py
+++ b/src/middlewared/middlewared/api/base/handler/dump_params.py
@@ -17,7 +17,7 @@ def dump_params(model: type[BaseModel], args: list, expose_secrets: bool) -> lis
 
     :param model: `BaseModel` that defines method args.
     :param args: a list of method args.
-    :param expose_secrets: if false, will replace `Private` parameters with a placeholder.
+    :param expose_secrets: if false, will replace `Secret` parameters with a placeholder.
     :return: A list of method call arguments ready to be printed.
     """
     try:
@@ -32,10 +32,10 @@ def dump_params(model: type[BaseModel], args: list, expose_secrets: bool) -> lis
 
 def remove_secrets(model: type[BaseModel], value):
     """
-    Removes `Private` values from a model value.
+    Removes `Secret` values from a model value.
     :param model: `BaseModel` that corresponds to `value`.
-    :param value: value that potentially contains `Private` data.
-    :return: `value` with `Private` parameters replaced with a placeholder.
+    :param value: value that potentially contains `Secret` data.
+    :return: `value` with `Secret` parameters replaced with a placeholder.
     """
     if isinstance(value, dict) and (nested_model := model_field_is_model(model)):
         return {

--- a/src/middlewared/middlewared/api/base/handler/result.py
+++ b/src/middlewared/middlewared/api/base/handler/result.py
@@ -2,6 +2,14 @@ __all__ = ["serialize_result"]
 
 
 def serialize_result(model, result, expose_secrets):
+    """
+    Serializes a `result` of the method execution using the corresponding `model`.
+
+    :param model: `BaseModel` that defines method return value.
+    :param result: method return value.
+    :param expose_secrets: if false, will replace `Secret` parameters with a placeholder.
+    :return: serialized method execution result.
+    """
     return model(result=result).model_dump(
         context={"expose_secrets": expose_secrets},
         warnings=False,

--- a/src/middlewared/middlewared/api/base/server/method.py
+++ b/src/middlewared/middlewared/api/base/server/method.py
@@ -39,13 +39,17 @@ class Method:
 
         result = await self.middleware.call_with_audit(self.name, self.serviceobj, methodobj, params, app)
         if isinstance(result, Job):
-            result = result.id
-        elif isinstance(result, types.GeneratorType):
+            return result.id
+
+        if isinstance(result, types.GeneratorType):
             result = list(result)
         elif isinstance(result, types.AsyncGeneratorType):
             result = [i async for i in result]
 
-        return result
+        return self._dump_result(app, methodobj, result)
+
+    def _dump_result(self, app: "RpcWebSocketApp", methodobj, result):
+        return self.middleware.dump_result(self.serviceobj, methodobj, app, result)
 
     def dump_args(self, params: list) -> list:
         """

--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -636,7 +636,7 @@ class Job:
                 result = self.result
             else:
                 try:
-                    result = self.middleware.dump_result(self.method, self.result, False)
+                    result = self.middleware.dump_result(self.serviceobj, self.method, self.result, False)
                 except Exception as e:
                     result = None
                     result_encoding_error = repr(e)

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_legacy_api_method.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_legacy_api_method.py
@@ -59,7 +59,3 @@ legacy_api_method = LegacyAPIMethod(
 
 def test_adapt_params():
     assert legacy_api_method._adapt_params([1]) == [1, "Default", 2]
-
-
-def test_adapt_result():
-    assert legacy_api_method._adapt_result(1) == "1"

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -856,6 +856,7 @@ class Resource(object):
             if authorized:
                 result = await self.middleware.call_with_audit(methodname, serviceobj, methodobj, method_args,
                                                                **method_kwargs)
+                result = self.middleware.dump_result(serviceobj, methodobj, app, result)
             else:
                 await self.middleware.log_audit_message_for_method(methodname, methodobj, method_args, app,
                                                                    True, False, False)

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -804,11 +804,11 @@ class CoreService(Service):
                 # entries for external callers to methods. app is only None
                 # on internal calls to core.bulk.
                 if app:
-                    msg = await self.middleware.call_with_audit(method, serviceobj, methodobj, p, app=app)
+                    msg = await self.middleware.call_with_audit(method, serviceobj, methodobj, p, app)
                 else:
                     msg = await self.middleware.call(method, *p)
 
-                status = {"result": msg, "error": None}
+                status = {"error": None}
 
                 if isinstance(msg, Job):
                     b_job = msg
@@ -817,6 +817,8 @@ class CoreService(Service):
 
                     if b_job.error:
                         status["error"] = b_job.error
+                else:
+                    status["result"] = self.middleware.dump_result(serviceobj, methodobj, app, msg)
 
                 statuses.append(status)
             except Exception as e:

--- a/tests/api2/test_legacy_websocket.py
+++ b/tests/api2/test_legacy_websocket.py
@@ -7,11 +7,12 @@ from truenas_api_client import Client
 
 from middlewared.test.integration.assets.account import unprivileged_user
 from middlewared.test.integration.assets.cloud_sync import credential
-from middlewared.test.integration.utils import password, websocket_url
+from middlewared.test.integration.utils import call, password, websocket_url
 
 
 @pytest.fixture(scope="module")
 def c():
+    call("rate.limit.cache_clear")
     with Client(websocket_url() + "/websocket") as c:
         c.call("auth.login_ex", {
             "mechanism": "PASSWORD_PLAIN",
@@ -23,6 +24,7 @@ def c():
 
 @pytest.fixture(scope="module")
 def unprivileged_client():
+    call("rate.limit.cache_clear")
     suffix = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
     with unprivileged_user(
         username=f"unprivileged_{suffix}",
@@ -39,6 +41,11 @@ def unprivileged_client():
                 "password": t.password,
             })
             yield c
+
+
+@pytest.fixture(scope="function")
+def clear_ratelimit():
+    call("rate.limit.cache_clear")
 
 
 @pytest.fixture(scope="module")

--- a/tests/api2/test_legacy_websocket.py
+++ b/tests/api2/test_legacy_websocket.py
@@ -1,7 +1,11 @@
+import random
+import string
+
 import pytest
 
 from truenas_api_client import Client
 
+from middlewared.test.integration.assets.account import unprivileged_user
 from middlewared.test.integration.assets.cloud_sync import credential
 from middlewared.test.integration.utils import password, websocket_url
 
@@ -17,7 +21,28 @@ def c():
         yield c
 
 
-def test_adapts_cloud_credentials(c):
+@pytest.fixture(scope="module")
+def unprivileged_client():
+    suffix = "".join([random.choice(string.ascii_lowercase + string.digits) for _ in range(8)])
+    with unprivileged_user(
+        username=f"unprivileged_{suffix}",
+        group_name=f"unprivileged_users_{suffix}",
+        privilege_name=f"Unprivileged users ({suffix})",
+        allowlist=[],
+        roles=["READONLY_ADMIN"],
+        web_shell=False,
+    ) as t:
+        with Client(websocket_url() + "/websocket") as c:
+            c.call("auth.login_ex", {
+                "mechanism": "PASSWORD_PLAIN",
+                "username": t.username,
+                "password": t.password,
+            })
+            yield c
+
+
+@pytest.fixture(scope="module")
+def ftp_credential():
     with credential({
         "provider": {
             "type": "FTP",
@@ -27,5 +52,14 @@ def test_adapts_cloud_credentials(c):
             "pass": "",
         },
     }) as cred:
-        result = c.call("cloudsync.credentials.get_instance", cred["id"])
-        assert result["provider"] == "FTP"
+        yield cred
+
+
+def test_adapts_cloud_credentials(c, ftp_credential):
+    result = c.call("cloudsync.credentials.get_instance", ftp_credential["id"])
+    assert result["provider"] == "FTP"
+
+
+def test_adapts_cloud_credentials_for_unprivileged(unprivileged_client, ftp_credential):
+    result = unprivileged_client.call("cloudsync.credentials.get_instance", ftp_credential["id"])
+    assert result["attributes"] == "********"


### PR DESCRIPTION
Previously, `call_with_audit` was redacting the secrets. This caused issues when its result was passed to the API versions conversion code (as it was trying to validate `port="********"` as integer).