### PR TITLE
NAS-133250 / 25.04 / fix loading nvidia kernel modules

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -168,7 +168,11 @@ class DockerService(ConfigService):
             subprocess.run(['ldconfig'], capture_output=True, check=True, text=True)
 
         if config['nvidia']:
-            cp = subprocess.run(['modprobe', 'nvidia'], capture_output=True, text=True)
+            cp = subprocess.run(
+                ['modprobe', '-a', 'nvidia', 'nvidia_drm', 'nvidia_modeset'],
+                capture_output=True,
+                text=True
+            )
             if cp.returncode != 0:
                 self.logger.error('Error loading nvidia driver: %s', cp.stderr)
 


### PR DESCRIPTION
Certain apps have the ability to choose GPUs for various tasks (Plex is a popular one). Users have noticed that plex (and other apps) no longer provide a list of their nvidia gpus. I tracked this down to the simple fact that we're not loading the `nvidia_drm` kernel module. This module is responsible for populating the `/dev/dri` directory with `render` nodes which is subsequently used by apps (like plex).