### PR TITLE
NAS-134483 / 25.04.0 / Expand validation for incus paths in middleware (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -42,8 +42,9 @@ def volume(volume_name: str, size: int):
 
 @contextlib.contextmanager
 def virt_device(instance_name: str, device_name: str, payload: dict):
+    resp = call('virt.instance.device_add', instance_name, {'name': device_name, **payload})
     try:
-        yield call('virt.instance.device_add', instance_name, {'name': device_name, **payload})
+        yield resp
     finally:
         call('virt.instance.device_delete', instance_name, device_name)
 


### PR DESCRIPTION
This commit restricts what we consider to be valid paths for incus containers to dataset mountpoints within known storage pools.

Original PR: https://github.com/truenas/middleware/pull/15857
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134483