### PR TITLE
NAS-133968 / 25.10 / Add scheduled cryptographic verification of OS file system for STIG

### DIFF
--- a/src/middlewared/middlewared/alert/source/truenas_verify.py
+++ b/src/middlewared/middlewared/alert/source/truenas_verify.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+import subprocess
+
+from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, ThreadedAlertSource
+from middlewared.alert.schedule import IntervalSchedule
+from middlewared.utils.security import system_security_config_to_stig_type
+
+
+# --------------- Monitored Alerts ----------------
+class TrueNASVerifyServiceChangeDetectionAlertClass(AlertClass):
+    category = AlertCategory.AUDIT
+    level = AlertLevel.ERROR
+    title = "TrueNAS Verify Service: Changes detected in root file system."
+    text = "%(verrs)s"
+
+
+class TrueNASVerifyServiceChangeDetectionAlertSource(ThreadedAlertSource):
+    '''
+    Periodic verification of root file system
+    '''
+    schedule = IntervalSchedule(timedelta(hours=24))
+    run_on_backup_node = False
+
+    def check_sync(self):
+        # Run only if in stig mode
+        if self.enabled():
+            # Capture the results in syslog
+            res = subprocess.run(['truenas_verify', 'syslog'], capture_output=True, text=True)
+            if res.returncode:
+                errmsg = f"{res.stderr}  See syslog for details."
+                return Alert(
+                    TrueNASVerifyServiceChangeDetectionAlertClass,
+                    {'verrs': errmsg},
+                    key=None
+                )
+
+    def enabled(self):
+        security_config = self.middleware.call_sync('system.security.config')
+        enabled_stig = system_security_config_to_stig_type(security_config)
+        return enabled_stig

--- a/src/middlewared/middlewared/alert/source/truenas_verify.py
+++ b/src/middlewared/middlewared/alert/source/truenas_verify.py
@@ -23,7 +23,7 @@ class TrueNASVerifyServiceChangeDetectionAlertSource(ThreadedAlertSource):
 
     def check_sync(self):
         # Run only if in stig mode
-        if self.enabled():
+        if self.stig_enabled():
             # Capture the results in syslog
             res = subprocess.run(['truenas_verify', 'syslog'], capture_output=True, text=True)
             if res.returncode:
@@ -34,7 +34,7 @@ class TrueNASVerifyServiceChangeDetectionAlertSource(ThreadedAlertSource):
                     key=None
                 )
 
-    def enabled(self):
+    def stig_enabled(self):
         security_config = self.middleware.call_sync('system.security.config')
         enabled_stig = system_security_config_to_stig_type(security_config)
         return enabled_stig

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -1,7 +1,6 @@
 import asyncio
 import csv
 import errno
-import json
 import middlewared.sqlalchemy as sa
 import os
 import shutil
@@ -22,6 +21,7 @@ from .utils import (
     AUDITED_SERVICES,
     parse_query_filters,
     requires_python_filtering,
+    setup_truenas_verify,
 )
 from .schema.middleware import AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS, AUDIT_EVENT_MIDDLEWARE_PARAM_SET
 from .schema.smb import AUDIT_EVENT_SMB_JSON_SCHEMAS, AUDIT_EVENT_SMB_PARAM_SET
@@ -597,6 +597,18 @@ class AuditService(ConfigService):
         except Exception:
             await self.middleware.call('alert.oneshot_create', 'AuditSetup', None)
             self.logger.error('Failed to apply auditing dataset configuration.', exc_info=True)
+
+        # Generate the initial truenas_verify file
+        try:
+            current_version = await self.middleware.call('system.version')
+            rc, err = await setup_truenas_verify(self.middleware, current_version)
+            if rc:
+                self.logger.error(
+                    'Unexpected result from truenas_verify initial setup. '
+                    'rc=%d, error=%s', rc, err
+                )
+        except Exception:
+            self.logger.error('Error detected in truenas_verify setup.', exe_info=True)
 
     @private
     @filterable

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -608,7 +608,7 @@ class AuditService(ConfigService):
                     'rc=%d, error=%s', rc, err
                 )
         except Exception:
-            self.logger.error('Error detected in truenas_verify setup.', exe_info=True)
+            self.logger.error('Error detected in truenas_verify setup.', exc_info=True)
 
     @private
     @filterable


### PR DESCRIPTION
Scheduled cryptographic verification of the OS file system
----------------------------------------------------------------
This PR should be merged with the same named PRs in `truenas_verify` and `scale-build`

- Added scheduled cryptographic verification via Alert `check`.  The current schedule is once every 60 minutes.
    - Discrepancies found during the scheduled runs are logged to `syslog`
- Install and update:  Generate a version tagged discrepancy log in `/var/log/audit` directory.

NOTE: A verification run can take several seconds on a VM.  This time is added to the initial boot and update boots.  All other boots are not impacted.

---------------------------------------------------------------
**CI tests and update to the diagnostic will be done in separate PRs**