### PR TITLE
NAS-134065 / 25.10 / Disable API_KEY role in GPOS STIG mode

### DIFF
--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -306,6 +306,12 @@ class ApiKeyService(CRUDService):
             # internal session
             return
 
+        if self.middleware.call_sync('system.security.config')['enable_gpos_stig']:
+            raise CallError(
+                'Changes to API keys are not permitted in GPOS STIG mode',
+                errno.EACCES
+            )
+
         if credential_has_full_admin(app.authenticated_credentials):
             return
 

--- a/src/middlewared/middlewared/role.py
+++ b/src/middlewared/middlewared/role.py
@@ -25,7 +25,7 @@ ROLES = {
     'ACCOUNT_WRITE': Role(includes=['ACCOUNT_READ']),
 
     'API_KEY_READ': Role(),
-    'API_KEY_WRITE': Role(includes=['API_KEY_READ']),
+    'API_KEY_WRITE': Role(includes=['API_KEY_READ'], stig=None),
 
     'BOOT_ENV_READ': Role(),
     'BOOT_ENV_WRITE': Role(includes=['BOOT_ENV_READ']),


### PR DESCRIPTION
Currently API key authentication is disabled in STIG mode. This commit prevents users from having write permissions to the plugin to avoid a misapprehension that they will be able to auth using them in STIG mode.