### PR TITLE
Fix dump_result for redacted middleware jobs

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -636,12 +636,28 @@ class Job:
             }
 
         result_encoding_error = None
+
+        # Depending on the situation we either need to encode the raw result or a
+        # redacted result:
+        #
+        # raw - return value to caller of method
+        # redacted - core.get_jobs output when the extra output option "raw_result" is False
+        #
+        # Changes to how we generate results must be validated against both of these
+        # situations. Redaction is critically important because we include core.get_jobs
+        # output in our debug files.
         if self.state == State.SUCCESS:
             if raw_result:
                 result = self.result
             else:
                 try:
-                    result = self.middleware.dump_result(self.serviceobj, self.method, self.result, False)
+                    result = self.middleware.dump_result(
+                        self.serviceobj,
+                        self.method,
+                        self.app,
+                        self.result,
+                        must_redact_secrets=True
+                    )
                 except Exception as e:
                     result = None
                     result_encoding_error = repr(e)

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -724,9 +724,43 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         return [method.accepts[i].dump(arg) if i < len(method.accepts) else arg
                 for i, arg in enumerate(args)]
 
-    def dump_result(self, serviceobj, methodobj, app, result, *, new_style_returns_model=None):
+    def dump_result(
+        self,
+        serviceobj,
+        methodobj:Method|LegacyAPIMethod,
+        app: object | None,
+        result: dict|str|int|list|None|Job,
+        *,
+        new_style_returns_model: object|None = None,
+        must_redact_secrets:bool = False
+    ):
+        """
+        Serialize and redact `result` based on authenticated credential and schema.  This method is used when
+        preparing middleware call results for external consumption (either as a call return, or as a value
+        that is logged somewhere). The goal is to ensure that secret / private fields are redacted, i.e.
+        replaced with "********" when appropriate.
+
+        Params:
+            serviceobj: middleware service object
+            methodobj: middleware method object
+            app: websocket app. None if this is an internal method call (full admin privileges)
+            result: result data to be normalized / redacted
+        Keyword-only params:
+            new_style_returns_model:
+            must_redact_secrets: when set to True, Secret/Private fields will _always_
+            be redacted. This is used when generating the results info for core.get_jobs output when
+            the raw_result option is set to False (which is how we call it when generating debugs).
+
+        Raises:
+            pydantic.ValidationError: The result contains values that are not permitted according
+            to the pydantic model. This means the return value or the model is wrong.
+        """
         expose_secrets = True
+
         if app and app.authenticated_credentials:
+            # Authenticated session is _always_ presented unredacted results in the following cases:
+            # 1. credential is a full_admin
+            # 2. credential has the WRITE role corresponding with the plugin's governing privilege.
             if app.authenticated_credentials.is_user_session and not (
                 credential_has_full_admin(app.authenticated_credentials) or
                 (
@@ -745,6 +779,10 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
                     if hasattr(do_method, "new_style_returns"):
                         # FIXME: Get rid of `create`/`do_create` duality
                         methodobj = do_method
+
+        if must_redact_secrets:
+            # Caller has explicitly requested that the results be redacted.
+            expose_secrets = False
 
         if hasattr(methodobj, "new_style_returns"):
             # FIXME: When all models become new style, this should be passed explicitly

--- a/tests/api2/test_job_result.py
+++ b/tests/api2/test_job_result.py
@@ -20,7 +20,7 @@ def test_job_result():
 
         # Querying by default should redact
         job = call("core.get_jobs", [["id", "=", job_id]], {"get": True})
-        assert job["result"] != "canary"
+        assert job["result"] == "********"
 
         # but we should also be able to get unredacted result if needed
         job = call("core.get_jobs", [["id", "=", job_id]], {"get": True, "extra": {"raw_result": True}})


### PR DESCRIPTION
The fix for NAS-132676 added `app` as an arg for dump_result which caused a portion of job encoding to fail when we specify that the result should be redacted.

This commit also fixes the check for redacted value in our job results test (which should have caught this regression).