### PR TITLE
NAS-133761 / 25.04 / Include event handler name in error message

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1092,7 +1092,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             try:
                 await handler(self, event_type, kwargs)
             except Exception:
-                self.logger.error('Unhandled exception in event handler', exc_info=True)
+                self.logger.error('%s: Unhandled exception in event handler', name, exc_info=True)
 
         # Send event also for internally subscribed plugins
         for handler in self.__event_subs.get(name, []):


### PR DESCRIPTION
We currently don't log the name of the event handler being called when the callback fails.
This commit prepends the name assigned to it so that we can have better chances of
fixing bugs.