### PR TITLE
NAS-133372 / 25.04 / Fix legacy websocket API serialization

### DIFF
--- a/src/middlewared/middlewared/apps/file_app.py
+++ b/src/middlewared/middlewared/apps/file_app.py
@@ -1,5 +1,4 @@
 from asyncio import run_coroutine_threadsafe
-from json import dumps, loads
 from urllib.parse import parse_qs
 
 from aiohttp import web
@@ -12,6 +11,7 @@ from middlewared.restful import (
     copy_multipart_to_pipe,
 )
 from middlewared.service_exception import CallError
+from truenas_api_client import json
 
 __all__ = ("FileApplication",)
 
@@ -128,7 +128,7 @@ class FileApplication:
             return resp
 
         try:
-            data = loads(await part.read())
+            data = json.loads(await part.read())
         except Exception as e:
             return web.Response(status=400, body=str(e))
 
@@ -222,6 +222,6 @@ class FileApplication:
             headers={
                 "Content-Type": "application/json",
             },
-            body=dumps({"job_id": job.id}).encode(),
+            body=json.dumps({"job_id": job.id}).encode(),
         )
         return resp

--- a/src/middlewared/middlewared/apps/webshell_app.py
+++ b/src/middlewared/middlewared/apps/webshell_app.py
@@ -2,7 +2,6 @@ import asyncio
 import collections
 import contextlib
 import fcntl
-import json
 import os
 import queue
 import struct
@@ -19,6 +18,7 @@ from middlewared.service_exception import (
     MatchNotFound,
 )
 from middlewared.utils.os import close_fds, terminate_pid
+from truenas_api_client import json
 
 __all__ = ("ShellApplication",)
 

--- a/src/middlewared/middlewared/apps/websocket_app.py
+++ b/src/middlewared/middlewared/apps/websocket_app.py
@@ -1,7 +1,6 @@
 from asyncio import AbstractEventLoop, run_coroutine_threadsafe, shield
 from binascii import b2a_base64
 from errno import EACCES, EAGAIN, EINVAL, ETOOMANYREFS
-from json import dumps as jdumps
 from pickle import dumps as pdumps
 from sys import exc_info
 from traceback import format_exception
@@ -28,6 +27,7 @@ from middlewared.service_exception import (
 from middlewared.utils.debug import get_frame_details
 from middlewared.utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
 from middlewared.utils.origin import ConnectionOrigin
+from truenas_api_client import json
 
 __all__ = ("WebSocketApplication",)
 
@@ -58,7 +58,7 @@ class WebSocketApplication(RpcWebSocketApp):
         self.__subscribed = {}
 
     def _send(self, data: dict[str, Any]):
-        run_coroutine_threadsafe(self.response.send_str(jdumps(data)), loop=self.loop)
+        run_coroutine_threadsafe(self.response.send_str(json.dumps(data)), loop=self.loop)
 
     def _tb_error(self, exc_info: ExcInfoType) -> dict[str, str | list[dict]]:
         klass, exc, trace = exc_info


### PR DESCRIPTION
When this was refactored to be a separate file, the json library was changed to one that does not support dumping a python set.