### PR TITLE
NAS-134183 / 25.10 / nvme-of: wait for timeout to pass if shelf was empty

### DIFF
--- a/src/freenas/usr/local/bin/nvmf-connect.sh
+++ b/src/freenas/usr/local/bin/nvmf-connect.sh
@@ -36,7 +36,7 @@ while [ -s $queue ]; do
       connect_nqns=$(nvme discover "$@" | grep subnqn: | awk '{gsub(/^subnqn: */,"")}1' \
           | tr -s '\n' | sort)
 
-      if [ "$local_nqns" != "$connect_nqns" ]; then
+      if [[ -n "$local_nqns" && "$local_nqns" != "$connect_nqns" ]]; then
         break
       fi
 


### PR DESCRIPTION
Removing power from the ES24N shelf does not trigger events on the discovery controller except for an Interface Link Down. Shelf drives keep retrying until a 10-minute timeout. After power restoration, it takes about 10 seconds to connect, yet the remote discovery log shows no entries. A discovery change event then removes all drives since the ES24N shelf reports none. One minute after Link Up, a Link Down occurs, followed by another Link Up a few seconds later that triggers a change event during which some entries, notably CM7 drives, are missed.
To address this, wait for the timeout to complete if the shelf was previously empty during a discovery change event on power restore. This avoids acting on incomplete discovery logs and ensures proper drive reconnection. In addition, when connecting the first disk to the enclosure, we add additional waiting time. The extra delay is minimal since disks already take a few seconds to appear in the discovery log after a change event.

Jira Ticket: https://ixsystems.atlassian.net/browse/NAS-134183
Validated by Jeff Ervin on f100-152