### PR TITLE
NAS-133536 / 25.04 / Add iSER to rdma.capable_protocols

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -42,4 +42,4 @@ class RdmaCapableProtocolsArgs(BaseModel):
 
 
 class RdmaCapableProtocolsResult(BaseModel):
-    result: list[Literal["NFS"]]
+    result: list[Literal["iSER", "NFS"]]

--- a/src/middlewared/middlewared/api/v25_04_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma.py
@@ -42,4 +42,4 @@ class RdmaCapableProtocolsArgs(BaseModel):
 
 
 class RdmaCapableProtocolsResult(BaseModel):
-    result: list[Literal["iSER", "NFS"]]
+    result: list[Literal["ISER", "NFS"]]

--- a/src/middlewared/middlewared/plugins/rdma/constants.py
+++ b/src/middlewared/middlewared/plugins/rdma/constants.py
@@ -3,7 +3,7 @@ import enum
 
 class RDMAprotocols(enum.Enum):
     NFS = 'NFS'
-    ISER = 'iSER'
+    ISER = 'ISER'
 
     def values():
         return [a.value for a in RDMAprotocols]

--- a/src/middlewared/middlewared/plugins/rdma/rdma.py
+++ b/src/middlewared/middlewared/plugins/rdma/rdma.py
@@ -132,5 +132,5 @@ class RDMAService(Service):
         is_ent = await self.middleware.call('system.is_enterprise')
         if is_ent and 'MINI' not in await self.middleware.call('truenas.get_chassis_hardware'):
             if await self.middleware.call('rdma.get_link_choices', True):
-                result.append(RDMAprotocols.NFS.value)
+                result.extend([RDMAprotocols.NFS.value, RDMAprotocols.ISER.value])
         return result


### PR DESCRIPTION
Add `iSER` to `rdma.capable_protocols`, using the same criteria as for `NFS(/RDMA)`.