### PR TITLE
NAS-133583 / 25.04 / Convert webui.main.dashboard.sys_info to new API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -67,3 +67,4 @@ from .virt_volume import *  # noqa
 from .vm import *  # noqa
 from .vm_device import *  # noqa
 from .webui_enclosure import *  # noqa
+from .webui_main_dashboard import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/webui_main_dashboard.py
+++ b/src/middlewared/middlewared/api/v25_04_0/webui_main_dashboard.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from middlewared.api.base import BaseModel, NonEmptyString
+
+
+class WebUIMainDashboardSysInfoArgs(BaseModel):
+    pass
+
+
+class SysInfoEntry(BaseModel):
+    platform: NonEmptyString
+    version: NonEmptyString
+    codename: NonEmptyString
+    license: dict
+    system_serial: str
+    hostname: NonEmptyString
+    uptime_seconds: float
+    datetime_: datetime = Field(alias="datetime")
+
+
+class SysInfo(SysInfoEntry):
+    remote_info: SysInfoEntry | None
+
+
+class WebUIMainDashboardSysInfoResult(BaseModel):
+    result: SysInfo

--- a/src/middlewared/middlewared/plugins/webui/main_dashboard.py
+++ b/src/middlewared/middlewared/plugins/webui/main_dashboard.py
@@ -1,7 +1,11 @@
 from datetime import datetime, timezone
 from time import clock_gettime, CLOCK_MONOTONIC_RAW, time
 
-from middlewared.schema import accepts
+from middlewared.api import api_method
+from middlewared.api.current import (
+    WebUIMainDashboardSysInfoArgs,
+    WebUIMainDashboardSysInfoResult
+)
 from middlewared.service import Service
 from middlewared.utils import sw_version, sw_codename
 
@@ -40,7 +44,11 @@ class WebUIMainDashboardService(Service):
             'datetime': datetime.fromtimestamp(time(), timezone.utc),
         }
 
-    @accepts(roles=['READONLY_ADMIN'])
+    @api_method(
+        WebUIMainDashboardSysInfoArgs,
+        WebUIMainDashboardSysInfoResult,
+        roles=['READONLY_ADMIN']
+    )
     def sys_info(self):
         """This endpoint was designed to be exclusively
         consumed by the webUI team. This is what makes

--- a/src/middlewared/middlewared/plugins/webui/main_dashboard.py
+++ b/src/middlewared/middlewared/plugins/webui/main_dashboard.py
@@ -56,15 +56,14 @@ class WebUIMainDashboardService(Service):
         dashboard after a user logs in.
         """
         info = self.sys_info_impl()
-        try:
-            info['remote_info'] = self.middleware.call_sync(
-                'failover.call_remote', 'webui.main.dashboard.sys_info_impl'
-            )
-        except Exception:
-            # could be ENOMETHOD (fresh upgrade) or we could
-            # be on a non-HA system. Either way, doesn't matter
-            # we just need to try and get the information and
-            # set the key to None if we fail
-            info['remote_info'] = None
-
+        info['remote'] = None
+        if self.middleware.call_sync('failover.licensed'):
+            try:
+                info['remote_info'] = self.middleware.call_sync(
+                    'failover.call_remote', 'webui.main.dashboard.sys_info_impl'
+                )
+            except Exception:
+                # could be ENOMETHOD (fresh upgrade) or we could
+                # be on a non-HA system. Either way, doesn't matter
+                pass
         return info


### PR DESCRIPTION
While I was here working on this, I tested on a non-HA system and saw this endpoint taking ~2 seconds to return. This is because it's calling `failover.call_remote` on all systems (including non-HA). Fix this by only calling that on HA licensed machines.