### PR TITLE
NAS-132642 / 25.04 / remove unnecessary pong handler

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -354,11 +354,6 @@ class Application(RpcWebSocketApp):
                     self.send_error(message, e.errno, str(e), sys.exc_info(), extra=e.extra)
                 else:
                     self.middleware.create_task(self.call_method(message, serviceobj, methodobj))
-        elif message['msg'] == 'ping':
-            pong = {'msg': 'pong'}
-            if 'id' in message:
-                pong['id'] = message['id']
-            self._send(pong)
         elif message['msg'] == 'sub':
             if not self.middleware.can_subscribe(self, message['name'].split(':', 1)[0]):
                 self.send_error(message, errno.EACCES, 'Not authorized')


### PR DESCRIPTION
UI team discovered this because of the new API scheme being implemented. Come to find out, we had a completely separate "pong" handler that wasn't under any type of protections that we enforce for any of our other endpoints. After speaking with the security team, the best is to just remove this. The equivalent is `core.ping`. UI team has transitioned to using this as well.