### PR TITLE
NAS-134132 / 25.04-RC.1 / Fix STIG API tests (by yocalebo)

### DIFF
--- a/tests/api2/test_zzzz_stig.py
+++ b/tests/api2/test_zzzz_stig.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.utils import call, client, password
 from truenas_api_client import ValidationErrors
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(autouse=True)
 def clear_ratelimit():
     call('rate.limit.cache_clear')
 

--- a/tests/api2/test_zzzz_stig.py
+++ b/tests/api2/test_zzzz_stig.py
@@ -1,7 +1,5 @@
-import errno
 import pytest
 
-from middlewared.service_exception import CallError
 from middlewared.service_exception import ValidationErrors as Verr
 from middlewared.test.integration.assets.product import product_type, set_fips_available
 from middlewared.test.integration.assets.two_factor_auth import (


### PR DESCRIPTION
We've still got some failing STIG tests because of them tripping rate limit logic. Change the cache clear fixture to be autouse=True. This resolves the regressing tests.

Original PR: https://github.com/truenas/middleware/pull/15656
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134132