### PR TITLE
NAS-133892 / 25.10 / Unlock SED drives using disk `real_name` (by themylogin) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -4,6 +4,7 @@ from middlewared.utils import ProductType
 from middlewared.schema import accepts, Bool, Datetime, Dict, Int, Patch, Str
 from middlewared.service import filterable, private, CallError, CRUDService, ValidationError
 import middlewared.sqlalchemy as sa
+from middlewared.utils.disks_.get_disks import get_disks
 
 
 class DiskModel(sa.Model):
@@ -142,6 +143,10 @@ class DiskService(CRUDService):
             disk['pool'] = context['boot_pool_name']
         else:
             disk['pool'] = context['zfs_guid_to_pool'].get(disk['zfs_guid'])
+
+        if context['real_names']:
+            disk['real_name'] = context['identifier_to_name'].get(disk['identifier'])
+
         return disk
 
     @private
@@ -150,6 +155,8 @@ class DiskService(CRUDService):
             'passwords': extra.get('passwords', False),
             'supports_smart': extra.get('supports_smart', False),
             'disks_keys': {},
+            'real_names': extra.get('real_names', False),
+            'identifier_to_name': {},
 
             'pools': extra.get('pools', False),
             'boot_pool_disks': [],
@@ -159,6 +166,12 @@ class DiskService(CRUDService):
 
         if context['passwords']:
             context['disks_keys'] = await self.middleware.call('kmip.retrieve_sed_disks_keys')
+
+        if context['real_names']:
+            context['identifier_to_name'] = {
+                disk.identifier: disk.name
+                for disk in await self.middleware.run_in_thread(lambda: list(get_disks()))
+            }
 
         if context['supports_smart']:
             if len(rows) > 1:

--- a/src/middlewared/middlewared/plugins/disk_/sed.py
+++ b/src/middlewared/middlewared/plugins/disk_/sed.py
@@ -30,11 +30,11 @@ class DiskService(Service):
     async def map_disks_to_passwd(self, disk_name=None):
         global_passwd = await self.middleware.call('system.advanced.sed_global_password')
         disks = []
-        filters = [] if disk_name is None else [('name', '=', disk_name)]
+        filters = [] if disk_name is None else [('real_name', '=', disk_name)]
         for disk in await self.middleware.call(
-            'disk.query', filters, {'extra': {'passwords': True}}
+            'disk.query', filters, {'extra': {'passwords': True, 'real_names': True}}
         ):
-            path = f'/dev/{disk["name"]}'
+            path = f'/dev/{disk["real_name"]}'
             # user can specify a per-disk password and/or a global password
             # we default to using the per-disk password with fallback to global
             passwd = disk['passwd'] if disk['passwd'] else global_passwd


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 1862a8c0964c824148fbe52b5402d102fca45464
    git cherry-pick -x 3231a7c621875d2f54743b86955acb1ac65b8e76
    git cherry-pick -x d07547ba67fdea74f757bbcd76f3d608b433894c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x ea8042877db897741c79340249692c54f5e2cc01

Original PR: https://github.com/truenas/middleware/pull/15531
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133892

Original PR: https://github.com/truenas/middleware/pull/15532
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133892