### PR TITLE
NAS-132269 / 25.04-RC.1 / Adjust IPC path for samba changes (by anodos325)

### DIFF
--- a/tests/api2/test_428_smb_rpc.py
+++ b/tests/api2/test_428_smb_rpc.py
@@ -43,7 +43,7 @@ def test_001_net_share_enum(setup_smb_user, setup_smb_share):
         assert shares[0]['path'].replace('\\', '/')[2:] == path
         # IPC$ share should always be present
         assert shares[1]['netname'] == 'IPC$'
-        assert shares[1]['path'] == 'C:\\tmp'
+        assert shares[1]['path'] == 'C:\\var\\empty'
 
 
 def test_002_enum_users(setup_smb_user, setup_smb_share):


### PR DESCRIPTION
This commit adjusts the path in our CI tests for samba changes.

Original PR: https://github.com/truenas/middleware/pull/15772
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132269