### PR TITLE
NAS-134554 / 25.10 / Do not allow zvols for virt containers

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -315,6 +315,8 @@ class VirtInstanceDeviceService(Service):
                     if instance_type == 'CONTAINER':
                         if device['boot_priority'] is not None:
                             verrors.add(schema, 'Boot priority is not valid for filesystem paths.')
+                        if source.startswith('/dev/zvol/'):
+                            verrors.add(schema, 'ZVOL are not allowed for containers')
 
                         if await self.middleware.run_in_thread(os.path.exists, source) is False:
                             verrors.add(schema, 'Source path does not exist.')

--- a/tests/api2/test_virt_002_instance.py
+++ b/tests/api2/test_virt_002_instance.py
@@ -196,16 +196,14 @@ def test_virt_instance_device_add(virt_instances):
 
     with dataset('virtshare', {'type': 'VOLUME', 'volsize': 200 * 1024 * 1024, 'sparse': True}) as ds:
         ssh(f'mkfs.ext3 /dev/zvol/{ds}')
-        call('virt.instance.device_add', INS3_NAME, {
+        call('virt.instance.device_add', INS1_NAME, {
             'name': 'disk2',
             'dev_type': 'DISK',
             'source': f'/dev/zvol/{ds}',
-            'destination': '/zvol',
         })
-        devices = call('virt.instance.device_list', INS3_NAME)
+        devices = call('virt.instance.device_list', INS1_NAME)
         assert any(i for i in devices if i['name'] == 'disk2'), devices
-        ssh(f'incus exec {INS3_NAME} mount|grep "on /zvol"|grep ext3')
-        assert call('virt.instance.device_delete', INS3_NAME, 'disk2') is True
+        assert call('virt.instance.device_delete', INS1_NAME, 'disk2') is True
 
 
 def test_virt_instance_device_update(virt_instances):


### PR DESCRIPTION
## Context

It was requested that we don't allow zvols to be used for virt containers because of the complexity required for setting it up actually for consumption with the container. So for the time being it is being disabled.