### PR TITLE
NAS-134362 / 25.04-RC.1 / Do not show a PCI device in choices if there is an error (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/device.py
+++ b/src/middlewared/middlewared/plugins/virt/device.py
@@ -101,6 +101,6 @@ class VirtDeviceService(Service):
         """
         pci_choices = {}
         for pci_addr, pci_details in get_all_pci_devices_details().items():
-            if pci_details['critical'] is False:
+            if pci_details['critical'] is False and not pci_details['error']:
                 pci_choices[pci_addr] = pci_details
         return pci_choices


### PR DESCRIPTION
## Context

We only want to show those PCI devices in choices which are not critical and have no error associated with them.

Original PR: https://github.com/truenas/middleware/pull/15806
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134362