### PR TITLE
NAS-133074 / 24.10.2 / always reinitialize pwenc in vrrp_backup (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -20,6 +20,7 @@ from middlewared.plugins.docker.state_utils import Status
 # from middlewared.plugins.failover_.zpool_cachefile import ZPOOL_CACHE_FILE
 from middlewared.plugins.failover_.event_exceptions import AllZpoolsFailedToImport, IgnoreFailoverEvent, FencedError
 from middlewared.plugins.failover_.scheduled_reboot_alert import WATCHDOG_ALERT_FILE
+from middlewared.plugins.pwenc import PWENC_FILE_SECRET
 
 logger = logging.getLogger('failover')
 FAILOVER_LOCK_NAME = 'vrrp_event'
@@ -900,6 +901,18 @@ class FailoverEventsService(Service):
         # Pools are now exported and so we can make disks available to other controller
         logger.warning('Stopping fenced')
         self.run_call('failover.fenced.stop')
+
+        # In the rare case where the pwenc_secret file doesn't match, we'll
+        # copy over the secret seed file from the active and reinitialize
+        try:
+            self.run_call(
+                'failover.call_remote',
+                'failover.send_small_file',
+                [PWENC_FILE_SECRET],
+                {'raise_connect_error': False}
+            )
+        except Exception:
+            self.logger.error('Failed to reinitialize pwenc', exc_info=True)
 
         # Now that fenced is stopped, attach NVMe/RoCE.
         logger.info('Start bring up of NVMe/RoCE')


### PR DESCRIPTION
QE has hit a rather rare, but painful, error whereby the secret seed between the controllers didn't match. To remedy this problem, we take the approach to always sync the pwenc_secret file from the active controller in the backup function. This ensures they stay in sync with one another.

Original PR: https://github.com/truenas/middleware/pull/15204
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133074

Original PR: https://github.com/truenas/middleware/pull/15206
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133074