### PR TITLE
NAS-133391 / 25.04 / Convert iscsi.initiator.* to new API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -28,6 +28,7 @@ from .ftp import *  # noqa
 from .group import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
+from .iscsi_initiator import *  # noqa
 from .iscsi_target import *  # noqa
 from .iscsi_target_to_extent import *  # noqa
 from .keychain import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_initiator.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_initiator.py
@@ -1,0 +1,52 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, excluded_field
+
+__all__ = [
+    "IscsiInitiatorEntry",
+    "IscsiInitiatorCreateArgs",
+    "IscsiInitiatorCreateResult",
+    "IscsiInitiatorUpdateArgs",
+    "IscsiInitiatorUpdateResult",
+    "IscsiInitiatorDeleteArgs",
+    "IscsiInitiatorDeleteResult",
+]
+
+
+class IscsiInitiatorEntry(BaseModel):
+    id: int
+    initiators: list[str] = []
+    comment: str = ''
+
+
+class IscsiInitiatorCreate(IscsiInitiatorEntry):
+    id: Excluded = excluded_field()
+
+
+class IscsiInitiatorCreateArgs(BaseModel):
+    iscsi_initiator_create: IscsiInitiatorCreate
+
+
+class IscsiInitiatorCreateResult(BaseModel):
+    result: IscsiInitiatorEntry
+
+
+class IscsiInitiatorUpdate(IscsiInitiatorEntry, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class IscsiInitiatorUpdateArgs(BaseModel):
+    id: int
+    iscsi_initiator_update: IscsiInitiatorUpdate
+
+
+class IscsiInitiatorUpdateResult(BaseModel):
+    result: IscsiInitiatorEntry
+
+
+class IscsiInitiatorDeleteArgs(BaseModel):
+    id: int
+
+
+class IscsiInitiatorDeleteResult(BaseModel):
+    result: Literal[True]

--- a/src/middlewared/middlewared/plugins/iscsi_/initiator.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/initiator.py
@@ -1,6 +1,8 @@
 import middlewared.sqlalchemy as sa
-
-from middlewared.schema import accepts, Dict, Int, List, Patch, Str
+from middlewared.api import api_method
+from middlewared.api.current import (IscsiInitiatorCreateArgs, IscsiInitiatorCreateResult, IscsiInitiatorDeleteArgs,
+                                     IscsiInitiatorDeleteResult, IscsiInitiatorEntry, IscsiInitiatorUpdateArgs,
+                                     IscsiInitiatorUpdateResult)
 from middlewared.service import CRUDService, private
 
 
@@ -35,13 +37,14 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
         datastore_extend = 'iscsi.initiator.extend'
         cli_namespace = 'sharing.iscsi.target.authorized_initiator'
         role_prefix = 'SHARING_ISCSI_INITIATOR'
+        entry = IscsiInitiatorEntry
 
-    @accepts(Dict(
-        'iscsi_initiator_create',
-        List('initiators'),
-        Str('comment'),
-        register=True
-    ), audit='Create iSCSI initiator', audit_extended=lambda data: initiator_summary(data))
+    @api_method(
+        IscsiInitiatorCreateArgs,
+        IscsiInitiatorCreateResult,
+        audit='Create iSCSI initiator',
+        audit_extended=lambda data: initiator_summary(data)
+    )
     async def do_create(self, data):
         """
         Create an iSCSI Initiator.
@@ -59,13 +62,9 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
 
         return await self.get_instance(data['id'])
 
-    @accepts(
-        Int('id'),
-        Patch(
-            'iscsi_initiator_create',
-            'iscsi_initiator_update',
-            ('attr', {'update': True})
-        ),
+    @api_method(
+        IscsiInitiatorUpdateArgs,
+        IscsiInitiatorUpdateResult,
         audit='Update iSCSI initiator',
         audit_callback=True,
     )
@@ -88,10 +87,12 @@ class iSCSITargetAuthorizedInitiator(CRUDService):
 
         return await self.get_instance(id_)
 
-    @accepts(Int('id'),
-             audit='Delete iSCSI initiator',
-             audit_callback=True,
-             )
+    @api_method(
+        IscsiInitiatorDeleteArgs,
+        IscsiInitiatorDeleteResult,
+        audit='Delete iSCSI initiator',
+        audit_callback=True,
+    )
     async def do_delete(self, audit_callback, id_):
         """
         Delete iSCSI initiator of `id`.

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -2532,6 +2532,19 @@ def test__initiator_group(iscsi_running):
                     with iscsi_scsi_connection(truenas_server.ip, iqn, initiator_name=initiator_iqn3) as s:
                         TUR(s)
                 assert 'Unable to connect to' in str(ve), ve
+
+                # Now UPDATE the initiator group
+                call('iscsi.initiator.update', twoinit_config['id'], {'initiators': [initiator_iqn2, initiator_iqn3]})
+                # Last two initiators can connect to the target
+                for initiator_iqn in [initiator_iqn2, initiator_iqn3]:
+                    with iscsi_scsi_connection(truenas_server.ip, iqn, initiator_name=initiator_iqn) as s:
+                        TUR(s)
+                # First initiator cannot connect to the target
+                with pytest.raises(RuntimeError) as ve:
+                    with iscsi_scsi_connection(truenas_server.ip, iqn, initiator_name=initiator_iqn1) as s:
+                        TUR(s)
+                assert 'Unable to connect to' in str(ve), ve
+
                 # Clear it again
                 set_target_initiator_id(config['target']['id'], None)
 


### PR DESCRIPTION
Convert `iscsi.initiator.*` to new API

Enhanced `test__initiator_group` to include a test that _actually_ exercised an `update`.

----
Passing (wrt iSCSI) CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2464/).