### PR TITLE
NAS-133070 / 25.04 / Prevent negative PIDs in terminate_process

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -439,7 +439,7 @@ class ServiceService(CRUDService):
         Returns:
             boolean: True if process was terminated with SIGTERM, false if SIGKILL was used
         """
-        if pid == 0 or pid == os.getpid():
+        if pid <= 0 or pid == os.getpid():
             raise ValidationError('terminate_process.pid', 'Invalid PID')
         try:
             return terminate_pid(pid, timeout)


### PR DESCRIPTION
Allowing negative PIDs would wreak havoc in ways we're not prepared. Let's just prevent negative PIDs altogether.