### PR TITLE
NAS-133380 / 25.04 / Fix KeyError preventing middleware from starting (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -106,6 +106,10 @@ class MailService(ConfigService):
     async def mail_extend(self, cfg):
         if cfg['security']:
             cfg['security'] = cfg['security'].upper()
+
+        if cfg['oauth'] and 'provider' not in cfg['oauth']:
+            cfg['oauth']['provider'] = ''
+
         return cfg
 
     @accepts(


### PR DESCRIPTION
bc57695c1acddeb321748d46a9ad175de2be7980 added oauth support for outlook.com mail users because Microsoft deprecated plain authentication to their servers. A migration was added that conditionally adds the `provider` key to the `oauth` column to the database. Because this is conditional the `provider` key is not guaranteed to exist in the database. We're unsafely checking for the `provider` key everywhere and so during start-up, we're crashing with a `KeyError` during middleware initialization which prevents the parent process from starting. This was seen during QE testing uploading a CORE database to a FT install.

Original PR: https://github.com/truenas/middleware/pull/15304
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133380