### PR TITLE
NAS-132518 / 25.04 / fix SED disk unlock at boot

### DIFF
--- a/debian/debian/ix-zfs.service
+++ b/debian/debian/ix-zfs.service
@@ -3,7 +3,16 @@ Description=Import ZFS pools
 DefaultDependencies=no
 Before=network-pre.target
 Before=local-fs.target
-After=middlewared.service
+# it's imperative that this service
+# Requires AND starts AFTER ix-syncdisks.service
+# because disk.sed_unlock_all uses
+# our database and the syncdisks.service
+# is responsible for updating the database
+# with any changes that could have occurred
+# between last boot and next boot
+# (i.e. /dev/sda could now be /dev/sdg)
+Requires=ix-syncdisks.service
+After=middlewared.service ix-syncdisks.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Internally, we have a system where device names for disks (i.e. `sda`) are changing on boot. This isn't that surprising since the kernel doesn't guarantee uniqueness. However, it is surprising when the device name changes and `sed_unlock_all` doesn't even _attempt_ to unlock the disk whose name changed.

After reproducing this in-house 100% of the time, I found that `disk.sed_unlock_all` is being called _before_ `disk.sync_all` is complete. To remedy the situation, I correct boot dependencies for the systemd.unit service files.