### PR TITLE
NAS-133306 / 25.04 / Fix API key authentication

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
@@ -19,7 +19,7 @@ auth		[success=1 default=die]		pam_tdb.so ${truenas_admin_string}
 %if ds_auth:
 @include common-account
 %else:
-${'\n'.join(line.as_conf() for line in STANDALONE_AUTH.primary)}
+${'\n'.join(line.as_conf() for line in STANDALONE_ACCOUNT.primary)}
 @include common-account-unix
 %endif
 password	required			pam_deny.so


### PR DESCRIPTION
This fixes a typo that caused pam authentication failures for API key authentication in nightlies.