### PR TITLE
NAS-134641 / 25.10 / Provide improved disk_choices results for API consumers

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/device.py
+++ b/src/middlewared/middlewared/plugins/virt/device.py
@@ -63,24 +63,46 @@ class VirtDeviceService(Service):
             }
         return choices
 
-    @api_method(VirtDeviceDiskChoicesArgs, VirtDeviceDiskChoicesResult, roles=['VIRT_INSTANCE_READ'])
-    async def disk_choices(self):
+    @private
+    async def disk_choices_internal(self, include_in_use=False):
         """
-        Returns disk (zvol) choices for device type "DISK".
+        This allows optionally including in-use choices because update payloads with
+        /dev/zvol paths are validated against it in instance_device.py. If our validation
+        changes at some time in the future we can consolidate this method with the public
+        disk_choices method.
         """
+        if include_in_use:
+            incus_vol_filter = []
+            zvol_filter = ['OR', [
+                ['attachment', '=', None],
+                ['attachment.method', '=', 'virt.instance.query']
+            ]]
+        else:
+            incus_vol_filter = [["used_by", "=", []]]
+            zvol_filter = ['attachment', '=', None]
+
         out = {}
-        zvols = await self.middleware.call(
+        for incus_vol in await self.middleware.call('virt.volume.query', incus_vol_filter):
+            out[incus_vol['name']] = incus_vol['name']
+
+        for zvol in await self.middleware.call(
             'zfs.dataset.unlocked_zvols_fast', [
-                ['OR', [['attachment', '=', None], ['attachment.method', '=', 'virt.instance.query']]],
-                ['ro', '=', False],
+                zvol_filter, ['ro', '=', False],
             ],
             {}, ['ATTACHMENT', 'RO']
-        )
-
-        for zvol in zvols:
+        ):
             out[zvol['path']] = zvol['name']
 
         return out
+
+    @api_method(VirtDeviceDiskChoicesArgs, VirtDeviceDiskChoicesResult, roles=['VIRT_INSTANCE_READ'])
+    async def disk_choices(self):
+        """
+        Returns disk choices available for device type "DISK" for virtual machines. This includes
+        both available virt volumes and zvol choices. Disk choices for containers depend on the
+        mounted file tree (paths).
+        """
+        return await self.disk_choices_internal()
 
     @api_method(VirtDeviceNICChoicesArgs, VirtDeviceNICChoicesResult, roles=['VIRT_INSTANCE_READ'])
     async def nic_choices(self, nic_type):

--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -308,7 +308,7 @@ class VirtInstanceDeviceService(Service):
                     verrors.add(schema, 'Source is required.')
                 elif source.startswith('/'):
                     if source.startswith('/dev/zvol/') and source not in await self.middleware.call(
-                        'virt.device.disk_choices'
+                        'virt.device.disk_choices_internal', True
                     ):
                         verrors.add(schema, 'Invalid ZVOL choice.')
 

--- a/tests/api2/test_virt_vm.py
+++ b/tests/api2/test_virt_vm.py
@@ -497,7 +497,10 @@ def test_volume_choices_ixvirt():
         call('virt.instance.stop', instance_name, {'force': True, 'timeout': 1}, job=True)
 
         with volume('vmtestzvol', 1024):
+            assert 'vmtestzvol' in call('virt.device.disk_choices')
             with virt_device(instance_name, 'test_disk', {'dev_type': 'DISK', 'source': 'vmtestzvol'}):
+
+                assert 'vmtestzvol' not in call('virt.device.disk_choices')
 
                 # Incus leaves zvols unmounted until VM is started
                 call('virt.instance.start', instance_name)


### PR DESCRIPTION
This is related to NAS-134583. The UI team needs an API to provide consistent choices for VM disks. This slight refactor does two things:

1. includes virt.volumes in API response
2. excludes in-use choices from API response

The second point is relevant to API consumers because it makes this API consistent with how choices are handled in other plugins, e.g. iscsi.extents.disk_choices.