### PR TITLE
NAS-132812 / 25.04 / Convert listdir and mkdir to api_method

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -3,17 +3,24 @@ from middlewared.api.base import (
     NonEmptyString,
     UnixPerm,
     single_argument_args,
+    query_result
 )
 from pydantic import Field, model_validator
 from typing import Literal, Self
 from middlewared.utils.filesystem.acl import (
     ACL_UNDEFINED_ID,
 )
+from middlewared.utils.filesystem.stat_x import (
+    StatxEtype,
+)
 from .acl import AceWhoId
+from .common import QueryFilters, QueryOptions
 
 __all__ = [
     'FilesystemChownArgs', 'FilesystemChownResult',
     'FilesystemSetPermArgs', 'FilesystemSetPermResult',
+    'FilesystemListdirArgs', 'FilesystemListdirResult',
+    'FilesystemMkdirArgs', 'FilesystemMkdirResult',
 ]
 
 
@@ -79,3 +86,97 @@ class FilesystemSetPermArgs(FilesystemPermChownBase):
 
 class FilesystemSetPermResult(BaseModel):
     result: Literal[None]
+
+
+FILESYSTEM_STATX_ATTRS = Literal[
+    'COMPRESSED',
+    'APPEND',
+    'NODUMP',
+    'IMMUTABLE',
+    'AUTOMOUNT',
+    'MOUNT_ROOT',
+    'VERIFY',
+    'DAX'
+]
+
+
+FILESYSTEM_ZFS_ATTRS = Literal[
+    'READONLY',
+    'HIDDEN',
+    'SYSTEM',
+    'ARCHIVE',
+    'IMMUTABLE',
+    'NOUNLINK',
+    'APPENDONLY',
+    'NODUMP',
+    'OPAQUE',
+    'AV_QUARANTINED',
+    'AV_MODIFIED',
+    'REPARSE',
+    'OFFLINE',
+    'SPARSE'
+]
+
+
+class FilesystemDirEntry(BaseModel):
+    name: NonEmptyString
+    """ Entry's base name. """
+    path: NonEmptyString
+    """ Entry's full path. """
+    realpath: NonEmptyString
+    """ Canonical path of the entry, eliminating any symbolic links"""
+    type: Literal[
+        StatxEtype.DIRECTORY,
+        StatxEtype.FILE,
+        StatxEtype.SYMLINK,
+        StatxEtype.OTHER,
+    ]
+    size: int
+    """ Size in bytes of a plain file. """
+    allocation_size: int
+    mode: int
+    """ Entry's mode including file type information and file permission bits. """
+    mount_id: int
+    """ The mount ID of the mount containing the entry. This corresponds to the number in first
+    field of /proc/self/mountinfo. """
+    acl: bool
+    """ Specifies whether ACL is present on the entry. If this is the case then file permission
+    bits as reported in `mode` may not be representative of the actual permissions. """
+    uid: int
+    """ User ID of the entry's owner. """
+    gid: int
+    """ Group ID of the entry's owner. """
+    is_mountpoint: bool
+    """ Specifies whether the entry is also the mountpoint of a filesystem. """
+    is_ctldir: bool
+    """ Specifies whether the entry is located within the ZFS ctldir (for example a snapshot). """
+    attributes: list[FILESYSTEM_STATX_ATTRS]
+    """ Extra file attribute indicators for entry as returned by statx. """
+    xattrs: list[NonEmptyString]
+    """ List of xattr names of extended attributes on file. """
+    zfs_attrs: list[FILESYSTEM_ZFS_ATTRS] | None
+    """ List of extra ZFS-related file attribute indicators on file. Will be None type if filesystem is not ZFS. """
+
+
+class FilesystemListdirArgs(BaseModel):
+    path: NonEmptyString
+    query_filters: QueryFilters = []
+    query_options: QueryOptions = QueryOptions()
+
+
+FilesystemListdirResult = query_result(FilesystemDirEntry)
+
+
+class FilesystemMkdirOptions(BaseModel):
+    mode: UnixPerm = '755'
+    raise_chmod_error: bool = True
+
+
+@single_argument_args('filesystem_mkdir')
+class FilesystemMkdirArgs(BaseModel):
+    path: NonEmptyString
+    options: FilesystemMkdirOptions = Field(default=FilesystemMkdirOptions())
+
+
+class FilesystemMkdirResult(BaseModel):
+    result: FilesystemDirEntry

--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -132,26 +132,27 @@ class FilesystemDirEntry(BaseModel):
         StatxEtype.OTHER,
     ]
     size: int
-    """ Size in bytes of a plain file. """
+    """ Size in bytes of a plain file. This corresonds with stx_size. """
     allocation_size: int
+    """ Allocated size of file. Calculated by multiplying stx_blocks by 512. """
     mode: int
-    """ Entry's mode including file type information and file permission bits. """
+    """ Entry's mode including file type information and file permission bits. This corresponds with stx_mode. """
     mount_id: int
     """ The mount ID of the mount containing the entry. This corresponds to the number in first
-    field of /proc/self/mountinfo. """
+    field of /proc/self/mountinfo and stx_mnt_id. """
     acl: bool
     """ Specifies whether ACL is present on the entry. If this is the case then file permission
     bits as reported in `mode` may not be representative of the actual permissions. """
     uid: int
-    """ User ID of the entry's owner. """
+    """ User ID of the entry's owner. This corresponds with stx_uid. """
     gid: int
-    """ Group ID of the entry's owner. """
+    """ Group ID of the entry's owner. This corresponds with stx_gid. """
     is_mountpoint: bool
     """ Specifies whether the entry is also the mountpoint of a filesystem. """
     is_ctldir: bool
     """ Specifies whether the entry is located within the ZFS ctldir (for example a snapshot). """
     attributes: list[FILESYSTEM_STATX_ATTRS]
-    """ Extra file attribute indicators for entry as returned by statx. """
+    """ Extra file attribute indicators for entry as returned by statx. Expanded from stx_attributes. """
     xattrs: list[NonEmptyString]
     """ List of xattr names of extended attributes on file. """
     zfs_attrs: list[FILESYSTEM_ZFS_ATTRS] | None

--- a/src/middlewared/middlewared/utils/filesystem/stat_x.py
+++ b/src/middlewared/middlewared/utils/filesystem/stat_x.py
@@ -8,16 +8,16 @@
 import os
 import ctypes
 import stat as statlib
-from enum import auto, Enum, IntFlag
+from enum import IntFlag, StrEnum
 from .constants import AT_FDCWD
 from .utils import path_in_ctldir
 
 
-class StatxEtype(Enum):
-    DIRECTORY = auto()
-    FILE = auto()
-    SYMLINK = auto()
-    OTHER = auto()
+class StatxEtype(StrEnum):
+    DIRECTORY = 'DIRECTORY'
+    FILE = 'FILE'
+    SYMLINK = 'SYMLINK'
+    OTHER = 'OTHER'
 
 
 class ATFlags(IntFlag):
@@ -177,8 +177,8 @@ def statx_entry_impl(entry, dir_fd=None, get_ctldir=True):
         # This is equivalent to lstat() call
         out['st'] = statx(
             path,
-            dir_fd = dir_fd,
-            flags = __statx_lstat_flags
+            dir_fd=dir_fd,
+            flags=__statx_lstat_flags
         )
     except FileNotFoundError:
         return None

--- a/tests/api2/test_190_filesystem.py
+++ b/tests/api2/test_190_filesystem.py
@@ -75,9 +75,9 @@ def test_immutable_flag():
             # 2) "is_immutable_set" returns sane response
             if flag_set:
                 with pytest.raises(PermissionError):
-                    call("filesystem.mkdir", f"{t_child_path}_{flag_set}")
+                    call('filesystem.mkdir', {'path': f"{t_child_path}_{flag_set}"})
             else:
-                call("filesystem.mkdir", f"{t_child_path}_{flag_set}")
+                call('filesystem.mkdir', {'path': f"{t_child_path}_{flag_set}"})
 
             is_immutable = 'IMMUTABLE' in call('filesystem.stat', t_path)['attributes']
             err = "Immutable flag is still not set"

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -70,7 +70,7 @@ def create_smb_share(path, share_name, mkdir=False, options=None):
     cr_opts = options or {}
 
     if mkdir:
-        call('filesystem.mkdir', path)
+        call('filesystem.mkdir', {'path': path, 'options': {'raise_chmod_error':   False}})
 
     with smb_share(path, share_name, cr_opts) as share:
         yield share
@@ -82,7 +82,7 @@ def setup_smb_shares(mountpoint):
 
     for share in SHARES:
         share_path = os.path.join(mountpoint, share)
-        call('filesystem.mkdir', share_path)
+        call('filesystem.mkdir', {'path': share_path, 'options': {'raise_chmod_error':   False}})
         new_share = call('sharing.smb.create', {
             'comment': 'My Test SMB Share',
             'name': share,
@@ -342,7 +342,7 @@ with regard to homes shares
 def test__create_homes_share(setup_for_tests):
     mp, ds, share_dict = setup_for_tests
     home_path = os.path.join(mp, 'HOME_SHARE')
-    call('filesystem.mkdir', home_path)
+    call('filesystem.mkdir', {'path': home_path, 'options': {'raise_chmod_error':   False}})
 
     new_share = call('sharing.smb.create', {
         "comment": "My Test SMB Share",

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -70,7 +70,7 @@ def create_smb_share(path, share_name, mkdir=False, options=None):
     cr_opts = options or {}
 
     if mkdir:
-        call('filesystem.mkdir', {'path': path, 'options': {'raise_chmod_error':   False}})
+        call('filesystem.mkdir', {'path': path, 'options': {'raise_chmod_error': False}})
 
     with smb_share(path, share_name, cr_opts) as share:
         yield share
@@ -82,7 +82,7 @@ def setup_smb_shares(mountpoint):
 
     for share in SHARES:
         share_path = os.path.join(mountpoint, share)
-        call('filesystem.mkdir', {'path': share_path, 'options': {'raise_chmod_error':   False}})
+        call('filesystem.mkdir', {'path': share_path, 'options': {'raise_chmod_error': False}})
         new_share = call('sharing.smb.create', {
             'comment': 'My Test SMB Share',
             'name': share,
@@ -342,7 +342,7 @@ with regard to homes shares
 def test__create_homes_share(setup_for_tests):
     mp, ds, share_dict = setup_for_tests
     home_path = os.path.join(mp, 'HOME_SHARE')
-    call('filesystem.mkdir', {'path': home_path, 'options': {'raise_chmod_error':   False}})
+    call('filesystem.mkdir', {'path': home_path, 'options': {'raise_chmod_error': False}})
 
     new_share = call('sharing.smb.create', {
         "comment": "My Test SMB Share",

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -113,7 +113,7 @@ def test_readonly_can_not_call_method():
 
         with pytest.raises(CallError) as ve:
             # fails with EPERM if API access granted
-            c.call("filesystem.mkdir", "/foo")
+            c.call("filesystem.mkdir", {"path": "/foo"})
 
         assert ve.value.errno == errno.EACCES
 

--- a/tests/api2/test_large_message.py
+++ b/tests/api2/test_large_message.py
@@ -13,7 +13,7 @@ def test_large_message_default():
 
     with pytest.raises(ClientException) as ce:
         with client() as c:
-            c.call('filesystem.mkdir', LARGE_PAYLOAD_1)
+            c.call('filesystem.mkdir', {'path': LARGE_PAYLOAD_1})
 
     assert MSG_TOO_BIG_ERR in ce.value.error
 


### PR DESCRIPTION
This commit converts the two filesystem API endpoints `filesystem.listdir` and `filesystem.mkdir` to new api_method.

As part of this change, the deprecated way of calling filesystem.mkdir using positional arguments was removed.