### PR TITLE
NAS-133396 / 25.04 / Fix regression in AD-related validation

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -147,7 +147,7 @@ class ActiveDirectoryService(ConfigService):
                                     f'{old[key][idx]} -> {new[key][idx]}: NetBIOS alias may not be changed while AD service is enabled.'
                                 )
 
-                    changed = True
+                changed = True
 
         return changed
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -562,6 +562,8 @@ class SMBService(ConfigService):
             DSStatus.HEALTHY.name, DSStatus.FAULTED.name
         ):
             await self.middleware.call('activedirectory.netbios_name_check', 'smb_update', old, new)
+            if old['workgroup'].casefold() != new['workgroup'].casefold():
+                verrors.add('smb_update.workgroup', 'Workgroup may not be changed while AD is enabled')
 
         if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['smb_options'] != new['smb_options']:


### PR DESCRIPTION
* Workgroup should not be allowed to be changed when AD is enabled.
* Fix indentation of block setting that netbios names were changed.