### PR TITLE
NAS-134234 / 25.04-RC.1 / fix deserialization of IPvAnyAddress for rdma api (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/rdma_interface.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma_interface.py
@@ -26,7 +26,7 @@ class RdmaInterfaceEntry(BaseModel):
     @field_validator('address')
     @classmethod
     def normalize_address(cls, value: IPvAnyAddress) -> str:
-        return str(value.ip)
+        return str(value)
 
 
 class RdmaInterfaceCreateCheck(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/rdma_interface.py
+++ b/src/middlewared/middlewared/api/v25_04_0/rdma_interface.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-from pydantic import IPvAnyAddress
+from pydantic import IPvAnyAddress, field_validator
 
 from middlewared.api.base import BaseModel, Excluded, excluded_field, ForUpdateMetaclass
 
@@ -22,6 +22,11 @@ class RdmaInterfaceEntry(BaseModel):
     address: IPvAnyAddress
     prefixlen: int
     mtu: int = 5000
+
+    @field_validator('address')
+    @classmethod
+    def normalize_address(cls, value: IPvAnyAddress) -> str:
+        return str(value.ip)
 
 
 class RdmaInterfaceCreateCheck(BaseModel):


### PR DESCRIPTION
After the address field has been validated as a proper ip address, we need to return the ip address as a string and not as a `ipaddress.IPv4Address` or `ipaddress.IPv6Address` type.

A future PR should consider adding our own `IPvAnyAddress` type that does just this since we're not used to getting the class type inside middleware.

Original PR: https://github.com/truenas/middleware/pull/15761
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134234