### PR TITLE
NAS-133038 / 25.04 / Run `ldconfig` after loading nvidia sysext (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -77,7 +77,9 @@ class DockerService(ConfigService):
                 # We want to clear upgrade alerts for apps at this point
                 await self.middleware.call('app.clear_upgrade_alerts_for_all')
 
-            if pool_changed or address_pools_changed:
+            nvidia_changed = old_config['nvidia'] != config['nvidia']
+
+            if pool_changed or address_pools_changed or nvidia_changed:
                 job.set_progress(20, 'Stopping Docker service')
                 try:
                     await self.middleware.call('service.stop', 'docker')
@@ -102,6 +104,9 @@ class DockerService(ConfigService):
 
             await self.middleware.call('datastore.update', self._config.datastore, old_config['id'], config)
 
+            if nvidia_changed:
+                await self.middleware.call('docker.configure_nvidia')
+
             if pool_changed:
                 job.set_progress(60, 'Applying requested configuration')
                 await self.middleware.call('docker.setup.status_change')
@@ -112,9 +117,6 @@ class DockerService(ConfigService):
                     await catalog_sync_job.wait()
 
                 await self.middleware.call('service.start', 'docker')
-
-            if old_config['nvidia'] != config['nvidia']:
-                await self.middleware.call('docker.configure_nvidia')
 
             if config['pool'] and address_pools_changed:
                 job.set_progress(95, 'Initiating redeployment of applications to apply new address pools changes')
@@ -163,6 +165,7 @@ class DockerService(ConfigService):
 
         if refresh:
             subprocess.run(['systemd-sysext', 'refresh'], capture_output=True, check=True, text=True)
+            subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
 
         if config['nvidia']:
             cp = subprocess.run(['modprobe', 'nvidia'], capture_output=True, text=True)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 797bed1eec2db65c43509a4794f395bb387c7e82

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 5f1661434aa23c1bfad72fd4c720740f61e1b70b



Original PR: https://github.com/truenas/middleware/pull/15188
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133038