### PR TITLE
NAS-132858 / 25.04 / improve disk.format and udev partuuid race

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/gpt_utils.py
+++ b/src/middlewared/middlewared/plugins/disk_/gpt_utils.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+from struct import unpack, unpack_from
+from uuid import UUID
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class PartitionEntry:
+    number: int
+    first_lba: int
+    last_lba: int
+    part_name: str
+    disk_guid: str
+    part_type_guid: str
+    part_entry_guid: str
+
+
+def read_gpt_partitions(device: str) -> list[PartitionEntry] | list:
+    with open(f"/dev/{device.removeprefix('/dev/')}", "rb") as f:
+        # it's _incredibly_ important to open this device
+        # as read-only. Otherwise, udevd will trigger
+        # events which will, ultimately, tear-down
+        # by-partuuid symlinks (if the disk has relevant
+        # partition information on it). Simply closing the
+        # device after being opened in write mode causes
+        # this behavior EVEN if the underlying device had
+        # no changes to it. A miserable, undeterministic design.
+        gpt_header = f.read(1024)[512:]  # GPT header starts at LBA 1
+        if gpt_header[0:8] != b"EFI PART":
+            return False
+
+        # Unpack GPT header fields
+        (
+            _,  # signature unused
+            _,  # revision unused
+            _,  # header unused
+            _,  # header_crc32 unused
+            _,  # reserved unused
+            _,  # current_lba unused
+            _,  # backup_lba unused
+            _,  # first_usable_lba unused
+            _,  # last_usable_lba unused
+            disk_guid_bytes,
+            partition_entry_lba,
+            num_part_entries,
+            size_part_entry,
+            _,  # partition_entry_array_crc32 unused
+            _,  # unused
+        ) = unpack("<8sIIIIQQQQ16sQIII420s", gpt_header)
+
+        # Read partition entries
+        f.seek(partition_entry_lba * 512)
+        partitions = []
+        for i in range(num_part_entries):
+            entry = f.read(size_part_entry)
+            if len(entry) < size_part_entry:
+                # end of entries
+                break
+
+            part_name = entry[56:size_part_entry].decode("utf-16le", errors="ignore")
+            partitions.append(
+                PartitionEntry(
+                    number=i + 1,
+                    first_lba=unpack_from("<Q", entry, 32)[0],
+                    last_lba=unpack_from("<Q", entry, 40)[0],
+                    part_name=part_name.rstrip("\x00"),
+                    disk_guid=str(UUID(bytes_le=disk_guid_bytes)),
+                    part_type_guid=str(UUID(bytes_le=entry[0:16])),
+                    part_entry_guid=str(UUID(bytes_le=entry[16:32])),
+                )
+            )
+    return partitions


### PR DESCRIPTION
We have a subtle race condition whereby when `disk.format` is called it generates a series of `remove -> change -> add` udev events for the partition (`sda1`). When the remove event is generated, the `/dev/disk/by-partuuid` symlink is torn down. This is rather ridiculous because it's prone to race conditions by design. Further investigation showed that by simply opening a parent block device (with an existing partition on it), a `remove -> change -> add` series of events are generated for the device JUST BY SIMPLY CLOSING THE DEVICE AND WRITING NOTHING.

I've come to the (personal) conclusion that udevd is a travesty. ANYWAYS, to try and work around this I do 2 things:

1. just read the block device directly and parse gpt partition information
2. once we've done that, then we will go back to udevd and retry a few times to make sure the UUID attribute for the partition exists (since it correlates to the symlink being present)

At this point, the `by-partuuid` behavior is almost unusable. A proper solution would to listen for `change` events (from udev) for `partition` devices and then go read directly from the parent block device to see if there are gpt partitions on there and create our own persistent `partuuid -> sd**` symlinks. This was found by QE and after a few days of digging into this, we were able to reproduce this problem 100% of the time
```
[2024/12/02 06:18:25] (ERROR) middlewared.job.run():522 - Job <function CRUDService._get_crud_wrapper_func.<locals>.nf at 0x7facf1f7a480> failed: CallError('Partition type 6a898cc3-1dd2-11b2-99a6-080020736631 not found on sdab')
```

With the changes introduced here, the problem goes away. It's not perfect by any stretch of the imagination but it's the best we got for now.