### PR TITLE
NAS-132854 / 25.04 / Convert filesystem plugin to new api_method

### DIFF
--- a/src/middlewared/middlewared/api/base/types/base/string.py
+++ b/src/middlewared/middlewared/api/base/types/base/string.py
@@ -17,7 +17,7 @@ class LongStringWrapper:
     We have to box our long strings in this class to bypass the global limit for string length.
     """
 
-    max_length = 2 ** 31 - 1
+    max_length = 2048000  # historic maximum length of string in filesystem.file_receive
 
     def __init__(self, value):
         if isinstance(value, LongStringWrapper):

--- a/src/middlewared/middlewared/api/v25_04_0/filesystem.py
+++ b/src/middlewared/middlewared/api/v25_04_0/filesystem.py
@@ -1,5 +1,6 @@
 from middlewared.api.base import (
     BaseModel,
+    LongNonEmptyString,
     NonEmptyString,
     UnixPerm,
     single_argument_args,
@@ -25,6 +26,9 @@ __all__ = [
     'FilesystemStatfsArgs', 'FilesystemStatfsResult',
     'FilesystemSetZfsAttrsArgs', 'FilesystemSetZfsAttrsResult',
     'FilesystemGetZfsAttrsArgs', 'FilesystemGetZfsAttrsResult',
+    'FilesystemGetFileArgs', 'FilesystemGetFileResult',
+    'FilesystemPutFileArgs', 'FilesystemPutFileResult',
+    'FilesystemReceiveFileArgs', 'FilesystemReceiveFileResult',
 ]
 
 
@@ -343,3 +347,42 @@ class FilesystemGetZfsAttrsArgs(BaseModel):
 
 class FilesystemGetZfsAttrsResult(BaseModel):
     result: ZFSFileAttrsData
+
+
+class FilesystemGetFileArgs(BaseModel):
+    path: NonEmptyString
+
+
+class FilesystemGetFileResult(BaseModel):
+    result: Literal[None]
+
+
+class FilesystemPutOptions(BaseModel):
+    append: bool = False
+    mode: int | None = None
+
+
+class FilesystemPutFileArgs(BaseModel):
+    path: NonEmptyString
+    options: FilesystemPutOptions = FilesystemPutOptions()
+
+
+class FilesystemPutFileResult(BaseModel):
+    result: Literal[True]
+
+
+class FilesystemReceiveFileOptions(BaseModel):
+    append: bool = False
+    mode: int = None
+    uid: int = ACL_UNDEFINED_ID
+    gid: int = ACL_UNDEFINED_ID
+
+
+class FilesystemReceiveFileArgs(BaseModel):
+    path: NonEmptyString
+    content: LongNonEmptyString
+    options: FilesystemReceiveFileOptions = FilesystemReceiveFileOptions()
+
+
+class FilesystemReceiveFileResult(BaseModel):
+    result: Literal[True]

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -18,12 +18,14 @@ from middlewared.api.current import (
     FilesystemStatfsArgs, FilesystemStatfsResult,
     FilesystemSetZfsAttrsArgs, FilesystemSetZfsAttrsResult,
     FilesystemGetZfsAttrsArgs, FilesystemGetZfsAttrsResult,
+    FilesystemGetFileArgs, FilesystemGetFileResult,
+    FilesystemPutFileArgs, FilesystemPutFileResult,
+    FilesystemReceiveFileArgs, FilesystemReceiveFileResult,
 )
 from middlewared.event import EventSource
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET, PWENC_FILE_SECRET_MODE
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
-from middlewared.schema import accepts, Bool, Dict, Int, returns, Str
-from middlewared.service import private, CallError, filterable, Service, job
+from middlewared.service import private, CallError, filterable_api_method, Service, job
 from middlewared.utils import filter_list
 from middlewared.utils.filesystem import attrs, stat_x
 from middlewared.utils.filesystem.acl import acl_is_present
@@ -106,8 +108,7 @@ class FilesystemService(Service):
     def is_dataset_path(self, path):
         return path.startswith('/mnt/') and os.stat(path).st_dev != os.stat('/mnt').st_dev
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     def mount_info(self, filters, options):
         mntinfo = getmntinfo()
         return filter_list(list(mntinfo.values()), filters, options)
@@ -392,18 +393,9 @@ class FilesystemService(Service):
 
         return stat
 
-    @private
-    @accepts(
-        Str('path'),
-        Str('content', max_length=2048000),
-        Dict(
-            'options',
-            Bool('append', default=False),
-            Int('mode'),
-            Int('uid'),
-            Int('gid'),
-        ),
-    )
+    # WARNING: following method cannot currently be audited properly due to RFC limitations on
+    # syslog message size.
+    @api_method(FilesystemReceiveFileArgs, FilesystemReceiveFileResult, private=True)
     def file_receive(self, path, content, options):
         """
         Simplified file receiving method for small files.
@@ -429,9 +421,7 @@ class FilesystemService(Service):
 
         return True
 
-    @accepts(Str('path'))
-    @returns()
-    @job(pipes=["output"])
+    @api_method(FilesystemGetFileArgs, FilesystemGetFileResult, audit='Filesystem get')
     def get(self, job, path):
         """
         Job to get contents of `path`.
@@ -443,15 +433,7 @@ class FilesystemService(Service):
         with open(path, 'rb') as f:
             shutil.copyfileobj(f, job.pipes.output.w)
 
-    @accepts(
-        Str('path'),
-        Dict(
-            'options',
-            Bool('append', default=False),
-            Int('mode'),
-        ),
-    )
-    @returns(Bool('successful_put'))
+    @api_method(FilesystemPutFileArgs, FilesystemPutFileResult, audit='Filesystem put')
     @job(pipes=["input"])
     def put(self, job, path, options):
         """


### PR DESCRIPTION
This commit converts remaining methods in filesystem plugin to the new schema design, and adjusts maximum long string value to match the historic maximum size of a file we receive. We really don't want to handle any strings larger than this in our API.