### PR TITLE
NAS-133468 / 25.04 / Convert iscsi.portal.* to new API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -31,6 +31,7 @@ from .initshutdownscript import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
 from .iscsi_initiator import *  # noqa
+from .iscsi_portal import *  # noqa
 from .iscsi_target import *  # noqa
 from .iscsi_target_to_extent import *  # noqa
 from .keychain import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_portal.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_portal.py
@@ -1,0 +1,81 @@
+from typing import Literal
+
+from pydantic import IPvAnyAddress, field_validator
+
+from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString
+
+__all__ = [
+    "IscsiPortalEntry",
+    "IscsiPortalListenIPChoicesArgs",
+    "IscsiPortalListenIPChoicesResult",
+    "IscsiPortalCreateArgs",
+    "IscsiPortalCreateResult",
+    "IscsiPortalUpdateArgs",
+    "IscsiPortalUpdateResult",
+    "IscsiPortalDeleteArgs",
+    "IscsiPortalDeleteResult",
+]
+
+
+class IscsiPortalIP(BaseModel):
+    ip: NonEmptyString
+
+    @field_validator('ip')
+    @classmethod
+    def check_ip(cls, v):
+        IPvAnyAddress(v)
+        return v
+
+
+class IscsiPortalIPInfo(IscsiPortalIP):
+    port: int
+
+
+class IscsiPortalEntry(BaseModel):
+    id: int
+    listen: list[IscsiPortalIPInfo]
+    tag: int
+    comment: str = ''
+
+
+class IscsiPortalListenIPChoicesArgs(BaseModel):
+    pass
+
+
+class IscsiPortalListenIPChoicesResult(BaseModel):
+    result: dict[str, str]
+
+
+class IscsiPortalCreate(IscsiPortalEntry):
+    id: Excluded = excluded_field()
+    tag: Excluded = excluded_field()
+    listen: list[IscsiPortalIP]
+
+
+class IscsiPortalCreateArgs(BaseModel):
+    iscsi_portal_create: IscsiPortalCreate
+
+
+class IscsiPortalCreateResult(BaseModel):
+    result: IscsiPortalEntry
+
+
+class IscsiPortalUpdate(IscsiPortalCreate, metaclass=ForUpdateMetaclass):
+    pass
+
+
+class IscsiPortalUpdateArgs(BaseModel):
+    id: int
+    iscsi_portal_update: IscsiPortalUpdate
+
+
+class IscsiPortalUpdateResult(BaseModel):
+    result: IscsiPortalEntry
+
+
+class IscsiPortalDeleteArgs(BaseModel):
+    id: int
+
+
+class IscsiPortalDeleteResult(BaseModel):
+    result: Literal[True]

--- a/tests/api2/assets/websocket/iscsi.py
+++ b/tests/api2/assets/websocket/iscsi.py
@@ -19,11 +19,10 @@ def initiator(comment='Default initiator', initiators=[]):
 
 
 @contextlib.contextmanager
-def portal(listen=[{'ip': '0.0.0.0'}], comment='Default portal', discovery_authmethod='NONE'):
+def portal(listen=[{'ip': '0.0.0.0'}], comment='Default portal'):
     payload = {
         'listen': listen,
         'comment': comment,
-        'discovery_authmethod': discovery_authmethod
     }
     portal_config = call('iscsi.portal.create', payload)
 

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -1198,7 +1198,7 @@ def test__modify_portal(iscsi_running):
         new_config = call('iscsi.portal.get_instance', portal_config['id'])
         assert new_config['comment'] == 'New comment', new_config
         # Then try to reapply everything
-        payload = {'comment': 'test1', 'discovery_authmethod': 'NONE', 'discovery_authgroup': None, 'listen': [{'ip': '0.0.0.0'}]}
+        payload = {'comment': 'test1', 'listen': [{'ip': '0.0.0.0'}]}
         call('iscsi.portal.update', portal_config['id'], payload)
         new_config = call('iscsi.portal.get_instance', portal_config['id'])
         assert new_config['comment'] == 'test1', new_config

--- a/tests/api2/test_audit_iscsi.py
+++ b/tests/api2/test_audit_iscsi.py
@@ -268,7 +268,6 @@ def test_iscsi_portal_audit():
                 {
                     'listen': [{'ip': '0.0.0.0'}],
                     'comment': comment,
-                    'discovery_authmethod': 'NONE',
                 }
             ],
             'description': f'Create iSCSI portal {comment}',
@@ -276,7 +275,6 @@ def test_iscsi_portal_audit():
             payload = {
                 'listen': [{'ip': '0.0.0.0'}],
                 'comment': comment,
-                'discovery_authmethod': 'NONE',
             }
             portal_config = call('iscsi.portal.create', payload)
         # UPDATE

--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -36,7 +36,7 @@ def my_ip4():
 
 @contextlib.contextmanager
 def portal():
-    portal_config = call('iscsi.portal.create', {'listen': [{'ip': truenas_server.ip}], 'discovery_authmethod': 'NONE'})
+    portal_config = call('iscsi.portal.create', {'listen': [{'ip': truenas_server.ip}]})
     try:
         yield portal_config
     finally:


### PR DESCRIPTION
Convert `iscsi.portal.*` to new API

Also remove last vestiges of obsolete `discovery_authmethod` and `discovery_authgroup`.  In SCST these are global rather than being tied to a particular portal.

----
Passing abridged CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2519/).