### PR TITLE
NAS-134488 / 25.10 / Improve validation while changing io_bus for virt disks

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -356,8 +356,11 @@ class VirtInstanceDeviceService(Service):
                     verrors.add(schema, 'Destination cannot be /')
                 if destination and instance_type == 'VM':
                     verrors.add(schema, 'Destination is not valid for VM')
-                if device.get('io_bus') and instance_type != 'VM':
-                    verrors.add(f'{schema}.io_bus', 'IO bus is only available for VMs')
+                if device.get('io_bus'):
+                    if instance_type != 'VM':
+                        verrors.add(f'{schema}.io_bus', 'IO bus is only available for VMs')
+                    elif instance_config and instance_config['status'] != 'STOPPED':
+                        verrors.add(f'{schema}.io_bus', 'VM should be stopped before updating IO bus')
 
             case 'NIC':
                 if await self.middleware.call('interface.has_pending_changes'):


### PR DESCRIPTION
## Problem

When a VM is not in stopped state and we try to update `io_bus` attr for disks, that will result in VM hanging.

## Solution

Make sure we do not allow changing `io_bus` for virt disks if VM is in running state.