### PR TITLE
NAS-134489 / 25.04.0 / Validate key/values for virt instance's environment variables (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_instance_env.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_instance_env.py
@@ -1,0 +1,107 @@
+import unittest.mock
+
+import pytest
+
+from middlewared.plugins.virt.instance import VirtInstanceService
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service_exception import ValidationErrors
+
+
+@pytest.mark.parametrize('environment, should_work', [
+    (
+        {'': ''},
+        False
+    ),
+    (
+        {'FOO': ''},
+        False
+    ),
+    (
+        {'FOO': '  '},
+        False
+    ),
+    (
+        {'': 'BAR'},
+        False
+    ),
+    (
+        {'    ': '    '},
+        False
+    ),
+    (
+        {'FOO': 'BAR'},
+        True
+    ),
+    (
+        {'FOO': 'bar'},
+        True
+    ),
+    (
+        {'local_host': '127.0.0.1'},
+        True
+    ),
+    (
+        {'123_ABC': 'XYZ'},
+        True
+    ),
+    (
+        {'WORKING_DIR': '/home/user'},
+        True
+    ),
+    (
+        {'API_BASE_URL': 'https://api.example.com/v1/'},
+        True
+    ),
+    (
+        {'@username': 'xyz'},
+        False
+    ),
+    (
+        {'USER': 'truenas admin'},
+        True
+    )
+])
+@unittest.mock.patch('middlewared.plugins.virt.instance.VirtInstanceService.validate')
+@unittest.mock.patch('middlewared.plugins.virt.instance.incus_call_and_wait')
+@unittest.mock.patch('middlewared.plugins.virt.instance.VirtInstanceService.get_account_idmaps')
+@unittest.mock.patch('middlewared.plugins.virt.instance.VirtInstanceService.set_account_idmaps')
+@unittest.mock.patch('middlewared.plugins.virt.instance.VirtInstanceService.start_impl')
+@unittest.mock.patch('middlewared.plugins.virt.instance.incus_call')
+@pytest.mark.asyncio
+async def test_virt_environment_validation(
+    mock_incus_call, mock_start_impl, mock_set_idmaps,
+    mock_get_idmaps, mock_incus_call_and_wait, mock_validate,
+    environment, should_work
+):
+    middleware = Middleware()
+    mock_validate.return_value = None
+    mock_incus_call_and_wait.return_value = None
+    mock_get_idmaps.return_value = []
+    mock_start_impl.return_value = True
+    mock_incus_call.return_value = {'status_code': 400}
+    virt_obj = VirtInstanceService(middleware)
+
+    if should_work:
+        instance = {
+            'name': 'test-vm',
+            'image': 'alpine/3.18/default',
+            'environment': environment,
+            'raw': {'config': {}}
+        }
+        mock_set_idmaps.return_value = instance
+        middleware['virt.global.check_initialized'] = lambda *args: True
+        middleware['virt.instance.get_instance'] = lambda *args: instance
+
+        result = await virt_obj.do_create(12, {
+            'name': 'test-vm',
+            'image': 'alpine/3.18/default',
+            'environment': environment
+        })
+        assert result is not None
+    else:
+        with pytest.raises(ValidationErrors):
+            await virt_obj.do_create(12, {
+                'name': 'test-vm',
+                'image': 'alpine/3.18/default',
+                'environment': environment
+            })


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 73b39900026858bc4d13b067264149f9a887a39b

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a518e799eb25d8f2884894633d3bffdd0a97a232

## Context

Earlier we were allowing anything to be specified for key/value in a virt instance's environment. This has been restricted by adding some basic validation to what kind of values are allowed (inspired from https://linuxcontainers.org/incus/docs/main/environment/).

Original PR: https://github.com/truenas/middleware/pull/15931
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134489