### PR TITLE
NAS-134070 / 25.04-RC.1 / `smart_support` key is not always available` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -26,7 +26,7 @@ async def ensure_smart_enabled(args):
 
     p = await smartctl(args + ["-i", "--json=c"], check=False, stderr=subprocess.STDOUT, encoding="utf8", errors="ignore")
     pjson = json.loads(p.stdout)
-    if not pjson["smart_support"]["available"]:
+    if not pjson.get("smart_support", {}).get("available"):
         logger.debug("SMART is not supported on %r", args)
         return False
 


### PR DESCRIPTION
Crash seen in https://ixsystems.atlassian.net/browse/NAS-133954

Original PR: https://github.com/truenas/middleware/pull/15618
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134070