### PR TITLE
NAS-133635 / 24.10.2 / Fix nameserver validation logic (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -660,6 +660,53 @@ def is_empty(val):
     return val in [None, ''] or val.isspace()
 
 
+def are_indices_in_consecutive_order(arr: list[int]) -> bool:
+    """
+    Determine if the integers in an array form a consecutive sequence 
+    with respect to their indices.
+
+    This function checks whether each integer at a given index position is 
+    exactly one greater than the integer at the previous index. In other 
+    words, it verifies that the sequence of numbers increases by exactly one 
+    as you move from left to right through the array.
+
+    Parameters:
+    arr (list[int]): A list of integers whose index-based order needs to be 
+                     validated.
+
+    Returns:
+    bool: 
+        - True if the numbers are consecutive.
+        - False if any number does not follow the previous number by exactly one.
+
+    Examples:
+    >>> are_indices_in_consecutive_order([1, 2])
+    True
+
+    >>> are_indices_in_consecutive_order([1, 3])
+    False
+
+    >>> are_indices_in_consecutive_order([5, 6, 7])
+    True
+
+    >>> are_indices_in_consecutive_order([4, 6, 7])
+    False
+
+    Edge Cases:
+    - An empty array will return True as there are no elements to violate 
+      the order.
+    - A single-element array will also return True for the same reason.
+
+    Notes:
+    - The function does not modify the input array and operates in O(n) time
+      complexity, where n is the number of elements in the list.
+    """
+    for i in range(1, len(arr)):
+        if arr[i] != arr[i - 1] + 1:
+            return False
+    return True
+
+
 class Nid(object):
 
     def __init__(self, _id):


### PR DESCRIPTION
My present self is often disappointed with my past self. The validation logic I wrote back in 2023 is bad...The logic fails when a 3rd name server is given. It crashes like so:
```
middlewared.service_exception.ValidationErrors: [EINVAL] global_configuration_update.nameserver1.nameserver2.nameserver3.nameserver0: When providing nameservers, they must be provided in consecutive order (i.e. nameserver1, nameserver2, nameserver3)
```

I've noticed (and fixed) 2 issues here:
1. the `schema` variable is being overwritten (it's being passed into this method)
2. the logic for validation consecutiveness was wrong. Add an `are_indices_in_consecutive_order` helper function that is documented and explains what it does.

Original PR: https://github.com/truenas/middleware/pull/15423
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133635