### PR TITLE
Remove default FULL_ADMIN role in api_method decorator

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -116,7 +116,7 @@ def api_method(
         wrapped.audit_callback = audit_callback
         wrapped.audit_extended = audit_extended
         wrapped.rate_limit = rate_limit
-        wrapped.roles = roles or ['FULL_ADMIN']
+        wrapped.roles = roles or []
         wrapped._private = private
         wrapped._cli_private = cli_private
 


### PR DESCRIPTION
This caused FULL_ADMIN under stig mode to be able to write to VM / VIRT plugins which should have been prevented in STIG mode because the FULL_ADMIN role was being registered with the CRUD method for those plugins.

In general the failsafe here is unnecessary since we now crash when developer writes a plugin that lacks explicitly-defined roles.