### PR TITLE
NAS-134293 / 25.04-RC.1 / Convert update plugin to use SYSTEM_UPDATE_WRITE (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -254,7 +254,7 @@ class UpdateService(Service):
         Bool('resume', default=False),
         Str('train', null=True, default=None),
         Bool('reboot', default=False),
-    ), roles=['FULL_ADMIN'])
+    ), roles=['SYSTEM_UPDATE_WRITE'])
     @job(lock='update')
     @pass_app(rest=True)
     async def update(self, app, job, attrs):
@@ -293,7 +293,7 @@ class UpdateService(Service):
 
         return True
 
-    @accepts(roles=['FULL_ADMIN'])
+    @accepts(roles=['SYSTEM_UPDATE_WRITE'])
     @job(lock='updatedownload')
     def download(self, job):
         """
@@ -317,7 +317,7 @@ class UpdateService(Service):
             Bool('resume', default=False),
             Bool('cleanup', default=True),
         ),
-        roles=['FULL_ADMIN']
+        roles=['SYSTEM_UPDATE_WRITE']
     )
     @job(lock='update')
     def manual(self, job, path, options):
@@ -426,7 +426,7 @@ class UpdateService(Service):
         'updatefile',
         Bool('resume', default=False),
         Str('destination', null=True, default=None),
-    ), roles=['FULL_ADMIN'])
+    ), roles=['SYSTEM_UPDATE_WRITE'])
     @job(lock='update')
     async def file(self, job, options):
         """


### PR DESCRIPTION
Various methods were changed in a previous commit to require FULL_ADMIN without updating our unit tests. This commit changes the required role to SYSTEM_UPDATE_WRITE.

Original PR: https://github.com/truenas/middleware/pull/15757
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134293