### PR TITLE
NAS-132896 / 25.04 / add systemd.link files for f-series chelsio NICs

### DIFF
--- a/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f0np0_mlx.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f0np0_mlx.link
@@ -6,7 +6,7 @@
 # enp135* and the B controller's NIC name will be enp141*.
 # This breaks effectively everything related to our HA
 # logic. To mitigate this issue, this link file will
-# match on pci path name
+# match on pci path name for the Mellanox NIC.
 [Match]
 Firmware=smbios-field(product_name $= "TRUENAS-F*")
 Path=pci-0000:87:00.0 pci-0000:8d:00.0

--- a/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f1np1_mlx.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_141_s0f1np1_mlx.link
@@ -6,7 +6,7 @@
 # enp135* and the B controller's NIC name will be enp141*.
 # This breaks effectively everything related to our HA
 # logic. To mitigate this issue, this link file will
-# match on pci path name
+# match on pci path name for the Mellanox NIC.
 [Match]
 Firmware=smbios-field(product_name $= "TRUENAS-F*")
 Path=pci-0000:87:00.1 pci-0000:8d:00.1

--- a/src/freenas/usr/lib/systemd/network/10-enp135_s0f4_cxgb.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_s0f4_cxgb.link
@@ -1,0 +1,18 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on kernel INTERFACE name for the Chelsio NIC.
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:87:00.4
+Property=INTERFACE=enp135s0f4
+Driver=cxgb4
+Type=ether
+
+[Link]
+Name=enp200s0f4

--- a/src/freenas/usr/lib/systemd/network/10-enp135_s0f4d1_cxgb.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp135_s0f4d1_cxgb.link
@@ -1,0 +1,18 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on kernel INTERFACE name for the Chelsio NIC.
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:87:00.4
+Property=INTERFACE=enp135s0f4d1
+Driver=cxgb4
+Type=ether
+
+[Link]
+Name=enp200s0f4d1

--- a/src/freenas/usr/lib/systemd/network/10-enp141_s0f4_cxgb.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp141_s0f4_cxgb.link
@@ -1,0 +1,18 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on kernel INTERFACE name for the Chelsio NIC.
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:8d:00.4
+Property=INTERFACE=enp141s0f4
+Driver=cxgb4
+Type=ether
+
+[Link]
+Name=enp200s0f4

--- a/src/freenas/usr/lib/systemd/network/10-enp141_s0f4d1_cxgb.link
+++ b/src/freenas/usr/lib/systemd/network/10-enp141_s0f4d1_cxgb.link
@@ -1,0 +1,18 @@
+# The f-series HA system has a quirk with a specific
+# hardware configuration that shows up when 2x pcie
+# slots are filled with add-on NICs. This has something
+# to do with the AMD NTB hardware mapping but the end
+# result is that the A controller's NIC name will be
+# enp135* and the B controller's NIC name will be enp141*.
+# This breaks effectively everything related to our HA
+# logic. To mitigate this issue, this link file will
+# match on kernel INTERFACE name for the Chelsio NIC.
+[Match]
+Firmware=smbios-field(product_name $= "TRUENAS-F*")
+Path=pci-0000:8d:00.4
+Property=INTERFACE=enp141s0f4d1
+Driver=cxgb4
+Type=ether
+
+[Link]
+Name=enp200s0f4d1


### PR DESCRIPTION
The same NIC naming peculiarity (for when a certain pci slot being enumerated) on the f-series is a platform quirk, so we need to apply the same NIC renaming logic to our chelsio NIC as well.

NOTE: The Chelsio NIC has 2 NIC ports hanging off the same pci bus and function but I could not find a way to rename based on the "dev_port" attribute. Instead, we just name on parent pci path and INTERFACE name property (which is the original name. Platform team has said this should be fine as an identifier).

While I'm here, I renamed the existing `*.link` files to have `mlx` in the name to (hopefully) help reader understand those are files for the Mellanox NIC.