### PR TITLE
NAS-133721 / 25.04 / Make onetime password more readable

### DIFF
--- a/src/middlewared/middlewared/alert/source/api_key.py
+++ b/src/middlewared/middlewared/alert/source/api_key.py
@@ -10,7 +10,7 @@ class ApiKeyRevokedAlertClass(AlertClass, SimpleOneShotAlertClass):
     text = (
         "%(key_name)s: API key has been revoked and must either be renewed or deleted. "
         "Once the maintenance is complete, API client configuration must be updated to "
-        "use the renwed API key."
+        "use the renewed API key."
     )
 
     async def create(self, args):

--- a/src/middlewared/middlewared/utils/auth.py
+++ b/src/middlewared/middlewared/utils/auth.py
@@ -138,14 +138,15 @@ class OnetimePasswordManager:
         We store a sha512 hash of the plaintext for authentication purposes
         """
         with self.lock:
-            plaintext = generate_string(string_size=24)
-            keyhash = sha512_crypt(plaintext)
+            p = generate_string(string_size=24)
+            human_friendly = '-'.join([p[0:6], p[6:12], p[12:18], p[18:24]])
+            keyhash = sha512_crypt(human_friendly)
             expires = monotonic() + 86400
 
             entry = UserOnetimePassword(uid=uid, expires=expires, keyhash=keyhash)
             self.cnt += 1
             self.otpasswd[str(self.cnt)] = entry
-            return f'{self.cnt}_{plaintext}'
+            return f'{self.cnt}_{human_friendly}'
 
     def authenticate(self, uid: int, plaintext: str) -> OTPWResponse:
         """ Check passkey matches plaintext string.  """


### PR DESCRIPTION
Insert dashes into password chunks for one-time passwords so that
```
1_mLHJWwcR2EaxlGOLSuSDO88z
```

becomes

```
1_mLHJWw-cR2Eax-lGOLSu-SDO88z
```

Which is simpler for end-users to read if required.