### PR TITLE
NAS-134378 / 25.04-RC.1 / Ensure that SMB attachment delegate properly removes share (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1650,6 +1650,14 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
     service = 'cifs'
     service_class = SharingSMBService
 
+    async def delete(self, attachments):
+        for attachment in attachments:
+            await self.middleware.call('sharing.smb.delete', attachment['id'])
+            await self.remove_alert(attachment)
+
+        if attachments:
+            await self.restart_reload_services(attachments)
+
     async def restart_reload_services(self, attachments):
         """
         mDNS may need to be reloaded if a time machine share is located on

--- a/src/middlewared/middlewared/test/integration/assets/smb.py
+++ b/src/middlewared/middlewared/test/integration/assets/smb.py
@@ -6,6 +6,7 @@ import shlex
 import sys
 
 from base64 import b64encode, b64decode
+from middlewared.service_exception import InstanceNotFound
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
 
@@ -40,7 +41,13 @@ def smb_share(path, name, options=None):
     try:
         yield share
     finally:
-        call("sharing.smb.delete", share["id"])
+        try:
+            call("sharing.smb.delete", share["id"])
+        except InstanceNotFound:
+            # for some tests we delete the share
+            # this should not cause an error
+            pass
+
         call("service.stop", "cifs")
 
 

--- a/tests/api2/test_smb_delete_share_dataset.py
+++ b/tests/api2/test_smb_delete_share_dataset.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+
+from contextlib import contextmanager
+from middlewared.test.integration.assets.account import user
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+from protocols import smb_connection
+from samba import ntstatus
+from samba import NTSTATUSError
+
+SHAREUSER = 'notintheface'
+PASSWD = 'abcd1234'
+SMB_NAME = 'delme'
+
+
+@contextmanager
+def create_share_ds():
+    with dataset('delme', data={'share_type': 'SMB'}) as ds:
+        with user({
+            'username': SHAREUSER,
+            'full_name': SHAREUSER,
+            'group_create': True,
+            'password': PASSWD
+        }, get_instance=False):
+            with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
+                try:
+                    call('service.start', 'cifs')
+                    yield {'dataset': ds, 'share': s}
+                finally:
+                    call('service.stop', 'cifs')
+
+
+def test__smb_share_dataset_destroy():
+    with create_share_ds() as smb_setup:
+        with smb_connection(
+            share=smb_setup['share']['name'],
+            username=SHAREUSER,
+            password=PASSWD,
+        ) as c:
+            # perform basic op to fully initialize SMB session
+            c.mkdir('foo')
+
+            call('pool.dataset.delete', smb_setup['dataset'])
+
+            # Verify that middleware properly closed the share
+            with pytest.raises(NTSTATUSError) as nterr:
+                c.ls('/')
+
+            assert nterr.value.args[0] == ntstatus.NT_STATUS_NETWORK_NAME_DELETED


### PR DESCRIPTION
The default for lockable fileystem delegates is to delete the datastore entry directly, which bypasses the share method to delete the datastore. This has the effect of bypassing our code to cleanly close the share resulting in SMB sessions keeping the dataset busy and preventing deletion.

Original PR: https://github.com/truenas/middleware/pull/15815
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134378