### PR TITLE
Add support for randomizing user passwords

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -70,6 +70,12 @@ class UserEntry(BaseModel):
     api_keys: list[int]
 
 
+class UserCreateUpdateResult(UserEntry):
+    password: NonEmptyString | None
+    """Password if it was specified in create or update payload. If random_password
+    was specified then this will be a 20 character random string."""
+
+
 class UserCreate(UserEntry):
     id: Excluded = excluded_field()
     unixhash: Excluded = excluded_field()
@@ -93,6 +99,8 @@ class UserCreate(UserEntry):
     home_create: bool = False
     home_mode: str = "700"
     password: Secret[str | None] = None
+    random_password: bool = False
+    "Generate a random 20 character password for the user"
 
 
 class UserUpdate(UserCreate, metaclass=ForUpdateMetaclass):
@@ -105,7 +113,7 @@ class UserCreateArgs(BaseModel):
 
 
 class UserCreateResult(BaseModel):
-    result: int
+    result: UserCreateUpdateResult
 
 
 class UserUpdateArgs(BaseModel):
@@ -114,7 +122,7 @@ class UserUpdateArgs(BaseModel):
 
 
 class UserUpdateResult(BaseModel):
-    result: int
+    result: UserCreateUpdateResult
 
 
 class UserDeleteOptions(BaseModel):

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -51,7 +51,7 @@ from middlewared.service import CallError, CRUDService, ValidationErrors, pass_a
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run, filter_list
-from middlewared.utils.crypto import generate_nt_hash, sha512_crypt
+from middlewared.utils.crypto import generate_nt_hash, sha512_crypt, generate_string
 from middlewared.utils.directoryservices.constants import DSType, DSStatus
 from middlewared.utils.filesystem.copy import copytree, CopyTreeConfig
 from middlewared.utils.nss import pwd, grp
@@ -305,6 +305,7 @@ class UserService(CRUDService):
             'immutable',
             'home_create',
             'roles',
+            'random_password',
             'twofactor_auth_configured',
         ]
 
@@ -610,6 +611,7 @@ class UserService(CRUDService):
                 raise
 
         pk = None  # Make sure pk exists to rollback in case of an error
+        password = data['password']
         data = self.user_compress(data)
         try:
             self.__set_password(data)
@@ -660,7 +662,7 @@ class UserService(CRUDService):
                 self.logger.warning('Failed to update authorized keys', exc_info=True)
                 raise CallError(f'Failed to update authorized keys: {e}')
 
-        return pk
+        return self.middleware.call_sync('user.query', [['id', '=', pk]], {'get': True}) | {'password': password}
 
     @api_method(UserUpdateArgs, UserUpdateResult, audit='Update user', audit_callback=True)
     @pass_app()
@@ -851,6 +853,8 @@ class UserService(CRUDService):
             perm_job.wait_sync()
 
         user.pop('sshpubkey', None)
+        password = user.get('password')
+
         self.__set_password(user)
 
         user = self.user_compress(user)
@@ -861,7 +865,7 @@ class UserService(CRUDService):
         if user['smb'] and must_change_pdb_entry:
             self.middleware.call_sync('smb.update_passdb_user', user)
 
-        return pk
+        return self.middleware.call_sync('user.query', [['id', '=', pk]], {'get': True}) | {'password': password}
 
     @private
     def recreate_homedir_if_not_exists(self, user, group, mode):
@@ -1268,6 +1272,15 @@ class UserService(CRUDService):
             exclude_filter,
             {'prefix': 'bsdusr_'}
         )
+
+        if data.get('random_password') and data.get('password'):
+            verrors.add(
+                f'{schema}.random_password',
+                'Specifying a randomized password while simultaneously supplying '
+                'an explicit password is not permitted.'
+            )
+        elif data.get('random_password'):
+            data['password'] = generate_string(string_size=20)
 
         if data.get('uid') is not None:
             try:

--- a/src/middlewared/middlewared/test/integration/assets/account.py
+++ b/src/middlewared/middlewared/test/integration/assets/account.py
@@ -14,17 +14,18 @@ def user(data, *, get_instance=True):
     data.setdefault('home_create', True)  # create user homedir by default
 
     user = call("user.create", data)
+    pk = user['id']
 
     try:
         value = None
 
         if get_instance:
-            value = call("user.get_instance", user)
+            value = user
 
         yield value
     finally:
         try:
-            call("user.delete", user)
+            call("user.delete", pk)
         except InstanceNotFound:
             pass
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -132,8 +132,9 @@ def create_user_with_dataset(ds_info, user_info):
 
         user_id = None
         try:
-            user_id = call('user.create', user_info['payload'])
-            yield call('user.query', [['id', '=', user_id]], {'get': True})
+            user = call('user.create', user_info['payload'])
+            user_id = user['id']
+            yield user
         finally:
             if user_id is not None:
                 call('user.delete', user_id, {"delete_group": True})

--- a/tests/api2/test_426_smb_vss.py
+++ b/tests/api2/test_426_smb_vss.py
@@ -121,7 +121,7 @@ def test_002_creating_shareuser_to_test_acls(request):
         "group_create": True,
         "password": SMB_PWD,
         "uid": next_uid,
-    })
+    })['id']
 
 
 def test_003_changing_dataset_owner(request):

--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -33,7 +33,7 @@ def test_create_account_audit():
                 "home": "/nonexistent",
                 "password": "password",
             }
-            user_id = call("user.create", payload)
+            user_id = call("user.create", payload)['id']
     finally:
         if user_id is not None:
             call("user.delete", user_id)

--- a/tests/api2/test_audit_rest.py
+++ b/tests/api2/test_audit_rest.py
@@ -126,7 +126,7 @@ def test_authenticated_call():
                 "password": "password",
             })
             assert r.status_code == 200
-            user_id = r.json()
+            user_id = r.json()['id']
     finally:
         if user_id is not None:
             call("user.delete", user_id)


### PR DESCRIPTION
This commit adds support for randomizing the user password for new users. This is to fulfill backend expectations of password being present while admin provides a one-time password to log into the server and perform operations.