### PR TITLE
NAS-134316 / 25.04-RC.1 / Fix API key deletion (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/api_key.py
+++ b/src/middlewared/middlewared/plugins/api_key.py
@@ -171,6 +171,12 @@ class ApiKeyService(CRUDService):
 
         `name` is a user-readable name for key.
         """
+        if self.middleware.call_sync('system.security.config')['enable_gpos_stig']:
+            raise CallError(
+                'Changes to API keys are not permitted in GPOS STIG mode',
+                errno.EACCES
+            )
+
         # First catch any privilege errors to avoid leaking potentially sensitive information
         self.api_key_privilege_check(app, data['username'], 'api_key.create')
 
@@ -229,6 +235,12 @@ class ApiKeyService(CRUDService):
 
         Specify `reset: true` to reset this API Key.
         """
+        if self.middleware.call_sync('system.security.config')['enable_gpos_stig']:
+            raise CallError(
+                'Changes to API keys are not permitted in GPOS STIG mode',
+                errno.EACCES
+            )
+
         reset = data.pop("reset", False)
 
         old = self.middleware.call_sync('api_key.query', [['id', '=', id_]], {'get': True})
@@ -305,12 +317,6 @@ class ApiKeyService(CRUDService):
         if not app or not app.authenticated_credentials.is_user_session:
             # internal session
             return
-
-        if self.middleware.call_sync('system.security.config')['enable_gpos_stig']:
-            raise CallError(
-                'Changes to API keys are not permitted in GPOS STIG mode',
-                errno.EACCES
-            )
 
         if credential_has_full_admin(app.authenticated_credentials):
             return


### PR DESCRIPTION
This commit shifts STIG checks to only occur in create and update methods, which in addition to fixing a testing regression also allows for admins to delete existing API keys if needed.

Original PR: https://github.com/truenas/middleware/pull/15771
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134316