### PR TITLE
Fix crash when handling job locks with invalid call arguments

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -369,7 +369,12 @@ class Job:
     def get_lock_name(self):
         lock_name = self.options.get('lock')
         if callable(lock_name):
-            lock_name = lock_name(self.args)
+            try:
+                lock_name = lock_name(self.args)
+            except Exception:
+                self.middleware.logger.error("Error handling job lock", exc_info=True)
+                raise CallError("Error handling job lock. This is most likely caused by invalid call arguments.",
+                                errno.EINVAL)
         return lock_name
 
     def set_id(self, id_):

--- a/src/middlewared/middlewared/plugins/apps/crud.py
+++ b/src/middlewared/middlewared/plugins/apps/crud.py
@@ -177,7 +177,7 @@ class AppService(CRUDService):
             Str('version', default='latest'),
         )
     )
-    @job(lock=lambda args: f'app_create_{args[0]["app_name"]}')
+    @job(lock=lambda args: f'app_create_{args[0].get("app_name")}')
     def do_create(self, job, data):
         """
         Create an app with `app_name` using `catalog_app` with `train` and `version`.

--- a/src/middlewared/middlewared/plugins/pool_/dedup.py
+++ b/src/middlewared/middlewared/plugins/pool_/dedup.py
@@ -9,7 +9,7 @@ class PoolService(Service):
         cli_namespace = 'storage.pool'
 
     @api_method(DDTPruneArgs, DDTPruneResult)
-    @job(lock=lambda args: f'ddt_prune_{args[0]["pool_name"]}')
+    @job(lock=lambda args: f'ddt_prune_{args[0].get("pool_name")}')
     async def ddt_prune(self, job, options):
         """
         Prune DDT entries in pool `pool_name` based on the specified options.


### PR DESCRIPTION
It's not possible to validate payload before calling `lock` as the ticket suggests because payload validation is the part of the job.