### PR TITLE
NAS-132752 / 25.04 / Refactor out zvol create function and include wait_zvol check

### DIFF
--- a/tests/api2/assets/websocket/pool.py
+++ b/tests/api2/assets/websocket/pool.py
@@ -1,0 +1,41 @@
+import contextlib
+from time import sleep
+
+from middlewared.service_exception import InstanceNotFound
+from middlewared.test.integration.utils import call, ssh
+
+MB = 1024 * 1024
+
+
+@contextlib.contextmanager
+def zvol(name, volsizeMB=512, pool=None, recursive=False, force=False, wait_zvol=True):
+    payload = {
+        'name': f'{pool}/{name}' if pool else name,
+        'type': 'VOLUME',
+        'volsize': volsizeMB * MB,
+        'volblocksize': '16K'
+    }
+    config = call('pool.dataset.create', payload)
+    try:
+        if wait_zvol:
+            # Ensure that the zvol has surfaced
+            testpath = f'/dev/zvol/{config["name"]}'
+            retries = 5
+            found = False
+            while retries:
+                result = ssh(f'ls -1 {testpath}', False, True)
+                if result['stdout']:
+                    for line in result['stdout'].splitlines():
+                        if line == testpath:
+                            found = True
+                            break
+                if found:
+                    break
+                sleep(1)
+                retries -= 1
+        yield config
+    finally:
+        try:
+            call('pool.dataset.delete', config['id'], {'recursive': recursive, 'force': force})
+        except InstanceNotFound:
+            pass


### PR DESCRIPTION
Recently saw some **_occasional_** race conditions in tests where would create a zvol and then the subsequent code to use it in an extent complained that it didn't exist.  Rectify with a check/delay.

- Refactor 3 different variants of `zvol` (or `zvol_dataset`) our of their respective test files and create a new version that includes a check/delay for the zvol (will delay up to 5 seconds).
- Refactor all callers as necessary.  (Previously had 2 different ways of specifying size, now just use a MB count).

----
CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2010/) ... has another (unrelated) intermittent error that will be addressed elsewhere/shortly.