### PR TITLE
NAS-132809 / 24.10.1 / Only call `get_task_extra_args` for cloud sync tasks (not for bucket … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -76,9 +76,11 @@ class RcloneConfig:
             config["pass"] = rclone_encrypt_password(config["pass"])
 
         remote_path = None
-        extra_args = await self.provider.get_task_extra_args(self.cloud_sync)
+        extra_args = []
 
         if "attributes" in self.cloud_sync:
+            extra_args = await self.provider.get_task_extra_args(self.cloud_sync)
+
             config.update(dict(self.cloud_sync["attributes"], **await self.provider.get_task_extra(self.cloud_sync)))
             for k, v in list(config.items()):
                 if v is undefined:


### PR DESCRIPTION
…list requests, etc.)

Original PR: https://github.com/truenas/middleware/pull/15090
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132809