### PR TITLE
NAS-134560 / 25.04.0 / Add migration to add userns_idmap for apps user and group

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-03-03_21-02_apps-userns-idmap.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-03-03_21-02_apps-userns-idmap.py
@@ -1,0 +1,22 @@
+"""Add userns_idmap to apps user and group
+
+Revision ID: 0257529fa6d5
+Revises: 9ada77affbb9
+Create Date: 2025-03-03 21:02:55.899182+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0257529fa6d5'
+down_revision = '9ada77affbb9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute('UPDATE account_bsdusers SET bsdusr_userns_idmap="DIRECT" WHERE bsdusr_uid=568')
+    conn.execute('UPDATE account_bsdgroups SET bsdgrp_userns_idmap="DIRECT" WHERE bsdgrp_gid=568')


### PR DESCRIPTION
This change sets a DIRECT userns_idmap for the apps user and group so that this UID / GID always resolve in incus containers. The reason for this is that our userbase is already somewhat familiar with the idea that there are these "apps" accounts that are available for setting permissions to make things outside the host work. Having a single group that can be added to grant access to both apps and containers is simpler and avoids the need for a UI implementation of the userns_idmap field for the 25.04 release candidate.