### PR TITLE
NAS-134244 / 25.04-RC.1 / Improve pool selection validation for virt (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -150,8 +150,12 @@ class VirtGlobalService(ConfigService):
         """
         pools = {POOL_DISABLED: '[Disabled]'}
         for p in (await self.middleware.call('zfs.pool.query_imported_fast')).values():
-            if p['name'] in BOOT_POOL_NAME_VALID:
+            # Do not show boot pools or pools with spaces in their name
+            # Incus is not gracefully able to handle pools which have spaces in their names
+            # https://ixsystems.atlassian.net/browse/NAS-134244
+            if p['name'] in BOOT_POOL_NAME_VALID or ' ' in p['name']:
                 continue
+
             ds = await self.middleware.call(
                 'pool.dataset.get_instance_quick', p['name'], {'encryption': True},
             )


### PR DESCRIPTION
## Problem

Incus is not gracefully able to handle pools which have spaces in their names and while creating various resources it fails as it is not properly able to escape the space.

## Solution

Until this is fixed upstream, validation has been added to prevent users from selecting such pools which have spaces in their names after discussing with William.

Original PR: https://github.com/truenas/middleware/pull/15800
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134244