### PR TITLE
NAS-133222 / 25.04 / Fix VM de-initialisation

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -72,9 +72,9 @@ class VMService(Service, VMSupervisorMixin):
     @private
     async def deinitialize_vms(self, options):
         await self.middleware.call('vm.close_libvirt_connection')
-        if options['reload_ui']:
+        if options.get('reload_ui'):
             await self.middleware.call('service.reload', 'http')
-        if options['stop_libvirt']:
+        if options.get('stop_libvirt'):
             await self.middleware.call('service.stop', 'libvirtd')
 
     @private


### PR DESCRIPTION
## Problem  

Deleting a VM is failing because de-initializing the VM is resulting in a key error due to recent schema changes.

## Solution  

Resolve the key error during the de-initialization process by safely retrieving the keys.