### PR TITLE
NAS-134630 / 25.04.0 / Fix recently added check, use dbid as key not 'dbid' string (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1425,10 +1425,10 @@ class UserService(CRUDService):
                     )
 
                 entry = existing_groups.get(dbid)
-                if entry and entry['builtin'] and entry['gid'] not in ALLOWED_BUILTIN_GIDS:
+                if entry and entry['bsdgrp_builtin'] and entry['bsdgrp_gid'] not in ALLOWED_BUILTIN_GIDS:
                     verrors.add(
                         f'{schema}.groups.{idx}',
-                        f'{entry["group"]}: membership of this builtin group may not be altered.'
+                        f'{entry["bsdgrp_group"]}: membership of this builtin group may not be altered.'
                     )
 
         if 'full_name' in data and ':' in data['full_name']:

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -1424,8 +1424,8 @@ class UserService(CRUDService):
                         'Local users may not be members of directory services groups.'
                     )
 
-                entry = existing_groups['dbid']
-                if entry['builtin'] and entry['gid'] not in ALLOWED_BUILTIN_GIDS:
+                entry = existing_groups.get(dbid)
+                if entry and entry['builtin'] and entry['gid'] not in ALLOWED_BUILTIN_GIDS:
                     verrors.add(
                         f'{schema}.groups.{idx}',
                         f'{entry["group"]}: membership of this builtin group may not be altered.'


### PR DESCRIPTION
A change in PR #15908 used the wrong key for `existing_groups`.


Original PR: https://github.com/truenas/middleware/pull/15919
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134630