### PR TITLE
NAS-133925 / 25.04-RC.1 / Do not start iscsitarget on STANDBY node unless ALUA is enabled. (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -38,6 +38,13 @@ class ISCSITargetService(SimpleService):
         else:
             await self._wait_to_avoid_states(['deactivating'])
 
+    async def start(self):
+        if await self.middleware.call("failover.status") not in ["MASTER", "SINGLE"]:
+            if not await self.middleware.call("iscsi.global.alua_enabled"):
+                # Do not start SCST on STANDBY node unless ALUA is enabled.
+                return
+        await super().start()
+
     async def after_start(self):
         await self.middleware.call("iscsi.alua.after_start")
 


### PR DESCRIPTION
Do not start `iscsitarget` on STANDBY node unless ALUA is enabled.

----
Abridged CI [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3206/).


Original PR: https://github.com/truenas/middleware/pull/15809
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133925