### PR TITLE
NAS-134478 / 25.10 / Add name filters to get_disks()

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/get_disks.py
+++ b/src/middlewared/middlewared/utils/disks_/get_disks.py
@@ -8,33 +8,41 @@ from .private_utils import DiskEntry, __get_disks_impl, __get_serial_lunid
 __all__ = ("get_disks",)
 
 
-def get_disks(get_partitions: bool = False) -> Generator[DiskEntry]:
+def get_disks(
+    get_partitions: bool = False, name_filters: list[str] | None = None
+) -> Generator[DiskEntry]:
     """Iterate over /dev and yield a `DiskEntry` object for
     each disk detected on the system.
 
     Args:
         get_partitions: bool if True, will enumerate
-            GPT partition information"""
+            GPT partition information
+        name_filters: list of strings, represent a list
+            of disk names that will be filtered upon.
+            The name of the disk may take the form
+            of 'sda' or '/dev/sda'.
+    """
     ctx = Context()
     for name, devpath in __get_disks_impl():
-        serial, lunid = __get_serial_lunid(ctx, name)
-        parts = None
-        if get_partitions:
-            try:
-                parts = __get_gpt_parts_impl(devpath)
-            except Exception:
-                # On an internal system, a disk died in
-                # a spectacular way. Issuing an ioctl and
-                # stat'ing the disk returned just fine.
-                # However, the moment I/O was issued, it
-                # fell over. No reason to fail on a single
-                # disk.
-                pass
+        if name_filters is None or name in name_filters or devpath in name_filters:
+            serial, lunid = __get_serial_lunid(ctx, name)
+            parts = None
+            if get_partitions:
+                try:
+                    parts = __get_gpt_parts_impl(devpath)
+                except Exception:
+                    # On an internal system, a disk died in
+                    # a spectacular way. Issuing an ioctl and
+                    # stat'ing the disk returned just fine.
+                    # However, the moment I/O was issued, it
+                    # fell over. No reason to fail on a single
+                    # disk.
+                    pass
 
-        yield DiskEntry(
-            name=name,
-            devpath=devpath,
-            serial=serial,
-            lunid=lunid,
-            parts=parts,
-        )
+            yield DiskEntry(
+                name=name,
+                devpath=devpath,
+                serial=serial,
+                lunid=lunid,
+                parts=parts,
+            )

--- a/src/middlewared/middlewared/utils/disks_/gpt_parts.py
+++ b/src/middlewared/middlewared/utils/disks_/gpt_parts.py
@@ -4,12 +4,11 @@ from io import TextIOWrapper
 from os import stat
 from struct import unpack
 from types import MappingProxyType
-from typing import Literal
 from uuid import UUID
 
 # ioctl cmd for getting logical block size
 BLKSSZGET = 0x1268
-# there are a TON more but we only care about ZFS
+# there are a TON more but we only care about a few
 PART_TYPES = MappingProxyType(
     {
         "21686148-6449-6e6f-744e-656564454649": "BIOS Boot Partition",  # boot drives

--- a/tests/unit/test_get_disks.py
+++ b/tests/unit/test_get_disks.py
@@ -1,0 +1,17 @@
+from middlewared.utils.disks_.get_disks import get_disks
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "name,should_find", [(["sda"], True), (["/dev/sdb"], True), (["nope"], False)]
+)
+def test__get_disks_filters(name, should_find):
+    found = False
+    for i in get_disks(name_filters=name):
+        found = i
+
+    if should_find:
+        assert found
+    else:
+        assert not found


### PR DESCRIPTION
This adds the ability to filter disks that are returned from `get_disks()`. Since this is done before we enumerate information, this can dramatically decrease the time it takes to return (instead it yields all disks by default).