### PR TITLE
NAS-133437 / 25.04 / Better handle docker not starting on boot when on HDDs

### DIFF
--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,8 +1,6 @@
 [Unit]
-# If the service fails mroe than once in 10 secs without
-# ever hitting an active state, we will have systemd to stop retrying
 StartLimitBurst=1
-StartLimitIntervalSec=10
+StartLimitIntervalSec=910
 
 [Service]
 ExecStartPost=/bin/sh -c "iptables -P FORWARD ACCEPT && ip6tables -P FORWARD ACCEPT"

--- a/src/freenas/etc/systemd/system/docker.service.d/override.conf
+++ b/src/freenas/etc/systemd/system/docker.service.d/override.conf
@@ -1,2 +1,11 @@
+[Unit]
+# If the service fails mroe than once in 10 secs without
+# ever hitting an active state, we will have systemd to stop retrying
+StartLimitBurst=1
+StartLimitIntervalSec=10
+
 [Service]
 ExecStartPost=/bin/sh -c "iptables -P FORWARD ACCEPT && ip6tables -P FORWARD ACCEPT"
+TimeoutStartSec=900
+TimeoutStartFailureMode=terminate
+Restart=on-failure

--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -24,9 +24,10 @@ class DockerService(SimpleService):
     async def start(self):
         try:
             await super().start()
-            timeout = 120  # We have this at 120 because HDDs are notorious and docker can take more time there
-            # First time when docker is started, it takes a bit more time to initialise itself properly
-            # and we need to have sleep here so that after start is called post_start is not dismissed
+            # We have a timeout for docker to start within 15 minutes of the above call, if that doesn't happen
+            # then we get into a failed start that docker failed to start. This has been necessary because
+            # HDDs have been notorious and can take quite some time for docker to start on boot.
+            timeout = 8 * 60  # We do 8 because we sleep for 2 secs - so in total it is 16 minutes
             while timeout > 0:
                 if not await self.middleware.call('service.started', 'docker'):
                     await asyncio.sleep(2)


### PR DESCRIPTION
This PR adds changes to better handle docker state when HDDs are being used for apps. Basically what was happening was that when HDDs based pool is being used for starting apps, it can take a few minutes to get apps to start - while we were waiting for 2 minutes earlier and then setting our status to failure. Now systemd would after a few minutes have docker start just fine but middleware would report it as being in failed state.
The changes being done here have made sure that middleware reflects systemd status and systemd fails docker service after 15 minutes of waiting for it to start (earlier docker had removed the systemd time limit which meant systemd would not have been marking it as failed to start and would wait). 