### PR TITLE
NAS-134361 / 25.04.0 / Mark PCI host bridge device as critical (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/utils/iommu.py
+++ b/src/middlewared/middlewared/utils/iommu.py
@@ -13,6 +13,7 @@ SENSITIVE_PCI_DEVICE_TYPES = {
     '0x0601': 'ISA Bridge',
     '0x0500': 'RAM memory',
     '0x0c05': 'SMBus',
+    '0x0600': 'Host bridge',
 }
 
 


### PR DESCRIPTION
## Context

Host bridge device needs to be marked as critical because it can potentially result in the system being inaccessible as it is required by the host to function properly.

Original PR: https://github.com/truenas/middleware/pull/15841
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134361