### PR TITLE
NAS-132861 / 24.10.1 / Reduce verbosity of cloud_backup logging (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -32,7 +32,7 @@ def get_restic_config(cloud_backup):
 
 
 async def run_restic(job, cmd, env, stdin=None, track_progress=False):
-    job.middleware.logger.debug("Running %r", cmd)
+    job.middleware.logger.trace("Running %r", cmd)
     proc = await Popen(
         cmd,
         env=env,


### PR DESCRIPTION
Passing cloud_backup tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2079/testReport/api2/test_008_cloud_backup/

Original PR: https://github.com/truenas/middleware/pull/15105
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132861