### PR TITLE
NAS-134104 / 25.04-RC.1 / Fix netmask being empty string (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -25,7 +25,7 @@ REMOTE_CHOICES: TypeAlias = Literal['LINUX_CONTAINERS']
 class VirtInstanceAlias(BaseModel):
     type: Literal['INET', 'INET6']
     address: NonEmptyString
-    netmask: int
+    netmask: int | None
 
 
 class Image(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -141,7 +141,7 @@ class VirtInstanceService(CRUDService):
                     entry['aliases'].append({
                         'type': address['family'].upper(),
                         'address': address['address'],
-                        'netmask': int(address['netmask']),
+                        'netmask': int(address['netmask']) if address['netmask'] else None,
                     })
 
         return filter_list(entries, filters, options)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x d6975d89b23f87119b8162172199a1ed163d2c19

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 0464eafd719c08ff391be3f5c3013eabafe5370e

## Problem

In certain race conditions i.e stopping/crashing a virt instance, it is possible that netmask is an empty string returned by incus which breaks our query logic which in turn breaks consumers of `virt.instance.query`.

## Solution

Gracefully handle the case when netmask is reported as an empty string

Original PR: https://github.com/truenas/middleware/pull/15660
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134104