### PR TITLE
NAS-133480 / 25.04 / Crash if public api_method does not have roles

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -21,7 +21,7 @@ class UserService(Service):
             'iXsystems'
         )
 
-    @api_method(UserProvisioningUriArgs, UserProvisioningUriResult)
+    @api_method(UserProvisioningUriArgs, UserProvisioningUriResult, roles=['ACCOUNT_WRITE'])
     async def provisioning_uri(self, username):
         """
         Returns the provisioning URI for the OTP for `username`. This can then be encoded in a QR code and used
@@ -36,7 +36,7 @@ class UserService(Service):
 
         return await self.provisioning_uri_internal(username, user_twofactor_config)
 
-    @api_method(UserTwofactorConfigArgs, UserTwofactorConfigResult)
+    @api_method(UserTwofactorConfigArgs, UserTwofactorConfigResult, roles=['ACCOUNT_READ'])
     async def twofactor_config(self, username):
         """
         Returns two-factor authentication configuration settings for specified `username`.
@@ -57,7 +57,7 @@ class UserService(Service):
             'otp_digits': user_twofactor_config['otp_digits'],
         }
 
-    @api_method(UserVerifyTwofactorTokenArgs, UserVerifyTwofactorTokenResult)
+    @api_method(UserVerifyTwofactorTokenArgs, UserVerifyTwofactorTokenResult, roles=['FULL_ADMIN'])
     def verify_twofactor_token(self, username, token):
         """
         Returns boolean true if provided `token` is successfully authenticated for `username`.
@@ -92,7 +92,9 @@ class UserService(Service):
         return await self.middleware.call('user.query', [['username', '=', user['pw_name']]], {'get': True})
 
     @api_method(UserUnset2faSecretArgs, UserUnset2faSecretResult,
-                audit='Unset two-factor authentication secret:', audit_extended=lambda username: username)
+                audit='Unset two-factor authentication secret:',
+                audit_extended=lambda username: username,
+                roles=['ACCOUNT_WRITE'])
     async def unset_2fa_secret(self, username):
         """
         Unset two-factor authentication secret for `username`.
@@ -120,12 +122,12 @@ class UserService(Service):
             }
         )
 
-    @no_authz_required
     @api_method(
         UserRenew2faSecretArgs,
         UserRenew2faSecretResult,
         audit='Renew two-factor authentication secret:',
-        audit_extended=lambda username, options: username
+        audit_extended=lambda username, options: username,
+        authorization_required=False
     )
     @pass_app()
     async def renew_2fa_secret(self, app, username, twofactor_options):

--- a/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
+++ b/src/middlewared/middlewared/plugins/account_/builtin_administrator.py
@@ -6,7 +6,7 @@ from middlewared.service import filter_list, Service, private
 
 class GroupService(Service):
 
-    @api_method(GroupHasPasswordEnabledUserArgs, GroupHasPasswordEnabledUserResult)
+    @api_method(GroupHasPasswordEnabledUserArgs, GroupHasPasswordEnabledUserResult, roles=['ACCOUNT_READ'])
     async def has_password_enabled_user(self, gids, exclude_user_ids):
         """
         Checks whether at least one local user with a password is a member of any of the `group_ids`.

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -400,7 +400,7 @@ class AlertService(Service):
         except IndexError:
             return None
 
-    @api_method(AlertDismissArgs, AlertDismissResult)
+    @api_method(AlertDismissArgs, AlertDismissResult, roles=['ALERT_LIST_WRITE'])
     async def dismiss(self, uuid):
         """
         Dismiss `id` alert.
@@ -436,7 +436,7 @@ class AlertService(Service):
         if removed:
             self._send_alert_deleted_event(alert)
 
-    @api_method(AlertRestoreArgs, AlertRestoreResult)
+    @api_method(AlertRestoreArgs, AlertRestoreResult, roles=['ALERT_LIST_WRITE'])
     async def restore(self, uuid):
         """
         Restore `id` alert which had been dismissed.
@@ -999,6 +999,7 @@ class AlertServiceService(CRUDService):
         datastore_order_by = ["name"]
         cli_namespace = "system.alert.service"
         entry = AlertServiceEntry
+        role_prefix = 'ALERT'
 
     @private
     async def _extend(self, service):
@@ -1098,7 +1099,7 @@ class AlertServiceService(CRUDService):
         """
         return await self.middleware.call("datastore.delete", self._config.datastore, id_)
 
-    @api_method(AlertServiceTestArgs, AlertServiceTestResult)
+    @api_method(AlertServiceTestArgs, AlertServiceTestResult, roles=['ALERT_WRITE'])
     async def test(self, data):
         """
         Send a test alert using `type` of Alert Service.
@@ -1170,6 +1171,7 @@ class AlertClassesService(ConfigService):
         datastore = "system.alertclasses"
         cli_namespace = "system.alert.class"
         entry = AlertClassesEntry
+        role_prefix = 'ALERT'
 
     @api_method(AlertClassesUpdateArgs, AlertClassesUpdateResult)
     async def do_update(self, data):

--- a/src/middlewared/middlewared/plugins/boot_/environments.py
+++ b/src/middlewared/middlewared/plugins/boot_/environments.py
@@ -92,7 +92,7 @@ class BootEnvironmentService(Service):
                     except Exception:
                         self.logger.exception("Unexpected error promoting %r", ds)
 
-    @filterable_api_method(item=BootEnvironmentEntry)
+    @filterable_api_method(item=BootEnvironmentEntry, roles=['BOOT_ENV_READ'])
     def query(self, filters, options):
         results = list()
         try:
@@ -129,7 +129,7 @@ class BootEnvironmentService(Service):
 
         return filter_list(results, filters, options)
 
-    @api_method(BootEnvironmentActivateArgs, BootEnvironmentActivateResult)
+    @api_method(BootEnvironmentActivateArgs, BootEnvironmentActivateResult, roles=["BOOT_ENV_WRITE"])
     def activate(self, data):
         info = self.validate_be("boot.environment.activate", data["id"])
         if info["activated"]:
@@ -144,14 +144,14 @@ class BootEnvironmentService(Service):
             run_zectl_cmd(["activate", data["id"]])
             return self.query([["id", "=", data["id"]]], {"get": True})
 
-    @api_method(BootEnvironmentCloneArgs, BootEnvironmentCloneResult)
+    @api_method(BootEnvironmentCloneArgs, BootEnvironmentCloneResult, roles=['BOOT_ENV_WRITE'])
     def clone(self, data):
         be = self.validate_be("boot.environment.clone", data["id"])
         self.validate_be("boot.environment.clone", data["target"], should_exist=False)
         run_zectl_cmd(["create", "-r", "-e", be["dataset"], data["target"]])
         return self.query([["id", "=", data["target"]]], {"get": True})
 
-    @api_method(BootEnvironmentDestroyArgs, BootEnvironmentDestroyResult)
+    @api_method(BootEnvironmentDestroyArgs, BootEnvironmentDestroyResult, roles=['BOOT_ENV_WRITE'])
     def destroy(self, data):
         if self.validate_be("boot.environment.destroy", data["id"])["active"]:
             raise ValidationError(
@@ -160,7 +160,7 @@ class BootEnvironmentService(Service):
             )
         run_zectl_cmd(["destroy", data["id"]])
 
-    @api_method(BootEnvironmentKeepArgs, BootEnvironmentKeepResult)
+    @api_method(BootEnvironmentKeepArgs, BootEnvironmentKeepResult, roles=['BOOT_ENV_WRITE'])
     def keep(self, data):
         self.middleware.call_sync(
             "zfs.dataset.update",

--- a/src/middlewared/middlewared/plugins/cloud_backup/restore.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restore.py
@@ -11,7 +11,7 @@ class CloudBackupService(Service):
         cli_namespace = "task.cloud_backup"
         namespace = "cloud_backup"
 
-    @api_method(CloudBackupRestoreArgs, CloudBackupRestoreResult)
+    @api_method(CloudBackupRestoreArgs, CloudBackupRestoreResult, roles=["FILESYSTEM_DATA_WRITE"])
     @job(logs=True)
     async def restore(self, job, id_, snapshot_id, subfolder, destination_path, options):
         """

--- a/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/snapshot.py
@@ -17,7 +17,7 @@ class CloudBackupService(Service):
         cli_namespace = "task.cloud_backup"
         namespace = "cloud_backup"
 
-    @api_method(CloudBackupListSnapshotsArgs, CloudBackupListSnapshotsResult)
+    @api_method(CloudBackupListSnapshotsArgs, CloudBackupListSnapshotsResult, roles=['CLOUD_BACKUP_READ'])
     def list_snapshots(self, id_):
         """
         List existing snapshots for the cloud backup job `id`.
@@ -44,7 +44,8 @@ class CloudBackupService(Service):
 
         return snapshots
 
-    @api_method(CloudBackupListSnapshotDirectoryArgs, CloudBackupListSnapshotDirectoryResult)
+    @api_method(CloudBackupListSnapshotDirectoryArgs, CloudBackupListSnapshotDirectoryResult,
+                roles=['CLOUD_BACKUP_READ'])
     def list_snapshot_directory(self, id_, snapshot_id, path):
         """
         List files in the directory `path` of the `snapshot_id` created by the cloud backup job `id`.
@@ -80,7 +81,8 @@ class CloudBackupService(Service):
 
         return contents
 
-    @api_method(CloudBackupDeleteSnapshotArgs, CloudBackupDeleteSnapshotResult)
+    @api_method(CloudBackupDeleteSnapshotArgs, CloudBackupDeleteSnapshotResult,
+                roles=['CLOUD_BACKUP_WRITE'])
     @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1)
     def delete_snapshot(self, job, id_, snapshot_id):
         """

--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -121,7 +121,7 @@ class CloudBackupService(Service):
         namespace = "cloud_backup"
 
     @item_method
-    @api_method(CloudBackupSyncArgs, CloudBackupSyncResult)
+    @api_method(CloudBackupSyncArgs, CloudBackupSyncResult, roles=['CLOUD_BACKUP_WRITE'])
     @job(lock=lambda args: "cloud_backup:{}".format(args[-1]), lock_queue_size=1, logs=True, abortable=True)
     async def sync(self, job, id_, options):
         """
@@ -163,7 +163,7 @@ class CloudBackupService(Service):
             raise
 
     @item_method
-    @api_method(CloudBackupAbortArgs, CloudBackupAbortResult)
+    @api_method(CloudBackupAbortArgs, CloudBackupAbortResult, roles=['CLOUD_BACKUP_WRITE'])
     async def abort(self, id_):
         """
         Aborts cloud backup task.

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -63,7 +63,7 @@ class ConfigService(Service):
             with open(ntf.name, 'rb') as f:
                 shutil.copyfileobj(f, job.pipes.output.w)
 
-    @api_method(ConfigSaveArgs, ConfigSaveResult)
+    @api_method(ConfigSaveArgs, ConfigSaveResult, roles=['FULL_ADMIN'])
     @job(pipes=["output"])
     async def save(self, job, options):
         """
@@ -83,7 +83,7 @@ class ConfigService(Service):
         method = self.save_db_only if not any(options.values()) else self.save_tar_file
         await self.middleware.run_in_thread(method, options, job)
 
-    @api_method(ConfigUploadArgs, ConfigUploadResult)
+    @api_method(ConfigUploadArgs, ConfigUploadResult, roles=['FULL_ADMIN'])
     @job(pipes=["input"])
     @pass_app(rest=True)
     def upload(self, app, job):
@@ -190,7 +190,7 @@ class ConfigService(Service):
         self._handle_failover(job, 'uploaded', send_to_remote, UPLOADED_DB_PATH, True,
                               CONFIGURATION_UPLOAD_REBOOT_REASON)
 
-    @api_method(ConfigResetArgs, ConfigResetResult)
+    @api_method(ConfigResetArgs, ConfigResetResult, roles=['FULL_ADMIN'])
     @job(lock='config_reset', logs=True)
     @pass_app(rest=True)
     def reset(self, app, job, options):

--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -187,7 +187,7 @@ class CronJobService(CRUDService):
 
         return response
 
-    @api_method(CronJobRunArgs, CronJobRunResult)
+    @api_method(CronJobRunArgs, CronJobRunResult, roles=['FULL_ADMIN'])
     @job(lock=lambda args: f'cron_job_run_{args[0]}', logs=True, lock_queue_size=1)
     def run(self, job, id_, skip_disabled):
         """

--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -136,7 +136,7 @@ class DockerService(ConfigService):
         """
         return await self.middleware.call('docker.state.get_status_dict')
 
-    @api_method(DockerNvidiaPresentArgs, DockerNvidiaPresentResult)
+    @api_method(DockerNvidiaPresentArgs, DockerNvidiaPresentResult, roles=['DOCKER_READ'])
     def nvidia_present(self):
         adv_config = self.middleware.call_sync("system.advanced.config")
 

--- a/src/middlewared/middlewared/plugins/enclosure_/enclosure_label.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/enclosure_label.py
@@ -25,7 +25,7 @@ class EnclosureService(Service):
             for label in await self.middleware.call("datastore.query", "enclosure.label")
         }
 
-    @api_method(EnclosureLabelSetArgs, EnclosureLabelUpdateResult)
+    @api_method(EnclosureLabelSetArgs, EnclosureLabelUpdateResult, roles=["ENCLOSURE_WRITE"])
     async def set(self, id_, label):
         await self.middleware.call(
             "datastore.delete", "enclosure.label", [["encid", "=", id_]]

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -421,7 +421,7 @@ class FilesystemService(Service):
 
         return True
 
-    @api_method(FilesystemGetFileArgs, FilesystemGetFileResult, audit='Filesystem get')
+    @api_method(FilesystemGetFileArgs, FilesystemGetFileResult, audit='Filesystem get', roles=['FULL_ADMIN'])
     @job(pipes=["output"])
     def get(self, job, path):
         """
@@ -434,7 +434,7 @@ class FilesystemService(Service):
         with open(path, 'rb') as f:
             shutil.copyfileobj(f, job.pipes.output.w)
 
-    @api_method(FilesystemPutFileArgs, FilesystemPutFileResult, audit='Filesystem put')
+    @api_method(FilesystemPutFileArgs, FilesystemPutFileResult, audit='Filesystem put', roles=['FULL_ADMIN'])
     @job(pipes=["input"])
     def put(self, job, path, options):
         """

--- a/src/middlewared/middlewared/plugins/init_shutdown_script.py
+++ b/src/middlewared/middlewared/plugins/init_shutdown_script.py
@@ -38,7 +38,7 @@ class InitShutdownScriptService(CRUDService):
         cli_namespace = 'system.init_shutdown_script'
         entry = InitShutdownScriptEntry
 
-    @api_method(InitShutdownScriptCreateArgs, InitShutdownScriptCreateResult)
+    @api_method(InitShutdownScriptCreateArgs, InitShutdownScriptCreateResult, roles=['FULL_ADMIN'])
     async def do_create(self, data):
         """
         Create an initshutdown script task.
@@ -67,7 +67,7 @@ class InitShutdownScriptService(CRUDService):
         )
         return await self.get_instance(data['id'])
 
-    @api_method(InitShutdownScriptUpdateArgs, InitShutdownScriptUpdateResult)
+    @api_method(InitShutdownScriptUpdateArgs, InitShutdownScriptUpdateResult, roles=['FULL_ADMIN'])
     async def do_update(self, id_, data):
         """
         Update initshutdown script task of `id`.

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -428,7 +428,7 @@ class KeychainCredentialService(CRUDService):
             id_,
         )
 
-    @api_method(KeychainCredentialUsedByArgs, KeychainCredentialUsedByResult)
+    @api_method(KeychainCredentialUsedByArgs, KeychainCredentialUsedByResult, roles=['KEYCHAIN_CREDENTIAL_READ'])
     async def used_by(self, id_):
         """
         Returns list of objects that use this credential.

--- a/src/middlewared/middlewared/plugins/pool_/scrub.py
+++ b/src/middlewared/middlewared/plugins/pool_/scrub.py
@@ -182,7 +182,7 @@ class PoolScrubService(CRUDService):
         await self.middleware.call('service.restart', 'cron')
         return response
 
-    @api_method(PoolScrubScrubArgs, PoolScrubScrubResult)
+    @api_method(PoolScrubScrubArgs, PoolScrubScrubResult, roles=['POOL_WRITE'])
     @job(
         description=lambda name, action="START": (
             f"Scrub of pool {name!r}" if action == "START"
@@ -219,7 +219,7 @@ class PoolScrubService(CRUDService):
 
                 await asyncio.sleep(1)
 
-    @api_method(PoolScrubRunArgs, PoolScrubRunResult)
+    @api_method(PoolScrubRunArgs, PoolScrubRunResult, roles=['POOL_WRITE'])
     async def run(self, name, threshold):
         """
         Initiate a scrub of a pool `name` if last scrub was performed more than `threshold` days before.

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -46,6 +46,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         namespace = 'pool.snapshottask'
         cli_namespace = 'task.snapshot'
         entry = PoolSnapshotTaskEntry
+        role_prefix='SNAPSHOT_TASK'
 
     @private
     async def extend_context(self, rows, extra):
@@ -296,7 +297,7 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         return response
 
-    @api_method(PoolSnapshotTaskMaxCountArgs, PoolSnapshotTaskMaxCountResult)
+    @api_method(PoolSnapshotTaskMaxCountArgs, PoolSnapshotTaskMaxCountResult, roles=['SNAPSHOT_TASK_READ'])
     def max_count(self):
         """
         Returns a maximum amount of snapshots (per-dataset) the system can sustain.
@@ -306,7 +307,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         # with too many, then File Explorer will show no snapshots available.
         return 512
 
-    @api_method(PoolSnapshotTaskMaxTotalCountArgs, PoolSnapshotTaskMaxTotalCountResult)
+    @api_method(PoolSnapshotTaskMaxTotalCountArgs, PoolSnapshotTaskMaxTotalCountResult, roles=['SNAPSHOT_TASK_READ'])
     def max_total_count(self):
         """
         Returns a maximum amount of snapshots (total) the system can sustain.
@@ -317,7 +318,7 @@ class PeriodicSnapshotTaskService(CRUDService):
         return 10000
 
     @item_method
-    @api_method(PoolSnapshotTaskRunArgs, PoolSnapshotTaskRunResult)
+    @api_method(PoolSnapshotTaskRunArgs, PoolSnapshotTaskRunResult, roles=['SNAPSHOT_TASK_WRITE'])
     async def run(self, id_):
         """
         Execute a Periodic Snapshot Task of `id`.

--- a/src/middlewared/middlewared/plugins/snapshot_/task_retention.py
+++ b/src/middlewared/middlewared/plugins/snapshot_/task_retention.py
@@ -14,7 +14,8 @@ class PeriodicSnapshotTaskService(Service):
         namespace = "pool.snapshottask"
 
     @item_method
-    @api_method(PoolSnapshotTaskUpdateWillChangeRetentionForArgs, PoolSnapshotTaskUpdateWillChangeRetentionForResult)
+    @api_method(PoolSnapshotTaskUpdateWillChangeRetentionForArgs, PoolSnapshotTaskUpdateWillChangeRetentionForResult,
+		roles=['SNAPSHOT_TASK_READ'])
     async def update_will_change_retention_for(self, id_, data):
         """
         Returns a list of snapshots which will change the retention if periodic snapshot task `id` is updated
@@ -36,7 +37,8 @@ class PeriodicSnapshotTaskService(Service):
         return result
 
     @item_method
-    @api_method(PoolSnapshotTaskDeleteWillChangeRetentionForArgs, PoolSnapshotTaskDeleteWillChangeRetentionForResult)
+    @api_method(PoolSnapshotTaskDeleteWillChangeRetentionForArgs, PoolSnapshotTaskDeleteWillChangeRetentionForResult,
+		roles=['SNAPSHOT_TASK_READ'])
     async def delete_will_change_retention_for(self, id_):
         """
         Returns a list of snapshots which will change the retention if periodic snapshot task `id` is deleted.

--- a/src/middlewared/middlewared/plugins/system/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/system/lifecycle.py
@@ -55,7 +55,7 @@ class SystemService(Service):
             return 'READY'
         return 'BOOTING'
 
-    @api_method(SystemRebootArgs, SystemRebootResult)
+    @api_method(SystemRebootArgs, SystemRebootResult, roles=['FULL_ADMIN'])
     @job()
     @pass_app(rest=True)
     async def reboot(self, app, job, reason, options):
@@ -73,7 +73,7 @@ class SystemService(Service):
 
         await run(['/sbin/shutdown', '-r', 'now'])
 
-    @api_method(SystemShutdownArgs, SystemShutdownResult)
+    @api_method(SystemShutdownArgs, SystemShutdownResult, roles=['FULL_ADMIN'])
     @job()
     @pass_app(rest=True)
     async def shutdown(self, app, job, reason, options):

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -27,8 +27,7 @@ class TrueNASService(Service):
     class Config:
         cli_namespace = 'system.truenas'
 
-    @no_auth_required
-    @api_method(TrueNASManagedByTruecommandArgs, TrueNASManagedByTruecommandResult)
+    @api_method(TrueNASManagedByTruecommandArgs, TrueNASManagedByTruecommandResult, authentication_required=False)
     async def managed_by_truecommand(self):
         """
         Returns whether TrueNAS is being managed by TrueCommand or not.
@@ -40,7 +39,7 @@ class TrueNASService(Service):
             (await self.middleware.call('truecommand.config'))['status']
         ) == TrueCommandStatus.CONNECTED
 
-    @api_method(TrueNASGetChassisHardwareArgs, TrueNASGetChassisHardwareResult)
+    @api_method(TrueNASGetChassisHardwareArgs, TrueNASGetChassisHardwareResult, roles=['READONLY_ADMIN'])
     @cli_private
     @cache
     async def get_chassis_hardware(self):
@@ -77,7 +76,7 @@ class TrueNASService(Service):
         """
         return not os.path.exists(EULA_PENDING_PATH)
 
-    @api_method(TrueNASAcceptEULAArgs, TrueNASAcceptEULAResult)
+    @api_method(TrueNASAcceptEULAArgs, TrueNASAcceptEULAResult, roles=['FULL_ADMIN'])
     def accept_eula(self):
         """
         Accept TrueNAS EULA.
@@ -100,7 +99,7 @@ class TrueNASService(Service):
         """
         return await self.middleware.call('keyvalue.get', 'truenas:production', False)
 
-    @api_method(TrueNASSetProductionArgs, TrueNASSetProductionResult)
+    @api_method(TrueNASSetProductionArgs, TrueNASSetProductionResult, roles=['FULL_ADMIN'])
     @job()
     async def set_production(self, job, production, attach_debug):
         """

--- a/src/middlewared/middlewared/plugins/virt/volume.py
+++ b/src/middlewared/middlewared/plugins/virt/volume.py
@@ -16,6 +16,7 @@ class VirtVolumeService(CRUDService):
         namespace = 'virt.volume'
         cli_namespace = 'virt.volume'
         entry = VirtVolumeEntry
+        role_prefix = 'VIRT_IMAGE'
 
     async def query(self, filters, options):
         config = await self.middleware.call('virt.global.config')
@@ -89,7 +90,7 @@ class VirtVolumeService(CRUDService):
 
         return True
 
-    @api_method(VirtVolumeImportISOArgs, VirtVolumeImportISOResult)
+    @api_method(VirtVolumeImportISOArgs, VirtVolumeImportISOResult, roles=['VIRT_IMAGE_WRITE'])
     @job(lock=lambda args: f'virt_volume_import_iso_{args[0]}', pipes=['input'], check_pipes=False)
     async def import_iso(self, job, data):
         await self.middleware.call('virt.global.check_initialized')

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_legacy_api_method.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_legacy_api_method.py
@@ -35,7 +35,7 @@ class MethodResult(BaseModel):
         return value
 
 
-@api_method(MethodArgs, MethodResult)
+@api_method(MethodArgs, MethodResult, roles=['FULL_ADMIN'])
 def method(number, text, multiplier):
     return {
         "number": number * multiplier,

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -26,6 +26,9 @@ ROLES = {
     'API_KEY_READ': Role(),
     'API_KEY_WRITE': Role(includes=['API_KEY_READ']),
 
+    'BOOT_ENV_READ': Role(),
+    'BOOT_ENV_WRITE': Role(includes=['BOOT_ENV_READ']),
+
     'FAILOVER_READ': Role(),
     'FAILOVER_WRITE': Role(includes=['FAILOVER_READ']),
 
@@ -63,8 +66,13 @@ ROLES = {
 
     'FULL_ADMIN': Role(full_admin=True, builtin=False),
 
-    # Alert roles
+    # Limited ability to read / clear individual alerts
     'ALERT_LIST_READ': Role(),
+    'ALERT_LIST_WRITE': Role(includes=['ALERT_LIST_READ']),
+
+    # Global alert privileges to configure alert plugin
+    'ALERT_READ': Role(includes=['ALERT_LIST_READ']),
+    'ALERT_WRITE': Role(includes=['ALERT_LIST_WRITE', 'ALERT_READ']),
 
     'CLOUD_BACKUP_READ': Role(),
     'CLOUD_BACKUP_WRITE': Role(includes=['CLOUD_BACKUP_READ']),


### PR DESCRIPTION
This commit is in response to regressions that have crept into the product since 24.10 affecting restricted admins roles. To simplify development, middleware will refuse to start if a public api_method is present with the following characteristics:

1. requires authorization
2. requires authentication
3. does not have roles defined

This commit fixes the API definitions of current methods that do not have proper roles definitions.