### PR TITLE
NAS-132536 / 25.10 / fix find_vdev() ordering to resolve USED spare detach failure

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/pool_utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/pool_utils.py
@@ -49,15 +49,15 @@ def find_vdev(pool, vname):
     children = []
     for vdevs in pool.groups.values():
         children += vdevs
-    while children:
-        child = children.pop()
+        while children:
+            child = children.pop()
 
-        if str(vname) == str(child.guid):
-            return child
-
-        if child.type == 'disk':
-            path = child.path.replace('/dev/', '')
-            if path == vname:
+            if str(vname) == str(child.guid):
                 return child
 
-        children += list(child.children)
+            if child.type == 'disk':
+                path = child.path.replace('/dev/', '')
+                if path == vname:
+                    return child
+
+            children += list(child.children)


### PR DESCRIPTION
Adjust iteration order in find_vdev() to prioritize data vdevs over root-level spares. Previously, the function did not respect vdev hierarchy, leading it to incorrectly return root-level spare vdevs instead of the USED spare (which becomes a data vdev). By restructuring the loop order (placing the while under the for), data vdevs are checked first, ensuring py-libzfs detaches the correct vdev and avoids root-level detachment errors.