### PR TITLE
NAS-133778 / 25.04 / Make root device in virt instance to be configurable on creation

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -81,6 +81,11 @@ class VirtInstanceCreateArgs(BaseModel):
     iso_volume: NonEmptyString | None = None
     source_type: Literal[None, 'IMAGE', 'ZVOL', 'ISO'] = 'IMAGE'
     image: Annotated[NonEmptyString, StringConstraints(max_length=200)] | None = None
+    root_disk_size: int = Field(ge=5, default=10)  # In GBs
+    '''
+    This can be specified when creating VMs so the root device's size can be configured. Root device for VMs
+    is a sparse zvol and the field specifies space in GBs and defaults to 10 GBs.
+    '''
     remote: REMOTE_CHOICES = 'LINUX_CONTAINERS'
     instance_type: InstanceType = 'CONTAINER'
     environment: dict[str, str] | None = None

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -344,7 +344,14 @@ class VirtInstanceService(CRUDService):
             data['source_type'] = None
             data_devices.append(root_device_to_add)
 
-        devices = {}
+        devices = {
+            'root': {
+                'path': '/',
+                'pool': 'default',
+                'type': 'disk',
+                'size': f'{data["root_disk_size"] * (1024**3)}',
+            }
+        } if data['instance_type'] == 'VM' else {}
         for i in data_devices:
             await self.middleware.call(
                 'virt.instance.validate_device', i, 'virt_instance_create', verrors, data['instance_type'],


### PR DESCRIPTION
## Context

We would like the root device's size in incus virt instance to be configurable so users can increase/decrease that based on what their requirement would be.