### PR TITLE
NAS-133601 / 25.04 / Remove nscd from disable preset.

### DIFF
--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -20,7 +20,6 @@ disable nmbd.service
 disable nfs*
 disable rsync.service
 disable netdata.service
-disable nscd.service
 disable snmpd.service
 disable snmp-agent.service
 disable ssh*

--- a/src/middlewared/middlewared/etc_files/nscd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nscd.conf.mako
@@ -33,6 +33,7 @@
 #	auto-propagate		<service> <yes|no>
 #
 # Currently supported cache names (services): passwd, group, hosts, services
+# TrueNAS modification: enable for 'hosts' only
 #
 <%
     import os

--- a/tests/unit/test_after_boot_services.py
+++ b/tests/unit/test_after_boot_services.py
@@ -1,0 +1,51 @@
+import pytest
+import subprocess
+
+
+@pytest.fixture(scope='module')
+def systemctl_service_status():
+    """ Get and pre-process systemctl output
+    YIELD:  systemctl output formatted into a list of strings """
+
+    try:
+        raw_list_units = subprocess.run(['systemctl', 'list-units', '--type=service'], capture_output=True)
+        svc_data = raw_list_units.stdout.decode().strip().splitlines()
+        yield svc_data
+    except Exception:
+        pass
+
+
+def process_svc_data(svc_entry: str):
+    """ Process a service entry
+    RETURN: dictionary {alarm: None | 'set', status: (LOAD, ACTIVE, SUB)} """
+
+    assert svc_entry is not None
+    assert svc_entry != ""
+
+    retval = {"alarm": None, "status": ()}
+    retval["alarm"] = None if svc_entry[0] == "" else "active"
+
+    svc_parts = svc_entry[1:].split()
+    retval["status"] = (svc_parts[1], svc_parts[2], svc_parts[3])
+
+    return retval
+
+
+@pytest.mark.parametrize('svc_name,expected', [
+    ("nscd", {"state": "listed", "alarm": None, "status": ("loaded", "active", "running")}),
+])
+def test__systemctl_unit_state(systemctl_service_status, svc_name, expected):
+    """ Confirm status of services at boot """
+
+    svc_data = systemctl_service_status
+    svc_entry = [svc for svc in svc_data if svc_name in svc]
+
+    if expected['state'] == 'listed':
+        assert svc_entry != [], f"Expected to find {svc_name}"
+        assert len(svc_entry) == 1
+
+        svc = process_svc_data(svc_entry[0])
+        assert svc['status'] == expected['status'], \
+            f"{svc_name}: expected {expected['status']}, but found {svc['status']}"
+    else:
+        assert svc_entry == []


### PR DESCRIPTION
nscd is not automatically starting at boot.   It should be.
It was `disabled` in `10-truenas.preset` for reasons that are no longer valid. 
Removing the nscd prese disable from `10-truenas.preset` also repairs systems in the field on upgrade.

Add a comment in nscd.conf.mako.
Add a unit test for services at boot.