### PR TITLE
fix the "in" operator in the filters to `pool.dataset.query`

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -209,8 +209,8 @@ class PoolDatasetService(CRUDService):
         # Optimization for cases in which they can be filtered at zfs.dataset.query
         zfsfilters = []
         filters = filters or []
-        if len(filters) == 1 and len(filters[0]) == 3 and list(filters[0][:2]) == ['id', '=']:
-            zfsfilters.append(copy.deepcopy(filters[0]))
+        if len(filters) == 1 and len(f := filters[0]) == 3 and f[0] in ('id', 'name') and f[1] in ('=', 'in'):
+            zfsfilters.append(copy.deepcopy(f))
 
         internal_datasets_filters = self.middleware.call_sync('pool.dataset.internal_datasets_filters')
         filters.extend(internal_datasets_filters)

--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import pytest
 
 from middlewared.test.integration.assets.pool import dataset
@@ -10,3 +12,22 @@ def test_pool_dataset_create_ancestors(child):
         name = f"{test_ds}/{child}"
         call("pool.dataset.create", {"name": name, "create_ancestors": True})
         call("pool.dataset.get_instance", name)
+
+
+def test_pool_dataset_query():
+    fields = ("id", "name")
+    ops = ("=", "in")
+    flats = (True, False)
+
+    with dataset("query_test") as ds:
+        # Try all combinations
+        results = (call(
+            "pool.dataset.query",
+            [[field, op, ds if op == "=" else [ds]]],
+            {"extra": {"flat": flat, "properties": []}}
+        ) for field, op, flat in product(fields, ops, flats))
+
+        # Check all the returns are the same
+        first = next(results)
+        for next_ds in results:
+            assert next_ds == first


### PR DESCRIPTION
Currently `pool.dataset.query [["id", "in", ["tank/dataset"]]]` is returning an empty list.