### PR TITLE
NAS-133211 / 24.10.2 / Fix validate_nameservers() (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/global_config.py
+++ b/src/middlewared/middlewared/plugins/network_/global_config.py
@@ -147,8 +147,6 @@ class NetworkConfigurationService(ConfigService):
 
     @private
     async def validate_nameservers(self, verrors, data, schema):
-        verrors = ValidationErrors()
-
         ns_ints = []
         for ns, ns_value in filter(lambda x: x[0].startswith('nameserver') and x[1], data.items()):
             schema = f'{schema}.{ns}'

--- a/tests/api2/test_nameservers.py
+++ b/tests/api2/test_nameservers.py
@@ -1,0 +1,27 @@
+from contextlib import contextmanager
+
+import pytest
+
+from middlewared.test.integration.utils import call
+from middlewared.service_exception import ValidationErrors
+
+
+@contextmanager
+def revert_nameservers():
+    to_revert = call("network.general.summary")["nameservers"]
+    payload = dict()
+    for idx, i in enumerate(to_revert, start=1):
+        payload[f"nameserver{idx}"] = i
+
+    try:
+        yield
+    finally:
+        call("network.configuration.update", payload)
+
+
+def test_invalid_nameserver():
+    with revert_nameservers():
+        with pytest.raises(
+            ValidationErrors, match="Loopback is not a valid nameserver"
+        ):
+            call("network.configuration.update", {"nameserver1": "127.0.0.1"})


### PR DESCRIPTION
`verrors` is being overwritten and so the `validate_nameservers` method isn't being applied. We're supposed to be preventing localhost from being used as a DNS server. Since the `verrors` object is being overwritten, the validation isn't being applied.

I've fixed the problem of the verrors object being overwritten, and I've also added a test to ensure this doesn't happen again. 

Original PR: https://github.com/truenas/middleware/pull/15257
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133211