### PR TITLE
NAS-134449 / 25.04.0 / On service restart avoid injecting iSER module while deactivating (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -29,7 +29,6 @@ class ISCSITargetService(SimpleService):
                 self.middleware.logger.debug(f'Waited sucessfully for {self.name} to enter {curstate} state')
 
     async def before_start(self):
-        await self.middleware.call("iscsi.iser.before_start")
         await self.middleware.call("iscsi.alua.before_start")
         # Because we are a systemd_async_start service, it is possible that
         # a start could be requested while a stop is still in progress.
@@ -37,6 +36,7 @@ class ISCSITargetService(SimpleService):
             await self._wait_to_avoid_states(['deactivating'], 5)
         else:
             await self._wait_to_avoid_states(['deactivating'])
+        await self.middleware.call("iscsi.iser.before_start")
 
     async def start(self):
         if await self.middleware.call("failover.status") not in ["MASTER", "SINGLE"]:


### PR DESCRIPTION
On service restart avoid injecting iSER module while deactivating.

Original PR: https://github.com/truenas/middleware/pull/15854
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134449