### PR TITLE
NAS-133398 / 25.04 / Dramatically speed up processing messages

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/api/base/server/ws_handler.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/ws_handler.py
@@ -1,0 +1,96 @@
+import pytest
+
+from middlewared.api.base.server.ws_handler.rpc import RpcWebSocketHandler
+
+
+@pytest.mark.parametrize(
+    "ws_msg, should_raise_value_error",
+    [
+        # test "id" member
+        (
+            {"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": ["a", "b"]},
+            False,
+        ),
+        (
+            {
+                "id": "1",
+                "method": "test.method",
+                "jsonrpc": "2.0",
+                "params": ["a", "b"],
+            },
+            False,
+        ),
+        (
+            {
+                "id": None,
+                "method": "test.method",
+                "jsonrpc": "2.0",
+                "params": ["a", "b"],
+            },
+            False,
+        ),
+        (
+            {
+                "id": ["bad"],
+                "method": "test.method",
+                "jsonrpc": "2.0",
+                "params": ["a", "b"],
+            },
+            True,
+        ),
+        ({"method": "test.method", "jsonrpc": "2.0", "params": ["a", "b"]}, True),
+        # test "method" member
+        ({"id": 1, "method": [], "jsonrpc": "2.0", "params": ["a", "b"]}, True),
+        ({"id": 1, "method": "", "jsonrpc": "2.0", "params": ["a", "b"]}, True),
+        ({"id": 1, "method": None, "jsonrpc": "2.0", "params": ["a", "b"]}, True),
+        ({"id": 1, "jsonrpc": "2.0", "params": ["a", "b"]}, True),
+        # test "jsonrpc" member
+        (
+            {"id": 1, "method": "test.method", "jsonrpc": "1.0", "params": ["a", "b"]},
+            True,
+        ),
+        (
+            {"id": 1, "method": "test.method", "jsonrpc": None, "params": ["a", "b"]},
+            True,
+        ),
+        (
+            {
+                "id": 1,
+                "method": "test.method",
+                "jsonrpc": ["bad"],
+                "params": ["a", "b"],
+            },
+            True,
+        ),
+        (
+            {"id": 1, "method": "test.method", "jsonrpc": [""], "params": ["a", "b"]},
+            True,
+        ),
+        ({"id": 1, "method": "test.method", "jsonrpc": [], "params": ["a", "b"]}, True),
+        ({"id": 1, "method": "test.method", "params": ["a", "b"]}, True),
+        # test "params" member
+        (
+            {"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": ["a", "b"]},
+            False,
+        ),
+        ({"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": []}, False),
+        ({"id": 1, "method": "test.method", "jsonrpc": "2.0"}, False),
+        ({"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": 1}, True),
+        ({"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": "bad"}, True),
+        ({"id": 1, "method": "test.method", "jsonrpc": "2.0", "params": None}, True),
+        # fuzzy
+        ("", True),
+        ({}, True),
+        (None, True),
+        ([], True),
+        (["bad"], True),
+        (b"bad", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_validate_message(ws_msg, should_raise_value_error):
+    if should_raise_value_error:
+        with pytest.raises(ValueError):
+            RpcWebSocketHandler.validate_message(ws_msg)
+    else:
+        RpcWebSocketHandler.validate_message(ws_msg)


### PR DESCRIPTION
I've been working on investigating why middlewared daemon is taking > 10 seconds to be restarted. During this time, I profiled a running middlewared instance while our full CI test was running against it.

Investigating the flamegraph showed an abnormal amount of time spent in the 3rd party `jsonschema` module.
![image](https://github.com/user-attachments/assets/45dedb44-bc80-44ee-9454-5117d9ffa450)

This is way too much time spent validating messages that adhere to an extremely simple message format (JSON-RPC 2.0). I've added a `validate_message` coroutine that replaces the need to call `jsonschema.validate`. I made it a `staticmethod` so that it could easily be unit tested. I also added unit tests.

This is easy to run some synthetic tests to compare the times before and after the changes. In my tests I'm seeing a ridiculous difference in time. I ran each method a total of 10k times repeating them 3 times (total of 30k). Below is minimum and maximum times spent during my synthetic testing.
```
old: minimum 16.372773373994278 maximum 16.44008369499352
new: minimum 0.005350747000193223 maximum 0.005455498991068453
```

Link to full CI run can be found [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2481/)