### PR TITLE
NAS-134476 / 25.04.0 / Add functional test for NFSv4 ACL in containers (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -2,13 +2,16 @@ import contextlib
 import os.path
 import uuid
 
-from middlewared.test.integration.utils import call, ssh
+from middlewared.test.integration.utils import call, ssh, pool
+from time import sleep
 
 
 @contextlib.contextmanager
-def virt(pool: dict):
-    virt_config = call('virt.global.update', {'pool': pool['name']}, job=True)
-    assert virt_config['pool'] == pool['name'], virt_config
+def virt(pool_data: dict | None = None):
+    pool_name = pool_data['name'] if pool_data else pool
+
+    virt_config = call('virt.global.update', {'pool': pool_name}, job=True)
+    assert virt_config['pool'] == pool_name, virt_config
     try:
         yield virt_config
     finally:
@@ -42,3 +45,27 @@ def virt_device(instance_name: str, device_name: str, payload: dict):
         yield call('virt.instance.device_add', instance_name, {'name': device_name, **payload})
     finally:
         call('virt.instance.device_delete', instance_name, device_name)
+
+
+@contextlib.contextmanager
+def virt_instance(
+    instance_name: str = 'tmp-instance',
+    image: str = 'debian/trixie',
+    **kwargs
+) -> dict:
+    # Create a virt instance and return dict containing full config and raw info
+    call('virt.instance.create', {
+        'name': instance_name,
+        'image': image,
+        **kwargs
+    }, job=True)
+
+    instance = call('virt.instance.get_instance', instance_name, {'extra': {'raw': True}})
+    try:
+        yield instance
+    finally:
+        # TODO: currently virt.instance.delete doesn't properly check
+        # for the instance actually stopping before deletion. Once this
+        # is fixed, remove the sleep.
+        sleep(5)
+        call('virt.instance.delete', instance_name, job=True)

--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -64,7 +64,7 @@ def virt_instance(
     try:
         yield instance
     finally:
-        # TODO: currently virt.instance.delete doesn't properly check
+        # NAS-134443: currently virt.instance.delete doesn't properly check
         # for the instance actually stopping before deletion. Once this
         # is fixed, remove the sleep.
         sleep(5)

--- a/tests/api2/test_virt_instance_acl.py
+++ b/tests/api2/test_virt_instance_acl.py
@@ -1,0 +1,260 @@
+import pytest
+
+from contextlib import contextmanager
+from copy import deepcopy
+
+from middlewared.test.integration.assets.account import user, group
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.virt import (
+    virt,
+    virt_device,
+    virt_instance,
+)
+from middlewared.test.integration.utils.call import call
+from middlewared.test.integration.utils.ssh import ssh
+from time import sleep
+
+
+@contextmanager
+def userns_user(username, userns_idmap='DIRECT'):
+    with user({
+        'username': username,
+        'full_name': username,
+        'group_create': True,
+        'random_password': True,
+        'userns_idmap': userns_idmap
+    }) as u:
+        yield u
+
+
+@contextmanager
+def userns_group(groupname, userns_idmap='DIRECT'):
+    with group({
+        'name': groupname,
+        'userns_idmap': userns_idmap
+    }) as g:
+        yield g
+
+
+@pytest.fixture(scope='module')
+def instance():
+    with virt():
+        with virt_instance('virtacltest') as i:
+            # install dependencies
+
+            # libjansson is required for our nfsv4 acl tools (once they work)
+            ssh(f'incus exec {i["name"]} -- apt install -y libjansson4')
+
+            yield i
+
+
+@pytest.fixture(scope='function')
+def nfs4acl_dataset(instance):
+    with userns_group('testgrp') as g:
+        with userns_user('testusr') as u:
+            # restart to get idmap changes
+            call('virt.instance.restart', instance['name'])
+            sleep(5)
+            with dataset('virtnfsshare', {'share_type': 'SMB'}) as ds:
+                with virt_device(instance['name'], 'disknfs', {
+                    'dev_type': 'DISK',
+                    'source': f'/mnt/{ds}',
+                    'destination': '/nfs4acl',
+                }):
+                    yield {
+                        'user': u,
+                        'group': g,
+                        'dataset': ds,
+                        'dev': '/nfs4acl'
+                    }
+
+
+def create_virt_users(instance_name, uid, gid):
+    """
+    Create three test users.
+    * One with the specified UID.
+    * One with the specified GID.
+    * One who has auxiliary group of specified GID
+
+    These all get evaluated differently based on ACL
+    """
+    prefix = f'incus exec {instance_name} --'
+    ssh(' '.join([prefix, 'useradd', f'-u {uid}', 'larry']))
+    ssh(' '.join([prefix, 'useradd', f'-g {gid}', 'curly']))
+    ssh(' '.join([prefix, 'useradd', f'-G {gid}', 'moe']))
+
+
+def check_access(instance_name, path, username, expected_access):
+    prefix = f'incus exec {instance_name}'
+    account_string = f'-- sudo -i -u {username}'
+
+    # READ and MODIFY should be able to list
+    match expected_access:
+        case 'READ':
+            ssh(' '.join([prefix, account_string, 'ls', path]))
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'mkdir', f'{path}/testdir']))
+
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'chown', username, path]))
+
+        case 'MODIFY':
+            ssh(' '.join([prefix, account_string, 'ls', path]))
+            ssh(' '.join([prefix, account_string, 'mkdir', f'{path}/testdir']))
+            ssh(' '.join([prefix, account_string, 'rmdir', f'{path}/testdir']))
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'chown', username, path]))
+
+        case 'FULL_CONTROL':
+            ssh(' '.join([prefix, account_string, 'chown', username, path]))
+
+        case None:
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'ls', path]))
+
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'mkdir', f'{path}/testdir']))
+
+            with pytest.raises(AssertionError, match='Operation not permitted'):
+                ssh(' '.join([prefix, account_string, 'chown', username, path]))
+        case _:
+            raise ValueError(f'{expected_access}: unexpected access string')
+
+
+def test_virt_instance_nfs4acl_functional(instance, nfs4acl_dataset):
+    create_virt_users(
+        instance['name'],
+        nfs4acl_dataset['user']['uid'],
+        nfs4acl_dataset['group']['gid']
+    )
+
+    path = f'/mnt/{nfs4acl_dataset["dataset"]}'
+    acl_info = call('filesystem.getacl', path)
+    assert acl_info['acltype'] == 'NFS4'
+    acl = deepcopy(acl_info['acl'])
+    acl.extend([
+        {
+            'tag': 'GROUP',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'READ'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['group']['gid']
+        },
+        {
+            'tag': 'USER',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'READ'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['user']['uid']
+        }
+    ])
+
+    for username in ('larry', 'curly', 'moe'):
+        check_access(
+            instance['name'],
+            nfs4acl_dataset['dev'],
+            username,
+            None
+        )
+
+    # set READ ACL
+    call('filesystem.setacl', {'path': path, 'dacl': acl}, job=True)
+
+    ssh(f'cp /bin/nfs4xdr_getfacl {path}/nfs4xdr_getfacl')
+    ssh(f'cp /bin/nfs4xdr_setfacl {path}/nfs4xdr_setfacl')
+
+    # FIXME - NAS-134466 
+    """
+    ssh(f'cp /bin/nfs4xdr_getfacl /mnt/{ds}/nfs4xdr_getfacl')
+
+    cmd = [
+        'incus', 'exec', '-T', instance['name'],
+        '-- bash -c "/host/nfs4xdr_getfacl -j /host"'
+    ]
+    instance_acl = json.loads(ssh(' '.join(cmd)))
+
+    # Check that the ids in the ACL have been mapped
+    check_nfs4_acl_entry(
+        instance_acl['acl'],
+        nfs4acl_dataset['group']['gid'],
+        'ALLOW',
+        'GROUP',
+        {'BASIC': 'READ'},
+        {'BASIC': 'INHERIT'}
+    )
+
+    check_nfs4_acl_entry(
+        instance_acl['acl'],
+        instance['user']['uid'],
+        'ALLOW',
+        'USER',
+        {'BASIC': 'READ'},
+        {'BASIC': 'INHERIT'}
+    )
+    """
+
+    for username in ('larry', 'curly', 'moe'):
+        check_access(
+            instance['name'],
+            nfs4acl_dataset['dev'],
+            username,
+            'READ'
+        )
+
+    acl = deepcopy(acl_info['acl'])
+    acl.extend([
+        {
+            'tag': 'GROUP',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'MODIFY'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['group']['gid']
+        },
+        {
+            'tag': 'USER',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'MODIFY'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['user']['uid']
+        }
+    ])
+
+    # set MODIFY ACL
+    call('filesystem.setacl', {'path': path, 'dacl': acl}, job=True)
+
+    for username in ('larry', 'curly', 'moe'):
+        check_access(
+            instance['name'],
+            nfs4acl_dataset['dev'],
+            username,
+            'MODIFY'
+        )
+
+    acl = deepcopy(acl_info['acl'])
+    acl.extend([
+        {
+            'tag': 'GROUP',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'FULL_CONTROL'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['group']['gid']
+        },
+        {
+            'tag': 'USER',
+            'type': 'ALLOW',
+            'perms': {'BASIC': 'FULL_CONTROL'},
+            'flags': {'BASIC': 'INHERIT'},
+            'id': nfs4acl_dataset['user']['uid']
+        }
+    ])
+
+    # set FULL_CONTROL ACL
+    call('filesystem.setacl', {'path': path, 'dacl': acl}, job=True)
+
+    for username in ('larry', 'curly', 'moe'):
+        check_access(
+            instance['name'],
+            nfs4acl_dataset['dev'],
+            username,
+            'FULL_CONTROL'
+        )


### PR DESCRIPTION
This commit adds a minimal functional test that our uid and gid idmaps work correctly with NFSv4 acltype datasets within a container.

Original PR: https://github.com/truenas/middleware/pull/15851
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134476