### PR TITLE
NAS-133119 / 25.04 / remove psutil from devices/display.py

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -91,7 +91,7 @@ class DISPLAY(Device):
     def post_stop_vm(self, *args, **kwargs):
         if self.web_process:
             for proc in filter(lambda x: x and x.pid == self.web_process.pid, get_pids()):
-                proc.terminate_process()
+                proc.terminate()
         self.web_process = None
 
     def get_webui_info(self):

--- a/src/middlewared/middlewared/plugins/vm/devices/display.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/display.py
@@ -1,10 +1,10 @@
-import psutil
 import subprocess
 
 from urllib.parse import urlencode, quote_plus
 
 from middlewared.api.current import VMDisplayDevice
 from middlewared.schema import Dict, ValidationErrors
+from middlewared.utils.os import get_pids
 
 from .device import Device
 from .utils import create_element, NGINX_PREFIX
@@ -89,8 +89,9 @@ class DISPLAY(Device):
         )
 
     def post_stop_vm(self, *args, **kwargs):
-        if self.web_process and psutil.pid_exists(self.web_process.pid):
-            self.middleware.call_sync('service.terminate_process', self.web_process.pid)
+        if self.web_process:
+            for proc in filter(lambda x: x and x.pid == self.web_process.pid, get_pids()):
+                proc.terminate_process()
         self.web_process = None
 
     def get_webui_info(self):

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -19,6 +19,9 @@ class PidEntry:
     def send_signal(self, sig: int):
         kill(self.pid, sig)
 
+    def terminate_process(self, timeout: int = 10) -> bool:
+        return terminate_pid(self.pid, timeout=timeout)
+
 
 def close_fds(low_fd, max_fd=None):
     if max_fd is None:

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -19,7 +19,7 @@ class PidEntry:
     def send_signal(self, sig: int):
         kill(self.pid, sig)
 
-    def terminate_process(self, timeout: int = 10) -> bool:
+    def terminate(self, timeout: int = 10) -> bool:
         return terminate_pid(self.pid, timeout=timeout)
 
 


### PR DESCRIPTION
Use `get_pids()` in vm/devices/display.py to terminate the web console process.

Jira: https://ixsystems.atlassian.net/browse/NAS-133119