### PR TITLE
NAS-133945 / 25.10 / Make `run_with_user_context` crash if multiprocessing worker tries to import API

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
+++ b/src/middlewared/middlewared/plugins/filesystem_/perm_check.py
@@ -4,7 +4,6 @@ import pathlib
 
 from middlewared.schema import accepts, Bool, Dict, returns, Str
 from middlewared.service import CallError, Service, private
-
 from middlewared.utils.filesystem.access import check_access, check_acl_execute_impl
 from middlewared.utils.user_context import run_with_user_context
 


### PR DESCRIPTION
Follow-up to https://github.com/truenas/middleware/pull/15551