### PR TITLE
NAS-134080 / 25.04-RC.1 / Generate single-use API tokens for failover plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -745,7 +745,7 @@ class AuthService(Service):
                                 'credentials': cred_type,
                                 'credentials_data': {'username': data['username']},
                             },
-                        'error': 'User does not have two factor authentication enabled.'
+                            'error': 'User does not have two factor authentication enabled.'
                         }, False)
 
                     else:
@@ -754,7 +754,7 @@ class AuthService(Service):
                                 'credentials': cred_type,
                                 'credentials_data': {'username': data['username']},
                             },
-                        'error': 'Bad username or password'
+                            'error': 'Bad username or password'
                         }, False)
 
                     return response

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -394,6 +394,11 @@ class AuthService(Service):
 
         if token.single_use:
             self.token_manager.destroy(token)
+        else:
+            if CURRENT_AAL.level != AA_LEVEL1:
+                raise CallError('Multi-use API tokens are not supported '
+                                'at the current security level',
+                                errno.EOPNOTSUPP)
 
         return {
             'attributes': token.attributes,
@@ -412,6 +417,11 @@ class AuthService(Service):
 
         if token.single_use:
             self.token_manager.destroy(token)
+        else:
+            if CURRENT_AAL.level != AA_LEVEL1:
+                raise CallError('Multi-use API tokens are not supported '
+                                'at the current security level',
+                                errno.EOPNOTSUPP)
 
         return TokenSessionManagerCredentials(self.token_manager, token)
 

--- a/src/middlewared/middlewared/plugins/failover_/datastore.py
+++ b/src/middlewared/middlewared/plugins/failover_/datastore.py
@@ -84,7 +84,12 @@ class FailoverDatastoreService(Service):
             start_daemon_thread(target=send_retry)
 
     def send(self):
-        token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token')
+        token = self.middleware.call_sync('failover.call_remote', 'auth.generate_token', [
+            300,  # ttl
+            {},  # Attributes (not required for file uploads)
+            True,  # match origin
+            True,  # single-use (required if STIG enabled)
+        ])
         self.middleware.call_sync('failover.send_file', token, FREENAS_DATABASE, FREENAS_DATABASE_REPLICATED, {'mode': db_utils.FREENAS_DATABASE_MODE})
         self.middleware.call_sync('failover.call_remote', 'failover.datastore.receive')
 


### PR DESCRIPTION
This commit switches the failover plugin to consuming single-use API tokens for performing file sends across the heartbeat connection.

This is an interim fix until we have better file-related read / write APIs.

This commit also relaxes authentication requirements for STIG mode to allow single-use API tokens for REST authentication. This is specifically for the file upload / download endpoints.

Original PR: https://github.com/truenas/middleware/pull/15638
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134080