### PR TITLE
NAS-133996 / 25.04-RC.1 / Send error when middleware response fails to serialize (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -50,7 +50,7 @@ class RpcWebSocketApp(App):
     def send(self, data):
         try:
             data_ = json.dumps(data)
-        except TypeError as e:
+        except Exception as e:
             self.send_truenas_error(
                 data.get("id"),
                 JSONRPCError.INTERNAL_ERROR.value,

--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -51,7 +51,7 @@ class RpcWebSocketApp(App):
         try:
             data_ = json.dumps(data)
         except Exception as e:
-            self.middleware.logger.exception(str(e))
+            self.middleware.logger.error(f"Failed to JSON serialize server message: {e}", exc_info=True)
             self.send_truenas_error(
                 data.get("id"),
                 JSONRPCError.INTERNAL_ERROR.value,

--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -51,14 +51,14 @@ class RpcWebSocketApp(App):
         try:
             data_ = json.dumps(data)
         except Exception as e:
+            self.middleware.logger.exception(str(e))
             self.send_truenas_error(
                 data.get("id"),
                 JSONRPCError.INTERNAL_ERROR.value,
                 "Failed to JSON serialize server message",
                 None,
                 str(e),
-                sys.exc_info(),
-                str(data.get("result"))
+                sys.exc_info()
             )
         else:
             asyncio.run_coroutine_threadsafe(self.ws.send_str(data_), self.middleware.loop)

--- a/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
+++ b/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py
@@ -48,7 +48,20 @@ class RpcWebSocketApp(App):
         self.subscriptions = {}
 
     def send(self, data):
-        asyncio.run_coroutine_threadsafe(self.ws.send_str(json.dumps(data)), self.middleware.loop)
+        try:
+            data_ = json.dumps(data)
+        except TypeError as e:
+            self.send_truenas_error(
+                data.get("id"),
+                JSONRPCError.INTERNAL_ERROR.value,
+                "Failed to JSON serialize server message",
+                None,
+                str(e),
+                sys.exc_info(),
+                str(data.get("result"))
+            )
+        else:
+            asyncio.run_coroutine_threadsafe(self.ws.send_str(data_), self.middleware.loop)
 
     def send_error(self, id_: Any, code: int, message: str, data: Any = None):
         error = {


### PR DESCRIPTION
Instead of timing out, we should catch the error and send it to the client to assist with debugging.


http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2916/

Original PR: https://github.com/truenas/middleware/pull/15582
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133996