### PR TITLE
NAS-133098 / 25.04 / typing_extensions -> typing

### DIFF
--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -7,7 +7,6 @@ import typing
 from pydantic import BaseModel as PydanticBaseModel, ConfigDict, create_model, Field, model_serializer, Secret
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.main import IncEx
-from typing_extensions import Annotated
 
 from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
 from middlewared.utils.lang import undefined
@@ -165,7 +164,7 @@ def single_argument_args(name: str):
             klass.__name__,
             __base__=(BaseModel,),
             __module__=klass.__module__,
-            **{name: Annotated[klass, Field()]},
+            **{name: typing.Annotated[klass, Field()]},
         )
         model.from_previous = klass.from_previous
         model.to_previous = klass.to_previous
@@ -200,7 +199,7 @@ def single_argument_result(klass, klass_name=None):
         klass_name,
         __base__=(BaseModel,),
         __module__=inspect.getmodule(inspect.stack()[1][0]),
-        result=Annotated[klass, Field()],
+        result=typing.Annotated[klass, Field()],
     )
     if issubclass(klass, BaseModel):
         model.from_previous = klass.from_previous
@@ -214,7 +213,7 @@ def query_result(item):
         item.__name__.removesuffix("Entry") + "QueryResult",
         __base__=(BaseModel,),
         __module__=item.__module__,
-        result=Annotated[list[result_item] | result_item | int, Field()],
+        result=typing.Annotated[list[result_item] | result_item | int, Field()],
     )
 
 

--- a/src/middlewared/middlewared/api/base/types/fc.py
+++ b/src/middlewared/middlewared/api/base/types/fc.py
@@ -1,5 +1,6 @@
+from typing import Annotated
+
 from pydantic import StringConstraints
-from typing_extensions import Annotated
 
 __all__ = ["FibreChannelHostAlias", "FibreChannelPortAlias", "WWPN"]
 

--- a/src/middlewared/middlewared/api/base/types/filesystem.py
+++ b/src/middlewared/middlewared/api/base/types/filesystem.py
@@ -1,5 +1,6 @@
+from typing import Annotated
+
 from pydantic.functional_validators import AfterValidator
-from typing_extensions import Annotated
 
 __all__ = ["UnixPerm"]
 

--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import AfterValidator, BeforeValidator, Field, GetCoreSchemaHandler, HttpUrl as _HttpUrl, PlainSerializer
 from pydantic_core import CoreSchema, core_schema, PydanticKnownError
-from typing_extensions import Annotated
 
 from middlewared.api.base.validators import time_validator
 from middlewared.utils.netbios import validate_netbios_name, validate_netbios_domain

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -1,9 +1,9 @@
 import string
+from typing import Annotated
 
 from annotated_types import Ge, Le
 from pydantic import Field
 from pydantic.functional_validators import AfterValidator
-from typing_extensions import Annotated
 
 from middlewared.utils.sid import sid_is_valid
 

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from typing import Literal, TypeAlias
-from typing_extensions import Annotated
+from typing import Annotated, Literal, TypeAlias
 
 from pydantic import Secret, StringConstraints
 

--- a/src/middlewared/middlewared/api/v25_04_0/common.py
+++ b/src/middlewared/middlewared/api/v25_04_0/common.py
@@ -1,4 +1,4 @@
-from typing_extensions import Annotated, Self
+from typing import Annotated, Self
 
 from middlewared.api.base import BaseModel
 from middlewared.utils import filters

--- a/src/middlewared/middlewared/api/v25_04_0/ftp.py
+++ b/src/middlewared/middlewared/api/v25_04_0/ftp.py
@@ -1,7 +1,6 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import Field, field_validator, ValidationInfo
-from typing_extensions import Annotated
 
 from middlewared.api.base import (
     BaseModel,

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_extent.py
@@ -1,8 +1,7 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from annotated_types import Ge, Le
 from pydantic import Field, StringConstraints
-from typing_extensions import Annotated
 
 from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, IscsiExtentBlockSize, IscsiExtentRPM,
                                   IscsiExtentType, NonEmptyString, excluded_field)

--- a/src/middlewared/middlewared/api/v25_04_0/reporting.py
+++ b/src/middlewared/middlewared/api/v25_04_0/reporting.py
@@ -1,7 +1,6 @@
 import typing
 
 from pydantic import Field
-from typing_extensions import Annotated
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString, single_argument_args,
@@ -30,7 +29,7 @@ class ReportingUpdateResult(BaseModel):
     result: ReportingEntry
 
 
-timestamp: typing.TypeAlias = Annotated[int, Field(gt=0)]
+timestamp: typing.TypeAlias = typing.Annotated[int, Field(gt=0)]
 
 
 class ReportingQuery(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/snmp.py
+++ b/src/middlewared/middlewared/api/v25_04_0/snmp.py
@@ -1,8 +1,7 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic.types import StringConstraints
 from pydantic import EmailStr, Field, Secret
-from typing_extensions import Annotated, Union
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, single_argument_args
@@ -14,7 +13,7 @@ __all__ = ["SnmpEntry",
 
 class SnmpEntry(BaseModel):
     location: str
-    contact: Union[EmailStr, Annotated[str, StringConstraints(pattern=r'^[-_a-zA-Z0-9\s]*$')]]
+    contact: EmailStr | Annotated[str, StringConstraints(pattern=r'^[-_a-zA-Z0-9\s]*$')]
     traps: bool
     v3: bool
     community: str = Field(pattern=r'^[-_a-zA-Z0-9\s]*$', default='public')

--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -1,11 +1,21 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from annotated_types import Ge, Le
 from pydantic import EmailStr, Field, Secret
-from typing_extensions import Annotated
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LocalUsername, RemoteUsername,
-                                  LocalUID, LongString, NonEmptyString, single_argument_args, single_argument_result)
+from middlewared.api.base import (
+    BaseModel,
+    Excluded,
+    excluded_field,
+    ForUpdateMetaclass,
+    LocalUsername,
+    RemoteUsername,
+    LocalUID,
+    LongString,
+    NonEmptyString,
+    single_argument_args,
+    single_argument_result
+)
 
 __all__ = ["UserEntry",
            "UserCreateArgs", "UserCreateResult",

--- a/src/middlewared/middlewared/pytest/unit/api/handler/accept/test_accept_1.py
+++ b/src/middlewared/middlewared/pytest/unit/api/handler/accept/test_accept_1.py
@@ -1,6 +1,7 @@
+from typing import Annotated
+
 from annotated_types import Gt
 import pytest
-from typing_extensions import Annotated
 
 from middlewared.api.base import BaseModel
 from middlewared.api.base.handler.accept import accept_params

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -1,8 +1,8 @@
 import asyncio
 import copy
+from typing import Annotated
 
 from pydantic import create_model, Field
-from typing_extensions import Annotated
 
 from middlewared.api import api_method
 from middlewared.api.base.model import BaseModel

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -1,9 +1,9 @@
 import asyncio
 import copy
 import errno
+from typing import Annotated
 
 from pydantic import create_model, Field
-from typing_extensions import Annotated
 
 from middlewared.api import api_method
 from middlewared.api.base.model import BaseModel, query_result, query_result_item


### PR DESCRIPTION
There is no reason to use `typing_extensions` since we can use python's builtin `typing` module.