### PR TITLE
Convert ipmi.lan namespace to new API

### DIFF
--- a/src/middlewared/middlewared/api/base/types/string.py
+++ b/src/middlewared/middlewared/api/base/types/string.py
@@ -1,6 +1,13 @@
 from typing import Annotated, Any
 
-from pydantic import AfterValidator, BeforeValidator, Field, GetCoreSchemaHandler, HttpUrl as _HttpUrl, PlainSerializer
+from pydantic import (
+    AfterValidator,
+    BeforeValidator,
+    Field,
+    GetCoreSchemaHandler,
+    HttpUrl as _HttpUrl,
+    PlainSerializer,
+)
 from pydantic_core import CoreSchema, core_schema, PydanticKnownError
 
 from middlewared.api.base.validators import time_validator
@@ -62,5 +69,4 @@ TimeString = Annotated[str, AfterValidator(time_validator)]
 NetbiosDomain = Annotated[str, AfterValidator(validate_netbios_domain)]
 NetbiosName = Annotated[str, AfterValidator(validate_netbios_name)]
 SnapshotNameSchema = Annotated[str, AfterValidator(lambda val: validate_snapshot_naming_schema(val) or val)]
-
 SECRET_VALUE = "********"

--- a/src/middlewared/middlewared/api/base/validators.py
+++ b/src/middlewared/middlewared/api/base/validators.py
@@ -3,7 +3,9 @@ import re
 
 from pydantic import HttpUrl
 
-__all__ = ["match_validator", "time_validator"]
+from .validators_.passwd_complexity import passwd_complexity_validator
+
+__all__ = ["match_validator", "time_validator", "passwd_complexity_validator",]
 
 
 def match_validator(pattern: re.Pattern, explanation: str | None = None):

--- a/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
+++ b/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
@@ -1,0 +1,105 @@
+from functools import partial
+from string import digits, ascii_uppercase, ascii_lowercase, punctuation
+
+from pydantic import SecretStr
+
+
+__all__ = ("passwd_complexity_validator",)
+
+ALLOWED_TYPES = (
+    "ASCII_LOWER",
+    "ASCII_UPPER",
+    "SPECIAL",
+    "DIGIT",
+)
+
+
+def __complexity_impl(
+    value: SecretStr,
+    *,
+    required_types: list[str] | None,
+    required_cnt: int,
+    min_length: int,
+    max_length: int,
+) -> str:
+    passwd_length = len(value)
+    if passwd_length < min_length:
+        raise ValueError(f"Length of password must be at least {min_length} chars")
+    elif passwd_length > max_length:
+        raise ValueError(f"Length of password can not be more than {max_length} chars")
+
+    cnt = 0
+    reqs = []
+    errstr = ""
+    cleartext_passwd = value.get_secret_value()
+    if cleartext_passwd and required_types:
+        for rt in filter(lambda x: x not in ALLOWED_TYPES, required_types):
+            raise ValueError(
+                f"{rt} is in invalid type. Allowed types are {','.join(ALLOWED_TYPES)}"
+            )
+
+        if "ASCII_LOWER" in required_types:
+            reqs.append("lowercase character")
+            if not any(c in ascii_lowercase for c in cleartext_passwd):
+                if required_cnt is None:
+                    errstr += "Must contain at least one lowercase character. "
+            else:
+                cnt += 1
+
+        if "ASCII_UPPER" in required_types:
+            reqs.append("uppercase character")
+            if not any(c in ascii_uppercase for c in cleartext_passwd):
+                if required_cnt is None:
+                    errstr += "Must contain at least one uppercase character. "
+            else:
+                cnt += 1
+
+        if "DIGIT" in required_types:
+            reqs.append("digits 0-9")
+            if not any(c in digits for c in cleartext_passwd):
+                if required_cnt is None:
+                    errstr += "Must contain at least one numeric digit (0-9). "
+            else:
+                cnt += 1
+
+        if "SPECIAL" in required_types:
+            reqs.append("special characters (!, $, #, %, etc.)")
+            if not any(c in punctuation for c in cleartext_passwd):
+                if required_cnt is None:
+                    errstr += "Must contain at least one special character (!, $, #, %, etc.). "
+            else:
+                cnt += 1
+
+    if required_cnt and required_cnt > cnt:
+        raise ValueError(
+            f"Must contain at least {required_cnt} of the following categories: {', '.join(reqs)}"
+        )
+
+    if errstr:
+        raise ValueError(errstr)
+    return value
+
+
+def passwd_complexity_validator(
+    required_types: list[str] | None = None,
+    required_cnt: int = 0,
+    min_length: int = 8,
+    max_length: int = 16,
+) -> str:
+    """Enforce password complexity.
+
+    Args:
+        required_types: list of strings or None.
+            The allowed types are `ALLOWED_TYPES`.
+        required_cnt: integer, The number of categories
+            (in `ALLOWED_TYPES`) that the password must use.
+        min_length: integer, The minimum length of the password.
+        max_length: integer, The maximum length of the password.
+    """
+    return partial(
+        __complexity_impl,
+        required_types=required_types,
+        required_cnt=required_cnt,
+        min_length=min_length,
+        max_length=max_length,
+    )

--- a/src/middlewared/middlewared/api/v25_10_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_10_0/__init__.py
@@ -36,6 +36,7 @@ from .group import *  # noqa
 from .initshutdownscript import *  # noqa
 from .ipmi import *  # noqa
 from .ipmi_chassis import *  # noqa
+from .ipmi_lan import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
 from .iscsi_global import *  # noqa

--- a/src/middlewared/middlewared/api/v25_10_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_10_0/__init__.py
@@ -35,6 +35,7 @@ from .ftp import *  # noqa
 from .group import *  # noqa
 from .initshutdownscript import *  # noqa
 from .ipmi import *  # noqa
+from .ipmi_chassis import *  # noqa
 from .iscsi_auth import *  # noqa
 from .iscsi_extent import *  # noqa
 from .iscsi_global import *  # noqa

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_chassis.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_chassis.py
@@ -1,0 +1,36 @@
+from typing import Literal
+
+from middlewared.api.base import BaseModel, ForUpdateMetaclass
+
+from pydantic import Field
+
+
+class ChassisInfoEntry(BaseModel):
+    system_power: str
+    power_overload: str
+    interlock: str
+    power_fault: str
+    power_control_fault: str
+    power_restore_policy: str
+    last_power_event: str
+    chassis_intrusion: str
+    front_panel_lockout: str
+    drive_fault: str
+    cooling_fan_fault: str = Field(alias="cooling/fan_fault")
+    chassis_identify_state: str
+
+
+class ChassisIdentifyArgs(BaseModel):
+    verb: Literal["ON", "OFF"]
+
+
+class ChassisIdentifyResult(BaseModel):
+    pass
+
+
+class ChassisInfoArgs(BaseModel):
+    pass
+
+
+class ChassisInfoResult(ChassisInfoEntry, metaclass=ForUpdateMetaclass):
+    pass

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
@@ -1,0 +1,84 @@
+from ipaddress import IPv4Address
+from typing import Annotated
+
+from pydantic import AfterValidator, Field, SecretStr
+
+from middlewared.api.base import BaseModel, ForUpdateMetaclass, NotRequired, query_result
+from middlewared.api.base.validators import passwd_complexity_validator
+from .comon import QueryFilters, QueryOptions
+
+
+class IPMILanQueryEntry(BaseModel, metaclass=ForUpdateMetaclass):
+    channel: int
+    id_: int = Field(alias="id")
+    ip_address_source: str
+    ip_address: str
+    mac_address: str
+    subnet_mask: str
+    default_gateway_ip_address: str
+    default_gateway_mac_address: str
+    backup_gateway_ip_address: str
+    backup_gateway_mac_address: str
+    vlan_id: int | None
+    vlan_id_enable: bool
+    vlan_priority: int
+
+
+class IPMILanQueryOptions(BaseModel):
+    query_remote: bool = Field(alias='query-remote', default=False)
+
+
+class IPMILanQueryArgs(BaseModel):
+    query_filters: QueryFilters = Field(alias='query-filters', default=[])
+    query_options: QueryOptions = Field(alias='query-options', default=QueryOptions())
+    ipmi_options: IPMILanQueryOptions = Field(alias='ipmi-options', default=IPMILanQueryOptions())
+
+
+class IPMILanQueryResult(BaseModel):
+    result: query_result(IPMILanQueryEntry)
+
+
+class IPMILanChannelsArgs(BaseModel):
+    pass
+
+
+class IPMILanChannelsResult(BaseModel):
+    result: list[int]
+
+
+class IPMILanUpdateOptions(BaseModel):
+    dhcp: bool = NotRequired
+    """Turn on DHCP protocol for ip address management"""
+    ipddress: IPv4Address = NotRequired
+    """The IPv4 address in the form of `192.168.1.150`"""
+    netmask: IPv4Address = NotRequired
+    """The netmask in the form of `255.255.255.0`"""
+    gateway: IPv4Address = NotRequired
+    """The gateway in the form of `192.168.1.1`"""
+    password: Annotated[
+        SecretStr,
+        AfterValidator(
+            passwd_complexity_validator(
+                required_types=["ASCII_UPPER", "ASCII_LOWER", "DIGIT", "SPECIAL"],
+                required_cnt=3,
+                min_length=8,
+                max_length=16,
+            )
+        )
+    ] | None = None
+    """The password to be applied. Must be between 8 and 16 characters long and
+    contain only ascii upper,lower, 0-9, and special characters."""
+    vlan_id: int = Field(ge=0, le=4096, default=NotRequired)
+    """The vlan tag number"""
+    apply_remote: bool = Field(default=False)
+    """If on an HA system, and this field is set to True,
+    the settings will be sent to the remote controller."""
+
+
+class IPMILanUpdateArgs(BaseModel):
+    channel: int
+    data: IPMILanUpdateOptions
+
+
+class IPMILanUpdateResult(BaseModel):
+    result: int

--- a/src/middlewared/middlewared/plugins/ipmi_/chassis.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/chassis.py
@@ -1,7 +1,13 @@
 from subprocess import run, DEVNULL
 
+from middlewared.api import api_method
+from middlewared.api.current import (
+    IPMIChassisIdentifyArgs,
+    IPMIChassisIdentifyResult,
+    IPMIChassisInfoArgs,
+    IPMIChassisInfoResult,
+)
 from middlewared.service import Service
-from middlewared.schema import Str, Dict, accepts, returns
 
 
 class IpmiChassisService(Service):
@@ -10,25 +16,13 @@ class IpmiChassisService(Service):
         namespace = 'ipmi.chassis'
         cli_namespace = 'service.ipmi.chassis'
 
-    @accepts(roles=['IPMI_READ'])
-    @returns(Dict('chassis_info', additional_attrs=True))
+    @api_method(
+        IPMIChassisInfoArgs,
+        IPMIChassisInfoResult,
+        roles=['IPMI_READ'],
+    )
     def info(self):
-        """Return looks like:
-        {
-            "system_power": "on",
-            "power_overload": "false",
-            "interlock": "inactive",
-            "power_fault": "false",
-            "power_control_fault": "false",
-            "power_restore_policy": "Always off",
-            "last_power_event": "unknown",
-            "chassis_intrusion": "inactive",
-            "front_panel_lockout": "inactive",
-            "drive_fault": "false",
-            "cooling/fan_fault": "false",
-            "chassis_identify_state": "off"
-        }
-        """
+        """Return IPMI chassis info."""
         rv = {}
         if not self.middleware.call_sync('ipmi.is_loaded'):
             return rv
@@ -40,8 +34,11 @@ class IpmiChassisService(Service):
 
         return rv
 
-    @accepts(Str('verb', default='ON', enum=['ON', 'OFF']), roles=['IPMI_WRITE'])
-    @returns()
+    @api_method(
+        IPMIChassisIdentifyArgs,
+        IPMIChassisIdentifyResult,
+        roles=['IPMI_WRITE'],
+    )
     def identify(self, verb):
         """
         Toggle the chassis identify light.


### PR DESCRIPTION
This converts the `ipmi_/lan.py` endpoints to our new API definitions. Before this could happen, I also had to port the `Password` class from our legacy schema. I simply copy and pasted the exact same logic, only tweaking it slightly to the new `password_complexity_validator` that may be used by other plugins. Added docstrings as well.