### PR TITLE
NAS-131451 / 25.04 / Limit the number of host and network entries in NFS share config

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/nfs.py
+++ b/src/middlewared/middlewared/api/v25_04_0/nfs.py
@@ -18,6 +18,8 @@ __all__ = ["NfsEntry",
            "NfsShareUpdateArgs", "NfsShareUpdateResult",
            "NfsShareDeleteArgs", "NfsShareDeleteResult"]
 
+MAX_NUM_NFS_NETWORKS = 42
+MAX_NUM_NFS_HOSTS = 42
 NFS_protocols = Literal["NFSV3", "NFSV4"]
 NFS_RDMA_DEFAULT_PORT = 20049
 EXCLUDED_PORTS = [NFS_RDMA_DEFAULT_PORT]
@@ -90,12 +92,14 @@ class NfsShareEntry(BaseModel):
     """ IGNORED for now. """
     comment: str = ""
     """ User comment associated with share. """
-    networks: list[NonEmptyString] = []
+    networks: Annotated[list[NonEmptyString], Field(max_length=MAX_NUM_NFS_NETWORKS)] = []
     """ List of authorized networks that are allowed to access the share having format
-        "network/mask" CIDR notation. Each entry must be unique. If empty, all networks are allowed. """
-    hosts: list[NonEmptyString] = []
+        "network/mask" CIDR notation. Each entry must be unique. If empty, all networks are allowed.
+        Maximum number of entries: 42 """
+    hosts: Annotated[list[NonEmptyString], Field(max_length=MAX_NUM_NFS_HOSTS)] = []
     """ list of IP's/hostnames which are allowed to access the share.  No quotes or spaces are allowed.
-        Each entry must be unique. If empty, all IP's/hostnames are allowed. """
+        Each entry must be unique. If empty, all IP's/hostnames are allowed.
+        Maximum number of entries: 42 """
     ro: bool = False
     """ Export the share as read only. """
     maproot_user: str | None = None

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -346,6 +346,14 @@ def move_systemdataset(new_pool_name):
     return call('systemdataset.config')
 
 
+def make_list_of_ipaddr(size: int) -> list:
+    """ Return a list of ip addresses """
+    genlist = []
+    for i in range(1, size + 1):
+        genlist.append(f"192.168.1.{i}")
+    return genlist
+
+
 @contextlib.contextmanager
 def system_dataset(new_pool_name):
     '''
@@ -683,6 +691,9 @@ class TestNFSops:
                False, "do not appear to be valid IPv4 or IPv6", id="IPv6 - invalid range"),
             pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                True, "", id="IPv6 - auto-convert to CIDR"),
+            # The following two entries use hostlist to specify the size of the list to create
+            pp(42, True, "", id="Valid - Max allowed entries"),
+            pp(43, False, "should have at most", id="Invalid - Too many entries"),
         ],
     )
     def test_share_networks(
@@ -698,6 +709,10 @@ class TestNFSops:
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
         nfsid = nfs_dataset_and_share['nfsid']
+
+        # Boundary test on list size
+        if not isinstance(networklist, list):
+            networklist = make_list_of_ipaddr(networklist)
 
         with nfs_share_config(nfsid):
             if ExpectedToPass:
@@ -747,7 +762,10 @@ class TestNFSops:
             pp(["*", "*.ixsystems.com"], True, "", id="Valid - mix everybody and wildcard name"),
             pp(["192.168.1.o"], False, "Unable to resolve", id="Invalid - character in address"),
             pp(["bad host"], False, "Cannot contain spaces", id="Invalid - name with spaces"),
-            pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"], True, "", id="Valid - IPv6 address")
+            pp(["2001:0db8:85a3:0000:0000:8a2e:0370:7334"], True, "", id="Valid - IPv6 address"),
+            # The following two entries use hostlist to specify size of the list to create
+            pp(42, True, "", id="Valid - Max allowed entries"),
+            pp(43, False, "should have at most", id="Invalid - Too many entries"),
         ],
     )
     def test_share_hosts(
@@ -773,6 +791,10 @@ class TestNFSops:
         assert start_nfs is True
         assert nfs_dataset_and_share['nfsid'] is not None
         nfsid = nfs_dataset_and_share['nfsid']
+
+        # Boundary test on list size
+        if not isinstance(hostlist, list):
+            hostlist = make_list_of_ipaddr(hostlist)
 
         with nfs_share_config(nfsid):
             if ExpectedToPass:


### PR DESCRIPTION
The number of hosts and/or networks entries for NFS shares is unbounded.  This allows for undesirable behaviors where users specify _many_ entries.  Long host or network lists cause timeouts when applying the configuration.  We want to discourage this behavior.  Better to use groups, network ranges or directory services.

This PR limits the hosts and networks lists to 42 entries.  This value is somewhat arbitrary, but a good compromise to allow a list just not an excessive list.

Abbreviated tests (ignore failures or timeouts in the setup tests) are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2661/):
