### PR TITLE
NAS-134627 / 25.04.0 / Add reboot and shutdown audit rules (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/utils/auditd.py
+++ b/src/middlewared/middlewared/utils/auditd.py
@@ -16,17 +16,18 @@ class AUDITRules(enum.StrEnum):
     MODULE = '43-module-load.rules'
     FINALIZE = '99-finalize.rules'
     COMMUNITY = 'truenas-community-edition.rules'
+    TRUENAS = 'truenas.rules'  # Rules for all versions of TrueNAS
 
 
 # Set of rules applied for STIG mode
 STIG_AUDIT_RULES = frozenset([
     AUDITRules.BASE, AUDITRules.STIG, AUDITRules.PRIVILEGED,
-    AUDITRules.MODULE, AUDITRules.FINALIZE
+    AUDITRules.MODULE, AUDITRules.TRUENAS, AUDITRules.FINALIZE
 ])
 
 # Set of rules applied in Non-STIG mode (default)
 NOSTIG_AUDIT_RULES = frozenset([
-    AUDITRules.BASE, AUDITRules.COMMUNITY
+    AUDITRules.BASE, AUDITRules.TRUENAS, AUDITRules.COMMUNITY
 ])
 
 

--- a/tests/unit/test_auditd_rules.py
+++ b/tests/unit/test_auditd_rules.py
@@ -13,11 +13,12 @@ IMMUTABLE_STIG_RULE = "-e 2"
 SAMPLE_CE_RULE = "-a always,exclude -F msgtype=USER_START"
 # Common test items
 INCUS_RULE = "-a always,exit -F arch=b64 -S all -F path=/usr/bin/incus -F perm=x -F auid!=-1 -F key=escalation"
+REBOOT_RULE = "-a exit,always -F arch=b64 -S execve -F path=/sbin/reboot -k escalation"
 
-STIG_ASSERT_IN = [MODULE_STIG_RULE, SAMPLE_STIG_RULE]  # TODO:  IMMUTABLE_STIG_RULE when enabled
+STIG_ASSERT_IN = [MODULE_STIG_RULE, SAMPLE_STIG_RULE, REBOOT_RULE]  # TODO:  IMMUTABLE_STIG_RULE when enabled
 STIG_ASSERT_NOT_IN = [SAMPLE_CE_RULE]
 
-NON_STIG_ASSERT_IN = [SAMPLE_CE_RULE, INCUS_RULE]
+NON_STIG_ASSERT_IN = [SAMPLE_CE_RULE, INCUS_RULE, REBOOT_RULE]
 NON_STIG_ASSERT_NOT_IN = [SAMPLE_STIG_RULE]
 
 

--- a/tests/unit/test_auditd_rules.py
+++ b/tests/unit/test_auditd_rules.py
@@ -13,7 +13,7 @@ IMMUTABLE_STIG_RULE = "-e 2"
 SAMPLE_CE_RULE = "-a always,exclude -F msgtype=USER_START"
 # Common test items
 INCUS_RULE = "-a always,exit -F arch=b64 -S all -F path=/usr/bin/incus -F perm=x -F auid!=-1 -F key=escalation"
-REBOOT_RULE = "-a exit,always -F arch=b64 -S execve -F path=/sbin/reboot -k escalation"
+REBOOT_RULE = "-a exit,always -F arch=b64 -S execve -F path=/usr/sbin/reboot -k escalation"
 
 STIG_ASSERT_IN = [MODULE_STIG_RULE, SAMPLE_STIG_RULE, REBOOT_RULE]  # TODO:  IMMUTABLE_STIG_RULE when enabled
 STIG_ASSERT_NOT_IN = [SAMPLE_CE_RULE]


### PR DESCRIPTION
Add common audit rules to trap reboot and shutdown events instigated via command line.
Added simple CI test to confirm rule exists for STIG and non-STIG.

This relies on companion changes in the `audit_rules` repo.

Original PR: https://github.com/truenas/middleware/pull/15954
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134627