### PR TITLE
NAS-133603 / 25.04 / fix type annotation for dashboard.sys_info

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/webui_main_dashboard.py
+++ b/src/middlewared/middlewared/api/v25_04_0/webui_main_dashboard.py
@@ -13,7 +13,7 @@ class SysInfoEntry(BaseModel):
     platform: NonEmptyString
     version: NonEmptyString
     codename: NonEmptyString
-    license: dict
+    license: dict | None
     system_serial: str
     hostname: NonEmptyString
     uptime_seconds: float


### PR DESCRIPTION
License will be a dict or None.