### PR TITLE
NAS-132911 / 25.04-RC.1 / Forcefully remove known-bad share-level aux params

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
@@ -31,7 +31,7 @@ def upgrade():
         changed = False
         not_blacklisted = []
         for param in share.get('cifs_auxsmbconf', '').splitlines():
-            if param.strip().startswith(SHARE_BLACKLIST):
+            if param.lower().strip().startswith(SHARE_BLACKLIST):
                 changed = True
                 continue
 

--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
@@ -20,7 +20,7 @@ SHARE_BLACKLIST = (
     'wide links',
     'use sendfile',
     'vfs objects',
-    'insecure',
+    'allow insecure',
 )
 
 def upgrade():

--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-02-19_18-47_remove_blacklisted_aux_params.py
@@ -1,0 +1,48 @@
+"""Remove blacklisted SMB share aux params
+
+Revision ID: ae78ab5ebf07
+Revises: d93139a68db5
+Create Date: 2025-02-19 18:47:53.749089+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ae78ab5ebf07'
+down_revision = 'd93139a68db5'
+branch_labels = None
+depends_on = None
+
+
+SHARE_BLACKLIST = (
+    'wide links',
+    'use sendfile',
+    'vfs objects',
+    'insecure',
+)
+
+def upgrade():
+
+    conn = op.get_bind()
+    smb_shares = [dict(row) for row in conn.execute("SELECT * FROM sharing_cifs_share").fetchall()]
+    for share in smb_shares:
+        changed = False
+        not_blacklisted = []
+        for param in share.get('cifs_auxsmbconf', '').splitlines():
+            if param.strip().startswith(SHARE_BLACKLIST):
+                changed = True
+                continue
+
+            not_blacklisted.append(param)
+
+        if not changed:
+            continue
+
+        new_aux = '\n'.join(not_blacklisted)
+
+        conn.execute(
+            'UPDATE sharing_cifs_share SET cifs_auxsmbconf = :aux WHERE id = :share_id',
+            aux=new_aux, share_id=share['id']
+        )


### PR DESCRIPTION
This commit removes some known-bad auxiliary parameters that are now blacklisted in fangtooth. This is especially true for "vfs objects" overrides which are one of the leading causes of issues for people migrating from really old Core installs.