### PR TITLE
NAS-133053 / 25.04 / Disable API keys if used over insecure transport

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -167,6 +167,7 @@ class AuthSessionEntry(BaseModel):
     ]
     credentials_data: BaseCredentialData | UserCredentialData | APIKeyCredentialData | TokenCredentialData
     created_at: datetime
+    secure_transport: bool
 
 
 class AuthTerminateSessionArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -181,6 +181,7 @@ class Session:
             "origin": str(self.app.origin),
             **dump_credentials(self.credentials),
             "created_at": utc_now() - timedelta(seconds=time.monotonic() - self.created_at),
+            "secure_transport": self.app.origin.secure_transport,
         }
 
 
@@ -771,6 +772,21 @@ class AuthService(Service):
                     resp['pam_response']['reason'] = 'Api key is expired.'
 
                 if resp['pam_response']['code'] == pam.PAM_SUCCESS:
+                    if not app.origin.secure_transport:
+                        # Per NEP if plain API key auth occurs over insecure transport
+                        # the key should be automatically revoked.
+                        await self.middleware.call('api_key.revoke', key_id)
+                        await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
+                            'credentials': {
+                                'credentials': 'API_KEY',
+                                'credentials_data': {'username': data['username']},
+                            },
+                            'error': 'API key revoked due to insecure transport.'
+                        }, False)
+
+                        response['response_type'] = AuthResp.EXPIRED.name
+                        return response
+
                     if thehash.startswith('$pbkdf2-sha256'):
                         # Legacy API key with insufficient iterations. Since we
                         # know that the plain-text we have here is correct, we can

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -116,7 +116,7 @@ class TrueNAS_Server:
             raise RuntimeError('IP is not set')
 
         uri = host_websocket_uri(addr)
-        cl = Client(uri, py_exceptions=True, log_py_exceptions=True)
+        cl = Client(uri, py_exceptions=True, log_py_exceptions=True, verify_ssl=False)
         try:
             resp = cl.call('auth.login_ex', {
                 'mechanism': 'PASSWORD_PLAIN',
@@ -160,13 +160,13 @@ truenas_server = TrueNAS_Server()
 
 
 @contextlib.contextmanager
-def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None):
+def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exceptions=True, host_ip=None, ssl=True):
     if auth is undefined:
         auth = ("root", password())
 
-    uri = host_websocket_uri(host_ip)
+    uri = host_websocket_uri(host_ip, ssl)
     try:
-        with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions) as c:
+        with Client(uri, py_exceptions=py_exceptions, log_py_exceptions=log_py_exceptions, verify_ssl=False) as c:
             if auth is not None:
                 auth_req = {
                     "mechanism": "PASSWORD_PLAIN",
@@ -215,8 +215,9 @@ def host():
     return truenas_server
 
 
-def host_websocket_uri(host_ip=None):
-    return f"ws://{host_ip or host().ip}/api/current"
+def host_websocket_uri(host_ip=None, ssl=True):
+    prefix = 'wss://' if ssl else 'ws://'
+    return f"{prefix}{host_ip or host().ip}/api/current"
 
 
 def password():


### PR DESCRIPTION
This commit adds a new attribute (secure_transport) to ConnectionOrigin to indicate whether the websocket session has secure transport. This flag is set in the following scenarios:

1) AF_UNIX
2) localhost
3) https / wss

New behavior based on security team feedback is introduced in this commit such that API keys will be automatically revoked when used over insecure transport. This is to prevent them being used in replay attacks.