### PR TITLE
NAS-133758 / 25.04-RC.1 / Add support for randomizing user passwords (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -70,6 +70,12 @@ class UserEntry(BaseModel):
     api_keys: list[int]
 
 
+class UserCreateUpdateResult(UserEntry):
+    password: NonEmptyString | None
+    """Password if it was specified in create or update payload. If random_password
+    was specified then this will be a 20 character random string."""
+
+
 class UserCreate(UserEntry):
     id: Excluded = excluded_field()
     unixhash: Excluded = excluded_field()
@@ -93,6 +99,8 @@ class UserCreate(UserEntry):
     home_create: bool = False
     home_mode: str = "700"
     password: Secret[str | None] = None
+    random_password: bool = False
+    "Generate a random 20 character password for the user"
 
 
 class UserUpdate(UserCreate, metaclass=ForUpdateMetaclass):
@@ -105,7 +113,7 @@ class UserCreateArgs(BaseModel):
 
 
 class UserCreateResult(BaseModel):
-    result: int
+    result: UserCreateUpdateResult
 
 
 class UserUpdateArgs(BaseModel):
@@ -114,7 +122,7 @@ class UserUpdateArgs(BaseModel):
 
 
 class UserUpdateResult(BaseModel):
-    result: int
+    result: UserCreateUpdateResult
 
 
 class UserDeleteOptions(BaseModel):

--- a/src/middlewared/middlewared/test/integration/assets/account.py
+++ b/src/middlewared/middlewared/test/integration/assets/account.py
@@ -14,17 +14,18 @@ def user(data, *, get_instance=True):
     data.setdefault('home_create', True)  # create user homedir by default
 
     user = call("user.create", data)
+    pk = user['id']
 
     try:
         value = None
 
         if get_instance:
-            value = call("user.get_instance", user)
+            value = user
 
         yield value
     finally:
         try:
-            call("user.delete", user)
+            call("user.delete", pk)
         except InstanceNotFound:
             pass
 

--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -132,8 +132,9 @@ def create_user_with_dataset(ds_info, user_info):
 
         user_id = None
         try:
-            user_id = call('user.create', user_info['payload'])
-            yield call('user.query', [['id', '=', user_id]], {'get': True})
+            user = call('user.create', user_info['payload'])
+            user_id = user['id']
+            yield user
         finally:
             if user_id is not None:
                 call('user.delete', user_id, {"delete_group": True})

--- a/tests/api2/test_426_smb_vss.py
+++ b/tests/api2/test_426_smb_vss.py
@@ -121,7 +121,7 @@ def test_002_creating_shareuser_to_test_acls(request):
         "group_create": True,
         "password": SMB_PWD,
         "uid": next_uid,
-    })
+    })['id']
 
 
 def test_003_changing_dataset_owner(request):

--- a/tests/api2/test_audit_rest.py
+++ b/tests/api2/test_audit_rest.py
@@ -126,7 +126,7 @@ def test_authenticated_call():
                 "password": "password",
             })
             assert r.status_code == 200
-            user_id = r.json()
+            user_id = r.json()['id']
     finally:
         if user_id is not None:
             call("user.delete", user_id)


### PR DESCRIPTION
This commit adds support for randomizing the user password for new users. This is to fulfill backend expectations of password being present while admin provides a one-time password to log into the server and perform operations.

Note: this commit changes the output of `user.create` and `user.update` so that it returns a copy of the
entry instead of just returning the pk.

Original PR: https://github.com/truenas/middleware/pull/15469
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133758