### PR TITLE
NAS-132846 / 24.10.2 / Move warning about changes from shell to MOTD (by anodos325)

### DIFF
--- a/src/freenas/root/.warning
+++ b/src/freenas/root/.warning
@@ -1,6 +1,0 @@
-
-Warning: the supported mechanisms for making configuration changes
-are the TrueNAS WebUI, CLI, and API exclusively. ALL OTHERS ARE
-NOT SUPPORTED AND WILL RESULT IN UNDEFINED BEHAVIOR AND MAY
-RESULT IN SYSTEM FAILURE.
-

--- a/src/freenas/root/.zlogin
+++ b/src/freenas/root/.zlogin
@@ -1,5 +1,3 @@
 if [ -f /usr/local/sbin/hactl ]; then
 	/usr/local/sbin/hactl status -q
 fi
-
-cat ~/.warning

--- a/src/middlewared/middlewared/etc_files/motd.mako
+++ b/src/middlewared/middlewared/etc_files/motd.mako
@@ -12,6 +12,11 @@
 	For more information, documentation, help or support, go here:
 	http://truenas.com
 
+Warning: the supported mechanisms for making configuration changes
+are the TrueNAS WebUI, CLI, and API exclusively. ALL OTHERS ARE
+NOT SUPPORTED AND WILL RESULT IN UNDEFINED BEHAVIOR AND MAY
+RESULT IN SYSTEM FAILURE.
+
 % if motd:
 ${motd}
 % endif


### PR DESCRIPTION
This warning originally only displayed in root shell. As users are switching to having multiple admin accounts, we need to provide constructive notice that what they are doing is potentially unsupported and may result in terrible things.

Original PR: https://github.com/truenas/middleware/pull/15086
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132846