### PR TITLE
NAS-133106 / 25.04 / psutil.process_iter -> get_pids

### DIFF
--- a/src/middlewared/middlewared/plugins/system/cli.py
+++ b/src/middlewared/middlewared/plugins/system/cli.py
@@ -1,16 +1,16 @@
 import contextlib
+import os
 import signal
 
-import psutil
-
 from middlewared.service import Service, private
+from middlewared.utils.os import get_pids
 
 
 class SystemService(Service):
     @private
     def reload_cli(self):
-        for process in psutil.process_iter(['pid', 'cmdline']):
-            cmdline = process.cmdline()
-            if len(cmdline) >= 2 and cmdline[1] == '/usr/bin/cli':
+        for process in filter(lambda x: x and b'/usr/bin/cli' in x.cmdline, get_pids()):
+            args = process.cmdline.split(b' ')
+            if len(args) >= 2 and args[1] == b'/usr/bin/cli':
                 with contextlib.suppress(Exception):
-                    process.send_signal(signal.SIGUSR1)
+                    os.kill(process.pid, signal.SIGUSR1)

--- a/src/middlewared/middlewared/plugins/system/cli.py
+++ b/src/middlewared/middlewared/plugins/system/cli.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 import signal
 
 from middlewared.service import Service, private
@@ -13,4 +12,4 @@ class SystemService(Service):
             args = process.cmdline.split(b' ')
             if len(args) >= 2 and args[1] == b'/usr/bin/cli':
                 with contextlib.suppress(Exception):
-                    os.kill(process.pid, signal.SIGUSR1)
+                    process.send_signal(signal.SIGUSR1)

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -12,6 +12,7 @@ ALIVE_SIGNAL = 0
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class PidEntry:
+    name: bytes
     cmdline: bytes
     pid: int
 
@@ -62,6 +63,12 @@ def terminate_pid(pid: int, timeout: int = 10) -> bool:
 
 
 def get_pids(pid: int | None = None) -> Generator[PidEntry] | PidEntry | None:
+    """Get the currently running processes on the OS.
+
+    pid: int if provided, will short-circuit and return a
+        `PidEntry` with the same pid. If not provided, the
+        will yield a `PidEntry`.
+    """
     spid = str(pid) if pid is not None else None
     with scandir("/proc/") as sdir:
         for i in filter(lambda x: x.name.isdigit(), sdir):
@@ -73,6 +80,6 @@ def get_pids(pid: int | None = None) -> Generator[PidEntry] | PidEntry | None:
                 pass
             else:
                 if spid == i.name:
-                    return PidEntry(cmdline=cmdline, pid=pid)
+                    return PidEntry(name=cmdline, cmdline=cmdline, pid=pid)
                 else:
-                    yield PidEntry(cmdline=cmdline, pid=int(i.name))
+                    yield PidEntry(name=cmdline, cmdline=cmdline, pid=int(i.name))

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -1,11 +1,19 @@
-from os import closerange, kill
+from collections.abc import Generator
+from dataclasses import dataclass
+from os import closerange, kill, scandir
 from resource import getrlimit, RLIMIT_NOFILE, RLIM_INFINITY
 from signal import SIGKILL, SIGTERM
 from time import sleep, time
 
-__all__ = ['close_fds', 'terminate_pid']
+__all__ = ['close_fds', 'get_pids', 'PidEntry', 'terminate_pid']
 
 ALIVE_SIGNAL = 0
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class PidEntry:
+    cmdline: bytes
+    pid: int
 
 
 def close_fds(low_fd, max_fd=None):
@@ -51,3 +59,20 @@ def terminate_pid(pid: int, timeout: int = 10) -> bool:
     except ProcessLookupError:
         # Process may have terminated between checks
         return True
+
+
+def get_pids(pid: int | None = None) -> Generator[PidEntry] | PidEntry | None:
+    spid = str(pid) if pid is not None else None
+    with scandir("/proc/") as sdir:
+        for i in filter(lambda x: x.name.isdigit(), sdir):
+            try:
+                with open(f'{i.path}/cmdline', 'rb') as f:
+                    cmdline = f.read().replace(b'\x00', b' ')
+            except FileNotFoundError:
+                # process could have gone away
+                pass
+            else:
+                if spid == i.name:
+                    return PidEntry(cmdline=cmdline, pid=pid)
+                else:
+                    yield PidEntry(cmdline=cmdline, pid=int(i.name))

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -66,8 +66,8 @@ def get_pids(pid: int | None = None) -> Generator[PidEntry] | PidEntry | None:
     """Get the currently running processes on the OS.
 
     pid: int if provided, will short-circuit and return a
-        `PidEntry` with the same pid. If not provided, the
-        will yield a `PidEntry`.
+        `PidEntry` with the same pid. If not provided, will
+        yield a `PidEntry`.
     """
     spid = str(pid) if pid is not None else None
     with scandir("/proc/") as sdir:

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -5,7 +5,7 @@ from resource import getrlimit, RLIMIT_NOFILE, RLIM_INFINITY
 from signal import SIGKILL, SIGTERM
 from time import sleep, time
 
-__all__ = ['close_fds', 'get_pids', 'PidEntry', 'terminate_pid']
+__all__ = ['close_fds', 'get_pids', 'terminate_pid']
 
 ALIVE_SIGNAL = 0
 
@@ -15,6 +15,9 @@ class PidEntry:
     name: bytes
     cmdline: bytes
     pid: int
+
+    def send_signal(self, sig: int):
+        kill(self.pid, sig)
 
 
 def close_fds(low_fd, max_fd=None):


### PR DESCRIPTION
This adds a helper function `get_pids` that allows us to replace the `psutil.process_iter` method. The latter being dramatically more expensive to run. There should be no change in behavior.