### PR TITLE
NAS-134446 / 25.04.0 / use a deque in error path in virt.instance.start (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -515,10 +515,9 @@ class VirtInstanceService(CRUDService):
         except CallError as e:
             log = 'lxc.log' if instance['type'] == 'CONTAINER' else 'qemu.log'
             content = await incus_call(f'1.0/instances/{id}/logs/{log}', 'get', json=False)
-            output = []
+            output = collections.deque(maxlen=10)  # only keep last 10 lines
             while line := await content.readline():
                 output.append(line)
-                output = output[-10:]
             output = b''.join(output).strip()
             errmsg = f'Failed to start instance: {e.errmsg}.'
             try:


### PR DESCRIPTION
A deque is more efficient and performant and fits the use-case perfectly here. Use it instead.

Original PR: https://github.com/truenas/middleware/pull/15844
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134446