### PR TITLE
NAS-134606 / 25.04.0 / restrict changes to builtin groups (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -16,3 +16,15 @@ MIDDLEWARE_PAM_API_KEY_SERVICE = '/etc/pam.d/middleware-api-key'
 
 USERNS_IDMAP_DIRECT = -1
 USERNS_IDMAP_NONE = 0
+
+# Apart from a few exceptions we don't want admins making random
+# interactive users members of builtin groups. These groups usually
+# have enhanced privileges to the server and group membership can expose
+# unexpected security issues.
+ALLOWED_BUILTIN_GIDS = {
+    544,  # builtin_administrators
+    545,  # builtin_users
+    568,  # apps
+    951,  # truenas_readonly_administrators
+    952,  # truenas_sharing_administrators
+}

--- a/tests/unit/test_builtin_gid.py
+++ b/tests/unit/test_builtin_gid.py
@@ -1,0 +1,53 @@
+import pytest
+from truenas_api_client import Client, ClientException
+
+
+@pytest.fixture(scope='module')
+def local_user():
+    with Client() as c:
+        usr = c.call('user.create', {
+            'username': 'test_local_user',
+            'full_name': 'test_local_user',
+            'random_password': True,
+            'group_create': True
+        })
+        try:
+            yield usr
+
+        finally:
+            c.call('user.delete', usr['id'])
+
+
+@pytest.fixture(scope='module')
+def incus_admin_dbid():
+    with Client() as c:
+        yield c.call('group.query', [['name', '=', 'incus-admin']], {'get': True})['id']
+
+
+@pytest.fixture(scope='module')
+def builtin_admins_dbid():
+    with Client() as c:
+        yield c.call('group.query', [['name', '=', 'builtin_administrators']], {'get': True})['id']
+
+
+@pytest.mark.parametrize('key,value', (
+    ('name', 'canary'),
+    ('smb', True),
+    ('sudo_commands', ['/usr/sbin/zpool']),
+    ('sudo_commands_nopasswd', ['/usr/sbin/zpool']),
+))
+def test__builtin_group_immutable(key, value, incus_admin_dbid):
+    with pytest.raises(ClientException, match='may not be changed for builtin groups'):
+        with Client() as c:
+            c.call('group.update', incus_admin_dbid, {key: value})
+
+
+def test__builtin_group_deny_member_change(incus_admin_dbid, local_user):
+    with pytest.raises(ClientException, match='Group membership for this builtin group may not be changed.'):
+        with Client() as c:
+            c.call('group.update', incus_admin_dbid, {'users': [local_user['id']]})
+
+
+def test__change_full_admin_member(local_user, builtin_admins_dbid):
+    with Client() as c:
+        c.call('group.update', builtin_admins_dbid, {'users': [1, local_user['id']]})


### PR DESCRIPTION
Historically TrueNAS has done little to limit the changes admins can make to builtin groups (root, sssd, ntp, sudo, etc). This usually isn't problematic because admins know enough to not alter builtin groups. This is because changes to them can cause undefined system behavior, including introducing security vulnerabilities. This commit introduces additional validation to prevent problematic changes to these special system groups.

Original PR: https://github.com/truenas/middleware/pull/15908
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134606