### PR TITLE
NAS-134440 / 25.10 / Apply idmap configuration to incus instances

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -508,6 +508,9 @@ class VirtInstanceService(CRUDService):
         await self.middleware.call('virt.global.check_initialized')
         instance = await self.middleware.call('virt.instance.get_instance', id)
 
+        # Apply any idmap changes
+        await self.set_account_idmaps(id)
+
         try:
             await incus_call_and_wait(f'1.0/instances/{id}/state', 'put', {'json': {
                 'action': 'start',
@@ -559,6 +562,10 @@ class VirtInstanceService(CRUDService):
         """
         await self.middleware.call('virt.global.check_initialized')
         instance = await self.middleware.call('virt.instance.get_instance', id)
+
+        # Apply any idmap changes
+        await self.set_account_idmaps(id)
+
         if instance['status'] == 'RUNNING':
             await incus_call_and_wait(f'1.0/instances/{id}/state', 'put', {'json': {
                 'action': 'stop',
@@ -608,6 +615,21 @@ class VirtInstanceService(CRUDService):
                 ports[instance['id']].append(device['source_port'])
 
         return ports
+
+    @private
+    async def set_account_idmaps(self, instance_id):
+        idmaps = await self.get_account_idmaps()
+
+        raw_idmaps_value = '\n'.join([f'{i["type"]} {i["from"]} {i["to"]}' for i in idmaps])
+        instance = await self.middleware.call('virt.instance.get_instance', instance_id, {'extra': {'raw': True}})
+        if raw_idmaps_value:
+            instance['raw']['config']['raw.idmap'] = raw_idmaps_value
+        else:
+            # Remove any stale raw idmaps. This is required because entries that don't correlate
+            # to subuid / subgid entries will cause validation failure in incus
+            instance['raw']['config'].pop('raw.idmap', None)
+
+        await incus_call_and_wait(f'1.0/instances/{instance_id}', 'put', {'json': instance['raw']})
 
     @private
     async def get_account_idmaps(self, filters=None, options=None):

--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
 from threading import Event
+from time import sleep
 
+from middlewared.test.integration.assets.account import user, group
 from middlewared.test.integration.assets.filesystem import mkfile
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils.client import client
@@ -25,6 +28,53 @@ def clean():
     call('virt.global.update', {'pool': None}, job=True)
     ssh(f'zfs destroy -r {pool_name}/.ix-virt || true')
     call('virt.global.update', {'pool': 'tank'}, job=True)
+
+
+@contextmanager
+def userns_user(username, userns_idmap='DIRECT'):
+    with user({
+        'username': username,
+        'full_name': username,
+        'group_create': True,
+        'random_password': True,
+        'userns_idmap': userns_idmap
+    }) as u:
+        yield u
+
+
+@contextmanager
+def userns_group(groupname, userns_idmap='DIRECT'):
+    with group({
+        'name': groupname,
+        'userns_idmap': userns_idmap
+    }) as g:
+        yield g
+
+
+@contextmanager
+def temporary_instance():
+    # Create first so there is time for the agent to start
+    call('virt.instance.create', {
+        'name': 'tmp-instance',
+        'image': INS1_IMAGE,
+    }, job=True)
+
+    instance = call('virt.instance.get_instance', 'tmp-instance', {'extra': {'raw': True}})
+    try:
+        yield instance
+    finally:
+        # TODO: currently virt.instance.delete doesn't properly check
+        # for the instance actually stopping before deletion. Once this
+        # is fixed, remove the sleep.
+        sleep(5)
+        call('virt.instance.delete', 'tmp-instance', job=True)
+
+
+def check_idmap_entry(instance_name, entry):
+    raw = call('virt.instance.get_instance', instance_name, {'extra': {'raw': True}})['raw']
+
+    assert 'raw.idmap' in raw['config']
+    assert entry in raw['config']['raw.idmap']
 
 
 def test_virt_instance_create():
@@ -209,6 +259,44 @@ def test_virt_instance_proxy():
 
 def test_virt_instance_shell():
     assert call('virt.instance.get_shell', INS3_NAME) == '/bin/bash'
+
+
+def test_virt_instance_idmap():
+    with temporary_instance() as instance:
+        # We don't have any users so we shouldn't have any raw idmap entries
+        assert 'raw.idmap' not in instance['raw']['config']
+        with userns_user('bob') as u:
+            # check user DIRECT map
+            assert u['userns_idmap'] == 'DIRECT'
+            call('virt.instance.restart', instance['name'], job=True)
+            check_idmap_entry(instance['name'], f'uid {u["uid"]} {u["uid"]}')
+
+            # check custom user map
+            call('user.update', u['id'], {'userns_idmap': 8675309})
+
+            # restart to update idmap
+            call('virt.instance.restart', instance['name'], job=True)
+            check_idmap_entry(instance['name'], f'uid {u["uid"]} 8675309')
+
+        call('virt.instance.restart', instance['name'], job=True)
+        raw = call('virt.instance.get_instance', instance['name'], {'extra': {'raw': True}})['raw']
+        assert 'raw.idmap' not in raw['config']
+
+        with userns_group('bob_group') as g:
+            assert g['userns_idmap'] == 'DIRECT'
+            call('virt.instance.restart', instance['name'], job=True)
+
+            check_idmap_entry(instance['name'], f'gid {g["gid"]} {g["gid"]}')
+            # check custom user map
+            call('group.update', g['id'], {'userns_idmap': 8675309})
+
+            # restart to update idmap
+            call('virt.instance.restart', instance['name'], job=True)
+            check_idmap_entry(instance['name'], f'gid {g["gid"]} 8675309')
+
+        call('virt.instance.restart', instance['name'], job=True)
+        raw = call('virt.instance.get_instance', instance['name'], {'extra': {'raw': True}})['raw']
+        assert 'raw.idmap' not in raw['config']
 
 
 def test_virt_instance_device_delete():


### PR DESCRIPTION
This commit reads our local account related idmap namespace configuration and applies it to incus instances. Since raw.idmap changes require a container restart in order to be effective we apply fresh idmap configuration prior to instance start / restart.