### PR TITLE
NAS-134311 / 25.10 / Make sure pid is reported as integer

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -191,7 +191,7 @@ class PoolDatasetService(Service):
                         with open(f'/proc/{pid}/comm') as comm:
                             name = comm.read().strip()
 
-                        proc = {'pid': pid, 'name': name}
+                        proc = {'pid': int(pid), 'name': name}
 
                         if svc := self.middleware.call_sync('service.identify_process', name):
                             proc['service'] = svc


### PR DESCRIPTION
This commit fixes an issue where pid for dataset processes is being reported as a string which causes problems when trying to consume as expectation is it will be an integer.

i.e
```
❯ midclt call -j pool.export 41 '{"cascade": true, "destroy": true}'
Status: Terminating processes that are using this pool
Total Progress: [########________________________________] 20.00%
'<=' not supported between instances of 'str' and 'int'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 515, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 560, in __run_body
    rv = await self.method(*args)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 174, in nf
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 48, in nf
    res = await f(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/pool_/export.py", line 126, in export
    await self.middleware.call('pool.dataset.kill_processes', pool['name'],
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 977, in call
    return await self._call(
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 692, in _call
    return await methodobj(*prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/pool_/dataset_processes.py", line 103, in kill_processes
    await self.middleware.call('service.terminate_process', process['pid'])
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 977, in call
    return await self._call(
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 703, in _call
    return await self.run_in_executor(prepared_call.executor, methodobj, *prepared_call.args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/main.py", line 596, in run_in_executor
    return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/service.py", line 442, in terminate_process
    if pid <= 0 or pid == os.getpid():
       ^^^^^^^^
TypeError: '<=' not supported between instances of 'str' and 'int'
```