### PR TITLE
Set extra="ignore" for CoreSetOptionsOptions

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/core.py
+++ b/src/middlewared/middlewared/api/v25_04_0/core.py
@@ -30,6 +30,7 @@ class CoreSetOptionsOptions(BaseModel, metaclass=ForUpdateMetaclass):
         strict=True,
         str_max_length=1024,
         use_attribute_docstrings=True,
+        extra="ignore",
     )
 
     private_methods: bool


### PR DESCRIPTION
Set `extra="ignore"` for `CoreSetOptionsOptions`

This enhances a previous change made with the same goal (PR #15682)