### PR TITLE
NAS-133257 / 25.04 / Fix mako formatting of syslog-ng message template

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -5,7 +5,7 @@ logger = middleware.logger
 
 # The messages coming in via middleware are already formatted by logger
 # and so we don't want to do additional formatting.
-syslog_template = 'template("${MESSAGE}\n")'
+syslog_template = 'template("${MESSAGE}\\n")'
 
 
 def generate_syslog_remote_destination(advanced_config):


### PR DESCRIPTION
The mako template was inserting a new line instead of a literal newline character. This apparently accidentally works in the syslog-ng configuration, but looks bad.