### PR TITLE
NAS-133396 / 24.10.2 / Fix regression in AD-related validation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -148,7 +148,7 @@ class ActiveDirectoryService(ConfigService):
                                     f'{old[key][idx]} -> {new[key][idx]}: NetBIOS alias may not be changed while AD service is enabled.'
                                 )
 
-                    changed = True
+                changed = True
 
         return changed
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -671,6 +671,8 @@ class SMBService(ConfigService):
             DSStatus.HEALTHY.name, DSStatus.FAULTED.name
         ):
             await self.middleware.call('activedirectory.netbios_name_check', 'smb_update', old, new)
+            if old['workgroup'].casefold() != new['workgroup'].casefold():
+                verrors.add('smb_update.workgroup', 'Workgroup may not be changed while AD is enabled')
 
         if app and not credential_has_full_admin(app.authenticated_credentials):
             if old['smb_options'] != new['smb_options']:


### PR DESCRIPTION
* Workgroup should not be allowed to be changed when AD is enabled.
* Fix indentation of block setting that netbios names were changed.

Original PR: https://github.com/truenas/middleware/pull/15310
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133396