### PR TITLE
NAS-134291 / 25.10 / Fix registry test for multiprotocol NFS

### DIFF
--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -173,6 +173,8 @@ def test__test_presets(setup_for_tests, share_presets, preset):
     mp, ds, SHARE_DICT = setup_for_tests
     if 'TIMEMACHINE' in preset:
         call('smb.update', {'aapl_extensions': True})
+    elif preset == 'MULTI_PROTOCOL_NFS':
+        call('smb.update', {'aapl_extensions': False})
 
     to_test = share_presets[preset]['params']
     to_test_aux = to_test['auxsmbconf']

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -145,10 +145,10 @@ def test__renamed_shares_in_registry(setup_for_tests):
 
 def check_aux_param(param, share, expected, fruit_enable=False):
     match expected:
-        case 'yes':
+        case 'yes' | 'True':
             expected = True
-        case 'no':
-            expeected = False
+        case 'no' | 'False':
+            expected = False
         case _:
             pass
 
@@ -174,6 +174,7 @@ def test__test_presets(setup_for_tests, share_presets, preset):
     if 'TIMEMACHINE' in preset:
         call('smb.update', {'aapl_extensions': True})
     elif preset == 'MULTI_PROTOCOL_NFS':
+        call('sharing.smb.update', SHARE_DICT['REGISTRYTEST_0'], {'purpose': 'NO_PRESET', 'timemachine': False})
         call('smb.update', {'aapl_extensions': False})
 
     to_test = share_presets[preset]['params']


### PR DESCRIPTION
Recently this SMB preset was flagged as incompatible with aapl_extensions. This commit adjusts one of the older tests to ensure that we have them disabled before toggling the preset.