### PR TITLE
NAS-133911 / 25.04-RC.1 / Increase auth failure delay to minimum of 4 seconds (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
@@ -23,6 +23,9 @@
             raise TypeError(f'{dstype}: unknown DSType')
 %>\
 
+%if render_ctx['system.security.config']['enable_gpos_stig']:
+auth	optional	pam_faildelay.so	delay=4000000
+%endif
 % if conf.primary:
 ${'\n'.join(line.as_conf() for line in conf.primary)}
 % endif

--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -739,7 +739,7 @@ class AuthService(Service):
                     if resp['pam_response'] == 'SUCCESS':
                         # Insert a failure delay so that we don't leak information about
                         # the PAM response
-                        await asyncio.sleep(random.uniform(4, 5))
+                        await asyncio.sleep(CURRENT_AAL.get_delay_interval())
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
                                 'credentials': cred_type,
@@ -749,7 +749,7 @@ class AuthService(Service):
                         }, False)
 
                     else:
-                        await asyncio.sleep(random.uniform(3, 4))
+                        await asyncio.sleep(CURRENT_AAL.get_delay_interval())
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
                                 'credentials': cred_type,
@@ -769,10 +769,6 @@ class AuthService(Service):
 
                         await login_fn(app, cred)
                     case pam.PAM_AUTH_ERR:
-                        if CURRENT_AAL.level != AA_LEVEL1:
-                            # Insert a minimum additional failure delay to ensure at least 4 seconds required by STIG
-                            await asyncio.sleep(random.uniform(3, 4))
-
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
                                 'credentials': cred_type,
@@ -781,10 +777,6 @@ class AuthService(Service):
                             'error': 'Bad username or password'
                         }, False)
                     case _:
-                        if CURRENT_AAL.level != AA_LEVEL1:
-                            # Insert a minimum additional failure delay to ensure at least 4 seconds required by STIG
-                            await asyncio.sleep(random.uniform(3, 4))
-
                         await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                             'credentials': {
                                 'credentials': cred_type,
@@ -909,10 +901,7 @@ class AuthService(Service):
                     await login_fn(app, cred)
                 else:
                     # Add a sleep like pam_delay() would add for pam_oath
-                    if CURRENT_AAL.level == AA_LEVEL1:
-                        await asyncio.sleep(random.uniform(1, 2))
-                    else:
-                        await asyncio.sleep(random.uniform(4, 5))
+                    await asyncio.sleep(CURRENT_AAL.get_delay_interval())
 
                     await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                         'credentials': {
@@ -944,11 +933,7 @@ class AuthService(Service):
                 token_str = data['token']
                 token = self.token_manager.get(token_str, app.origin)
                 if token is None:
-                    if CURRENT_AAL.level == AA_LEVEL1:
-                        await asyncio.sleep(random.uniform(1, 2))
-                    else:
-                        await asyncio.sleep(random.uniform(4, 5))
-
+                    await asyncio.sleep(CURRENT_AAL.get_delay_interval())
                     await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                         'credentials': {
                             'credentials': 'TOKEN',
@@ -961,11 +946,7 @@ class AuthService(Service):
                     return response
 
                 if token.attributes:
-                    if CURRENT_AAL.level == AA_LEVEL1:
-                        await asyncio.sleep(random.uniform(1, 2))
-                    else:
-                        await asyncio.sleep(random.uniform(4, 5))
-
+                    await asyncio.sleep(CURRENT_AAL.get_delay_interval())
                     await self.middleware.log_audit_message(app, 'AUTHENTICATION', {
                         'credentials': {
                             'credentials': 'TOKEN',


### PR DESCRIPTION
SRG-OS-000480-GPOS-00226 requires that the OS enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt. This commit adds an additional failure delay when in STIG mode to meet this requirement.

Original PR: https://github.com/truenas/middleware/pull/15742
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133911