### PR TITLE
NAS-134634 / 25.04.0 / Do not present incus-managed zvols to middleware (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -139,7 +139,16 @@ def unlocked_zvols_fast(options=None, data=None):
 
             for file in files:
                 path = root + '/' + file
+
+                # zvols located within ix-virt are managed by incus and should
+                # never be presented as choices in middleware. Removing this
+                # check may introduce data corruption bugs by allowing zvols
+                # to be simultaneously used by multiple VMs.
+                if '.ix-virt' in path:
+                    continue
+
                 zvol_name = zvol_path_to_name(path)
+
                 try:
                     dev_name = os.readlink(path).split('/')[-1]
                 except Exception:


### PR DESCRIPTION
This commit prevents zvols within ix-virt from being exposed as choices within the virt and iscsi plugins. Prior to this change users could create a zvol via virt.volume.create and its /dev/zvol path was presented as a disk choice for other VMs, which allowed for having the same zvol mounted rw in two VMs simultaneously.

Original PR: https://github.com/truenas/middleware/pull/15923
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134634