### PR TITLE
NAS-132851 / 25.04 / Refresh cloud sync credentials even if cloud sync task fails

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -235,18 +235,6 @@ async def rclone(middleware, job, cloud_sync, dry_run):
         if snapshot:
             await middleware.call("zfs.snapshot.delete", snapshot)
 
-        if cancelled_error is not None:
-            raise cancelled_error
-        if proc.returncode != 0:
-            message = "".join(job.internal_data.get("messages", []))
-            if message and proc.returncode != 1:
-                if not message.endswith("\n"):
-                    message += "\n"
-                message += f"rclone failed with exit code {proc.returncode}"
-            raise CallError(message)
-
-        await run_script(job, "Post-script", cloud_sync["post_script"], env)
-
         refresh_credentials = REMOTES[cloud_sync["credentials"]["provider"]["type"]].refresh_credentials
         if refresh_credentials:
             credentials_attributes = cloud_sync["credentials"]["provider"].copy()
@@ -266,6 +254,18 @@ async def rclone(middleware, job, cloud_sync, dry_run):
                 await middleware.call("cloudsync.credentials.update", cloud_sync["credentials"]["id"], {
                     "provider": credentials_attributes
                 })
+
+        if cancelled_error is not None:
+            raise cancelled_error
+        if proc.returncode != 0:
+            message = "".join(job.internal_data.get("messages", []))
+            if message and proc.returncode != 1:
+                if not message.endswith("\n"):
+                    message += "\n"
+                message += f"rclone failed with exit code {proc.returncode}"
+            raise CallError(message)
+
+        await run_script(job, "Post-script", cloud_sync["post_script"], env)
 
 
 # Prevents clogging job logs with progress reports every second


### PR DESCRIPTION
Cloud sync task might use up the refresh token and get a new one, and still fail to unrelated reason. We need to store the refresh token that it had put to its config file; otherwise, the next run will not work. This is the only cause of the described issue I can think of.