### PR TITLE
NAS-134005 / 25.04-RC.1 / cache immutable type in get_country_codes (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/cert_info.py
+++ b/src/middlewared/middlewared/plugins/crypto_/cert_info.py
@@ -34,7 +34,7 @@ class CertificateService(Service):
     )
     def country_choices(self):
         """Returns country choices for creating a certificate/csr."""
-        return get_country_codes()
+        return dict(get_country_codes())
 
     @api_method(
         CertificateAcmeServerChoicesArgs,

--- a/src/middlewared/middlewared/plugins/system_general/country.py
+++ b/src/middlewared/middlewared/plugins/system_general/country.py
@@ -22,4 +22,4 @@ class SystemGeneralService(Service):
         """Return a dictionary whose keys represent the
         ISO 3166-1 alpha 2 country code and values represent
         the English short name (used in ISO 3166/MA)"""
-        return get_country_codes()
+        return dict(get_country_codes())

--- a/src/middlewared/middlewared/utils/country_codes.py
+++ b/src/middlewared/middlewared/utils/country_codes.py
@@ -5,9 +5,9 @@ __all__ = ("get_country_codes",)
 
 
 @cache
-def get_country_codes() -> dict[str, str]:
+def get_country_codes() -> tuple[tuple[str, str]]:
     """Return the ISO 3166-1 alpha 2 code as the key and the
     English short name (used in ISO 3166/MA) of the country
     as the value (i.e {"US": "United States of America", ...})"""
     with open("/usr/share/iso-codes/json/iso_3166-1.json") as f:
-        return {i["alpha_2"]: i["name"] for i in load(f)["3166-1"]}
+        return tuple((i["alpha_2"], i["name"]) for i in load(f)["3166-1"])


### PR DESCRIPTION
I have this tendency to cache functions that return mutable objects. That can lead to a set of issues that no one should have to endure :smile:.

I'll start fixing these 1-by-1 so I started with `get_country_codes` function.

Original PR: https://github.com/truenas/middleware/pull/15587
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134005