### PR TITLE
NAS-133318 / 25.04 / Detect when /usr is a system extension when going to dev mode

### DIFF
--- a/src/freenas/usr/local/libexec/disable-rootfs-protection
+++ b/src/freenas/usr/local/libexec/disable-rootfs-protection
@@ -10,6 +10,8 @@ from pathlib import Path
 from subprocess import run
 
 from middlewared.utils import ProductType
+from middlewared.utils.mount import getmntinfo
+from middlewared.utils.filesystem.stat_x import statx
 
 
 ZFS_CMD = '/usr/sbin/zfs'
@@ -32,6 +34,31 @@ def set_readwrite(entry):
 
     print(f'Setting readonly=off on dataset {entry["ds"]}')
     run([ZFS_CMD, 'set', 'readonly=off', entry['ds']])
+
+
+def usr_fs_check():
+    mntid = statx('/usr').stx_mnt_id
+    mntinfo = getmntinfo(mnt_id=mntid)[mntid]
+    match mntinfo['fs_type']:
+        case 'zfs':
+            return
+
+        case 'overlay':
+            if mntinfo['mount_source'] == 'sysext':
+                print((
+                    '/usr is currently provided by a readonly systemd system extension. '
+                    'This may occur if nvidia module support is enabled. System extensions '
+                    'must be disabled prior to disabling rootfs protection.'
+                ))
+            else:
+                print(f'/usr is currently provided by an unexpected overlayfs filesystem: {mntinfo}.')
+        case _:
+            print((
+                f'{mntinfo["fs_type"]}: /usr is currently provided by an unexpected filesystem type. '
+                'Unable to disable rootfs protection.'
+            ))
+
+    sys.exit(1)
 
 
 def chmod_files():
@@ -84,6 +111,8 @@ if __name__ == '__main__':
             'or with sudo.'
         ))
         sys.exit(1)
+
+    usr_fs_check()
 
     rv = run([ZFS_CMD, 'get', '-o', 'value', '-H', 'truenas:developer', '/'], capture_output=True)
 


### PR DESCRIPTION
Users who want to hack on TrueNAS are running into issues where they get an uninformative message when trying to install dev tools.

This commit gives them some hints about what they need to do.