### PR TITLE
NAS-132885 / 24.10.2 / robustize test_disk_wipe (by yocalebo)

### DIFF
--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -127,7 +127,16 @@ def test_disk_format():
     disk = call("disk.get_unused")[0]["name"]
     # create a GPT label and a 100MiB EXT4 partition
     ssh(f"parted -s /dev/{disk} mklabel gpt mkpart ext4 16384s 100MiB; mkfs.ext4 /dev/{disk}1")
-    info = call("disk.list_partitions", disk)
+    for i in range(20):
+        # Depending on the load of the CI infrastructure
+        # this can take a bit of time for the partition
+        # to surface. Let's give it a bit of time.
+        info = call("disk.list_partitions", disk)
+        if len(info) == 0:
+            time.sleep(0.5)
+        else:
+            break
+
     assert len(info) == 1, info
     assert info[0]["partition_type"] == "0fc63daf-8483-4772-8e79-3d69d8477de4"
     assert info[0]["start_sector"] == 16384

--- a/tests/api2/test_disk_wipe.py
+++ b/tests/api2/test_disk_wipe.py
@@ -130,7 +130,7 @@ def test_disk_format():
     for i in range(20):
         # Depending on the load of the CI infrastructure
         # this can take a bit of time for the partition
-        # to surface. Let's give it a bit of time.
+        # to surface.
         info = call("disk.list_partitions", disk)
         if len(info) == 0:
             time.sleep(0.5)


### PR DESCRIPTION
Noticed this fail randomly under high CI infrastructure load. Let's robustize it a bit so we don't fail on transient external factors.

Original PR: https://github.com/truenas/middleware/pull/15119
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132885