### PR TITLE
NAS-133849 / 25.04-RC.1 / Remove handling for POST requests for legacy TC (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf.mako
@@ -267,9 +267,6 @@ http {
         location /ui {
             allow all;
 
-            if ( $request_method ~ ^POST$ ) {
-                proxy_pass http://127.0.0.1:6000;
-            }
             # `allow`/`deny` are not allowed in `if` blocks so we'll have to make that check in the middleware itself.
             proxy_set_header X-Real-Remote-Addr $remote_addr;
             proxy_set_header X-Https $https;


### PR DESCRIPTION
Remove some nginx logic for handling deprecated TC authentication type
that is not required anymore since the middleware path was removed.

Original PR: https://github.com/truenas/middleware/pull/15511
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133849