### PR TITLE
NAS-133663 / 25.04 / Add OneDrive name and description to the drives list

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
@@ -104,3 +104,5 @@ class CloudSyncOneDriveListDrivesResult(BaseModel):
 class CloudSyncOneDriveListDrivesDrive(BaseModel):
     drive_id: str
     drive_type: Literal["PERSONAL", "BUSINESS", "DOCUMENT_LIBRARY"]
+    name: str
+    description: str

--- a/src/middlewared/middlewared/rclone/remote/onedrive.py
+++ b/src/middlewared/middlewared/rclone/remote/onedrive.py
@@ -71,6 +71,8 @@ class OneDriveRcloneRemote(BaseRcloneRemote):
             return {
                 "drive_type": DRIVES_TYPES_INV.get(drive["driveType"], ""),
                 "drive_id": drive["id"],
+                "name": drive.get("name") or "",
+                "description": drive.get("description") or "",
             }
 
         result = []


### PR DESCRIPTION
Nothing can be done about unusable drives being listed via API, they're indistinguishable from normal drives. At least let's add their names and description (those are `AEEE102E-CFF8-4E2A-89C6-03841FF83500` / `Document library to store albums and album items` and `ODCMetadataArchive` / `ODC Archived Metadata`) to help user identify them.