### PR TITLE
NAS-134382 / 25.04.0 / Forbid `@filterable` methods for new-style API classes (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/apps_images/images.py
+++ b/src/middlewared/middlewared/plugins/apps_images/images.py
@@ -3,7 +3,7 @@ from middlewared.api.current import (
     AppImageEntry, AppImagePullArgs, AppImagePullResult, AppImageDeleteArgs, AppImageDeleteResult,
 )
 from middlewared.plugins.apps.ix_apps.docker.images import delete_image, list_images, pull_image
-from middlewared.service import CRUDService, filterable, job
+from middlewared.service import CRUDService, job
 from middlewared.utils import filter_list
 
 from .utils import get_normalized_auth_config, parse_tags
@@ -17,7 +17,6 @@ class AppImageService(CRUDService):
         role_prefix = 'APPS'
         entry = AppImageEntry
 
-    @filterable
     def query(self, filters, options):
         """
         Query all docker images with `query-filters` and `query-options`.

--- a/src/middlewared/middlewared/plugins/docker/network.py
+++ b/src/middlewared/middlewared/plugins/docker/network.py
@@ -1,6 +1,6 @@
 from middlewared.api.current import DockerNetworkEntry
 from middlewared.plugins.apps.ix_apps.docker.networks import list_networks
-from middlewared.service import CRUDService, filterable, private
+from middlewared.service import CRUDService, private
 from middlewared.utils import filter_list
 
 
@@ -13,7 +13,6 @@ class DockerNetworkService(CRUDService):
         role_prefix = 'DOCKER'
         entry = DockerNetworkEntry
 
-    @filterable
     def query(self, filters, options):
         """
         Query all docker networks

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -6,7 +6,7 @@ import platform
 import aiohttp
 
 from middlewared.service import (
-    CallError, CRUDService, ValidationErrors, filterable, job, private
+    CallError, CRUDService, ValidationErrors, job, private
 )
 from middlewared.utils import filter_list
 
@@ -39,7 +39,6 @@ class VirtInstanceService(CRUDService):
         role_prefix = 'VIRT_INSTANCE'
         event_register = True
 
-    @filterable
     async def query(self, filters, options):
         """
         Query all instances with `query-filters` and `query-options`.

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -82,6 +82,14 @@ class CRUDServiceMetabase(ServiceBase):
                 klass.query = api_method(QueryArgs, query_result_model)(
                     klass.query.wraps if hasattr(klass.query, "wraps") else klass.query
                 )
+            else:
+                if getattr(klass.query, '_legacy_filterable', False):
+                    raise RuntimeError(
+                        'Legacy-style @filterable can\'t be used on classes with new-style `entry` defined. Please, '
+                        'either use @filterable_api_method or don\'t use any decorator at all (it will be applied '
+                        f'automatically). Offending class: {klass!r}.'
+                    )
+
             # FIXME: Remove `wraps` handling when we get rid of `@accepts` in `CRUDService.get_instance` definition
             get_instance_args_model = get_instance_args(klass._config.entry)
             get_instance_result_model = get_instance_result(klass._config.entry)

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -25,6 +25,7 @@ def cli_private(fn):
 def filterable(fn=None, /, *, roles=None):
     def filterable_internal(fn):
         fn._filterable = True
+        fn._legacy_filterable = True
         if hasattr(fn, 'wraps'):
             fn.wraps._filterable = True
         return accepts(Ref('query-filters'), Ref('query-options'), roles=roles)(fn)


### PR DESCRIPTION
Using `@filterable` in new-style API classes prevents `query` method from appearing in the docs. Let's prohibit this and offer an alternative.

Original PR: https://github.com/truenas/middleware/pull/15874
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134382