### PR TITLE
NAS-133709 / 25.04 / Do not import middleware API in ZFS process pool

### DIFF
--- a/src/middlewared/middlewared/api/__init__.py
+++ b/src/middlewared/middlewared/api/__init__.py
@@ -1,1 +1,3 @@
 from .base.decorator import *
+
+API_LOADING_FORBIDDEN = False

--- a/src/middlewared/middlewared/api/base/types/urls.py
+++ b/src/middlewared/middlewared/api/base/types/urls.py
@@ -1,10 +1,12 @@
-from typing import Annotated
+from typing import Annotated, Literal, TypeAlias
 
 from pydantic import AfterValidator, HttpUrl
 
 from middlewared.api.base.validators import https_only_check
 
-__all__ = ["HttpsOnlyURL"]
+__all__ = ["HttpsOnlyURL", "HttpVerb"]
 
 
 HttpsOnlyURL = Annotated[HttpUrl, AfterValidator(https_only_check)]
+
+HttpVerb: TypeAlias = Literal["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]

--- a/src/middlewared/middlewared/api/current.py
+++ b/src/middlewared/middlewared/api/current.py
@@ -1,1 +1,8 @@
+from . import API_LOADING_FORBIDDEN
+if API_LOADING_FORBIDDEN:
+    raise RuntimeError(
+        "Middleware API loading forbidden in this code path as it is too resource-consuming. Please, inspect the "
+        "provided traceback and ensure that nothing is imported from `middlewared.api.current`."
+    )
+
 from .v25_04_0 import *  # noqa

--- a/src/middlewared/middlewared/api/v25_04_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_04_0/api_key.py
@@ -1,15 +1,12 @@
 from datetime import datetime
-from typing import Annotated, Literal, TypeAlias
+from typing import Annotated, Literal
 
 from pydantic import Secret, StringConstraints
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
-    LocalUsername, RemoteUsername
+    LocalUsername, RemoteUsername, HttpVerb,
 )
-
-
-HttpVerb: TypeAlias = Literal["GET", "POST", "PUT", "DELETE", "CALL", "SUBSCRIBE", "*"]
 
 
 class AllowListItem(BaseModel):

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -17,7 +17,7 @@ from .role import ROLES, RoleManager
 from .schema import OROperator
 import middlewared.service
 from .service_exception import CallError, ErrnoMixin
-from .utils import MIDDLEWARE_RUN_DIR, sw_version
+from .utils import MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH, sw_version
 from .utils.audit import audit_username_from_session
 from .utils.debug import get_threads_stacks
 from .utils.limits import MsgSizeError, MsgSizeLimit, parse_message
@@ -27,7 +27,6 @@ from .utils.profile import profile_wrap
 from .utils.rate_limit.cache import RateLimitCache
 from .utils.service.call import ServiceCallMixin
 from .utils.service.crud import real_crud_method
-from .utils.syslog import syslog_message
 from .utils.threading import set_thread_name, IoThreadPoolExecutor, io_thread_pool_executor
 from .utils.time_utils import utc_now
 from .utils.type import copy_function_metadata
@@ -200,7 +199,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         self.app.router.add_route('GET', f'/api/{version}', RpcWebSocketHandler(self, api.methods))
 
     def __init_services(self):
-        from middlewared.service import CoreService
+        from middlewared.service.core_service import CoreService
         self.add_service(CoreService(self))
         self.event_register('core.environ', 'Send on middleware process environment changes.', private=True)
 
@@ -448,7 +447,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         systemd_notify(f'EXTEND_TIMEOUT_USEC={SYSTEMD_EXTEND_USECS}')
 
     def __notify_startup_complete(self):
-        with open(middlewared.service.MIDDLEWARE_STARTED_SENTINEL_PATH, 'w'):
+        with open(MIDDLEWARE_STARTED_SENTINEL_PATH, 'w'):
             pass
 
         systemd_notify('READY=1')

--- a/src/middlewared/middlewared/plugins/datastore/connection.py
+++ b/src/middlewared/middlewared/plugins/datastore/connection.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 
 from middlewared.service import private, Service
 
-from middlewared.plugins.config import FREENAS_DATABASE
+from middlewared.utils.db import FREENAS_DATABASE
 
 thread_pool = ThreadPoolExecutor(1)
 

--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -3,9 +3,7 @@ import re
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.sql import Alias
-from sqlalchemy.sql.elements import UnaryExpression
 from sqlalchemy.sql.expression import nullsfirst, nullslast
-from sqlalchemy.sql.operators import desc_op, nullsfirst_op, nullslast_op
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, Str
 from middlewared.service import Service

--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -44,7 +44,8 @@ from zettarepl.utils.logging import (
 from zettarepl.zettarepl import create_zettarepl
 
 from middlewared.logger import setup_logging
-from middlewared.service import CallError, Service
+from middlewared.service.service import Service
+from middlewared.service_exception import CallError
 from middlewared.utils.cgroups import move_to_root_cgroups
 from middlewared.utils.prctl import die_with_parent
 from middlewared.utils.size import format_size

--- a/src/middlewared/middlewared/pytest/unit/test_service_cli_descriptions.py
+++ b/src/middlewared/middlewared/pytest/unit/test_service_cli_descriptions.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from middlewared.service import CoreService
+from middlewared.service.core_service import CoreService
 
 
 @pytest.mark.parametrize("doc,names,descriptions", [

--- a/src/middlewared/middlewared/service/__init__.py
+++ b/src/middlewared/middlewared/service/__init__.py
@@ -6,7 +6,6 @@ from middlewared.utils import filter_list # noqa
 
 from .compound_service import CompoundService # noqa
 from .config_service import ConfigService # noqa
-from .core_service import CoreService, MIDDLEWARE_RUN_DIR, MIDDLEWARE_STARTED_SENTINEL_PATH # noqa
 from .crud_service import CRUDService # noqa
 from .decorators import ( # noqa
     cli_private, filterable, filterable_returns, item_method, job, lock, no_auth_required,

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -33,7 +33,7 @@ from middlewared.job import Job, JobAccess
 from middlewared.pipe import Pipes
 from middlewared.schema import accepts, Any, Bool, Datetime, Dict, Int, List, Str
 from middlewared.service_exception import CallError, ValidationErrors
-from middlewared.utils import BOOTREADY, filter_list, MIDDLEWARE_RUN_DIR
+from middlewared.utils import BOOTREADY, filter_list, MIDDLEWARE_STARTED_SENTINEL_PATH
 from middlewared.utils.debug import get_frame_details, get_threads_stacks
 from middlewared.validators import IpAddress, Range
 
@@ -42,9 +42,6 @@ from .config_service import ConfigService
 from .crud_service import CRUDService
 from .decorators import filterable, filterable_returns, job, no_auth_required, no_authz_required, pass_app, private
 from .service import Service
-
-
-MIDDLEWARE_STARTED_SENTINEL_PATH = os.path.join(MIDDLEWARE_RUN_DIR, 'middlewared-started')
 
 
 def is_service_class(service, klass):

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -5,9 +5,10 @@ from typing import Annotated
 
 from pydantic import create_model, Field
 
-from middlewared.api import api_method
+from middlewared.api import API_LOADING_FORBIDDEN, api_method
 from middlewared.api.base.model import BaseModel, query_result, query_result_item
-from middlewared.api.current import QueryArgs, QueryOptions
+if not API_LOADING_FORBIDDEN:
+    from middlewared.api.current import QueryArgs, QueryOptions
 from middlewared.service_exception import CallError, InstanceNotFound
 from middlewared.schema import accepts, Any, Bool, convert_schema, Dict, Int, List, OROperator, Patch, Ref, returns
 from middlewared.utils import filter_list

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -4,9 +4,10 @@ import threading
 from collections import defaultdict, namedtuple
 from functools import wraps
 
-from middlewared.api import api_method
+from middlewared.api import API_LOADING_FORBIDDEN, api_method
 from middlewared.api.base import query_result
-from middlewared.api.current import QueryArgs, GenericQueryResult
+if not API_LOADING_FORBIDDEN:
+    from middlewared.api.current import QueryArgs, GenericQueryResult
 from middlewared.schema import accepts, Int, List, OROperator, Ref, returns
 
 

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -34,6 +34,7 @@ ProductName = ProductNames()
 
 MID_PID = None
 MIDDLEWARE_RUN_DIR = '/var/run/middleware'
+MIDDLEWARE_STARTED_SENTINEL_PATH = f'{MIDDLEWARE_RUN_DIR}/middlewared-started'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 MANIFEST_FILE = '/data/manifest.json'
 BRAND = ProductName.PRODUCT_NAME

--- a/src/middlewared/middlewared/utils/allowlist.py
+++ b/src/middlewared/middlewared/utils/allowlist.py
@@ -1,7 +1,7 @@
 import fnmatch
 import re
 
-from middlewared.api.current import HttpVerb
+from middlewared.api.base.types import HttpVerb
 from middlewared.utils.privilege_constants import ALLOW_LIST_FULL_ADMIN
 
 

--- a/src/middlewared/middlewared/worker.py
+++ b/src/middlewared/middlewared/worker.py
@@ -5,6 +5,7 @@ import setproctitle
 
 from truenas_api_client import Client
 
+import middlewared.api
 from . import logger
 from .common.environ import environ_update
 from .utils import MIDDLEWARE_RUN_DIR
@@ -49,29 +50,32 @@ class FakeMiddleware(LoadPluginsMixin, ServiceCallMixin):
         """
         Calls a method using middleware client
         """
-        serviceobj, methodobj = self.get_method(method)
+        try:
+            serviceobj, methodobj = self.get_method(method)
+        except Exception:
+            pass
+        else:
+            if serviceobj._config.process_pool and not hasattr(method, '_job'):
+                if asyncio.iscoroutinefunction(methodobj):
+                    try:
+                        # Search for a synchronous implementation of the asynchronous method (i.e. `get_instance`).
+                        # Why is this needed? Imagine we have a `ZFSSnapshot` service that uses a process pool. Let's say
+                        # its `create` method calls `zfs.snapshot.get_instance` to return the result. That call will have
+                        # to be forwarded to the main middleware process, which will call `zfs.snapshot.query` in the
+                        # process pool. If the process pool is already exhausted, it will lead to a deadlock.
+                        # By executing a synchronous implementation of the same method in the same process pool we
+                        # eliminate `Hold and wait` condition and prevent deadlock situation from arising.
+                        _, sync_methodobj = self.get_method(f'{method}__sync')
+                    except MethodNotFoundError:
+                        # FIXME: Make this an exception in 22.MM
+                        self.logger.warning('Service uses a process pool but has an asynchronous method: %r', method)
+                        sync_methodobj = None
+                else:
+                    sync_methodobj = methodobj
 
-        if serviceobj._config.process_pool and not hasattr(method, '_job'):
-            if asyncio.iscoroutinefunction(methodobj):
-                try:
-                    # Search for a synchronous implementation of the asynchronous method (i.e. `get_instance`).
-                    # Why is this needed? Imagine we have a `ZFSSnapshot` service that uses a process pool. Let's say
-                    # its `create` method calls `zfs.snapshot.get_instance` to return the result. That call will have
-                    # to be forwarded to the main middleware process, which will call `zfs.snapshot.query` in the
-                    # process pool. If the process pool is already exhausted, it will lead to a deadlock.
-                    # By executing a synchronous implementation of the same method in the same process pool we
-                    # eliminate `Hold and wait` condition and prevent deadlock situation from arising.
-                    _, sync_methodobj = self.get_method(f'{method}__sync')
-                except MethodNotFoundError:
-                    # FIXME: Make this an exception in 22.MM
-                    self.logger.warning('Service uses a process pool but has an asynchronous method: %r', method)
-                    sync_methodobj = None
-            else:
-                sync_methodobj = methodobj
-
-            if sync_methodobj is not None:
-                self.logger.trace('Calling %r in current process', method)
-                return sync_methodobj(*params)
+                if sync_methodobj is not None:
+                    self.logger.trace('Calling %r in current process', method)
+                    return sync_methodobj(*params)
 
         return self.client.call(method, *params, timeout=timeout, **kwargs)
 
@@ -128,9 +132,13 @@ def receive_events():
 
 def worker_init(debug_level, log_handler):
     global MIDDLEWARE
+    middlewared.api.API_LOADING_FORBIDDEN = True
     MIDDLEWARE = FakeMiddleware()
     os.environ['MIDDLEWARED_LOADING'] = 'True'
-    MIDDLEWARE._load_plugins()
+    MIDDLEWARE._load_plugins(whitelist=[
+        'middlewared.plugins.datastore',
+        'middlewared.plugins.zfs_',
+    ])
     os.environ['MIDDLEWARED_LOADING'] = 'False'
     setproctitle.setproctitle('middlewared (worker)')
     die_with_parent()


### PR DESCRIPTION
Previously, ZFS process pool was importing pydantic API. Middleware was waiting for it to finish during the startup (as middleware startup calls ZFS modules). The middleware startup time included 3 pydantic API import waits (middleware itself + 3 ZFS workers).

Now, it's only importing pydantic API once.