### PR TITLE
NAS-133451 / 25.04 / fix edge-case crashes in rpc.py

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -263,10 +263,6 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
                 )
         except KeyError:
             raise ValueError("Missing 'jsonrpc' member")
-        except TypeError:
-            # if the message doesn't adhere to minimum
-            # format (i.e. a dict) then we'll short-circuit
-            raise ValueError("Invalid message format")
 
         try:
             if not isinstance(message["id"], None | int | str):
@@ -289,6 +285,10 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
     async def process_message(self, app: RpcWebSocketApp, message: Any):
         try:
             await self.validate_message(message)
+        except TypeError:
+            # TypeError here means message doesn't adhere to minimum
+            # format of the message (i.e. needs to be a dict)
+            app.send_error(None, JSONRPCError.INVALID_REQUEST.value, "Invalid Message Format")
         except ValueError as e:
             app.send_error(message["id"], JSONRPCError.INVALID_REQUEST.value, str(e))
             return

--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -290,7 +290,7 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
             # format of the message (i.e. needs to be a dict)
             app.send_error(None, JSONRPCError.INVALID_REQUEST.value, "Invalid Message Format")
         except ValueError as e:
-            app.send_error(message["id"], JSONRPCError.INVALID_REQUEST.value, str(e))
+            app.send_error(message.get("id"), JSONRPCError.INVALID_REQUEST.value, str(e))
             return
 
         try:


### PR DESCRIPTION
Does 2 primary things (both of which are still sufficiently unit tested).

1. Move the `TypeError` to `process_message` (caller) so that we can send a formatted message before closing websocket connection
2. In the event `validate_message` fails because it's missing the "id" member, we need to access that member safely (i.e. message.get("id") instead of message["id"])

There is no functional change here. Just better behavior when we receive malformed messages.