### PR TITLE
NAS-133888 / 25.10 / Initial round of disk enumeration improvements

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/__init__.py
+++ b/src/middlewared/middlewared/utils/disks_/__init__.py
@@ -1,0 +1,3 @@
+from .get_disks import get_disks
+
+__all__ = ("get_disks",)

--- a/src/middlewared/middlewared/utils/disks_/get_disks.py
+++ b/src/middlewared/middlewared/utils/disks_/get_disks.py
@@ -1,0 +1,21 @@
+from collections.abc import Generator
+
+from pyudev import Context
+
+from .private_utils import DiskEntry, __get_disks_impl, __get_serial_lunid
+
+__all__ = ("get_disks",)
+
+
+def get_disks() -> Generator[DiskEntry]:
+    """Iterate over /dev and yield a `DiskEntry` object for
+    each disk detected on the system."""
+    ctx = Context()
+    for name, devpath in __get_disks_impl():
+        serial, lunid = __get_serial_lunid(ctx, name)
+        yield DiskEntry(
+            name=name,
+            devpath=devpath,
+            serial=serial,
+            lunid=lunid,
+        )

--- a/src/middlewared/middlewared/utils/disks_/private_utils.py
+++ b/src/middlewared/middlewared/utils/disks_/private_utils.py
@@ -50,7 +50,7 @@ def __get_disks_impl() -> Generator[tuple[str, str]]:
             yield i.name, i.path
 
 
-def __get_serial_lunid(ctx: Context, devname: str) -> tuple[str, str]:
+def __get_serial_lunid(ctx: Context, devname: str) -> tuple[str | None, str | None]:
     serial = lunid = None
     try:
         dev = Devices.from_name(ctx, "block", devname)

--- a/src/middlewared/middlewared/utils/disks_/private_utils.py
+++ b/src/middlewared/middlewared/utils/disks_/private_utils.py
@@ -1,0 +1,76 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from os import scandir
+from re import compile as rcompile
+
+from pyudev import Context, Devices, DeviceNotFoundByNameError
+
+# sda, pmem0, vda, nvme0n1 but not sda1/vda1/nvme0n1p1
+VALID_WHOLE_DISK = rcompile(r"^pmem\d+$|^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$")
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class DiskEntry:
+    name: str | None = None
+    """The disk name (i.e. 'sda')"""
+    devpath: str | None = None
+    """The disk /dev path (i.e. '/dev/sda')"""
+    serial: str | None = None
+    """The disk serial number as reported by udevd"""
+    lunid: str | None = None
+    """The 'lunid' as presented by udevd.
+
+    NOTE: 'lunid' might be a bit of a misnomer since
+        we're using the 'ID_WWN' property of the disk
+        but it is the same principle and it allows us
+        to use common terms that most recognize."""
+
+    @property
+    def identifier(self) -> str:
+        """Return, ideally, a unique identifier for the disk.
+
+        NOTE: If someone is using a usb 'hub', for example, then
+            all bets are off the table. Those devices will often
+            report duplicate serial numbers for all disks attached
+            to it AND will report the same lunid. It's impossible
+            for us to handle that and this is a scenario that isn't
+            supported."""
+        if self.serial and self.lunid:
+            return f"{{serial_lunid}}{self.serial}_{self.lunid}"
+        elif self.serial:
+            return f"{{serial}}{self.serial}"
+        else:
+            return f"{{devicename}}{self.name}"
+
+
+def __get_disks_impl() -> Generator[tuple[str, str]]:
+    """Iterate over /dev and yield valid devices."""
+    with scandir("/dev") as sdir:
+        for i in filter(lambda x: VALID_WHOLE_DISK.match(x.name), sdir):
+            yield i.name, i.path
+
+
+def __get_serial_lunid(ctx: Context, devname: str) -> tuple[str, str]:
+    serial = lunid = None
+    try:
+        dev = Devices.from_name(ctx, "block", devname)
+    except DeviceNotFoundByNameError:
+        # disk could have been yanked
+        # (or died) by the time we
+        # enumerated the path
+        return serial, lunid
+
+    # order of these keys are important
+    for key in ("ID_SCSI_SERIAL", "ID_SERIAL_SHORT", "ID_SERIAL"):
+        try:
+            serial = dev.properties[key]
+            break
+        except KeyError:
+            continue
+
+    try:
+        lunid = dev.properties["ID_WWN"].removeprefix("0x").removeprefix("eui.")
+    except (KeyError, AttributeError):
+        pass
+
+    return serial, lunid


### PR DESCRIPTION
We need to clean up how we enumerate disks. The SED investigations have exposed some very obvious issues in this area. This is the first step at adding stand-alone functions for this task. Please note that there is some duplicate functionality spread out all over our code in this area, but this will be used as the "source" moving forward. Most importantly, however, is that we have an oustanding SED unlock issue that we need to address but we need the `get_disks` function that I've written in here first.

On an internal system with ~1.2k+ disks, this takes ~0.23 seconds to complete. That's pretty darn good since it enumerates the serial AND "lunid" information of each disk in real-time. Careful reviewers will note that it uses the udevd database which is not the end of the world. Udevd does a _ton_ of work caching the various disk information for us in 1 place. We shouldn't throw the baby out with the bathwater just because of some (very) painful issues that we've experienced in the past.

Subsequent PRs will follow to change existing code to use this new functionality. We've chosen to do it this way since enumerating disk information is a _critical_ part of our product.