### PR TITLE
NAS-133326 / 25.04 / Add enterprise license check for virt plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -88,6 +88,9 @@ class VirtGlobalService(ConfigService):
         if pool == POOL_DISABLED:
             new['pool'] = None
 
+        if pool and not await self.middleware.call('virt.global.license_active'):
+            verrors.add(f'{schema_name}.pool', 'System is not licensed to run virtualization')
+
     @api_method(VirtGlobalUpdateArgs, VirtGlobalUpdateResult)
     @job()
     async def do_update(self, job, data):

--- a/src/middlewared/middlewared/plugins/virt/license.py
+++ b/src/middlewared/middlewared/plugins/virt/license.py
@@ -1,0 +1,34 @@
+from ixhardware.chassis import TRUENAS_UNKNOWN
+
+from middlewared.service import private, Service
+
+
+class VirtLicenseGlobalService(Service):
+
+    class Config:
+        namespace = 'virt.global'
+
+    @private
+    async def license_active(self, instance_type=None):
+        """
+        If this is iX enterprise hardware and has NOT been licensed to run virt plugin
+        then this will return False, otherwise this will return true.
+        """
+        system_chassis = await self.middleware.call('truenas.get_chassis_hardware')
+        if system_chassis == TRUENAS_UNKNOWN or 'MINI' in system_chassis:
+            # 1. if it's not iX branded hardware
+            # 2. OR if it's a MINI, then allow containers/vms
+            return True
+
+        license_ = await self.middleware.call('system.license')
+        if license_ is None:
+            # it's iX branded hardware but has no license
+            return False
+
+        if instance_type is None:
+            # licensed JAILS (containers) and/or VMs
+            return any(k in license_['features'] for k in ('JAILS', 'VM'))
+        else:
+            # license could only have JAILS (containers) licensed or VM
+            feature = 'JAILS' if instance_type == 'CONTAINER' else 'VM'
+            return feature in license_['features']

--- a/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_license.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_license.py
@@ -1,0 +1,68 @@
+import pytest
+
+from middlewared.plugins.virt.license import VirtLicenseGlobalService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+@pytest.mark.parametrize('instance_type,chassis_hardware,license_active,expected_result', [
+    (
+        None,
+        'TRUENAS-UNKNOWN',
+        None,
+        True
+    ),
+    (
+        None,
+        'TRUENAS-MINI-3.0-XL+',
+        None,
+        True
+    ),
+    (
+        None,
+        'TRUENAS-M60-HA',
+        {'features': ['JAILS', 'VM']},
+        True
+    ),
+    (
+        'CONTAINER',
+        'TRUENAS-M60-HA',
+        {'features': ['JAILS', 'VM']},
+        True
+    ),
+    (
+        'VM',
+        'TRUENAS-M60-HA',
+        {'features': ['JAILS', 'VM']},
+        True
+    ),
+    (
+        'CONTAINER',
+        'TRUENAS-M60-HA',
+        {'features': ['VM']},
+        False
+    ),
+    (
+        'VM',
+        'TRUENAS-M60-HA',
+        {'features': ['JAILS']},
+        False
+    ),
+    (
+        None,
+        'TRUENAS-M60-HA',
+        None,
+        False
+    ),
+    (
+        'VM',
+        'TRUENAS-M60-HA',
+        None,
+        False
+    ),
+])
+@pytest.mark.asyncio
+async def test_virt_license_validation(instance_type, chassis_hardware, license_active, expected_result):
+    m = Middleware()
+    m['truenas.get_chassis_hardware'] = lambda *arg: chassis_hardware
+    m['system.license'] = lambda *arg: license_active
+    assert await VirtLicenseGlobalService(m).license_active(instance_type) == expected_result


### PR DESCRIPTION
## Context

We need to have a license check in place to not let enterprise consumers consume virt plugin if they are not licensed for it.