### PR TITLE
NAS-133102 / 25.04 / async_timeout -> asyncio.timeout

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/client.py
+++ b/src/middlewared/middlewared/plugins/apps_images/client.py
@@ -1,8 +1,7 @@
-import aiohttp
-import aiohttp.client_exceptions
-import async_timeout
 import asyncio
 import urllib.parse
+
+import aiohttp
 
 from middlewared.service import CallError
 
@@ -22,7 +21,7 @@ class ContainerRegistryClientMixin:
         assert mode in ('get', 'head')
         response = {'error': None, 'response': {}, 'response_obj': None}
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 async with aiohttp.ClientSession(
                     raise_for_status=True, trust_env=True,
                 ) as session:
@@ -40,7 +39,7 @@ class ContainerRegistryClientMixin:
             else:
                 try:
                     response['response'] = await req.json()
-                except aiohttp.client_exceptions.ContentTypeError as e:
+                except aiohttp.ContentTypeError as e:
                     # quay.io registry returns malformed content type header which aiohttp fails to parse
                     # even though the content returned by registry is valid json
                     response['error'] = f'Unable to parse response: {e}'

--- a/src/middlewared/middlewared/plugins/disk_/temperature.py
+++ b/src/middlewared/middlewared/plugins/disk_/temperature.py
@@ -3,8 +3,6 @@ import datetime
 import time
 import json
 
-import async_timeout
-
 from middlewared.api import api_method
 from middlewared.api.current import DiskTemperatureAlertsArgs, DiskTemperatureAlertsResult
 from middlewared.common.smart.smartctl import SMARTCTL_POWERMODES
@@ -113,7 +111,7 @@ class DiskService(Service):
 
         async def temperature(name):
             try:
-                async with async_timeout.timeout(15):
+                async with asyncio.timeout(15):
                     return await self.middleware.call('disk.temperature', name, options)
             except asyncio.TimeoutError:
                 return None

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -6,7 +6,6 @@ import tempfile
 import time
 
 import aiohttp
-import async_timeout
 import requests
 
 from licenselib.utils import proactive_support_allowed
@@ -24,7 +23,7 @@ ADDRESS = 'support-proxy.ixsystems.com'
 
 async def post(url, data, timeout=INTERNET_TIMEOUT):
     try:
-        async with async_timeout.timeout(timeout):
+        async with asyncio.timeout(timeout):
             async with aiohttp.ClientSession(
                 raise_for_status=True, trust_env=True,
             ) as session:

--- a/src/middlewared/middlewared/plugins/truecommand/connection.py
+++ b/src/middlewared/middlewared/plugins/truecommand/connection.py
@@ -1,7 +1,7 @@
-import aiohttp
-import async_timeout
 import asyncio
 import json
+
+import aiohttp
 
 
 class TruecommandAPIMixin:
@@ -16,7 +16,7 @@ class TruecommandAPIMixin:
         timeout = options.get('timeout', 15)
         response = {'error': None, 'response': {}}
         try:
-            async with async_timeout.timeout(timeout):
+            async with asyncio.timeout(timeout):
                 async with aiohttp.ClientSession(
                     raise_for_status=True, trust_env=True,
                 ) as session:


### PR DESCRIPTION
async_timeout 3rd party module has been deprecated because the identical functionality exists within python's builtin modules. Use that instead.