### PR TITLE
NAS-134330 / 25.10 / Respect `master` parameter in `failover.update`

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -97,7 +97,7 @@ class FailoverService(ConfigService):
         old = await self.middleware.call('datastore.config', 'system.failover')
         new = old.copy()
         new.update(data)
-        if master is not NOT_PROVIDED:
+        if master is NOT_PROVIDED:
             # The node making the call is the one we want to make MASTER by default
             new['master_node'] = await self.middleware.call('failover.node')
         else:


### PR DESCRIPTION
Our `failover.update` always sets the master node to the return of `failover.node` regardless of whatever is passed to `failover.update.master`.

Tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3373/