### PR TITLE
Change scope of getting FD count in unit test fixture

### DIFF
--- a/tests/unit/test_copytree.py
+++ b/tests/unit/test_copytree.py
@@ -129,7 +129,7 @@ def get_fd_count() -> int:
     return len(os.listdir('/proc/self/fd'))
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def fd_count() -> int:
     return get_fd_count()
 


### PR DESCRIPTION
This commit changes the scope for getting the count of open file descriptors for our copytree tests. This gives more accurate view of where an fd may leak during the test runs and eliminates a potential area for false-positives.