### PR TITLE
NAS-134037 / 25.10 / Fix `NotRequired`

### DIFF
--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -20,14 +20,11 @@ __all__ = ["BaseModel", "ForUpdateMetaclass", "query_result", "query_result_item
 class _NotRequiredMixin(PydanticBaseModel):
     @model_serializer(mode="wrap")
     def serialize_basemodel(self, serializer):
-        obj = serializer(self)
-        if isinstance(obj, dict):
-            return {
-                k: v
-                for k, v in obj.items()
-                if v is not undefined
-            }
-        return obj
+        return {
+            k: v
+            for k, v in serializer(self).items()
+            if v is not undefined
+        }
 
 
 NotRequired = undefined
@@ -99,7 +96,7 @@ class BaseModel(PydanticBaseModel, metaclass=_BaseModelMetaclass):
         exclude_none: bool = False,
         round_trip: bool = False,
         warnings: bool | typing.Literal['none', 'warn', 'error'] = True,
-        serialize_as_any: bool = True,  # so that nested models set to `NotRequired` do not serialize
+        serialize_as_any: bool = False
     ) -> dict[str, typing.Any]:
         return self.__pydantic_serializer__.to_python(
             self,

--- a/src/middlewared/middlewared/api/base/model.py
+++ b/src/middlewared/middlewared/api/base/model.py
@@ -9,7 +9,7 @@ from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.main import IncEx
 
 from middlewared.api.base.types.string import SECRET_VALUE, LongStringWrapper
-from middlewared.utils.lang import undefined
+from middlewared.utils.lang import undefined, Undefined
 
 
 __all__ = ["BaseModel", "ForUpdateMetaclass", "query_result", "query_result_item", "added_event_model",
@@ -53,7 +53,7 @@ class _BaseModelMetaclass(ModelMetaclass):
                     __module__=cls.__module__,
                     __cls_kwargs__={"__BaseModelMetaclass_skip_patching": True},
                     **{
-                        k: (v.annotation, v)
+                        k: (Secret[typing.get_args(v.annotation)[0] | Undefined] if typing.get_origin(v.annotation) is Secret else (v.annotation | Undefined), v)
                         for k, v in cls.model_fields.items()
                     }
                 )
@@ -67,6 +67,7 @@ class BaseModel(PydanticBaseModel, metaclass=_BaseModelMetaclass):
         strict=True,
         str_max_length=1024,
         use_attribute_docstrings=True,
+        arbitrary_types_allowed=True,
     )
 
     @classmethod

--- a/src/middlewared/middlewared/pytest/unit/api/base/test_excluded.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/test_excluded.py
@@ -37,7 +37,10 @@ def test_not_required():
     class NestedModel(BaseModel):
         a: int = NotRequired
 
-    class NotRequiredTestModel(BaseModel):
+    class ParentModel(BaseModel):
+        k: int
+
+    class NotRequiredTestModel(ParentModel):
         b: int
         c: int = 3
         d: int = NotRequired
@@ -48,6 +51,7 @@ def test_not_required():
         h: list[NestedModel] = NotRequired
         i_: int = Field(alias="i", default=NotRequired)
         j: Secret[int] = NotRequired
+        k: Excluded = excluded_field()
 
     test_cases = (
         (


### PR DESCRIPTION
Fix tests following #15462

Applying `serialize_as_any` across the board for all BaseModels was a mistake since it makes serialization far less reliable as opposed to always producing a dictionary. Using the same `undefined` object for `NotRequired` as the one returned by `excluded_field` was also a mistake since it invited overlap between the behavior of `NotRequired` fields and `Excluded` fields.

Solution:
- Use a new singleton class for `NotRequired`
- Disable `serialize_as_any` so that fields are serialized according to their annotations only, not according to their values
- Enable `arbitrary_types_allowed` so that `NotRequired` and other custom types can be used as field annotations
- Update the annotations of all fields with `NotRequired` as their default in BaseModel's metaclass (may also be useful for our generated documentation)
- Test `NotRequired` and `Excluded` together in the same model

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2948/