### PR TITLE
NAS-133934 / 25.04-RC.1 / Allow updating root disk size for virt VM instances (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -155,6 +155,7 @@ class VirtInstanceUpdate(BaseModel, metaclass=ForUpdateMetaclass):
     vnc_password: Secret[NonEmptyString | None]
     '''Setting vnc_password to null will unset VNC password'''
     secure_boot: bool = False
+    root_disk_size: int | None = Field(ge=5, default=None)
 
 
 class VirtInstanceUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -21,7 +21,9 @@ from middlewared.api.current import (
     VirtInstanceRestartArgs, VirtInstanceRestartResult,
     VirtInstanceImageChoicesArgs, VirtInstanceImageChoicesResult,
 )
-from .utils import get_vnc_info_from_config, Status, incus_call, incus_call_and_wait, VNC_BASE_PORT
+from .utils import (
+    get_vnc_info_from_config, get_root_device_dict, Status, incus_call, incus_call_and_wait, VNC_BASE_PORT
+)
 
 
 LC_IMAGES_SERVER = 'https://images.linuxcontainers.org'
@@ -366,23 +368,22 @@ class VirtInstanceService(CRUDService):
             data_devices.append(root_device_to_add)
 
         devices = {
-            'root': {
-                'path': '/',
-                'pool': 'default',
-                'type': 'disk',
-                'size': f'{data["root_disk_size"] * (1024**3)}',
-            }
+            'root': get_root_device_dict(data['root_disk_size']),
         } if data['instance_type'] == 'VM' else {}
         for i in data_devices:
             await self.middleware.call(
                 'virt.instance.validate_device', i, 'virt_instance_create', verrors, data['instance_type'],
             )
             if i['name'] is None:
-                i['name'] = await self.middleware.call('virt.instance.generate_device_name', devices.keys(), i['dev_type'])
+                i['name'] = await self.middleware.call(
+                    'virt.instance.generate_device_name', devices.keys(), i['dev_type']
+                )
             devices[i['name']] = await self.middleware.call('virt.instance.device_to_incus', data['instance_type'], i)
 
         if not verrors and data['devices']:
-            await self.middleware.call('virt.instance.validate_devices', data['devices'], 'virt_instance_create', verrors)
+            await self.middleware.call(
+                'virt.instance.validate_devices', data['devices'], 'virt_instance_create', verrors
+            )
 
         verrors.check()
 
@@ -439,12 +440,27 @@ class VirtInstanceService(CRUDService):
 
         verrors = ValidationErrors()
         await self.validate(data, 'virt_instance_update', verrors, old=instance)
-        if instance['type'] == 'CONTAINER' and data.get('enable_vnc'):
-            verrors.add('virt_instance_update.vnc_port', 'VNC is not supported for containers')
+        if instance['type'] == 'CONTAINER':
+            if data.get('enable_vnc'):
+                verrors.add('virt_instance_update.enable_vnc', 'VNC is not supported for containers')
+            if data.get('root_disk_size'):
+                verrors.add(
+                    'virt_instance_update.root_disk_size', 'Updating root_disk_size is not supported for containers'
+                )
+
+        if instance['type'] == 'VM' and data.get('root_disk_size'):
+            if ((instance['root_disk_size'] or 0) / (1024 ** 3)) >= data['root_disk_size']:
+                verrors.add(
+                    'virt_instance_update.root_disk_size',
+                    'Specified size if set should be greater than the current root disk size.'
+                )
 
         verrors.check()
 
         instance['raw']['config'].update(self.__data_to_config(data, instance['raw']['config'], instance['type']))
+        if data.get('root_disk_size'):
+            instance['raw']['devices']['root'] = get_root_device_dict(data['root_disk_size'])
+
         await incus_call_and_wait(f'1.0/instances/{id}', 'put', {'json': instance['raw']})
 
         return await self.middleware.call('virt.instance.get_instance', id)

--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -103,3 +103,12 @@ def get_vnc_info_from_config(config: dict):
         return vnc_config
 
     return json.loads(vnc_raw_config)
+
+
+def get_root_device_dict(size: int) -> dict:
+    return {
+        'path': '/',
+        'pool': 'default',
+        'type': 'disk',
+        'size': f'{size * (1024**3)}',
+    }

--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -82,6 +82,29 @@ def test_virt_instance_update():
     assert rv.strip() == ''
 
 
+def test_virt_instance_update_root_disk_size():
+    current_root_disk_size = call(
+        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
+    )['root_disk_size']
+    # updating root_disk_size of VM
+    call('virt.instance.update', INS1_NAME, {'root_disk_size': 11}, job=True)
+    updated_root_disk_size = call(
+        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
+    )['root_disk_size']
+
+    assert current_root_disk_size != updated_root_disk_size
+    assert updated_root_disk_size == 11 * (1024 ** 3)
+
+    # not updating root_disk_size
+    current_root_disk_size = updated_root_disk_size
+    call('virt.instance.update', INS1_NAME, {}, job=True)
+    updated_root_disk_size = call(
+        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
+    )['root_disk_size']
+
+    assert current_root_disk_size == updated_root_disk_size
+
+
 def test_virt_instance_stop():
     wait_status_event = Event()
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 7a3bd62c2b431e8731c986712c3d64e8237ddef7

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 813b6d95373c64b9bee9123f6a66b0d7419c7c3d

## Context

We allow setting root disk size for virt VMs and changes have been made to allow updating root disk size a well for virt VMs.

Original PR: https://github.com/truenas/middleware/pull/15626
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133934