### PR TITLE
NAS-133640 / 25.04 / Use ALLOW_LIST_FULL_ADMIN where practical

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -7,8 +7,8 @@ from middlewared.api.current import *
 from middlewared.plugins.account import unixhash_is_valid
 from middlewared.service import CallError, CRUDService, filter_list, private, ValidationErrors
 from middlewared.service_exception import MatchNotFound
+from middlewared.utils.privilege_constants import ALLOW_LIST_FULL_ADMIN, LocalAdminGroups
 from middlewared.utils.privilege import (
-    LocalAdminGroups,
     privilege_has_webui_access,
     privileges_group_mapping
 )
@@ -382,7 +382,7 @@ class PrivilegeService(CRUDService):
     async def full_privilege(self):
         return {
             'roles': {'FULL_ADMIN'},
-            'allowlist': [{'method': '*', 'resource': '*'}],
+            'allowlist': [ALLOW_LIST_FULL_ADMIN.copy()],
             'web_shell': True,
             'webui_access': True,
         }

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
+from middlewared.utils.privilege_constants import ALLOW_LIST_FULL_ADMIN
 from middlewared.utils.security import STIGType
 import typing
 
@@ -351,7 +352,7 @@ class RoleManager:
                 ], [])
 
             # Only non-stig FULL_ADMIN privilege can access REST endpoints
-            return [{"method": "*", "resource": "*"}]
+            return [ALLOW_LIST_FULL_ADMIN.copy()]
 
         return sum([
             self.methods.allowlists_for_roles[role] + self.events.allowlists_for_roles[role]

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -2,8 +2,7 @@ import fnmatch
 import re
 
 from middlewared.api.current import HttpVerb
-
-ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
+from middlewared.utils.privilege_constants import ALLOW_LIST_FULL_ADMIN
 
 
 class Allowlist:

--- a/src/middlewared/middlewared/utils/privilege.py
+++ b/src/middlewared/middlewared/utils/privilege.py
@@ -1,10 +1,5 @@
-import enum
 from middlewared.auth import TruenasNodeSessionManagerCredentials
 from middlewared.role import ROLES
-
-
-class LocalAdminGroups(enum.IntEnum):
-    BUILTIN_ADMINISTRATORS = 544
 
 
 def privilege_has_webui_access(privilege: dict) -> bool:

--- a/src/middlewared/middlewared/utils/privilege_constants.py
+++ b/src/middlewared/middlewared/utils/privilege_constants.py
@@ -1,0 +1,7 @@
+import enum
+
+ALLOW_LIST_FULL_ADMIN = {'method': '*', 'resource': '*'}
+
+
+class LocalAdminGroups(enum.IntEnum):
+    BUILTIN_ADMINISTRATORS = 544


### PR DESCRIPTION
There are several places in the codebase where we return or evaluate the dictionary `{"method": "*", "resource": "*"}`.

Place this in a privilege_constants file that has minimal imports to avoid potential issues with circular imports and to speed up usage in external applications and unit tests.