### PR TITLE
NAS-133058 / 25.04 / simplify service.terminate_process

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -1,4 +1,3 @@
-import psutil
 import time
 
 from middlewared.event import EventSource

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -1,17 +1,53 @@
-import logging
-import os
-import resource
+from os import closerange, kill
+from resource import getrlimit, RLIMIT_NOFILE, RLIM_INFINITY
+from signal import SIGKILL, SIGTERM
+from time import sleep, time
 
-logger = logging.getLogger(__name__)
+__all__ = ['close_fds', 'terminate_pid']
 
-__all__ = ['close_fds']
+ALIVE_SIGNAL = 0
 
 
 def close_fds(low_fd, max_fd=None):
     if max_fd is None:
-        max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-        # Avoid infinity as thats not practical
-        if max_fd == resource.RLIM_INFINITY:
+        max_fd = getrlimit(RLIMIT_NOFILE)[1]
+        if max_fd == RLIM_INFINITY:
+            # Avoid infinity as thats not practical
             max_fd = 8192
 
-    os.closerange(low_fd, max_fd)
+    closerange(low_fd, max_fd)
+
+
+def terminate_pid(pid: int, timeout: int = 10) -> bool:
+    # Send SIGTERM to request the process to terminate
+    kill(pid, SIGTERM)
+
+    try:
+        kill(pid, ALIVE_SIGNAL)
+    except ProcessLookupError:
+        # SIGTERM was honored
+        return True
+
+    # process still alive (could take awhile)
+    start_time = time()
+    while True:
+        try:
+            kill(pid, ALIVE_SIGNAL)
+        except ProcessLookupError:
+            # SIGTERM was honored (eventually)
+            return True
+
+        if time() - start_time >= timeout:
+            # Timeout reached; break out of the loop to send SIGKILL
+            break
+
+        # Wait a bit before checking again
+        sleep(0.1)
+
+    try:
+        # Send SIGKILL to forcefully terminate the process
+        kill(pid, SIGKILL)
+        return False
+    except ProcessLookupError:
+        # Process may have terminated between checks
+        return True

--- a/tests/unit/test_terminate_pid.py
+++ b/tests/unit/test_terminate_pid.py
@@ -1,9 +1,15 @@
 from os import kill
+from signal import signal, SIGCHLD, SIG_IGN
 from subprocess import Popen
 from textwrap import dedent
 from time import sleep
 
 from middlewared.utils.os import terminate_pid
+
+# ignore SIGCHLD so child process is removed
+# from process table immediately without parent
+# process having to do any (formal) clean-up
+signal(SIGCHLD, SIG_IGN)
 
 
 def test_sigterm():

--- a/tests/unit/test_terminate_pid.py
+++ b/tests/unit/test_terminate_pid.py
@@ -4,12 +4,19 @@ from subprocess import Popen
 from textwrap import dedent
 from time import sleep
 
+import pytest
+
 from middlewared.utils.os import terminate_pid
 
-# ignore SIGCHLD so child process is removed
-# from process table immediately without parent
-# process having to do any (formal) clean-up
-signal(SIGCHLD, SIG_IGN)
+
+@pytest.fixture(scope="module", autouse=True)
+def signal_handler():
+    # ignore SIGCHLD so child process is removed
+    # from process table immediately without parent
+    # process having to do any (formal) clean-up
+    orig = signal(SIGCHLD, SIG_IGN)
+    yield
+    signal(SIGCHLD, orig)
 
 
 def test_sigterm():

--- a/tests/unit/test_terminate_pid.py
+++ b/tests/unit/test_terminate_pid.py
@@ -1,0 +1,52 @@
+from os import kill
+from subprocess import Popen
+from textwrap import dedent
+from time import sleep
+
+from middlewared.utils.os import terminate_pid
+
+
+def test_sigterm():
+    p = Popen(['python', '-c', 'import time; time.sleep(60)'])
+    # Allow process to start
+    sleep(0.2)
+
+    # Call terminate_pid with timeout
+    terminate_pid(p.pid, timeout=5)
+    # Wait a bit to ensure process has time to terminate
+    sleep(0.5)
+
+    # Check if process has terminated
+    try:
+        kill(p.pid, 0)
+        assert False, f"{p.pid!r} still running"
+    except ProcessLookupError:
+        # Process has terminated
+        pass
+
+
+def test_sigkill():
+    script = dedent("""
+        import signal
+        import os
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        max_sleep = 60
+        slept_time = 0
+        while slept_time < max_sleep:
+            time.sleep(1)
+            slept_time += 1
+    """)
+    p = Popen(['python', '-c', script])
+
+    # Call terminate_pid with short timeout
+    terminate_pid(p.pid, timeout=1)
+    # Wait a bit to ensure process has time to terminate
+    sleep(0.5)
+
+    # Check if process has terminated
+    try:
+        kill(p.pid, 0)
+        assert False, f"{p.pid!r} still running"
+    except ProcessLookupError:
+        # Process has terminated
+        pass


### PR DESCRIPTION
psutil is expensive in about every way imaginable. This method doesn't require using it so I've simplified the method to use built-in modules provided by python.

1. add validation to `terminate_process` since it allowed terminating pid 0 or middlewared (itself)
2. make it private, there is no reason for this to be a public method (UI, TC doesn't call it)