### PR TITLE
NAS-132905 / 25.04 / Properly retrieve vms in dataset details

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/vm.py
+++ b/src/middlewared/middlewared/api/v25_04_0/vm.py
@@ -40,7 +40,7 @@ class VMStatus(BaseModel):
 
 class VMEntry(BaseModel):
     command_line_args: str = ''
-    cpu_mode: Literal['CUSTOM', 'HOST-MODEL', 'HOST_PASSTHROUGH'] = 'CUSTOM'
+    cpu_mode: Literal['CUSTOM', 'HOST-MODEL', 'HOST-PASSTHROUGH'] = 'CUSTOM'
     cpu_model: str | None = None
     name: NonEmptyString
     description: str = ''

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -437,13 +437,14 @@ class PoolDatasetService(Service):
     @private
     def get_vms(self, ds, _vms):
         vms = []
+        vms_mapping = {vm['id']: vm for vm in self.middleware.call_sync('datastore.query', 'vm.vm')}
         for i in _vms:
             if (
                 'zvol' in i and i['zvol'] == ds['id'] or
                 i['attributes']['path'] == ds['mountpoint'] or
                 i.get('mount_info', {}).get('mount_source') == ds['id']
             ):
-                vms.append({'name': i['vm']['name'], 'path': i['attributes']['path']})
+                vms.append({'name': vms_mapping[i['vm']]['name'], 'path': i['attributes']['path']})
 
         return vms
 


### PR DESCRIPTION
## Problem

With recent shift to pydantic models for VM plugins, we had changed how we were retrieving vm devices which resulted in `pool.dataset.details` not working when disk based vm devices were being used.

## Solution

Properly retrieve vms which are consuming datasets when retrieving dataset details.