### PR TITLE
NAS-133616 / 25.04 / Introduce support for app config migrations

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/migration_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/migration_utils.py
@@ -1,0 +1,91 @@
+import os
+import yaml
+
+from apps_validation.json_schema_utils import APP_CONFIG_MIGRATIONS_SCHEMA
+from jsonschema import validate, ValidationError
+from pkg_resources import parse_version
+
+from middlewared.plugins.apps.ix_apps.path import get_installed_app_version_path
+
+
+def version_in_range(version: str, min_version: str = None, max_version: str = None) -> bool:
+    parsed_version = parse_version(version)
+    if min_version and max_version and (min_version == max_version):
+        return parsed_version == parse_version(min_version)
+    if min_version and parsed_version < parse_version(min_version):
+        return False
+    if max_version and parsed_version > parse_version(max_version):
+        return False
+    return True
+
+
+def validate_versions(current_version: str, target_version: str):
+    if not current_version or not target_version:
+        return {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    try:
+        if parse_version(current_version) >= parse_version(target_version):
+            return {
+                'error': 'Target version should be greater than current version',
+                'migration_files': []
+            }
+    except ValueError:
+        return {
+            'error': 'Both versions should be numeric string',
+            'migration_files': []
+        }
+
+    # If no error, return the default response
+    return {'error': None, 'migration_files': []}
+
+
+def get_migration_scripts(app_name: str, current_version: str, target_version: str) -> dict:
+    migration_files = validate_versions(current_version, target_version)
+    if migration_files['error']:
+        return migration_files
+
+    target_version_path = get_installed_app_version_path(app_name, target_version)
+    migration_yaml_path = os.path.join(target_version_path, 'app_migrations.yaml')
+
+    try:
+        with open(migration_yaml_path, 'r') as f:
+            data = yaml.safe_load(f)
+
+        validate(data, APP_CONFIG_MIGRATIONS_SCHEMA)
+    except FileNotFoundError:
+        return migration_files
+    except yaml.YAMLError:
+        migration_files['error'] = 'Invalid YAML'
+        return migration_files
+    except ValidationError:
+        migration_files['error'] = 'Data structure in the YAML file does not conform to the JSON schema'
+        return migration_files
+    else:
+        for migrations in data['migrations']:
+            migration_file = migrations['file']
+            from_constraint = migrations.get('from', {})
+            target_constraint = migrations.get('target', {})
+            if (
+                version_in_range(
+                    current_version,
+                    min_version=from_constraint.get('min_version'),
+                    max_version=from_constraint.get('max_version'),
+                ) and
+                version_in_range(
+                    target_version,
+                    min_version=target_constraint.get('min_version'),
+                    max_version=target_constraint.get('max_version'),
+                )
+            ):
+                migration_file_path = os.path.join(target_version_path, f'migrations/{migration_file}')
+                if os.access(migration_file_path, os.X_OK):
+                    migration_files['migration_files'].append({'error': None, 'migration_file': migration_file_path})
+                else:
+                    migration_files['migration_files'].append({
+                        'error': f'{migration_file!r} Migration file is not executable',
+                        'migration_file': migration_file_path
+                    })
+
+        return migration_files

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_migration_utils.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_migration_utils.py
@@ -1,0 +1,411 @@
+import textwrap
+import unittest.mock
+
+import pytest
+
+from jsonschema import validate, ValidationError
+
+from middlewared.plugins.apps.migration_utils import (
+    APP_CONFIG_MIGRATIONS_SCHEMA, get_migration_scripts, parse_version, validate_versions, version_in_range,
+)
+
+
+MOCKED_YAML = textwrap.dedent(
+    '''
+    migrations:
+      # No constraints - always run
+      - file: always.py
+        # Should run for any current/target combination
+
+      # Only min_version "from"
+      - file: only_min_version_from.py
+        from:
+          min_version: 1.0.0
+
+      # Only max_version "from"
+      - file: only_max_version_from.py
+        from:
+          max_version: 1.9.9
+
+      # min_version and max_version "from"
+      - file: range_from.py
+        from:
+          min_version: 1.0.0
+          max_version: 1.9.9
+
+      # Only min_version "target"
+      - file: only_min_version_target.py
+        target:
+          min_version: 2.0.0
+
+      # Only max_version "target"
+      - file: only_max_version_target.py
+        target:
+          max_version: 1.9.9
+
+      # min_version and max_version "target"
+      - file: range_target.py
+        target:
+          min_version: 2.0.0
+          max_version: 2.9.9
+
+      # Complex: from range and target range
+      - file: range_to_range.py
+        from:
+          min_version: 1.0.0
+          max_version: 1.9.9
+        target:
+          min_version: 2.0.0
+          max_version: 2.9.9
+
+      # Exact version match (using min_version/max_version)
+      - file: exact_version.py
+        from:
+          min_version: 1.0.0
+          max_version: 1.0.0
+    '''
+)
+
+
+@pytest.mark.parametrize('app_name, current_version, target_version, expected', [
+    (
+        'plex', '1.0.0', '2.0.0',
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_version_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_max_version_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_from.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_version_target.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_target.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_to_range.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/exact_version.py'
+                },
+            ]
+        }
+    ),
+    (
+        'plex', '1.5.0', '2.1.0',
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_version_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_max_versoin_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_from.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_version_target.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_target.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_to_range.py'
+                },
+            ]
+        }
+    ),
+    (
+        'plex', '0.9.9', None,
+        {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    ),
+    (
+        'plex', '1.5.0', None,
+        {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    ),
+    (
+        'plex', '0.9.9', '2.0.0',
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_max_versoin_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_version_target.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_target.py'
+                }
+            ]
+        }
+    ),
+    (
+        'plex', '1.5.0', '1.9.9',
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_min_versoin_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_max_versoin_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/range_from.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/2.0.0/migrations/only_max_version_target.py'
+                    )
+                }
+            ]
+        }
+    ),
+    (
+        'plex', None, None,
+        {
+            'error': 'Both current and target version should be specified', 'migration_files': []
+        }
+    ),
+    (
+        'plex', '2.0.0', '1.5.0',
+        {
+            'error': 'Target version should be greater than current version', 'migration_files': []
+        }
+    )
+])
+@unittest.mock.patch('builtins.open', new_callable=unittest.mock.mock_open, read_data=MOCKED_YAML)
+@unittest.mock.patch('os.path.join')
+@unittest.mock.patch('os.access')
+def test_get_migration_scripts(mock_access, mock_join, mock_open, app_name, current_version, target_version, expected):
+    migration_file_paths = [item['migration_file'] for item in expected['migration_files']]
+    mock_join.side_effect = [
+        '/mnt/.ix-apps/app_configs',
+        '/mnt/.ix-apps/app_configs/plex',
+        '/mnt/.ix-apps/app_configs/plex/versions',
+        f'/mnt/.ix-apps/app_configs/plex/versions/{target_version}',
+        '/path/to/migration.yaml',
+        *migration_file_paths,
+        ]
+    mock_access.return_value = True
+    result = get_migration_scripts(app_name, current_version, target_version)
+    assert result == expected
+
+
+@pytest.mark.parametrize('current_version, target_version, expected', [
+    (
+        '1.0.0', '1.5.0',
+        {
+            'error': None, 'migration_files': []
+        }
+    ),
+    (
+        '1.5.0', '2.0.0',
+        {
+            'error': None, 'migration_files': []
+        }
+    ),
+    (
+        '2.0.0', '1.5.0',
+        {
+            'error': 'Target version should be greater than current version',
+            'migration_files': []
+        }
+    ),
+    (
+        None, '1.5.0',
+        {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    ),
+    (
+        None, None,
+        {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    ),
+    (
+        'None', '1.1.1',
+        {
+            'error': 'Both versions should be numeric string',
+            'migration_files': []
+        }
+    ),
+    (
+        '', '1.0.0',
+        {
+            'error': 'Both current and target version should be specified',
+            'migration_files': []
+        }
+    )
+
+])
+def test_validate_versions(current_version, target_version, expected):
+    result = validate_versions(current_version, target_version)
+    assert result == expected
+
+
+@pytest.mark.parametrize('version, expected', [
+    ('1.0.0', '1.0.0'),
+    ('1.1.13', '1.1.13'),
+    ('abc', ValueError),
+    ('', ValueError)
+])
+def test_parse_versions(version, expected):
+    if isinstance(expected, str):
+        assert parse_version(version) == parse_version(expected)
+    else:
+        with pytest.raises(ValueError):
+            parse_version(version)
+
+
+@pytest.mark.parametrize('version, min_version, max_version, expected', [
+    (
+        '1.0.0', '1.0.0', '1.5.0', True
+    ),
+    (
+        '0.9.9', '1.0.0', '2.0.0', False
+    ),
+    (
+        '1.8.0', '1.5.0', '2.0.0', True
+    ),
+    (
+        '2.2.0', '1.0.0', '2.1.0', False
+    ),
+    (
+        '1.0.0', '1.0.0', '1.0.0', True
+    ),
+    (
+        '1.0.0', None, '2.0.0', True
+    ),
+    (
+        '1.0.0', 'None', '2.1.0', ValueError
+    ),
+    (
+        'Invalid', '1.0.0', '2.0.0', ValueError
+    )
+])
+def test_version_in_range(version, min_version, max_version, expected):
+    if isinstance(expected, bool):
+        result = version_in_range(version, min_version, max_version)
+        assert result == expected
+    else:
+        with pytest.raises(ValueError):
+            version_in_range(version, min_version, max_version)
+
+
+@pytest.mark.parametrize('valid_yaml_data', [
+    {
+        'migrations': [
+            {
+                'file': 'always.py',
+                'from': {'min_version': '1.0.0', 'max_version': '1.9.9'}
+            }
+        ]
+    },
+    {
+        'migrations': [
+            {
+                'file': 'always.py',
+                'target': {'min_version': '1.0.0', 'max_version': '1.9.9'}
+            }
+        ]
+    },
+    {
+        'migrations': [
+            {
+                'file': 'always.py'
+            }
+        ]
+    },
+    {
+        'migrations': [
+            {
+                'file': 'always.py',
+                'from': {'min_version': '1.0.0', 'max_version': '1.9.9'},
+                'target': {'min_version': '2.0.0', 'max_version': '2.5.0'}
+            }
+        ]
+    }
+])
+def test_validate_yaml_schema_valid(valid_yaml_data):
+    assert validate(valid_yaml_data, APP_CONFIG_MIGRATIONS_SCHEMA) is None
+
+
+@pytest.mark.parametrize('invalid_yaml_data', [
+    {'invalid_key': 'invalid_value'},
+    {},
+    None
+])
+def test_validate_yaml_schema_invalid_structure(invalid_yaml_data):
+    with pytest.raises(ValidationError):
+        validate(invalid_yaml_data, APP_CONFIG_MIGRATIONS_SCHEMA)

--- a/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_values.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/apps/test_upgrade_values.py
@@ -1,0 +1,192 @@
+import textwrap
+import unittest.mock
+import yaml
+
+import pytest
+
+from middlewared.plugins.apps.upgrade import AppService
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service import CallError
+
+
+APP_CONFIG = textwrap.dedent(
+    '''
+    app_version: 1.41.3.9314-a0bfb8370
+    capabilities:
+      - description: Plex is able to chown files.
+        name: CHOWN
+      - description: Plex is able to bypass permission checks for its sub-processes.
+        name: FOWNER
+      - description: Plex is able to bypass permission checks.
+        name: DAC_OVERRIDE
+      - description: Plex is able to set group ID for its sub-processes.
+        name: SETGID
+      - description: Plex is able to set user ID for its sub-processes.
+        name: SETUID
+      - description: Plex is able to kill processes.
+        name: KILL
+    categories:
+      - media
+    '''
+)
+
+
+@pytest.mark.parametrize('file_paths', [
+    [
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/always.py',
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/only_min_version_from.py'
+    ],
+    [],
+    [
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/always.py',
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/only_min_version_from.py',
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/only_max_versoin_from.py',
+        '/mnt/.ix-apps/app_configs/plex/version/1.1.13/migrations/range_from.py'
+    ]
+])
+@unittest.mock.patch('middlewared.plugins.apps.upgrade.subprocess.Popen')
+@unittest.mock.patch('tempfile.NamedTemporaryFile')
+@unittest.mock.patch('middlewared.plugins.apps.upgrade.get_current_app_config')
+@unittest.mock.patch('middlewared.plugins.apps.upgrade.AppService.get_data_for_upgrade_values')
+def test_upgrade_values(mock_get_data_for_upgrade_values, mock_current_config, mock_tempfile, mock_popen, file_paths):
+    mock_temp_file_instance = unittest.mock.MagicMock()
+    mock_temp_file_instance.name = '/mocked/tempfile/path'
+    mock_tempfile.return_value.__enter__.return_value = mock_temp_file_instance
+    mock_current_config.return_value = yaml.safe_load(APP_CONFIG)
+
+    mock_process = unittest.mock.MagicMock()
+    mock_process.communicate.return_value = (APP_CONFIG.encode(), b'')
+    mock_process.returncode = 0  # Mock a successful return code
+    mock_popen.return_value = mock_process
+    mock_get_data_for_upgrade_values.return_value = file_paths, APP_CONFIG
+
+    middleware = Middleware()
+    app_upgrade = AppService(middleware)
+    app = {
+        'name': 'plex',
+        'metadata': {'version': '1.1.12'}
+    }
+    upgrade_version = {
+        'version': '1.1.13'
+    }
+
+    result = app_upgrade.upgrade_values(app, upgrade_version)
+    expected_dict = yaml.safe_load(APP_CONFIG)
+    assert result is not None
+    assert mock_popen.call_count == len(file_paths)
+    if file_paths:
+        assert result == expected_dict
+    else:
+        assert result == APP_CONFIG
+
+
+@pytest.mark.parametrize('migration_files, expected', [
+    (
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/range_from.py'
+                }
+            ]
+        },
+        [
+            '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/always.py',
+            '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/range_from.py'
+        ]
+    ),
+    (
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': 'Migration file is not executable',
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/always.py'
+                },
+                {
+                    'error': 'Migration file is not executable',
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_min_version_from.py'
+                    )
+                },
+                {
+                    'error': 'Migration file is not executable',
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_max_version_from.py'
+                    )
+                }
+            ]
+        },
+        CallError
+    ),
+    (
+        {
+            'error': 'Invalid Yaml', 'migration_files': []
+        },
+        CallError
+    ),
+    (
+        {
+            'error': 'target version should be greater than current version',
+            'migration_file': []
+        },
+        CallError
+    ),
+    (
+        {
+            'error': 'No current or target version specified',
+            'migration_file': []
+        },
+        CallError
+    ),
+    (
+        {
+            'error': None, 'migration_files': [
+                {
+                    'error': None,
+                    'migration_file': '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/always.py'
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_min_version_from.py'
+                    )
+                },
+                {
+                    'error': None,
+                    'migration_file': (
+                        '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_max_version_from.py'
+                    )
+                }
+            ]
+        },
+        [
+            '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/always.py',
+            '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_min_version_from.py',
+            '/mnt/.ix-apps/app_configs/plex/versions/1.1.13/migrations/only_max_version_from.py'
+        ]
+    ),
+])
+@unittest.mock.patch('middlewared.plugins.apps.upgrade.get_migration_scripts')
+@unittest.mock.patch('middlewared.plugins.apps.upgrade.get_current_app_config')
+def test_get_data_for_upgrade_values(mock_current_config, mock_migration_scripts, migration_files, expected):
+    middleware = Middleware()
+    upgrade_app = AppService(middleware)
+    mock_migration_scripts.return_value = migration_files
+    mock_current_config.return_value = APP_CONFIG
+    app = {
+        'name': 'plex',
+        'version': '1.1.12'
+    }
+    upgrade_version = {
+        'version': '1.1.13'
+    }
+    if isinstance(expected, list):
+        files, new_config = upgrade_app.get_data_for_upgrade_values(app, upgrade_version)
+        assert files == expected
+    else:
+        with pytest.raises(CallError):
+            upgrade_app.get_data_for_upgrade_values(app, upgrade_version)


### PR DESCRIPTION
## Context

We would like support for app config migrations so app developer can mutate/change key/value pairs of the config while maintaining original consumer's existing configuration to make sure it complies with the new upgraded schema of the app.