### PR TITLE
NAS-132991 / 25.04 / make hardware.cpu plugin private

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware/cpu.py
+++ b/src/middlewared/middlewared/plugins/hardware/cpu.py
@@ -1,4 +1,3 @@
-import enum
 import os
 
 from middlewared.service import Service
@@ -6,7 +5,7 @@ from middlewared.service_exception import ValidationError
 from middlewared.utils.functools_ import cache
 
 
-class SysfsCpuEnum(enum.StrEnum):
+class SysfsCpuObj:
     BASE = "/sys/devices/system/cpu/"
     GOVERNOR_BASE = os.path.join(BASE, "cpu0/cpufreq")
     CURRENT_GOVERNOR = os.path.join(GOVERNOR_BASE, "scaling_governor")
@@ -23,7 +22,7 @@ class HardwareCpuService(Service):
     def available_governors(self) -> dict[str, str] | dict:
         """Return available cpu governors"""
         try:
-            with open(SysfsCpuEnum.GOVERNORS_AVAIL.value) as f:
+            with open(SysfsCpuObj.GOVERNORS_AVAIL) as f:
                 return {i: i for i in f.read().split()}
         except FileNotFoundError:
             # doesn't support changing governor
@@ -32,7 +31,7 @@ class HardwareCpuService(Service):
     def current_governor(self) -> str | None:
         """Returns currently set cpu governor"""
         try:
-            with open(SysfsCpuEnum.CURRENT_GOVERNOR.value) as f:
+            with open(SysfsCpuObj.CURRENT_GOVERNOR) as f:
                 return f.read().strip()
         except FileNotFoundError:
             # doesn't support changing governor
@@ -56,7 +55,7 @@ class HardwareCpuService(Service):
             )
 
         try:
-            with os.scandir(SysfsCpuEnum.BASE.value) as sdir:
+            with os.scandir(SysfsCpuObj.BASE) as sdir:
                 for i in filter(
                     lambda x: x.is_dir() and x.name.startswith("cpu"), sdir
                 ):


### PR DESCRIPTION
These endpoints were initially added for our performance team to be added so that they can quickly toggle these governor settings to see if it had any impact on the numbers. Instead of converting these to new api, just mark this plugin private. It's not used by UI team and was never designed otherwise. While I'm here, format the file and use an enum to reduce a bunch of statically typed strings.