### PR TITLE
NAS-133214 / 25.04 / Convert iscsi.targetextent.* to new api

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -26,6 +26,7 @@ from .group import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
 from .iscsi_target import *  # noqa
+from .iscsi_target_to_extent import *  # noqa
 from .keychain import *  # noqa
 from .k8s_to_docker import *  # noqa
 from .netdata import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_target_to_extent.py
@@ -1,0 +1,63 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, excluded_field
+
+__all__ = [
+    "IscsiTargetToExtentEntry",
+    "IscsiTargetToExtentCreateArgs",
+    "IscsiTargetToExtentCreateResult",
+    "IscsiTargetToExtentUpdateArgs",
+    "IscsiTargetToExtentUpdateResult",
+    "IscsiTargetToExtentDeleteArgs",
+    "IscsiTargetToExtentDeleteResult",
+]
+
+
+class IscsiTargetToExtentEntry(BaseModel):
+    id: int
+    target: int
+    lunid: int
+    extent: int
+
+
+class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
+    id: Excluded = excluded_field()
+    lunid: int | None = None
+
+
+class IscsiTargetToExtentCreateArgs(BaseModel):
+    iscsi_target_to_extent_create: IscsiTargetToExtentCreate
+
+
+class IscsiTargetToExtentCreateResult(BaseModel):
+    result: IscsiTargetToExtentEntry
+
+
+class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class IscsiTargetToExtentUpdateArgs(BaseModel):
+    id: int
+    iscsi_target_to_extent_update: IscsiTargetToExtentUpdate
+
+
+class IscsiTargetToExtentUpdateResult(BaseModel):
+    result: IscsiTargetToExtentEntry
+
+
+class IscsiTargetToExtentDeleteArgs(BaseModel):
+    id: int
+    force: bool = False
+
+
+class IscsiTargetToExtentDeleteResult(BaseModel):
+    result: Literal[True]
+
+
+class IscsiTargetToExtentRemoveArgs(BaseModel):
+    name: str
+
+
+class IscsiTargetToExtentRemoveResult(BaseModel):
+    result: None

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -1,7 +1,16 @@
 import asyncio
 
 import middlewared.sqlalchemy as sa
-from middlewared.schema import Bool, Dict, Int, Patch, accepts
+from middlewared.api import api_method
+from middlewared.api.current import (
+    IscsiTargetToExtentEntry,
+    IscsiTargetToExtentCreateArgs,
+    IscsiTargetToExtentCreateResult,
+    IscsiTargetToExtentUpdateArgs,
+    IscsiTargetToExtentUpdateResult,
+    IscsiTargetToExtentDeleteArgs,
+    IscsiTargetToExtentDeleteResult)
+
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 
 
@@ -29,14 +38,14 @@ class iSCSITargetToExtentService(CRUDService):
         datastore_extend = 'iscsi.targetextent.extend'
         cli_namespace = 'sharing.iscsi.target.extent'
         role_prefix = 'SHARING_ISCSI_TARGETEXTENT'
+        entry = IscsiTargetToExtentEntry
 
-    @accepts(Dict(
-        'iscsi_targetextent_create',
-        Int('target', required=True),
-        Int('lunid', null=True),
-        Int('extent', required=True),
-        register=True
-    ), audit='Create iSCSI target/LUN/extent mapping', audit_callback=True)
+    @api_method(
+        IscsiTargetToExtentCreateArgs,
+        IscsiTargetToExtentCreateResult,
+        audit='Create iSCSI target/LUN/extent mapping',
+        audit_callback=True
+    )
     async def do_create(self, audit_callback, data):
         """
         Create an Associated Target.
@@ -85,16 +94,11 @@ class iSCSITargetToExtentService(CRUDService):
 
         return f'{target}/{data.get("lunid")}/{extent}'
 
-    @accepts(
-        Int('id'),
-        Patch(
-            'iscsi_targetextent_create',
-            'iscsi_targetextent_update',
-            ('edit', _set_null_false('lunid')),
-            ('attr', {'update': True})
-        ),
+    @api_method(
+        IscsiTargetToExtentUpdateArgs,
+        IscsiTargetToExtentUpdateResult,
         audit='Update iSCSI target/LUN/extent mapping',
-        audit_callback=True,
+        audit_callback=True
     )
     async def do_update(self, audit_callback, id_, data):
         """
@@ -119,10 +123,12 @@ class iSCSITargetToExtentService(CRUDService):
 
         return await self.get_instance(id_)
 
-    @accepts(Int('id'),
-             Bool('force', default=False),
-             audit='Delete iSCSI target/LUN/extent mapping',
-             audit_callback=True,)
+    @api_method(
+        IscsiTargetToExtentDeleteArgs,
+        IscsiTargetToExtentDeleteResult,
+        audit='Delete iSCSI target/LUN/extent mapping',
+        audit_callback=True
+    )
     async def do_delete(self, audit_callback, id_, force):
         """
         Delete Associated Target of `id`.

--- a/tests/api2/assets/websocket/iscsi.py
+++ b/tests/api2/assets/websocket/iscsi.py
@@ -96,9 +96,10 @@ def target_extent_associate(target_id, extent_id, lun_id=0):
     alua_enabled = call('iscsi.global.alua_enabled')
     payload = {
         'target': target_id,
-        'lunid': lun_id,
         'extent': extent_id
     }
+    if lun_id is not None:
+        payload['lunid'] = lun_id
     associate_config = call('iscsi.targetextent.create', payload)
     if alua_enabled:
         # Give a little time for the STANDBY target to surface

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -2575,7 +2575,7 @@ def test__portal_access(iscsi_running):
                             assert MB_100 == read_capacity16(s)
 
 
-def test__multiple_extents():
+def test__multiple_extents(iscsi_running):
     """
     Verify that an iSCSI client can access multiple target LUNs
     when multiple extents are configured.
@@ -2593,7 +2593,8 @@ def test__multiple_extents():
                 with file_extent(pool_name, dataset_name, "target.extent1", filesize_mb=100, extent_name="extent1") as extent1_config:
                     with file_extent(pool_name, dataset_name, "target.extent2", filesize_mb=256, extent_name="extent2") as extent2_config:
                         with target_extent_associate(target_id, extent1_config['id'], 0):
-                            with target_extent_associate(target_id, extent2_config['id'], 1):
+                            # Now call iscsi.targetextent.create without a lunid parameter
+                            with target_extent_associate(target_id, extent2_config['id'], None):
                                 with iscsi_scsi_connection(truenas_server.ip, iqn, 0) as s:
                                     TUR(s)
                                     assert MB_100 == read_capacity16(s)


### PR DESCRIPTION
- Convert `iscsi.targetextent.*` to new API
- Test `iscsi.targetextent.create` with no `lunid`

---
Abridged CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2349/) (one unrelated failure/race)