### PR TITLE
NAS-134279 / 25.04-RC.1 / Use `LongString` for cloud credential errors (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/api/v24_10/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v24_10/cloud_sync.py
@@ -1,6 +1,6 @@
 from pydantic import Secret
 
-from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
+from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LongString, NonEmptyString,
                                   single_argument_args, single_argument_result)
 
 __all__ = ["CloudCredentialEntry",
@@ -59,5 +59,5 @@ class CloudCredentialVerifyArgs(BaseModel):
 @single_argument_result
 class CloudCredentialVerifyResult(BaseModel):
     valid: bool
-    error: str | None = None
-    excerpt: str | None = None
+    error: LongString | None = None
+    excerpt: LongString | None = None

--- a/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
+++ b/src/middlewared/middlewared/api/v25_04_0/cloud_sync.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Secret
 
 from middlewared.api.base import (BaseModel, Excluded, excluded_field, ForUpdateMetaclass, LongNonEmptyString,
-                                  NonEmptyString, single_argument_args, single_argument_result)
+                                  LongString, NonEmptyString, single_argument_args, single_argument_result)
 from .cloud_sync_providers import CloudCredentialProvider
 
 __all__ = ["CloudCredentialEntry",
@@ -86,8 +86,8 @@ class CloudCredentialVerifyArgs(BaseModel):
 @single_argument_result
 class CloudCredentialVerifyResult(BaseModel):
     valid: bool
-    error: str | None = None
-    excerpt: str | None = None
+    error: LongString | None = None
+    excerpt: LongString | None = None
 
 
 @single_argument_args("onedrive_list_drives")

--- a/src/middlewared/middlewared/api/v25_04_0/keychain.py
+++ b/src/middlewared/middlewared/api/v25_04_0/keychain.py
@@ -137,7 +137,7 @@ class KeychainCredentialRemoteSSHHostKeyScanArgs(BaseModel):
 
 
 class KeychainCredentialRemoteSSHHostKeyScanResult(BaseModel):
-    result: str
+    result: LongString
 
 
 class KeychainCredentialRemoteSSHSemiautomaticSetup(BaseModel):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 358481bad55c8c8f9d8aef048822d257d358342d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8004c5f79925e77521ee0751e7e50524831212b6



Original PR: https://github.com/truenas/middleware/pull/15746
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134279