### PR TITLE
NAS-133125 / 25.04 / remove psutil from webshell_app.py

### DIFF
--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -5,7 +5,6 @@ import fcntl
 import json
 import os
 import queue
-import signal
 import struct
 import termios
 import threading
@@ -19,7 +18,7 @@ from middlewared.service_exception import (
     InstanceNotFound,
     MatchNotFound,
 )
-from middlewared.utils.os import close_fds
+from middlewared.utils.os import close_fds, terminate_pid
 
 __all__ = ("ShellApplication",)
 
@@ -197,7 +196,7 @@ class ShellWorkerThread(threading.Thread):
         asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
 
         with contextlib.suppress(ProcessLookupError):
-            os.killpg(os.getpgid(self.shell_pid), signal.SIGTERM)
+            terminate_pid(self.shell_pid, timeout=5, get_pgid=True)
 
         self.die()
 

--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -196,7 +196,7 @@ class ShellWorkerThread(threading.Thread):
         asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
 
         with contextlib.suppress(ProcessLookupError):
-            terminate_pid(self.shell_pid, timeout=5, get_pgid=True)
+            terminate_pid(self.shell_pid, timeout=5, use_pgid=True)
 
         self.die()
 

--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -12,9 +12,6 @@ import threading
 import time
 import uuid
 
-
-import psutil
-
 from middlewared.api.base.server.ws_handler.base import BaseWebSocketHandler
 from middlewared.service_exception import (
     CallError,
@@ -200,7 +197,7 @@ class ShellWorkerThread(threading.Thread):
         asyncio.run_coroutine_threadsafe(self.ws.close(), self.loop)
 
         with contextlib.suppress(ProcessLookupError):
-            os.kill(self.shell_pid, signal.SIGTERM)
+            os.killpg(os.getpgid(self.shell_pid), signal.SIGTERM)
 
         self.die()
 
@@ -363,22 +360,4 @@ class ShellApplication:
         return ws
 
     async def worker_kill(self, t_worker):
-        def worker_kill_impl():
-            # If connection has been closed lets make sure shell is killed
-            if t_worker.shell_pid:
-                with contextlib.suppress(psutil.NoSuchProcess):
-                    shell = psutil.Process(t_worker.shell_pid)
-                    to_terminate = [shell] + shell.children(recursive=True)
-
-                    for p in to_terminate:
-                        with contextlib.suppress(psutil.NoSuchProcess):
-                            p.terminate()
-                    gone, alive = psutil.wait_procs(to_terminate, timeout=2)
-
-                    for p in alive:
-                        with contextlib.suppress(psutil.NoSuchProcess):
-                            p.kill()
-
-            t_worker.join()
-
-        await self.middleware.run_in_thread(worker_kill_impl)
+        await self.middleware.run_in_thread(t_worker.abort)

--- a/src/middlewared/middlewared/utils/os.py
+++ b/src/middlewared/middlewared/utils/os.py
@@ -42,9 +42,21 @@ def close_fds(low_fd, max_fd=None):
     closerange(low_fd, max_fd)
 
 
-def terminate_pid(pid: int, timeout: int = 10, get_pgid: bool = False) -> bool:
+def terminate_pid(pid: int, timeout: int = 10, use_pgid: bool = False) -> bool:
+    """
+    Send SIGTERM to `pid` and wait `timeout` seconds for the process to terminate.
+    If the process is still alive after `timeout`, proceed to send SIGKILL to the
+    process.
+
+    `pid`: integer represents the PID to terminate.
+    `timeout`: integer represents the total time (in seconds) to wait
+        before sending SIGKILL to `pid` if the process doesn't honor
+        SIGTERM or takes longer than `timeout` seconds to terminate.
+    `use_pgid`: boolean, if true will lookup the process group id of
+        `pid` and apply the same logic.
+    """
     pid_or_pgid, method = pid, kill
-    if get_pgid:
+    if use_pgid:
         method = killpg
         pid_or_pgid = getpgid(pid)
 


### PR DESCRIPTION
This removes the final user of `psutil`. After investigation (and testing), I realized that someone had already added an `abort()` method to the shell worker thread. This is all that's needed to be called to ensure the `login` parent process AND the immediate child process (the shell) is terminated including all children below it.

I changed to using kill process group id so that it handles all dependents for us instead of generating a list of child processes unnecessarily.