### PR TITLE
NAS-133862 / 25.10 / Prevent fcport.status exception when CORE config not migrated

### DIFF
--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -156,6 +156,8 @@ class FCPortService(CRUDService):
         result = {}
         for p in ports:
             naa = p[key]
+            if naa is None:
+                continue
             sessions_path = qla_target_path / wwn_as_colon_hex(naa) / 'sessions'
             sessions = []
             try:


### PR DESCRIPTION
When a CORE FC config is migrated to SCALE, some manual fixup will be required to remap the targets to the the SCALE equivalents (e.g. `isp0` -> `fc0`).  In the meantime we do not want `fcport.status` to crash because this will prevent the UI from displaying the _Fibre Channel Ports_ tab.