### PR TITLE
NAS-133475 / 24.10.2 / add front_loaded key to r30 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/nvme2.py
@@ -249,6 +249,7 @@ def map_r30_or_fseries(model, ctx):
     ui_info = {
         'rackmount': True,
         'top_loaded': False,
+        'front_loaded': True,
         'front_slots': front_slots,
         'rear_slots': rear_slots,
         'internal_slots': internal_slots


### PR DESCRIPTION
This key needs to be added for r30/f-series for the UI to function properly.

Original PR: https://github.com/truenas/middleware/pull/15344
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133475