### PR TITLE
NAS-134056 / 25.04-RC.1 / Add `secureboot` to the installed instance image attributes (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -36,6 +36,7 @@ class Image(BaseModel):
     serial: str | None
     type: str | None
     variant: str | None
+    secureboot: bool | None
 
 
 class IdmapUserNsEntry(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -58,6 +58,11 @@ class VirtInstanceService(CRUDService):
                 status = 'UNKNOWN'
             else:
                 status = i['state']['status'].upper()
+            secureboot = None
+            if i['config'].get('image.requirements.secureboot') == 'true':
+                secureboot = True
+            elif i['config'].get('image.requirements.secureboot') == 'false':
+                secureboot = False
             entry = {
                 'id': i['name'],
                 'name': i['name'],
@@ -75,6 +80,7 @@ class VirtInstanceService(CRUDService):
                     'serial': i['config'].get('image.serial'),
                     'type': i['config'].get('image.type'),
                     'variant': i['config'].get('image.variant'),
+                    'secureboot': secureboot,
                 },
                 **get_vnc_info_from_config(i['config']),
                 'raw': None,  # Default required by pydantic


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ad41091a9d77720d8b9e20e2d76eed9bcb62bcd3
    git cherry-pick -x 379c4264d8200f087d64ef613ce3470cfbe7f46f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f8e9723d6196a76f78deda903e4188a596b7ddfa

This will be used in https://ixsystems.atlassian.net/browse/NAS-133963

Original PR: https://github.com/truenas/middleware/pull/15598
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134056