### PR TITLE
NAS-133001 / 25.04 / Add flag to delete extents when removing a target

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_target.py
@@ -86,6 +86,7 @@ class IscsiTargetUpdateResult(BaseModel):
 class IscsiTargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
+    delete_extents: bool = False
 
 
 class IscsiTargetDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -334,7 +334,7 @@ class iSCSITargetService(CRUDService):
         audit='Delete iSCSI target',
         audit_callback=True
     )
-    async def do_delete(self, audit_callback, id_, force):
+    async def do_delete(self, audit_callback, id_, force, delete_extents):
         """
         Delete iSCSI Target of `id`.
 
@@ -350,6 +350,8 @@ class iSCSITargetService(CRUDService):
                 raise CallError(f'Target {target["name"]} is in use.')
         for target_to_extent in await self.middleware.call('iscsi.targetextent.query', [['target', '=', id_]]):
             await self.middleware.call('iscsi.targetextent.delete', target_to_extent['id'], force)
+            if delete_extents:
+                await self.middleware.call('iscsi.extent.delete', target_to_extent['extent'], False, force)
 
         await self.middleware.call(
             'datastore.delete', 'services.iscsitargetgroups', [['iscsi_target', '=', id_]]

--- a/tests/api2/assets/websocket/iscsi.py
+++ b/tests/api2/assets/websocket/iscsi.py
@@ -72,7 +72,8 @@ def target(target_name, groups, alias=None):
     try:
         yield target_config
     finally:
-        call('iscsi.target.delete', target_config['id'], True)
+        if call('iscsi.target.query', [['id', '=', target_config['id']]]):
+            call('iscsi.target.delete', target_config['id'], True)
 
 
 @contextlib.contextmanager
@@ -86,7 +87,8 @@ def zvol_extent(zvol, extent_name):
     try:
         yield config
     finally:
-        call('iscsi.extent.delete', config['id'], True, True)
+        if call('iscsi.extent.query', [['id', '=', config['id']]]):
+            call('iscsi.extent.delete', config['id'], True, True)
 
 
 @contextlib.contextmanager
@@ -105,7 +107,9 @@ def target_extent_associate(target_id, extent_id, lun_id=0):
     try:
         yield associate_config
     finally:
-        call('iscsi.targetextent.delete', associate_config['id'], True)
+        # We may have deleted the association
+        if call('iscsi.targetextent.query', [['id', '=', associate_config['id']]]):
+            call('iscsi.targetextent.delete', associate_config['id'], True)
     if alua_enabled:
         sleep(2)
 


### PR DESCRIPTION
Add an additional optional `delete_extents` parameter to `iscsi.target.delete`

Add iSCSI unit test `test__target_delete_extents`

---
Passing CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2314/).