### PR TITLE
NAS-134351 / 25.04.0 / Prevent rpcbind from starting at boot by default (by mgrimesix)

### DIFF
--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -38,6 +38,7 @@ systemctl disable wsdd
 systemctl disable walinuxagent
 systemctl disable openipmi
 systemctl disable nfs-server
+systemctl disable rpcbind
 
 # NAS-123024: disable proftpd.socket, if it starts it will block proftpd.service
 # proftpd.socket is used in conjunction with xinetd

--- a/tests/unit/test_after_boot_services.py
+++ b/tests/unit/test_after_boot_services.py
@@ -8,7 +8,7 @@ def systemctl_service_status():
     YIELD:  systemctl output formatted into a list of strings """
 
     try:
-        raw_list_units = subprocess.run(['systemctl', 'list-units', '--type=service'], capture_output=True)
+        raw_list_units = subprocess.run(['systemctl', 'list-units', '--all', '--type=service'], capture_output=True)
         svc_data = raw_list_units.stdout.decode().strip().splitlines()
         yield svc_data
     except Exception:
@@ -33,6 +33,7 @@ def process_svc_data(svc_entry: str):
 
 @pytest.mark.parametrize('svc_name,expected', [
     ("nscd", {"state": "listed", "alarm": None, "status": ("loaded", "active", "running")}),
+    ("rpcbind", {"state": "listed", "alarm": None, "status": ("loaded", "inactive", "dead")}),
 ])
 def test__systemctl_unit_state(systemctl_service_status, svc_name, expected):
     """ Confirm status of services at boot """


### PR DESCRIPTION
The Debian default is to always run the rpcbind daemon, it starts at boot regardless if it's required. 
On TrueNAS, this rpcbind is used only by NFS. 

This PR defaults rpcbind to disabled.   On NFS start, rpcbind will become  `active` and report `running`.   On NFS stop rpcbind will 
become `inactive` and report `dead`.

A CI test was added to confirm the rpcbind state at boot.


Original PR: https://github.com/truenas/middleware/pull/15830
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134351