### PR TITLE
NAS-134512 / 25.10 / use get_disks() in _process_topology()

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -9,6 +9,7 @@ from middlewared.plugins.zfs_.validation_utils import validate_pool_name
 from middlewared.schema import Bool, Dict, Int, List, Patch, Str
 from middlewared.service import accepts, CallError, CRUDService, job, private, returns, ValidationErrors
 from middlewared.utils import BOOT_POOL_NAME_VALID
+from middlewared.utils.disks_.get_disks import get_disks
 from middlewared.utils.size import format_size
 from middlewared.validators import Range
 
@@ -267,7 +268,10 @@ class PoolService(CRUDService):
         )
         verrors.check()
 
-        disks_cache = dict(map(lambda x: (x['devname'], x), await self.middleware.call('disk.query')))
+        disks_cache = dict()
+        for i in await self.middleware.run_in_thread(get_disks):
+            disks_cache[i.name] = {'size': i.size_bytes}
+
         min_data_size = min([
             disks_cache[disk]['size']
             for disk in (


### PR DESCRIPTION
For reasons not fully understood, `ix-syncdisks.service` is failing at boot only. After system is booted, it can be called without issue. This prevents our `storage_disk` table from being populated with disk information. This causes a cascading set of failures because creating a zpool fails. This fixes all of the problems by using the new `get_disks` function in the `_process_topology`. (`get_disks` is written in a way that will render storing disk information in our database obsolete.)

Passing test run: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3342