### PR TITLE
NAS-134026 / 25.10 / change timezone_choices cache to immutable type

### DIFF
--- a/src/middlewared/middlewared/plugins/system_general/timezone.py
+++ b/src/middlewared/middlewared/plugins/system_general/timezone.py
@@ -1,19 +1,6 @@
-from functools import cache
-
 from middlewared.schema import accepts, Dict, returns
 from middlewared.service import Service
-
-
-@cache
-def tz_choices() -> tuple[tuple[str, str]]:
-    # Logic deduced from what timedatectl list-timezones does
-    tz = list()
-    with open('/usr/share/zoneinfo/tzdata.zi') as f:
-        for line in filter(lambda x: x[0] in ('Z', 'L'), f):
-            index = 1 if line[0] == 'Z' else 2
-            tz_choice = line.split()[index].strip()
-            tz.append((tz_choice, tz_choice))
-    return tuple(tz)
+from middlewared.utils.timezone_choices import tz_choices
 
 
 class SystemGeneralService(Service):

--- a/src/middlewared/middlewared/utils/timezone_choices.py
+++ b/src/middlewared/middlewared/utils/timezone_choices.py
@@ -1,0 +1,15 @@
+from functools import cache
+
+__all__ = ("tz_choices",)
+
+
+@cache
+def tz_choices() -> tuple[tuple[str, str]]:
+    # Logic deduced from what timedatectl list-timezones does
+    tz = list()
+    with open("/usr/share/zoneinfo/tzdata.zi") as f:
+        for line in filter(lambda x: x[0] in ("Z", "L"), f):
+            index = 1 if line[0] == "Z" else 2
+            tz_choice = line.split()[index].strip()
+            tz.append((tz_choice, tz_choice))
+    return tuple(tz)


### PR DESCRIPTION
Again, don't need to cache mutable objects. While I'm here, took the liberty to remove an unnecessary `subprocess` call. We can get the same information via reading the tzdata.zi file provided by upstream Debian.