### PR TITLE
NAS-132474 / 25.04 / Refactor realtime reporting memory

### DIFF
--- a/src/freenas/usr/lib/netdata/conf.d/python.d.conf
+++ b/src/freenas/usr/lib/netdata/conf.d/python.d.conf
@@ -4,3 +4,4 @@ cputemp: yes
 smart_log: yes
 truenas_disk_stats: yes
 truenas_arcstats: yes
+truenas_meminfo: yes

--- a/src/freenas/usr/lib/netdata/python.d/truenas_meminfo.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_meminfo.chart.py
@@ -1,0 +1,31 @@
+from dataclasses import asdict
+
+from middlewared.utils.metrics.meminfo import get_memory_info
+
+from bases.FrameworkServices.SimpleService import SimpleService
+
+
+CHARTS = {
+    'total': {
+        'options': [None, 'total', 'Bytes', 'total', 'Total memory', 'line'],
+        'lines': [
+            ['total', 'total', 'absolute'],
+        ]
+    },
+}
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.order = [chart_name for chart_name in CHARTS.keys()]
+        self.definitions = CHARTS
+
+    def get_data(self):
+        data = {}
+        for key, value in asdict(get_memory_info()).items():
+            data[key] = value
+        return data
+
+    def check(self):
+        return True

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -31,24 +31,13 @@ class RealtimeEventSource(EventSource):
         Dict('interfaces', additional_attrs=True),
         Dict(
             'memory',
-            Dict(
-                'classes',
-                Int('apps'),
-                Int('arc'),
-                Int('buffers'),
-                Int('cache'),
-                Int('page_tables'),
-                Int('slab_cache'),
-                Int('unused'),
-            ),
-            Dict('extra', additional_attrs=True),
-        ),
-        Dict('virtual_memory', additional_attrs=True),
-        Dict(
-            'zfs',
+            Int('arc_size'),
             Int('arc_free_memory'),
             Int('arc_available_memory'),
-            Int('arc_size'),
+            Int('physical_memory_total'),
+        ),
+        Dict(
+            'zfs',
             Int('demand_accesses_per_second'),
             Int('demand_data_accesses_per_second'),
             Int('demand_metadata_accesses_per_second'),
@@ -103,7 +92,6 @@ class RealtimeEventSource(EventSource):
                 data = {
                     'zfs': get_arc_stats(netdata_metrics),  # ZFS ARC Size
                     'memory': get_memory_info(netdata_metrics),
-                    'virtual_memory': psutil.virtual_memory()._asdict(),
                     'cpu': get_cpu_stats(netdata_metrics),
                     'disks': get_disk_stats(netdata_metrics, disks, disk_mapping),
                     'interfaces': get_interface_stats(

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/arcstat.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/arcstat.py
@@ -3,15 +3,6 @@ from .utils import normalize_value, safely_retrieve_dimension
 
 def get_arc_stats(netdata_metrics: dict) -> dict:
     data = {
-        'arc_free_memory': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.free', 'free', 0),
-        ),
-        'arc_available_memory': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.avail', 'avail', 0),
-        ),
-        'arc_size': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.size', 'size', 0),
-        ),
         'demand_accesses_per_second': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.dread', 'dread', 0),
         ),

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
@@ -1,55 +1,19 @@
-import humanfriendly
-
 from .utils import normalize_value, safely_retrieve_dimension
 
 
 def get_memory_info(netdata_metrics: dict) -> dict:
-    with open('/proc/meminfo') as f:
-        meminfo = {
-            s[0]: humanfriendly.parse_size(s[1], binary=True)
-            for s in [
-                line.split(':', 1)
-                for line in f.readlines()
-            ]
-        }
-
-    classes = {
-        'page_tables': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'PageTables', 0), multiplier=1024 * 1024,
-        ),
-        'slab_cache': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'Slab', 0), multiplier=1024 * 1024,
-        ),
-        'cache': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'system.ram', 'cached', 0), multiplier=1024 * 1024,
-        ),
-        'buffers': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'system.ram', 'buffers', 0), multiplier=1024 * 1024,
-        ),
-        'unused': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'system.ram', 'free', 0), multiplier=1024 * 1024,
-        ),
-        'arc': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.size', 'size', 0),
-        ),
-        'apps': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'system.ram', 'used', 0), multiplier=1024 * 1024,
-        ),
-    }
-
-    extra = {
-        'inactive': normalize_value(meminfo['Inactive'], multiplier=1024),
-        'committed': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'mem.committed', 'Committed_AS', 0), multiplier=1024 * 1024,
-        ),
-        'active': normalize_value(meminfo['Active'], multiplier=1024),
-        'vmalloc_used': normalize_value(
-            safely_retrieve_dimension(netdata_metrics, 'mem.kernel', 'VmallocUsed', 0), multiplier=1024 * 1024,
-        ),
-        'mapped': normalize_value(meminfo['Mapped'], multiplier=1024),
-    }
 
     return {
-        'classes': classes,
-        'extra': extra,
+        'arc_size': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.size', 'size', 0),
+        ),
+        'arc_free_memory': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.free', 'free', 0),
+        ),
+        'arc_available_memory': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'truenas_arcstats.avail', 'avail', 0),
+        ),
+        'physical_memory_total': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'truenas_meminfo.total', 'total', 0),
+        ),
     }

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -84,6 +84,7 @@ def get_metrics_approximation(
             'mem.kernel': 5,
             'mem.slab': 2,
             'mem.transparent_hugepages': 2,
+            'truenas_meminfo': 1,
 
             # net
             'system.net': 2,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 748, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 8905, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 929, 60: 10}),
+    (4, 2, 1, 2, 10, 2, {1: 749, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 8906, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 930, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
@@ -19,13 +19,13 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 431),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 432),
         (4, 2, 1, 2, 10, 1, 7, 4, 60, 26),
         (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2991),
         (1600, 32, 4, 10, 1, 4, 4, 4, 900, 13),
-        (10, 16, 2, 2, 12, 1, 3, 1, 1, 205),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 206),
         (10, 16, 2, 2, 10, 3, 3, 4, 60, 15),
-        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13407),
+        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13408),
         (1600, 32, 4, 4, 12, 1, 18, 4, 900, 58),
     ],
 )

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -57,86 +57,20 @@ NETDATA_ALL_METRICS = {
             }
         }
     },
-    'system.ram': {
-        'name': 'system.ram',
-        'family': 'ram',
-        'context': 'system.ram',
-        'units': 'MiB',
-        'last_updated': 1691150349,
+    'truenas_meminfo.total': {
+        'name': 'truenas_meminfo.total',
+        'family': 'total',
+        'context': 'Total memory',
+        'units': 'Bytes',
+        'last_updated': 1732714553,
         'dimensions': {
-            'free': {
-                'name': 'free',
-                'value': 301.0585938
-            },
-            'used': {
-                'name': 'used',
-                'value': 1414.1318359
-            },
-            'cached': {
-                'name': 'cached',
-                'value': 250.1103516
-            },
-            'buffers': {
-                'name': 'buffers',
-                'value': 2.0820312
+            'total': {
+                'name': 'total',
+                'value': 6119460864
             }
         }
     },
-    'mem.available': {
-        'name': 'mem.available',
-        'family': 'system',
-        'context': 'mem.available',
-        'units': 'MiB',
-        'last_updated': 1691150349,
-        'dimensions': {
-            'MemAvailable': {
-                'name': 'avail',
-                'value': 428.5869141
-            }
-        }
-    },
-    'mem.committed': {
-        'name': 'mem.committed',
-        'family': 'system',
-        'context': 'mem.committed',
-        'units': 'MiB',
-        'last_updated': 1691150349,
-        'dimensions': {
-            'Committed_AS': {
-                'name': 'Committed_AS',
-                'value': 1887.0546875
-            }
-        }
-    },
-    'mem.kernel': {
-        'name': 'mem.kernel',
-        'family': 'kernel',
-        'context': 'mem.kernel',
-        'units': 'MiB',
-        'last_updated': 1691150349,
-        'dimensions': {
-            'Slab': {
-                'name': 'Slab',
-                'value': 150.78125
-            },
-            'KernelStack': {
-                'name': 'KernelStack',
-                'value': 5.25
-            },
-            'PageTables': {
-                'name': 'PageTables',
-                'value': 6.53125
-            },
-            'VmallocUsed': {
-                'name': 'VmallocUsed',
-                'value': 99.6875
-            },
-            'Percpu': {
-                'name': 'Percpu',
-                'value': 0.8984375
-            }
-        }
-    },
+
     'net.enp1s0': {
         'name': 'net.enp1s0',
         'family': 'enp1s0',
@@ -720,24 +654,11 @@ NETDATA_ALL_METRICS = {
     },
 
 }
-MEM_INFO = '''Active:            67772 kB
-Inactive:        1379892 kB
-Mapped:            54768 kB
-'''
 
 
 def test_arc_stats():
     arc_stats = get_arc_stats(NETDATA_ALL_METRICS)
 
-    assert arc_stats['arc_free_memory'] == normalize_value(
-        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.free', 'free', 0)
-    )
-    assert arc_stats['arc_available_memory'] == normalize_value(
-        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.avail', 'avail', 0)
-    )
-    assert arc_stats['arc_size'] == normalize_value(
-        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.size', 'size', 0)
-    )
     assert arc_stats['demand_accesses_per_second'] == normalize_value(
         safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.dread', 'dread', 0)
     )
@@ -873,36 +794,16 @@ def test_network_stats():
 
 
 def test_memory_stats():
-    with patch('builtins.open', mock_open(read_data=MEM_INFO)):
-        memory_stats = get_memory_info(NETDATA_ALL_METRICS)
-        assert memory_stats['classes']['page_tables'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'PageTables', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['classes']['slab_cache'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'Slab', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['classes']['cache'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.ram', 'cached', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['classes']['buffers'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.ram', 'buffers', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['classes']['unused'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.ram', 'free', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['classes']['arc'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.size', 'size', 0)
-        )
-        assert memory_stats['classes']['apps'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'system.ram', 'used', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['extra']['inactive'] == 1413009408 * 1024
-        assert memory_stats['extra']['committed'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.committed', 'Committed_AS', 0), multiplier=1024 * 1024,
-        )
-        assert memory_stats['extra']['active'] == 69398528 * 1024
-        assert memory_stats['extra']['vmalloc_used'] == normalize_value(
-            safely_retrieve_dimension(NETDATA_ALL_METRICS, 'mem.kernel', 'VmallocUsed', 0), multiplier=1024 * 1024
-        )
-        assert memory_stats['extra']['mapped'] == 56082432 * 1024
-        
+    memory_stats = get_memory_info(NETDATA_ALL_METRICS)
+    assert memory_stats['arc_size'] == normalize_value(
+        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.size', 'size', 0)
+    )
+    assert memory_stats['arc_free_memory'] == normalize_value(
+        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.free', 'free', 0)
+    )
+    assert memory_stats['arc_available_memory'] == normalize_value(
+        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_arcstats.avail', 'avail', 0)
+    )
+    assert memory_stats['physical_memory_total'] == normalize_value(
+        safely_retrieve_dimension(NETDATA_ALL_METRICS, 'truenas_meminfo.total', 'total', 0),
+    )

--- a/src/middlewared/middlewared/utils/metrics/meminfo.py
+++ b/src/middlewared/middlewared/utils/metrics/meminfo.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class MemoryInfo:
+    total: int
+
+
+def get_memory_info() -> MemoryInfo:
+    total = 0
+    with open('/proc/meminfo') as f:
+        for line in filter(lambda x: 'MemTotal' in x, f):
+            total = int(line.split()[1]) * 1024
+            break
+
+        return MemoryInfo(
+            total=total,
+        )


### PR DESCRIPTION
## Context

We had tons of unnecessary metrics in realtime reporting which was extra and caused an extra overhead. With the current changes, what has been done is that we have removed the bloat and added a new memory plugin for netdata and will be using that to retrieve relevant memory datapoints we want.