### PR TITLE
NAS-134045 / 25.10 / Prevent enabling STIG if apps / vms are configured

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -119,6 +119,20 @@ class SystemSecurityService(ConfigService):
                 'authentication for the currently-authenticated session.'
             )
 
+        if await self.middleware.call('app.query', [], {'count': True}):
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Apps are not supported under General Purpose OS STIG compatibility '
+                'mode.'
+            )
+
+        if await self.middleware.call('virt.instance.query', [], {'count': True}):
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'VMs are not supported under General Purpose OS STIG compatibility '
+                'mode.'
+            )
+
     @private
     async def validate(self, is_ha, ha_disabled_reasons):
         schema = 'system_security_update.enable_fips'


### PR DESCRIPTION
This feature is incompatible with apps / vms and so we should have some sanity checks.