### PR TITLE
NAS-133885 / 25.04-RC.1 / More Fibre Channel NPIV fixes (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/scst.conf.mako
+++ b/src/middlewared/middlewared/etc_files/scst.conf.mako
@@ -73,7 +73,7 @@
     fc_host_by_port_name = {}
 
     def ha_node_wwpn_for_fcport_or_fchost(fcport):
-        if render_ctx['failover.node'] == 'A':
+        if not is_ha or render_ctx['failover.node'] == 'A':
             return wwn_as_colon_hex(fcport['wwpn'])
         elif render_ctx['failover.node'] == 'B':
             return wwn_as_colon_hex(fcport['wwpn_b'])
@@ -81,7 +81,7 @@
     def ha_node_wwpn_for_target(target, node):
         if target['id'] in fcports_by_target_id:
             fcport = fcports_by_target_id[target['id']]
-            if node == 'A':
+            if not is_ha or node == 'A':
                 return wwn_as_colon_hex(fcport['wwpn'])
             elif node == 'B':
                 return wwn_as_colon_hex(fcport['wwpn_b'])
@@ -730,9 +730,14 @@ TARGET_DRIVER qla2x00t {
 <%
     wwpn = wwn_as_colon_hex(fcport['wwpn'])
     target = fcport_to_target(fcport)
+    parent_host = fcport_to_parent_host(fcport)
 %>
     % if wwpn and target:
     TARGET ${wwpn} {
+% if parent_host:
+        node_name ${parent_host}
+        parent_host ${parent_host}
+% endif  ## parent_host
         rel_tgt_id ${target['rel_tgt_id'] + REL_TGT_ID_FC_OFFSET}
         enabled 1
         % for associated_target in associated_targets[fcport['target']['id']]:

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -615,6 +615,8 @@ class TestFixtureFibreChannel:
                 assert scst_qla_targets[key2] == {
                     'LUN': {'0': 'fcextent1'},
                     'enabled': '1',
+                    'node_name': key0,
+                    'parent_host': key0,
                     'rel_tgt_id': str(5001 + rel_tgt_id_node_offset)
                 }
 


### PR DESCRIPTION
A recent PR (#15495) ensured that we added `node_name` and `parent_host` for NPIV targets.  However the CI test was not updated to reflect this, leading to CI test failures (e.g. [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2837/))

Update the test to include `node_name` and `parent_host` for NPIV targets.

Further, noticed that previous PR did **not** make the change for non-HA systems.  Rectify.

With these changes the CI test pass against both HA and non-HA systems.


Original PR: https://github.com/truenas/middleware/pull/15527
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133885