### PR TITLE
NAS-133235 / 25.04 / Make recovery attempt when initializing directory services

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -186,7 +186,7 @@ class DirectoryServices(Service):
         except Exception:
             self.logger.warning('Cache flush failed', exc_info=True)
 
-        await self.middleware.call('directoryservices.health.check')
+        await self.middleware.call('directoryservices.health.recover')
 
     @private
     def restart_dependent_services(self):


### PR DESCRIPTION
This commit changes us from using a simple health check to actually trying to recover directory services during the initialization step. `directoryservices.health.recover` performs a health check first and so the change here is not large (apart from recovery attempt).