### PR TITLE
NAS-133742 / 25.04 / Expand validation for changing 2FA settings while in STIG mode

### DIFF
--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -6,6 +6,7 @@ import middlewared.sqlalchemy as sa
 
 from middlewared.schema import accepts, Bool, Dict, Int, Patch
 from middlewared.service import CallError, ConfigService, periodic, private
+from middlewared.service_exception import ValidationErrors
 from middlewared.utils.directoryservices.constants import DSStatus, DSType
 from middlewared.validators import Range
 
@@ -72,11 +73,28 @@ class TwoFactorAuthService(ConfigService):
 
         Update Two-Factor Authentication Service Configuration.
         """
+        verrors = ValidationErrors()
+        security = await self.middleware.call('system.security.config')
+
         old_config = await self.config()
         config = old_config.copy()
 
         config.update(data)
 
+        if security['enable_gpos_stig']:
+            if not config['enabled']:
+                verrors.add(
+                    'auth_twofactor_update.enable',
+                    'Two factor authentication may not be disabled in General Purpose OS STIG mode.'
+                )
+
+            if not config['services']['ssh']:
+                verrors.add(
+                    'auth_twofactor_update.services.ssh',
+                    'Two factor authentication for ssh service is required in General Purpose OS STIG mode.'
+                )
+
+        verrors.check()
         if config == old_config:
             return config
 

--- a/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
+++ b/src/middlewared/middlewared/test/integration/assets/two_factor_auth.py
@@ -9,11 +9,11 @@ from middlewared.test.integration.utils import call
 
 
 @contextlib.contextmanager
-def enabled_twofactor_auth():
+def enabled_twofactor_auth(ssh=False):
     try:
-        yield call('auth.twofactor.update', {'enabled': True, 'window': 3})
+        yield call('auth.twofactor.update', {'enabled': True, 'window': 3, 'services': {'ssh': ssh}})
     finally:
-        call('auth.twofactor.update', {'enabled': False, 'window': 0})
+        call('auth.twofactor.update', {'enabled': False, 'window': 0, 'services': {'ssh': False}})
 
 
 def get_user_secret(user_id: int, get: typing.Optional[bool] = True) -> typing.Union[dict, list]:

--- a/tests/api2/test_stig.py
+++ b/tests/api2/test_stig.py
@@ -12,6 +12,11 @@ from truenas_api_client import ValidationErrors
 
 
 @pytest.fixture(scope='function')
+def clear_ratelimit():
+    call('rate.limit.cache_clear')
+
+
+@pytest.fixture(scope='function')
 def enterprise_product():
     with product_type('ENTERPRISE'):
         with set_fips_available(True):
@@ -27,7 +32,7 @@ def community_product():
 
 @pytest.fixture(scope='module')
 def two_factor_enabled():
-    with enabled_twofactor_auth() as two_factor_config:
+    with enabled_twofactor_auth(ssh=True) as two_factor_config:
         yield two_factor_config
 
 
@@ -145,7 +150,7 @@ def test_no_current_cred_no_2fa(enterprise_product, two_factor_full_admin):
 # At this point STIG should be enabled on TrueNAS until end of file
 
 
-def test_stig_enabled_authenticator_assurance_level(setup_stig):
+def test_stig_enabled_authenticator_assurance_level(setup_stig, clear_ratelimit):
     # Validate that admin user can authenticate and perform operations
     setup_stig['connection'].call('system.info')
 
@@ -163,7 +168,7 @@ def test_stig_enabled_authenticator_assurance_level(setup_stig):
         c.call('system.info')
 
 
-def test_stig_roles_decrease(setup_stig):
+def test_stig_roles_decrease(setup_stig, clear_ratelimit):
 
     # We need new websocket connection to verify that privileges
     # are appropriately decreased
@@ -181,7 +186,17 @@ def test_stig_roles_decrease(setup_stig):
         assert me['privilege']['webui_access'] is True
 
 
-def test_stig_smb_auth_disabled(setup_stig):
+def test_stig_prevent_disable_2fa(setup_stig, clear_ratelimit):
+    with client(auth=None) as c:
+        do_stig_auth(c, setup_stig['user_obj'], setup_stig['secret'])
+        with pytest.raises(Verr, match='Two factor authentication may not be disabled'):
+            c.call('auth.twofactor.update', {'enabled': False})
+
+        with pytest.raises(Verr, match='for ssh service is required'):
+            c.call('auth.twofactor.update', {'services': {'ssh': False}})
+
+
+def test_stig_smb_auth_disabled(setup_stig, clear_ratelimit):
     # We need new websocket connection to verify that privileges
     # are appropriately decreased
 


### PR DESCRIPTION
Users should not be able to lock themselves out of the system by disabling 2FA in STIG mode.