### PR TITLE
NAS-134175 / 25.10 / Ensure failover has not been disabled

### DIFF
--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -2021,6 +2021,7 @@ def test__alua_config(iscsi_running):
     _ensure_alua_state(False)
 
     if ha:
+        assert call('failover.config')['disabled'] is False
         _check_ha_node_configuration()
 
     # Next create a target

--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -136,6 +136,7 @@ class TestFixtureConfiguredALUA:
 
     @pytest.fixture(scope='class')
     def alua_configured(self):
+        assert call('failover.config')['disabled'] is False
         with ensure_service_enabled(SERVICE_NAME):
             call('service.start', SERVICE_NAME)
             with alua_enabled():


### PR DESCRIPTION
Some ALUA tests were going AWOL because a previous failure had left failover administratively disabled.  Add an explicit check that this is not the case.

----

Passing (abridged) CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3083/).