### PR TITLE
NAS-134516 / 25.04.0 / Fix check for whether acltype has changed (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -303,21 +303,22 @@ class PoolDatasetService(CRUDService):
                 # Prevent users from changing acltype settings underneath an active SMB share
                 # If this dataset hosts an SMB share, then prompt the user to first delete the share,
                 # make the dataset change, the recreate the share.
-                keys = ('acltype',)
-                if any([data.get(key) for key in keys]):
+                acltype = data.get('acltype')
+                if acltype == 'INHERIT':
+                    acltype = parent['acltype']['value']
+
+                if acltype and acltype != cur_dataset['acltype']['value']:
                     ds_attachments = await self.middleware.call('pool.dataset.attachments', data['name'])
                     if smb_attachments := [share for share in ds_attachments if share['type'] == "SMB Share"]:
                         share_names = [smb_share['attachments'] for smb_share in smb_attachments]
-                        for key in (k for k in keys if data.get(k)):
-                            if cur_dataset and (cur_dataset[key]['value'] == data.get(key)):
-                                continue
-                            verrors.add(
-                                f'{schema}.{key}',
-                                'This dataset is hosting SMB shares. '
-                                f'Before {key} can be updated the following shares must be disabled: '
-                                f'{share_names[0]}. '
-                                'The shares may be re-enabled after the change.'
-                            )
+
+                        verrors.add(
+                            f'{schema}.acltype',
+                            'This dataset is hosting SMB shares. '
+                            f'Before acltype can be updated the following shares must be disabled: '
+                            f'{share_names[0]}. '
+                            'The shares may be re-enabled after the change.'
+                        )
 
             # Prevent users from setting incorrect combinations of aclmode and acltype parameters
             # The final value to be set may have one of several different possible origins

--- a/tests/api2/test_pool_dataset_acl.py
+++ b/tests/api2/test_pool_dataset_acl.py
@@ -1,9 +1,10 @@
 import dataclasses
-import errno
 
+import os
 import pytest
 
 from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.assets.smb import smb_share
 from middlewared.test.integration.utils import call, ssh
 from truenas_api_client import ClientException
 
@@ -102,3 +103,10 @@ def test_simplified_apps_api_nfs4_acl(request):
         assert check_for_entry(acl, 'USER', AclIds.user_to_add, {'BASIC': 'MODIFY'}), acl
         assert check_for_entry(acl, 'GROUP', AclIds.group_to_add, {'BASIC': 'READ'}), acl
         assert check_for_entry(acl, 'USER', AclIds.user2_to_add, {'BASIC': 'FULL_CONTROL'}), acl
+
+
+def test_nested_dataset_acltype_validation():
+    with dataset('D1') as ds:
+        with dataset('D1/D2') as ds2:
+            with smb_share(os.path.join('/mnt', ds2), 'TEST_SHARE'):
+                call('pool.dataset.update', ds, {'readonly': 'ON'})

--- a/tests/api2/test_pool_dataset_acl.py
+++ b/tests/api2/test_pool_dataset_acl.py
@@ -109,4 +109,4 @@ def test_nested_dataset_acltype_validation():
     with dataset('D1') as ds:
         with dataset('D1/D2') as ds2:
             with smb_share(os.path.join('/mnt', ds2), 'TEST_SHARE'):
-                call('pool.dataset.update', ds, {'readonly': 'ON'})
+                call('pool.dataset.update', ds, {'readonly': 'ON', 'acltype': 'INHERIT'})


### PR DESCRIPTION
This commit fixes an oversight for extra validation of acltype changes. The validation was added because our userbase was changing the acltype ZFS property on active SMB shares causing samba to assert due to the ACL xattrs being ripped out from under it.

Unfortunately, the original commit did not properly account for the possibility that dataset properties can be set to INHERIT.

Original PR: https://github.com/truenas/middleware/pull/15870
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134516