### PR TITLE
NAS-133918 / 25.04-RC.1 / fix usage plugin crash (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -11,6 +11,7 @@ from middlewared.utils.path import is_child
 from middlewared.plugins.audit.utils import (
     AUDIT_DEFAULT_FILL_CRITICAL, AUDIT_DEFAULT_FILL_WARNING
 )
+from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
 from middlewared.utils.tdb import (
     get_tdb_handle,
     TDBBatchAction,
@@ -348,7 +349,6 @@ def path_to_dataset_impl(path: str, mntinfo: dict | None = None) -> str:
     can be raised by a failed call to os.stat() are
     possible.
     """
-    from middlewared.plugins.boot import BOOT_POOL_NAME
     st = os.stat(path)
     if mntinfo is None:
         mntinfo = getmntinfo(st.st_dev)[st.st_dev]
@@ -359,7 +359,8 @@ def path_to_dataset_impl(path: str, mntinfo: dict | None = None) -> str:
     if mntinfo['fs_type'] != 'zfs':
         raise CallError(f'{path}: path is not a ZFS filesystem')
 
-    if is_child(ds_name, BOOT_POOL_NAME):
-        raise CallError(f'{path}: path is on boot pool')
+    for bp_name in BOOT_POOL_NAME_VALID:
+        if is_child(ds_name, bp_name):
+            raise CallError(f'{path}: path is on boot pool')
 
     return ds_name


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/15247 caused a regression because it lazy imports the BOOT_POOL_NAME module variable. Seems like the usage plugin is being loaded before this is being set so call path ends up crashing like so:
```

  File "/usr/lib/python3/dist-packages/middlewared/plugins/zfs_/utils.py", line 362, in path_to_dataset_impl
    if is_child(ds_name, BOOT_POOL_NAME):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/path.py", line 156, in is_child
    if os.path.isabs(child) or os.path.isabs(parent):
                               ^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 62, in isabs
TypeError: expected str, bytes or os.PathLike object, not NoneType
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/usage.py", line 156, in gather_backup_data
    task_ds = self.middleware.call_sync('zfs.dataset.path_to_dataset', task['path'], context['mntinfo'])
```
The original commit isn't clear on why this was changed to being lazy loaded every time this function was being called. The fix is to use the statically defined global variable that is a list of valid boot pool names (they don't change).

Original PR: https://github.com/truenas/middleware/pull/15542
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133918