### PR TITLE
NAS-133227 / 25.04 / Fix docker wiping ipv6 default route

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -13,9 +13,11 @@ class DockerService(SimpleService):
     async def before_start(self):
         await self.middleware.call('docker.state.set_status', Status.INITIALIZING.value)
         await self.middleware.call('docker.state.before_start_check')
+        physical_ifaces = await self.middleware.call('interface.query', [['type', '=', 'PHYSICAL']])
         for key, value in (
             ('vm.panic_on_oom', 0),
             ('vm.overcommit_memory', 1),
+            *[(f'net.ipv6.conf.{i["name"]}.accept_ra', 2) for i in physical_ifaces],
         ):
             await self.middleware.call('sysctl.set_value', key, value)
 


### PR DESCRIPTION
## Problem  
By default, Docker does not enable Router Advertisements (RA) for IPv6 networks.  

## Solution  
Enable the forwarding of Router Advertisements (RA) for IPv6 networks by using the sysctl argument `net.ipv6.conf.enp1s0.accept_ra`.  

For more details, you can refer to the following issue:  
[Docker for Linux Issue #844](https://github.com/docker/for-linux/issues/844)