### PR TITLE
Fix filesystem.get job

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -422,6 +422,7 @@ class FilesystemService(Service):
         return True
 
     @api_method(FilesystemGetFileArgs, FilesystemGetFileResult, audit='Filesystem get')
+    @job(pipes=["output"])
     def get(self, job, path):
         """
         Job to get contents of `path`.


### PR DESCRIPTION
This commit fixes an error introduced while converting the filesystem.get endpoint into the new api_method schema.