### PR TITLE
NAS-132989 / 25.04 / Fix failing SMB tests

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/smb.py
+++ b/src/middlewared/middlewared/api/v25_04_0/smb.py
@@ -193,7 +193,7 @@ class SmbSharePresetsResult(BaseModel):
 
 @single_argument_args('smb_share_precheck')
 class SmbSharePrecheckArgs(BaseModel):
-    name: NonEmptyString
+    name: NonEmptyString | None = None
 
 
 class SmbSharePrecheckResult(BaseModel):

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -33,8 +33,6 @@ SAMPLE_AUX = [
     '# Include recycle, crossrename, and exclude readonly, as share=RW', '',
     '#vfs objects = zfs_space zfsacl winmsa streams_xattr recycle shadow_copy2 crossrename aio_pthread', '',
     '# testing without shadow_copy2', '',
-    'valid users = MY_ACCOUNT @ALLOWED_USERS',
-    'invalid users = root anonymous guest',
     'hide dot files = yes',
 ]
 

--- a/tests/api2/test_simple_share.py
+++ b/tests/api2/test_simple_share.py
@@ -28,7 +28,7 @@ def test__smb_simple_share_validation():
         "smb": True,
     }):
         # First check that basic call of this endpoint succeeds
-        call('sharing.smb.share_precheck')
+        call('sharing.smb.share_precheck', {})
 
         # Verify works with basic share name
         call('sharing.smb.share_precheck', {'name': 'test_share'})


### PR DESCRIPTION
This fixes two failing auxiliary parameters tests that were caused because the output type of a private API for SMB share parameters was changed from string to a list in some cases.

It also fixes a test regression for case where SMB share precheck is called without arguments.