### PR TITLE
NAS-132742 / 25.04 / fix key collision in zpool.status

### DIFF
--- a/tests/api2/test_alert.py
+++ b/tests/api2/test_alert.py
@@ -44,7 +44,7 @@ def alert_id(degraded_pool_gptid):
 
 def test_verify_the_pool_is_degraded(degraded_pool_gptid):
     status = call("zpool.status", {"name": pool_name})
-    disk_status = status[pool_name]["data"][ID_PATH + degraded_pool_gptid]["disk_status"]
+    disk_status = status["pools"][pool_name]["data"][ID_PATH + degraded_pool_gptid]["disk_status"]
     assert disk_status == "DEGRADED"
 
 
@@ -63,7 +63,7 @@ def test_restore_alert(alert_id):
 def test_clear_the_pool_degradation(degraded_pool_gptid):
     ssh(f"zpool clear {pool_name}")
     status = call("zpool.status", {"name": pool_name})
-    disk_status = status[pool_name]["data"][ID_PATH + degraded_pool_gptid]["disk_status"]
+    disk_status = status["pools"][pool_name]["data"][ID_PATH + degraded_pool_gptid]["disk_status"]
     assert disk_status != "DEGRADED"
 
 

--- a/tests/api2/test_zpool_status.py
+++ b/tests/api2/test_zpool_status.py
@@ -104,117 +104,119 @@ def get_pool_status(unused_disks, real_paths=False, replaced=False):
                 ]
             }
         },
-        POOL_NAME: {
-            'spares': {
-                f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'AVAIL' if not replaced else 'INUSE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'spares',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
-                    ]
-                }
-            },
-            'logs': {
-                f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'logs',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}'
-                    ]
-                }
-            },
-            'dedup': {
-                f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'dedup',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}'
-                    ]
-                }
-            },
-            'special': {
-                f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'special',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}'
-                    ]
-                }
-            },
-            'l2cache': {
-                f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'l2cache',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}'
-                    ]
-                }
-            },
-            'data': {
-                f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'stripe',
-                    'vdev_type': 'data',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}'
-                    ]
-                }
-            } if not replaced else {
-                f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'spare-0',
-                    'vdev_type': 'data',
-                    'vdev_disks': [
-                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
-                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
-                    ]
+        'pools': {
+            POOL_NAME: {
+                'spares': {
+                    f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'AVAIL' if not replaced else 'INUSE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'spares',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                        ]
+                    }
                 },
-                f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
-                    'pool_name': POOL_NAME,
-                    'disk_status': 'ONLINE',
-                    'disk_read_errors': 0,
-                    'disk_write_errors': 0,
-                    'disk_checksum_errors': 0,
-                    'vdev_name': 'spare-0',
-                    'vdev_type': 'data',
-                    'vdev_disks':  [
-                        f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
-                        f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
-                    ]
+                'logs': {
+                    f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'logs',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[3]] if not real_paths else unused_disks[3]}'
+                        ]
+                    }
                 },
+                'dedup': {
+                    f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'dedup',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[2]] if not real_paths else unused_disks[2]}'
+                        ]
+                    }
+                },
+                'special': {
+                    f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'special',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[5]] if not real_paths else unused_disks[5]}'
+                        ]
+                    }
+                },
+                'l2cache': {
+                    f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'l2cache',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[0]] if not real_paths else unused_disks[0]}'
+                        ]
+                    }
+                },
+                'data': {
+                    f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'stripe',
+                        'vdev_type': 'data',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}'
+                        ]
+                    }
+                } if not replaced else {
+                    f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'spare-0',
+                        'vdev_type': 'data',
+                        'vdev_disks': [
+                            f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                            f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                        ]
+                    },
+                    f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}': {
+                        'pool_name': POOL_NAME,
+                        'disk_status': 'ONLINE',
+                        'disk_read_errors': 0,
+                        'disk_write_errors': 0,
+                        'disk_checksum_errors': 0,
+                        'vdev_name': 'spare-0',
+                        'vdev_type': 'data',
+                        'vdev_disks':  [
+                            f'{disk_uuid_mapping[unused_disks[1]] if not real_paths else unused_disks[1]}',
+                            f'{disk_uuid_mapping[unused_disks[4]] if not real_paths else unused_disks[4]}'
+                        ]
+                    },
+                }
             }
         }
     }


### PR DESCRIPTION
Someone named one of their zpools `disks`..... A strange zpool name but it caused a key collision in `zpool.status`. Place all zpools underneath a top-level `pools` key to prevent this scenario.