### PR TITLE
NAS-134012 / 25.10 / stop triple caching DMI info

### DIFF
--- a/src/middlewared/middlewared/plugins/system/dmi.py
+++ b/src/middlewared/middlewared/plugins/system/dmi.py
@@ -1,5 +1,3 @@
-from functools import cache
-
 from ixhardware import parse_dmi
 
 from middlewared.service import private, Service
@@ -7,10 +5,8 @@ from middlewared.service import private, Service
 
 class SystemService(Service):
     @private
-    @cache
     def dmidecode_info(self):
-        dmi_info = self.dmidecode_info_internal()
-
+        dmi_info = parse_dmi()
         return {
             'bios-release-date': dmi_info.bios_release_date or "",
             'ecc-memory': dmi_info.ecc_memory,
@@ -22,8 +18,3 @@ class SystemService(Service):
             'system-version': dmi_info.system_version,
             'has-ipmi': dmi_info.has_ipmi,
         }
-
-    @private
-    @cache
-    def dmidecode_info_internal(self):
-        return parse_dmi()

--- a/src/middlewared/middlewared/plugins/truenas.py
+++ b/src/middlewared/middlewared/plugins/truenas.py
@@ -5,7 +5,6 @@ from ixhardware import TRUENAS_UNKNOWN, get_chassis_hardware
 
 from middlewared.plugins.truecommand.enums import Status as TrueCommandStatus
 from middlewared.service import cli_private, job, private, Service
-from middlewared.utils.functools_ import cache
 from middlewared.api.current import (
     TrueNASSetProductionArgs, TrueNASSetProductionResult,
     TrueNASIsProductionArgs, TrueNASIsProductionResult,
@@ -42,15 +41,17 @@ class TrueNASService(Service):
             (await self.middleware.call('truecommand.config'))['status']
         ) == TrueCommandStatus.CONNECTED
 
-    @api_method(TrueNASGetChassisHardwareArgs, TrueNASGetChassisHardwareResult, roles=['READONLY_ADMIN'])
-    @cli_private
-    @cache
+    @api_method(
+        TrueNASGetChassisHardwareArgs,
+        TrueNASGetChassisHardwareResult,
+        cli_private=True,
+        roles=['READONLY_ADMIN'],
+    )
     async def get_chassis_hardware(self):
         """
         Returns what type of hardware this is, detected from dmidecode.
         """
-        dmi = await self.middleware.call('system.dmidecode_info_internal')
-        return get_chassis_hardware(dmi)
+        return get_chassis_hardware()
 
     @api_method(TrueNASIsIXHardwareArgs, TrueNASIsIXHardwareResult, roles=['READONLY_ADMIN'])
     async def is_ix_hardware(self):


### PR DESCRIPTION
`parse_dmi` in `ixhardware` module was being cached and then we were caching `dmidecode_info` which calls `dmidecode_info_internal` which was also being cached.

Dependent PR at: https://github.com/truenas/ixhardware/pull/6