### PR TITLE
NAS-133184 / 25.04 / Expose scale version in app metadata

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/lifecycle.py
@@ -5,6 +5,7 @@ import typing
 import yaml
 
 from middlewared.service_exception import CallError
+from middlewared.utils import sw_version
 from middlewared.utils.io import write_if_changed
 
 from .path import (
@@ -98,6 +99,7 @@ def add_context_to_values(
             'operation': operation,
             'app_metadata': app_metadata,
             f'is_{operation.lower()}': True,
+            'scale_version': sw_version(),
             **({'upgrade_metadata': upgrade_metadata} if operation == 'UPGRADE' else {})
         })
 


### PR DESCRIPTION
## Context

It was requested that we expose scale version in the metadata provided to app developer so actions can be taken consciously when rendering the relevant compose files.