### PR TITLE
NAS-134353 / 25.10 / Adjust unit test for API_KEY STIG

### DIFF
--- a/tests/unit/test_role_manager.py
+++ b/tests/unit/test_role_manager.py
@@ -35,8 +35,8 @@ EXPECTED_FA_RESOURCES = frozenset({
 
 @pytest.fixture(scope='module')
 def nostig_roles():
-    # Generate list of expected roles that should be unavailble for STIG mode
-    PREFIXES = ('VM', 'TRUECOMMAND', 'CATALOG', 'DOCKER', 'APPS', 'VIRT', 'TRUENAS_CONNECT')
+    # Generate list of expected roles that should be unavailable for STIG mode
+    PREFIXES = ('VM', 'TRUECOMMAND', 'CATALOG', 'DOCKER', 'APPS', 'VIRT', 'TRUENAS_CONNECT', 'API_KEY')
     yield set([
         role_name for
         role_name in list(ROLES.keys()) if role_name.startswith(PREFIXES) and not role_name.endswith('READ')


### PR DESCRIPTION
This commit updates the role manager unit test so that the API_KEY plugin is in set of expected nostig roles.