### PR TITLE
Bring back original `test_system_general_ui_rollback.py`

### DIFF
--- a/tests/api2/test_system_general_ui_rollback.py
+++ b/tests/api2/test_system_general_ui_rollback.py
@@ -1,94 +1,57 @@
 import time
-from contextlib import contextmanager
 
-from middlewared.test.integration.utils import call, client, ssh
-from middlewared.test.integration.utils.client import truenas_server
+import pytest
+import requests
 
-ROLLBACK = 20
-UI_DELAY = 3
-ORIG_PORT = 80
-NEW_PORT = 81
-
-
-def fallback_ui_fix():
-    """Fix the UI port settings using SSH in case an
-    unexpected failure is met or we just want to reset
-    our changes"""
-    ssh(f"midclt call system.general.update '{{\"ui_port\": {ORIG_PORT}}}'")
-    ssh("midclt call system.general.ui_restart 0")
-    time.sleep(5)
-
-
-@contextmanager
-def client_with_timeout(host_ip=None, tries=30):
-    for _ in range(tries):
-        try:
-            with client(host_ip=host_ip) as c:
-                assert c.call("core.ping") == "pong"
-                yield c
-                break
-        except ConnectionRefusedError:
-            time.sleep(1)
-    else:
-        assert False, "Could not connect to client."
+from middlewared.test.integration.utils import call, ssh, url
 
 
 def test_system_general_ui_rollback():
-    """This tests the following:
-        1. change the port the nginx service binds to (our UI)
-        2. ensure communication with the API on the original port failsinal port fails
-        3. ensure communication with the API on the new port succeeds
-        4. check the time left before the changes are rolled back
-        5. sleep that amount of time (plus a few seconds for a buffer)
-        6. ensure communication with the API on the original port succeeds
-        7. if any above steps fail, revert the UI port settings via ssh"""
     try:
-        # Step 1
-        call(
-            "system.general.update",
-            {"ui_port": NEW_PORT, "rollback_timeout": ROLLBACK, "ui_restart_delay": UI_DELAY}
-        )
+        # Apply incorrect changes
+        call("system.general.update", {"ui_port": 81, "rollback_timeout": 20, "ui_restart_delay": 3})
 
-        # Step 2
-        try:
-            assert call("core.ping") != "pong"
-        except Exception:
-            pass
+        # Wait for changes to be automatically applied
+        time.sleep(10)
 
-        # Step 3
-        with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
-            rollback_left = c.call("system.general.checkin_waiting")
-            # Step 4
-            assert rollback_left < ROLLBACK
+        # Ensure that changes were applied and the UI is now inaccessible
+        with pytest.raises(requests.ConnectionError):
+            requests.get(url(), timeout=10)
 
-        # Step 5
-        time.sleep(rollback_left + 5)
-        # Step 6
-        assert call("core.ping") == "pong"
+        # Additionally ensure that it is still working
+        assert requests.get(url() + ":81", timeout=10).status_code == 200
+
+        # Ensure that the check-in timeout is ticking back
+        assert 3 <= int(ssh("midclt call system.general.checkin_waiting").strip()) < 10
+
+        # Wait for changes to be automatically rolled back
+        time.sleep(15)
+
+        # Ensure that the UI is now accessible
+        assert requests.get(url(), timeout=10).status_code == 200
     except Exception:
-        # Step 7
-        fallback_ui_fix()
+        # Bring things back to normal via SSH in case of any error
+        ssh("midclt call system.general.update '{\"ui_port\": 80}'")
+        ssh("midclt call system.general.ui_restart 0")
+        time.sleep(10)
         raise
 
 
 def test_system_general_ui_checkin():
-    """This tests the following:
-        1. change the port the nginx service binds to (our UI)
-        2. immediately checkin the UI port changes
-        3. ensure we don't have a checkin pending
-        4. revert any UI port settings via ssh"""
     try:
-        # Step 1
-        call(
-            "system.general.update",
-            {"ui_port": NEW_PORT, "rollback_timeout": ROLLBACK, "ui_restart_delay": UI_DELAY}
-        )
+        # Apply incorrect changes
+        call("system.general.update", {"ui_port": 81, "rollback_timeout": 20, "ui_restart_delay": 3})
 
-        # Step 2
-        with client_with_timeout(host_ip=f"{truenas_server.ip}:{NEW_PORT}") as c:
-            # Step 3
-            c.call("system.general.checkin")
-            # Step 4
-            assert c.call("system.general.checkin_waiting") is None
+        # Wait for changes to be automatically applied
+        time.sleep(10)
+
+        # Check-in our new settings
+        assert ssh("midclt call system.general.checkin")
+
+        # Checking should not be pending anymore
+        assert ssh("midclt call system.general.checkin_waiting").strip() == "null"
     finally:
-        fallback_ui_fix()
+        # Bring things back to normal via SSH
+        ssh("midclt call system.general.update '{\"ui_port\": 80}'")
+        ssh("midclt call system.general.ui_restart 0")
+        time.sleep(10)


### PR DESCRIPTION
Rewritten test is double the code and fails always, not sometimes. Let's roll back, see how the original code flakes and fix that.