### PR TITLE
NAS-133501 / 25.04 / expose r-series drive identify

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/slot_mappings.py
@@ -381,7 +381,7 @@ def get_slot_info(enc):
                 'DEFAULT': {
                     'model': {
                         enc.model: {
-                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: False}
+                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
                             for i in range(1, 25)
                         },
                     }
@@ -399,12 +399,12 @@ def get_slot_info(enc):
                     'product': {
                         'eDrawer4048S1': {
                             # 1 - 24
-                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: False}
+                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: i, SUPPORTS_IDENTIFY_KEY: True}
                             for i in range(1, 25)
                         },
                         'eDrawer4048S2': {
                             # 25 - 48
-                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: False}
+                            i: {SYSFS_SLOT_KEY: i - 1, MAPPED_SLOT_KEY: j, SUPPORTS_IDENTIFY_KEY: True}
                             for i, j in zip(range(1, 25), range(25, 49))
                         }
                     },
@@ -418,22 +418,22 @@ def get_slot_info(enc):
                 'DEFAULT': {
                     'model': {
                         enc.model: {
-                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: False},
-                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: False},
-                            9: {SYSFS_SLOT_KEY: 8, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: False},
-                            13: {SYSFS_SLOT_KEY: 12, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: False},
-                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
-                            6: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
-                            10: {SYSFS_SLOT_KEY: 9, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False},
-                            14: {SYSFS_SLOT_KEY: 13, MAPPED_SLOT_KEY: 8, SUPPORTS_IDENTIFY_KEY: False},
-                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 9, SUPPORTS_IDENTIFY_KEY: False},
-                            7: {SYSFS_SLOT_KEY: 6, MAPPED_SLOT_KEY: 10, SUPPORTS_IDENTIFY_KEY: False},
-                            11: {SYSFS_SLOT_KEY: 10, MAPPED_SLOT_KEY: 11, SUPPORTS_IDENTIFY_KEY: False},
-                            15: {SYSFS_SLOT_KEY: 14, MAPPED_SLOT_KEY: 12, SUPPORTS_IDENTIFY_KEY: False},
-                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 13, SUPPORTS_IDENTIFY_KEY: False},
-                            8: {SYSFS_SLOT_KEY: 7, MAPPED_SLOT_KEY: 14, SUPPORTS_IDENTIFY_KEY: False},
-                            12: {SYSFS_SLOT_KEY: 11, MAPPED_SLOT_KEY: 15, SUPPORTS_IDENTIFY_KEY: False},
-                            16: {SYSFS_SLOT_KEY: 15, MAPPED_SLOT_KEY: 16, SUPPORTS_IDENTIFY_KEY: False}
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: True},
+                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: True},
+                            9: {SYSFS_SLOT_KEY: 8, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: True},
+                            13: {SYSFS_SLOT_KEY: 12, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: True},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: True},
+                            6: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: True},
+                            10: {SYSFS_SLOT_KEY: 9, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: True},
+                            14: {SYSFS_SLOT_KEY: 13, MAPPED_SLOT_KEY: 8, SUPPORTS_IDENTIFY_KEY: True},
+                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 9, SUPPORTS_IDENTIFY_KEY: True},
+                            7: {SYSFS_SLOT_KEY: 6, MAPPED_SLOT_KEY: 10, SUPPORTS_IDENTIFY_KEY: True},
+                            11: {SYSFS_SLOT_KEY: 10, MAPPED_SLOT_KEY: 11, SUPPORTS_IDENTIFY_KEY: True},
+                            15: {SYSFS_SLOT_KEY: 14, MAPPED_SLOT_KEY: 12, SUPPORTS_IDENTIFY_KEY: True},
+                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 13, SUPPORTS_IDENTIFY_KEY: True},
+                            8: {SYSFS_SLOT_KEY: 7, MAPPED_SLOT_KEY: 14, SUPPORTS_IDENTIFY_KEY: True},
+                            12: {SYSFS_SLOT_KEY: 11, MAPPED_SLOT_KEY: 15, SUPPORTS_IDENTIFY_KEY: True},
+                            16: {SYSFS_SLOT_KEY: 15, MAPPED_SLOT_KEY: 16, SUPPORTS_IDENTIFY_KEY: True}
                         }
                     }
                 }
@@ -477,18 +477,18 @@ def get_slot_info(enc):
                 'DEFAULT': {
                     'model': {
                         enc.model: {
-                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: False},
-                            6: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: False},
-                            9: {SYSFS_SLOT_KEY: 8, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: False},
-                            12: {SYSFS_SLOT_KEY: 11, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: False},
-                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: False},
-                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: False},
-                            8: {SYSFS_SLOT_KEY: 7, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: False},
-                            11: {SYSFS_SLOT_KEY: 10, MAPPED_SLOT_KEY: 8, SUPPORTS_IDENTIFY_KEY: False},
-                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 9, SUPPORTS_IDENTIFY_KEY: False},
-                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 10, SUPPORTS_IDENTIFY_KEY: False},
-                            7: {SYSFS_SLOT_KEY: 6, MAPPED_SLOT_KEY: 11, SUPPORTS_IDENTIFY_KEY: False},
-                            10: {SYSFS_SLOT_KEY: 9, MAPPED_SLOT_KEY: 12, SUPPORTS_IDENTIFY_KEY: False}
+                            3: {SYSFS_SLOT_KEY: 2, MAPPED_SLOT_KEY: 1, SUPPORTS_IDENTIFY_KEY: True},
+                            6: {SYSFS_SLOT_KEY: 5, MAPPED_SLOT_KEY: 2, SUPPORTS_IDENTIFY_KEY: True},
+                            9: {SYSFS_SLOT_KEY: 8, MAPPED_SLOT_KEY: 3, SUPPORTS_IDENTIFY_KEY: True},
+                            12: {SYSFS_SLOT_KEY: 11, MAPPED_SLOT_KEY: 4, SUPPORTS_IDENTIFY_KEY: True},
+                            2: {SYSFS_SLOT_KEY: 1, MAPPED_SLOT_KEY: 5, SUPPORTS_IDENTIFY_KEY: True},
+                            5: {SYSFS_SLOT_KEY: 4, MAPPED_SLOT_KEY: 6, SUPPORTS_IDENTIFY_KEY: True},
+                            8: {SYSFS_SLOT_KEY: 7, MAPPED_SLOT_KEY: 7, SUPPORTS_IDENTIFY_KEY: True},
+                            11: {SYSFS_SLOT_KEY: 10, MAPPED_SLOT_KEY: 8, SUPPORTS_IDENTIFY_KEY: True},
+                            1: {SYSFS_SLOT_KEY: 0, MAPPED_SLOT_KEY: 9, SUPPORTS_IDENTIFY_KEY: True},
+                            4: {SYSFS_SLOT_KEY: 3, MAPPED_SLOT_KEY: 10, SUPPORTS_IDENTIFY_KEY: True},
+                            7: {SYSFS_SLOT_KEY: 6, MAPPED_SLOT_KEY: 11, SUPPORTS_IDENTIFY_KEY: True},
+                            10: {SYSFS_SLOT_KEY: 9, MAPPED_SLOT_KEY: 12, SUPPORTS_IDENTIFY_KEY: True}
                         }
                     },
                     'id': {


### PR DESCRIPTION
This enables drive identify on the r10, r20a, r40, r50/b/bm platforms per discussion with QE and platform teams.