### PR TITLE
NAS-133972 / 25.04-BETA.1 / Fix public view of version string (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -14,9 +14,9 @@ from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
 from middlewared.schema import accepts, Bool, Dict, Int, List, Password, returns, Str
 from middlewared.service import CallError, ConfigService, job, ValidationErrors
 import middlewared.sqlalchemy as sa
+from middlewared.utils import sw_version
 from middlewared.utils.network import INTERNET_TIMEOUT
 from middlewared.validators import Email
-from middlewared.utils import PRODUCT
 
 ADDRESS = 'support-proxy.ixsystems.com'
 
@@ -226,7 +226,7 @@ class SupportService(ConfigService):
             if i not in data:
                 raise CallError(f'{i} is required', errno.EINVAL)
 
-        data['version'] = f'{PRODUCT}-{await self.middleware.call("system.version_short")}'
+        data['version'] = sw_version()
         debug = data.pop('attach_debug')
 
         type_ = data.get('type')

--- a/src/middlewared/middlewared/plugins/system/info.py
+++ b/src/middlewared/middlewared/plugins/system/info.py
@@ -118,7 +118,7 @@ class SystemService(Service):
         timezone_setting = (await self.middleware.call('datastore.config', 'system.settings'))['stg_timezone']
 
         return {
-            'version': await self.middleware.call('system.version'),
+            'version': await self.middleware.call('system.version_short'),
             'buildtime': await self.build_time(),
             'hostname': await self.hostname(),
             'physmem': mem_info['physmem_size'],

--- a/src/middlewared/middlewared/plugins/webui/main_dashboard.py
+++ b/src/middlewared/middlewared/plugins/webui/main_dashboard.py
@@ -7,7 +7,7 @@ from middlewared.api.current import (
     WebUIMainDashboardSysInfoResult
 )
 from middlewared.service import Service
-from middlewared.utils import sw_version, sw_codename
+from middlewared.utils import sw_info
 
 
 class WebUIMainDashboardService(Service):
@@ -35,8 +35,8 @@ class WebUIMainDashboardService(Service):
 
         return {
             'platform': platform,
-            'version': sw_version(),
-            'codename': sw_codename(),
+            'version': sw_info()['version'],
+            'codename': sw_info()['codename'],
             'license': self.middleware.call_sync('system.license'),
             'system_serial': dmi['system-serial-number'],
             'hostname': hostname,

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -38,8 +38,6 @@ MIDDLEWARE_STARTED_SENTINEL_PATH = f'{MIDDLEWARE_RUN_DIR}/middlewared-started'
 BOOTREADY = f'{MIDDLEWARE_RUN_DIR}/.bootready'
 MANIFEST_FILE = '/data/manifest.json'
 BRAND = ProductName.PRODUCT_NAME
-PRODUCT = ProductType.COMMUNITY_EDITION
-BRAND_PRODUCT = f'{BRAND}-{PRODUCT}'
 NULLS_FIRST = 'nulls_first:'
 NULLS_LAST = 'nulls_last:'
 REVERSE_CHAR = '-'
@@ -649,7 +647,7 @@ def sw_info():
             'stable': 'MASTER' not in manifest['version'],
             'codename': manifest['codename'],
             'version': version,
-            'fullname': f'{BRAND_PRODUCT}-{version}',
+            'fullname': f'{BRAND}-{version}',
             'buildtime': manifest['buildtime'],
         }
 


### PR DESCRIPTION
No reason to show `TrueNAS-` or `COMMUNITY_EDITION` or `ENTERPRISE`. The first is implied and the other two are implementation details.

Original PR: https://github.com/truenas/middleware/pull/15572
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133972