### PR TITLE
NAS-133482 / 25.04 / Prune restic snapshots after every cloud_backup sync

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_backup/sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/sync.py
@@ -146,7 +146,7 @@ class CloudBackupService(Service):
             restic_config = get_restic_config(cloud_backup)
             await run_restic(
                 job,
-                restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"])],
+                restic_config.cmd + ["forget", "--keep-last", str(cloud_backup["keep_last"]), "--prune"],
                 restic_config.env,
             )
 


### PR DESCRIPTION
Currently our `keep_last` setting only deletes snapshots without removing the files that those snapshots reference (see [restic docs](https://restic.readthedocs.io/en/stable/060_forget.html)). Over time, this can waste a lot of space in the user's Storj repositories.

Note that pruning uses some space in the repository, so pruning may fail if it runs out of available space. Users should heed storage warnings when their available space runs low.