### PR TITLE
NAS-134250 / 25.04-RC.1 / Expose specifying IO bus for disk devices (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_device.py
@@ -32,6 +32,7 @@ class Disk(Device):
     '''
     destination: str | None = None
     boot_priority: int | None = Field(default=None, ge=0)
+    io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None] = None
 
     @field_validator('source')
     @classmethod

--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -68,6 +68,7 @@ class VirtInstanceEntry(BaseModel):
     vnc_password: Secret[NonEmptyString | None]
     secure_boot: bool | None
     root_disk_size: int | None
+    root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None]
 
 
 # Lets require at least 32MiB of reserved memory
@@ -88,6 +89,7 @@ class VirtInstanceCreateArgs(BaseModel):
     This can be specified when creating VMs so the root device's size can be configured. Root device for VMs
     is a sparse zvol and the field specifies space in GBs and defaults to 10 GBs.
     '''
+    root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI'] = 'NVME'
     remote: REMOTE_CHOICES = 'LINUX_CONTAINERS'
     instance_type: InstanceType = 'CONTAINER'
     environment: dict[str, str] | None = None
@@ -156,6 +158,7 @@ class VirtInstanceUpdate(BaseModel, metaclass=ForUpdateMetaclass):
     '''Setting vnc_password to null will unset VNC password'''
     secure_boot: bool = False
     root_disk_size: int | None = Field(ge=5, default=None)
+    root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI'] = None
 
 
 class VirtInstanceUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -105,10 +105,11 @@ def get_vnc_info_from_config(config: dict):
     return json.loads(vnc_raw_config)
 
 
-def get_root_device_dict(size: int) -> dict:
+def get_root_device_dict(size: int, io_bus: str) -> dict:
     return {
         'path': '/',
         'pool': 'default',
         'type': 'disk',
         'size': f'{size * (1024**3)}',
+        'io.bus': io_bus.lower(),
     }

--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -82,29 +82,6 @@ def test_virt_instance_update():
     assert rv.strip() == ''
 
 
-def test_virt_instance_update_root_disk_size():
-    current_root_disk_size = call(
-        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
-    )['root_disk_size']
-    # updating root_disk_size of VM
-    call('virt.instance.update', INS1_NAME, {'root_disk_size': 11}, job=True)
-    updated_root_disk_size = call(
-        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
-    )['root_disk_size']
-
-    assert current_root_disk_size != updated_root_disk_size
-    assert updated_root_disk_size == 11 * (1024 ** 3)
-
-    # not updating root_disk_size
-    current_root_disk_size = updated_root_disk_size
-    call('virt.instance.update', INS1_NAME, {}, job=True)
-    updated_root_disk_size = call(
-        'virt.instance.query', [['id', '=', INS1_NAME]], {'select': ['root_disk_size'], 'get': True}
-    )['root_disk_size']
-
-    assert current_root_disk_size == updated_root_disk_size
-
-
 def test_virt_instance_stop():
     wait_status_event = Event()
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 56b4f4d4377a6b9913c51081a972ba157087abed

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 909317e372a0e3187ee9d92c129c5103ecbe4fb0

## Context

We would like to expose specifying IO bus for disk devices so users can have it configurable. This is helpful especially in cases like where in the OS virtio drivers etc are not already present and if disk is attached in virito mode - drivers need to be attached/setup as ewll which makes it a more complex problem to tackle.

So in this case, users can set it to something like NVME whose drivers are already available in the base OS making it a much simpler way to setup the VM.

Original PR: https://github.com/truenas/middleware/pull/15812
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134250