### PR TITLE
NAS-133474 / 25.04 / Fix authorization checks for subscriptions with args

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -854,7 +854,8 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             raise CallError('Not authorized', errno.EACCES)
 
     def can_subscribe(self, app, name):
-        if event := self.events.get_event(name):
+        short_name = name.split(':')[0]
+        if event := self.events.get_event(short_name):
             if event['no_auth_required']:
                 return True
 
@@ -865,7 +866,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             if event['no_authz_required']:
                 return True
 
-        return app.authenticated_credentials.authorize('SUBSCRIBE', name)
+        return app.authenticated_credentials.authorize('SUBSCRIBE', short_name)
 
     async def call_with_audit(self, method, serviceobj, methodobj, params, app, **kwargs):
         audit_callback_messages = []

--- a/tests/api2/test_account_privilege_role.py
+++ b/tests/api2/test_account_privilege_role.py
@@ -185,3 +185,5 @@ def test_can_not_subscribe_to_event():
 def test_can_subscribe_to_event():
     with unprivileged_user_client(["READONLY_ADMIN"]) as unprivileged:
         unprivileged.subscribe("alert.list", lambda *args, **kwargs: None)
+        # Verify that can also subscribe using unprivileged user.
+        unprivileged.subscribe('virt.instance.metrics:{"id": "test"}', lambda *args, **kwargs: None)


### PR DESCRIPTION
If the API user call to subscribe to and endpoint whilst specifying arguments.

For example,
```
"virt.instance.metrics:{\"id\": \"test\"}"
```

We should omit the args from the authorization check:
```
"virt.instance.metrics"
```