### PR TITLE
NAS-133899 / 25.10 / Reduce number of 2FA public endpoints

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -251,12 +251,15 @@ class UserTwofactorConfigArgs(BaseModel):
     username: str
 
 
-@single_argument_result
-class UserTwofactorConfigResult(BaseModel):
+class UserTwofactorConfigEntry(BaseModel):
     provisioning_uri: str | None
     secret_configured: bool
     interval: int
     otp_digits: int
+
+
+class UserTwofactorConfigResult(BaseModel):
+    result = UserTwofactorConfigEntry
 
 
 class UserVerifyTwofactorTokenArgs(BaseModel):
@@ -288,4 +291,5 @@ class UserRenew2faSecretArgs(BaseModel):
     twofactor_options: TwofactorOptions
 
 
-UserRenew2faSecretResult = single_argument_result(UserEntry, "UserRenew2faSecretResult")
+class UserRenew2faSecretResult(UserEntry):
+    twofactor_config = UserTwofactorConfigEntry

--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -258,8 +258,9 @@ class UserTwofactorConfigEntry(BaseModel):
     otp_digits: int
 
 
-class UserTwofactorConfigResult(BaseModel):
-    result = UserTwofactorConfigEntry
+@single_argument_result
+class UserTwofactorConfigResult(UserTwofactorConfigEntry):
+    pass
 
 
 class UserVerifyTwofactorTokenArgs(BaseModel):
@@ -291,5 +292,6 @@ class UserRenew2faSecretArgs(BaseModel):
     twofactor_options: TwofactorOptions
 
 
+@single_argument_result
 class UserRenew2faSecretResult(UserEntry):
-    twofactor_config = UserTwofactorConfigEntry
+    twofactor_config: UserTwofactorConfigEntry

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -21,11 +21,13 @@ class UserService(Service):
             'iXsystems'
         )
 
-    @api_method(UserProvisioningUriArgs, UserProvisioningUriResult, roles=['ACCOUNT_WRITE'])
+    @api_method(UserProvisioningUriArgs, UserProvisioningUriResult, private=True)
     async def provisioning_uri(self, username):
         """
         Returns the provisioning URI for the OTP for `username`. This can then be encoded in a QR code and used
         to provision an OTP app like Google Authenticator.
+
+        WARNING: response for this endpoint includes the 2FA secret for the user
         """
         user = await self.translate_username(username)
         user_twofactor_config = await self.middleware.call(
@@ -36,10 +38,12 @@ class UserService(Service):
 
         return await self.provisioning_uri_internal(username, user_twofactor_config)
 
-    @api_method(UserTwofactorConfigArgs, UserTwofactorConfigResult, roles=['ACCOUNT_READ'])
+    @api_method(UserTwofactorConfigArgs, UserTwofactorConfigResult, private=True)
     async def twofactor_config(self, username):
         """
         Returns two-factor authentication configuration settings for specified `username`.
+
+        WARNING: response for this endpoint includes the 2FA secret for the user
         """
         user = await self.translate_username(username)
         user_twofactor_config = await self.middleware.call(
@@ -57,7 +61,7 @@ class UserService(Service):
             'otp_digits': user_twofactor_config['otp_digits'],
         }
 
-    @api_method(UserVerifyTwofactorTokenArgs, UserVerifyTwofactorTokenResult, roles=['FULL_ADMIN'])
+    @api_method(UserVerifyTwofactorTokenArgs, UserVerifyTwofactorTokenResult, private=True)
     def verify_twofactor_token(self, username, token):
         """
         Returns boolean true if provided `token` is successfully authenticated for `username`.
@@ -179,4 +183,6 @@ class UserService(Service):
             # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
             await self.middleware.call('service.reload', 'ssh')
 
-        return await self.translate_username(username)
+        user_entry = await self.translate_username(username)
+        twofactor_config = await self.twofactor_config(username)
+        return user_entry | {'twofactor_config': twofactor_config}

--- a/tests/unit/test_role_manager.py
+++ b/tests/unit/test_role_manager.py
@@ -20,7 +20,6 @@ WRITE_METHODS = frozenset(['fakemethod3', 'fakemethod6'])
 READONLY_ADMIN_METHODS = ALL_METHODS - WRITE_METHODS
 FULL_ADMIN_STIG = ALL_METHODS - FAKE_METHODS_NOSTIG
 EXPECTED_FA_RESOURCES = frozenset({
-    'user.verify_twofactor_token',
     'failover.reboot.other_node',
     'truenas.accept_eula',
     'filesystem.put',


### PR DESCRIPTION
This commit removes several 2FA-related public endpoints from the API as they are unused by the UI team and are of dubious benefit.

The API response for resetting a user's 2FA token now includes the token in the response. This simplifies the task for API users to generate a 2FA token for a user and presenting it for use by removing the necessity to call `auth.me` after generating the token.