### PR TITLE
NAS-132195 / 25.04 / Improve audit HA test

### DIFF
--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -124,15 +124,6 @@ def standby_audit_event():
     username = "backup"
     user = call('user.query', [["username", "=", username]], {"select": ["id"], "get": True})
 
-    # NOTE: This assumes we're not asynchously generating audit events
-    #       concurrent with this test run.
-    audit_payload = {
-        "query-filters": [["event_data.method", "=", event], ["success", "=", False]],
-        "query-options": {"select": ["event_data", "success"]},
-        "remote_controller": True
-    }
-    audit_start_len = len(call('audit.query', audit_payload))
-
     # Generate an audit entry on the remote node
     with pytest.raises(CallError):
         call('failover.call_remote', event, [user['id']])
@@ -140,8 +131,7 @@ def standby_audit_event():
     yield {
         "event": event,
         "username": username,
-        "audit_start_len": audit_start_len,
-        "audit_payload": audit_payload,
+        "user_id": user["id"]
     }
 
 
@@ -337,15 +327,16 @@ class TestAuditOpsHA:
             2) Generate an exception on remote node audit event get if the remote node is unavailable.
         NOTE: The standby_audit_event fixture generates the remote node audit event.
         '''
-        # event = standby_audit_event['event']
+        event = standby_audit_event['event']
         username = standby_audit_event['username']
-        audit_start_len = standby_audit_event['audit_start_len']
-        audit_payload = standby_audit_event['audit_payload']
-        # payload = {
-        #     "query-filters": [["event_data.method", "=", event], ["success", "=", False]],
-        #     "query-options": {"select": ["event_data", "success"]},
-        #     "remote_controller": True
-        # }
+        user_id = standby_audit_event['user_id']
+
+        audit_payload = {
+            "query-filters": [["event_data.method", "=", event], ["event_data.params", "=", [user_id]]],
+            "query-options": {"select": ["event_data", "success"]},
+            "remote_controller": True
+        }
+
         if not remote_available:
             job_id = call('failover.reboot.other_node')
             # Let the reboot get churning
@@ -359,25 +350,16 @@ class TestAuditOpsHA:
         else:
             # Handle delays in the audit database
             remote_audit_entry = []
-            remote_audit_len = 0
-            tries = 3
-            # while tries > 0 and remote_audit_entry == []:
-            while tries > 0 and audit_start_len < remote_audit_len:
+            tries = 5
+            while tries > 0 and remote_audit_entry == []:
                 sleep(1)
                 remote_audit_entry = call('audit.query', audit_payload)
-                # if remote_audit_entry != []:
-                remote_audit_len = len(remote_audit_entry)
-                # if audit_start_len < remote_audit_len:
-                #     break
                 tries -= 1
 
             assert tries > 0, f"Failed to get expected audit entry. tries={tries}"
-            # assert remote_audit_entry != []
-            assert remote_audit_len > 0, f"audit_start_len = {audit_start_len}, tries={tries}"
             description = remote_audit_entry[0]['event_data']['description']
             evt0 = remote_audit_entry[0]['event_data']
-            evt1 = remote_audit_entry[0]['event_data'] if remote_audit_len > 0 else {}
-            assert username in description, f"tries={tries}\nENTRIES:\n{evt0}\n{evt1}"
+            assert username in description, f"tries={tries}\nENTRY:\n{evt0}"
 
     def test_audit_ha_export(self, standby_audit_event):
         """


### PR DESCRIPTION
Every once in a while the basic HA audit test would fail.  Possibly because earlier tests generated audit events that confused this test.  Possibly because the remote node was slow to respond.

This PR addresses both conditions by improving the query filter and adding a couple more retry loops.
Also improved the assert output in case more tweaks are necessary.

Test results are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2069/).