### PR TITLE
NAS-133570 / 25.04 / define roles for registered middleware events

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -453,5 +453,6 @@ class PrivilegeService(CRUDService):
 async def setup(middleware):
     middleware.event_register(
         'user.web_ui_login_disabled',
-        'Sent when root user login to the Web UI is disabled.'
+        'Sent when root user login to the Web UI is disabled.',
+        roles=['FULL_ADMIN']
     )

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -1063,5 +1063,5 @@ async def check_permission(middleware, app):
 
 
 def setup(middleware):
-    middleware.event_register('auth.sessions', 'Notification of new and removed sessions.')
+    middleware.event_register('auth.sessions', 'Notification of new and removed sessions.', roles=['FULL_ADMIN'])
     middleware.register_hook('core.on_connect', check_permission)

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -123,7 +123,7 @@ async def _event_system_shutdown(middleware, event_type, args):
 
 
 async def setup(middleware):
-    middleware.event_register('docker.state', 'Docker state events')
+    middleware.event_register('docker.state', 'Docker state events', roles=['DOCKER_READ'])
     middleware.event_subscribe('system.ready', _event_system_ready)
     middleware.event_subscribe('system.shutdown', _event_system_shutdown)
     await middleware.call('docker.state.initialize')

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1254,8 +1254,8 @@ def remote_status_event(middleware, *args, **kwargs):
 
 
 async def setup(middleware):
-    middleware.event_register('failover.setup', 'Sent when failover is being setup.')
-    middleware.event_register('failover.status', 'Sent when failover status changes.')
+    middleware.event_register('failover.setup', 'Sent when failover is being setup.', roles=['FAILOVER_READ'])
+    middleware.event_register('failover.status', 'Sent when failover status changes.', roles=['FAILOVER_READ'])
     middleware.event_subscribe('system.ready', _event_system_ready)
     middleware.register_hook('core.on_connect', ha_permission, sync=True)
     middleware.register_hook('interface.pre_sync', interface_pre_sync_hook, sync=True)

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -17,7 +17,7 @@ class FailoverDisabledReasonsService(Service):
     LAST_DISABLED_REASONS = None
     SYSTEM_DATASET_SETUP_IN_PROGRESS = False
 
-    @accepts()
+    @accepts(roles=['FAILOVER_READ'])
     @returns(List("reasons", items=[Str("reason")]))
     @pass_app()
     def reasons(self, app):
@@ -211,5 +211,6 @@ async def setup(middleware):
     middleware.event_register(
         "failover.disabled.reasons",
         "Sent when failover status reasons change.",
+        roles=['FAILOVER_READ']
     )
     middleware.register_hook("sysdataset.setup", systemdataset_setup_hook)

--- a/src/middlewared/middlewared/plugins/system/__init__.py
+++ b/src/middlewared/middlewared/plugins/system/__init__.py
@@ -31,9 +31,9 @@ def read_system_boot_id(middleware):
 
 async def setup(middleware):
     lifecycle_conf.SYSTEM_BOOT_ID = await middleware.run_in_thread(read_system_boot_id, middleware)
-    middleware.event_register('system.ready', 'Finished boot process')
-    middleware.event_register('system.reboot', 'Started reboot process')
-    middleware.event_register('system.shutdown', 'Started shutdown process')
+    middleware.event_register('system.ready', 'Finished boot process', roles=['SYSTEM_GENERAL_READ'])
+    middleware.event_register('system.reboot', 'Started reboot process', roles=['SYSTEM_GENERAL_READ'])
+    middleware.event_register('system.shutdown', 'Started shutdown process', roles=['SYSTEM_GENERAL_READ'])
 
     await middleware.run_in_thread(firstboot, middleware)
 


### PR DESCRIPTION
Many registered events lack RBAC roles preventing UI from working properly in STIG mode or under restricted admin.