### PR TITLE
NAS-133859 / 25.04-RC.1 / Make sure virt instance is not created if create call fails (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -398,16 +398,21 @@ class VirtInstanceService(CRUDService):
                 'mode': 'pull',
                 'alias': data['image'],
             })
-
-        await incus_call_and_wait('1.0/instances', 'post', {'json': {
-            'name': data['name'],
-            'ephemeral': False,
-            'config': self.__data_to_config(data, instance_type=data['instance_type']),
-            'devices': devices,
-            'source': source,
-            'type': 'container' if data['instance_type'] == 'CONTAINER' else 'virtual-machine',
-            'start': data['autostart'],
-        }}, running_cb, timeout=15 * 60)  # We will give 15 minutes to incus to download relevant image and then timeout
+        try:
+            await incus_call_and_wait('1.0/instances', 'post', {'json': {
+                'name': data['name'],
+                'ephemeral': False,
+                'config': self.__data_to_config(data, instance_type=data['instance_type']),
+                'devices': devices,
+                'source': source,
+                'type': 'container' if data['instance_type'] == 'CONTAINER' else 'virtual-machine',
+                'start': data['autostart'],
+            }}, running_cb, timeout=15 * 60)
+            # We will give 15 minutes to incus to download relevant image and then timeout
+        except CallError as e:
+            if await self.middleware.call('virt.instance.query', [['name', '=', data['name']]]):
+                await (await self.middleware.call('virt.instance.delete', data['name'])).wait()
+            raise e
 
         return await self.middleware.call('virt.instance.get_instance', data['name'])
 


### PR DESCRIPTION
## Context

It is possible in certain scenarios that incus on instance creation raises an error which we propagate but the instance still does get created - although can't be used until some more settings are tweaked. This is not very reliable and in these cases after discussing with William, we should be nuking the instance if it has been created as `virt.instance.create` had failed.

Original PR: https://github.com/truenas/middleware/pull/15515
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133859