### PR TITLE
NAS-133335 / 25.04 / Add timestamp to structured log data

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -8,6 +8,7 @@ from .logging.console_formatter import ConsoleLogFormatter
 from collections import deque
 from json import dumps
 from dataclasses import dataclass
+from .utils.time_utils import utc_now
 
 # markdown debug is also considered useless
 logging.getLogger('MARKDOWN').setLevel(logging.INFO)
@@ -151,6 +152,7 @@ class TNLogFormatter(logging.Formatter):
 
         if structured_data:
             structured_data['type'] = 'PYTHON_EXCEPTION'
+            structured_data['time'] = utc_now().strftime('%Y-%m-%d %H:%M:%S.%f')
             json_data = dumps({'TNLOG': structured_data})
             msg += f' @cee:{json_data}'
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -207,4 +207,5 @@ def test__syslog_exception_parameterization(working_syslog, test_message):
     exc = log_line.split('@cee:')[1]
     data = json.loads(exc)
     assert data['TNLOG']['type'] == 'PYTHON_EXCEPTION'
+    assert 'time' in data['TNLOG']
     assert 'FileNotFoundError' in data['TNLOG']['exception']


### PR DESCRIPTION
Including a timestamp in the JSON data for python exceptions simplifies parsing.