### PR TITLE
NAS-133444 / 25.04 / Expose authenticator level in login_ex response

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -76,7 +76,7 @@ class AuthOTPToken(BaseModel):
 class AuthRespSuccess(BaseModel):
     response_type: Literal[AuthResp.SUCCESS]
     user_info: AuthUserInfo | None
-    assurance: Literal['LEVEL_1', 'LEVEL_2']
+    authenticator: Literal['LEVEL_1', 'LEVEL_2']
 
 
 class AuthRespAuthErr(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -76,6 +76,7 @@ class AuthOTPToken(BaseModel):
 class AuthRespSuccess(BaseModel):
     response_type: Literal[AuthResp.SUCCESS]
     user_info: AuthUserInfo | None
+    assurance: Literal['LEVEL_1', 'LEVEL_2']
 
 
 class AuthRespAuthErr(BaseModel):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -846,6 +846,8 @@ class AuthService(Service):
                 else:
                     response['user_info'] = None
 
+                response['authenticator'] = await self.get_authenticator_assurance_level()
+
             case pam.PAM_AUTH_ERR | pam.PAM_USER_UNKNOWN:
                 # We have to squash AUTH_ERR and USER_UNKNOWN into a generic response
                 # to prevent unauthenticated remote clients from guessing valid usernames.

--- a/tests/api2/test_authenticator_assurance_level.py
+++ b/tests/api2/test_authenticator_assurance_level.py
@@ -93,3 +93,4 @@ def test_level2_password_with_otp(sharing_admin_user):
                 })
 
                 assert resp['response_type'] == 'SUCCESS'
+                assert resp['authenticator'] == 'LEVEL_2'


### PR DESCRIPTION
On successful authentication pass the current authenticator level in response message so that API client can determine whether they can generate auth tokens.