### PR TITLE
NAS-134119 / 25.10 / Specify secure boot key in image choices

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -221,6 +221,7 @@ class ImageChoiceItem(BaseModel):
     archs: list[str]
     variant: str
     instance_types: list[InstanceType]
+    secureboot: bool | None
 
 
 class VirtInstanceImageChoicesResult(BaseModel):


### PR DESCRIPTION
## Context

We regressed with a change introduced by 6bc0a1255614cfbebbcb57ba29495131ddb8b9e8, secure boot key is added back to image choices as pydantic will error out otherwise