### PR TITLE
NAS-133405 / 25.04 / Disable process pool

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -15,7 +15,7 @@ class ZFSDatasetService(CRUDService):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = True
+        process_pool = False
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -16,7 +16,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = True
+        process_pool = False
 
     def path_to_dataset(self, path, mntinfo=None):
         """

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_encryption.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_encryption.py
@@ -13,7 +13,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = True
+        process_pool = False
 
     @accepts(
         Ref('query-filters'),

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_quota.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_quota.py
@@ -8,7 +8,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = True
+        process_pool = False
 
     def query_for_quota_alert(self):
         options = {

--- a/src/middlewared/middlewared/plugins/zfs_/disks.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks.py
@@ -8,7 +8,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = True
+        process_pool = False
 
     def get_disks(self, name):
         sys_devices = {}

--- a/src/middlewared/middlewared/plugins/zfs_/pool.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool.py
@@ -13,7 +13,7 @@ class ZFSPoolService(CRUDService):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = True
+        process_pool = False
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
@@ -16,7 +16,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = True
+        process_pool = False
 
     @functools.cache
     def get_search_paths(self):

--- a/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
@@ -12,7 +12,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = True
+        process_pool = False
 
     @accepts(
         Str('pool_name'),

--- a/src/middlewared/middlewared/plugins/zfs_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/zfs_/snapshot.py
@@ -17,7 +17,7 @@ class ZFSSnapshot(CRUDService):
     class Config:
         datastore_primary_key_type = 'string'
         namespace = 'zfs.snapshot'
-        process_pool = True
+        process_pool = False
         cli_namespace = 'storage.snapshot'
         role_prefix = 'SNAPSHOT'
         role_separate_delete = True

--- a/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
@@ -9,7 +9,7 @@ class ZFSSnapshot(Service):
 
     class Config:
         namespace = 'zfs.snapshot'
-        process_pool = True
+        process_pool = False
 
     @accepts(Dict(
         'snapshot_clone',


### PR DESCRIPTION
The process pool has served us well-enough these many years. It was added because libzfs wasn't thread-safe and because we had some subtle and hard to find memory leaks in py-libzfs. The obvious solution for these problems was to use a process pool. Over the past few years, libzfs and py-libzfs have had numerous improvements. Upstream zfs has made significant improvements in making their api thread-safe. py-libzfs has also had memory leak fixes over the last couple of years.

Furthermore, the `py-libzfs` module that we wrote uses a global mutex at the _module_ level. This is another layer of protection for the sharp-edges about thread-safety. Working on unrelated issues, I had the random idea to disable the process pool and run our entire CI test against it. To my pleasant surprise, the suite ran without any issues and the memory usage of the parent middleware process was normal.

You can find the results [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2465/).

I've simply set the `process_pool` config option to `False` and left all the scaffolding for the process pool in place. This would allow us to easily revert the changes if we see some issue crop up during BETA test cycle.
