### PR TITLE
NAS-132862 / 25.04 / dont synccache in disk.format

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -20,7 +20,7 @@ class DiskService(Service):
             raise CallError(f'Disk: {disk!r} is incorrectly formatted with Data Integrity Feature (DIF).')
 
         # wipe the disk (quickly) of any existing filesystems
-        self.middleware.call_sync('disk.wipe', disk, 'QUICK').wait_sync(raise_error=True)
+        self.middleware.call_sync('disk.wipe', disk, 'QUICK', False).wait_sync(raise_error=True)
 
         dev = parted.getDevice(f'/dev/{disk}')
         parted_disk = parted.freshDisk(dev, 'gpt')


### PR DESCRIPTION
A fix of `disk.format` exposed another issue where-by `disk.wipe` is running `disk.sync <disk>` for every disk that is in the format list. This eventually leads to smartd failing to be restarted because we're restarting the smartd service for every disk that gets formatted. Fix the issue by not restarting smartd for each disk by setting synccache to False.