### PR TITLE
NAS-134693 / 25.04.0 / If local group does not exist then skip the userns_idmap check (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/privilege.py
+++ b/src/middlewared/middlewared/plugins/account_/privilege.py
@@ -182,6 +182,8 @@ class PrivilegeService(CRUDService):
                     "This error may be addressed by either re-creating the missing group "
                     "with the specified group id or removing this entry from the privilege."
                 )
+                # If the group does not exist then cannot check the userns_idmap
+                continue
 
             # Currently only local groups may have privileges
             if groups['by_gid'][local_group_id]['userns_idmap']:


### PR DESCRIPTION
In PR #15832 an additional (`userns_idmap`) check was added to `_validate`.  However, when the local group is not present this causes a `KeyError` exception.  If we have already detected that the group is not present, then skip the second check.

----

CI run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3494/).

Original PR: https://github.com/truenas/middleware/pull/15951
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134693