### PR TITLE
NAS-133680 / 25.10 / Disable SMB2 lease support in multiprotocol SMB mode

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -498,6 +498,14 @@ class SMBService(ConfigService):
                     'smb_update.aapl_extensions',
                     'This option must be enabled when AFP or time machine shares are present'
                 )
+        else:
+            if await self.middleware.call('sharing.smb.query', [['purpose', '=', 'MULTI_PROTOCOL_NFS']]):
+                verrors.add(
+                    'smb_update.aapl_extensions',
+                    'This option may not be enabled concurrently with shares that are configured for '
+                    'multi-protocol NFS access.'
+                )
+
 
         if new['enable_smb1']:
             if audited_shares := await self.middleware.call(
@@ -1314,6 +1322,13 @@ class SharingSMBService(SharingService):
                 f'{schema_name}.afp',
                 'Apple SMB2/3 protocol extension support is required by this parameter. '
                 'This feature may be enabled in the general SMB server configuration.'
+            )
+
+        if data['purpose'] == 'MULTI_PROTOCOL_NFS' and smb_config['aapl_extensions']:
+            verrors.add(
+                f'{schema_name}.purpose',
+                'MULTI_PROTOCOL_NFS purpose requires global changes that are incompatible '
+                'with the enabling Apple SMB protocol extensions.'
             )
 
         if data['timemachine'] or data['purpose'] in ('TIMEMACHINE', 'ENHANCED_TIMEMACHINE'):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1328,7 +1328,7 @@ class SharingSMBService(SharingService):
             verrors.add(
                 f'{schema_name}.purpose',
                 'MULTI_PROTOCOL_NFS purpose requires global changes that are incompatible '
-                'with the enabling Apple SMB protocol extensions.'
+                'with the enabling of Apple SMB protocol extensions.'
             )
 
         if data['timemachine'] or data['purpose'] in ('TIMEMACHINE', 'ENHANCED_TIMEMACHINE'):

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -139,7 +139,7 @@ class SMBSharePreset(enum.Enum):
     MULTI_PROTOCOL_NFS = {"verbose_name": "Multi-protocol (NFSv4/SMB) shares", "params": {
         'streams': True,
         'durablehandle': False,
-        'auxsmbconf': '',
+        'auxsmbconf': 'kernel oplocks=True',
     }, "cluster": False}
     PRIVATE_DATASETS = {"verbose_name": "Private SMB Datasets and Shares", "params": {
         'path_suffix': '%U',

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -181,8 +181,6 @@ def generate_smb_share_conf_dict(
 
     if share_config['durablehandle']:
         config_out['posix locking'] = False
-    else:
-        config_out['kernel oplocks'] = True
 
     if share_config['timemachine']:
         config_out['fruit:timemachine'] = True
@@ -294,6 +292,7 @@ def generate_smb_conf_dict(
         case _:
             pass
 
+    has_mixed_mode = filter_list(smb_shares, [['purpose', '=', 'MULTI_PROTOCOL_NFS']])
     home_share = filter_list(smb_shares, [['home', '=', True]])
     if home_share:
         if ds_type is DSType.AD:
@@ -558,6 +557,13 @@ def generate_smb_conf_dict(
                     value = v
 
             smbconf.update({f'{idmap_prefix} {backend_parameter}': value})
+
+    """
+    Mixed NFS / SMB shares enables kernel oplock support, which requires
+    globally disabling SMB2 leases
+    """
+    if has_mixed_mode:
+        smbconf['smb2 leases'] = False
 
     for e in smb_service_config['smb_options'].splitlines():
         # Add relevant auxiliary parameters

--- a/tests/unit/test_smb_service.py
+++ b/tests/unit/test_smb_service.py
@@ -465,3 +465,11 @@ def test__enable_stig():
     )
     assert conf['client use kerberos'] == 'required'
     assert conf['ntlm auth'] == 'disabled'
+
+
+def test__multiprotocol_share_leases():
+    conf = generate_smb_conf_dict(
+        None, None, BASE_SMB_CONFIG, [BASE_SMB_SHARE | {'purpose': 'MULTI_PROTOCOL_NFS'}],
+        BIND_IP_CHOICES, BASE_IDMAP, False, SYSTEM_SECURITY_DEFAULT
+    )
+    assert conf['smb2 leases'] is False

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -252,8 +252,6 @@ def test__durablehandle(nfsacl_dataset, enabled):
 
     if enabled:
         assert conf['posix locking'] is False
-    else:
-        assert conf['kernel oplocks'] is True
 
 
 @pytest.mark.parametrize('enabled', [True, False])
@@ -382,6 +380,16 @@ def test__worm_preset(nfsacl_dataset):
         TrueNASVfsObjects.IO_URING,
         TrueNASVfsObjects.WORM,
     ]
+
+
+def test__multiprotocol_nfs_preset(nfsacl_dataset):
+    conf = generate_smb_share_conf_dict(None, BASE_SMB_SHARE | {
+        'path': nfsacl_dataset,
+        'purpose': 'MULTI_PROTOCOL_NFS',
+    }, BASE_SMB_CONFIG)
+
+    assert conf['path'] == nfsacl_dataset
+    assert conf['kernel oplocks'] is True
 
 
 def test__shadow_copy_off(nfsacl_dataset):

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -389,7 +389,7 @@ def test__multiprotocol_nfs_preset(nfsacl_dataset):
     }, BASE_SMB_CONFIG)
 
     assert conf['path'] == nfsacl_dataset
-    assert conf['kernel oplocks'] is True
+    assert conf['kernel oplocks'] == 'True'
 
 
 def test__shadow_copy_off(nfsacl_dataset):


### PR DESCRIPTION
This commit disables SMB2/3 lease support globally when multiprotocol SMB shares are enabled. This is because despite kernel_oplocks being a per-share parameter in libsmbconf, it is incompatible with SMB2/3 lease support and can lead to unexpected failures depending on the order in which the SMB client has negotiated its first SMB tree connect.

Validation logic is simplified by making this share type mutually exclusive with AAPL extension support because timemachine -- the main driver for enabling this -- requires SMB2/3 lease support.