### PR TITLE
NAS-134149 / 25.10 / remove unnecessary api test

### DIFF
--- a/tests/api2/test_device_get_disk_names.py
+++ b/tests/api2/test_device_get_disk_names.py
@@ -1,5 +1,0 @@
-from middlewared.test.integration.utils import call
-
-
-def test_device_get_disk_names():
-    assert set(list(call('device.get_disks', False, True))) == set(call('device.get_disk_names'))


### PR DESCRIPTION
This test is no longer needed after https://github.com/truenas/middleware/pull/15550 was merged.