### PR TITLE
NAS-134346 / 25.04-RC.1 / Force passdb.tdb username keys to lower case (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -364,13 +364,13 @@ def insert_passdb_entries(entries: list[PDBEntry]) -> None:
         batch_ops.extend([
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
-                key=f'{USER_PREFIX}{entry.username}',
+                key=f'{USER_PREFIX}{entry.username.lower()}',
                 value=b64encode(samu_data)
             ),
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{RID_PREFIX}{entry.user_rid:08x}',
-                value=b64encode(entry.username.encode() + b'\x00')
+                value=b64encode(entry.username.lower().encode() + b'\x00')
             )
         ])
 
@@ -394,7 +394,7 @@ def delete_passdb_entry(username: str, rid: int) -> None:
             hdl.batch_op([
                 TDBBatchOperation(
                     action=TDBBatchAction.DEL,
-                    key=f'{USER_PREFIX}{username}'
+                    key=f'{USER_PREFIX}{username.lower()}'
                 ),
                 TDBBatchOperation(
                     action=TDBBatchAction.DEL,
@@ -441,7 +441,7 @@ def update_passdb_entry(entry: PDBEntry) -> None:
                 batch_ops.append(
                     TDBBatchOperation(
                         action=TDBBatchAction.DEL,
-                        key=f'{USER_PREFIX}{current_username}'
+                        key=f'{USER_PREFIX}{current_username.lower()}'
                     ),
                 )
 
@@ -449,13 +449,13 @@ def update_passdb_entry(entry: PDBEntry) -> None:
         batch_ops.extend([
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
-                key=f'{USER_PREFIX}{entry.username}',
+                key=f'{USER_PREFIX}{entry.username.lower()}',
                 value=b64encode(samu_data)
             ),
             TDBBatchOperation(
                 action=TDBBatchAction.SET,
                 key=f'{RID_PREFIX}{entry.user_rid:08x}',
-                value=b64encode(entry.username.encode() + b'\x00')
+                value=b64encode(entry.username.lower().encode() + b'\x00')
             )
         ])
         hdl.batch_op(batch_ops)

--- a/tests/api2/test_smb_camelcase.py
+++ b/tests/api2/test_smb_camelcase.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+from protocols import smb_connection
+
+SHAREUSER = 'CamelCamel'
+PASSWD = 'abcd1234'
+SMB_NAME = 'camel_share'
+
+
+@pytest.fixture(scope='module')
+def smb_setup(request):
+    with dataset('smb-camel', data={'share_type': 'SMB'}) as ds:
+        with user({
+            'username': SHAREUSER,
+            'full_name': SHAREUSER,
+            'group_create': True,
+            'password': PASSWD
+        }, get_instance=False):
+            with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
+                try:
+                    call('service.start', 'cifs')
+                    yield {'dataset': ds, 'share': s}
+                finally:
+                    call('service.stop', 'cifs')
+
+
+def test__smb_auth_camel(smb_setup):
+    with smb_connection(
+        share=smb_setup['share']['name'],
+        username=SHAREUSER,
+        password=PASSWD,
+    ) as c:
+        # perform basic op to fully initialize SMB session
+        c.ls('/')


### PR DESCRIPTION
This is a subtle regression caused by removing subprocessing to pdbedit. The passdb.tdb file gets written by samba tools to have keys forced to lower case. Our direct tdb library usage was resulting in keys that contained upper-case characters causing samba to fail to look up usernames. This slipped by testing because our UI and general unix admin defaults are always to use lowercase names.

Original PR: https://github.com/truenas/middleware/pull/15795
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134346