### PR TITLE
NAS-133655 / Fix app portal URI normalization for IPv6 URIs

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
+++ b/src/middlewared/middlewared/plugins/apps/ix_apps/query.py
@@ -47,6 +47,16 @@ def normalize_portal_uri(portal_uri: str, host_ip: str | None) -> str:
     if not host_ip or '0.0.0.0' not in portal_uri:
         return portal_uri
 
+    # 'portal_uri' contains '0.0.0.0:<port>'.
+    # We want to replace the '0.0.0.0' part with the IP address of the host.
+    # However, if the host IP address is an IPv6 address,
+    # we need to wrap it in brackets '[]' in order to produce a valid URI.
+    # We already assume that host_ip doesn't contain a port number,
+    # so checking if it contains a ':' should be sufficient to determine
+    # whether or not it's an IPv6 address.
+    if ':' in host_ip:
+        host_ip = f'[{host_ip}]'
+
     return portal_uri.replace('0.0.0.0', host_ip)
 
 


### PR DESCRIPTION
This fixes a bug I reported here: https://ixsystems.atlassian.net/browse/NAS-133655

There's a more thorough investigation there, but basically, when accessing TrueNAS over IPv6, the "Web UI" button in the application detals pane would be broken. This is because it would try to parse `http://<IPv6 address>:<port>` as a URL, which doesn't work. The front-end gets the URL from the function I modified here.