### PR TITLE
NAS-134688 / 25.04.0 / Add support for multiple storage pools to incus

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-03-07_13-40_add-incus-storage-pools.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-03-07_13-40_add-incus-storage-pools.py
@@ -1,0 +1,21 @@
+"""Add incus storage pools
+
+Revision ID: df0bffcf1595
+Revises: 0257529fa6d5
+Create Date: 2025-03-07 13:40:53.611152+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'df0bffcf1595'
+down_revision = '0257529fa6d5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('virt_global', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('storage_pools', sa.Text(), nullable=True))

--- a/src/middlewared/middlewared/api/v25_04_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_device.py
@@ -33,6 +33,13 @@ class Disk(Device):
     destination: str | None = None
     boot_priority: int | None = Field(default=None, ge=0)
     io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None] = None
+    storage_pool: NonEmptyString | None = None
+    '''
+    Storage pool in which the device is located. This must be one
+    of the storage pools listed in virt.global.config output.
+    If this is set to None during device creation, then the default storage
+    pool defined in virt.global.config will be used.
+    '''
 
     @field_validator('source')
     @classmethod

--- a/src/middlewared/middlewared/api/v25_04_0/virt_global.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_global.py
@@ -15,7 +15,10 @@ __all__ = [
 class VirtGlobalEntry(BaseModel):
     id: int
     pool: str | None = None
+    "Default storage pool when creating new instances and volumes"
     dataset: str | None = None
+    storage_pools: list[str] | None = None
+    "ZFS pools to use as storage pools"
     bridge: str | None = None
     v4_network: str | None = None
     v6_network: str | None = None
@@ -29,7 +32,10 @@ class VirtGlobalUpdateResult(BaseModel):
 @single_argument_args('virt_global_update')
 class VirtGlobalUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     pool: NonEmptyString | None = None
+    "Default storage pool when creating new instances and volumes"
     bridge: NonEmptyString | None = None
+    storage_pools: list[str] | None = None
+    "ZFS pools to use as storage pools"
     v4_network: str | None = None
     v6_network: str | None = None
 

--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -69,6 +69,8 @@ class VirtInstanceEntry(BaseModel):
     secure_boot: bool | None
     root_disk_size: int | None
     root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None]
+    storage_pool: NonEmptyString
+    "Storage pool in which the root of the instance is located."
 
 
 # Lets require at least 32MiB of reserved memory
@@ -83,6 +85,12 @@ class VirtInstanceCreateArgs(BaseModel):
     name: Annotated[NonEmptyString, StringConstraints(max_length=200)]
     iso_volume: NonEmptyString | None = None
     source_type: Literal[None, 'IMAGE', 'ZVOL', 'ISO'] = 'IMAGE'
+    storage_pool: NonEmptyString | None = None
+    '''
+    Storage pool under which to allocate root filesystem. Must be one of the pools
+    listed in virt.global.config output under "storage_pools". If None (default) then the pool
+    specified in the global configuration will be used.
+    '''
     image: Annotated[NonEmptyString, StringConstraints(max_length=200)] | None = None
     root_disk_size: int = Field(ge=5, default=10)  # In GBs
     '''

--- a/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
@@ -32,6 +32,7 @@ VOLUME_NAME: TypeAlias = Annotated[
 class VirtVolumeEntry(BaseModel):
     id: NonEmptyString
     name: NonEmptyString
+    storage_pool: NonEmptyString
     content_type: NonEmptyString
     created_at: str
     type: NonEmptyString
@@ -45,6 +46,12 @@ class VirtVolumeCreateArgs(BaseModel):
     content_type: Literal['BLOCK'] = 'BLOCK'
     size: int = Field(ge=512, default=1024)  # 1 gb default
     '''Size of volume in MB and it should at least be 512 MB'''
+    storage_pool: NonEmptyString | None = None
+    '''
+    Storage pool in which to create the volume. This must be one of pools listed
+    in virt.global.config output under `storage_pools`. If the value is None, then
+    the pool defined as `pool` in virt.global.config will be used.
+    '''
 
 
 class VirtVolumeCreateResult(BaseModel):
@@ -78,6 +85,12 @@ class VirtVolumeImportISOArgs(BaseModel):
     '''Specify name of the newly created volume from the ISO specified'''
     iso_location: NonEmptyString | None = None
     upload_iso: bool = False
+    storage_pool: NonEmptyString | None = None
+    '''
+    Storage pool in which to create the volume. This must be one of pools listed
+    in virt.global.config output under `storage_pools`. If the value is None, then
+    the pool defined as `pool` in virt.global.config will be used.
+    '''
 
     @field_validator('iso_location')
     @classmethod

--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -1,4 +1,6 @@
 from typing import TYPE_CHECKING
+import asyncio
+import errno
 import shutil
 import subprocess
 import middlewared.sqlalchemy as sa
@@ -18,7 +20,10 @@ from middlewared.service_exception import CallError
 from middlewared.utils import run
 from middlewared.plugins.boot import BOOT_POOL_NAME_VALID
 
-from .utils import Status, incus_call, VNC_PASSWORD_DIR
+from .utils import (
+    Status, incus_call, VNC_PASSWORD_DIR, TRUENAS_STORAGE_PROP_STR, INCUS_STORAGE
+)
+
 if TYPE_CHECKING:
     from middlewared.main import Middleware
 
@@ -43,6 +48,7 @@ class VirtGlobalModel(sa.Model):
 
     id = sa.Column(sa.Integer(), primary_key=True)
     pool = sa.Column(sa.String(120), nullable=True)
+    storage_pools = sa.Column(sa.Text(), nullable=True)
     bridge = sa.Column(sa.String(120), nullable=True)
     v4_network = sa.Column(sa.String(120), nullable=True)
     v6_network = sa.Column(sa.String(120), nullable=True)
@@ -64,10 +70,16 @@ class VirtGlobalService(ConfigService):
             data['dataset'] = f'{data["pool"]}/.ix-virt'
         else:
             data['dataset'] = None
-        try:
-            data['state'] = await self.middleware.call('cache.get', 'VIRT_STATE')
-        except KeyError:
-            data['state'] = Status.INITIALIZING.value
+
+        if data['storage_pools']:
+            data['storage_pools'] = data['storage_pools'].split()
+        else:
+            data['storage_pools'] = []
+
+        if data['pool'] and data['pool'] not in data['storage_pools']:
+            data['storage_pools'].append(data['pool'])
+
+        data['state'] = INCUS_STORAGE.state.value
         return data
 
     @private
@@ -108,14 +120,50 @@ class VirtGlobalService(ConfigService):
 
         new = old.copy()
         new.update(data)
+        new_storage_pools = set(new['storage_pools']) - set(old['storage_pools'])
+        removed_storage_pools = set(old['storage_pools']) - set(new['storage_pools'])
 
         verrors = ValidationErrors()
         await self.validate(new, 'virt_global_update', verrors)
+
+        pool_choices = await self.pool_choices()
+        for idx, pool in enumerate(new['storage_pools']):
+            if pool in pool_choices:
+                continue
+
+            verrors.add(
+                f'virt_global_update.storage_pools.{idx}',
+                f'{pool}: pool is not available for incus storage'
+            )
+
+        if new['pool'] and old['pool']:
+            # If we're stopping or starting the virt plugin then we don't need to worry
+            # about how storage changes will impact the overall running configuration.
+            for pool in removed_storage_pools:
+                if usage := (await self.storage_pool_usage(pool)):
+                    verrors.add(
+                        'virt_global_update.storage_pools',
+                        f'{pool}: pool to be removed is used by the following assets: {usage}'
+                    )
+
+        if new['pool'] in removed_storage_pools:
+            verrors.add(
+                'virt_global_update.storage_pools',
+                'Default incus pool may not be removed from list of storage pools.'
+            )
+
         verrors.check()
+
+        if new['pool'] and old['pool']:
+            # If we're stopping or starting the virt plugin then we don't need to worry
+            # about how storage changes will impact the overall running configuration.
+            for pool in removed_storage_pools:
+                await self.remove_storage_pool(pool)
 
         # Not part of the database
         new.pop('state')
         new.pop('dataset')
+        new['storage_pools'] = ' '.join(new['storage_pools'])
 
         await self.middleware.call(
             'datastore.update', self._config.datastore,
@@ -181,8 +229,8 @@ class VirtGlobalService(ConfigService):
             raise CallError('Virtualization service not started.')
 
     @private
-    async def get_default_profile(self):
-        result = await incus_call('1.0/profiles/default', 'get')
+    async def get_profile(self, profile_name):
+        result = await incus_call(f'1.0/profiles/{profile_name}', 'get')
         if result.get('status_code') != 200:
             raise CallError(result.get('error'))
         return result['metadata']
@@ -214,23 +262,198 @@ class VirtGlobalService(ConfigService):
         Will create necessary storage datasets if required.
         """
         try:
-            await self.middleware.call('cache.put', 'VIRT_STATE', Status.INITIALIZING.value)
+            INCUS_STORAGE.state = Status.INITIALIZING
             await self._setup_impl()
         except NoPoolConfigured:
-            await self.middleware.call('cache.put', 'VIRT_STATE', Status.NO_POOL.value)
+            INCUS_STORAGE.state = Status.NO_POOL
         except LockedDataset:
-            await self.middleware.call('cache.put', 'VIRT_STATE', Status.LOCKED.value)
+            INCUS_STORAGE.state = Status.LOCKED
         except Exception:
-            await self.middleware.call('cache.put', 'VIRT_STATE', Status.ERROR.value)
+            INCUS_STORAGE.state = Status.ERROR
             raise
         else:
-            await self.middleware.call('cache.put', 'VIRT_STATE', Status.INITIALIZED.value)
+            INCUS_STORAGE.state = Status.INITIALIZED
         finally:
             self.middleware.send_event('virt.global.config', 'CHANGED', fields=await self.config())
             await self.auto_start_instances()
 
+    @private
+    async def setup_storage_pool(self, pool_name):
+        ds_name = f'{pool_name}/.ix-virt'
+        try:
+            ds = await self.middleware.call(
+                'zfs.dataset.get_instance', ds_name, {
+                    'extra': {
+                        'retrieve_children': False,
+                        'user_properties': True,
+                        'properties': ['encryption', 'keystatus'],
+                    }
+                },
+            )
+        except Exception:
+            ds = None
+        if not ds:
+            await self.middleware.call('zfs.dataset.create', {
+                'name': ds_name,
+                'properties': {
+                    'aclmode': 'discard',
+                    'acltype': 'posix',
+                    'exec': 'on',
+                    'casesensitivity': 'sensitive',
+                    'atime': 'off',
+                    TRUENAS_STORAGE_PROP_STR: pool_name,
+                },
+            })
+        else:
+            if ds['encrypted'] and not ds['key_loaded']:
+                self.logger.info('Dataset %r not unlocked, skipping virt setup.', ds['name'])
+                raise LockedDataset()
+            if TRUENAS_STORAGE_PROP_STR not in ds['properties']:
+                if INCUS_STORAGE.default_storage_pool is not None:
+                    if INCUS_STORAGE.default_storage_pool != pool_name:
+                        raise CallError(
+                            f'ZFS pools {pool_name} and {INCUS_STORAGE.default_storage_pool} are both '
+                            'configured as the default incus storage pool and may therefore not be '
+                            'used simultaneously for virt storage pools.'
+                        )
+                else:
+                    INCUS_STORAGE.default_storage_pool = pool_name
+
+                pool_name = 'default'
+
+            else:
+                expected_pool_name = ds['properties'][TRUENAS_STORAGE_PROP_STR]['value']
+                if pool_name != expected_pool_name:
+                    raise CallError(
+                        f'The configured incus storage pool for the ZFS pool {pool_name} '
+                        f'is {expected_pool_name}, which should match the ZFS pool name. '
+                        'This mismatch may indicate that the TrueNAS ix-virt dataset was '
+                        'not initially created on this ZFS pool.'
+                    )
+
+        storage = await incus_call(f'1.0/storage-pools/{pool_name}', 'get')
+        if storage['type'] != 'error':
+            if storage['metadata']['config']['source'] == ds_name:
+                self.logger.debug('Virt storage pool for %s already configured.', ds_name)
+                pool_name = None  # skip recovery
+            else:
+                job = await self.middleware.call('virt.global.reset', True, None)
+                await job.wait(raise_error=True)
+
+        return pool_name
+
+    @private
+    async def storage_pool_usage(self, pool_name):
+        """
+        Create a list of various user-managed incus assets that are
+        dependent on the specified pool. This can be used for validation prior
+        to deletion of an incus storage pool.
+        """
+        resp = await incus_call(f'1.0/storage-pools/{pool_name}', 'get')
+        if resp['type'] == 'error':
+            if resp['error_code'] == 404:
+                # storage doesn't exist. Nothing to do.
+                return []
+
+            raise CallError(resp['error'])
+
+        out = []
+
+        for dependent in resp['metadata']['used_by']:
+            if dependent.startswith(('/1.0/images/')):
+                continue
+
+            path = dependent.split('/')
+            if 'storage-pools' in path:
+                # sample:
+                # /1.0/storage-pools/dozer/volumes/custom/foo
+                incus_type = path[4]
+            else:
+                # sample:
+                # /1.0/instances/myinstance
+                incus_type = path[2]
+
+            out.append({'type': incus_type, 'name': path[-1]})
+
+        return out
+
+    @private
+    async def recover(self, to_import):
+        """
+        Call into incus's private API to initiate a recovery action.
+        This is roughly equivalent to running the command "incus admin recover", and is performed
+        to make it so that incus on TrueNAS does not rely on the contents of /var/lib/incus.
+
+        https://linuxcontainers.org/incus/docs/main/reference/manpages/incus/admin/recover/#incus-admin-recover-md
+
+        The current design is to do this in the following scenarios:
+        1. Setting up incus for this first time on the server
+        2. After change to the storage pool path
+        3. After an HA failover event
+        4. After TrueNAS upgrades
+
+        NOTE: this will potentially cause user-initiated changes from incus commands to be lost.
+        """
+        payload = {
+            'pools': to_import,
+            'project': 'default',
+        }
+
+        result = await incus_call('internal/recover/validate', 'post', {'json': payload})
+        if result['type'] == 'error':
+            raise CallError(f'Internal storage validation failed: {result["error"]}')
+
+        elif result.get('status') == 'Success':
+            if result['metadata']['DependencyErrors']:
+                raise CallError('Missing depedencies: ' + ', '.join(result['metadata']['DependencyErrors']))
+
+            result = await incus_call('internal/recover/import', 'post', {'json': payload})
+            if result.get('status') != 'Success':
+                raise CallError(result.get('error'))
+        else:
+            raise CallError('Internal storage validation failed')
+
+    @private
+    async def remove_storage_pool(self, pool_name):
+        resp = await incus_call(f'1.0/storage-pools/{pool_name}', 'get')
+        if resp['type'] == 'error':
+            if resp['error_code'] == 404:
+                # storage doesn't exist. Nothing to do.
+                return
+
+            raise CallError(resp['error'])
+
+        to_delete = []
+
+        for dependent in resp['metadata']['used_by']:
+            # Middleware internally manages the images and profiles for
+            # storage pools
+            if dependent.startswith('/1.0/images/'):
+                to_delete.append(dependent)
+
+        if remainder := (set(resp['metadata']['used_by']) - set(to_delete)):
+            raise CallError(
+                f'Storage volume currently used by the following incus resource {", ".join(remainder)}', errno.EBUSY
+            )
+
+        for entry in to_delete:
+            path = entry[1:]  # remove leading slash
+            resp = await incus_call(path, 'delete')
+            if resp['type'] == 'error' and resp['error_code'] != 404:
+                raise CallError(f"{resp['error_code']}: {resp['error']}")
+
+        # Finally remove the pool itself
+        # We get intermittent errors here from incus API (appears to be replaying last command)
+        # unless we have a sleep
+        await asyncio.sleep(1)
+
+        resp = await incus_call(f'1.0/storage-pools/{pool_name}', 'delete')
+        if resp['type'] == 'error':
+            raise CallError(resp['error'])
+
     async def _setup_impl(self):
         config = await self.config()
+        to_import = []
 
         if not config['pool']:
             if await self.middleware.call('service.started', 'incus'):
@@ -240,45 +463,17 @@ class VirtGlobalService(ConfigService):
             self.logger.debug('No pool set for virtualization, skipping.')
             raise NoPoolConfigured()
         else:
-            await self.middleware.call('service.start', 'incus')
+            await self.middleware.call('service.start', 'incus', {'ha_propagate': False})
 
-        try:
-            ds = await self.middleware.call(
-                'zfs.dataset.get_instance', config['dataset'], {
-                    'extra': {
-                        'retrieve_children': False,
-                        'user_properties': False,
-                        'properties': ['encryption', 'keystatus'],
-                    }
-                },
-            )
-        except Exception:
-            ds = None
-        if not ds:
-            await self.middleware.call('zfs.dataset.create', {
-                'name': config['dataset'],
-                'properties': {
-                    'aclmode': 'discard',
-                    'acltype': 'posix',
-                    'exec': 'on',
-                    'casesensitivity': 'sensitive',
-                    'atime': 'off',
-                },
-            })
-        else:
-            if ds['encrypted'] and not ds['key_loaded']:
-                self.logger.info('Dataset %r not unlocked, skipping virt setup.', ds['name'])
-                raise LockedDataset()
-
-        import_storage = True
-        storage = await incus_call('1.0/storage-pools/default', 'get')
-        if storage['type'] != 'error':
-            if storage['metadata']['config']['source'] == config['dataset']:
-                self.logger.debug('Storage pool for virt already configured.')
-                import_storage = False
-            else:
-                job = await self.middleware.call('virt.global.reset', True, config)
-                await job.wait(raise_error=True)
+        # Set up the default storage pool
+        for pool in config['storage_pools']:
+            if (pool_name := (await self.setup_storage_pool(pool))) is not None:
+                to_import.append({
+                    'config': {'source': f'{pool}/.ix-virt'},
+                    'description': '',
+                    'name': pool_name,
+                    'driver': 'zfs',
+                })
 
         # If no bridge interface has been set, use incus managed
         if not config['bridge']:
@@ -355,57 +550,19 @@ class VirtGlobalService(ConfigService):
                 'parent': config['bridge'],
             }
 
-        if import_storage:
-            # Call into incus's private API to initiate a recovery action.
-            # This is roughly equivalent to running the command "incus admin recover", and is performed
-            # to make it so that incus on TrueNAS does not rely on the contents of /var/lib/incus.
-            #
-            # https://linuxcontainers.org/incus/docs/main/reference/manpages/incus/admin/recover/#incus-admin-recover-md
-            #
-            # The current design is to do this in the following scenarios:
-            # 1. Setting up incus for this first time on the server
-            # 2. After change to the storage pool path
-            # 3. After an HA failover event
-            # 4. After TrueNAS upgrades
-            #
-            # NOTE: this will potentially cause user-initiated changes from incus commands to be lost.
-            payload = {
-                'pools': [{
-                    'config': {'source': config['dataset']},
-                    'description': '',
-                    'name': 'default',
-                    'driver': 'zfs',
-                }],
-            }
-            result = await incus_call('internal/recover/validate', 'post', {'json': payload})
-            if result.get('status') == 'Success':
-                if result['metadata']['DependencyErrors']:
-                    raise CallError('Missing depedencies: ' + ', '.join(result['metadata']['DependencyErrors']))
-                result = await incus_call('internal/recover/import', 'post', {'json': payload})
-                if result.get('status') != 'Success':
-                    raise CallError(result.get('error'))
-            else:
-                raise CallError('Invalid storage')
-
         result = await incus_call('1.0/profiles/default', 'put', {'json': {
             'config': {},
             'description': 'Default TrueNAS profile',
             'devices': {
-                'root': {
-                    'path': '/',
-                    'pool': 'default',
-                    'type': 'disk',
-                },
                 'eth0': nic,
             },
         }})
         if result.get('status') != 'Success':
             raise CallError(result.get('error'))
 
-        # If storage was imported we need to restart incus service so instances
-        # with autostart can be started
-        if import_storage:
-            await self.middleware.call('service.restart', 'incus')
+        if to_import:
+            await self.recover(to_import)
+            await self.middleware.call('service.restart', 'incus', {'ha_propagate': False})
 
     @private
     @job()
@@ -428,7 +585,7 @@ class VirtGlobalService(ConfigService):
             if await self.middleware.call('virt.instance.query', [('status', '=', 'RUNNING')]):
                 raise CallError('Failed to stop instances')
 
-        await self.middleware.call('service.stop', 'incus')
+        await self.middleware.call('service.stop', 'incus', {'ha_propagate': False})
         if await self.middleware.call('service.started', 'incus'):
             raise CallError('Failed to stop virtualization service')
 
@@ -446,7 +603,7 @@ class VirtGlobalService(ConfigService):
         # and we do have instances datasets that might be mounted beneath
         await run(f'rm -rf --one-file-system {INCUS_PATH}/*', shell=True, check=True)
 
-        if start and not await self.middleware.call('service.start', 'incus'):
+        if start and not await self.middleware.call('service.start', 'incus', {'ha_propagate': False}):
             raise CallError('Failed to start virtualization service')
 
         if not start:

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -23,7 +23,8 @@ from middlewared.api.current import (
 )
 from .utils import (
     create_vnc_password_file, get_vnc_info_from_config, get_root_device_dict, get_vnc_password_file_path,
-    Status, incus_call, incus_call_and_wait, VNC_BASE_PORT,
+    Status, incus_call, incus_call_and_wait, VNC_BASE_PORT, root_device_pool_from_raw,
+    storage_pool_to_incus_pool, incus_pool_to_storage_pool,
 )
 
 
@@ -91,6 +92,7 @@ class VirtInstanceService(CRUDService):
                 'secure_boot': None,
                 'root_disk_size': None,
                 'root_disk_io_bus': None,
+                'storage_pool': incus_pool_to_storage_pool(root_device_pool_from_raw(i)),
             }
             if entry['type'] == 'VM':
                 entry['secure_boot'] = True if i['config'].get('security.secureboot') == 'true' else False
@@ -160,6 +162,11 @@ class VirtInstanceService(CRUDService):
             verrors.add(
                 f'{schema_name}.instance_type', f'System is not licensed to manage {instance_type!r} instances'
             )
+
+        if new.get('storage_pool'):
+            valid_pools = await self.middleware.call('virt.global.pool_choices')
+            if new['storage_pool'] not in valid_pools:
+                verrors.add(f'{schema_name}.storage_pool', 'Not a valid ZFS pool')
 
         if not old and await self.query([('name', '=', new['name'])]):
             verrors.add(f'{schema_name}.name', f'Name {new["name"]!r} already exists')
@@ -346,6 +353,12 @@ class VirtInstanceService(CRUDService):
         verrors = ValidationErrors()
         await self.validate(data, 'virt_instance_create', verrors)
 
+        if data.get('storage_pool'):
+            pool = storage_pool_to_incus_pool(data['storage_pool'])
+        else:
+            defpool = (await self.middleware.call('virt.global.config'))['pool']
+            pool = storage_pool_to_incus_pool(defpool)
+
         data_devices = data['devices'] or []
         iso_volume = data.pop('iso_volume', None)
         root_device_to_add = None
@@ -365,7 +378,7 @@ class VirtInstanceService(CRUDService):
             root_device_to_add = {
                 'name': iso_volume,
                 'dev_type': 'DISK',
-                'pool': 'default',
+                'pool': pool,
                 'source': iso_volume,
                 'destination': None,
                 'readonly': False,
@@ -378,8 +391,14 @@ class VirtInstanceService(CRUDService):
             data_devices.append(root_device_to_add)
 
         devices = {
-            'root': get_root_device_dict(data['root_disk_size'], data['root_disk_io_bus']),
-        } if data['instance_type'] == 'VM' else {}
+            'root': get_root_device_dict(data['root_disk_size'], data['root_disk_io_bus'], pool),
+        } if data['instance_type'] == 'VM' else {
+            'root': {
+                'path': '/',
+                'pool': pool,
+                'type': 'disk'
+            }
+        }
         for i in data_devices:
             await self.middleware.call(
                 'virt.instance.validate_device', i, 'virt_instance_create', verrors, data['instance_type'],
@@ -421,6 +440,7 @@ class VirtInstanceService(CRUDService):
                 'mode': 'pull',
                 'alias': data['image'],
             })
+
         try:
             await incus_call_and_wait('1.0/instances', 'post', {'json': {
                 'name': data['name'],
@@ -428,6 +448,7 @@ class VirtInstanceService(CRUDService):
                 'config': self.__data_to_config(data['name'], data, instance_type=data['instance_type']),
                 'devices': devices,
                 'source': source,
+                'profiles': ['default'],
                 'type': 'container' if data['instance_type'] == 'CONTAINER' else 'virtual-machine',
                 'start': False,
             }}, running_cb, timeout=15 * 60)
@@ -479,9 +500,12 @@ class VirtInstanceService(CRUDService):
 
         instance['raw']['config'].update(self.__data_to_config(id, data, instance['raw']['config'], instance['type']))
         if data.get('root_disk_size') or data.get('root_disk_io_bus'):
+            if (pool := root_device_pool_from_raw(instance['raw'])) is None:
+                raise CallError(f'{id}: instance does not have a configured pool')
+
             root_disk_size = data.get('root_disk_size') or int(instance['root_disk_size'] / (1024 ** 3))
             io_bus = data.get('root_disk_io_bus') or instance['root_disk_io_bus']
-            instance['raw']['devices']['root'] = get_root_device_dict(root_disk_size, io_bus)
+            instance['raw']['devices']['root'] = get_root_device_dict(root_disk_size, io_bus, pool)
 
         await incus_call_and_wait(f'1.0/instances/{id}', 'put', {'json': instance['raw']})
 

--- a/src/middlewared/middlewared/plugins/virt/volume.py
+++ b/src/middlewared/middlewared/plugins/virt/volume.py
@@ -9,7 +9,7 @@ from middlewared.api.current import (
 from middlewared.service import CallError, CRUDService, job, ValidationErrors
 from middlewared.utils import filter_list
 
-from .utils import incus_call, incus_call_sync, Status, incus_wait
+from .utils import incus_call, incus_call_sync, Status, incus_wait, storage_pool_to_incus_pool
 
 
 class VirtVolumeService(CRUDService):
@@ -25,35 +25,50 @@ class VirtVolumeService(CRUDService):
         if config['state'] != Status.INITIALIZED.value:
             return []
 
-        storage_devices = await incus_call('1.0/storage-pools/default/volumes/custom?recursion=2', 'get')
-        if storage_devices.get('status_code') != 200:
-            return []
-
         entries = []
-        for storage_device in storage_devices['metadata']:
-            entries.append({
-                'id': storage_device['name'],
-                'name': storage_device['name'],
-                'content_type': storage_device['content_type'].upper(),
-                'created_at': storage_device['created_at'],
-                'type': storage_device['type'],
-                'config': storage_device['config'],
-                'used_by': [instance.replace('/1.0/instances/', '') for instance in storage_device['used_by']]
-            })
-            if storage_device['config'].get('size'):
-                entries[-1]['config']['size'] = int(storage_device['config']['size']) // (1024 * 1024)
+        for storage_pool in config['storage_pools']:
+            pool = storage_pool_to_incus_pool(storage_pool)
+            storage_devices = await incus_call(f'1.0/storage-pools/{pool}/volumes/custom?recursion=2', 'get')
+            if storage_devices.get('status_code') != 200:
+                # This particular pool may not be available
+                continue
+
+            for storage_device in storage_devices['metadata']:
+                entries.append({
+                    'id': storage_device['name'],
+                    'name': storage_device['name'],
+                    'content_type': storage_device['content_type'].upper(),
+                    'created_at': storage_device['created_at'],
+                    'type': storage_device['type'],
+                    'storage_pool': storage_pool,
+                    'config': storage_device['config'],
+                    'used_by': [instance.replace('/1.0/instances/', '') for instance in storage_device['used_by']]
+                })
+                if storage_device['config'].get('size'):
+                    entries[-1]['config']['size'] = int(storage_device['config']['size']) // (1024 * 1024)
+
         return filter_list(entries, filters, options)
 
     @api_method(VirtVolumeCreateArgs, VirtVolumeCreateResult)
     async def do_create(self, data):
         await self.middleware.call('virt.global.check_initialized')
+        global_config = await self.middleware.call('virt.global.config')
+        target_pool = global_config['pool'] if not data['storage_pool'] else data['storage_pool']
 
         verrors = ValidationErrors()
         if await self.middleware.call('virt.volume.query', [['id', '=', data['name']]]):
             verrors.add('virt_volume_create.name', 'Volume with this name already exists')
+
+        if target_pool not in global_config['storage_pools']:
+            verrors.add(
+                'virt_volume_create.storage_pool',
+                f'Not a valid storage pool. Choices are: {", ".join(global_config["storage_pools"])}'
+            )
+
         verrors.check()
 
-        result = await incus_call('1.0/storage-pools/default/volumes/custom', 'post', {
+        incus_pool = storage_pool_to_incus_pool(target_pool)
+        result = await incus_call(f'1.0/storage-pools/{incus_pool}/volumes/custom', 'post', {
             'json': {
                 'name': data['name'],
                 'content_type': data['content_type'].lower(),
@@ -73,7 +88,8 @@ class VirtVolumeService(CRUDService):
         if data.get('size') is None:
             return volume
 
-        result = await incus_call(f'1.0/storage-pools/default/volumes/custom/{name}', 'patch', {
+        pool = storage_pool_to_incus_pool(volume['storage_pool'])
+        result = await incus_call(f'1.0/storage-pools/{pool}/volumes/custom/{name}', 'patch', {
             'json': {
                 'config': {
                     'size': str(data['size'] * 1024 * 1024)
@@ -91,7 +107,8 @@ class VirtVolumeService(CRUDService):
         if volume['used_by']:
             raise CallError(f'Volume {name!r} is in use by instances: {", ".join(volume["used_by"])}')
 
-        result = await incus_call(f'1.0/storage-pools/default/volumes/custom/{name}', 'delete')
+        pool = storage_pool_to_incus_pool(volume['storage_pool'])
+        result = await incus_call(f'1.0/storage-pools/{pool}/volumes/custom/{name}', 'delete')
         if result.get('status_code') != 200:
             raise CallError(f'Failed to delete volume: {result["error"]}')
 
@@ -101,6 +118,12 @@ class VirtVolumeService(CRUDService):
     @job(lock=lambda args: f'virt_volume_import_iso_{args[0]}', pipes=['input'], check_pipes=False)
     async def import_iso(self, job, data):
         await self.middleware.call('virt.global.check_initialized')
+        global_config = await self.middleware.call('virt.global.config')
+        target_pool = global_config['pool'] if not data['storage_pool'] else data['storage_pool']
+        if target_pool not in global_config['storage_pools']:
+            raise CallError('Not a valid storage pool')
+
+        target_pool = storage_pool_to_incus_pool(target_pool)
 
         if data['upload_iso']:
             job.check_pipe('input')
@@ -126,14 +149,14 @@ class VirtVolumeService(CRUDService):
             job.set_progress(25, 'Importing ISO as incus volume')
             if data['upload_iso']:
                 return incus_call_sync(
-                    '1.0/storage-pools/default/volumes/custom',
+                    f'1.0/storage-pools/{target_pool}/volumes/custom',
                     'post',
                     request_kwargs=request_kwargs | {'data': read_input_stream()},
                 )
             else:
                 with open(data['iso_location'], 'rb') as f:
                     return incus_call_sync(
-                        '1.0/storage-pools/default/volumes/custom',
+                        f'1.0/storage-pools/{target_pool}/volumes/custom',
                         'post',
                         request_kwargs=request_kwargs | {'data': f},
                     )
@@ -144,4 +167,3 @@ class VirtVolumeService(CRUDService):
 
         job.set_progress(95, 'ISO successfully imported as incus volume')
         return await self.get_instance(data['name'])
-

--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -32,8 +32,13 @@ def import_iso_as_volume(volume_name: str, pool_name: str, size: int):
 
 
 @contextlib.contextmanager
-def volume(volume_name: str, size: int):
-    vol = call('virt.volume.create', {'name': volume_name, 'size': size, 'content_type': 'BLOCK'})
+def volume(volume_name: str, size: int, storage_pool: str | None = None):
+    vol = call('virt.volume.create', {
+        'name': volume_name,
+        'size': size,
+        'content_type': 'BLOCK',
+        'storage_pool': storage_pool
+    })
     try:
         yield vol
     finally:

--- a/tests/api2/test_virt_storage_pool.py
+++ b/tests/api2/test_virt_storage_pool.py
@@ -1,0 +1,191 @@
+import pytest
+
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.assets.virt import (
+    virt,
+    virt_device,
+    virt_instance,
+    volume,
+)
+from middlewared.test.integration.utils import call
+from truenas_api_client import ValidationErrors as ClientValidationErrors
+
+
+@pytest.fixture(scope='module')
+def virt_init():
+    # NOTE this yields only initial config
+    with virt() as v:
+        yield v
+
+
+@pytest.fixture(scope='module')
+def virt_two_pools(virt_init):
+    with another_pool() as pool:
+        call('virt.global.update', {'storage_pools': [virt_init['pool'], pool['name']]}, job=True)
+        config = call('virt.global.config')
+        assert len(config['storage_pools']) == 2
+
+        try:
+            yield (pool, config)
+        finally:
+            call('virt.global.update', {'storage_pools': virt_init['storage_pools']}, job=True)
+
+
+def test_add_second_pool(virt_init):
+    with another_pool() as pool:
+        pool_choices = call('virt.global.pool_choices')
+        assert pool['name'] in pool_choices
+
+        call('virt.global.update', {'storage_pools': [virt_init['pool'], pool['name']]}, job=True)
+
+        try:
+            config = call('virt.global.config')
+            assert config['state'] == 'INITIALIZED'
+            assert pool['name'] in config['storage_pools']
+        finally:
+            call('virt.global.update', {'storage_pools': [virt_init['pool']]}, job=True)
+
+
+def test_add_instance_second_pool(virt_two_pools):
+    pool, config = virt_two_pools
+
+    # Simply adding the pool should not be treated as an attachment
+    assert call('pool.dataset.attachments', pool['name']) == []
+
+    with virt_instance('inst-second-pool', storage_pool=pool['name']) as instance:
+        assert instance['storage_pool'] == pool['name']
+
+        dsa = call('pool.dataset.attachments', pool['name'])
+        assert len(dsa) == 1
+
+        assert dsa[0]['type'] == 'Virtualization'
+        assert dsa[0]['attachments'] == ['inst-second-pool']
+
+        with pytest.raises(ClientValidationErrors, match='pool to be removed is used by the following assets'):
+
+            # Trying to remove pool holding instances should fail
+            call('virt.global.update', {'storage_pools': [config['pool']]}, job=True)
+
+    # Removing instance should cause attachment to be removed
+    assert call('pool.dataset.attachments', pool['name']) == []
+
+
+def test_add_volume_second_pool(virt_two_pools):
+    pool, config = virt_two_pools
+    VOLNAME = 'test-vol-pool2'
+
+    # Make sure we're in a clean state
+    assert call('pool.dataset.attachments', pool['name']) == []
+
+    with volume(VOLNAME, 1024, pool['name']):
+        vol = call('virt.volume.get_instance', VOLNAME)
+        assert vol['storage_pool'] == pool['name']
+
+        # Simply creating a volume handled by incus should not create a pool attachment
+        assert call('pool.dataset.attachments', pool['name']) == []
+
+
+def test_virt_device_second_pool(virt_two_pools):
+    pool, config = virt_two_pools
+
+    # Make sure we're in a clean state
+    assert call('pool.dataset.attachments', pool['name']) == []
+
+    with virt_instance(
+        'inst-second-pool',
+        storage_pool=pool['name'],
+        instance_type='VM'
+    ) as instance:
+        instance_name = instance['name']
+
+        assert instance['storage_pool'] == pool['name']
+
+        # Make sure that VMs also generate attachments properly
+        dsa = call('pool.dataset.attachments', pool['name'])
+        assert len(dsa) == 1
+
+        assert dsa[0]['type'] == 'Virtualization'
+        assert dsa[0]['attachments'] == ['inst-second-pool']
+
+        call('virt.instance.stop', instance_name, {'force': True, 'timeout': 1}, job=True)
+
+        with volume('vmtestzvol', 1024, pool['name']):
+            assert 'vmtestzvol' in call('virt.device.disk_choices')
+
+            with virt_device(instance_name, 'test_disk', {'dev_type': 'DISK', 'source': 'vmtestzvol'}):
+                devices = call('virt.instance.device_list', instance_name)
+                root_pool = None
+                test_disk_pool = None
+
+                for device in devices:
+                    if device['name'] == 'root':
+                        root_pool = device['storage_pool']
+
+                    elif device.get('source') == 'vmtestzvol':
+                        test_disk_pool = device['storage_pool']
+
+                assert root_pool == pool['name']
+                assert test_disk_pool == pool['name']
+
+
+def test_virt_span_two_pools(virt_two_pools):
+    pool, config = virt_two_pools
+
+    # Make sure we're in a clean state
+    assert call('pool.dataset.attachments', pool['name']) == []
+    assert call('pool.dataset.attachments', config['pool']) == []
+
+    # Sanity check that we're properly testing both pools
+    assert pool['name'] != config['pool']
+
+    with virt_instance(
+        'inst-second-pool',
+        storage_pool=pool['name'],
+        instance_type='VM'
+    ) as instance:
+        instance_name = instance['name']
+
+        assert instance['storage_pool'] == pool['name']
+
+        # Make sure that VMs also generate attachments properly
+        dsa = call('pool.dataset.attachments', pool['name'])
+        assert len(dsa) == 1
+
+        assert dsa[0]['type'] == 'Virtualization'
+        assert dsa[0]['attachments'] == ['inst-second-pool']
+
+        # Make sure VM is not attached to the other pool
+        assert call('pool.dataset.attachments', config['pool']) == []
+
+        call('virt.instance.stop', instance_name, {'force': True, 'timeout': 1}, job=True)
+
+        # create volume on other pool and attach to VM as disk
+        with volume('vmtestzvol', 1024, config['pool']):
+            assert 'vmtestzvol' in call('virt.device.disk_choices')
+
+            with virt_device(instance_name, 'test_disk', {'dev_type': 'DISK', 'source': 'vmtestzvol'}):
+                devices = call('virt.instance.device_list', instance_name)
+                root_pool = None
+                test_disk_pool = None
+
+                for device in devices:
+                    if device['name'] == 'root':
+                        root_pool = device['storage_pool']
+
+                    elif device.get('source') == 'vmtestzvol':
+                        test_disk_pool = device['storage_pool']
+
+                assert root_pool == pool['name']
+                assert test_disk_pool == config['pool']
+
+                # The volume on other pool should cause VM to show as attached to it
+                dsa = call('pool.dataset.attachments', config['pool'])
+                assert len(dsa) == 1
+                assert dsa[0]['type'] == 'Virtualization'
+                assert dsa[0]['attachments'] == ['inst-second-pool']
+
+        # volume should be removed from VM now, removing attachment
+        assert call('pool.dataset.attachments', config['pool']) == []
+
+    # instance should be removed now
+    assert call('pool.dataset.attachments', pool['name']) == []

--- a/tests/unit/test_virt_utils.py
+++ b/tests/unit/test_virt_utils.py
@@ -1,0 +1,40 @@
+import pytest
+
+from middlewared.plugins.virt import utils
+
+storage = utils.INCUS_STORAGE
+
+DEFAULT_POOL = 'pool_default'
+REGULAR_POOL = 'pool_regular'
+
+
+@pytest.fixture(scope='function')
+def default_storage_pool():
+    storage.default_storage_pool = 'pool_default'
+    try:
+        yield
+    finally:
+        storage.default_storage_pool = None
+
+
+def test__init_storage_value():
+    assert storage.state is utils.Status.INITIALIZING
+    assert storage.default_storage_pool is None
+
+
+@pytest.mark.parametrize('status', utils.Status)
+def test__setting_storage_state(status):
+    storage.state = status
+    assert storage.state is status
+
+
+def test__setting_invalid_storage_status():
+    with pytest.raises(TypeError):
+        storage.state = 'Canary'
+
+
+def test_default_storage_pool(default_storage_pool):
+    assert utils.storage_pool_to_incus_pool(DEFAULT_POOL) == 'default'
+    assert utils.storage_pool_to_incus_pool(REGULAR_POOL) == REGULAR_POOL
+    assert utils.incus_pool_to_storage_pool('default') == DEFAULT_POOL
+    assert utils.incus_pool_to_storage_pool(REGULAR_POOL) == REGULAR_POOL


### PR DESCRIPTION
This commit adds the ability for the administrator to configure multiple storage pools for incus on TrueNAS. This is required in order to give administrators flexibility about where to store instances and the ability to shift them to different storage pools.

Due to the complexity of potential incus instance configurations, failure to initialize any incus storage pool is treated from the standpoint of middleware as a global failure to properly set up the virt plugin.

Since it touches all areas of the virt plugin APIs it is a pre-requisite for developing backup / restore and snapshot endpoints.

The middleware virt plugin has been changed in the following ways:

* virt.global.config / virt.global.update -- these methods now have a storage_pools key, that provides a list of ZFS pools that are configured for use with incus. There is a 1-1 correspondence between incus storage pool name and ZFS pool name.

  As a result of this change, the `pool` key in virt.global indicates the default pool in which new instances and volumes will be created if the optional `storage_pool` key from relevant API payload is omitted. This is to maintain backwards-compatibility with earlier API behavior so as to keep the UI in a functional state until the new storage behavior can be implemented.

  Storage pools are removed from the running configuration and deleted from the incus config by removing from the `storage_pools` list. Attempts to remove pools that are in use by incus instances or volumes will raise a ValidationError until those instances or volumes are deleted.

* virt.instance -- entries now contain a `storage_pool` key indicating the incus / ZFS pool in which the instance's root filesystem is located. As a result of this, changing the location of the root filesystem of an instance will result in changing the `storage_pool` in which that instance appears.

* virt.instance.create -- this methods now can take an additional key in the creation payload: `storage_pool`. If specified, then the instance's root filesystem will be created in the specified pool. If omitted, then the instance will be created in the pool designated as the default `pool` in `virt.global.config` output.

* virt.volume -- entries now contain a `storage_pool` key indicating the incus / ZFS pool in which the volume is located.

* virt.volume.create -- this methods now can take an additional key in the creation payload: `storage_pool`. If specified, then the volume will be created in the specified pool. If omitted, then the instance will be created in the pool designated as the default `pool` in `virt.global.config` output.

* virt.instance.device_* -- Disk type devices now have a `storage_pool` property indicating the storage pool in which the disk exists.

The middleware API changes corresponds with the following changes for incus configuration:

* The `default` profile now does not include a hard-coded root filesystem disk. The root filesystem for new instances is defined by middleware when it is created through our APIs.

* There is no longer a hard-coded `default` incus storage pool. Storage pools are named based on their underly ZFS pool.