### PR TITLE
fix anchor in build version info URL

### DIFF
--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -86,7 +86,7 @@ class SystemService(Service):
             if len_to_format == 2:
                 return base_url
             else:
-                return f'{base_url}/#{"".join(to_format)}'
+                return f'{base_url}/#{"".join(to_format)}-changelog'
 
     @no_authz_required
     @accepts()


### PR DESCRIPTION
Replace the anchor suffix form `#XXXXXX` to `#XXXXXX-changelog`, because the first one is invalid.

For example, valid release notes URL: https://www.truenas.com/docs/scale/24.04/gettingstarted/scalereleasenotes/#240425-changelog

![image](https://github.com/user-attachments/assets/e85d2575-8e8d-4c76-b050-aade3030727f)
