### PR TITLE
NAS-134025 / 25.04-RC.1 / Stop apps when pool attr for docker service is changed (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -76,6 +76,16 @@ class DockerService(ConfigService):
             if pool_changed:
                 # We want to clear upgrade alerts for apps at this point
                 await self.middleware.call('app.clear_upgrade_alerts_for_all')
+                # We want to stop all apps if pool attr has changed because docker on stopping service
+                # does not result in clean umount of ix-apps dataset if we have 20+ running apps
+                job.set_progress(15, 'Stopping Apps')
+                apps = await self.middleware.call('app.query', [['state', '!=', 'STOPPED']])
+                batch_size = 10
+                # Let's do this in batches to avoid creating lots of tasks at once
+                for i in range(0, len(apps), batch_size):
+                    await (await self.middleware.call(
+                        'core.bulk', 'app.stop', [[app['name']] for app in apps[i:i + batch_size]]
+                    )).wait()
 
             nvidia_changed = old_config['nvidia'] != config['nvidia']
 


### PR DESCRIPTION
## Problem

When we have 20+ running apps, we have seen that if we docker pool is unset or changed - what happens in the background is that ix-apps dataset is umounted after stopping docker service and the new one mounted (if anotehr pool has been selected).
However we have observed that that with 20+ running apps, docker does not cleanly exit and we are unable to umount ix-apps dataset because of that.

## Solution

Make sure if pool attr is being changed, we stop all apps and then stop docker service as that results in a clean docker exit and we are able to umount ix-apps dataset without any issues.

Original PR: https://github.com/truenas/middleware/pull/15686
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134025