### PR TITLE
NAS-133737 / 25.04 / fix CA profile choices

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/crypto_ca_profiles.py
+++ b/src/middlewared/middlewared/api/v25_04_0/crypto_ca_profiles.py
@@ -39,12 +39,17 @@ class CertExtensionsModel(BaseModel):
 
 
 @final
-class CAProfilesModel(BaseModel):
+class CAExtensions(BaseModel):
     key_length: int = 2048
     key_type: str = "RSA"
     lifetime: int = DEFAULT_LIFETIME_DAYS
     digest_algorithm: str = "SHA256"
     cert_extensions: CertExtensionsModel = CertExtensionsModel()
+
+
+@final
+class CAProfilesModel(BaseModel):
+    CA: CAExtensions = CAExtensions()
 
 
 class CAProfilesArgs(BaseModel):


### PR DESCRIPTION
Regression introduced when moving this to new API schema (https://github.com/truenas/middleware/pull/15417). The profiles need to be under a top-level `CA` key.