### PR TITLE
NAS-133074 / 25.04 / always reinitialize pwenc in vrrp_backup

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -900,11 +900,9 @@ class FailoverEventsService(Service):
             self.run_call(
                 'failover.call_remote',
                 'failover.send_small_file',
-                [PWENC_FILE_SECRET, f'{PWENC_FILE_SECRET}.tmp'],
+                [PWENC_FILE_SECRET],
                 {'raise_connect_error': False}
             )
-            os.rename(f'{PWENC_FILE_SECRET}.tmp', PWENC_FILE_SECRET)
-            self.run_call('pwenc.reset_secret_cache')
         except Exception:
             self.logger.error('Failed to reinitialize pwenc', exc_info=True)
 

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -895,7 +895,7 @@ class FailoverEventsService(Service):
         self.run_call('failover.fenced.stop')
 
         # In the rare case where the pwenc_secret file doesn't match, we'll
-        # copy over the secret seed file from the active and reinialitize
+        # copy over the secret seed file from the active and reinitialize
         try:
             self.run_call(
                 'failover.call_remote',

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -21,6 +21,7 @@ from middlewared.plugins.docker.state_utils import Status as DockerStatus
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
 from middlewared.plugins.virt.utils import Status as VirtStatus
+from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 
 logger = logging.getLogger('failover')
 FAILOVER_LOCK_NAME = 'vrrp_event'
@@ -892,6 +893,20 @@ class FailoverEventsService(Service):
         # Pools are now exported and so we can make disks available to other controller
         logger.warning('Stopping fenced')
         self.run_call('failover.fenced.stop')
+
+        # In the rare case where the pwenc_secret file doesn't match, we'll
+        # copy over the secret seed file from the active and reinialitize
+        try:
+            self.run_call(
+                'failover.call_remote',
+                'failover.send_small_file',
+                [PWENC_FILE_SECRET, f'{PWENC_FILE_SECRET}.tmp'],
+                {'raise_connect_error': False}
+            )
+            os.rename(f'{PWENC_FILE_SECRET}.tmp', PWENC_FILE_SECRET)
+            self.run_call('pwenc.reset_secret_cache')
+        except Exception:
+            self.logger.error('Failed to reinitialize pwenc', exc_info=True)
 
         # Now that fenced is stopped, attach NVMe/RoCE.
         logger.info('Start bring up of NVMe/RoCE')


### PR DESCRIPTION
QE has hit a rather rare, but painful, error whereby the secret seed between the controllers didn't match. To remedy this problem, we take the approach to always sync the pwenc_secret file from the active controller in the backup function. This ensures they stay in sync with one another.