### PR TITLE
NAS-134180 / 25.04-RC.1 / Remove `extra="forbid"` for `CoreSetOptionsOptions` (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/core.py
+++ b/src/middlewared/middlewared/api/v25_04_0/core.py
@@ -1,5 +1,7 @@
 from typing import Literal
 
+from pydantic import ConfigDict
+
 from middlewared.api.base import BaseModel, ForUpdateMetaclass, single_argument_result
 
 __all__ = [
@@ -23,6 +25,13 @@ class CorePingResult(BaseModel):
 
 
 class CoreSetOptionsOptions(BaseModel, metaclass=ForUpdateMetaclass):
+    # We can't use `extra="forbid"` here because newer version clients might try to set more options than we support
+    model_config = ConfigDict(
+        strict=True,
+        str_max_length=1024,
+        use_attribute_docstrings=True,
+    )
+
     py_exceptions: bool
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 37f7d927e33102b9cecca97f3bd53f8bf834ad42

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 50d0f3f9803ee56978565cfc6bd4e2c05904fb15



Original PR: https://github.com/truenas/middleware/pull/15682
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134180