### PR TITLE
NAS-132640 / 25.04 / Apply systemctl mask to ipa-epn.service

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -83,6 +83,9 @@ systemctl mask mdadm.service mdmonitor.service
 # on large disk systems
 systemctl mask lvm2-monitor.service
 
+# ipa-epn.service is in conflict with our implementation of support for IPA
+systemctl mask ipa-epn.service
+
 systemctl set-default truenas.target
 
 sed -i.bak 's/CHARMAP="ISO-8859-15"/CHARMAP="UTF-8"/' /etc/default/console-setup


### PR DESCRIPTION
As mentioned in the ticket, the ipa-epn.service fails to start and is in conflict with our support for IPA.

Disable systemd ipa-epn.service

Safe to backport to 24.10.2