### PR TITLE
NAS-133181 / 24.10.2 / Improve validation for adding CSR to system's trusted store (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -622,7 +622,12 @@ class CertificateService(CRUDService):
                     'certificate_update.revoked',
                     'A CSR cannot be marked as revoked.'
                 )
-            elif new['revoked'] and not old['revoked'] and not new['can_be_revoked']:
+            if new['add_to_trusted_store'] and new['cert_type_CSR']:
+                verrors.add(
+                    'certificate_update.add_to_trusted_store',
+                    'A CSR cannot be added to the system\'s trusted store'
+                )
+            if new['revoked'] and not old['revoked'] and not new['can_be_revoked']:
                 verrors.add(
                     'certificate_update.revoked',
                     'Only certificate(s) can be revoked which have a CA present on the system'


### PR DESCRIPTION
This commit improves validation where we make sure a CSR cannot be added to system's trusted store as that does not actually materialize.

Original PR: https://github.com/truenas/middleware/pull/15242
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133181