### PR TITLE
NAS-132701 / 24.10.2 / Clean up FTP banner (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/proftpd/proftpd.motd.mako
+++ b/src/middlewared/middlewared/etc_files/proftpd/proftpd.motd.mako
@@ -1,9 +1,9 @@
 <%
     ftp = render_ctx['ftp.config']
     if ftp["banner"]:
-        banner = ftp["banner"] + "\n"
+        banner = ftp["banner"]
     else:
-        banner = "Welcome to TrueNAS FTP Server\n"
+        banner = "Welcome to TrueNAS FTP Server"
 
-%>
+%>\
 ${banner}


### PR DESCRIPTION
The blank lines in the banner are causing Reolink cameras to fail.

Changing the management of the banner from python to mako introduced blank lines in the banner.
Between Dragonfish and Electric Eel the default banner went from:
`230-Welcome to TrueNAS FTP Server`
to
```
230-
 Welcome to TrueNAS FTP Server

```
These extra carriage returns confused the Reolink camera causing login failures.

This PR restores the previous default banner.

NOTE: Without this PR a custom banner will _not_ avoid the extra carriage returns.

Original PR: https://github.com/truenas/middleware/pull/15148
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132701