### PR TITLE
NAS-133661 / 25.04 / simplify country_choices endpoints

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/cert_info.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_info.py
@@ -1,5 +1,6 @@
 from middlewared.schema import accepts, Dict, Ref, returns, Str
 from middlewared.service import private, Service
+from middlewared.utils.country_codes import get_iso_3166_2_country_codes
 
 from .utils import EC_CURVES, EKU_OIDS
 
@@ -18,11 +19,9 @@ class CertificateService(Service):
 
     @accepts()
     @returns(Ref('country_choices'))
-    async def country_choices(self):
-        """
-        Returns country choices for creating a certificate/csr.
-        """
-        return await self.middleware.call('system.general.country_choices')
+    def country_choices(self):
+        """Returns country choices for creating a certificate/csr."""
+        return get_iso_3166_2_country_codes()
 
     @accepts()
     @returns(Dict('acme_server_choices', additional_attrs=True))

--- a/src/middlewared/middlewared/plugins/crypto_/cert_info.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_info.py
@@ -1,6 +1,6 @@
 from middlewared.schema import accepts, Dict, Ref, returns, Str
 from middlewared.service import private, Service
-from middlewared.utils.country_codes import get_iso_3166_2_country_codes
+from middlewared.utils.country_codes import get_country_codes
 
 from .utils import EC_CURVES, EKU_OIDS
 
@@ -21,7 +21,7 @@ class CertificateService(Service):
     @returns(Ref('country_choices'))
     def country_choices(self):
         """Returns country choices for creating a certificate/csr."""
-        return get_iso_3166_2_country_codes()
+        return get_country_codes()
 
     @accepts()
     @returns(Dict('acme_server_choices', additional_attrs=True))

--- a/src/middlewared/middlewared/plugins/system_general/country.py
+++ b/src/middlewared/middlewared/plugins/system_general/country.py
@@ -1,6 +1,6 @@
 from middlewared.schema import accepts, Dict, returns
 from middlewared.service import Service
-from middlewared.utils.country_codes import get_iso_3166_2_country_codes
+from middlewared.utils.country_codes import get_country_codes
 
 class SystemGeneralService(Service):
 
@@ -11,5 +11,7 @@ class SystemGeneralService(Service):
     @accepts()
     @returns(Dict('country_choices', additional_attrs=True, register=True))
     def country_choices(self):
-        """Return the ISO 3166-2 representation of countries."""
-        return get_iso_3166_2_country_codes()
+        """Return a dictionary whose keys represent the
+        ISO 3166-1 alpha 2 country code and values represent
+        the English short name (used in ISO 3166/MA)"""
+        return get_country_codes()

--- a/src/middlewared/middlewared/plugins/system_general/country.py
+++ b/src/middlewared/middlewared/plugins/system_general/country.py
@@ -1,12 +1,8 @@
-import csv
-
 from middlewared.schema import accepts, Dict, returns
-from middlewared.service import private, Service
-
+from middlewared.service import Service
+from middlewared.utils.country_codes import get_iso_3166_2_country_codes
 
 class SystemGeneralService(Service):
-
-    COUNTRY_CHOICES = None
 
     class Config:
         namespace = 'system.general'
@@ -14,45 +10,6 @@ class SystemGeneralService(Service):
 
     @accepts()
     @returns(Dict('country_choices', additional_attrs=True, register=True))
-    async def country_choices(self):
-        """
-        Returns country choices.
-        """
-        if not self.COUNTRY_CHOICES:
-            self.COUNTRY_CHOICES = await self.middleware.call('system.general.get_country_choices')
-
-        return self.COUNTRY_CHOICES
-
-    @private
-    def get_country_choices(self):
-        def _get_index(country_columns, column):
-            index = -1
-            i = 0
-            for c in country_columns:
-                if c.lower() == column.lower():
-                    index = i
-                    break
-
-                i += 1
-            return index
-
-        country_file = '/etc/iso_3166_2_countries.csv'
-        cni, two_li = None, None
-        country_choices = {}
-        with open(country_file, 'r', encoding='utf-8') as csvfile:
-            reader = csv.reader(csvfile)
-
-            for index, row in enumerate(reader):
-                if index != 0:
-                    if row[cni] and row[two_li]:
-                        if row[two_li] in country_choices:
-                            # If two countries in the iso file have the same key, we concatenate their names
-                            country_choices[row[two_li]] += f' + {row[cni]}'
-                        else:
-                            country_choices[row[two_li]] = row[cni]
-                else:
-                    # ONLY CNI AND TWO_LI ARE BEING CONSIDERED FROM THE CSV
-                    cni = _get_index(row, 'Common Name')
-                    two_li = _get_index(row, 'ISO 3166-1 2 Letter Code')
-
-        return country_choices
+    def country_choices(self):
+        """Return the ISO 3166-2 representation of countries."""
+        return get_iso_3166_2_country_codes()

--- a/src/middlewared/middlewared/utils/country_codes.py
+++ b/src/middlewared/middlewared/utils/country_codes.py
@@ -1,0 +1,10 @@
+from functools import cache
+from json import load
+
+__all__ = ("get_iso_3166_2_country_codes",)
+
+
+@cache
+def get_iso_3166_2_country_codes() -> dict[str, str]:
+    with open("/usr/share/iso-codes/json/iso_3166-1.json") as f:
+        return {i["alpha_2"]: i["name"] for i in load(f)["3166-1"]}

--- a/src/middlewared/middlewared/utils/country_codes.py
+++ b/src/middlewared/middlewared/utils/country_codes.py
@@ -1,10 +1,13 @@
 from functools import cache
 from json import load
 
-__all__ = ("get_iso_3166_2_country_codes",)
+__all__ = ("get_country_codes",)
 
 
 @cache
-def get_iso_3166_2_country_codes() -> dict[str, str]:
+def get_country_codes() -> dict[str, str]:
+    """Return the ISO 3166-1 alpha 2 code as the key and the
+    English short name (used in ISO 3166/MA) of the country
+    as the value (i.e {"US": "United States of America", ...})"""
     with open("/usr/share/iso-codes/json/iso_3166-1.json") as f:
         return {i["alpha_2"]: i["name"] for i in load(f)["3166-1"]}


### PR DESCRIPTION
Simplify the country code choices dramatically. When looking at this, I have no idea where `'/etc/iso_3166_2_countries.csv'` is coming from. Debian ships `iso-codes` package which puts this info in `/usr/share/iso-codes/`. So this switches to using what upstream uses instead of an unknown source. Also, add a utility function and call that instead.