### PR TITLE
NAS-133637 / 25.04 / Add role manage sanity check and tests

### DIFF
--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -246,6 +246,12 @@ ROLES = {
 }
 ROLES['READONLY_ADMIN'] = Role(includes=[role for role in ROLES if role.endswith('_READ')], builtin=False)
 
+READ_RESOURCE_BLACKLIST = (
+    '.create', '.do_create',
+    '.update', '.do_update',
+    '.delete', '.do_delete',
+)
+
 
 class ResourceManager:
     def __init__(self, resource_title: str, resource_method: str, roles: typing.Dict[str, Role]):
@@ -271,6 +277,9 @@ class ResourceManager:
         for role in roles:
             if role not in self.roles:
                 raise ValueError(f"Invalid role {role!r}")
+
+            if role.endswith("_READ") and resource_name.endswith(READ_RESOURCE_BLACKLIST):
+                raise ValueError(f'{resource_name}: resource may not be granted to {role}')
 
         self.resources[resource_name] += roles
 


### PR DESCRIPTION
Add a sanity check that we never grant a READ role access to a CRUD/Config method.

This commit also updates our check on STIG roles to add the TRUENAS_CONNECT role to the expected STIG roles.

This commit also adds a few tests to validate that the role manager is raising expected exceptions in some scenarios.