### PR TITLE
NAS-133418 / 25.04 / Convert `device.get_info` to new api

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -16,6 +16,7 @@ from .common import *  # noqa
 from .config import *  # noqa
 from .core import *  # noqa
 from .cronjob import *  # noqa
+from .device import *  # noqa
 from .disk import *  # noqa
 from .docker import *  # noqa
 from .docker_network import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/device.py
@@ -1,0 +1,67 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel
+
+
+__all__ = ["DeviceGetInfoArgs", "DeviceGetInfoResult"]
+
+
+class SerialInfo(BaseModel):
+    name: str
+    location: str
+    drivername: str
+    start: str
+    size: int
+    description: str
+
+
+class GPUInfoAddr(BaseModel):
+    pci_slot: str
+    domain: str
+    bus: str
+    slot: str
+
+
+class GPUInfoDevice(BaseModel):
+    pci_id: str
+    pci_slot: str
+    vm_pci_slot: str
+
+
+class GPUInfo(BaseModel):
+    addr: GPUInfoAddr
+    description: str
+    devices: list[GPUInfoDevice]
+    vendor: str | None
+    available_to_host: bool
+    uses_system_critical_devices: bool
+    critical_reason: str | None
+
+    class Config:
+        extra = "allow"
+
+
+class DeviceGetInfoDisk(BaseModel):
+    type: Literal["DISK"] = "DISK"
+    """Get disk info."""
+    get_partitions: bool = False
+    """
+    If set, query partition information for the disks.
+    NOTE: This can be expensive on systems with a large number of disks present.
+    """
+    serials_only: bool = False
+    """If set, query _ONLY_ serial information for the disks (overrides `get_partitions`)."""
+
+
+class DeviceGetInfoOther(BaseModel):
+    type: Literal["SERIAL", "GPU"]
+    """Get info for either serial devices or GPUs."""
+
+
+class DeviceGetInfoArgs(BaseModel):
+    data: DeviceGetInfoDisk | DeviceGetInfoOther
+
+
+class DeviceGetInfoResult(BaseModel):
+    result: dict[str, str] | dict[str, dict] | list[SerialInfo] | list[GPUInfo]
+    """Return an object if `type="DISK"` or an array otherwise."""

--- a/src/middlewared/middlewared/api/v25_04_0/device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/device.py
@@ -42,7 +42,7 @@ class GPUInfo(BaseModel):
 
 
 class DeviceGetInfoDisk(BaseModel):
-    type: Literal["DISK"] = "DISK"
+    type: Literal["DISK"]
     """Get disk info."""
     get_partitions: bool = False
     """

--- a/src/middlewared/middlewared/plugins/device.py
+++ b/src/middlewared/middlewared/plugins/device.py
@@ -10,16 +10,7 @@ class DeviceService(Service):
 
     @api_method(DeviceGetInfoArgs, DeviceGetInfoResult, roles=['READONLY_ADMIN'])
     async def get_info(self, data):
-        """
-        Get info for `type` device.
-
-        If `type` is "DISK":
-            `get_partitions`: when set to `True` will query partition
-                information for the disks. NOTE: this can be expensive on
-                systems with a large number of disks present.
-            `serials_only`: when set to `True` will query serial information
-                _ONLY_ for the disks.
-        """
+        """Get info for `type` device."""
         method = f'device.get_{data["type"].lower()}s'
         if method == 'device.get_disks':
             return await self.middleware.call(method, data['get_partitions'], data['serials_only'])


### PR DESCRIPTION
I believe this is our only public endpoint under the `device` namespace so this PR takes care of the `device` plugin.