### PR TITLE
NAS-133959 / 25.04-BETA.1 / Add `secureboot` to image choices (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -218,6 +218,7 @@ class ImageChoiceItem(BaseModel):
     archs: list[str]
     variant: str
     instance_types: list[InstanceType]
+    secureboot: bool | None
 
 
 class VirtInstanceImageChoicesResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -306,6 +306,9 @@ class VirtInstanceService(CRUDService):
                             'archs': [v['arch']],
                             'variant': v['variant'],
                             'instance_types': list(instance_types),
+                            'secureboot': (
+                                False if v['requirements'].get('secureboot') == 'false' else True
+                            ),
                         }
                     else:
                         choices[alias]['archs'].append(v['arch'])

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -299,6 +299,11 @@ class VirtInstanceService(CRUDService):
                                 instance_types.add('VM')
                         if not instance_types:
                             continue
+                        secureboot = None
+                        if v['requirements'].get('secureboot') == 'false':
+                            secureboot = False
+                        elif v['requirements'].get('secureboot') == 'true':
+                            secureboot = True
                         choices[alias] = {
                             'label': f'{v["os"]} {v["release"]} ({v["arch"]}, {v["variant"]})',
                             'os': v['os'],
@@ -306,9 +311,7 @@ class VirtInstanceService(CRUDService):
                             'archs': [v['arch']],
                             'variant': v['variant'],
                             'instance_types': list(instance_types),
-                            'secureboot': (
-                                False if v['requirements'].get('secureboot') == 'false' else True
-                            ),
+                            'secureboot': secureboot,
                         }
                     else:
                         choices[alias]['archs'].append(v['arch'])


### PR DESCRIPTION
This is required to tell whether or not secure boot option for instance should be allowed.

Original PR: https://github.com/truenas/middleware/pull/15530
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133959