### PR TITLE
NAS-133588 / 25.04 / Exclude SYSTEM audit db from generic audit.query

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -39,7 +39,7 @@ from middlewared.validators import Range
 
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]
-BULK_AUDIT = ['SMB']
+BULK_AUDIT = ['SMB', 'SYSTEM']
 NON_BULK_AUDIT = [svc for svc in ALL_AUDITED if svc not in BULK_AUDIT]
 
 # We set the refquota limit


### PR DESCRIPTION
The SYSTEM audit database records a large number of events since it's being fed by auditd. This means we probably don't want to overload users with its results in our UI.