### PR TITLE
NAS-133012 / 25.04 / Fix API keys for restricted admins

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -30,7 +30,7 @@ class ApiKeyEntry(BaseModel):
 
 
 class ApiKeyEntryWithKey(ApiKeyEntry):
-    key: Secret[str]
+    key: str
 
 
 class ApiKeyCreate(ApiKeyEntry):

--- a/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
@@ -1,7 +1,7 @@
 <%
     from middlewared.utils import filter_list
     from middlewared.utils.auth import LEGACY_API_KEY_USERNAME
-    from middlewared.utils.pam import STANDALONE_AUTH
+    from middlewared.utils.pam import STANDALONE_ACCOUNT
 
     ds_auth = render_ctx['datastore.config']['stg_ds_auth']
     truenas_admin_string = ''

--- a/tests/api2/test_api_key.py
+++ b/tests/api2/test_api_key.py
@@ -242,7 +242,7 @@ def test_api_key_crud_restricted_admin_own_keys(sharing_admin_user):
             })
             assert 'key' not in updated
             updated = c.call('api_key.update', key_info['id'], {'reset': True})
-            assert updated['key'] is not '********'
+            assert updated['key'] != '********'
         finally:
             c.call('api_key.delete', key_info['id'])
 


### PR DESCRIPTION
The API key CRUD interface returns the plain-text of the key to be used for authentication in the following scenarios:

1. api_key.create (new api key created)
2. api_key.update (with option specified to renew the key)

Users who do not have the API_KEY_WRITE privilege, but do have general API_KEY_READ access are allowed to create API keys for their own account. This means that the returned plain-text key must not be marked as secret otherwise it will be redacted and not usable. This is not a security concern since plain-text keys are not stored on TrueNAS (they are only returned to account that will be using the key in this case).

This PR also fixes a broken test that should have caught the redacted key value, and also fixes a bug in pam_tdb generation.