### PR TITLE
NAS-133005 / 25.04 / Various improvements to reporting

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/truenas_meminfo.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_meminfo.chart.py
@@ -10,6 +10,12 @@ CHARTS = {
             ['total', 'total', 'absolute'],
         ]
     },
+    'available': {
+        'options': [None, 'total', 'Bytes', 'total', 'Available memory', 'line'],
+        'lines': [
+            ['available', 'available', 'absolute'],
+        ]
+    },
 }
 
 
@@ -20,7 +26,8 @@ class Service(SimpleService):
         self.definitions = CHARTS
 
     def get_data(self):
-        return {'total': get_memory_info()['total']}
+        mem_info = get_memory_info()
+        return {'total': mem_info['total'], 'available': mem_info['available']}
 
     def check(self):
         return True

--- a/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
+++ b/src/middlewared/middlewared/etc_files/netdata/netdata.conf.mako
@@ -61,7 +61,7 @@
 [plugin:proc]
 	netdata server resources = yes
 	/proc/diskstats = no
-	/proc/meminfo = yes
+	/proc/meminfo = no
 	/proc/net/dev = yes
 	/proc/pagetypeinfo = no
 	# /proc/stat = yes - we keep this uncommented as by default that enables it, for some reason
@@ -94,6 +94,7 @@
 	/proc/net/rpc/nfsd = yes
 	/proc/net/rpc/nfs = yes
 	/proc/spl/kstat/zfs/arcstats = no
+	/proc/spl/kstat/zfs/pool/state = no
 	/sys/fs/btrfs = no
 	ipc = no
 	/sys/class/power_supply = no
@@ -123,5 +124,7 @@
 [plugin:proc:/proc/stat]
     per cpu core utilization = no
     context switches = no
+    cpu interrupts = no
     processes started = no
     processes running = no
+    cpu idle states = no

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -34,6 +34,7 @@ class RealtimeEventSource(EventSource):
             Int('arc_free_memory'),
             Int('arc_available_memory'),
             Int('physical_memory_total'),
+            Int('physical_memory_available'),
         ),
         Dict(
             'zfs',

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -32,6 +32,16 @@ class CPUTempPlugin(GraphBase):
         return 'cputemp.temperatures'
 
 
+class MemoryPlugin(GraphBase):
+
+    title = 'Physical memory available'
+    uses_identifiers = False
+    vertical_label = 'Bytes'
+
+    def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
+        return 'truenas_meminfo.available'
+
+
 class DISKPlugin(GraphBase):
 
     title = 'Disk I/O Bandwidth'
@@ -111,26 +121,6 @@ class LoadPlugin(GraphBase):
         metrics = super().normalize_metrics(metrics)
         metrics['legend'] = [self.LOAD_MAPPING.get(legend, legend) for legend in metrics['legend']]
         return metrics
-
-
-class ProcessesPlugin(GraphBase):
-
-    title = 'System Active Processes'
-    uses_identifiers = False
-    vertical_label = 'Processes'
-
-    def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
-        return 'system.active_processes'
-
-
-class MemoryPlugin(GraphBase):
-
-    title = 'Physical memory utilization'
-    uses_identifiers = False
-    vertical_label = 'Mebibytes'
-
-    def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
-        return 'system.ram'
 
 
 class UptimePlugin(GraphBase):

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/memory.py
@@ -16,4 +16,7 @@ def get_memory_info(netdata_metrics: dict) -> dict:
         'physical_memory_total': normalize_value(
             safely_retrieve_dimension(netdata_metrics, 'truenas_meminfo.total', 'total', 0),
         ),
+        'physical_memory_available': normalize_value(
+            safely_retrieve_dimension(netdata_metrics, 'truenas_meminfo.available', 'available', 0),
+        ),
     }

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -6,7 +6,6 @@ from middlewared.api.current import ChartMetricsArgs, ChartMetricsResult, ChartD
 from middlewared.service import Service
 from middlewared.utils.cpu import cpu_info
 from middlewared.utils.disk_stats import get_disk_stats
-from middlewared.utils.zfs import query_imported_fast_impl
 
 from .netdata import ClientConnectError, Netdata
 from .utils import calculate_disk_space_for_netdata, get_metrics_approximation, TIER_0_POINT_SIZE, TIER_1_POINT_SIZE
@@ -49,7 +48,6 @@ class NetdataService(Service):
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
-            len(query_imported_fast_impl()),
             self.middleware.call_sync('datastore.query', 'vm.vm', [], {'count': True}),
             len(glob.glob('/sys/fs/cgroup/**/*.service')),
         )

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -54,18 +54,12 @@ def get_netdata_state_path() -> str:
 
 
 def get_metrics_approximation(
-    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int,
+    disk_count: int, core_count: int, interface_count: int, vms_count: int,
     systemd_service_count: int, containers_count: typing.Optional[int] = 10,
 ) -> dict:
     data = {
         1: {
             'system.cpu': 10,
-            'cpu.cpu0_cpuidle': 4 * core_count,
-            'system.intr': 1,
-            'system.ctxt': 1,
-            'system.forks': 1,
-            'system.processes': 2,
-            'zfs_state_pool': pool_count * 6,
             'system.clock_sync_state': 1,
             'system.clock_status': 2,
             'system.clock_sync_offset': 1,
@@ -75,16 +69,6 @@ def get_metrics_approximation(
             'truenas_disk_stats.ops': 2 * disk_count,
             'truenas_disk_stats.io': 2 * disk_count,
             'truenas_disk_stats.busy': 1 * disk_count,
-
-            # meminfo
-            'system.ram': 4,
-            'mem.available': 1,
-            'mem.committed': 1,
-            'mem.writeback': 5,
-            'mem.kernel': 5,
-            'mem.slab': 2,
-            'mem.transparent_hugepages': 2,
-            'truenas_meminfo': 1,
 
             # net
             'system.net': 2,
@@ -96,6 +80,9 @@ def get_metrics_approximation(
             'net_packets': 3 * interface_count,
             'net_drops': 2 * interface_count,
             'net_carrier': 2 * interface_count,
+
+            # meminfo
+            'truenas_meminfo': 2,
 
             # uptime
             'system.uptime': 1,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -3,58 +3,58 @@ import pytest
 from middlewared.plugins.reporting.utils import get_metrics_approximation, calculate_disk_space_for_netdata
 
 
-@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 749, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 8906, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 930, 60: 10}),
+@pytest.mark.parametrize('disk_count,core_count,interface_count,services_count,vms_count,expected_output', [
+    (4, 2, 1, 10, 2, {1: 705, 60: 4}),
+    (1600, 32, 4, 10, 1, {1: 8730, 60: 1600}),
+    (10, 16, 2, 12, 3, {1: 830, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
-    disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
+    disk_count, core_count, interface_count, services_count, vms_count, expected_output
 ):
     assert get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, interface_count, vms_count, services_count
     ) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
+    'disk_count,core_count,interface_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 432),
-        (4, 2, 1, 2, 10, 1, 7, 4, 60, 26),
-        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2991),
-        (1600, 32, 4, 10, 1, 4, 4, 4, 900, 13),
-        (10, 16, 2, 2, 12, 1, 3, 1, 1, 206),
-        (10, 16, 2, 2, 10, 3, 3, 4, 60, 15),
-        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13408),
-        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 58),
+        (4, 2, 1, 10, 2, 7, 1, 1, 406),
+        (4, 2, 1, 10, 1, 7, 4, 60, 25),
+        (1600, 32, 4, 2, 4, 4, 1, 1, 2917),
+        (1600, 32, 4, 1, 4, 4, 4, 900, 12),
+        (10, 16, 2, 12, 1, 3, 1, 1, 181),
+        (10, 16, 2, 10, 3, 3, 4, 60, 13),
+        (1600, 32, 4, 12, 3, 18, 1, 1, 13147),
+        (1600, 32, 4, 12, 1, 18, 4, 900, 57),
     ],
 )
 def test_netdata_disk_space_approximation(
-    disk_count, core_count, interface_count, pool_count, services_count,
+    disk_count, core_count, interface_count, services_count,
     vms_count, days, bytes_per_point, tier_interval, expected_output
 ):
     assert calculate_disk_space_for_netdata(get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, interface_count, vms_count, services_count
     ), days, bytes_per_point, tier_interval) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,bytes_per_point,tier_interval', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1),
-        (4, 2, 1, 2, 12, 2, 7, 4, 60),
-        (1600, 32, 4, 4, 10, 3, 4, 1, 1),
-        (1600, 32, 4, 4, 12, 3, 4, 4, 900),
-        (10, 16, 2, 2, 10, 4, 3, 1, 1),
-        (10, 16, 2, 2, 12, 4, 3, 4, 60),
-        (1600, 32, 4, 4, 10, 5, 18, 1, 1),
-        (1600, 32, 4, 4, 12, 5, 18, 4, 900),
+    'disk_count,core_count,interface_count,services_count,vms_count,days,bytes_per_point,tier_interval', [
+        (4, 2, 1, 10, 2, 7, 1, 1),
+        (4, 2, 1, 12, 2, 7, 4, 60),
+        (1600, 32, 4, 10, 3, 4, 1, 1),
+        (1600, 32, 4, 12, 3, 4, 4, 900),
+        (10, 16, 2, 10, 4, 3, 1, 1),
+        (10, 16, 2, 12, 4, 3, 4, 60),
+        (1600, 32, 4, 10, 5, 18, 1, 1),
+        (1600, 32, 4, 12, 5, 18, 4, 900),
     ],
 )
 def test_netdata_days_approximation(
-    disk_count, core_count, interface_count, pool_count, services_count, vms_count, days, bytes_per_point, tier_interval
+    disk_count, core_count, interface_count, services_count, vms_count, days, bytes_per_point, tier_interval
 ):
     metric_intervals = get_metrics_approximation(
-        disk_count, core_count, interface_count, pool_count, vms_count, services_count
+        disk_count, core_count, interface_count, vms_count, services_count
     )
     disk_size = calculate_disk_space_for_netdata(metric_intervals, days, bytes_per_point, tier_interval)
     total_metrics = metric_intervals[1] + (metric_intervals[60] / 60)


### PR DESCRIPTION
## Context

Following changes were requested to be made to our reporting plugin:

1. Remove System Processes report
2. `/proc/meminfo = no` should be set in netdata.conf
3. To turn off the zfspool state plugin provided by netdata (we already capture this in UI)

While here, i have also added `available` to our memory plugin and exposed that to realtime reporting as well so it can be consumed by the UI.