### PR TITLE
NAS-132958 / 25.04 / Fix static route entry

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/static_route.py
+++ b/src/middlewared/middlewared/api/v25_04_0/static_route.py
@@ -1,4 +1,4 @@
-from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass
+from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString
 
 from pydantic import IPvAnyAddress, IPvAnyNetwork
 
@@ -15,14 +15,16 @@ __all__ = [
 
 
 class StaticRouteEntry(BaseModel):
-    destination: IPvAnyNetwork
-    gateway: IPvAnyAddress
+    destination: NonEmptyString
+    gateway: NonEmptyString
     description: str = ""
     id: int
 
 
 class StaticRouteCreate(StaticRouteEntry):
     id: Excluded = excluded_field()
+    destination: IPvAnyNetwork
+    gateway: IPvAnyAddress
 
 
 class StaticRouteCreateArgs(BaseModel):


### PR DESCRIPTION
Similar to how `docker.config` was returning ip objects, this is also returning ip objects. However for the former, `truenas_api_client` had changes in place to convert python objects to serializable objects but that changed the format of the output. For static routes, this resulted in error when we tried to query them
```
[2024/12/08 23:53:59] (ERROR) asyncio.default_exception_handler():1771 - Task exception was never retrieved
future: <Task finished name='Task-1226' coro=<RpcWebSocketHandler.process_method_call() done, defined at /usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py:279> exception=TypeError('Object of type IPv4Network is not JSON serializable')>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py", line 314, in process_method_call
    app.send({
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py", line 64, in send
    asyncio.run_coroutine_threadsafe(self.ws.send_str(json.dumps(data)), self.middleware.loop)
                                                      ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/truenas_api_client/ejson.py", line 100, in dumps
    return json.dumps(obj, cls=JSONEncoder, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/truenas_api_client/ejson.py", line 57, in default
    return super(JSONEncoder, self).default(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type IPv4Network is not JSON serializable
```

This was not happening before, likely because we were not doing this before.