### PR TITLE
NAS-133606 / 25.04 / convert cert/csr profiles to new api

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -17,6 +17,7 @@ from .common import *  # noqa
 from .config import *  # noqa
 from .core import *  # noqa
 from .cronjob import *  # noqa
+from .crypto_cert_profiles import *  # noqa
 from .device import *  # noqa
 from .disk import *  # noqa
 from .docker import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
@@ -106,18 +106,23 @@ class ECCCertExtensions(BaseModel):
     digest_algorithm: str = SHA256
 
 
-class CertProfilesArgs(BaseModel):
-    pass
-
-
 @final
-class CertProfilesResult(BaseModel):
+class CertProfilesModel(BaseModel):
     https_rsa_certificate: RSACertExtensions = Field(
         default_factory=RSACertExtensions, alias="HTTPS RSA Certificate"
     )
     https_ecc_certificate: ECCCertExtensions = Field(
         default_factory=ECCCertExtensions, alias="HTTPS ECC Certificate"
     )
+
+
+class CertProfilesArgs(BaseModel):
+    pass
+
+
+@final
+class CertProfilesResult(BaseModel):
+    result: CertProfilesModel = CertProfilesModel()
 
 
 @final
@@ -152,12 +157,8 @@ class ECCCSRExtensions(BaseModel):
     digest_algorithm: str = SHA256
 
 
-class CSRProfilesArgs(BaseModel):
-    pass
-
-
 @final
-class CSRProfilesResult(BaseModel):
+class CSRProfilesModel(BaseModel):
     https_rsa_certificate: RSACSRExtensions = Field(
         default_factory=RSACSRExtensions, alias="HTTPS RSA Certificate"
     )
@@ -166,5 +167,14 @@ class CSRProfilesResult(BaseModel):
     )
 
 
-CERTPROFILES = CertProfilesResult().model_dump(by_alias=True)
-CSRPROFILES = CSRProfilesResult().model_dump(by_alias=True)
+class CSRProfilesArgs(BaseModel):
+    pass
+
+
+@final
+class CSRProfilesResult(BaseModel):
+    result: CSRProfilesModel = CSRProfilesModel()
+
+
+CERTPROFILES = CertProfilesModel().model_dump(by_alias=True)
+CSRPROFILES = CSRProfilesModel().model_dump(by_alias=True)

--- a/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
@@ -1,0 +1,164 @@
+from typing import final
+
+from middlewared.api.base import BaseModel
+
+from pydantic import Field
+
+__all__ = (
+    "CertProfilesArgs",
+    "CertProfilesResult",
+    "CSRProfilesArgs",
+    "CSRProfilesResult",
+)
+
+
+# Defines the default lifetime of a certificate
+# (https://support.apple.com/en-us/HT211025)
+DEFAULT_LIFETIME_DAYS = 397
+RSA = "RSA"
+EC = "EC"
+EC_CURVE = "SECP384R1"
+SHA256 = "SHA256"
+KEY_LENGTH = 2048
+EX_KEY_USAGE = ["SERVER_AUTH", "CLIENT_AUTH"]
+
+
+@final
+class BasicConstraintsModel(BaseModel):
+    enabled: bool = True
+    ca: bool = False
+    extension_critical: bool = True
+
+
+@final
+class AuthorityKeyIdentifierModel(BaseModel):
+    enabled: bool = True
+    authority_cert_issuer: bool = True
+    extension_critical: bool = False
+
+
+@final
+class ExtendedKeyUsageModel(BaseModel):
+    # These days, most TLS certs want "ClientAuth".
+    # LetsEncrypt appears to want this extension to issue.
+    # https://community.letsencrypt.org/t/extendedkeyusage-tls-client-
+    # authentication-in-tls-server-certificates/59140/7
+    enabled: bool = True
+    extension_critical: bool = True
+    usages: list[str] = EX_KEY_USAGE
+
+
+@final
+class RSAKeyUsageModel(BaseModel):
+    # RSA certs need "digitalSignature" for DHE,
+    # and "keyEncipherment" for nonDHE
+    # Include "keyAgreement" for compatibility (DH_DSS / DH_RSA)
+    # See rfc5246
+    enabled: bool = True
+    extension_critical: bool = True
+    digital_signature: bool = True
+    key_encipherment: bool = True
+    key_agreement: bool = True
+
+
+@final
+class ECCKeyUsageModel(BaseModel):
+    # keyAgreement is not generally required for EC certs.
+    # See Google, cloudflare certs
+    enabled: bool = True
+    extension_critical: bool = True
+    digital_signature: bool = True
+
+
+@final
+class RSACertExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = BasicConstraintsModel()
+    AuthorityKeyIdentifier: AuthorityKeyIdentifierModel = AuthorityKeyIdentifierModel()
+    ExtendedKeyUsage: ExtendedKeyUsageModel = ExtendedKeyUsageModel()
+    KeyUsage: RSAKeyUsageModel = RSAKeyUsageModel()
+
+
+@final
+class ECCCertExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = BasicConstraintsModel()
+    AuthorityKeyIdentifier: AuthorityKeyIdentifierModel = AuthorityKeyIdentifierModel()
+    ExtendedKeyUsage: ExtendedKeyUsageModel = ExtendedKeyUsageModel()
+    KeyUsage: ECCKeyUsageModel = ECCKeyUsageModel()
+
+
+@final
+class RSACertExtensions(BaseModel):
+    cert_extensions: RSACertExtensionsModel = RSACertExtensionsModel()
+    key_length: int = KEY_LENGTH
+    key_type: str = RSA
+    lifetime: int = DEFAULT_LIFETIME_DAYS
+    digest_algorithm: str = SHA256
+
+
+@final
+class ECCCertExtensions(BaseModel):
+    cert_extensions: ECCCertExtensionsModel = ECCCertExtensionsModel()
+    ec_curve: str = EC_CURVE
+    key_type: str = EC
+    lifetime: int = DEFAULT_LIFETIME_DAYS
+    digest_algorithm: str = SHA256
+
+
+class CertProfilesArgs(BaseModel):
+    pass
+
+
+@final
+class CertProfilesResult(BaseModel):
+    https_rsa_certificate: RSACertExtensions = Field(
+        default_factory=RSACertExtensions, alias="HTTPS RSA Certificate"
+    )
+    https_ecc_certificate: ECCCertExtensions = Field(
+        default_factory=ECCCertExtensions, alias="HTTPS ECC Certificate"
+    )
+
+
+@final
+class RSACSRExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = BasicConstraintsModel()
+    ExtendedKeyUsage: ExtendedKeyUsageModel = ExtendedKeyUsageModel()
+    KeyUsage: RSAKeyUsageModel = RSAKeyUsageModel()
+
+
+@final
+class ECCCSRExtensionsModel(BaseModel):
+    BasicConstraints: BasicConstraintsModel = BasicConstraintsModel()
+    ExtendedKeyUsage: ExtendedKeyUsageModel = ExtendedKeyUsageModel()
+    KeyUsage: ECCKeyUsageModel = ECCKeyUsageModel()
+
+
+@final
+class RSACSRExtensions(BaseModel):
+    cert_extensions: RSACSRExtensionsModel = RSACertExtensionsModel()
+    key_length: int = KEY_LENGTH
+    key_type: str = RSA
+    lifetime: int = DEFAULT_LIFETIME_DAYS
+    digest_algorithm: str = SHA256
+
+
+@final
+class ECCCSRExtensions(BaseModel):
+    cert_extensions: ECCCSRExtensionsModel = ECCCertExtensionsModel()
+    ec_curve: str = EC_CURVE
+    key_type: str = EC
+    lifetime: int = DEFAULT_LIFETIME_DAYS
+    digest_algorithm: str = SHA256
+
+
+class CSRProfilesArgs(BaseModel):
+    pass
+
+
+@final
+class CSRProfilesResult(BaseModel):
+    https_rsa_certificate: RSACSRExtensions = Field(
+        default_factory=RSACSRExtensions, alias="HTTPS RSA Certificate"
+    )
+    https_ecc_certificate: ECCCSRExtensions = Field(
+        default_factory=ECCCSRExtensions, alias="HTTPS ECC Certificate"
+    )

--- a/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_cert_profiles.py
@@ -9,6 +9,8 @@ __all__ = (
     "CertProfilesResult",
     "CSRProfilesArgs",
     "CSRProfilesResult",
+    "CERTPROFILES",
+    "CSRPROFILES",
 )
 
 
@@ -162,3 +164,7 @@ class CSRProfilesResult(BaseModel):
     https_ecc_certificate: ECCCSRExtensions = Field(
         default_factory=ECCCSRExtensions, alias="HTTPS ECC Certificate"
     )
+
+
+CERTPROFILES = CertProfilesResult().model_dump(by_alias=True)
+CSRPROFILES = CSRProfilesResult().model_dump(by_alias=True)

--- a/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
@@ -1,119 +1,26 @@
-import copy
-
-from middlewared.schema import accepts, Dict, returns
+from middlewared.api import api_method
+from middlewared.api.current import (
+    CertProfilesArgs,
+    CertProfilesResult,
+    CSRProfilesArgs,
+    CSRProfilesResult,
+)
 from middlewared.service import Service
-
-from .utils import DEFAULT_LIFETIME_DAYS
-
-
-CERTIFICATE_PROFILES = {
-    # Options / EKUs reference rfc5246
-    'HTTPS RSA Certificate': {
-        'cert_extensions': {
-            'BasicConstraints': {
-                'enabled': True,
-                'ca': False,
-                'extension_critical': True
-            },
-            'AuthorityKeyIdentifier': {
-                'enabled': True,
-                'authority_cert_issuer': True,
-                'extension_critical': False
-            },
-            # These days, most TLS certs want "ClientAuth".
-            # LetsEncrypt appears to want this extension to issue.
-            # https://community.letsencrypt.org/t/extendedkeyusage-tls-client-
-            # authentication-in-tls-server-certificates/59140/7
-            'ExtendedKeyUsage': {
-                'enabled': True,
-                'extension_critical': True,
-                'usages': [
-                    'SERVER_AUTH',
-                    'CLIENT_AUTH',
-                ]
-            },
-            # RSA certs need "digitalSignature" for DHE,
-            # and "keyEncipherment" for nonDHE
-            # Include "keyAgreement" for compatibility (DH_DSS / DH_RSA)
-            # See rfc5246
-            'KeyUsage': {
-                'enabled': True,
-                'extension_critical': True,
-                'digital_signature': True,
-                'key_encipherment': True,
-                'key_agreement': True,
-            }
-        },
-        'key_length': 2048,
-        'key_type': 'RSA',
-        'lifetime': DEFAULT_LIFETIME_DAYS,
-        'digest_algorithm': 'SHA256'
-    },
-    'HTTPS ECC Certificate': {
-        'cert_extensions': {
-            'BasicConstraints': {
-                'enabled': True,
-                'ca': False,
-                'extension_critical': True
-            },
-            'AuthorityKeyIdentifier': {
-                'enabled': True,
-                'authority_cert_issuer': True,
-                'extension_critical': False
-            },
-            # These days, most TLS certs want "ClientAuth".
-            # LetsEncrypt appears to want this extension to issue.
-            # https://community.letsencrypt.org/t/extendedkeyusage-tls-client-
-            # authentication-in-tls-server-certificates/59140/7
-            'ExtendedKeyUsage': {
-                'enabled': True,
-                'extension_critical': True,
-                'usages': [
-                    'SERVER_AUTH',
-                    'CLIENT_AUTH',
-                ]
-            },
-            # keyAgreement is not generally required for EC certs.
-            # See Google, cloudflare certs
-            'KeyUsage': {
-                'enabled': True,
-                'extension_critical': True,
-                'digital_signature': True,
-            }
-        },
-        'ec_curve': 'SECP384R1',
-        'key_type': 'EC',
-        'lifetime': DEFAULT_LIFETIME_DAYS,
-        'digest_algorithm': 'SHA256'
-    },
-}
-CSR_PROFILES = copy.deepcopy(CERTIFICATE_PROFILES)
-for key, schema in filter(lambda v: 'cert_extensions' in v[1], CSR_PROFILES.items()):
-    schema['cert_extensions'].pop('AuthorityKeyIdentifier', None)
 
 
 class CertificateService(Service):
-
-    @accepts(roles=['CERTIFICATE_READ'])
-    @returns(Dict(
-        'certificate_profiles',
-        *[Dict(profile, additional_attrs=True) for profile in CERTIFICATE_PROFILES]
-    ))
+    @api_method(CertProfilesArgs, CertProfilesResult, roles=["CERTIFICATE_READ"])
     async def profiles(self):
         """
-        Returns a dictionary of predefined options for specific use cases i.e openvpn client/server
-        configurations which can be used for creating certificates.
+        Returns a dictionary of predefined configuration
+        options for creating certificates.
         """
-        return CERTIFICATE_PROFILES
+        return CertProfilesResult.model_dump()
 
-    @accepts(roles=['CERTIFICATE_READ'])
-    @returns(Dict(
-        *[Dict(profile, additional_attrs=True) for profile in CSR_PROFILES],
-        example=CSR_PROFILES,
-    ))
+    @api_method(CSRProfilesArgs, CSRProfilesResult, roles=["CERTIFICATE_READ"])
     async def certificate_signing_requests_profiles(self):
         """
-        Returns a dictionary of predefined options for specific use cases i.e openvpn client/server
-        configurations which can be used for creating certificate signing requests.
+        Returns a dictionary of predefined configuration
+        options for creating certificate signing requests.
         """
-        return CSR_PROFILES
+        return CSRProfilesResult.model_dump()

--- a/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_profiles.py
@@ -1,9 +1,11 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
+    CERTPROFILES,
     CertProfilesArgs,
     CertProfilesResult,
     CSRProfilesArgs,
     CSRProfilesResult,
+    CSRPROFILES,
 )
 from middlewared.service import Service
 
@@ -15,7 +17,7 @@ class CertificateService(Service):
         Returns a dictionary of predefined configuration
         options for creating certificates.
         """
-        return CertProfilesResult.model_dump()
+        return CERTPROFILES
 
     @api_method(CSRProfilesArgs, CSRProfilesResult, roles=["CERTIFICATE_READ"])
     async def certificate_signing_requests_profiles(self):
@@ -23,4 +25,4 @@ class CertificateService(Service):
         Returns a dictionary of predefined configuration
         options for creating certificate signing requests.
         """
-        return CSRProfilesResult.model_dump()
+        return CSRPROFILES

--- a/src/middlewared/middlewared/plugins/truenas_connect/cert_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/cert_utils.py
@@ -1,6 +1,4 @@
-import copy
-
-from middlewared.plugins.crypto_.cert_profiles import CSR_PROFILES
+from middlewared.api.current import CSRPROFILES
 from middlewared.plugins.crypto_.csr import generate_certificate_signing_request
 
 
@@ -23,6 +21,6 @@ def generate_csr(hostnames: list[str]) -> (str, str):
         'organizational_unit': 'TNC',
         'email': CERT_BOT_EMAIL,
         'digest_algorithm': 'SHA256',
-        'cert_extensions': copy.deepcopy(CSR_PROFILES['HTTPS RSA Certificate']['cert_extensions']),
+        'cert_extensions': CSRPROFILES['HTTPS RSA Certificate']['cert_extensions'],
         # We do not specify a common as domain hostname is bigger then 64 chars and cryptography starts complaining
     })

--- a/src/middlewared/middlewared/plugins/truenas_connect/cert_utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/cert_utils.py
@@ -1,4 +1,3 @@
-from middlewared.api.current import CSRPROFILES
 from middlewared.plugins.crypto_.csr import generate_certificate_signing_request
 
 
@@ -21,6 +20,23 @@ def generate_csr(hostnames: list[str]) -> (str, str):
         'organizational_unit': 'TNC',
         'email': CERT_BOT_EMAIL,
         'digest_algorithm': 'SHA256',
-        'cert_extensions': CSRPROFILES['HTTPS RSA Certificate']['cert_extensions'],
-        # We do not specify a common as domain hostname is bigger then 64 chars and cryptography starts complaining
+        'cert_extensions': {
+            'BasicConstraints': {
+                'enabled': True,
+                'ca': False,
+                'extension_critical': True,
+            },
+            'ExtendedKeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'usages': ['SERVER_AUTH', 'CLIENT_AUTH'],
+            },
+            'KeyUsage': {
+                'enabled': True,
+                'extension_critical': True,
+                'digital_signature': True,
+                'key_encipherment': True,
+                'key_agreement': True,
+            },
+        }
     })

--- a/src/middlewared/middlewared/plugins/webui/crypto.py
+++ b/src/middlewared/middlewared/plugins/webui/crypto.py
@@ -1,3 +1,10 @@
+from middlewared.api import api_method
+from middlewared.api.current import (
+    CertProfilesArgs,
+    CertProfilesResult,
+    CSRProfilesArgs,
+    CSRProfilesResult,
+)
 from middlewared.schema import accepts, Int
 from middlewared.service import Service
 
@@ -9,9 +16,13 @@ class WebUICryptoService(Service):
         private = True
         cli_private = True
 
-    @accepts(roles=['READONLY_ADMIN'])
+    @api_method(
+        CertProfilesArgs,
+        CertProfilesResult,
+        roles=['READONLY_ADMIN']
+    )
     async def certificate_profiles(self):
-        return await self.middleware.call('certificate.profiles')
+        return CertProfilesResult.model_dump()
 
     @accepts(roles=['READONLY_ADMIN'])
     async def certificateauthority_profiles(self):
@@ -21,6 +32,10 @@ class WebUICryptoService(Service):
     async def get_certificate_domain_names(self, cert_id):
         return await self.middleware.call('certificate.get_domain_names', cert_id)
 
-    @accepts(roles=['READONLY_ADMIN'])
+    @api_method(
+        CSRProfilesArgs,
+        CSRProfilesResult,
+        roles=['READONLY_ADMIN']
+    )
     async def csr_profiles(self):
-        return await self.middleware.call('certificate.certificate_signing_requests_profiles')
+        return CSRProfilesResult.model_dump()

--- a/src/middlewared/middlewared/plugins/webui/crypto.py
+++ b/src/middlewared/middlewared/plugins/webui/crypto.py
@@ -1,9 +1,11 @@
 from middlewared.api import api_method
 from middlewared.api.current import (
+    CERTPROFILES,
     CertProfilesArgs,
     CertProfilesResult,
     CSRProfilesArgs,
     CSRProfilesResult,
+    CSRPROFILES,
 )
 from middlewared.schema import accepts, Int
 from middlewared.service import Service
@@ -22,7 +24,7 @@ class WebUICryptoService(Service):
         roles=['READONLY_ADMIN']
     )
     async def certificate_profiles(self):
-        return CertProfilesResult.model_dump()
+        return CERTPROFILES
 
     @accepts(roles=['READONLY_ADMIN'])
     async def certificateauthority_profiles(self):
@@ -38,4 +40,4 @@ class WebUICryptoService(Service):
         roles=['READONLY_ADMIN']
     )
     async def csr_profiles(self):
-        return CSRProfilesResult.model_dump()
+        return CSRPROFILES


### PR DESCRIPTION
This one is interesting, it's a static set of information that isn't changing but we return it in public methods. I've moved it over to our new api_method scheme.

It's a bit verbose, however, we now get programmatic api generation for each field (instead of copying a docstring that someone may, or may not read) and it's now "protected" between each version of truenas.