### PR TITLE
NAS-134345 / 25.10 / dont wipe disks on zpool detach

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool_disk_operations.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool_disk_operations.py
@@ -13,10 +13,17 @@ class PoolService(Service):
         event_send = False
 
     @item_method
-    @accepts(Int('id'), Dict(
-        'options',
-        Str('label', required=True),
-    ), audit='Disk Detach', audit_callback=True, roles=['POOL_WRITE'])
+    @accepts(
+        Int('id'),
+        Dict(
+            'options',
+            Str('label', required=True),
+            Bool('wipe', required=False, default=False)
+        ),
+        audit='Disk Detach',
+        audit_callback=True,
+        roles=['POOL_WRITE']
+    )
     @returns(Bool('detached'))
     async def detach(self, audit_callback, oid, options):
         """
@@ -52,7 +59,7 @@ class PoolService(Service):
         audit_callback(disk)
         await self.middleware.call('zfs.pool.detach', pool['name'], found[1]['guid'])
 
-        if disk:
+        if disk and options['wipe']:
             wipe_job = await self.middleware.call('disk.wipe', disk, 'QUICK')
             await wipe_job.wait()
             if wipe_job.error:


### PR DESCRIPTION
Fixing a bug with detaching INUSE hot-spares in https://github.com/truenas/middleware/pull/15791 exposed another bug whereby we're failing with EBUSY errors. This is because we're trying to wipe a hot-spare that is INUSE and still in the zpool. Regardless of that bug, we should not be wiping disks on zpool detach. Wiping a disk should be an explicit operation requested by the end-user.