### PR TITLE
NAS-134277 / 25.04-RC.1 / Allow file downloads STIG mode (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/auth.py
+++ b/src/middlewared/middlewared/api/v25_04_0/auth.py
@@ -161,6 +161,7 @@ class AuthSessionEntry(BaseModel):
         'UNIX_SOCKET',
         'LOGIN_PASSWORD',
         'LOGIN_TWOFACTOR',
+        'LOGIN_ONETIME_PASSWORD',
         'API_KEY',
         'TOKEN',
         'TRUENAS_NODE',

--- a/src/middlewared/middlewared/auth.py
+++ b/src/middlewared/middlewared/auth.py
@@ -72,7 +72,6 @@ class UserSessionManagerCredentials(SessionManagerCredentials):
         self.last_used_at = now
 
         if assurance:
-            self.may_create_auth_token = AuthMech.TOKEN_PLAIN in assurance.mechanisms
             self.expiry = now + self.assurance.max_session_age
             self.inactivity_timeout = self.assurance.max_inactivity
 

--- a/src/middlewared/middlewared/service/core_service.py
+++ b/src/middlewared/middlewared/service/core_service.py
@@ -646,7 +646,12 @@ class CoreService(Service):
             pipes=Pipes(output=self.middleware.pipe(buffered))
         )
         token = await self.middleware.call(
-            'auth.generate_token', 300, {'filename': filename, 'job': job.id}, True, True, app=app
+            'auth.generate_token',
+            300,  # ttl
+            {'filename': filename, 'job': job.id},  # attrs
+            True,  # match origin
+            True,  # single-use token
+            app=app
         )
         self.middleware.fileapp.register_job(job.id, buffered)
         return job.id, f'/_download/{job.id}?auth_token={token}'


### PR DESCRIPTION
This commit fixes an issue that was preventing STIG mode file downloads as
well as a few opportunistic fixes.

* Add LOGIN_ONETIME_PASSWORD to session types enum
* Allow token generation for user sessions
* Add comments to explain generate_tokens arguments in download method

Original PR: https://github.com/truenas/middleware/pull/15736
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134277