### PR TITLE
NAS-133651 / 25.04 / Reduce situations in which hard-coded root privilege returned

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -1084,7 +1084,7 @@ async def check_permission(middleware, app):
         return
 
     if origin.is_unix_family:
-        if origin.uid == 0:
+        if origin.uid == 0 and not origin.session_is_interactive:
             user = await middleware.call('auth.authenticate_root')
         else:
             try:

--- a/tests/unit/test_stig.py
+++ b/tests/unit/test_stig.py
@@ -1,0 +1,17 @@
+import pytest
+from truenas_api_client import Client, ClientException
+
+@pytest.fixture(scope='function')
+def enable_stig():
+    with Client() as c:
+        c.call('datastore.update', 'system.security', 1, {'enable_gpos_stig': True})
+        try:
+            yield c
+        finally:
+            c.call('datastore.update', 'system.security', 1, {'enable_gpos_stig': False})
+
+def test__stig_restrictions_af_unix(enable_stig):
+    # STIG RBAC should still be effective despite root session
+    with pytest.raises(ClientException, match='Not authorized'):
+        with Client() as c:
+            c.call('virt.global.update', {}, job=True)


### PR DESCRIPTION
We should only return the wildcard allowlist when the root unix domain socket session is not created by an interactive shell session. This is achieved by storing the loginuid for the middleware client pid and checking as part of the check_permission call.

This ensures that STIG restrictions are properly evaluated for users who use midclt, midcli, etc from shell.