### PR TITLE
NAS-133491 / 25.04 / Always add `MOCK` role when running tests

### DIFF
--- a/src/middlewared/middlewared/plugins/test/mock.py
+++ b/src/middlewared/middlewared/plugins/test/mock.py
@@ -36,15 +36,16 @@ class TestService(Service):
         else:
             raise CallError("Invalid mock declaration")
 
-        await self.set_mock_role()
         self.middleware.set_mock(name, args, method)
+
+        await self.middleware.call("alert.oneshot_create", "SystemTesting", None)
 
     async def remove_mock(self, name, args):
         self.middleware.remove_mock(name, args)
 
-    async def set_mock_role(self):
+    async def add_mock_role(self):
         """
-        adds a MOCK role to role_manager and grants access to test.test1 and test.test2
+        Adds a MOCK role to role_manager and grants access to test.test1 and test.test2
 
         This allows testing RBAC against mocked endpoint
         """
@@ -57,7 +58,7 @@ class TestService(Service):
         self.middleware.role_manager.register_method(method_name='test.test1', roles=['MOCK'])
         self.middleware.role_manager.register_method(method_name='test.test2', roles=['MOCK'])
 
-        await self.middleware.call('alert.oneshot_create', 'SystemTesting')
+        await self.middleware.call('alert.oneshot_create', 'SystemTesting', None)
 
     # Dummy methods to mock for internal infrastructure testing (i.e. jobs manager)
     # When these are mocked over they will be available to users with the "MOCK" role.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,9 @@ def log_test_name_to_middlewared_log(request):
     # and the next test start is caused by session/package/module/class
     # fixtures setup code.
     truenas_server.client.call("test.notify_test_end", test_name)
+
+
+@pytest.fixture(autouse=True)
+def mock_role():
+    truenas_server.client.call("test.add_mock_role")
+    yield


### PR DESCRIPTION
Previously, the presence of this role was defined by whether `test.set_mock` was called during the middleware lifetime. This yields to partial tests run failing.