### PR TITLE
NAS-133626 / 25.04 / Prevent enabling TrueNAS connect while in STIG mode

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -116,7 +116,7 @@ ROLES = {
 
     # Truenas connect roles
     'TRUENAS_CONNECT_READ': Role(),
-    'TRUENAS_CONNECT_WRITE': Role(includes=['TRUENAS_CONNECT_READ']),
+    'TRUENAS_CONNECT_WRITE': Role(includes=['TRUENAS_CONNECT_READ'], stig=None),
 
     # Crypto roles
     'CERTIFICATE_READ': Role(),


### PR DESCRIPTION
The authentication methods used by TrueNAS connect aren't supported in GPOS STIG mode and so the admins should not be allowed to configure it.