### PR TITLE
NAS-132669 / 25.04 / Make `parse_message` ensure that the message is a dict

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -283,13 +283,9 @@ class RpcWebSocketHandler(BaseWebSocketHandler):
         except KeyError:
             message["params"] = []
 
-    async def process_message(self, app: RpcWebSocketApp, message: Any):
+    async def process_message(self, app: RpcWebSocketApp, message: dict):
         try:
             await self.validate_message(message)
-        except TypeError:
-            # TypeError here means message doesn't adhere to minimum
-            # format of the message (i.e. needs to be a dict)
-            app.send_error(None, JSONRPCError.INVALID_REQUEST.value, "Invalid Message Format")
         except ValueError as e:
             if (id_ := message.get("id", undefined)) != undefined:
                 app.send_error(id_, JSONRPCError.INVALID_REQUEST.value, str(e))

--- a/src/middlewared/middlewared/pytest/unit/api/base/server/test_ws_handler.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/server/test_ws_handler.py
@@ -87,12 +87,7 @@ from middlewared.api.base.server.ws_handler.rpc import RpcWebSocketHandler
             ValueError,
         ),
         # fuzzy
-        ("", TypeError),
         ({}, ValueError),
-        (None, TypeError),
-        ([], TypeError),
-        (["bad"], TypeError),
-        (b"bad", TypeError),
     ],
 )
 @pytest.mark.asyncio

--- a/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
@@ -64,4 +64,4 @@ def test__invalid_type__list():
     with pytest.raises(ValueError) as ve:
         limits.parse_message(True, json.dumps([]))
 
-    assert ve.value.args[0] == "Batch messages are not supported yet"
+    assert ve.value.args[0] == "Batch messages are not supported at this time"

--- a/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
@@ -1,7 +1,8 @@
-import pytest
 import json
 
 from aiohttp.http_websocket import WSCloseCode
+import pytest
+
 from middlewared.utils import limits
 
 
@@ -49,3 +50,11 @@ def test__limit_authenticated_parse():
     data = {'msg': 'method', 'method': 'canary', 'params': ['x' * 1000]}
     parsed = limits.parse_message(True, json.dumps(data))
     assert parsed == data
+
+
+@pytest.mark.parametrize("value", [False, 0, "0", []])
+def test__invalid_type(value):
+    with pytest.raises(ValueError) as ve:
+        limits.parse_message(True, json.dumps(value))
+
+    assert ve.value.args[0] == "Invalid Message Format"

--- a/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_limits.py
@@ -52,9 +52,16 @@ def test__limit_authenticated_parse():
     assert parsed == data
 
 
-@pytest.mark.parametrize("value", [False, 0, "0", []])
+@pytest.mark.parametrize("value", [False, 0, "0"])
 def test__invalid_type(value):
     with pytest.raises(ValueError) as ve:
         limits.parse_message(True, json.dumps(value))
 
     assert ve.value.args[0] == "Invalid Message Format"
+
+
+def test__invalid_type__list():
+    with pytest.raises(ValueError) as ve:
+        limits.parse_message(True, json.dumps([]))
+
+    assert ve.value.args[0] == "Batch messages are not supported yet"

--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -8,9 +8,9 @@ from truenas_api_client import json as ejson
 
 
 # WARNING: below methods must _not_ be audited. c.f. comment in parse_message() below
-MSG_SIZE_EXTENDED_METHODS = set((
+MSG_SIZE_EXTENDED_METHODS = frozenset(
     'filesystem.file_receive',
-))
+)
 
 
 class MsgSizeLimit(enum.IntEnum):
@@ -39,7 +39,7 @@ class MsgSizeError(Exception):
 
 def parse_message(authenticated: bool, msg_data: str) -> dict:
     """
-    Check given message to determine whether it exceeds size limits
+    Parses the JSON message and ensures that it is a dict, and it does not exceed size limits.
 
     WARNING: RFC5424 (syslog) specifies that SDATA of message should never
     exceed 64 KiB. The default syslog-ng configuration will not parse messages
@@ -71,7 +71,12 @@ def parse_message(authenticated: bool, msg_data: str) -> dict:
 
     message = ejson.loads(msg_data)
 
-    if (method := message.get('method')) in MSG_SIZE_EXTENDED_METHODS:
+    try:
+        method = message.get('method')
+    except Exception:
+        raise ValueError('Invalid Message Format')
+
+    if method in MSG_SIZE_EXTENDED_METHODS:
         return message
 
     if datalen > MsgSizeLimit.AUTHENTICATED:

--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -74,6 +74,9 @@ def parse_message(authenticated: bool, msg_data: str) -> dict:
     try:
         method = message.get('method')
     except Exception:
+        if isinstance(message, list):
+            raise ValueError('Batch messages are not supported yet')
+
         raise ValueError('Invalid Message Format')
 
     if method in MSG_SIZE_EXTENDED_METHODS:

--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -75,7 +75,7 @@ def parse_message(authenticated: bool, msg_data: str) -> dict:
         method = message.get('method')
     except Exception:
         if isinstance(message, list):
-            raise ValueError('Batch messages are not supported yet')
+            raise ValueError('Batch messages are not supported at this time')
 
         raise ValueError('Invalid Message Format')
 


### PR DESCRIPTION
The following traceback occurred when the message was `[]`:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/aiohttp/web_protocol.py", line 477, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_middlewares.py", line 105, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_urldispatcher.py", line 210, in handler_wrapper
    result = await result
             ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/base.py", line 32, in __call__
    await self.process(origin, ws)
  File "/usr/lib/python3/dist-packages/middlewared/api/base/server/ws_handler/rpc.py", line 211, in process
    message = parse_message(app.authenticated, msg.data)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/limits.py", line 74, in parse_message
    if (method := message.get('method')) in MSG_SIZE_EXTENDED_METHODS:
                  ^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```