### PR TITLE
NAS-134517 / 25.10 / fix disk.check_disk_availability

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/availability.py
+++ b/src/middlewared/middlewared/plugins/disk_/availability.py
@@ -4,6 +4,7 @@ from middlewared.service import accepts, private, Service
 from middlewared.service_exception import ValidationErrors
 from middlewared.schema import Bool, Dict, Str
 from middlewared.utils.disks import dev_to_ident
+from middlewared.utils.disks_.get_disks import get_disks
 
 
 class DiskService(Service):
@@ -162,7 +163,9 @@ class DiskService(Service):
             verrors, dict - validation errors (if any) and disk.query for all disks
         """
         verrors = ValidationErrors()
-        disks_cache = dict(map(lambda x: (x['devname'], x), await self.middleware.call('disk.query')))
+        disks_cache = dict()
+        for i in await self.middleware.run_in_thread(get_disks):
+            disks_cache[i.name] = {'serial': i.serial, 'lunid': i.lunid}
 
         disks_set = set(disks)
         disks_not_in_cache = disks_set - set(disks_cache.keys())

--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -75,6 +75,10 @@ class DiskEntry:
         wwid = self.__opener("device/wwid")
         if wwid is None:
             wwid = self.__opener("wwid")
+
+        if wwid is not None:
+            wwid = wwid.removeprefix("0x").removeprefix("eui.")
+
         return wwid
 
     @cached_property


### PR DESCRIPTION
Same issue as described in https://github.com/truenas/middleware/pull/15869. The biggest issue is that this is only failing on fresh install on first boot. Anytime I try to get on a system, the issue doesn't reproduce.