### PR TITLE
NAS-133020 / 25.04 / Remove `nvidia` leftovers (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -111,13 +111,6 @@ async def _event_system_ready(middleware, event_type, args):
     if await middleware.call('failover.licensed'):
         return
 
-    if (
-        (await middleware.call('docker.config'))['nvidia'] and
-        await middleware.call('nvidia.present') and
-        not await middleware.call('nvidia.installed')
-    ):
-        await middleware.call('nvidia.install', False)
-
     if (await middleware.call('docker.config'))['pool']:
         middleware.create_task(middleware.call('docker.state.start_service', True))
     else:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x be04dfff9e2327d7c6225b740a426a267522e3c0

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a0e98d2bd43065077da8fc44527f38497d3bf0d2



Original PR: https://github.com/truenas/middleware/pull/15179
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133020