### PR TITLE
NAS-133762 / 25.04-RC.1 / Allow password change for OTPW sessions (by anodos325)

### DIFF
--- a/tests/api2/test_password_reset.py
+++ b/tests/api2/test_password_reset.py
@@ -138,3 +138,23 @@ def test_restricted_user_set_password():
                     'old_password': TEST_PASSWORD2,
                     'new_password': TEST_PASSWORD2_2
                 })
+
+
+def test_password_reset_via_onetime_password():
+    with unprivileged_user(
+        username=TEST_USERNAME,
+        group_name=TEST_GROUPNAME,
+        privilege_name='TEST_PASSWD_RESET_PRIVILEGE',
+        web_shell=False,
+        roles=['READONLY_ADMIN']
+    ) as acct:
+        otp = call('auth.generate_onetime_password', {'username': acct.username})
+        with client(auth=(acct.username, otp)) as c:
+            c.call('user.set_password', {
+                'username': TEST_USERNAME,
+                'new_password': TEST_PASSWORD2_2
+            })
+
+        # Verify that password change worked
+        with client(auth=(acct.username, TEST_PASSWORD2_2)):
+            pass


### PR DESCRIPTION
When provisioning new admin users on TrueNAS the sysadmin may provide the user with a one-time password in order to set up their own credentials. This means that OTPW authentication should be allowed to set the associated user's password.

Original PR: https://github.com/truenas/middleware/pull/15472
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133762