### PR TITLE
NAS-133215 / 25.04 / fix failing memory API test

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_memory_info.py
@@ -53,7 +53,7 @@ class VMService(Service):
         available at the current moment and if a VM should be allowed to be launched.
         """
         # Use 90% of available memory to play safe
-        free = get_memory_info()['available'] * 0.9
+        free = int(get_memory_info()['available'] * 0.9)
 
         # Difference between current ARC total size and the minimum allowed
         arc_total = await self.middleware.call('sysctl.get_arcstats_size')


### PR DESCRIPTION
2c636bc35c8 caused a regression in the test. Instead of returning a float, we need to return an integer.