### PR TITLE
NAS-133510 / 24.10.2 / Improve error message when an app fails to install (by stavros-k)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -54,6 +54,8 @@ def compose_action(
     cp = run(['docker', 'compose'] + compose_files + args, timeout=1200)
     if cp.returncode != 0:
         logger.error('Failed %r action for %r app: %s', action, app_name, cp.stderr)
-        raise CallError(
-            f'Failed {action!r} action for {app_name!r} app, please check /var/log/app_lifecycle.log for more details'
-        )
+        err_msg = f'Failed {action!r} action for {app_name!r} app.'
+        if 'toomanyrequests: You have reached your pull rate limit.' in cp.stderr:
+            err_msg += ' It appears you have reached your pull rate limit. Please try again later.'
+        err_msg += ' Please check /var/log/app_lifecycle.log for more details'
+        raise CallError(err_msg)

--- a/src/middlewared/middlewared/plugins/apps/compose_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/compose_utils.py
@@ -55,7 +55,7 @@ def compose_action(
     if cp.returncode != 0:
         logger.error('Failed %r action for %r app: %s', action, app_name, cp.stderr)
         err_msg = f'Failed {action!r} action for {app_name!r} app.'
-        if 'toomanyrequests: You have reached your pull rate limit.' in cp.stderr:
+        if 'toomanyrequests:' in cp.stderr:
             err_msg += ' It appears you have reached your pull rate limit. Please try again later.'
         err_msg += ' Please check /var/log/app_lifecycle.log for more details'
         raise CallError(err_msg)


### PR DESCRIPTION
Improves error message when a rate limit is detected.
There are lots of tickets where the generic message to look in the log file appears.
But its just the rate limit making the app install fail.

Example: https://ixsystems.atlassian.net/browse/NAS-133507

Original PR: https://github.com/truenas/middleware/pull/15371
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133510