### PR TITLE
NAS-133167 / 24.10.2 / Fix netbiosname validation logic if AD enabled (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -120,37 +120,41 @@ class ActiveDirectoryService(ConfigService):
         return await self.middleware.call('directoryservices.nss_info_choices', 'ACTIVEDIRECTORY')
 
     @private
-    async def update_netbios_data(self, old, new):
-        must_update = False
+    async def netbios_name_check(self, schema, old, new):
+        changed = False
 
-        # None here as opposed to empty list indicates to preserve current value
         if new['netbiosalias'] is None:
             new['netbiosalias'] = old['netbiosalias']
 
         for key in ['netbiosname', 'netbiosalias']:
             # netbios names are case-insensitive
             if key in new and old[key] != new[key]:
-                if old['enable']:
+                if old.get('enable', True):
                     if key == 'netbiosname' and new[key].casefold() != old[key].casefold():
                         raise ValidationError(
-                            f'activedirectory.{key}',
-                            f'{old[key]} -> {new[key]}: NetBIOS name may not be changed while service is enabled.'
+                            f'{schema}.{key}',
+                            f'{old[key]} -> {new[key]}: NetBIOS name may not be changed while AD service is enabled.'
                         )
                     elif len(old[key]) != len(new[key]):
                         raise ValidationError(
-                            f'activedirectory.{key}',
-                            f'{old[key]} -> {new[key]}: NetBIOS aliases may not be changed while service is enabled.'
+                            f'{schema}.{key}',
+                            f'{old[key]} -> {new[key]}: NetBIOS aliases may not be changed while AD service is enabled.'
                         )
                     else:
                         for idx, alias in enumerate(old[key]):
                             if old[key][idx].casefold() != new[key][idx].casefold():
                                 raise ValidationError(
-                                    f'activedirectory.{key}.{idx}',
-                                    f'{old[key][idx]} -> {new[key][idx]}: NetBIOS alias may not be changed while service is enabled.'
+                                    f'{schema}.{key}.{idx}',
+                                    f'{old[key][idx]} -> {new[key][idx]}: NetBIOS alias may not be changed while AD service is enabled.'
                                 )
 
-                must_update = True
-                break
+                    changed = True
+
+        return changed
+
+    @private
+    async def update_netbios_data(self, old, new):
+        must_update = await self.netbios_name_check('activedirectory', old, new)
 
         if not must_update:
             return

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -670,12 +670,7 @@ class SMBService(ConfigService):
         if ds['type'] == DSType.AD.value and ds['status'] in (
             DSStatus.HEALTHY.name, DSStatus.FAULTED.name
         ):
-            for i in ('workgroup', 'netbiosname', 'netbiosalias'):
-                if old[i] != new[i]:
-                    verrors.add(f'smb_update.{i}',
-                                'This parameter may not be changed after joining Active Directory (AD). '
-                                'If it must be changed, the proper procedure is to leave the AD domain '
-                                'and then alter the parameter before re-joining the domain.')
+            await self.middleware.call('activedirectory.netbios_name_check', 'smb_update', old, new)
 
         if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['smb_options'] != new['smb_options']:


### PR DESCRIPTION
This commit switches the SMB and AD plugins to use common validation code for netbios name changes when AD is enabled.

Original PR: https://github.com/truenas/middleware/pull/15301
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133167