### PR TITLE
NAS-133443 / 25.04 / Only retrieve aggregated CPU temperature

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -6,6 +6,7 @@ from middlewared.utils.disks import get_disk_names, get_disks_with_identifiers
 from middlewared.validators import Range
 
 from .realtime_reporting import get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info
+from .realtime_reporting.utils import safely_retrieve_dimension
 
 
 class RealtimeEventSource(EventSource):
@@ -105,7 +106,9 @@ class RealtimeEventSource(EventSource):
                 }
 
                 # CPU temperature
-                data['cpu']['temperature_celsius'] = self.middleware.call_sync('reporting.cpu_temperatures') or None
+                data['cpu']['temperature_celsius'] = safely_retrieve_dimension(
+                    netdata_metrics, 'cputemp.temp', 'cpu_temp',
+                ) or None
 
             self.send_event('ADDED', fields=data)
             time.sleep(interval)

--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -29,7 +29,7 @@ class CPUTempPlugin(GraphBase):
     skip_zero_values_in_aggregation = True
 
     def get_chart_name(self, identifier: typing.Optional[str]) -> str:
-        return 'cputemp.temperatures'
+        return 'cputemp.temp'
 
 
 class MemoryPlugin(GraphBase):

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -122,7 +122,7 @@ def get_metrics_approximation(
             'cpu.usage': core_count + 1,
 
             # cputemp
-            'cputemp.temperatures': core_count,
+            'cputemp.temp': 1,
 
             # ups
             'nut_ups.charge': 1,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 10, 2, {1: 708, 60: 4}),
-    (1600, 32, 4, 10, 1, {1: 8763, 60: 1600}),
-    (10, 16, 2, 12, 3, {1: 847, 60: 10}),
+    (4, 2, 1, 10, 2, {1: 707, 60: 4}),
+    (1600, 32, 4, 10, 1, {1: 8732, 60: 1600}),
+    (10, 16, 2, 12, 3, {1: 832, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, services_count, vms_count, expected_output
@@ -19,14 +19,14 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 10, 2, 7, 1, 1, 408),
+        (4, 2, 1, 10, 2, 7, 1, 1, 407),
         (4, 2, 1, 10, 1, 7, 4, 60, 25),
-        (1600, 32, 4, 2, 4, 4, 1, 1, 2928),
-        (1600, 32, 4, 1, 4, 4, 4, 900, 13),
-        (10, 16, 2, 12, 1, 3, 1, 1, 185),
+        (1600, 32, 4, 2, 4, 4, 1, 1, 2918),
+        (1600, 32, 4, 1, 4, 4, 4, 900, 12),
+        (10, 16, 2, 12, 1, 3, 1, 1, 181),
         (10, 16, 2, 10, 3, 3, 4, 60, 13),
-        (1600, 32, 4, 12, 3, 18, 1, 1, 13196),
-        (1600, 32, 4, 12, 1, 18, 4, 900, 58),
+        (1600, 32, 4, 12, 3, 18, 1, 1, 13150),
+        (1600, 32, 4, 12, 1, 18, 4, 900, 57),
     ],
 )
 def test_netdata_disk_space_approximation(


### PR DESCRIPTION
## Context

It was requested by UI that they don't require per core temperature anymore and changes have been made to only have aggregated CPU temperature saved of all cores and similarly retrieved instead of having all the temperature data serialized per core.