### PR TITLE
NAS-134640 / 25.04.0 / Do not attempt to update idmap on running virt instance (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -580,15 +580,15 @@ class VirtInstanceService(CRUDService):
         await self.middleware.call('virt.global.check_initialized')
         instance = await self.middleware.call('virt.instance.get_instance', id)
 
-        # Apply any idmap changes
-        await self.set_account_idmaps(id)
-
         if instance['status'] == 'RUNNING':
             await incus_call_and_wait(f'1.0/instances/{id}/state', 'put', {'json': {
                 'action': 'stop',
                 'timeout': data['timeout'],
                 'force': data['force'],
             }})
+
+        # Apply any idmap changes
+        await self.set_account_idmaps(id)
 
         await incus_call_and_wait(f'1.0/instances/{id}/state', 'put', {'json': {
             'action': 'start',


### PR DESCRIPTION
## Problem

If idmap configuration has changed while a virt instance was running and an attempt to restart it is done, what happens is that the new configuration fails to apply as it will only apply if the instance is not running.

## Solution


Make sure instance is stopped and then apply relevant idmap changes.

Original PR: https://github.com/truenas/middleware/pull/15926
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134640