### PR TITLE
NAS-133641 / 25.04 / Convert iscsi.global.* to new API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_04_0/__init__.py
@@ -34,6 +34,7 @@ from .group import *  # noqa
 from .initshutdownscript import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
+from .iscsi_global import *  # noqa
 from .iscsi_initiator import *  # noqa
 from .iscsi_portal import *  # noqa
 from .iscsi_target import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
@@ -1,0 +1,77 @@
+from pydantic import Field
+
+from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass, single_argument_args
+from .common import QueryFilters, QueryOptions
+
+__all__ = [
+    "IscsiGlobalEntry",
+    "IscsiGlobalUpdateArgs",
+    "IscsiGlobalUpdateResult",
+    "IscsiGlobalAluaEnabledArgs",
+    "IscsiGlobalAluaEnabledResult",
+    "IscsiGlobalClientCountArgs",
+    "IscsiGlobalClientCountResult",
+    "IscsiGlobalSessionsArgs",
+    "IscsiGlobalSessionsResult"
+]
+
+
+class IscsiGlobalEntry(BaseModel):
+    id: int
+    basename: str
+    isns_servers: list[str]
+    listen_port: int = Field(ge=1025, le=65535, default=3260)
+    pool_avail_threshold: int | None = Field(ge=1, le=99, default=None)
+    alua: bool
+
+
+@single_argument_args('iscsi_update')
+class IscsiGlobalUpdateArgs(IscsiGlobalEntry, metaclass=ForUpdateMetaclass):
+    id: Excluded = excluded_field()
+
+
+class IscsiGlobalUpdateResult(BaseModel):
+    result: IscsiGlobalEntry
+
+
+class IscsiGlobalAluaEnabledArgs(BaseModel):
+    pass
+
+
+class IscsiGlobalAluaEnabledResult(BaseModel):
+    result: bool
+
+
+class IscsiGlobalClientCountArgs(BaseModel):
+    pass
+
+
+class IscsiGlobalClientCountResult(BaseModel):
+    result: int
+
+
+class IscsiSession(BaseModel):
+    initiator: str
+    initiator_addr: str
+    initiator_alias: str | None
+    target: str
+    target_alias: str
+    header_digest: str | None
+    data_digest: str | None
+    max_data_segment_length: int | None
+    max_receive_data_segment_length: int | None
+    max_xmit_data_segment_length: int | None
+    max_burst_length: int | None
+    first_burst_length: int | None
+    immediate_data: bool
+    iser: bool
+    offload: bool
+
+
+class IscsiGlobalSessionsArgs(BaseModel):
+    query_filters: QueryFilters = []
+    query_options: QueryOptions = QueryOptions()
+
+
+class IscsiGlobalSessionsResult(BaseModel):
+    result: list[IscsiSession]

--- a/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/global_linux.py
@@ -1,8 +1,9 @@
 import glob
 import os
 
-from middlewared.schema import Bool, Dict, Int, Str
-from middlewared.service import filterable, filterable_returns, private, Service
+from middlewared.api import api_method
+from middlewared.api.current import IscsiGlobalSessionsArgs, IscsiGlobalSessionsResult
+from middlewared.service import private, Service
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils import filter_list, run
 
@@ -12,24 +13,11 @@ class ISCSIGlobalService(Service):
     class Config:
         namespace = 'iscsi.global'
 
-    @filterable(roles=['SHARING_ISCSI_GLOBAL_READ'])
-    @filterable_returns(Dict(
-        'session',
-        Str('initiator'),
-        Str('initiator_addr'),
-        Str('initiator_alias', null=True),
-        Str('target'),
-        Str('target_alias'),
-        Str('header_digest', null=True),
-        Str('data_digest', null=True),
-        Int('max_data_segment_length', null=True),
-        Int('max_receive_data_segment_length', null=True),
-        Int('max_burst_length', null=True),
-        Int('first_burst_length', null=True),
-        Bool('immediate_data'),
-        Bool('iser'),
-        Bool('offload'),
-    ))
+    @api_method(
+        IscsiGlobalSessionsArgs,
+        IscsiGlobalSessionsResult,
+        roles=['SHARING_ISCSI_GLOBAL_READ']
+    )
     def sessions(self, filters, options):
         """
         Get a list of currently running iSCSI sessions. This includes initiator and target names

--- a/src/middlewared/middlewared/plugins/iscsi_/status.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/status.py
@@ -1,4 +1,6 @@
-from middlewared.service import accepts, Service
+from middlewared.api import api_method
+from middlewared.api.current import IscsiGlobalClientCountArgs, IscsiGlobalClientCountResult
+from middlewared.service import Service
 
 
 class ISCSIGlobalService(Service):
@@ -7,7 +9,11 @@ class ISCSIGlobalService(Service):
         namespace = 'iscsi.global'
         cli_namespace = 'sharing.iscsi.global'
 
-    @accepts(roles=['SHARING_ISCSI_GLOBAL_READ'])
+    @api_method(
+        IscsiGlobalClientCountArgs,
+        IscsiGlobalClientCountResult,
+        roles=['SHARING_ISCSI_GLOBAL_READ']
+    )
     async def client_count(self):
         """
         Return currently connected clients count.


### PR DESCRIPTION
Convert `iscsi.global.*` to new API

(Note: `max_xmit_data_segment_length` was returned previously, but was not documented.  Now corrected.)

----
Passing abridged CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2648/).