### PR TITLE
NAS-133492 / 24.10.2 / Fix AWS S3 endpoint URL for restic (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -101,7 +101,10 @@ class S3RcloneRemote(BaseRcloneRemote):
     def get_restic_config(self, task):
         url = task["credentials"]["attributes"].get("endpoint", "").rstrip("/")
         if not url:
-            url = "s3.amazonaws.com"
+            if region := task["attributes"].get("region") or task["credentials"]["provider"].get("region"):
+                url = f"s3.{region}.amazonaws.com"
+            else:
+                url = "s3.amazonaws.com"
 
         env = {
             "AWS_ACCESS_KEY_ID": task["credentials"]["attributes"]["access_key_id"],


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c6ea9b5475b12ee8c966ca0fb57d5bdee950dae6

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a13693f9329e2eaafdb692511b7ae9c36a1fcecd



Original PR: https://github.com/truenas/middleware/pull/15354
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133492