### PR TITLE
Improve populating boot pool disks cache

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_status.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_status.py
@@ -12,7 +12,6 @@ class ZPoolService(Service):
         namespace = 'zpool'
         private = True
         cli_private = True
-        process_pool = True
 
     def resolve_block_path(self, path, should_resolve):
         if not should_resolve:


### PR DESCRIPTION
Troubleshooting an issue with slow middlewared daemon start-up times, I've found 2 issues:

1. zfs.pool.get_disks does not need to be called when determining the disks for the boot pool, we can use the `zpool.status` endpoint.
2. `zpool.status` endpoint had `process_pool = True` set in it's config. This defeats the entire purpose for why I wrote that endpoint in the first place. It does not use libzfs and so therefore does not need to be put into our process pool. This has added benefit that anyone consuming `zpool.status` now no longer uses a child process in our process pool.