### PR TITLE
NAS-133703 / 25.04 / Raise ValidationError on perm change for readonly paths

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/acl.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/acl.py
@@ -84,6 +84,13 @@ class FilesystemService(Service):
                 f'{schema}.path',
                 'Path component for is currently encrypted and locked'
             )
+        else:
+            statfs_flags = self.middleware.call_sync('filesystem.statfs', path)['flags']
+            if 'RO' in statfs_flags:
+                verrors.add(
+                    f'{schema}.path',
+                    f'{path}: dataset underlying path has the readonly property enabled.'
+                )
 
         return loc
 


### PR DESCRIPTION
This commit introduces additional validation to check whether the path on which user is trying to change permissions is set to readonly. This appears to be a fairly common occurance with our SCALE userbase and so we need to cleanly explain why they can't do this.