### PR TITLE
NAS-132929 / 25.04 / Add back in call to set smb.configured

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -319,6 +319,7 @@ class SMBService(ConfigService):
         await pdb_job.wait()
         await grp_job.wait()
 
+        await self.middleware.call('smb.set_configured')
         """
         It is possible that system dataset was migrated or an upgrade
         wiped our secrets.tdb file. Re-import directory service secrets


### PR DESCRIPTION
This call was removed as part of refactoring to remove the registry configuration and not caught in testing because it would only appear on a reboot.