### PR TITLE
NAS-134646 / 25.10 / Add the FTP group to builtin group whitelist

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -22,6 +22,7 @@ USERNS_IDMAP_NONE = 0
 # have enhanced privileges to the server and group membership can expose
 # unexpected security issues.
 ALLOWED_BUILTIN_GIDS = {
+    14,  # ftp -- required for FTP access
     544,  # builtin_administrators
     545,  # builtin_users
     568,  # apps


### PR DESCRIPTION
We need to manage membership of the FTP group to control FTP access with default configuration.
This fixes a regression caused by a previous commit to introduce restrictions on changes that
admins can make to builtin groups.

**Changes:**

Add the FTP group to the whitelist of builtin groups that are allowed membership changes.

**Testing:**

No additional testing required. This was caught by automated testing.

### Downstream


|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | None - backend change only
|WebUI           | None - backend change only
