### PR TITLE
NAS-133759 / 25.04 / Add missing await in sed_unlock_all

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sed.py
+++ b/src/middlewared/middlewared/plugins/disk_/sed.py
@@ -82,7 +82,7 @@ class DiskService(Service):
 
     @private
     async def sed_unlock_all(self, force=False):
-        if not self.should_try_unlock(force):
+        if not await self.should_try_unlock(force):
             return
 
         disks_to_unlock = await self.map_disks_to_passwd()


### PR DESCRIPTION
Add missing `await` in `sed_unlock_all`.  Seems to have been introduced in PR #15375

Noticed 
```
/usr/lib/python3/dist-packages/middlewared/plugins/disk_/sed.py:85: RuntimeWarning: coroutin>
```
in `systemctl status middlewared` output.

Add an `await`.