### PR TITLE
NAS-134532 / 25.10 / Add comment explaining incus private API usage

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -363,6 +363,7 @@ class VirtGlobalService(ConfigService):
             # 1. Setting up incus for this first time on the server
             # 2. After change to the storage pool path
             # 3. After an HA failover event
+            # 4. After TrueNAS upgrades
             #
             # NOTE: this will potentially cause user-initiated changes from incus commands to be lost.
             payload = {

--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -353,6 +353,18 @@ class VirtGlobalService(ConfigService):
             }
 
         if import_storage:
+            # Call into incus's private API to initiate a recovery action.
+            # This is roughly equivalent to running the command "incus admin recover", and is performed
+            # to make it so that incus on TrueNAS does not rely on the contents of /var/lib/incus.
+            #
+            # https://linuxcontainers.org/incus/docs/main/reference/manpages/incus/admin/recover/#incus-admin-recover-md
+            #
+            # The current design is to do this in the following scenarios:
+            # 1. Setting up incus for this first time on the server
+            # 2. After change to the storage pool path
+            # 3. After an HA failover event
+            #
+            # NOTE: this will potentially cause user-initiated changes from incus commands to be lost.
             payload = {
                 'pools': [{
                     'config': {'source': config['dataset']},


### PR DESCRIPTION
During incus storage setup the TrueNAS middleware calls into a private incus recovery API in order to rebuild the incus configuration from data in the specified path. It is not very obvious that we're doing this and why we're doing this and so this commit adds a brief developer-facing comment based on discussion with the solutions team.