### PR TITLE
NAS-132959 / 24.10.2 / Mark extent read-only if underlying zvol is R/O (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -104,8 +104,8 @@ class iSCSITargetExtentService(SharingService):
 
         `ro` when set to true prevents the initiator from writing to this LUN.
         """
+        await self.validate(data)
         verrors = ValidationErrors()
-        await self.middleware.call('iscsi.extent.validate', data)
         await self.clean(data, 'iscsi_extent_create', verrors)
         verrors.check()
 
@@ -114,7 +114,16 @@ class iSCSITargetExtentService(SharingService):
         # This change is being made in conjunction with threads_num being specified in scst.conf
         if data['type'] == 'DISK' and data['path'].startswith('zvol/'):
             zvolname = zvol_path_to_name(os.path.join('/dev', data['path']))
-            await self.middleware.call('zfs.dataset.update', zvolname, {'properties': {'volthreading': {'value': 'off'}}})
+            await self.middleware.call(
+                'zfs.dataset.update',
+                zvolname,
+                {
+                    'properties': {
+                        'volthreading': {'value': 'off'},
+                        'readonly': {'value': 'on' if data['ro'] else 'off'}
+                    }
+                }
+            )
 
         data['id'] = await self.middleware.call(
             'datastore.insert', self._config.datastore, {**data, 'vendor': 'TrueNAS'},
@@ -145,14 +154,25 @@ class iSCSITargetExtentService(SharingService):
         new.update(data)
 
         await self.middleware.call('iscsi.extent.validate', new)
-        await self.clean(
-            new, 'iscsi_extent_update', verrors, old=old
-        )
+        await self.clean(new, 'iscsi_extent_update', verrors, old=old)
         verrors.check()
 
         await self.middleware.call('iscsi.extent.save', new, 'iscsi_extent_create', verrors, old)
         verrors.check()
         new.pop(self.locked_field)
+
+        zvolpath = new.get('path')
+        if zvolpath is not None and zvolpath.startswith('zvol/'):
+            zvolname = zvol_path_to_name(os.path.join('/dev', zvolpath))
+            await self.middleware.call(
+                'zfs.dataset.update',
+                zvolname,
+                {
+                    'properties': {
+                        'readonly': {'value': 'on' if new['ro'] else 'off'}
+                    }
+                }
+            )
 
         await self.middleware.call(
             'datastore.update',
@@ -162,6 +182,9 @@ class iSCSITargetExtentService(SharingService):
             {'prefix': self._config.datastore_prefix}
         )
 
+        await self._service_change('iscsitarget', 'reload')
+
+        # scstadmin can have issues when modifying an existing extent, re-run
         await self._service_change('iscsitarget', 'reload')
 
         return await self.get_instance(id_)
@@ -219,8 +242,8 @@ class iSCSITargetExtentService(SharingService):
                 await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
     @private
-    def validate(self, data):
-        data['serial'] = self.extent_serial(data['serial'])
+    async def validate(self, data):
+        data['serial'] = await self.extent_serial(data['serial'])
         data['naa'] = self.extent_naa(data.get('naa'))
 
     @private
@@ -386,10 +409,10 @@ class iSCSITargetExtentService(SharingService):
         return data
 
     @private
-    def extent_serial(self, serial):
+    async def extent_serial(self, serial):
         if serial in [None, '']:
             used_serials = [i['serial'] for i in (
-                self.middleware.call_sync('iscsi.extent.query', [], {'select': ['serial']})
+                await self.middleware.call('iscsi.extent.query', [], {'select': ['serial']})
             )]
             tries = 5
             for i in range(tries):

--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -939,10 +939,18 @@ class PoolDatasetService(CRUDService):
             verrors.add_child('pool_dataset_update', self.__handle_zfs_set_property_error(e, properties_definitions))
             raise verrors
 
-        if data['type'] == 'VOLUME' and 'volsize' in data and data['volsize'] > dataset[0]['volsize']['parsed']:
-            # means the zvol size has increased so we need to check if this zvol is shared via SCST (iscsi)
-            # and if it is, resync it so the connected initiators can see the new size of the zvol
-            await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id_)
+        if data['type'] == 'VOLUME':
+            if 'volsize' in data and data['volsize'] > dataset[0]['volsize']['parsed']:
+                # means the zvol size has increased so we need to check if this zvol is shared via SCST (iscsi)
+                # and if it is, resync it so the connected initiators can see the new size of the zvol
+                await self.middleware.call('iscsi.global.resync_lun_size_for_zvol', id_)
+
+            if 'readonly' in data:
+                # depending on the iscsi client connected to us, if someone marks a zvol
+                # as R/O (or R/W), we need to be sure and update the associated extent so
+                # that we don't get into a scenario where the iscsi extent is R/W but the
+                # underlying zvol is R/O. Windows clients seem to not handle this very well.
+                await self.middleware.call('iscsi.global.resync_readonly_property_for_zvol', id_, data['readonly'])
 
         updated_ds = await self.get_instance(id_)
         self.middleware.send_event('pool.dataset.query', 'CHANGED', id=id_, fields=updated_ds)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x b4b7f7501ca3d512c2af120cd2cd4fef723f8853
    git cherry-pick -x 6a93be9263c4bd9b0cc65ab5867892eaded0843b
    git cherry-pick -x 0e803cfe2e4bc84a37a3a8a79c066e865a39d361

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~4
    git cherry-pick -x bca13acb365ef5e95de7a111af2f78fb061ee4d1

If a SCST extent is based upon a zvol, then keep the extent `ro` setting in sync with the zvol `readonly` property.

- Update extent `ro` prop if zvol `readonly` changes.
- Update zvol `readonly` prop if extent is `ro` changed
- Add unit test `test__target_readonly_extent`

----
- CI test run is [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2190/).
- Also did some manual testing with Windows client.

Original PR: https://github.com/truenas/middleware/pull/15195
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132959