### PR TITLE
NAS-134473 / 25.10 / Add efficient method for reading GPT partitions on drives

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/get_disks.py
+++ b/src/middlewared/middlewared/utils/disks_/get_disks.py
@@ -2,20 +2,39 @@ from collections.abc import Generator
 
 from pyudev import Context
 
+from .gpt_parts import __get_gpt_parts_impl
 from .private_utils import DiskEntry, __get_disks_impl, __get_serial_lunid
 
 __all__ = ("get_disks",)
 
 
-def get_disks() -> Generator[DiskEntry]:
+def get_disks(get_partitions: bool = False) -> Generator[DiskEntry]:
     """Iterate over /dev and yield a `DiskEntry` object for
-    each disk detected on the system."""
+    each disk detected on the system.
+
+    Args:
+        get_partitions: bool if True, will enumerate
+            GPT partition information"""
     ctx = Context()
     for name, devpath in __get_disks_impl():
         serial, lunid = __get_serial_lunid(ctx, name)
+        parts = None
+        if get_partitions:
+            try:
+                parts = __get_gpt_parts_impl(devpath)
+            except Exception:
+                # On an internal system, a disk died in
+                # a spectacular way. Issuing an ioctl and
+                # stat'ing the disk returned just fine.
+                # However, the moment I/O was issued, it
+                # fell over. No reason to fail on a single
+                # disk.
+                pass
+
         yield DiskEntry(
             name=name,
             devpath=devpath,
             serial=serial,
             lunid=lunid,
+            parts=parts,
         )

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -13,6 +13,7 @@ BLKSSZGET = 0x1268
 PART_TYPES = MappingProxyType(
     {
         "21686148-6449-6e6f-744e-656564454649": "BIOS Boot Partition",  # boot drives
+        "c12a7328-f81f-11d2-ba4b-00a0c93ec93b": "EFI System Parition",  # boot drives
         "6a898cc3-1dd2-11b2-99a6-080020736631": "ZFS",  # linux
         "516e7cba-6ecf-11d6-8ff8-00022d09712b": "ZFS",  # freebsd
     }
@@ -28,7 +29,7 @@ class SectorSizeInfo:
 @dataclass(slots=True, frozen=True, kw_only=True)
 class GptPartEntry:
     partition_number: int
-    partition_type: Literal["ZFS", "BIOS Boot Partition", "UNKONWN"]
+    partition_type: str
     partition_type_guid: str
     unique_partition_guid: str
     partition_name: str | None
@@ -55,7 +56,7 @@ def __get_log_and_phys_blksz(f: TextIOWrapper) -> SectorSizeInfo:
         )
 
 
-def __get_part_type(guid: str) -> Literal["ZFS", "BIOS Boot Partition", "UNKNOWN"]:
+def __get_part_type(guid: str) -> str:
     try:
         return PART_TYPES[guid]
     except KeyError:

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -12,6 +12,7 @@ BLKSSZGET = 0x1268
 # there are a TON more but we only care about ZFS
 PART_TYPES = MappingProxyType(
     {
+        "21686148-6449-6e6f-744e-656564454649": "BIOS boot partition",  # boot drives
         "6a898cc3-1dd2-11b2-99a6-080020736631": "ZFS",  # linux
         "516e7cba-6ecf-11d6-8ff8-00022d09712b": "ZFS",  # freebsd
     }

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -12,7 +12,7 @@ BLKSSZGET = 0x1268
 # there are a TON more but we only care about ZFS
 PART_TYPES = MappingProxyType(
     {
-        "21686148-6449-6e6f-744e-656564454649": "BIOS boot partition",  # boot drives
+        "21686148-6449-6e6f-744e-656564454649": "BIOS Boot Partition",  # boot drives
         "6a898cc3-1dd2-11b2-99a6-080020736631": "ZFS",  # linux
         "516e7cba-6ecf-11d6-8ff8-00022d09712b": "ZFS",  # freebsd
     }
@@ -28,7 +28,7 @@ class SectorSizeInfo:
 @dataclass(slots=True, frozen=True, kw_only=True)
 class GptPartEntry:
     partition_number: int
-    partition_type: Literal["ZFS", "UNKONWN"]
+    partition_type: Literal["ZFS", "BIOS Boot Partition", "UNKONWN"]
     partition_type_guid: str
     unique_partition_guid: str
     partition_name: str | None
@@ -55,7 +55,7 @@ def __get_log_and_phys_blksz(f: TextIOWrapper) -> SectorSizeInfo:
         )
 
 
-def __get_part_type(guid: str) -> Literal["ZFS", "UNKNOWN"]:
+def __get_part_type(guid: str) -> Literal["ZFS", "BIOS Boot Partition", "UNKNOWN"]:
     try:
         return PART_TYPES[guid]
     except KeyError:

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from fcntl import ioctl
+from io import TextIOWrapper
+from os import stat
+from struct import unpack
+from types import MappingProxyType
+from typing import Literal
+from uuid import UUID
+
+# ioctl cmd for getting logical block size
+BLKSSZGET = 0x1268
+# there are a TON more but we only care about ZFS
+PART_TYPES = MappingProxyType(
+    {
+        "6a898cc3-1dd2-11b2-99a6-080020736631": "ZFS",  # linux
+        "516e7cba-6ecf-11d6-8ff8-00022d09712b": "ZFS",  # freebsd
+    }
+)
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class SectorSizeInfo:
+    logical_sector_size: int
+    physical_sector_size: int
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class GptPartEntry:
+    partition_number: int
+    partition_type: Literal["ZFS", "UNKONWN"]
+    partition_type_guid: str
+    unique_partition_guid: str
+    partition_name: str | None
+    sector_info: SectorSizeInfo
+    first_lba: int
+    last_lba: int
+    size_bytes: int
+
+
+def __get_log_and_phys_blksz(f: TextIOWrapper) -> SectorSizeInfo:
+    """Return a tuple of logical and physical sector size"""
+    try:
+        buf = bytearray(4)
+        ioctl(f, BLKSSZGET, buf)
+        return SectorSizeInfo(
+            logical_sector_size=unpack("I", buf)[0],
+            physical_sector_size=stat(f.fileno()).st_blksize,
+        )
+    except Exception:
+        # fallback to 512 which is standard practice
+        return SectorSizeInfo(
+            logical_sector_size=512,
+            physical_sector_size=512,
+        )
+
+
+def __get_part_type(guid: str) -> Literal["ZFS", "UNKNOWN"]:
+    try:
+        return PART_TYPES[guid]
+    except KeyError:
+        return "UNKNOWN"
+
+
+def __get_gpt_parts_impl(device: str) -> tuple[GptPartEntry]:
+    parts = list()
+    with open(device, "rb") as f:
+        ssi: SectorSizeInfo = __get_log_and_phys_blksz(f)
+        f.seek(0)
+        f.seek(ssi.logical_sector_size)
+        gpt_header = f.read(ssi.logical_sector_size)
+        if gpt_header[0:8] != b"EFI PART":
+            # invalid gpt header so no reason to continue
+            return tuple()
+
+        partition_entry_lba = unpack("<Q", gpt_header[72:80])[0]
+        num_partitions = unpack("<I", gpt_header[80:84])[0]
+        partition_entry_size = unpack("<I", gpt_header[84:88])[0]
+        f.seek(partition_entry_lba * ssi.logical_sector_size)
+        for i in range(min(num_partitions, 128)):  # 128 is max gpt partitions
+            entry = f.read(partition_entry_size)
+            partition_type_guid = str(UUID(bytes_le=entry[0:16]))
+            partition_type = __get_part_type(partition_type_guid)
+            partition_unique_guid = str(UUID(bytes_le=entry[16:32]))
+            first_lba = unpack("<Q", entry[32:40])[0]
+            last_lba = unpack("<Q", entry[40:48])[0]
+            name = entry[56:128].decode("utf-16").rstrip("\x00") or None
+            if first_lba != 0:
+                parts.append(
+                    GptPartEntry(
+                        partition_number=i + 1,
+                        partition_type=partition_type,
+                        partition_type_guid=partition_type_guid,
+                        unique_partition_guid=partition_unique_guid,
+                        partition_name=name,
+                        sector_info=ssi,
+                        first_lba=first_lba,
+                        last_lba=last_lba,
+                        size_bytes=(last_lba - first_lba + 1) * ssi.logical_sector_size,
+                    )
+                )
+    return tuple(parts)

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -83,7 +83,13 @@ def __get_gpt_parts_impl(device: str) -> tuple[GptPartEntry]:
             partition_unique_guid = str(UUID(bytes_le=entry[16:32]))
             first_lba = unpack("<Q", entry[32:40])[0]
             last_lba = unpack("<Q", entry[40:48])[0]
-            name = entry[56:128].decode("utf-16").rstrip("\x00") or None
+
+            try:
+                name = entry[56:128].decode("utf-16").rstrip("\x00") or None
+            except Exception:
+                # very rare, but maybe scrambled data so we'll play it safe
+                name = None
+
             if first_lba != 0:
                 parts.append(
                     GptPartEntry(

--- a/src/middlewared/middlewared/utils/disks_/private_utils.py
+++ b/src/middlewared/middlewared/utils/disks_/private_utils.py
@@ -26,7 +26,7 @@ class DiskEntry:
         we're using the 'ID_WWN' property of the disk
         but it is the same principle and it allows us
         to use common terms that most recognize."""
-    parts: GptPartEntry | None = None
+    parts: tuple[GptPartEntry] | None = None
     """A tuple of `GptPartEntry` information representing
         any GPT partitions on the disk."""
 

--- a/src/middlewared/middlewared/utils/disks_/private_utils.py
+++ b/src/middlewared/middlewared/utils/disks_/private_utils.py
@@ -5,6 +5,8 @@ from re import compile as rcompile
 
 from pyudev import Context, Devices, DeviceNotFoundByNameError
 
+from .gpt_parts import GptPartEntry
+
 # sda, pmem0, vda, nvme0n1 but not sda1/vda1/nvme0n1p1
 VALID_WHOLE_DISK = rcompile(r"^pmem\d+$|^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$")
 
@@ -24,6 +26,9 @@ class DiskEntry:
         we're using the 'ID_WWN' property of the disk
         but it is the same principle and it allows us
         to use common terms that most recognize."""
+    parts: GptPartEntry | None = None
+    """A tuple of `GptPartEntry` information representing
+        any GPT partitions on the disk."""
 
     @property
     def identifier(self) -> str:

--- a/tests/unit/test_gpt_parts.py
+++ b/tests/unit/test_gpt_parts.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+import uuid
+
+from middlewared.utils.disks_.get_disks import get_disks
+
+
+def test__get_disks():
+    at_least_one = False
+    for disk in get_disks(get_partitions=True):
+        if not disk.parts:
+            continue
+
+        at_least_one = True
+        sf = json.loads(
+            subprocess.run(
+                ["sfdisk", disk.devpath, "-J"], capture_output=True
+            ).stdout.decode()
+        )["partitiontable"]
+
+        assert len(disk.parts) == len(sf["partitions"])
+        for a, b in zip(
+            sorted(disk.parts, key=lambda i: i.first_lba),
+            sorted(sf["partitions"], key=lambda i: i["start"]),
+        ):
+            assert uuid.UUID(a.partition_type_guid) == uuid.UUID(b["type"])
+            assert uuid.UUID(a.unique_partition_guid) == uuid.UUID(b["uuid"])
+            assert a.first_lba == b["start"]
+            assert a.last_lba == (b["start"] + b["size"]) - 1
+            assert a.size_bytes == b["size"] * a.sector_info.logical_sector_size
+
+    assert at_least_one, "No disks with partitions! (or get_disks() failed)"


### PR DESCRIPTION
This adds the ability to read GPT partition information directly from drives using pure python. We have an ever-increasing amount of pressure to optimize our code. Disk related information is a "hot" area that we're trying to improve. We were spoiled on freeBSD with GEOM subsystem.

Anyways, on a system with 1294 GPT formatted disks, this returns in ~1.3 seconds. On the same system, the average time to call `device.get_disks true` (which includes gpt partitions) takes ~9.79 seconds. This means the newly added logic is running ~152.7% faster.

Currently, nothing uses this so there is 0 risk of adding it. In the future, this will eventually be used.

SIDE NOTE: The `device.get_disks` method is returning more information than what `get_disks(get_partitions=True)` does, however, the argument is that we don't _need_ all that information.

SIDE NOTE 2: I'm aware that sector sizes of disks have nothing to do with partitions directly, however, it was easier to just add that information into the partition logic instead of passing those values around between different functions.