### PR TITLE
NAS-133301 / 25.04 / Forcibly disable spotlight-related RPC servers

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -358,6 +358,8 @@ def generate_smb_conf_dict(
         'bind interfaces only': True,
         'fruit:nfs_aces': False,
         'fruit:zero_file_id': False,
+        'rpc_daemon:mdssd': 'disabled',
+        'rpc_server:mdssvc': 'disabled',
         'restrict anonymous': 0 if guest_enabled else 2,
         'winbind request timeout': 60 if ds_type is DSType.AD else 2,
         'passdb backend': f'tdbsam:{SMBPath.PASSDB_DIR.value[0]}/passdb.tdb',


### PR DESCRIPTION
This configuration was lost when removing clustering-related registry configuration in Electric Eel.