### PR TITLE
NAS-134104 / 25.10 / Fix netmask being empty string

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -25,7 +25,7 @@ REMOTE_CHOICES: TypeAlias = Literal['LINUX_CONTAINERS']
 class VirtInstanceAlias(BaseModel):
     type: Literal['INET', 'INET6']
     address: NonEmptyString
-    netmask: int
+    netmask: int | None
 
 
 class Image(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -25,7 +25,7 @@ REMOTE_CHOICES: TypeAlias = Literal['LINUX_CONTAINERS']
 class VirtInstanceAlias(BaseModel):
     type: Literal['INET', 'INET6']
     address: NonEmptyString
-    netmask: int
+    netmask: int | None
 
 
 class Image(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -141,7 +141,7 @@ class VirtInstanceService(CRUDService):
                     entry['aliases'].append({
                         'type': address['family'].upper(),
                         'address': address['address'],
-                        'netmask': int(address['netmask']),
+                        'netmask': int(address['netmask']) if address['netmask'] else None,
                     })
 
         return filter_list(entries, filters, options)


### PR DESCRIPTION
## Problem

In certain race conditions i.e stopping/crashing a virt instance, it is possible that netmask is an empty string returned by incus which breaks our query logic which in turn breaks consumers of `virt.instance.query`.

## Solution

Gracefully handle the case when netmask is reported as an empty string