### PR TITLE
Fixing erroneous SSSD.conf file header + QOL changes

### DIFF
--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -84,17 +84,23 @@ enumerate = ${not ldap['disable_freenas_cache']}
 % if kerberos_realm:
 ldap_sasl_mech = GSSAPI
 ldap_sasl_realm = ${kerberos_realm}
-  % if ldap['kerberos_principal']:
+% if ldap['kerberos_principal']:
 ldap_sasl_authid = ${ldap['kerberos_principal']}
-  % endif
+% endif
 % endif
 timeout = ${ldap['timeout']}
 ldap_schema = ${ldap['schema'].lower()}
 min_id = ${min_uid}
-${'\n    '.join(search_params)}
-${'\n    '.join(map_params)}
+% if search_params:
+# Search Parameters
+${'\n'.join(search_params)}
+% endif
+% if search_params:
+# Map Parameters
+${'\n'.join(map_params)}
+% endif
 % if aux:
-${'\n    '.join(aux)}
+${'\n'.join(aux)}
 % endif
 % elif ds_type == DSType.IPA.value:
 [sssd]

--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -1,5 +1,5 @@
 #
-# NSLCD.CONF(5)		The configuration file for LDAP nameservice daemon
+# SSSD.CONF(5)		The configuration file for SSSD
 #
 <%
     from middlewared.plugins.etc import FileShouldNotExist


### PR DESCRIPTION
Trying to get Truenas Scale LDAP to work with Authentik, I found a few issues in the sssd.conf template file, mainly the header being incorrect. 

I also added some quality-of-life changes to help when debugging stuff like this.