### PR TITLE
NAS-133602 / 24.10.2 / self.query -> self.middleware.call('disk.query')

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sed.py
+++ b/src/middlewared/middlewared/plugins/disk_/sed.py
@@ -61,7 +61,9 @@ class DiskService(Service):
         password = await self.middleware.call('system.advanced.sed_global_password')
 
         if disk is None:
-            disk = await self.query([('name', '=', disk_name)], {'extra': {'passwords': True}})
+            disk = await self.middleware.call(
+                'disk.query', [('name', '=', disk_name)], {'extra': {'passwords': True}}
+            )
             if disk and disk[0]['passwd']:
                 password = disk[0]['passwd']
         elif disk.get('passwd'):


### PR DESCRIPTION
SED functionality was moved to its own file in 416f697b2c7 however, it was moved into a class without a `query` method. Since this isn't a CRUDService, this is failing with
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/sed.py", line 64, in sed_unlock
    disk = await self.query([('name', '=', disk_name)], {'extra': {'passwords': True}})
                 ^^^^^^^^^^
AttributeError: 'DiskService' object has no attribute 'query'