### PR TITLE
NAS-134017 / 25.10 / change lan_channels cache to immutable type

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -8,7 +8,7 @@ from middlewared.validators import Netmask, PasswordComplexity, Range
 
 
 @cache
-def lan_channels():
+def lan_channels() -> tuple[int]:
     channels = []
     out = run(['bmc-info', '--get-channel-info'], capture_output=True)
     lines = out.stdout.decode().split('\n')
@@ -22,7 +22,7 @@ def lan_channels():
             except (IndexError, ValueError):
                 continue
 
-    return channels
+    return tuple(channels)
 
 
 def apply_config(channel, data):


### PR DESCRIPTION
Same reasoning for the changes I did in https://github.com/truenas/ixhardware/pull/6. When caching objects, they need to be of an immutable type. This changes this function to return a tuple of integers instead of a list of integers.