### PR TITLE
NAS-133523 / 25.04 / Make sure ipv6 is enabled by default for docker networks

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker/daemon.json.py
+++ b/src/middlewared/middlewared/etc_files/docker/daemon.json.py
@@ -23,6 +23,7 @@ def render(service, middleware):
         'exec-opts': ['native.cgroupdriver=cgroupfs'],
         'iptables': True,
         'ipv6': True,
+        'default-network-opts': {'bridge': {'com.docker.network.enable_ipv6': 'true'}},
         'storage-driver': 'overlay2',
         'fixed-cidr-v6': config['cidr_v6'],
         'default-address-pools': config['address_pools'],


### PR DESCRIPTION
## Problem  
Currently, IPv6 is not being configured by default for Docker networks. This is inconsistent with a previous change where IPv6 was enabled for Docker's main bridge network.  

## Solution  
Ensure that IPv6 is configured by default for all Docker networks.