### PR TITLE
NAS-133469 / 25.04 / Add ability for administrator to create onetime passwords

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -1,4 +1,4 @@
-from middlewared.api.base import BaseModel, single_argument_result
+from middlewared.api.base import BaseModel, single_argument_args, single_argument_result
 from middlewared.utils.auth import AuthMech, AuthResp
 from datetime import datetime
 from pydantic import Field, Secret
@@ -211,3 +211,12 @@ class AuthSetAttributeArgs(BaseModel):
 
 class AuthSetAttributeResult(BaseModel):
     result: Literal[None]
+
+
+@single_argument_args('generate_single_use_password')
+class AuthGenerateOnetimePasswordArgs(BaseModel):
+    username: str
+
+
+class AuthGenerateOnetimePasswordResult(BaseModel):
+    result: str

--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -11,6 +11,7 @@ from time import monotonic
 
 class SessionManagerCredentials:
     is_user_session = False
+    may_create_auth_token = True
     allowlist = None
 
     @classmethod
@@ -71,6 +72,7 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
         self.last_used_at = now
 
         if assurance:
+            self.may_create_auth_token = AuthMech.TOKEN_PLAIN in assurance.mechanisms
             self.expiry = now + self.assurance.max_session_age
             self.inactivity_timeout = self.assurance.max_inactivity
 
@@ -146,6 +148,15 @@ class LoginTwofactorSessionManagerCredentials(LoginPasswordSessionManagerCredent
     OTP token.
     """
     pass
+
+
+class LoginOnetimePasswordSessionManagerCredentials(UserSessionManagerCredentials):
+    """ Credentials for a specific user account  on TrueNAS
+    Authenticated by username + onetime password ccombination
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.may_create_auth_token = False
 
 
 class TokenSessionManagerCredentials(SessionManagerCredentials):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -19,22 +19,23 @@ from middlewared.api.current import (
     AuthSetAttributeArgs, AuthSetAttributeResult,
     AuthTerminateSessionArgs, AuthTerminateSessionResult,
     AuthTerminateOtherSessionsArgs, AuthTerminateOtherSessionsResult,
+    AuthGenerateOnetimePasswordArgs, AuthGenerateOnetimePasswordResult,
 )
 from middlewared.auth import (UserSessionManagerCredentials, UnixSocketSessionManagerCredentials,
                               ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials,
                               LoginTwofactorSessionManagerCredentials, AuthenticationContext,
                               TruenasNodeSessionManagerCredentials, TokenSessionManagerCredentials,
-                              dump_credentials)
+                              LoginOnetimePasswordSessionManagerCredentials, dump_credentials)
 from middlewared.plugins.account_.constants import MIDDLEWARE_PAM_SERVICE, MIDDLEWARE_PAM_API_KEY_SERVICE
 from middlewared.service import (
     Service, filterable_api_method, filter_list,
     pass_app, private, cli_private, CallError,
 )
-from middlewared.service_exception import MatchNotFound
+from middlewared.service_exception import MatchNotFound, ValidationError
 import middlewared.sqlalchemy as sa
 from middlewared.utils.auth import (
     aal_auth_mechanism_check, AuthMech, AuthResp, AuthenticatorAssuranceLevel, AA_LEVEL1,
-    AA_LEVEL2, AA_LEVEL3, CURRENT_AAL, MAX_OTP_ATTEMPTS,
+    AA_LEVEL2, AA_LEVEL3, CURRENT_AAL, MAX_OTP_ATTEMPTS, OTPW_MANAGER,
 )
 from middlewared.utils.crypto import generate_token
 from middlewared.utils.time_utils import utc_now
@@ -302,6 +303,25 @@ class AuthService(Service):
 
         return True
 
+    @api_method(
+        AuthGenerateOnetimePasswordArgs, AuthGenerateOnetimePasswordResult,
+        roles=['ACCOUNT_WRITE'],
+        audit='Generate onetime password for user'
+    )
+    def generate_onetime_password(self, data):
+        """
+        Generate a password for the specified username that may be used only a single time to authenticate
+        to TrueNAS. This may be used by server administrators to allow users authenticate and then set
+        a proper password and two-factor authentication token.
+        """
+        username = data['username']
+        user_data = self.middleware.call_sync('user.query', [['username', '=', username]])
+        if not user_data:
+            raise ValidationError('auth.generate_onetime_password.username', f'{username}: user does not exist.')
+
+        passwd = OTPW_MANAGER.generate_for_uid(user_data[0]['uid'])
+        return passwd
+
     @api_method(AuthGenerateTokenArgs, AuthGenerateTokenResult, authorization_required=False)
     @pass_app(rest=True)
     def generate_token(self, app, ttl, attrs, match_origin):
@@ -321,6 +341,13 @@ class AuthService(Service):
         if CURRENT_AAL.level != AA_LEVEL1:
             raise CallError(
                 'Authentication tokens are not supported at current authenticator level.',
+                errno.EOPNOTSUPP
+            )
+
+        if app and not app.authenticated_credentials.may_create_auth_token:
+            raise CallError(
+                f'{app.authenticated_credentials.class_name()}: the current session type does '
+                'not support creation of authentication tokens.',
                 errno.EOPNOTSUPP
             )
 
@@ -638,12 +665,14 @@ class AuthService(Service):
             case AuthMech.PASSWORD_PLAIN:
                 # Both of these mechanisms are de-factor username + password
                 # combinations and pass through libpam.
+                cred_type = 'LOGIN_PASSWORD'
                 resp = await self.get_login_user(
                     app,
                     data['username'],
                     data['password'],
                     mechanism
                 )
+
                 if resp['otp_required']:
                     # A one-time password is required for this user account and so
                     # we should request it from API client.
@@ -653,6 +682,8 @@ class AuthService(Service):
                         'response_type': AuthResp.OTP_REQUIRED,
                         'username': resp['user_data']['username']
                     }
+                elif resp['otpw_used']:
+                    cred_type = 'ONETIME_PASSWORD'
                 elif CURRENT_AAL.level.otp_mandatory:
                     if resp['pam_response'] == 'SUCCESS':
                         # Insert a failure delay so that we don't leak information about
@@ -665,12 +696,16 @@ class AuthService(Service):
 
                 match resp['pam_response']['code']:
                     case pam.PAM_SUCCESS:
-                        cred = LoginPasswordSessionManagerCredentials(resp['user_data'], CURRENT_AAL.level)
+                        if cred_type == 'ONETIME_PASSWORD':
+                            cred = LoginOnetimePasswordSessionManagerCredentials(resp['user_data'], CURRENT_AAL.level)
+                        else:
+                            cred = LoginPasswordSessionManagerCredentials(resp['user_data'], CURRENT_AAL.level)
+
                         await login_fn(app, cred)
                     case pam.PAM_AUTH_ERR:
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
-                                'credentials': 'LOGIN_PASSWORD',
+                                'credentials': cred_type,
                                 'credentials_data': {'username': data['username']},
                             },
                             'error': 'Bad username or password'
@@ -678,10 +713,10 @@ class AuthService(Service):
                     case _:
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
-                                'credentials': 'LOGIN_PASSWORD',
+                                'credentials': cred_type,
                                 'credentials_data': {'username': data['username']},
                             },
-                            'error': resp['pam_response']['reason']
+                            'error': resp['pam_response']['reason'] or resp['pam_response']['otpw_response']
                         }, False)
 
             case AuthMech.API_KEY_PLAIN:
@@ -890,6 +925,8 @@ class AuthService(Service):
         combination and returns user information and whether additional OTP is required.
         """
         otp_required = False
+        otpw_used = False
+
         resp = await self.middleware.call(
             'auth.authenticate_plain',
             username, password,
@@ -897,11 +934,14 @@ class AuthService(Service):
             app=app
         )
         if mechanism == AuthMech.PASSWORD_PLAIN and resp['pam_response']['code'] == pam.PAM_SUCCESS:
-            twofactor_auth = await self.middleware.call('auth.twofactor.config')
-            if twofactor_auth['enabled'] and '2FA' in resp['user_data']['account_attributes']:
-                otp_required = True
+            if 'OTPW' in resp['user_data']['account_attributes']:
+                otpw_used = True
+            else:
+                twofactor_auth = await self.middleware.call('auth.twofactor.config')
+                if twofactor_auth['enabled'] and '2FA' in resp['user_data']['account_attributes']:
+                    otp_required = True
 
-        return resp | {'otp_required': otp_required}
+        return resp | {'otp_required': otp_required, 'otpw_used': otpw_used}
 
     @cli_private
     @api_method(AuthLegacyApiKeyLoginArgs, AuthLoginResult, authentication_required=False)
@@ -1055,7 +1095,7 @@ async def check_permission(middleware, app):
                 query = {'uid': origin.uid}
                 user_info = {'id': None, 'uid': None, 'local': False}
 
-            user = await middleware.call('auth.authenticate_user', query, user_info, False)
+            user = await middleware.call('auth.authenticate_user', query, user_info, None)
             if user is None:
                 return
 

--- a/tests/api2/test_auth_onetime.py
+++ b/tests/api2/test_auth_onetime.py
@@ -1,0 +1,63 @@
+import errno
+import pytest
+
+from middlewared.service_exception import CallError
+from middlewared.test.integration.utils import client, call
+
+
+@pytest.fixture(scope='module')
+def onetime_password_user(unprivileged_user_fixture):
+    yield unprivileged_user_fixture
+
+
+@pytest.fixture(scope='function')
+def onetime_password(onetime_password_user):
+    otpw = call('auth.generate_onetime_password', {'username': onetime_password_user.username})
+    yield (onetime_password_user, otpw)
+
+
+def test_basic_onetime_password_auth(onetime_password):
+    user, otpw = onetime_password
+    with client(auth=None) as c:
+        resp = c.call('auth.login_ex', {
+            'mechanism': 'PASSWORD_PLAIN',
+            'username': user.username,
+            'password': otpw
+        })
+        assert resp['response_type'] == 'SUCCESS'
+        assert 'OTPW' in resp['user_info']['account_attributes']
+
+
+def test_onetime_password_auth_reuse_fail(onetime_password):
+    user, otpw = onetime_password
+    with client(auth=None) as c:
+        resp = c.call('auth.login_ex', {
+            'mechanism': 'PASSWORD_PLAIN',
+            'username': user.username,
+            'password': otpw
+        })
+        assert resp['response_type'] == 'SUCCESS'
+        assert 'OTPW' in resp['user_info']['account_attributes']
+
+        resp = c.call('auth.login_ex', {
+            'mechanism': 'PASSWORD_PLAIN',
+            'username': user.username,
+            'password': otpw
+        })
+        assert resp['response_type'] == 'AUTH_ERR'
+
+
+def test_onetime_password_generate_token_fail(onetime_password):
+    user, otpw = onetime_password
+    with client(auth=None) as c:
+        resp = c.call('auth.login_ex', {
+            'mechanism': 'PASSWORD_PLAIN',
+            'username': user.username,
+            'password': otpw
+        })
+        assert resp['response_type'] == 'SUCCESS'
+
+        with pytest.raises(CallError) as ce:
+            c.call('auth.generate_token')
+
+        assert ce.value.errno == errno.EOPNOTSUPP

--- a/tests/unit/test_otpw_manager.py
+++ b/tests/unit/test_otpw_manager.py
@@ -1,0 +1,51 @@
+from middlewared.utils.auth import OTPW_MANAGER, OTPWResponse
+
+
+def test__auth_success():
+    passwd = OTPW_MANAGER.generate_for_uid(1000)
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.SUCCESS
+
+
+def test__auth_used():
+    passwd = OTPW_MANAGER.generate_for_uid(1000)
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.SUCCESS
+
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.ALREADY_USED
+
+
+def test__auth_nokey():
+    resp = OTPW_MANAGER.authenticate(1000, '80000_canary')
+    assert resp is OTPWResponse.NO_KEY
+
+
+def test__auth_bad_passkey():
+    passwd = OTPW_MANAGER.generate_for_uid(1000)
+    resp = OTPW_MANAGER.authenticate(1000, passwd + 'bad')
+    assert resp is OTPWResponse.BAD_PASSKEY
+
+    # This shouldn't prevent using correct passkey
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.SUCCESS
+
+
+def test__auth_wrong_user():
+    passwd = OTPW_MANAGER.generate_for_uid(1000)
+    resp = OTPW_MANAGER.authenticate(1001, passwd)
+    assert resp is OTPWResponse.WRONG_USER
+
+    # This shouldn't prevent correct user
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.SUCCESS
+
+
+def test__auth_expired():
+    passwd = OTPW_MANAGER.generate_for_uid(1000)
+    idx, plaintext = passwd.split('_')
+
+    OTPW_MANAGER.otpasswd[idx].expires = 1
+
+    resp = OTPW_MANAGER.authenticate(1000, passwd)
+    assert resp is OTPWResponse.EXPIRED


### PR DESCRIPTION
This commit adds an API endpoint for administrator with ACCOUNT_WRITE privileges to create single-use passwords for user accounts that allow the user to authenticate to the truenas server. This is needed for STIG environments to allow administrators to help with creating new user accounts so that the user can authenticate to the TrueNAS server in order to configure two-factor authentication.

The single-use password may be used with the auth.login_ex mechanism ONETIME_PASSWORD.