### PR TITLE
NAS-134202 / 25.10 / Add alert for missing SMB user hashes

### DIFF
--- a/src/middlewared/middlewared/alert/source/smb.py
+++ b/src/middlewared/middlewared/alert/source/smb.py
@@ -1,5 +1,5 @@
 import time
-from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource
+from middlewared.alert.base import AlertClass, AlertCategory, Alert, AlertLevel, AlertSource, SimpleOneShotAlertClass
 from middlewared.alert.schedule import CrontabSchedule
 from middlewared.service_exception import ValidationErrors
 
@@ -147,3 +147,18 @@ class SMBPathAlertSource(AlertSource):
             return
 
         return Alert(SMBPathAlertClass, {'err': msg}, key=None)
+
+
+class SMBUserMissingHashAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = "SMB user is missing required password hash"
+    text = (
+        "The following users lack valid password hashes. "
+        "This may occur if the TrueNAS configuration was restored without the "
+        "secret seed and may be fixed by resetting the user password through the "
+        "TrueNAS UI or API: %(entries)s"
+    )
+
+    async def delete(self, alerts, query):
+        return []


### PR DESCRIPTION
This commit adds a oneshot alert for case where users lack an SMB hash, which can occur if config file was restored without the secret seed. The alert is deliberately not toggled by CRUD methods for accounts to keep it simple for what should be an obscure edge-case.