### PR TITLE
NAS-133186 / 25.04 / Fix port delegate test

### DIFF
--- a/tests/api2/test_port_delegates.py
+++ b/tests/api2/test_port_delegates.py
@@ -11,6 +11,11 @@ from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.utils import call
 
 
+def remove_FTP_anonymous():
+    """ remove spurrious onlyanonymous as it requires a path """
+    call('ftp.update', {"onlyanonymous": False})
+
+
 PAYLOAD = (
     ('ftp.config', 'ftp.update', ['port'], {}),
 )
@@ -36,6 +41,9 @@ def test_port_delegate_validation_with_invalid_ports(config_method, method, keys
 
 @pytest.mark.parametrize('config_method,method,keys,payload', PAYLOAD)
 def test_port_delegate_validation_with_valid_ports(config_method, method, keys, payload):
+    # Clean up previous config settings
+    remove_FTP_anonymous()
+
     in_use_ports = []
     for entry in call('port.get_in_use'):
         in_use_ports.extend(entry['ports'])

--- a/tests/api2/test_port_delegates.py
+++ b/tests/api2/test_port_delegates.py
@@ -12,7 +12,7 @@ from middlewared.test.integration.utils import call
 
 
 def remove_FTP_anonymous():
-    """ remove spurrious onlyanonymous as it requires a path """
+    """ remove spurious onlyanonymous as it requires a path """
     call('ftp.update', {"onlyanonymous": False})
 
 


### PR DESCRIPTION
The port delegate CI test is failing when setting an FTP port.

The problem is previous tests left FTP configured with `onlyanonymous` enabled.  This setting requires a valid path for the anonymous directory.  Additional factor playing into the failure is that the new api method does parameter checking in a slightly different order.

The fix:   Return `onlyanonymous` to false before commencing the failing test.

Passing test here: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2338/