### PR TITLE
NAS-134550 / 25.10 / Fix nfs conf mako

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfs.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.mako
@@ -21,7 +21,13 @@
     #    * Including 'insecure' appears to not be requried on the share settings
 
     # Start clean
-    pathlib.Path("/usr/etc/nfs.conf").unlink(missing_ok=True)
+    try:
+        pathlib.Path("/usr/etc/nfs.conf").unlink(missing_ok=True)
+    except OSError as e:
+        if "Read-only" not in str(e):
+            middleware.logger.warning(
+                "Unexpected error on /etc/etc/nfs.conf delete: %s", e
+            )
     for rmdir in ["/usr/etc/nfs.conf.d", "/etc/nfs.conf.d"]:
         shutil.rmtree(rmdir, ignore_errors=True)
 %>

--- a/src/middlewared/middlewared/etc_files/nfs.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.mako
@@ -26,7 +26,7 @@
     except OSError as e:
         if "Read-only" not in str(e):
             middleware.logger.warning(
-                "Unexpected error on /etc/etc/nfs.conf delete: %s", e
+                "Unexpected error on /usr/etc/nfs.conf delete: %s", e
             )
     for rmdir in ["/usr/etc/nfs.conf.d", "/etc/nfs.conf.d"]:
         shutil.rmtree(rmdir, ignore_errors=True)

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -142,7 +142,11 @@ def parse_server_config(conf_type="nfs"):
             assert section in expected_sections, f"Unexpected section found: {section}"
             continue
 
-        k, v = line.split(" = ", 1)
+        try:
+            k, v = line.split(" = ", 1)
+        except ValueError as ve:
+            raise ValueError(f"Error detected in: {line}") from ve
+
         rv[section].update({k: v})
 
     return rv


### PR DESCRIPTION
/usr/etc is by default Read-Only on TrueNAS.  Recent change in nfs mako attempted delete /usr/etc/nfs.conf which resulted in an exception. 
This PR fixes that issue and enhances the CI for improved reporting of conf file parsing.

Add try block around file delete in mako.
Update the CI test to better report where the parsing error occurred.

Passing CI tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3371/