### PR TITLE
NAS-134387 / 25.10 / Add root datasets information to realtime reporting

### DIFF
--- a/src/freenas/usr/lib/netdata/conf.d/python.d.conf
+++ b/src/freenas/usr/lib/netdata/conf.d/python.d.conf
@@ -6,3 +6,4 @@ truenas_arcstats: yes
 truenas_cpu_usage: yes
 truenas_disk_stats: yes
 truenas_meminfo: yes
+truenas_pool: yes

--- a/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
@@ -6,6 +6,7 @@ from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
+        self.update_every = 300
 
     def check(self):
         self.add_pool_stats_to_charts()
@@ -13,9 +14,10 @@ class Service(SimpleService):
 
     def get_data(self):
         data = {}
-        for pool_name, info in get_pool_dataset_stats().items():
+        for pool_guid, info in get_pool_dataset_stats().items():
             for i, value in info.items():
-                data[f'{pool_name}.{i}'] = value
+                data[f'{pool_guid}.{i}'] = value
+            data[f'{pool_guid}.total'] = info['used'] + info['available']
         return data
 
     def add_pool_stats_to_charts(self):
@@ -27,6 +29,7 @@ class Service(SimpleService):
             'line',
         ])
 
-        for pool_name in data.keys():
-            self.charts['usage'].add_dimension([f'{pool_name}.available', f'available', 'absolute'])
-            self.charts['usage'].add_dimension([f'{pool_name}.used', f'used', 'absolute'])
+        for pool_guid in data.keys():
+            self.charts['usage'].add_dimension([f'{pool_guid}.available', 'available', 'absolute'])
+            self.charts['usage'].add_dimension([f'{pool_guid}.used', 'used', 'absolute'])
+            self.charts['usage'].add_dimension([f'{pool_guid}.total', 'total', 'absolute'])

--- a/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
@@ -1,4 +1,8 @@
-from bases.FrameworkServices.SimpleService import SimpleService
+import time
+
+from bases.collection import safe_print
+from bases.FrameworkServices.SimpleService import ND_INTERNAL_MONITORING_DISABLED, RUNTIME_CHART_UPDATE, SimpleService
+from third_party.monotonic import monotonic
 
 from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
 
@@ -33,3 +37,48 @@ class Service(SimpleService):
             self.charts['usage'].add_dimension([f'{pool_guid}.available', 'available', 'absolute'])
             self.charts['usage'].add_dimension([f'{pool_guid}.used', 'used', 'absolute'])
             self.charts['usage'].add_dimension([f'{pool_guid}.total', 'total', 'absolute'])
+
+    # We would like to override netdata's run method to avoid having a 10 minute delay before we actually
+    # get stats, now with these changes we will have a 5 minute delay before we get our first data point
+    # for this plugin
+    def run(self):
+        """
+        Runs job in thread. Handles retries.
+        Exits when job failed or timed out.
+        :return: None
+        """
+        job = self._runtime_counters
+        self.debug('started, update frequency: {freq}'.format(freq=job.update_every))
+
+        job.start_mono = monotonic()
+        job.start_real = time.time()
+
+        while True:
+            since = 0
+            if job.prev_update:
+                since = int((job.start_real - job.prev_update) * 1e6)
+
+            try:
+                updated = self.update(interval=since)
+            except Exception as error:
+                self.error('update() unhandled exception: {error}'.format(error=error))
+                updated = False
+
+            job.runs += 1
+
+            if not updated:
+                job.handle_retries()
+            else:
+                job.elapsed = int((monotonic() - job.start_mono) * 1e3)
+                job.prev_update = job.start_real
+                job.retries, job.penalty = 0, 0
+                if not ND_INTERNAL_MONITORING_DISABLED:
+                    safe_print(RUNTIME_CHART_UPDATE.format(job_name=self.name,
+                                                           since_last=since,
+                                                           elapsed=job.elapsed))
+            self.debug('update => [{status}] (elapsed time: {elapsed}, failed retries in a row: {retries})'.format(
+                status='OK' if updated else 'FAILED',
+                elapsed=job.elapsed if updated else '-',
+                retries=job.retries))
+
+            job.sleep_until_next()

--- a/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
@@ -1,0 +1,34 @@
+from bases.FrameworkServices.SimpleService import SimpleService
+
+from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
+
+
+class Service(SimpleService):
+    def __init__(self, configuration=None, name=None):
+        SimpleService.__init__(self, configuration=configuration, name=name)
+        self.old_stats = {}
+
+    def check(self):
+        self.add_pool_stats_to_charts()
+        return True
+
+    def get_data(self):
+        data = {}
+        for pool_name, info in get_pool_dataset_stats().items():
+            for i, value in info.items():
+                data[f'{pool_name}.{i}'] = value
+        return data
+
+    def add_pool_stats_to_charts(self):
+        data = get_pool_
+        dataset_stats()
+        self.charts.add_chart([
+            'usage', 'usage', 'usage', 'bytes',
+            'pool.usage',
+            'pool.usage',
+            'line',
+        ])
+
+        for pool_name in data.keys():
+            self.charts['usage'].add_dimension([f'{pool_name}.available', f'available', 'absolute'])
+            self.charts['usage'].add_dimension([f'{pool_name}.used', f'used', 'absolute'])

--- a/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_pool.chart.py
@@ -6,7 +6,6 @@ from middlewared.utils.metrics.pool_stats import get_pool_dataset_stats
 class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
-        self.old_stats = {}
 
     def check(self):
         self.add_pool_stats_to_charts()
@@ -20,8 +19,7 @@ class Service(SimpleService):
         return data
 
     def add_pool_stats_to_charts(self):
-        data = get_pool_
-        dataset_stats()
+        data = get_pool_dataset_stats()
         self.charts.add_chart([
             'usage', 'usage', 'usage', 'bytes',
             'pool.usage',

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -6,8 +6,9 @@ from middlewared.service import Service
 from middlewared.utils.disks import get_disk_names, get_disks_with_identifiers
 from middlewared.validators import Range
 
-from .realtime_reporting import get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info
-
+from .realtime_reporting import (
+    get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info, get_pool_stats,
+)
 
 class ReportingRealtimeService(Service):
 
@@ -50,6 +51,7 @@ class ReportingRealtimeService(Service):
                         )
                     ]
                 ),
+                'pools': get_pool_stats(netdata_metrics),
                 'failed_to_connect': False,
             }
 
@@ -108,7 +110,8 @@ class RealtimeEventSource(EventSource):
             Int('l2arc_miss_percentage'),
             Int('bytes_read_per_second_from_the_l2arc'),
             Int('bytes_written_per_second_to_the_l2arc'),
-        )
+        ),
+        Dict('pools', additional_attrs=True),
     )
 
     def run_sync(self):

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/__init__.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/__init__.py
@@ -3,3 +3,4 @@ from .cpu import get_cpu_stats  # noqa
 from .ifstat import get_interface_stats  # noqa
 from .iostat import get_disk_stats  # noqa
 from .memory import get_memory_info  # noqa
+from .pool import get_pool_stats  # noqa

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
@@ -1,0 +1,12 @@
+from collections import defaultdict
+
+from .utils import safely_retrieve_dimension
+
+
+def get_pool_stats(netdata_metrics: dict) -> dict:
+    data = defaultdict(lambda: {'available': None, 'used': None})
+
+    for dimension_name, value in safely_retrieve_dimension(netdata_metrics, 'truenas_pool.usage').items():
+        pool_name, stat_key = dimension_name.split('.')
+        data[pool_name][stat_key] = value
+    return data

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
@@ -1,12 +1,16 @@
 from collections import defaultdict
 
+from middlewared.utils.zfs import query_imported_fast_impl
+
 from .utils import safely_retrieve_dimension
 
 
 def get_pool_stats(netdata_metrics: dict) -> dict:
-    data = defaultdict(lambda: {'available': None, 'used': None})
+    data = defaultdict(lambda: {'available': None, 'used': None, 'total': None})
+    pool_data = query_imported_fast_impl()
 
     for dimension_name, value in safely_retrieve_dimension(netdata_metrics, 'truenas_pool.usage').items():
-        pool_name, stat_key = dimension_name.split('.')
-        data[pool_name][stat_key] = value
+        value = value or {}
+        pool_guid, stat_key = dimension_name.split('.')
+        data[pool_data[pool_guid]['name']][stat_key] = value
     return data

--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
@@ -9,7 +9,7 @@ def get_pool_stats(netdata_metrics: dict) -> dict:
     data = defaultdict(lambda: {'available': None, 'used': None, 'total': None})
     pool_data = query_imported_fast_impl()
 
-    for dimension_name, value in safely_retrieve_dimension(netdata_metrics, 'truenas_pool.usage').items():
+    for dimension_name, value in (safely_retrieve_dimension(netdata_metrics, 'truenas_pool.usage') or {}).items():
         value = value or {}
         pool_guid, stat_key = dimension_name.split('.')
         data[pool_data[pool_guid]['name']][stat_key] = value

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -72,6 +72,9 @@ class NetdataService(Service):
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
+            self.middleware.call_sync('pool.dataset.query', [], {'count': True, 'extra': {
+                'properties': [], 'retrieve_children': False,
+            }}),
             len(self.middleware.call_sync('virt.instance.query', [['type', '=', 'VM']])),
             len(glob.glob('/sys/fs/cgroup/**/*.service')),
         )

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -8,6 +8,7 @@ from middlewared.api.base import BaseModel, NonEmptyString
 from middlewared.service import Service
 from middlewared.utils.cpu import cpu_info
 from middlewared.utils.disk_stats import get_disk_stats
+from middlewared.utils.zfs import query_imported_fast_impl
 
 from .netdata import ClientConnectError, Netdata
 from .utils import calculate_disk_space_for_netdata, get_metrics_approximation, TIER_0_POINT_SIZE, TIER_1_POINT_SIZE
@@ -72,9 +73,7 @@ class NetdataService(Service):
             len(self.middleware.call_sync('device.get_disks', False, True)),
             cpu_info()['core_count'],
             self.middleware.call_sync('interface.query', [], {'count': True}),
-            self.middleware.call_sync('pool.dataset.query', [], {'count': True, 'extra': {
-                'properties': [], 'retrieve_children': False,
-            }}),
+            len(query_imported_fast_impl()),
             len(self.middleware.call_sync('virt.instance.query', [['type', '=', 'VM']])),
             len(glob.glob('/sys/fs/cgroup/**/*.service')),
         )

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -121,7 +121,7 @@ def get_metrics_approximation(
             'cpu.usage': core_count + 1,
 
             # pool usage
-            'truenas_pool.usage': pool_count * 2,
+            'truenas_pool.usage': pool_count * 3,
 
             # cputemp
             'cputemp.temperatures': core_count + 1,

--- a/src/middlewared/middlewared/plugins/reporting/utils.py
+++ b/src/middlewared/middlewared/plugins/reporting/utils.py
@@ -54,7 +54,7 @@ def get_netdata_state_path() -> str:
 
 
 def get_metrics_approximation(
-    disk_count: int, core_count: int, interface_count: int, vms_count: int,
+    disk_count: int, core_count: int, interface_count: int, pool_count: int, vms_count: int,
     systemd_service_count: int, containers_count: typing.Optional[int] = 10,
 ) -> dict:
     data = {
@@ -119,6 +119,9 @@ def get_metrics_approximation(
 
             # cpu usage, it is core count + 1 with +1 saving aggregated stats
             'cpu.usage': core_count + 1,
+
+            # pool usage
+            'truenas_pool.usage': pool_count * 2,
 
             # cputemp
             'cputemp.temperatures': core_count + 1,

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -4,9 +4,9 @@ from middlewared.plugins.reporting.utils import get_metrics_approximation, calcu
 
 
 @pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 2, 10, 2, {1: 703, 60: 4}),
-    (1600, 32, 4, 4, 10, 1, {1: 8762, 60: 1600}),
-    (10, 16, 2, 2, 12, 3, {1: 842, 60: 10}),
+    (4, 2, 1, 2, 10, 2, {1: 705, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 8766, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 844, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
     disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
@@ -19,13 +19,13 @@ def test_netdata_metrics_count_approximation(
 @pytest.mark.parametrize(
     'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 2, 10, 2, 7, 1, 1, 405),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 406),
         (4, 2, 1, 2, 10, 1, 7, 4, 60, 25),
-        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2933),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2937),
         (1600, 32, 4, 10, 1, 4, 4, 4, 900, 13),
         (10, 16, 2, 2, 12, 1, 3, 1, 1, 184),
         (10, 16, 2, 2, 10, 3, 3, 4, 60, 13),
-        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13195),
+        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13201),
         (1600, 32, 4, 4, 12, 1, 18, 4, 900, 58),
     ],
 )

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_approximation.py
@@ -3,58 +3,59 @@ import pytest
 from middlewared.plugins.reporting.utils import get_metrics_approximation, calculate_disk_space_for_netdata
 
 
-@pytest.mark.parametrize('disk_count,core_count,interface_count,services_count,vms_count,expected_output', [
-    (4, 2, 1, 10, 2, {1: 699, 60: 4}),
-    (1600, 32, 4, 10, 1, {1: 8754, 60: 1600}),
-    (10, 16, 2, 12, 3, {1: 838, 60: 10}),
+@pytest.mark.parametrize('disk_count,core_count,interface_count,pool_count,services_count,vms_count,expected_output', [
+    (4, 2, 1, 2, 10, 2, {1: 703, 60: 4}),
+    (1600, 32, 4, 4, 10, 1, {1: 8762, 60: 1600}),
+    (10, 16, 2, 2, 12, 3, {1: 842, 60: 10}),
 ])
 def test_netdata_metrics_count_approximation(
-    disk_count, core_count, interface_count, services_count, vms_count, expected_output
+    disk_count, core_count, interface_count, pool_count, services_count, vms_count, expected_output
 ):
     assert get_metrics_approximation(
-        disk_count, core_count, interface_count, vms_count, services_count
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
     ) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,services_count,vms_count,days,'
+    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,'
     'bytes_per_point,tier_interval,expected_output', [
-        (4, 2, 1, 10, 2, 7, 1, 1, 403),
-        (4, 2, 1, 10, 1, 7, 4, 60, 25),
-        (1600, 32, 4, 2, 4, 4, 1, 1, 2925),
-        (1600, 32, 4, 1, 4, 4, 4, 900, 12),
-        (10, 16, 2, 12, 1, 3, 1, 1, 183),
-        (10, 16, 2, 10, 3, 3, 4, 60, 13),
-        (1600, 32, 4, 12, 3, 18, 1, 1, 13183),
-        (1600, 32, 4, 12, 1, 18, 4, 900, 57),
+        (4, 2, 1, 2, 10, 2, 7, 1, 1, 405),
+        (4, 2, 1, 2, 10, 1, 7, 4, 60, 25),
+        (1600, 32, 4, 12, 2, 4, 4, 1, 1, 2933),
+        (1600, 32, 4, 10, 1, 4, 4, 4, 900, 13),
+        (10, 16, 2, 2, 12, 1, 3, 1, 1, 184),
+        (10, 16, 2, 2, 10, 3, 3, 4, 60, 13),
+        (1600, 32, 4, 4, 12, 3, 18, 1, 1, 13195),
+        (1600, 32, 4, 4, 12, 1, 18, 4, 900, 58),
     ],
 )
 def test_netdata_disk_space_approximation(
-    disk_count, core_count, interface_count, services_count,
-    vms_count, days, bytes_per_point, tier_interval, expected_output
+        disk_count, core_count, interface_count, pool_count, services_count,
+        vms_count, days, bytes_per_point, tier_interval, expected_output
 ):
     assert calculate_disk_space_for_netdata(get_metrics_approximation(
-        disk_count, core_count, interface_count, vms_count, services_count
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
     ), days, bytes_per_point, tier_interval) == expected_output
 
 
 @pytest.mark.parametrize(
-    'disk_count,core_count,interface_count,services_count,vms_count,days,bytes_per_point,tier_interval', [
-        (4, 2, 1, 10, 2, 7, 1, 1),
-        (4, 2, 1, 12, 2, 7, 4, 60),
-        (1600, 32, 4, 10, 3, 4, 1, 1),
-        (1600, 32, 4, 12, 3, 4, 4, 900),
-        (10, 16, 2, 10, 4, 3, 1, 1),
-        (10, 16, 2, 12, 4, 3, 4, 60),
-        (1600, 32, 4, 10, 5, 18, 1, 1),
-        (1600, 32, 4, 12, 5, 18, 4, 900),
+    'disk_count,core_count,interface_count,pool_count,services_count,vms_count,days,bytes_per_point,tier_interval',
+    [
+        (4, 2, 1, 2, 10, 2, 7, 1, 1),
+        (4, 2, 1, 2, 12, 2, 7, 4, 60),
+        (1600, 32, 4, 4, 10, 3, 4, 1, 1),
+        (1600, 32, 4, 4, 12, 3, 4, 4, 900),
+        (10, 16, 2, 2, 10, 4, 3, 1, 1),
+        (10, 16, 2, 2, 12, 4, 3, 4, 60),
+        (1600, 32, 4, 4, 10, 5, 18, 1, 1),
+        (1600, 32, 4, 4, 12, 5, 18, 4, 900),
     ],
 )
 def test_netdata_days_approximation(
-    disk_count, core_count, interface_count, services_count, vms_count, days, bytes_per_point, tier_interval
-):
+        disk_count, core_count, interface_count, pool_count, services_count, vms_count, days, bytes_per_point,
+        tier_interval):
     metric_intervals = get_metrics_approximation(
-        disk_count, core_count, interface_count, vms_count, services_count
+        disk_count, core_count, interface_count, pool_count, vms_count, services_count
     )
     disk_size = calculate_disk_space_for_netdata(metric_intervals, days, bytes_per_point, tier_interval)
     total_metrics = metric_intervals[1] + (metric_intervals[60] / 60)

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -658,44 +658,68 @@ NETDATA_ALL_METRICS = {
         'family': 'pool.usage',
         'context': 'pool.usage',
         'units': 'bytes',
-        'last_updated': 1741023952,
+        'last_updated': 1741816789,
         'dimensions': {
-            'boot-pool.available': {
+            '11653691484309152344.available': {
                 'name': 'available',
-                'value': 16053874688
+                'value': 15574065152
             },
-            'boot-pool.used': {
+            '11653691484309152344.used': {
                 'name': 'used',
-                'value': 3730903040
+                'value': 4210708480
             },
-            'tank.available': {
+            '11653691484309152344.total': {
+                'name': 'total',
+                'value': 19784773632
+            },
+            '14935745712721614601.available': {
                 'name': 'available',
-                'value': 7181352960
+                'value': 6004465664
             },
-            'tank.used': {
+            '14935745712721614601.used': {
                 'name': 'used',
-                'value': 13102555136
+                'value': 14279315456
+            },
+            '14935745712721614601.total': {
+                'name': 'total',
+                'value': 20283781120
             }
         }
     },
-
 }
 
 
 def test_get_pool_stats():
-    pool_stats = get_pool_stats(NETDATA_ALL_METRICS)
-    assert pool_stats['tank']['available'] == safely_retrieve_dimension(
-        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'tank.available'
-    )
-    assert pool_stats['tank']['used'] == safely_retrieve_dimension(
-        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'tank.used'
-    )
-    assert pool_stats['boot-pool']['available'] == safely_retrieve_dimension(
-        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'boot-pool.available'
-    )
-    assert pool_stats['boot-pool']['used'] == safely_retrieve_dimension(
-        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'boot-pool.used'
-    )
+    with patch('middlewared.plugins.reporting.realtime_reporting.pool.query_imported_fast_impl') as pool_imp:
+        pool_imp.return_value = {
+            '14935745712721614601': {
+                'name': 'tank', 'state': 'ONLINE'
+            },
+            '11653691484309152344': {
+                'name': 'boot-pool', 'state': 'ONLINE'
+            }
+        }
+
+        pool_stats = get_pool_stats(NETDATA_ALL_METRICS)
+        assert pool_stats['tank']['available'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '14935745712721614601.available'
+        )
+        assert pool_stats['tank']['used'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '14935745712721614601.used'
+        )
+        assert pool_stats['tank']['total'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '14935745712721614601.total'
+        )
+        assert pool_stats['boot-pool']['available'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '11653691484309152344.available'
+        )
+        assert pool_stats['boot-pool']['used'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '11653691484309152344.used'
+        )
+        assert pool_stats['boot-pool']['total'] == safely_retrieve_dimension(
+            NETDATA_ALL_METRICS, 'truenas_pool.usage', '11653691484309152344.total'
+        )
+
 
 
 def test_arc_stats():

--- a/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/reporting/test_netdata_stats_func.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, mock_open
 
 from middlewared.plugins.reporting.netdata.utils import NETDATA_UPDATE_EVERY
 from middlewared.plugins.reporting.realtime_reporting import (
-    get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info,
+    get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info, get_pool_stats
 )
 from middlewared.plugins.reporting.realtime_reporting.utils import normalize_value, safely_retrieve_dimension
 
@@ -653,8 +653,49 @@ NETDATA_ALL_METRICS = {
             }
         }
     },
+    'truenas_pool.usage': {
+        'name': 'truenas_pool.usage',
+        'family': 'pool.usage',
+        'context': 'pool.usage',
+        'units': 'bytes',
+        'last_updated': 1741023952,
+        'dimensions': {
+            'boot-pool.available': {
+                'name': 'available',
+                'value': 16053874688
+            },
+            'boot-pool.used': {
+                'name': 'used',
+                'value': 3730903040
+            },
+            'tank.available': {
+                'name': 'available',
+                'value': 7181352960
+            },
+            'tank.used': {
+                'name': 'used',
+                'value': 13102555136
+            }
+        }
+    },
 
 }
+
+
+def test_get_pool_stats():
+    pool_stats = get_pool_stats(NETDATA_ALL_METRICS)
+    assert pool_stats['tank']['available'] == safely_retrieve_dimension(
+        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'tank.available'
+    )
+    assert pool_stats['tank']['used'] == safely_retrieve_dimension(
+        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'tank.used'
+    )
+    assert pool_stats['boot-pool']['available'] == safely_retrieve_dimension(
+        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'boot-pool.available'
+    )
+    assert pool_stats['boot-pool']['used'] == safely_retrieve_dimension(
+        NETDATA_ALL_METRICS, 'truenas_pool.usage', 'boot-pool.used'
+    )
 
 
 def test_arc_stats():

--- a/src/middlewared/middlewared/utils/metrics/pool_stats.py
+++ b/src/middlewared/middlewared/utils/metrics/pool_stats.py
@@ -7,7 +7,7 @@ def get_pool_dataset_stats() -> dict[str, dict]:
     pool_stats = {}
     kwargs = {
         'props': ['used', 'available'],
-        'user_props': True,
+        'user_props': False,
         'snapshots': None,
         'retrieve_children': False,
         'snapshots_recursive': None,

--- a/src/middlewared/middlewared/utils/metrics/pool_stats.py
+++ b/src/middlewared/middlewared/utils/metrics/pool_stats.py
@@ -1,0 +1,27 @@
+import contextlib
+
+import libzfs
+
+
+def get_pool_dataset_stats() -> dict[str, dict]:
+    pool_stats = {}
+    kwargs = {
+        'props': ['used', 'available'],
+        'user_props': True,
+        'snapshots': None,
+        'retrieve_children': False,
+        'snapshots_recursive': None,
+        'snapshot_props': [],
+    }
+    with contextlib.suppress(libzfs.ZFSException):
+        # We want to suppress it because if a plugin errors out once, it won't run again
+        # unless netdata is restarted
+        with libzfs.ZFS() as zfs:
+            dataset_info = list(zfs.datasets_serialized(**kwargs))
+            for info in dataset_info:
+                pool_stats[info['id']] = {
+                    'available': info['properties']['available']['parsed'],
+                    'used': info['properties']['used']['parsed'],
+                }
+
+    return pool_stats


### PR DESCRIPTION
This PR adds changes to retrieve root dataset's usage information in realtime reporting so TNC heartbeat can consume that information.