### PR TITLE
Correctly retrieve images which are valid for container type in virt plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -275,7 +275,7 @@ class VirtInstanceService(CRUDService):
                     if alias not in choices:
                         instance_types = set()
                         for i in v['versions'].values():
-                            if 'incus.tar.xz' in i['items']:
+                            if 'root.tar.xz' in i['items'] and 'desktop' not in v['aliases']:
                                 instance_types.add('CONTAINER')
                             if 'disk.qcow2' in i['items']:
                                 instance_types.add('VM')


### PR DESCRIPTION
## Problem
Currently, the `virt` image choices display images that are available for containers, but some of these images are not actually available for container use.  

## Solution  
Update the condition that determines whether an image is available for containers. Now, only images with **`root.tar.xz`** compression and **not a variant of a desktop image** will be considered valid.  
This condition is deduced based on the available images listed at [images.linuxcontainers.org](https://images.linuxcontainers.org).