### PR TITLE
NAS-134597 / 25.10 / Removed certificate_authority management requirement from syslog config.

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-03-06_01-25_remove_syslog_tls_certificate_authority.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-03-06_01-25_remove_syslog_tls_certificate_authority.py
@@ -1,0 +1,27 @@
+""" Remove syslog_tls_certificate_authority
+
+Revision ID: a156968d5cbb
+Revises: 616c19f82016
+Create Date: 2025-03-06 01:25:41.245074+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a156968d5cbb'
+down_revision = '616c19f82016'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('system_advanced', schema=None) as batch_op:
+        batch_op.drop_index('ix_system_advanced_adv_syslog_tls_certificate_authority_id')
+        batch_op.drop_constraint('fk_system_advanced_adv_syslog_tls_certificate_authority_id_system_certificateauthority', type_='foreignkey')
+        batch_op.drop_column('adv_syslog_tls_certificate_authority_id')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -22,7 +22,7 @@ def generate_syslog_remote_destination(advanced_config):
 
     if advanced_config["syslog_transport"] == "TLS":
         # The TLS (transport) cert should be added via certificate authority
-        tls_encrypt_stanza += f'syslog("{host}" port({port}) transport("tls") ip-protocol(6) '
+        tls_encrypt_stanza = f'syslog("{host}" port({port}) transport("tls") ip-protocol(6) '
         tls_encrypt_stanza += 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))'
         result += f"{tls_encrypt_stanza});"
     else:

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -22,18 +22,18 @@ def generate_syslog_remote_destination(advanced_config):
     remotelog_stanza += f'syslog("{host}" port({port}) ip-protocol(6) transport("{transport}")'
 
     if advanced_config["syslog_transport"] == "TLS":
+        # Both mutual and one-way TLS require this
+        remotelog_stanza += ' tls(ca-file("/etc/ssl/certs/ca-certificates.crt")'
+
         certificate = middleware.call_sync(
             "certificate.query", [("id", "=", advanced_config["syslog_tls_certificate"])]
         )
         if certificate and not certificate[0]["revoked"]:
-            remotelog_stanza += ' tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))'
-        else:
-            msg = 'Skipping setting cert-file for remote syslog as '
-            if not certificate:
-                msg += 'no certificate configured'
-            else:
-                msg += 'specified certificate has been revoked'
-            logger.debug(msg)
+            # Mutual TLS
+            remotelog_stanza += f' key-file(\"{certificate[0]["privatekey_path"]}\")'
+            remotelog_stanza += f' cert-file(\"{certificate[0]["certificate_path"]}\")'
+
+        remotelog_stanza += ')'
 
     remotelog_stanza += '); };\n'
     remotelog_stanza += 'log { source(tn_middleware_src); filter(f_tnremote); destination(loghost); };\n'

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -40,6 +40,7 @@ class SystemAdvancedModel(sa.Model):
     adv_sysloglevel = sa.Column(sa.String(120), default='f_info')
     adv_syslogserver = sa.Column(sa.String(120), default='')
     adv_syslog_transport = sa.Column(sa.String(12), default='UDP')
+    # tls IDs are placeholders for mutual authentication TLS
     adv_syslog_tls_certificate_id = sa.Column(sa.ForeignKey('system_certificate.id'), index=True, nullable=True)
     adv_syslog_tls_certificate_authority_id = sa.Column(
         sa.ForeignKey('system_certificateauthority.id'), index=True, nullable=True
@@ -88,8 +89,8 @@ class SystemAdvancedService(ConfigService):
         ], required=True),
         Str('syslogserver'),
         Str('syslog_transport', enum=['UDP', 'TCP', 'TLS'], required=True),
-        Int('syslog_tls_certificate', null=True, required=True),
-        Int('syslog_tls_certificate_authority', null=True, required=True),
+        Int('syslog_tls_certificate', null=True),               # Unused placeholder for mutual TLS
+        Int('syslog_tls_certificate_authority', null=True),     # Unused placeholder for mutual TLS
         Bool('syslog_audit'),
         List('isolated_gpu_pci_ids', items=[Str('pci_id')], required=True),
         Str('kernel_extra_options', required=True),
@@ -103,8 +104,9 @@ class SystemAdvancedService(ConfigService):
         if data.get('sed_user'):
             data['sed_user'] = data.get('sed_user').upper()
 
-        for k in filter(lambda k: data[k], ['syslog_tls_certificate_authority', 'syslog_tls_certificate']):
-            data[k] = data[k]['id']
+        # Currently unused. Force tls IDs to None.
+        data['syslog_tls_certificate'] = None
+        data['syslog_tls_certificate_authority'] = None
 
         data.pop('sed_passwd')
         data.pop('kmip_uid')
@@ -142,7 +144,7 @@ class SystemAdvancedService(ConfigService):
                     f'{schema}.syslogserver',
                     'Invalid syslog server format'
                 )
-            elif ']:' in syslog_server or (':' in syslog_server and not ']' in syslog_server):
+            elif ']:' in syslog_server or (':' in syslog_server and ']' not in syslog_server):
                 port = int(syslog_server.split(':')[-1])
                 if port < 0 or port > 65535:
                     verrors.add(
@@ -150,25 +152,13 @@ class SystemAdvancedService(ConfigService):
                         'Port must be in the range of 0 to 65535.'
                     )
 
-        if data['syslog_transport'] == 'TLS':
-            if not data['syslog_tls_certificate_authority']:
-                verrors.add(
-                    f'{schema}.syslog_tls_certificate_authority', 'This is required when using TLS as syslog transport'
-                )
-            ca_cert = await self.middleware.call(
-                'certificateauthority.query', [['id', '=', data['syslog_tls_certificate_authority']]]
+        # syslog with TLS (transport) does not manage any cert IDs
+        if data['syslog_tls_certificate_authority'] or data['syslog_tls_certificate']:
+            verrors.add(
+                f'{schema}.syslogserver',
+                'Please import the syslog certificate via the certificate authority UI widget.  '
+                'No selection is necessary.'
             )
-            if not ca_cert:
-                verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Unable to locate specified CA')
-            elif ca_cert[0]['revoked']:
-                verrors.add(f'{schema}.syslog_tls_certificate_authority', 'Specified CA has been revoked')
-
-            if data['syslog_tls_certificate']:
-                verrors.extend(await self.middleware.call(
-                    'certificate.cert_services_validation', data['syslog_tls_certificate'],
-                    f'{schema}.syslog_tls_certificate', False
-                ))
-        elif data['syslog_tls_certificate_authority'] or data['syslog_tls_certificate']:
             data['syslog_tls_certificate_authority'] = data['syslog_tls_certificate'] = None
 
         for invalid_char in ('\n', '"'):
@@ -277,9 +267,8 @@ class SystemAdvancedService(ConfigService):
                 original_data['sysloglevel'].lower() != config_data['sysloglevel'].lower() or
                 original_data['syslogserver'] != config_data['syslogserver'] or
                 original_data['syslog_transport'] != config_data['syslog_transport'] or
-                original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate'] or
-                original_data['syslog_audit'] != config_data['syslog_audit'] or
-                original_data['syslog_tls_certificate_authority'] != config_data['syslog_tls_certificate_authority']
+                original_data['syslog_audit'] != config_data['syslog_audit']
+                # NOTE: add cert change check if required by mutual TLS (when implemented)
             ):
                 await self.middleware.call('service.restart', 'syslogd')
 

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -153,7 +153,7 @@ class SystemAdvancedService(ConfigService):
                     f'{schema}.syslog_tls_certificate', False
                 ))
         elif data['syslog_tls_certificate']:
-            data['syslog_tls_certificate_authority'] = None
+            data['syslog_tls_certificate'] = None
 
         for invalid_char in ('\n', '"'):
             if invalid_char in data['kernel_extra_options']:

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -16,13 +16,14 @@ class SystemAdvancedService(Service):
     async def syslog_certificate_choices(self):
         """
         Return choices of certificates which can be used for `syslog_tls_certificate`.
-        ---- NO LONGER USED: TO BE REMOVED AFTER UI UPDATE ----
         """
-        # return {
-        #     i['id']: i['name']
-        #     for i in await self.middleware.call('certificate.query', [('cert_type_CSR', '=', False)])
-        # }
-        return {}
+        return {
+            i['id']: i['name']
+            for i in await self.middleware.call(
+                # NOTE: Temporarily using certificate authority
+                'certificateauthority.query', [['revoked', '=', False], ['cert_type_CSR', '=', False]]
+            )
+        }
 
     @accepts()
     @returns(Dict(

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -20,8 +20,7 @@ class SystemAdvancedService(Service):
         return {
             i['id']: i['name']
             for i in await self.middleware.call(
-                # NOTE: Temporarily using certificate authority
-                'certificateauthority.query', [['revoked', '=', False], ['cert_type_CSR', '=', False]]
+                'certificate.query', [['revoked', '=', False], ['cert_type_CSR', '=', False]]
             )
         }
 

--- a/src/middlewared/middlewared/plugins/system_advanced/syslog.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/syslog.py
@@ -16,11 +16,13 @@ class SystemAdvancedService(Service):
     async def syslog_certificate_choices(self):
         """
         Return choices of certificates which can be used for `syslog_tls_certificate`.
+        ---- NO LONGER USED: TO BE REMOVED AFTER UI UPDATE ----
         """
-        return {
-            i['id']: i['name']
-            for i in await self.middleware.call('certificate.query', [('cert_type_CSR', '=', False)])
-        }
+        # return {
+        #     i['id']: i['name']
+        #     for i in await self.middleware.call('certificate.query', [('cert_type_CSR', '=', False)])
+        # }
+        return {}
 
     @accepts()
     @returns(Dict(
@@ -30,8 +32,10 @@ class SystemAdvancedService(Service):
     async def syslog_certificate_authority_choices(self):
         """
         Return choices of certificate authorities which can be used for `syslog_tls_certificate_authority`.
+        ---- NO LONGER USED: TO BE REMOVED AFTER UI UPDATE ----
         """
-        return {
-            i['id']: i['name']
-            for i in await self.middleware.call('certificateauthority.query', [['revoked', '=', False]])
-        }
+        # return {
+        #     i['id']: i['name']
+        #     for i in await self.middleware.call('certificateauthority.query', [['revoked', '=', False]])
+        # }
+        return {}

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -110,10 +110,10 @@ def test_set_remote_syslog_with_TLS_transport():
     try:
         data = call('system.advanced.update', tls_cmd)
         assert data['syslog_transport'] == 'TLS'
-        conf = ssh('grep "tls" /etc/syslog-ng/syslog-ng.conf')
-        assert f"{remote}:{port}" in conf
-        assert 'transport("tls")' in conf
-        assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf
+        conf = ssh('grep "tls" /etc/syslog-ng/syslog-ng.conf', complete_response=True, check=False)
+        assert f"{remote}:{port}" in conf, f"conf={conf}"
+        assert 'transport("tls")' in conf, f"conf={conf}"
+        assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf, f"conf={conf}"
 
         print(f"MCG DEBUG: conf = '{conf}'")
     finally:

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -115,6 +115,5 @@ def test_set_remote_syslog_with_TLS_transport():
         assert 'transport("tls")' in conf['stdout'], f"conf={conf}"
         assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf['stdout'], f"conf={conf}"
 
-        print(f"MCG DEBUG: conf = '{conf}'")
     finally:
         call('system.advanced.update', restore_cmd)

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -2,7 +2,7 @@ from time import sleep
 
 import pytest
 from auto_config import password, user
-from middlewared.test.integration.utils import call, mock, ssh
+from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
 
 
@@ -106,15 +106,14 @@ def test_set_remote_syslog_with_TLS_transport():
     remote = "127.0.0.1"
     port = "5140"
     transport = "TLS"
-    tls_cmd = {"syslogserver": f"{remote}:{port}", "syslog_transport": f"{transport}", "syslog_tls_certificate": 1}
+    tls_cmd = {"syslogserver": f"{remote}:{port}", "syslog_transport": f"{transport}"}
     try:
-        with mock("system.advanced.syslog_certificate_choices", return_value={"1": "syslog-cert"}):
-            data = call('system.advanced.update', tls_cmd)
-            assert data['syslog_transport'] == 'TLS'
-            conf = ssh('grep "destination loghost" /etc/syslog-ng/syslog-ng.conf', complete_response=True, check=False)
-            assert f"port({port})" in conf['stdout'], f"conf={conf}"
-            assert 'transport("tls")' in conf['stdout'], f"conf={conf}"
-            assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf['stdout'], f"conf={conf}"
+        data = call('system.advanced.update', tls_cmd)
+        assert data['syslog_transport'] == 'TLS'
+        conf = ssh('grep "destination loghost" /etc/syslog-ng/syslog-ng.conf', complete_response=True, check=False)
+        assert f"port({port})" in conf['stdout'], f"conf={conf}"
+        assert 'transport("tls")' in conf['stdout'], f"conf={conf}"
+        assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf['stdout'], f"conf={conf}"
 
     finally:
         call('system.advanced.update', restore_cmd)

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -110,10 +110,10 @@ def test_set_remote_syslog_with_TLS_transport():
     try:
         data = call('system.advanced.update', tls_cmd)
         assert data['syslog_transport'] == 'TLS'
-        conf = ssh('grep "tls" /etc/syslog-ng/syslog-ng.conf', complete_response=True, check=False)
-        assert f"{remote}:{port}" in conf, f"conf={conf}"
-        assert 'transport("tls")' in conf, f"conf={conf}"
-        assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf, f"conf={conf}"
+        conf = ssh('grep "destination loghost" /etc/syslog-ng/syslog-ng.conf', complete_response=True, check=False)
+        assert f"port({port})" in conf['stdout'], f"conf={conf}"
+        assert 'transport("tls")' in conf['stdout'], f"conf={conf}"
+        assert 'tls(ca-file("/etc/ssl/certs/ca-certificates.crt"))' in conf['stdout'], f"conf={conf}"
 
         print(f"MCG DEBUG: conf = '{conf}'")
     finally:


### PR DESCRIPTION
Removed `syslog_tls_certificate authority_id`  from system.advanced database (includes migration).
When TLS is selected we now always include the file containing ca certs.  

Includes a simple CI test.

