### PR TITLE
NAS-133021 / 24.10.2 / fix TypeError in read_gpt_partitions (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/gpt_utils.py
+++ b/src/middlewared/middlewared/plugins/disk_/gpt_utils.py
@@ -26,7 +26,7 @@ def read_gpt_partitions(device: str) -> list[PartitionEntry] | list:
         # no changes to it. A miserable, undeterministic design.
         gpt_header = f.read(1024)[512:]  # GPT header starts at LBA 1
         if gpt_header[0:8] != b"EFI PART":
-            return False
+            return []
 
         # Unpack GPT header fields
         (


### PR DESCRIPTION
This is crashing with TypeError because I'm returning a boolean instead of honoring the type annotations. Change it to return an empty list to fix the error.
```
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/disk_info.py", line 142, in gptid_from_part_type
    for i in filter(lambda x: x.part_type_guid == part_type, read_gpt_partitions(disk)):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'bool' object is not iterable

Original PR: https://github.com/truenas/middleware/pull/15180
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133021