### PR TITLE
NAS-133954 / 25.04-RC.1 / Fix keychaincredentials schema errors (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/keychain.py
+++ b/src/middlewared/middlewared/api/v25_04_0/keychain.py
@@ -1,7 +1,7 @@
 import abc
-from typing import Literal
+from typing import Annotated, Literal, Union
 
-from pydantic import Secret
+from pydantic import Discriminator, Secret
 
 from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, HttpUrl, LongString,
                                   NonEmptyString, single_argument_args, single_argument_result)
@@ -182,10 +182,13 @@ class SetupSSHConnectionManualSetup(SSHCredentials):
 
 
 class SetupSSHConnectionManual(BaseModel):
-    private_key: KeychainCredentialSetupSSHConnectionKeyNew | KeychainCredentialSetupSSHConnectionKeyExisting
+    private_key: Annotated[
+        Union[KeychainCredentialSetupSSHConnectionKeyNew, KeychainCredentialSetupSSHConnectionKeyExisting],
+        Discriminator("generate_key"),
+    ]
     connection_name: NonEmptyString
     setup_type: Literal["MANUAL"] = "MANUAL"
-    manual_setup: SSHCredentials
+    manual_setup: SetupSSHConnectionManualSetup
 
 
 class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
@@ -195,7 +198,10 @@ class SetupSSHConnectionSemiautomatic(SetupSSHConnectionManual):
 
 
 class KeychainCredentialSetupSSHConnectionArgs(BaseModel):
-    options: SetupSSHConnectionManual | SetupSSHConnectionSemiautomatic
+    options: Annotated[
+        Union[SetupSSHConnectionManual, SetupSSHConnectionSemiautomatic],
+        Discriminator("setup_type"),
+    ]
 
 
 class KeychainCredentialSetupSSHConnectionResult(BaseModel):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fac029c263a5251f1ef14ab1fbc51d675905cecf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b69661c36a1547b8582f0690cad2dcf769784325



Original PR: https://github.com/truenas/middleware/pull/15617
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133954