### PR TITLE
NAS-134060 / 25.10 / Use app registry credentials when retrieving dockerhub limit

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/dockerhub_ratelimit.py
+++ b/src/middlewared/middlewared/plugins/apps_images/dockerhub_ratelimit.py
@@ -18,7 +18,11 @@ class ContainerImagesService(Service):
 
         Please refer to https://docs.docker.com/docker-hub/download-rate-limit/ for more information.
         """
-        limits_header = await ContainerRegistryClientMixin().get_docker_hub_rate_limit_preview()
+        auth = None
+        if creds := (await self.middleware.call('app.registry.query', [['uri', '=', 'https://index.docker.io/v1/']])):
+            auth = {'login': creds[0]['username'], 'password': creds[0]['password']}
+
+        limits_header = await ContainerRegistryClientMixin().get_docker_hub_rate_limit_preview(auth)
 
         if limits_header.get('response_obj') and hasattr(limits_header['response_obj'], 'headers'):
             return normalize_docker_limits_header(limits_header['response_obj'].headers)


### PR DESCRIPTION
## Problem

If a consumer configures app registry for dockerhub, the registry is being used when pulling images from dockerhub - however we have an endpoint which shows remaining left pull limit and that is not accounting for the creds user has already provided for dockerhub.

## Solution

Make sure we correctly report docker hub rate limit if docker registry creds have already been provided to the system.