### PR TITLE
NAS-134204 / 25.10 / Properly validate virt volume names

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
@@ -1,16 +1,31 @@
 import os
-from typing import Literal
+import re
+from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field, field_validator, StringConstraints
 
 from middlewared.api.base import (
-    BaseModel, ForUpdateMetaclass, NonEmptyString, single_argument_args,
+    BaseModel, ForUpdateMetaclass, match_validator, NonEmptyString, single_argument_args,
 )
 
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
     'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+]
+
+
+RE_VOLUME_NAME = re.compile(r'^[A-Za-z][A-Za-z0-9-_.]*[A-Za-z0-9]$', re.IGNORECASE)
+VOLUME_NAME: TypeAlias = Annotated[
+    NonEmptyString,
+    AfterValidator(
+        match_validator(
+            RE_VOLUME_NAME,
+            'Name can contain only letters, numbers, dashes, underscores and dots. '
+            'Name must start with a letter, and must not end with a dash.'
+        ),
+    ),
+    StringConstraints(max_length=63),
 ]
 
 
@@ -26,7 +41,7 @@ class VirtVolumeEntry(BaseModel):
 
 @single_argument_args('virt_volume_create')
 class VirtVolumeCreateArgs(BaseModel):
-    name: NonEmptyString
+    name: VOLUME_NAME
     content_type: Literal['BLOCK'] = 'BLOCK'
     size: int = Field(ge=512, default=1024)  # 1 gb default
     '''Size of volume in MB and it should at least be 512 MB'''
@@ -59,7 +74,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 @single_argument_args('virt_volume_import_iso')
 class VirtVolumeImportISOArgs(BaseModel):
-    name: NonEmptyString
+    name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
     upload_iso: bool = False

--- a/src/middlewared/middlewared/api/v25_10_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_volume.py
@@ -1,16 +1,31 @@
 import os
-from typing import Literal
+import re
+from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field, field_validator, StringConstraints
 
 from middlewared.api.base import (
-    BaseModel, ForUpdateMetaclass, NonEmptyString, single_argument_args,
+    BaseModel, ForUpdateMetaclass, match_validator, NonEmptyString, single_argument_args,
 )
 
 __all__ = [
     'VirtVolumeEntry', 'VirtVolumeCreateArgs', 'VirtVolumeCreateResult',
     'VirtVolumeUpdateArgs', 'VirtVolumeUpdateResult', 'VirtVolumeDeleteArgs',
     'VirtVolumeDeleteResult', 'VirtVolumeImportISOArgs', 'VirtVolumeImportISOResult',
+]
+
+
+RE_VOLUME_NAME = re.compile(r'^[A-Za-z][A-Za-z0-9-._]*[A-Za-z0-9]$', re.IGNORECASE)
+VOLUME_NAME: TypeAlias = Annotated[
+    NonEmptyString,
+    AfterValidator(
+        match_validator(
+            RE_VOLUME_NAME,
+            'Name can contain only letters, numbers, dashes, underscores and dots. '
+            'Name must start with a letter, and must not end with a dash.'
+        ),
+    ),
+    StringConstraints(max_length=63),
 ]
 
 
@@ -26,7 +41,7 @@ class VirtVolumeEntry(BaseModel):
 
 @single_argument_args('virt_volume_create')
 class VirtVolumeCreateArgs(BaseModel):
-    name: NonEmptyString
+    name: VOLUME_NAME
     content_type: Literal['BLOCK'] = 'BLOCK'
     size: int = Field(ge=512, default=1024)  # 1 gb default
     '''Size of volume in MB and it should at least be 512 MB'''
@@ -59,7 +74,7 @@ class VirtVolumeDeleteResult(BaseModel):
 
 @single_argument_args('virt_volume_import_iso')
 class VirtVolumeImportISOArgs(BaseModel):
-    name: NonEmptyString
+    name: VOLUME_NAME
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
     upload_iso: bool = False

--- a/tests/api2/test_virt_vm.py
+++ b/tests/api2/test_virt_vm.py
@@ -70,6 +70,30 @@ def test_iso_import_as_volume(virt_pool):
         assert vol['content_type'] == 'ISO'
 
 
+@pytest.mark.parametrize('vol_name, should_work', [
+    (
+        '-invlaid-name', False
+    ),
+    (
+        'valid-name', True
+    ),
+    (
+        'volume-name-should-not-have-characters-more-than-sixty-three-characters--',
+        False
+    ),
+    (
+        'alpine-3.18-default.iso', True
+    ),
+])
+def test_volume_name_validation(virt_pool, vol_name, should_work):
+    if should_work:
+        call('virt.volume.create', {'name': vol_name})
+        call('virt.volume.delete', vol_name)
+    else:
+        with pytest.raises(ClientValidationErrors):
+            call('virt.volume.create', {'name': vol_name})
+
+
 def test_upload_iso_file(virt_pool):
     vol_name = 'test_uploaded_iso'
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Context

We had limited validation for virt volume names which resulted in incus erroring out when trying to create virt volumes, so validation has been improved on this end to better validate virt volume names.