### PR TITLE
NAS-133449 / 25.10 / Fix system.security.update on HA

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -186,8 +186,8 @@ class SystemSecurityService(ConfigService):
             fips_toggled = True
 
         if new['enable_gpos_stig'] != old['enable_gpos_stig']:
-            reboot_reason = RebootReason.STIG
             if not fips_toggled:
+                reboot_reason = RebootReason.STIG
                 # Trigger reboot on standby to apply STIG-related configuration
                 # This should only happen if user already set FIPS and is subsequently changing
                 # STIG as a separate operation.

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -32,7 +32,9 @@ class SystemSecurityService(ConfigService):
         if not is_ha:
             return
 
-        await self.middleware.call('failover.sync_to_peer')
+        # Send the datastore to the remote node to ensure that the
+        # FIPS configuration has been synced up before reboot
+        await self.middleware.call('failover.datastore.send')
         await self.middleware.call('failover.call_remote', 'etc.generate', ['fips'])
 
         remote_reboot_reasons = await self.middleware.call('failover.call_remote', 'system.reboot.list_reasons')


### PR DESCRIPTION
This commit fixes two bugs regarding updates to system security settings on the HA platform

1) We were emitting the event that reboot is required before the
   standby controller finished rebooting and HA was in a healthy
   state.

2) We need to make sure database changes are synced to standby
   controller before reconfiguring FIPS settings and rebooting.