### PR TITLE
NAS-133752 / 25.04 / Change default URI of docker registry

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/app_registry.py
+++ b/src/middlewared/middlewared/api/v25_04_0/app_registry.py
@@ -20,7 +20,7 @@ class AppRegistryEntry(BaseModel):
 
 class AppRegistryCreate(AppRegistryEntry):
     id: Excluded = excluded_field()
-    uri: str = 'https://registry-1.docker.io/'
+    uri: str = 'https://index.docker.io/v1/'
 
 
 class AppRegistryCreateArgs(BaseModel):


### PR DESCRIPTION
## Context

We should be defaulting to `index.docker.io/v1/` because the URI we are using currently is valid but does not work with docker compose so we should default to one which would work in both cases i.e docker compose and explicitly pulling images