### PR TITLE
NAS-134531 / 25.10 / fix middlewared.service start-up

### DIFF
--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -46,7 +46,6 @@ class PWEncService(Service):
         )
         self.middleware.call_sync('datastore.sql', 'DELETE FROM tasks_rsync WHERE rsync_ssh_credentials_id IS NOT NULL')
         self.middleware.call_sync('datastore.sql', 'DELETE FROM system_keychaincredential')
-        self.middleware.call_sync('datastore.sql', 'DELETE FROM vm_device')
 
     @staticmethod
     def _secret_opener(path, flags):


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/15850 caused a regression where-by `disk.query` is returning an empty array. This is because `ix-syncdisks.service` was failing. That service was failing because `middlewared.service` was failing. This service is failing because of this
```
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3/dist-packages/middlewared/plugins/pwenc.py", line 49, in _reset_passwords
Mar  3 05:30:41 truenas middlewared[1046]:     self.middleware.call_sync('datastore.sql', 'DELETE FROM vm_device')
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1002, in call_sync
Mar  3 05:30:41 truenas middlewared[1046]:     return self.run_coroutine(methodobj(*prepared_call.args))
Mar  3 05:30:41 truenas middlewared[1046]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3/dist-packages/middlewared/main.py", line 1042, in run_coroutine
Mar  3 05:30:41 truenas middlewared[1046]:     return fut.result()
Mar  3 05:30:41 truenas middlewared[1046]:            ^^^^^^^^^^^^
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3.11/concurrent/futures/_base.py", line 449, in result
Mar  3 05:30:41 truenas middlewared[1046]:     return self.__get_result()
Mar  3 05:30:41 truenas middlewared[1046]:            ^^^^^^^^^^^^^^^^^^^
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
Mar  3 05:30:41 truenas middlewared[1046]:     raise self._exception
Mar  3 05:30:41 truenas middlewared[1046]:   File "/usr/lib/python3/dist-packages/middlewared/plugins/datastore/util.py", line 43, in sql
Mar  3 05:30:41 truenas middlewared[1046]:     raise CallError(e)
Mar  3 05:30:41 truenas middlewared[1046]: middlewared.service_exception.CallError: [EFAULT] (sqlite3.OperationalError) no such table: vm_device
Mar  3 05:30:41 truenas middlewared[1046]: [SQL: DELETE FROM vm_device]