### PR TITLE
NAS-133965 / 25.04-RC.1 / fixes a typo in version checking for apps (by stavros-k)

### DIFF
--- a/src/middlewared/middlewared/plugins/catalog/apps_util.py
+++ b/src/middlewared/middlewared/plugins/catalog/apps_util.py
@@ -49,8 +49,8 @@ def min_max_scale_version_check_update_impl(version_details: dict, check_support
     # we do not want to validate minimum scale version in that case. However, when we want to report to
     # the user as to why exactly the app version is not supported, we need to be able to make that distinction
     system_scale_version = sw_info()['version']
-    min_scale_version = version_details.get('chart_metadata', {}).get('annotations', {}).get('min_scale_version')
-    max_scale_version = version_details.get('chart_metadata', {}).get('annotations', {}).get('max_scale_version')
+    min_scale_version = version_details.get('app_metadata', {}).get('annotations', {}).get('min_scale_version')
+    max_scale_version = version_details.get('app_metadata', {}).get('annotations', {}).get('max_scale_version')
     if (
         version_details.get('healthy', True) and (not check_supported_key or version_details['supported'])
         and (min_scale_version or max_scale_version)

--- a/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_min_max_scale_version_update.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/catalog/test_min_max_scale_version_update.py
@@ -14,7 +14,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '21.01',
                     'max_scale_version': '24.04'
@@ -37,7 +37,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '21.01',
                     'max_scale_version': '24.04'
@@ -62,7 +62,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '21.01',
                     'max_scale_version': '27.04'
@@ -85,7 +85,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '21.01',
                     'max_scale_version': '27.04'
@@ -110,7 +110,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '26.04',
                     'max_scale_version': '24.04'
@@ -133,7 +133,7 @@ from middlewared.plugins.catalog.apps_util import minimum_scale_version_check_up
             'location': '/mnt/.ix-apps/truenas_catalog/trains/community/actual-budget/1.1.11',
             'last_update': '2024-10-09 20:30:25',
             'human_version': '24.10.1_1.1.11',
-            'chart_metadata': {
+            'app_metadata': {
                 'annotations': {
                     'min_scale_version': '26.04',
                     'max_scale_version': '24.04'


### PR DESCRIPTION
We likely need to make a copy of `app_metadata` to `chart_metadata` in all the generated `app_versions.json` files in apps repo, so EE systems will perform the correct check. 

https://github.com/truenas/apps/blob/05463c559bc6060c02a0bde7ca1877336efda95a/trains/stable/emby/app_versions.json#L11

Original PR: https://github.com/truenas/middleware/pull/15520
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133965