### PR TITLE
NAS-134182 / 25.04-RC.1 / Restore default to `disk.get_unused.join_partitions` (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -103,7 +103,7 @@ class DiskService(Service):
         return {'used': used, 'unused': unused}
 
     @private
-    async def get_unused(self, join_partitions):
+    async def get_unused(self, join_partitions=False):
         """
         Return disks that are NOT in use by any zpool that is currently imported OR exported.
 


### PR DESCRIPTION
Follows from #15651

Original PR: https://github.com/truenas/middleware/pull/15680
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134182