### PR TITLE
NAS-133489 / 25.04 / Revert "disable process pool (#15314)"

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/dataset.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset.py
@@ -15,7 +15,7 @@ class ZFSDatasetService(CRUDService):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = False
+        process_pool = True
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_actions.py
@@ -16,7 +16,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = False
+        process_pool = True
 
     def path_to_dataset(self, path, mntinfo=None):
         """

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_encryption.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_encryption.py
@@ -13,7 +13,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = False
+        process_pool = True
 
     @accepts(
         Ref('query-filters'),

--- a/src/middlewared/middlewared/plugins/zfs_/dataset_quota.py
+++ b/src/middlewared/middlewared/plugins/zfs_/dataset_quota.py
@@ -8,7 +8,7 @@ class ZFSDatasetService(Service):
     class Config:
         namespace = 'zfs.dataset'
         private = True
-        process_pool = False
+        process_pool = True
 
     def query_for_quota_alert(self):
         options = {

--- a/src/middlewared/middlewared/plugins/zfs_/disks.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks.py
@@ -8,7 +8,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = False
+        process_pool = True
 
     def get_disks(self, name):
         sys_devices = {}

--- a/src/middlewared/middlewared/plugins/zfs_/pool.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool.py
@@ -13,7 +13,7 @@ class ZFSPoolService(CRUDService):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = False
+        process_pool = True
 
     @filterable
     def query(self, filters, options):

--- a/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_actions.py
@@ -16,7 +16,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = False
+        process_pool = True
 
     @functools.cache
     def get_search_paths(self):

--- a/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_wait.py
@@ -12,7 +12,7 @@ class ZFSPoolService(Service):
     class Config:
         namespace = 'zfs.pool'
         private = True
-        process_pool = False
+        process_pool = True
 
     @accepts(
         Str('pool_name'),

--- a/src/middlewared/middlewared/plugins/zfs_/snapshot.py
+++ b/src/middlewared/middlewared/plugins/zfs_/snapshot.py
@@ -17,7 +17,7 @@ class ZFSSnapshot(CRUDService):
     class Config:
         datastore_primary_key_type = 'string'
         namespace = 'zfs.snapshot'
-        process_pool = False
+        process_pool = True
         cli_namespace = 'storage.snapshot'
         role_prefix = 'SNAPSHOT'
         role_separate_delete = True

--- a/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
@@ -9,7 +9,7 @@ class ZFSSnapshot(Service):
 
     class Config:
         namespace = 'zfs.snapshot'
-        process_pool = False
+        process_pool = True
 
     @accepts(Dict(
         'snapshot_clone',


### PR DESCRIPTION
Been keeping an eye on an internal system running with these changes the past couple days and parent process memory consumption slowly grows without stopping. Not surprising since we've been here before. Bring back the process pool to alleviate the memory leak issues. This reverts commit 6c1de368b991d2466a06c6593759445c5512cc7f.