### PR TITLE
NAS-133910 / 25.10 / Add schema handling for unmapped groups in privileges

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/privilege.py
+++ b/src/middlewared/middlewared/api/v25_04_0/privilege.py
@@ -8,12 +8,18 @@ __all__ = ["PrivilegeEntry", "PrivilegeRoleEntry",
            "PrivilegeDeleteArgs", "PrivilegeDeleteResult"]
 
 
+class UnmappedGroupEntry(BaseModel):
+    gid: int | None
+    sid: str | None
+    group: None
+
+
 class PrivilegeEntry(BaseModel):
     id: int
     builtin_name: str | None
     name: NonEmptyString
-    local_groups: list[GroupEntry]
-    ds_groups: list[GroupEntry]
+    local_groups: list[GroupEntry | UnmappedGroupEntry]
+    ds_groups: list[GroupEntry | UnmappedGroupEntry]
     roles: list[str] = []
     web_shell: bool
 

--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -220,6 +220,7 @@ class PrivilegeService(CRUDService):
                     result.append({
                         "gid": gid,
                         "group": None,
+                        "sid": None,
                     })
 
         return result
@@ -242,10 +243,12 @@ class PrivilegeService(CRUDService):
             mapped_sids = {}
 
         for xid in ds_groups:
+            is_sid = False
             if isinstance(xid, int):
                 if (group := groups['by_gid'].get(xid)) is None:
                     gid = xid
             else:
+                is_sid = True
                 if (group := groups['by_sid'].get(xid)) is None:
                     unixid = mapped_sids.get(xid)
                     if unixid is None or unixid['id_type'] == 'USER':
@@ -263,8 +266,8 @@ class PrivilegeService(CRUDService):
                 except MatchNotFound:
                     if include_nonexistent:
                         result.append({
-                            "gid": gid,
-                            "sid": None,
+                            "gid": None if gid == -1 else gid,
+                            "sid": xid if is_sid else None,
                             "group": None,
                         })
 


### PR DESCRIPTION
In various circumstances the privilege table may refer to gids that from the perspective of TrueNAS no longer exist. In this case a minimal entry is returned with basic gid and sid information so that the admin has a way of determining whether to delete it.