### PR TITLE
NAS-133858 / 25.04-RC.1 / Make sure CPU temperature is reported for virtual cores (by Qubad786)

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -86,11 +86,12 @@ class Service(SimpleService):
                 # temperatures. (i.e. we just copy the
                 # temp of the parent physical core id)
                 data[cinfo['ht_map'][core]] = temp
+                total_temp += temp
             except KeyError:
                 continue
 
         if total_temp:
-            data['cpu'] = total_temp / len(data.keys())
+            data['cpu'] = total_temp / len(data)
 
         return data or ({f'cpu{i}': 0 for i in range(cinfo['core_count'])} | {'cpu': 0})
 

--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -85,7 +85,7 @@ class Service(SimpleService):
                 # for filling in the hyper-threaded ids
                 # temperatures. (i.e. we just copy the
                 # temp of the parent physical core id)
-                data[cinfo['ht_map'][core]] = temp
+                data[cinfo['ht_map'][f'cpu{core}']] = temp
                 total_temp += temp
             except KeyError:
                 continue

--- a/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/cputemp.chart.py
@@ -3,8 +3,7 @@ from collections import defaultdict
 from copy import deepcopy
 from third_party import lm_sensors as sensors
 
-from middlewared.utils.cpu import amd_cpu_temperatures, generic_cpu_temperatures, cpu_info
-
+from middlewared.utils.cpu import amd_cpu_temperatures, cpu_info, generic_cpu_temperatures
 
 CPU_TEMPERATURE_FEAT_TYPE = 2
 
@@ -77,13 +76,23 @@ class Service(SimpleService):
 
         data = {}
         total_temp = 0
+        cinfo = cpu_info()
         for core, temp in cpu_temps.items():
             data[f'cpu{core}'] = temp
             total_temp += temp
+            try:
+                # we follow the paradigm that htop uses
+                # for filling in the hyper-threaded ids
+                # temperatures. (i.e. we just copy the
+                # temp of the parent physical core id)
+                data[cinfo['ht_map'][core]] = temp
+            except KeyError:
+                continue
 
         if total_temp:
             data['cpu'] = total_temp / len(data.keys())
-        return data or ({f'cpu{i}': 0 for i in range(cpu_info()['core_count'])} | {'cpu': 0})
+
+        return data or ({f'cpu{i}': 0 for i in range(cinfo['core_count'])} | {'cpu': 0})
 
     def check(self):
         try:

--- a/src/middlewared/middlewared/utils/cpu.py
+++ b/src/middlewared/middlewared/utils/cpu.py
@@ -26,9 +26,9 @@ class CpuInfo(typing.TypedDict):
     physical_core_count: int
     """The total number of physical CPU cores"""
     ht_map: dict[str, str]
-    """A mapping of hyper-threaded ids to their
-        parent physical core id
-        (i.e. {"cpu8": "cpu0", "cpu9": "cpu1"})"""
+    """A mapping of physical core ids to their
+        hyper-threaded ids
+        (i.e. {"cpu0": "cpu8", "cpu1": "cpu9"})"""
 
 
 @functools.cache
@@ -78,7 +78,7 @@ def cpu_info_impl() -> CpuInfo:
                         #   This means `cpu0` is a physical core because
                         #   the `0` in `cpu0` matches the first number
                         #   in the file (0,8)
-                        ht_map[i.name] = f'cpu{pcid}'
+                        ht_map[f'cpu{pcid}'] = i.name
             except FileNotFoundError:
                 continue
 


### PR DESCRIPTION
## Problem  

Currently, the Netdata CPU temperature plugin does not report temperatures for virtual cores.  

## Solution  

Mirror the temperature readings from physical cores to their respective virtual cores, similar to how **htop** handles it.

Ref: https://unix.stackexchange.com/questions/400605/understanding-core-ids

Original PR: https://github.com/truenas/middleware/pull/15514
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133858