### PR TITLE
NAS-134170 / 25.10 / Add iser setting to iscsi.global (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-02-11_22-45_iser.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-02-11_22-45_iser.py
@@ -1,0 +1,25 @@
+"""Add iSER configuration setting
+
+Revision ID: 673dd6925aba
+Revises: 287d5bdee5c5
+Create Date: 2025-02-11 22:45:50.021091+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '673dd6925aba'
+down_revision = '287d5bdee5c5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_iscsitargetglobalconfiguration', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('iscsi_iser', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_04_0/iscsi_global.py
@@ -9,6 +9,8 @@ __all__ = [
     "IscsiGlobalUpdateResult",
     "IscsiGlobalAluaEnabledArgs",
     "IscsiGlobalAluaEnabledResult",
+    "IscsiGlobalISEREnabledArgs",
+    "IscsiGlobalISEREnabledResult",
     "IscsiGlobalClientCountArgs",
     "IscsiGlobalClientCountResult",
     "IscsiGlobalSessionsArgs",
@@ -23,6 +25,7 @@ class IscsiGlobalEntry(BaseModel):
     listen_port: int = Field(ge=1025, le=65535, default=3260)
     pool_avail_threshold: int | None = Field(ge=1, le=99, default=None)
     alua: bool
+    iser: bool
 
 
 @single_argument_args('iscsi_update')
@@ -39,6 +42,14 @@ class IscsiGlobalAluaEnabledArgs(BaseModel):
 
 
 class IscsiGlobalAluaEnabledResult(BaseModel):
+    result: bool
+
+
+class IscsiGlobalISEREnabledArgs(BaseModel):
+    pass
+
+
+class IscsiGlobalISEREnabledResult(BaseModel):
     result: bool
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_global.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_global.py
@@ -9,6 +9,8 @@ __all__ = [
     "IscsiGlobalUpdateResult",
     "IscsiGlobalAluaEnabledArgs",
     "IscsiGlobalAluaEnabledResult",
+    "IscsiGlobalISEREnabledArgs",
+    "IscsiGlobalISEREnabledResult",
     "IscsiGlobalClientCountArgs",
     "IscsiGlobalClientCountResult",
     "IscsiGlobalSessionsArgs",
@@ -23,6 +25,7 @@ class IscsiGlobalEntry(BaseModel):
     listen_port: int = Field(ge=1025, le=65535, default=3260)
     pool_avail_threshold: int | None = Field(ge=1, le=99, default=None)
     alua: bool
+    iser: bool
 
 
 @single_argument_args('iscsi_update')
@@ -39,6 +42,14 @@ class IscsiGlobalAluaEnabledArgs(BaseModel):
 
 
 class IscsiGlobalAluaEnabledResult(BaseModel):
+    result: bool
+
+
+class IscsiGlobalISEREnabledArgs(BaseModel):
+    pass
+
+
+class IscsiGlobalISEREnabledResult(BaseModel):
     result: bool
 
 

--- a/src/middlewared/middlewared/plugins/iscsi_/iser.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iser.py
@@ -1,0 +1,21 @@
+import subprocess
+
+from middlewared.service import Service
+
+KERNEL_MODULE = 'isert_scst'
+
+
+class iSCSITargetISERService(Service):
+    """
+    Support iSER configuration.
+    """
+    class Config:
+        private = True
+        namespace = 'iscsi.iser'
+
+    async def before_start(self):
+        if await self.middleware.call('iscsi.global.iser_enabled'):
+            await self.middleware.run_in_thread(self._load_kernel_module)
+
+    def _load_kernel_module(self):
+        subprocess.run(['modprobe', KERNEL_MODULE])

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -29,6 +29,7 @@ class ISCSITargetService(SimpleService):
                 self.middleware.logger.debug(f'Waited sucessfully for {self.name} to enter {curstate} state')
 
     async def before_start(self):
+        await self.middleware.call("iscsi.iser.before_start")
         await self.middleware.call("iscsi.alua.before_start")
         # Because we are a systemd_async_start service, it is possible that
         # a start could be requested while a stop is still in progress.


### PR DESCRIPTION
- Add iSER setting (`iser`) to `iscsi.global`.  Kernel module will only be loaded if enabled.
- Alembic migration for iSER configuration setting

----
CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3081/)

Original PR: https://github.com/truenas/middleware/pull/15698
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134170

----
Since 25.10 does not yet have **any** alembic entries, no merge migration is required.