### PR TITLE
NAS-133959 / 25.10 / Add `secureboot` to image choices

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -219,6 +219,7 @@ class ImageChoiceItem(BaseModel):
     archs: list[str]
     variant: str
     instance_types: list[InstanceType]
+    secureboot: bool | None
 
 
 class VirtInstanceImageChoicesResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -309,6 +309,9 @@ class VirtInstanceService(CRUDService):
                             'archs': [v['arch']],
                             'variant': v['variant'],
                             'instance_types': list(instance_types),
+                            'secureboot': (
+                                False if v['requirements'].get('secureboot') == 'false' else True
+                            ),
                         }
                     else:
                         choices[alias]['archs'].append(v['arch'])

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -302,6 +302,11 @@ class VirtInstanceService(CRUDService):
                                 instance_types.add('VM')
                         if not instance_types:
                             continue
+                        secureboot = None
+                        if v['requirements'].get('secureboot') == 'false':
+                            secureboot = False
+                        elif v['requirements'].get('secureboot') == 'true':
+                            secureboot = True
                         choices[alias] = {
                             'label': f'{v["os"]} {v["release"]} ({v["arch"]}, {v["variant"]})',
                             'os': v['os'],
@@ -309,9 +314,7 @@ class VirtInstanceService(CRUDService):
                             'archs': [v['arch']],
                             'variant': v['variant'],
                             'instance_types': list(instance_types),
-                            'secureboot': (
-                                False if v['requirements'].get('secureboot') == 'false' else True
-                            ),
+                            'secureboot': secureboot,
                         }
                     else:
                         choices[alias]['archs'].append(v['arch'])


### PR DESCRIPTION
This is required to tell whether or not secure boot option for instance should be allowed.