### PR TITLE
NAS-133258 / 25.04 / Add auditd systemd unit override

### DIFF
--- a/src/freenas/etc/systemd/system/auditd.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/auditd.service.d/override.conf
@@ -1,0 +1,7 @@
+[Unit]
+# The tnaudit service manages a python script that handles conversion of auditd
+# messages to syslog-ng audit message for insertion into the truenas system
+# audit database. The aforementioned python script is located in the scripts
+# directory in the truenas/audit_rules git repository. The tnaudit service
+# should always be running while the auditd service is running.
+Upholds=tnaudit.service


### PR DESCRIPTION
This commit adds a systemd unit overrid for the auditd service so that it becomes responsible for upholding the systemd unit that controls the audit message parser.