### PR TITLE
NAS-134391 / 25.10 / Add iSCSI CI test__initiators

### DIFF
--- a/tests/api2/assets/websocket/iscsi.py
+++ b/tests/api2/assets/websocket/iscsi.py
@@ -15,7 +15,10 @@ def initiator(comment='Default initiator', initiators=[]):
     try:
         yield initiator_config
     finally:
-        call('iscsi.initiator.delete', initiator_config['id'])
+        # Per NAS-128872 we might have already deleted the initiator
+        # if the associated target was deleted.
+        if call('iscsi.initiator.query', [['id', '=', initiator_config['id']]]):
+            call('iscsi.initiator.delete', initiator_config['id'])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Add `test__initiators` to ensure that only permitted initiators are able to access a target.

Wiring this necessitated fixing `initiator_portal` test utility so that the initiators _actually_ get wired up.  This had subsequent breakage as initiators then were automatically torn down in certain circumstances.  Refactor tests slightly to counter this.

----
Abridged CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3222/).