### PR TITLE
NAS-132639 / 24.10.1 / Add empty `/etc/default/locale` file to be read by `/etc/pam.d/sshd` (by yocalebo)

### DIFF
--- a/tests/api2/test_default_locale.py
+++ b/tests/api2/test_default_locale.py
@@ -1,0 +1,11 @@
+from middlewared.test.integration.utils import call
+
+
+def test_default_locale_exists():
+    # it's important we keep this empty file
+    # since it causes error like these
+    # root@truenas[~]# tail -1 /var/log/error
+    #   Nov 20 21:17:01 truenas CRON[399613]: pam_env(cron:session): \
+    #   Unable to open env file: /etc/default/locale: No such file or directory
+    rv = call("filesystem.stat", "/etc/default/locale")
+    assert rv, rv

--- a/tests/api2/test_default_locale.py
+++ b/tests/api2/test_default_locale.py
@@ -3,7 +3,7 @@ from middlewared.test.integration.utils import call
 
 def test_default_locale_exists():
     # it's important we keep this empty file
-    # since it causes error like these
+    # since it causes error like these if its missing
     # root@truenas[~]# tail -1 /var/log/error
     #   Nov 20 21:17:01 truenas CRON[399613]: pam_env(cron:session): \
     #   Unable to open env file: /etc/default/locale: No such file or directory


### PR DESCRIPTION
We should not have any default locale as https://wiki.debian.org/Locale suggests ("If you have users who access the system through ssh, it is recommended that you choose None as your default locale").

Messages like this appear without this file
```
root@truenas[~]# tail -1 /var/log/error
Nov 20 21:17:01 truenas CRON[399613]: pam_env(cron:session): Unable to open env file: /etc/default/locale: No such file or directory

Original PR: https://github.com/truenas/middleware/pull/15085
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132639