### PR TITLE
Fix `mail.send` not working when config overrides are not speficied

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/mail.py
+++ b/src/middlewared/middlewared/api/v25_10_0/mail.py
@@ -109,7 +109,7 @@ class MailUpdateResult(BaseModel):
 
 class MailSendArgs(BaseModel):
     message: MailSendMessage
-    config: MailUpdate
+    config: MailUpdate = Field(default_factory=MailUpdate)
 
 
 class MailSendResult(BaseModel):


### PR DESCRIPTION
(which is a normal use case)