### PR TITLE
fix anchor in build version info URL 

### DIFF
--- a/src/middlewared/middlewared/plugins/system/product.py
+++ b/src/middlewared/middlewared/plugins/system/product.py
@@ -86,7 +86,7 @@ class SystemService(Service):
             if len_to_format == 2:
                 return base_url
             else:
-                return f'{base_url}/#{"".join(to_format)}'
+                return f'{base_url}/#{"".join(to_format)}-changelog'
 
     @no_authz_required
     @accepts()


### PR DESCRIPTION
Duplicate of closed #15557 (I can't reopen), see the last comment explaining URL bug.