### PR TITLE
NAS-133453 / 25.04 / Prevent users from generating auth tokens when STIG

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -314,7 +314,16 @@ class AuthService(Service):
         `attrs` is a general purpose object/dictionary to hold information about the token.
 
         `match_origin` will only allow using this token from the same IP address or with the same user UID.
+
+        NOTE: this endpoint is not supported when server security requires replay-resistant
+        authentication as part of GPOS STIG requirements.
         """
+        if CURRENT_AAL.level != AA_LEVEL1:
+            raise CallError(
+                'Authentication tokens are not supported at current authenticator level.',
+                errno.EOPNOTSUPP
+            )
+
         if ttl is None:
             ttl = 600
 

--- a/tests/api2/test_authenticator_assurance_level.py
+++ b/tests/api2/test_authenticator_assurance_level.py
@@ -94,3 +94,9 @@ def test_level2_password_with_otp(sharing_admin_user):
 
                 assert resp['response_type'] == 'SUCCESS'
                 assert resp['authenticator'] == 'LEVEL_2'
+
+                # Generating a token should fail
+                with pytest.raises(CallError) as ce:
+                    c.call('auth.generate_token')
+
+                assert ce.value.errno == errno.EOPNOTSUPP


### PR DESCRIPTION
We don't allow these for auth and so users shouldn't be allowed to generate them.