### PR TITLE
NAS-133244 / 25.04 / Add auditd socket configuration

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -80,6 +80,8 @@ ${textwrap.indent(get_db(svc), '  ')}
 log {
 % if svc == 'MIDDLEWARE':
   source(tn_middleware_src);
+% elif svc == 'SYSTEM':
+  source(tn_auditd_src);
 % else:
   source(s_src);
 % endif

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -71,6 +71,7 @@ def generate_syslog_remote_destination(advanced_config):
 
     result += ' };\n'
     result += 'log { source(tn_middleware_src); filter(f_tnremote); destination(loghost); };\n'
+    result += 'log { source(tn_auditd_src); filter(f_tnremote); destination(loghost); };\n'
     result += 'log { source(s_src); filter(f_tnremote); destination(loghost); };\n'
 
     return result
@@ -101,6 +102,10 @@ source s_src { system(); internal(); };
 
 source tn_middleware_src {
   unix-stream("${DEFAULT_SYSLOG_PATH}" create-dirs(yes) perm(0600));
+};
+
+source tn_auditd_src {
+  unix-stream("/var/run/syslog-ng/auditd.sock" create-dirs(yes) perm(0600));
 };
 
 ##################

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import declarative_base
 from .schema.common import AuditEventParam
 
 AUDIT_DATASET_PATH = '/audit'
-AUDITED_SERVICES = [('MIDDLEWARE', 0.1), ('SMB', 0.1), ('SUDO', 0.1)]
+AUDITED_SERVICES = [('MIDDLEWARE', 0.1), ('SMB', 0.1), ('SUDO', 0.1), ('SYSTEM', 0.1)]
 AUDIT_TABLE_PREFIX = 'audit_'
 AUDIT_LIFETIME = 7
 AUDIT_DEFAULT_RESERVATION = 0


### PR DESCRIPTION
Enable the af_unix plugin for auditd and configure syslog-ng and middleware to handle messages written
to a syslog-ng unix domain socket for auditd messages.

The application reading auditd messages from af_unix socket and rewriting for syslog-ng consumption is in separate PR.
Once that is merged, tests will be added to tests/unit.