### PR TITLE
NAS-133007 / 25.04 / Pass app for update method for ConfigService

### DIFF
--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -9,7 +9,7 @@ from middlewared.api.base.model import BaseModel
 from middlewared.schema import accepts, Dict, Patch, returns
 
 from .base import ServiceBase
-from .decorators import private
+from .decorators import pass_app, private
 from .service import Service
 from .service_mixin import ServiceChangeMixin
 
@@ -106,9 +106,10 @@ class ConfigService(ServiceChangeMixin, Service, metaclass=ConfigServiceMetabase
         options['prefix'] = self._config.datastore_prefix
         return await self._get_or_insert(self._config.datastore, options)
 
-    async def update(self, data):
+    @pass_app(rest=True)
+    async def update(self, app, data):
         rv = await self.middleware._call(
-            f'{self._config.namespace}.update', self, self.do_update, [data]
+            f'{self._config.namespace}.update', self, self.do_update, [data], app=app
         )
         await self.middleware.call_hook(f'{self._config.namespace}.post_update', rv)
         return rv

--- a/tests/api2/test_job_credentials.py
+++ b/tests/api2/test_job_credentials.py
@@ -17,3 +17,14 @@ def test_job_credentials():
             job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
 
             assert job["credentials"] == {"type": "LOGIN_PASSWORD", "data": {"username": c.username, "login_at": ANY}}
+
+
+def test_job_configservice_credentials():
+    # NOTE: using ldap plugin because it's a ConfigService
+    # for which do_update is also a job
+
+    # no-op job
+    job_id = call('ldap.update', {'enable': False})
+
+    job_data = call('core.get_jobs', [['id', '=', job_id]], {'get': True})
+    assert job_data['credentials'] is not None


### PR DESCRIPTION
When we have pair of update/do_update methods for a ConfigService we need to pass the authenticated credentials between them so that the latter method is called with appropriate privileges. If this doesn't happen, then in addition to the obvious problem of getting a privileged credential passed to the do_update method we also lose credential information for a job log if the method has a job decorator.