### PR TITLE
NAS-133496 / 25.04 / Generate audit trail for when middleware session changes cred

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -118,6 +118,10 @@ class SessionManager:
         if app.authenticated:
             self.sessions[app.session_id].credentials = credentials
             app.authenticated_credentials = credentials
+            await self.middleware.log_audit_message(app, "AUTHENTICATION", {
+                "credentials": dump_credentials(credentials),
+                "error": None,
+            }, True)
             return
 
         session = Session(self, credentials, app)


### PR DESCRIPTION
We were not generating an audit log entry when an authenticated middleware session calls auth.login* endpoints to change its effective credential.