### PR TITLE
Only add wireguard address if wireguard interface is up (#15487)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -52,12 +52,17 @@
     ip6_list = [f'[{ip}]' for ip in ip6_list]
 
     wg_config = middleware.call_sync('datastore.config', 'system.truecommand')
-    if middleware.call_sync('failover.is_single_master_node') and wg_config['api_key_state'] == 'CONNECTED' and wg_config['wg_address']:
+    if (
+        middleware.call_sync('failover.is_single_master_node') and wg_config['api_key_state'] == 'CONNECTED'
+        and wg_config['wg_address'] and middleware.call_sync('service.started', 'truecommand')
+    ):
         # We use api key state to determine connected because sometimes when nginx config is reloaded
         # it is not necessary that health of wireguard connection has been established at that point
         # and another reload of nginx config is required then at that point then which is redundant
         # An example is that when failover takes place, system knows it is master now but wireguard health hasn't
         # been established at this point and we miss out on adding wireguard address to listen directive
+        # We also want to make sure wireguard interface is actually up before we add this because it will definitely otherwise result in
+        # nginx to not start on boot as wireguard won't be up at that time
         ip4_list.append(ipaddress.ip_network(wg_config['wg_address'], False).network_address)
 
     ip_list = ip4_list + ip6_list


### PR DESCRIPTION
This commit fixes an issue where if nginx is listening to some specific IP other then wildcard and we add wireguard interface address but wireguard interface is not up (whihc happpens on boot) and this results in nginx not starting.