### PR TITLE
NAS-134073 / 25.10 / Remove redundant get_identifiers in cpu graph

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata/graphs.py
@@ -16,11 +16,6 @@ class CPUPlugin(GraphBase):
     def get_chart_name(self, identifier: typing.Optional[str] = None) -> str:
         return 'truenas_cpu_usage.cpu'
 
-    async def get_identifiers(self) -> typing.Optional[list]:
-        cpu_usage = [f'cpu{i}' for i in cpu_info()['core']]
-        cpu_usage.append('cpu')
-        return cpu_usage
-
 
 class CPUTempPlugin(GraphBase):
 


### PR DESCRIPTION
## Context

`get_identifiers` in CPU plugin is not being used and was brought in accidentally during a refactor and is being removed.