### PR TITLE
NAS-132845 / 25.04 / remove .zlogin for root account

### DIFF
--- a/src/freenas/root/.zlogin
+++ b/src/freenas/root/.zlogin
@@ -1,3 +1,0 @@
-if [ -f /usr/local/sbin/hactl ]; then
-	/usr/local/sbin/hactl status -q
-fi

--- a/src/middlewared/middlewared/migration/0013_root_zlogin.py
+++ b/src/middlewared/middlewared/migration/0013_root_zlogin.py
@@ -1,0 +1,10 @@
+import os
+
+
+def migrate(middleware):
+    try:
+        os.unlink("/root/.zlogin")
+    except FileNotFoundError:
+        pass
+    except Exception:
+        middleware.logger.warning("Unexpected error removing .zlogin", exc_info=True)

--- a/tests/api2/test_root_zlogin.py
+++ b/tests/api2/test_root_zlogin.py
@@ -1,0 +1,11 @@
+import errno
+
+import pytest
+
+from middlewared.test.integration.utils import call
+
+
+def test_root_zlogin_doesnt_exist():
+    with pytest.raises(Exception) as ce:
+        call("filesystem.stat", "/root/.zlogin")
+    assert ce.value.errno == errno.ENOENT


### PR DESCRIPTION
Remove this for a few reasons:

1. we're actively marketing the root account be disabled on TrueNAS (for security reasons)
2. we _only_ run this automatically for the root account and so no other user gets this message
3. we're calling it always (even on non-HA systems)
4. it can block for quite awhile on HA systems depending on the state of HA (unavoidable)

After discussion with support team, we've decided to just remove this to keep the fix simple (instead of trying to figure out how to call this dynamically based on hardware/user/etc).