### PR TITLE
NAS-134432 / 25.04.0 / Fix call processing of truenas_verify. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -601,11 +601,11 @@ class AuditService(ConfigService):
         # Generate the initial truenas_verify file
         try:
             current_version = await self.middleware.call('system.version')
-            rc, err = await setup_truenas_verify(self.middleware, current_version)
+            rc = await setup_truenas_verify(self.middleware, current_version)
             if rc:
                 self.logger.error(
-                    'Unexpected result from truenas_verify initial setup. '
-                    'rc=%d, error=%s', rc, err
+                    'Did not get clean result from truenas_verify initial setup. '
+                    'See /var/log/truenas_verify.%s.log', current_version
                 )
         except Exception:
             self.logger.error('Error detected in truenas_verify setup.', exc_info=True)

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -204,10 +204,6 @@ async def setup_truenas_verify(middleware, sysver: str) -> tuple:
     Called by audit setup to generate the initial truenas_verify
     file for an updated or initial TrueNAS version.
     """
-    verify_res = await middleware.run_in_thread(mtree_verify.do_verify, ['init', sysver])
+    verify_rc = await middleware.run_in_thread(mtree_verify.do_verify, ['init', sysver])
 
-    err = ""
-    if verify_res.stderr:
-        err = verify_res.stderr.decode()
-
-    return (verify_res.returncode, err)
+    return verify_rc

--- a/tests/api2/test_truenas_verify.py
+++ b/tests/api2/test_truenas_verify.py
@@ -1,9 +1,0 @@
-from middlewared.test.integration.utils import ssh
-
-
-def test_truenas_verify():
-    response = ssh('truenas_verify', check=False, complete_response=True)
-
-    # Jenkins vms alter the system files for setup, so truenas_verify should generate errors.
-    assert not response['result']
-    assert ssh('head /var/log/truenas_verify.log'), 'Test environment should log file verification errors.'

--- a/tests/unit/test_truenas_verify.py
+++ b/tests/unit/test_truenas_verify.py
@@ -1,0 +1,79 @@
+import os
+import pytest
+import subprocess
+import time
+
+from truenas_api_client import Client
+
+
+VERIFY_LOG_PREAMBLE = '/var/log/audit/truenas_verify'
+DEFAULT_VERIFY_LOG_NAME = f"{VERIFY_LOG_PREAMBLE}.log"
+CUSTOM_NAME = "init_test"
+CUSTOM_VERIFY_LOG_NAME = f"{VERIFY_LOG_PREAMBLE}.{CUSTOM_NAME}.log"
+
+
+def delete_file(fname):
+    try:
+        os.unlink(fname)
+    except FileNotFoundError:
+        pass
+
+
+@pytest.fixture(scope='module')
+def verify_setup():
+    # Setup:  Remove existing default log file
+    delete_file(DEFAULT_VERIFY_LOG_NAME)
+
+    try:
+        yield os.path.exists(DEFAULT_VERIFY_LOG_NAME)
+    finally:
+        # Clean up
+        for file in [DEFAULT_VERIFY_LOG_NAME, CUSTOM_VERIFY_LOG_NAME]:
+            delete_file(file)
+
+
+def test_truenas_verify_install_log():
+    """
+    The audit subsystem generates an 'as-installed' log
+    This should be clean with no detections or errors
+    """
+    with Client() as c:
+        current_version = c.call('system.version')
+        with open(f"/var/log/audit/truenas_verify.{current_version}.log", 'r') as f:
+            # The last entry is an empty string
+            tnv_init = f.read().splitlines()[:-1]
+
+        # A clean system will have only one entry: The header.
+        assert len(tnv_init) == 1, f"Found unexpected entries\n{tnv_init}"
+
+
+@pytest.mark.parametrize(
+    'type,params', [
+        ("default", []),
+        ("init", ["init", CUSTOM_NAME]),
+        ("syslog", ["syslog"])
+    ],
+    ids=["default", "init", "syslog"]
+)
+def test_truenas_verify(verify_setup, type, params):
+    """
+    Exercize and confirm the three call types: default, init, syslog
+    """
+    verify_cmd = ['truenas_verify'] + params
+    if type != 'syslog':
+        subprocess.run(verify_cmd)
+
+    match type:
+        case 'default':
+            assert os.path.exists(DEFAULT_VERIFY_LOG_NAME), f"Expected to find {DEFAULT_VERIFY_LOG_NAME}"
+        case 'init':
+            assert os.path.exists(CUSTOM_VERIFY_LOG_NAME), f"Expected to find {CUSTOM_VERIFY_LOG_NAME}"
+        case 'syslog':
+            with open('/var/log/syslog', 'r') as logfile:
+                # Go to the end of the file
+                logfile.seek(0, 2)
+                subprocess.run(verify_cmd)
+                time.sleep(1)   # Wait a sec for the output to get logged
+                log_entries = logfile.readlines()
+            assert 'discrepancies found' in log_entries[0], f"Expected to find verify message:\n{log_entries[0]}"
+


### PR DESCRIPTION
We are not properly processing the results of `truenas_verify`.  This started with [#15678](https://github.com/truenas/middleware/pull/15678).

This PR fixes the processing issues.

Moved CI tests from `api2` to `unit`.   Added tests for each use case.

CI testing of the STIG mode and alert generation is not yet included.

Passing  CI unit tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/unit_tests/876/

Original PR: https://github.com/truenas/middleware/pull/15835
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134432