### PR TITLE
NAS-134613 / 25.04-RC.1 / Apply idmap settings on new container creation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -425,13 +425,32 @@ class VirtInstanceService(CRUDService):
                 'devices': devices,
                 'source': source,
                 'type': 'container' if data['instance_type'] == 'CONTAINER' else 'virtual-machine',
-                'start': data['autostart'],
+                'start': False if data['instance_type'] == 'CONTAINER' else data['autostart'],
             }}, running_cb, timeout=15 * 60)
             # We will give 15 minutes to incus to download relevant image and then timeout
         except CallError as e:
             if await self.middleware.call('virt.instance.query', [['name', '=', data['name']]]):
                 await (await self.middleware.call('virt.instance.delete', data['name'])).wait()
             raise e
+
+        if data['instance_type'] == 'CONTAINER':
+            # apply idmap settings then apply autostart settings
+            await self.set_account_idmaps(data['name'])
+
+            if data['autostart']:
+                raw = (await self.middleware.call(
+                    'virt.instance.get_instance', data['name'], {'extra': {'raw': True}}
+                ))['raw']
+                raw['config']['boot.autostart'] = 'true'
+                try:
+                    await incus_call_and_wait(f'1.0/instances/{data["name"]}', 'put', {'json': raw})
+                except CallError as e:
+                    await (await self.middleware.call('virt.instance.delete', data['name'])).wait()
+                    raise e
+
+                await incus_call_and_wait(f'1.0/instances/{data["name"]}/state', 'put', {'json': {
+                    'action': 'start',
+                }})
 
         return await self.middleware.call('virt.instance.get_instance', data['name'])
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 2f1a75a2a14fe529dbc21c6519f039402ef74d5f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x aaf72d4590d00f82a013d5e718bbe85ddf7a65a3

This commit applies required idmap settings inside newly-created containers.

Original PR: https://github.com/truenas/middleware/pull/15914
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134613