### PR TITLE
NAS-133124 / 25.04 / Convert iscsi.target.* to new api

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -24,6 +24,7 @@ from .ftp import *  # noqa
 from .group import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
+from .iscsi_target import *  # noqa
 from .keychain import *  # noqa
 from .k8s_to_docker import *  # noqa
 from .netdata import *  # noqa
@@ -32,10 +33,10 @@ from .pool_resilver import *  # noqa
 from .pool_scrub import *  # noqa
 from .pool_snapshottask import *  # noqa
 from .privilege import *  # noqa
-from .reporting import *  # noqa
-from .reporting_exporters import *  # noqa
 from .rdma import *  # noqa
 from .rdma_interface import *  # noqa
+from .reporting import *  # noqa
+from .reporting_exporters import *  # noqa
 from .smartctl import *  # noqa
 from .smb import *  # noqa
 from .snmp import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
@@ -1,0 +1,100 @@
+import re
+from typing import Literal
+
+from pydantic import AfterValidator, StringConstraints
+from typing_extensions import Annotated
+
+from middlewared.api.base import (BaseModel, Excluded, ForUpdateMetaclass, IscsiAuthType, NonEmptyString,
+                                  excluded_field, match_validator)
+
+RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
+
+__all__ = [
+    "IscsiTargetEntry",
+    "IscsiTargetValidateNameArgs",
+    "IscsiTargetValidateNameResult",
+    "IscsiTargetCreateArgs",
+    "IscsiTargetCreateResult",
+    "IscsiTargetUpdateArgs",
+    "IscsiTargetUpdateResult",
+    "IscsiTargetDeleteArgs",
+    "IscsiTargetDeleteResult",
+    "IscsiTargetRemoveArgs",
+    "IscsiTargetRemoveResult"
+]
+
+
+class IscsiGroup(BaseModel):
+    portal: int
+    initiator: int | None = None
+    authmethod: IscsiAuthType = 'NONE'
+    auth: int | None = None
+
+
+class IscsiTargetEntry(BaseModel):
+    id: int
+    name: Annotated[NonEmptyString,
+                    AfterValidator(
+                        match_validator(
+                            RE_TARGET_NAME,
+                            "Name can only contain lowercase alphanumeric charactersplus dot (.), dash (-), and colon (:)",
+                        )
+                    ),
+                    StringConstraints(max_length=120)]
+    alias: str | None = None
+    mode: Literal['ISCSI', 'FC', 'BOTH'] = 'ISCSI'
+    groups: list[IscsiGroup] = []
+    auth_networks: list[str] = []  # IPvAnyNetwork: "Object of type IPv4Network is not JSON serializable", etc
+    rel_tgt_id: int
+
+
+class IscsiTargetValidateNameArgs(BaseModel):
+    name: str
+    existing_id: int | None = None
+
+
+class IscsiTargetValidateNameResult(BaseModel):
+    result: str | None
+
+
+class IscsiTargetCreate(IscsiTargetEntry):
+    id: Excluded = excluded_field()
+    rel_tgt_id: Excluded = excluded_field()
+
+
+class IscsiTargetCreateArgs(BaseModel):
+    iscsi_target_create: IscsiTargetCreate
+
+
+class IscsiTargetCreateResult(BaseModel):
+    result: IscsiTargetEntry
+
+
+class IscsiTargetUpdate(IscsiTargetCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class IscsiTargetUpdateArgs(BaseModel):
+    id: int
+    iscsi_target_update: IscsiTargetUpdate
+
+
+class IscsiTargetUpdateResult(BaseModel):
+    result: IscsiTargetEntry
+
+
+class IscsiTargetDeleteArgs(BaseModel):
+    id: int
+    force: bool = False
+
+
+class IscsiTargetDeleteResult(BaseModel):
+    result: Literal[True]
+
+
+class IscsiTargetRemoveArgs(BaseModel):
+    name: str
+
+
+class IscsiTargetRemoveResult(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/plugins/iscsi_/utils.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/utils.py
@@ -10,9 +10,9 @@ class IscsiAuthType(StrEnum):
 
 
 AUTHMETHOD_LEGACY_MAP = bidict.bidict({
-    'None': IscsiAuthType.NONE,
-    'CHAP': IscsiAuthType.CHAP,
-    'CHAP Mutual': IscsiAuthType.CHAP_MUTUAL,
+    'None': IscsiAuthType.NONE.value,
+    'CHAP': IscsiAuthType.CHAP.value,
+    'CHAP Mutual': IscsiAuthType.CHAP_MUTUAL.value,
 })
 
 # Currently SCST has this limit (scst_vdisk_dev->name)

--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -159,7 +159,7 @@ def test_iscsi_auth_networks_netmask_24(my_ip4, valid):
         call(
             'iscsi.target.update',
             config['target']['id'],
-            {'auth_networks': ["8.8.8.8/24", f"{good_ip}/24"] if valid else ["8.8.8.8/24", f"{bad_ip}/24"]}
+            {'auth_networks': ["8.8.8.0/24", f"{good_ip}/24"] if valid else ["8.8.8.0/24", f"{bad_ip}/24"]}
         )
         portal_listen_details = config['portal']['listen'][0]
         assert target_login_test(
@@ -170,9 +170,8 @@ def test_iscsi_auth_networks_netmask_24(my_ip4, valid):
 
 @pytest.mark.parametrize('valid', [True, False])
 def test_iscsi_auth_networks_netmask_16(my_ip4, valid):
-    # good_ip will be our IP with the second last byte changed and last byte cleared
-    n = (int(my_ip4.split('.')[2]) + 1) % 256
-    good_ip = '.'.join(my_ip4.split('.')[:2] + [str(n), '0'])
+    # good_ip will be our IP with the last 2 bytes cleared
+    good_ip = '.'.join(my_ip4.split('.')[:2] + ['0', '0'])
     # bad_ip will be the good_ip with the second byte changed
     ip_list = good_ip.split('.')
     n = (int(ip_list[1]) + 1) % 256
@@ -181,7 +180,7 @@ def test_iscsi_auth_networks_netmask_16(my_ip4, valid):
         call(
             'iscsi.target.update',
             config['target']['id'],
-            {'auth_networks': ["8.8.8.8/16", f"{good_ip}/16"] if valid else ["8.8.8.8/16", f"{bad_ip}/16"]}
+            {'auth_networks': ["8.8.0.0/16", f"{good_ip}/16"] if valid else ["8.8.0.0/16", f"{bad_ip}/16"]}
         )
         portal_listen_details = config['portal']['listen'][0]
         assert target_login_test(


### PR DESCRIPTION
Convert `iscsi.target.*` to new api.

Also needed to update/correct some CI tests now that the underlying API is stricter.  (A similar tightening of API was recently seen wrt network `staticroute`)

---
CI with only _test_iscsi_auth_network.py_ failures [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2301/).  Manually tested the updated test.