### PR TITLE
NAS-133528 / 25.04 / Increase timeout when pulling incus images on instance creation

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -350,7 +350,7 @@ class VirtInstanceService(CRUDService):
             'source': source,
             'type': 'container' if data['instance_type'] == 'CONTAINER' else 'virtual-machine',
             'start': data['autostart'],
-        }}, running_cb)
+        }}, running_cb, timeout=15 * 60)  # We will give 15 minutes to incus to download relevant image and then timeout
 
         return await self.middleware.call('virt.instance.get_instance', data['name'])
 


### PR DESCRIPTION
## Problem

By default we have a 5 minute timeout on incus jobs which can not be sufficient when pulling large images. 


## Solution

Pulling image on incus side is a job on incus and we were waiting for 5 minutes for the job to complete but as that was not sufficient to download large images, the timeout has been increased to make sure we don't cancel the job half way.