### PR TITLE
NAS-134288 / 25.10 / Fix auth failure delay

### DIFF
--- a/src/middlewared/middlewared/utils/auth.py
+++ b/src/middlewared/middlewared/utils/auth.py
@@ -46,8 +46,8 @@ class ServerAAL:
 
     def get_delay_interval(self):
         return uniform(
-            self.min_fail_delay,
-            self.min_fail_delay + 1
+            self.level.min_fail_delay,
+            self.level.min_fail_delay + 1
         )
 
 


### PR DESCRIPTION
This commit fixes a typo in the function to get the current failure delay interval.