### PR TITLE
NAS-131665 / 25.04 / Convert NFS config to new api.

### DIFF
--- a/src/middlewared/middlewared/api/base/types/__init__.py
+++ b/src/middlewared/middlewared/api/base/types/__init__.py
@@ -1,5 +1,6 @@
 from .fc import *  # noqa
 from .filesystem import *  # noqa
 from .iscsi import *  # noqa
+from .network import *  # noqa
 from .string import *  # noqa
 from .user import *  # noqa

--- a/src/middlewared/middlewared/api/base/types/network.py
+++ b/src/middlewared/middlewared/api/base/types/network.py
@@ -1,0 +1,20 @@
+import functools
+from typing import Annotated
+from pydantic import Field
+
+__all__ = ["TcpPort", "exclude_tcp_ports"]
+
+
+def _exclude_port_validation(value: int, *, ports: list[int]) -> int:
+    if value in ports:
+        raise ValueError(
+            f'{value} is a reserved for internal use. Please select another value.'
+        )
+    return value
+
+
+def exclude_tcp_ports(ports: list[int]):
+    return functools.partial(_exclude_port_validation, ports=ports or [])
+
+
+TcpPort = Annotated[int, Field(ge=1, le=65535)]

--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -39,6 +39,7 @@ from .iscsi_target_to_extent import *  # noqa
 from .keychain import *  # noqa
 from .k8s_to_docker import *  # noqa
 from .netdata import *  # noqa
+from .nfs import *  # noqa
 from .pool import *  # noqa
 from .pool_resilver import *  # noqa
 from .pool_scrub import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -108,10 +108,10 @@ class NfsShareEntry(BaseModel):
     """ User comment associated with share. """
     networks: list[NonEmptyString] = []
     """ List of authorized networks that are allowed to access the share having format
-        "network/mask" CIDR notation. If empty, all networks are allowed. """
+        "network/mask" CIDR notation. Each entry must be unique. If empty, all networks are allowed. """
     hosts: list[NonEmptyString] = []
-    """ list of IP's/hostnames which are allowed to access the share.
-        If empty, all IP's/hostnames are allowed. """
+    """ list of IP's/hostnames which are allowed to access the share.  No quotes or spaces are allowed.
+        Each entry must be unique. If empty, all IP's/hostnames are allowed. """
     ro: bool = False
     """ Export the share as read only. """
     maproot_user: str | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -1,9 +1,7 @@
-import re
-from ipaddress import ip_address, ip_network
 from typing import Annotated, Literal, TypeAlias
 
 from pydantic import (
-    Field, AfterValidator, field_validator
+    Field, AfterValidator
 )
 
 from middlewared.api.base import (
@@ -38,7 +36,7 @@ class NfsEntry(BaseModel):
     """ Force Kerberos authentication on NFS shares. """
     v4_domain: str
     """ Specify a DNS domain (NFSv4 only). """
-    bindip: list[NonEmptyString] = []  # Using IPvAnyAddress creates JSON serialization errors
+    bindip: list[NonEmptyString] = []
     """ Limit the server IP addresses available for NFS. """
     mountd_port: NfsTcpPort
     """ Specify the mountd port binding. """
@@ -62,19 +60,19 @@ class NfsEntry(BaseModel):
     rdma: bool
     """ Enable or disable NFS over RDMA.  Requires RDMA capable NIC. """
 
-    @field_validator('bindip')
-    @classmethod
-    def check_bind_ip(cls, field_value: list):
-        """ Custom validator for IP addresses to avoid JSON serialization errors """
-        not_valid = []
-        for v in field_value:
-            try:
-                ip_address(v)
-            except ValueError:
-                not_valid.append(v)
-        if not_valid:
-            raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 addresses: {not_valid}")
-        return field_value
+    # @field_validator('bindip')
+    # @classmethod
+    # def check_bind_ip(cls, field_value: list):
+    #     """ Custom validator for IP addresses to avoid JSON serialization errors """
+    #     not_valid = []
+    #     for v in field_value:
+    #         try:
+    #             ip_address(v)
+    #         except ValueError:
+    #             not_valid.append(v)
+    #     if not_valid:
+    #         raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 addresses: {not_valid}")
+    #     return field_value
 
 
 @single_argument_args('nfs_update')
@@ -129,49 +127,49 @@ class NfsShareEntry(BaseModel):
     locked: bool | None
     """ Lock state of the dataset (if encrypted). """
 
-    @field_validator('networks', 'hosts')
-    @classmethod
-    def check_unique(cls, field_value: list):
-        """ Custom validator to confirm unique entries """
-        s = set()
-        not_unique = []
-        for v in field_value:
-            if v in s:
-                not_unique.append(v)
-            s.add(v)
-        if not_unique:
-            raise ValueError(f"Entries must be unique, the following are not: {not_unique}")
-        return field_value
+    # @field_validator('networks', 'hosts')
+    # @classmethod
+    # def check_unique(cls, field_value: list):
+    #     """ Custom validator to confirm unique entries """
+    #     s = set()
+    #     not_unique = []
+    #     for v in field_value:
+    #         if v in s:
+    #             not_unique.append(v)
+    #         s.add(v)
+    #     if not_unique:
+    #         raise ValueError(f"Entries must be unique, the following are not: {not_unique}")
+    #     return field_value
 
-    @field_validator('networks')
-    @classmethod
-    def check_valid_network(cls, field_value: list):
-        """ Custom validator for IP networks """
-        not_valid = []
-        for v in field_value:
-            try:
-                ip_network(v, strict=False)
-            except ValueError:
-                not_valid.append(v)
-        if not_valid:
-            raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 networks: {not_valid}")
+    # @field_validator('networks')
+    # @classmethod
+    # def check_valid_network(cls, field_value: list):
+    #     """ Custom validator for IP networks """
+    #     not_valid = []
+    #     for v in field_value:
+    #         try:
+    #             ip_network(v, strict=False)
+    #         except ValueError:
+    #             not_valid.append(v)
+    #     if not_valid:
+    #         raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 networks: {not_valid}")
 
-        # Perform the courtesy conversion to a valid network format
-        field_value = [str(ip_network(fv, strict=False)) for fv in field_value]
-        return field_value
+    #     # Perform the courtesy conversion to a valid network format
+    #     field_value = [str(ip_network(fv, strict=False)) for fv in field_value]
+    #     return field_value
 
-    @field_validator('hosts')
-    @classmethod
-    def no_spaces_or_quotes(cls, field_value: list):
-        """ Custom validator for host field:  No spaces or quotes """
-        regex = re.compile(r'.*[\s"]')
-        not_valid = []
-        for v in field_value:
-            if v is not None and regex.match(v):
-                not_valid.append(v)
-        if not_valid:
-            raise ValueError(f"Cannot contain spaces or quotes: {not_valid}")
-        return field_value
+    # @field_validator('hosts')
+    # @classmethod
+    # def no_spaces_or_quotes(cls, field_value: list):
+    #     """ Custom validator for host field:  No spaces or quotes """
+    #     regex = re.compile(r'.*[\s"]')
+    #     not_valid = []
+    #     for v in field_value:
+    #         if v is not None and regex.match(v):
+    #             not_valid.append(v)
+    #     if not_valid:
+    #         raise ValueError(f"Cannot contain spaces or quotes: {not_valid}")
+    #     return field_value
 
 
 class NfsShareCreate(NfsShareEntry):

--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -1,0 +1,208 @@
+import re
+from ipaddress import ip_address, ip_network
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import (
+    Field, AfterValidator, field_validator
+)
+
+from middlewared.api.base import (
+    BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+    single_argument_args,
+    TcpPort, exclude_tcp_ports
+)
+
+__all__ = ["NfsEntry",
+           "NfsUpdateArgs", "NfsUpdateResult",
+           "NfsBindipChoicesArgs", "NfsBindipChoicesResult",
+           "NfsShareEntry",
+           "NfsShareCreateArgs", "NfsShareCreateResult",
+           "NfsShareUpdateArgs", "NfsShareUpdateResult",
+           "NfsShareDeleteArgs", "NfsShareDeleteResult"]
+
+NFS_protocols = Literal["NFSV3", "NFSV4"]
+NFS_RDMA_DEFAULT_PORT = 20049
+EXCLUDED_PORTS = [NFS_RDMA_DEFAULT_PORT]
+NfsTcpPort: TypeAlias = Annotated[TcpPort | None, AfterValidator(exclude_tcp_ports(EXCLUDED_PORTS))]
+
+
+class NfsEntry(BaseModel):
+    id: int
+    servers: Annotated[int | None, Field(ge=1, le=256)]
+    """ Specify the number of nfsd. Default: Number of nfsd is equal number of CPU. """
+    allow_nonroot: bool
+    """ Allow non-root mount requests.  This equates to 'insecure' share option. """
+    protocols: list[NFS_protocols]
+    """ Specify supported NFS protocols:  NFSv3, NFSv4 or both can be listed. """
+    v4_krb: bool
+    """ Force Kerberos authentication on NFS shares. """
+    v4_domain: str
+    """ Specify a DNS domain (NFSv4 only). """
+    bindip: list[NonEmptyString] = []  # Using IPvAnyAddress creates JSON serialization errors
+    """ Limit the server IP addresses available for NFS. """
+    mountd_port: NfsTcpPort
+    """ Specify the mountd port binding. """
+    rpcstatd_port: NfsTcpPort
+    """ Specify the rpc.statd port binding. """
+    rpclockd_port: NfsTcpPort
+    """ Specify the rpc.lockd port binding. """
+    mountd_log: bool
+    """ Enable or disable mountd logging. """
+    statd_lockd_log: bool
+    """ Enable or disable statd and lockd logging. """
+    v4_krb_enabled: bool
+    """ Status of NFSv4 authentication requirement (status only). """
+    userd_manage_gids: bool
+    """ Enable to allow server to manage gids. """
+    keytab_has_nfs_spn: bool
+    """ Report status of NFS Principal Name in keytab (status only). """
+    managed_nfsd: bool
+    """ Report status of 'servers' field.
+    If True the number of nfsd are managed by the server (status only). """
+    rdma: bool
+    """ Enable or disable NFS over RDMA.  Requires RDMA capable NIC. """
+
+    @field_validator('bindip')
+    @classmethod
+    def check_bind_ip(cls, field_value: list):
+        """ Custom validator for IP addresses to avoid JSON serialization errors """
+        not_valid = []
+        for v in field_value:
+            try:
+                ip_address(v)
+            except ValueError:
+                not_valid.append(v)
+        if not_valid:
+            raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 addresses: {not_valid}")
+        return field_value
+
+
+@single_argument_args('nfs_update')
+class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
+    id: Excluded = excluded_field()
+    managed_nfsd: Excluded = excluded_field()
+    v4_krb_enabled: Excluded = excluded_field()
+    keytab_has_nfs_spn: Excluded = excluded_field()
+
+
+class NfsUpdateResult(BaseModel):
+    result: NfsEntry
+
+
+class NfsBindipChoicesArgs(BaseModel):
+    pass
+
+
+class NfsBindipChoicesResult(BaseModel):
+    """ Return a dictionary of IP addresses """
+    result: dict[str, str]
+
+
+class NfsShareEntry(BaseModel):
+    id: int
+    path: NonEmptyString
+    """ Local path to be exported. """
+    aliases: list[NonEmptyString] = []
+    """ IGNORED for now. """
+    comment: str = ""
+    """ User comment associated with share. """
+    networks: list[NonEmptyString] = []
+    """ List of authorized networks that are allowed to access the share having format
+        "network/mask" CIDR notation. If empty, all networks are allowed. """
+    hosts: list[NonEmptyString] = []
+    """ list of IP's/hostnames which are allowed to access the share.
+        If empty, all IP's/hostnames are allowed. """
+    ro: bool = False
+    """ Export the share as read only. """
+    maproot_user: str | None = None
+    """ Map root user client to a specified user. """
+    maproot_group: str | None = None
+    """ Map root group client to a specified group. """
+    mapall_user: str | None = None
+    """ Map all client users to a specified user. """
+    mapall_group: str | None = None
+    """ Map all client groups to a specified group. """
+    security: list[Literal["SYS", "KRB5", "KRB5I", "KRB5P"]] = []
+    """ Specify the security schema. """
+    enabled: bool = True
+    """ Enable or disable the share. """
+    locked: bool | None
+    """ Lock state of the dataset (if encrypted). """
+
+    @field_validator('networks', 'hosts')
+    @classmethod
+    def check_unique(cls, field_value: list):
+        """ Custom validator to confirm unique entries """
+        s = set()
+        not_unique = []
+        for v in field_value:
+            if v in s:
+                not_unique.append(v)
+            s.add(v)
+        if not_unique:
+            raise ValueError(f"Entries must be unique, the following are not: {not_unique}")
+        return field_value
+
+    @field_validator('networks')
+    @classmethod
+    def check_valid_network(cls, field_value: list):
+        """ Custom validator for IP networks """
+        not_valid = []
+        for v in field_value:
+            try:
+                ip_network(v, strict=False)
+            except ValueError:
+                not_valid.append(v)
+        if not_valid:
+            raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 networks: {not_valid}")
+
+        # Perform the courtesy conversion to a valid network format
+        field_value = [str(ip_network(fv, strict=False)) for fv in field_value]
+        return field_value
+
+    @field_validator('hosts')
+    @classmethod
+    def no_spaces_or_quotes(cls, field_value: list):
+        """ Custom validator for host field:  No spaces or quotes """
+        regex = re.compile(r'.*[\s"]')
+        not_valid = []
+        for v in field_value:
+            if v is not None and regex.match(v):
+                not_valid.append(v)
+        if not_valid:
+            raise ValueError(f"Cannot contain spaces or quotes: {not_valid}")
+        return field_value
+
+
+class NfsShareCreate(NfsShareEntry):
+    id: Excluded = excluded_field()
+    locked: Excluded = excluded_field()
+
+
+class NfsShareCreateArgs(BaseModel):
+    data: NfsShareCreate
+
+
+class NfsShareCreateResult(BaseModel):
+    result: NfsShareEntry
+
+
+class NfsShareUpdate(NfsShareCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class NfsShareUpdateArgs(BaseModel):
+    id: int
+    data: NfsShareUpdate
+
+
+class NfsShareUpdateResult(BaseModel):
+    result: NfsShareEntry
+
+
+class NfsShareDeleteArgs(BaseModel):
+    id: int
+
+
+class NfsShareDeleteResult(BaseModel):
+    result: Literal[True]

--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -60,20 +60,6 @@ class NfsEntry(BaseModel):
     rdma: bool
     """ Enable or disable NFS over RDMA.  Requires RDMA capable NIC. """
 
-    # @field_validator('bindip')
-    # @classmethod
-    # def check_bind_ip(cls, field_value: list):
-    #     """ Custom validator for IP addresses to avoid JSON serialization errors """
-    #     not_valid = []
-    #     for v in field_value:
-    #         try:
-    #             ip_address(v)
-    #         except ValueError:
-    #             not_valid.append(v)
-    #     if not_valid:
-    #         raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 addresses: {not_valid}")
-    #     return field_value
-
 
 @single_argument_args('nfs_update')
 class NfsUpdateArgs(NfsEntry, metaclass=ForUpdateMetaclass):
@@ -126,50 +112,6 @@ class NfsShareEntry(BaseModel):
     """ Enable or disable the share. """
     locked: bool | None
     """ Lock state of the dataset (if encrypted). """
-
-    # @field_validator('networks', 'hosts')
-    # @classmethod
-    # def check_unique(cls, field_value: list):
-    #     """ Custom validator to confirm unique entries """
-    #     s = set()
-    #     not_unique = []
-    #     for v in field_value:
-    #         if v in s:
-    #             not_unique.append(v)
-    #         s.add(v)
-    #     if not_unique:
-    #         raise ValueError(f"Entries must be unique, the following are not: {not_unique}")
-    #     return field_value
-
-    # @field_validator('networks')
-    # @classmethod
-    # def check_valid_network(cls, field_value: list):
-    #     """ Custom validator for IP networks """
-    #     not_valid = []
-    #     for v in field_value:
-    #         try:
-    #             ip_network(v, strict=False)
-    #         except ValueError:
-    #             not_valid.append(v)
-    #     if not_valid:
-    #         raise ValueError(f"The following do not appear to be valid IPv4 or IPv6 networks: {not_valid}")
-
-    #     # Perform the courtesy conversion to a valid network format
-    #     field_value = [str(ip_network(fv, strict=False)) for fv in field_value]
-    #     return field_value
-
-    # @field_validator('hosts')
-    # @classmethod
-    # def no_spaces_or_quotes(cls, field_value: list):
-    #     """ Custom validator for host field:  No spaces or quotes """
-    #     regex = re.compile(r'.*[\s"]')
-    #     not_valid = []
-    #     for v in field_value:
-    #         if v is not None and regex.match(v):
-    #             not_valid.append(v)
-    #     if not_valid:
-    #         raise ValueError(f"Cannot contain spaces or quotes: {not_valid}")
-    #     return field_value
 
 
 class NfsShareCreate(NfsShareEntry):

--- a/src/middlewared/middlewared/plugins/nfs_/validators.py
+++ b/src/middlewared/middlewared/plugins/nfs_/validators.py
@@ -1,0 +1,74 @@
+import re
+
+from ipaddress import ip_address, ip_network
+from middlewared.service import ValidationErrors
+
+
+def confirm_unique(schema_name: str, item_name: str, data: dict, verrors: ValidationErrors):
+    """ Generat validation errors if list includes non-unique items """
+    s = set()
+    not_unique = []
+    for v in data[item_name]:
+        if v in s:
+            not_unique.append(v)
+        s.add(v)
+
+    if not_unique:
+        verrors.add(
+            f"{schema_name}.{item_name}",
+            f"Entries must be unique, the following are not: {', '.join(not_unique)}"
+        )
+
+
+def sanitize_networks(
+    schema_name: str, networks: list, verrors: ValidationErrors, strict_test=True, convert=False
+) -> list[str] | None:
+    """ Entries must be acceptible to ip_network and make all valid entries CIDR formatted """
+    not_valid = []
+    for v in networks:
+        try:
+            ip_network(v, strict=strict_test)
+        except ValueError:
+            not_valid.append(v)
+
+    if not_valid:
+        verrors.add(
+            f"{schema_name}.networks",
+            f"The following do not appear to be valid IPv4 or IPv6 networks: {', '.join(not_valid)}"
+        )
+    elif convert:
+        # Perform the courtesy conversion to CIDR format
+        return [str(ip_network(v, strict=False)) for v in networks]
+
+
+def sanitize_hosts(schema_name: str, hosts: list, verrors: ValidationErrors):
+    """ host entries cannot contain spaces or quotes """
+    regex = re.compile(r'.*[\s"]')
+    not_valid = []
+    for v in hosts:
+        # Entries in hosts are pre-validated to be NonEmptyString
+        if regex.match(v):
+            not_valid.append(v)
+
+    if not_valid:
+        verrors.add(
+            f"{schema_name}.hosts",
+            f"Cannot contain spaces or quotes: {', '.join(not_valid)}"
+        )
+
+
+def validate_bind_ip(ips: list):
+    """ Validate list strings are IP addresses """
+    not_valid = []
+    for ip in ips:
+        # The join below does no play well with None
+        if ip is None:
+            ip == "None"
+        try:
+            ip_address(ip)
+        except ValueError:
+            not_valid.append(ip)
+    if not_valid:
+        raise ValueError(
+            f"The following do not appear to be valid IPv4 or IPv6 addresses: {', '.join(not_valid)}"
+        )

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -186,10 +186,10 @@ def set_nfs_service_state(do_what=None, expect_to_pass=True, fail_check=False):
     assert do_what in ['start', 'stop'], f"Requested invalid service state: {do_what}"
     test_res = {'start': True, 'stop': False}
 
+    retval = None
     if expect_to_pass:
-        res = call(f'service.{do_what}', 'nfs', {'silent': False})
+        call(f'service.{do_what}', 'nfs', {'silent': False})
         sleep(1)
-        return res
     else:
         with pytest.raises(CallError) as e:
             call(f'service.{do_what}', 'nfs', {'silent': False})
@@ -198,9 +198,10 @@ def set_nfs_service_state(do_what=None, expect_to_pass=True, fail_check=False):
 
     # Confirm requested state
     if expect_to_pass:
-        res = call('service.started', 'nfs')
-        assert res == test_res[do_what], f"Expected {test_res[do_what]} for NFS started result, but found {res}"
-        return res
+        retval = call('service.started', 'nfs')
+        assert retval == test_res[do_what], f"Expected {test_res[do_what]} for NFS started result, but found {retval}"
+
+    return retval
 
 
 def get_client_nfs_port():
@@ -631,11 +632,9 @@ class TestNFSops:
                         # Test making change to non-'server' setting does not change managed_nfsd
                         assert call("nfs.config")['managed_nfsd'] == expected['managed']
                 else:
-                    with pytest.raises(ValidationErrors) as ve:
+                    with pytest.raises(ValidationErrors, match="Input should be"):
                         assert call("nfs.config")['managed_nfsd'] == expected['managed']
                         call("nfs.update", {"servers": nfsd})
-
-                    assert ve.value.errors == [ValidationError('nfs_update.servers', 'Should be between 1 and 256', 22)]
 
     def test_share_update(self, start_nfs, nfs_dataset_and_share):
         """
@@ -670,8 +669,8 @@ class TestNFSops:
             pp(["192.168.0.0/24", "192.168.1.0/24"], True, "", id="IPv4 - non-overlap"),
             pp(["192.168.0.0/16", "192.168.1.0/24"], False, "Overlapped", id="IPv4 - overlap wide"),
             pp(["192.168.0.0/24", "192.168.0.211/32"], False, "Overlapped", id="IPv4 - overlap narrow"),
-            pp(["192.168.0.0/64"], False, "does not appear to be an IPv4 or IPv6 network", id="IPv4 - invalid range"),
-            pp(["bogus_network"], False, "does not appear to be an IPv4 or IPv6 network", id="IPv4 - invalid format"),
+            pp(["192.168.0.0/64"], False, "do not appear to be valid IPv4 or IPv6", id="IPv4 - invalid range"),
+            pp(["bogus_network"], False, "do not appear to be valid IPv4 or IPv6", id="IPv4 - invalid format"),
             pp(["192.168.27.211"], True, "", id="IPv4 - auto-convert to CIDR"),
             # IPv6
             pp(["2001:0db8:85a3:0000:0000:8a2e::/96", "2001:0db8:85a3:0000:0000:8a2f::/96"],
@@ -681,7 +680,7 @@ class TestNFSops:
             pp(["2001:0db8:85a3:0000:0000:8a2e::/96", "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"],
                False, "Overlapped", id="IPv6 - overlap narrow"),
             pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334/256"],
-               False, "does not appear to be an IPv4 or IPv6 network", id="IPv6 - invalid range"),
+               False, "do not appear to be valid IPv4 or IPv6", id="IPv6 - invalid range"),
             pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                True, "", id="IPv6 - auto-convert to CIDR"),
         ],
@@ -704,9 +703,12 @@ class TestNFSops:
             if ExpectedToPass:
                 call('sharing.nfs.update', nfsid, {'networks': networklist})
             else:
-                with pytest.raises(ValidationErrors) as re:
+                with pytest.raises((ValueError, ValidationErrors)) as ve:
                     call('sharing.nfs.update', nfsid, {'networks': networklist})
-                assert FailureMsg in str(re.value.errors[0])
+                if ve.typename == "ValueError":
+                    assert FailureMsg in str(ve.value)
+                else:
+                    assert FailureMsg in str(ve.value.errors[0])
 
             parsed = parse_exports()
             assert len(parsed) == 1, str(parsed)
@@ -739,12 +741,12 @@ class TestNFSops:
             pp(["192.168.1.0/24"], False, "Unable to resolve", id="Invalid - name (network format)"),
             pp(["asdfdm[0-9].example.com", "-asdffail", "devteam-*.ixsystems.com", "*.asdffail.com"],
                False, "Unable to resolve", id="Mix - valid and invalid names"),
-            pp(["192.168.1.0", "192.168.1.0"], False, "not unique", id="Invalid - duplicate address"),
-            pp(["ixsystems.com", "ixsystems.com"], False, "not unique", id="Invalid - duplicate address"),
+            pp(["192.168.1.0", "192.168.1.0"], False, "Entries must be unique", id="Invalid - duplicate address"),
+            pp(["ixsystems.com", "ixsystems.com"], False, "Entries must be unique", id="Invalid - duplicate address"),
             pp(["ixsystems.com", "*"], True, "", id="Valid - mix name and everybody"),
             pp(["*", "*.ixsystems.com"], True, "", id="Valid - mix everybody and wildcard name"),
             pp(["192.168.1.o"], False, "Unable to resolve", id="Invalid - character in address"),
-            pp(["bad host"], False, "cannot contain spaces", id="Invalid - name with spaces"),
+            pp(["bad host"], False, "Cannot contain spaces", id="Invalid - name with spaces"),
             pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"], True, "", id="Valid - IPv6 address")
         ],
     )
@@ -776,9 +778,12 @@ class TestNFSops:
             if ExpectedToPass:
                 call('sharing.nfs.update', nfsid, {'hosts': hostlist})
             else:
-                with pytest.raises(ValidationErrors) as re:
+                with pytest.raises((ValueError, ValidationErrors)) as ve:
                     call('sharing.nfs.update', nfsid, {'hosts': hostlist})
-                assert FailureMsg in str(re.value.errors[0])
+                if ve.typename == "ValueError":
+                    assert FailureMsg in str(ve.value)
+                else:
+                    assert FailureMsg in str(ve.value.errors[0])
 
             parsed = parse_exports()
             assert len(parsed) == 1, str(parsed)
@@ -1305,9 +1310,24 @@ class TestNFSops:
         assert s.get('nfsd', {}).get('udp') is None, s
 
     @pytest.mark.parametrize('test_port', [
-        pp([["mountd", 618, None], ["rpcstatd", 871, None], ["rpclockd", 32803, None]], id="valid ports"),
-        pp([["rpcstatd", -21, 0], ["rpclockd", 328031, 0]], id="invalid ports"),
-        pp([["mountd", 20049, 1]], id="excluded ports"),
+        pp(
+            [
+                ["mountd", 618, None],
+                ["rpcstatd", 871, None],
+                ["rpclockd", 32803, None]
+            ], id="valid ports"
+        ),
+        pp(
+            [
+                ["rpcstatd", -21, "Input should be greater than"],
+                ["rpclockd", 328031, "Input should be less than"]
+            ], id="invalid ports"
+        ),
+        pp(
+            [
+                ["mountd", 20049, "reserved for internal use"]
+            ], id="excluded ports"
+        ),
     ])
     def test_service_ports(self, start_nfs, test_port):
         """
@@ -1324,9 +1344,6 @@ class TestNFSops:
         value = 1
         err = 2
 
-        # Error message snippets
-        errmsg = ["Should be between", "reserved for internal use"]
-
         # Test ports
         for port in test_port:
             port_name = port[name] + "_port"
@@ -1334,10 +1351,8 @@ class TestNFSops:
                 nfs_conf = call("nfs.update", {port_name: port[value]})
                 assert nfs_conf[port_name] == port[value]
             else:
-                with pytest.raises(ValidationErrors) as ve:
+                with pytest.raises(ValidationErrors, match=port[err]):
                     nfs_conf = call("nfs.update", {port_name: port[value]})
-                errStr = str(ve.value.errors[0])
-                assert errmsg[port[err]] in errStr
 
         # Compare DB with setting in /etc/nfs.conf.d/local.conf
         with nfs_config() as config_db:
@@ -1383,44 +1398,69 @@ class TestNFSops:
             res = call('nfs.get_debug')
             assert res == disabled
 
-    def test_bind_ip(self, start_nfs):
+    @pytest.mark.parametrize("TestType,param,errmsg", [
+        pp("basic", [], None, id="basic settings"),
+        pp("NotInChoice", ["1.2.3.4"], "Cannot use", id="Not in choices"),
+        pp("NotValidIP", ["a.b.c.d"], "do not appear to be", id="Not a valid IP"),
+        pp("HalfValid-1", ["", "8.8.8.8"], "Cannot use", id="2nd entry not in choices"),
+        pp("HalfValid-2", ["", "ixsystems.com"], "do not appear to be", id="2nd entry not valid IP"),
+        pp("HalfValid-3", ["", None], "Input should be", id="2nd entry is None")
+    ])
+    def test_bind_ip(self, start_nfs, TestType, param, errmsg):
         '''
         This test requires a static IP address
-        * Test the private nfs.bindip call
-        * Test the actual bindip config setting
-        - Confirm setting in conf files
-        - Confirm service on IP address
+        * Success testing:
+            - Test the private nfs.bindip call
+            - Test the actual bindip config setting
+                o Confirm setting in conf files
+                o Confirm service on IP address
+        * Failure testing:
+            - Valid IP, but does not match choices
+            - Invalid IP
+            - Two entries, one valid the other not
         '''
         assert start_nfs is True
 
-        # Multiple restarts cause systemd failures.  Reset the systemd counters.
-        reset_svcs("nfs-idmapd nfs-mountd nfs-server rpcbind rpc-statd")
+        if TestType == "basic":
+            # Multiple restarts cause systemd failures.  Reset the systemd counters.
+            reset_svcs("nfs-idmapd nfs-mountd nfs-server rpcbind rpc-statd")
 
-        choices = call("nfs.bindip_choices")
-        assert truenas_server.ip in choices
+            choices = call("nfs.bindip_choices")
+            assert truenas_server.ip in choices
 
-        call("nfs.bindip", {"bindip": [truenas_server.ip]})
-        call("nfs.bindip", {"bindip": []})
+            call("nfs.bindip", {"bindip": [truenas_server.ip]})
+            call("nfs.bindip", {"bindip": []})
 
-        # Test config with bindip.  Use choices from above
-        # TODO: check with 'nmap -sT <IP>' from the runner.
-        with nfs_config() as db_conf:
+            # Test config with bindip.  Use choices from above
+            # TODO: check with 'nmap -sT <IP>' from the runner.
+            with nfs_config() as db_conf:
 
-            # Should have no bindip setting
-            nfs_conf = parse_server_config()
-            rpc_conf = parse_rpcbind_config()
-            assert db_conf['bindip'] == []
-            assert nfs_conf['nfsd'].get('host') is None
-            assert rpc_conf.get('-h') is None
+                # Should have no bindip setting
+                nfs_conf = parse_server_config()
+                rpc_conf = parse_rpcbind_config()
+                assert db_conf['bindip'] == []
+                assert nfs_conf['nfsd'].get('host') is None
+                assert rpc_conf.get('-h') is None
 
-            # Set bindip
-            call("nfs.update", {"bindip": [truenas_server.ip]})
+                # Set bindip
+                call("nfs.update", {"bindip": [truenas_server.ip]})
 
-            # Confirm we see it in the nfs and rpc conf files
-            nfs_conf = parse_server_config()
-            rpc_conf = parse_rpcbind_config()
-            assert truenas_server.ip in nfs_conf['nfsd'].get('host'), f"nfs_conf = {nfs_conf}"
-            assert truenas_server.ip in rpc_conf.get('-h'), f"rpc_conf = {rpc_conf}"
+                # Confirm we see it in the nfs and rpc conf files
+                nfs_conf = parse_server_config()
+                rpc_conf = parse_rpcbind_config()
+                assert truenas_server.ip in nfs_conf['nfsd'].get('host'), f"nfs_conf = {nfs_conf}"
+                assert truenas_server.ip in rpc_conf.get('-h'), f"rpc_conf = {rpc_conf}"
+        else:
+            # None of these should make it to the config
+            if TestType.startswith("HalfValid"):
+                param[0] = truenas_server.ip
+
+            with pytest.raises((ValueError, ValidationErrors)) as ve:
+                call("nfs.update", {"bindip": param})
+            if ve.typename == "ValueError":
+                assert errmsg in str(ve.value)
+            else:
+                assert errmsg in str(ve.value.errors[0])
 
     def test_v4_domain(self, start_nfs):
         '''


### PR DESCRIPTION
Convert NFS config to new api.
Added a common 'TcpPort' type.

Addressed additional comments.  Moved all field_validator tests to new validator module in plugins/nfs_.
Updated the CI tests.

Passes NFS CI [tests]( http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2613/)

Ignore the spurrious failure in  test_008_check_root_dataset_settings.