### PR TITLE
NAS-133727 / 25.04-RC.1 / Make CORS policy exception for internal URLs like TrueConnect (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -135,6 +135,11 @@ http {
         '' close;
     }
 
+    map $http_origin $allow_origin {
+        ~ixsystems.net$ $http_origin;
+        default "";
+    }
+
     server {
         server_name  localhost;
 % if ssl_configuration:
@@ -317,6 +322,10 @@ http {
         }
 
         location /_download {
+            # Allow all internal origins.
+            add_header Access-Control-Allow-Origin $allow_origin always;
+            add_header Access-Control-Allow-Headers "*" always;
+
             proxy_pass http://127.0.0.1:6000;
             proxy_http_version 1.1;
             proxy_set_header X-Real-Remote-Addr $remote_addr;


### PR DESCRIPTION
TrueConnect needs access to /download to be able to remotely download a debug.

Original PR: https://github.com/truenas/middleware/pull/15621
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133727