### PR TITLE
NAS-134737 / 25.10 / Expose an endpoint to let consumer select which disk should be used to boot OS

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_device.py
@@ -11,6 +11,7 @@ __all__ = [
     'VirtDeviceDiskChoicesResult', 'VirtDeviceNICChoicesArgs', 'VirtDeviceNICChoicesResult',
     'VirtDeviceExportDiskImageArgs', 'VirtDeviceExportDiskImageResult', 'VirtDeviceImportDiskImageArgs',
     'VirtDeviceImportDiskImageResult', 'VirtDevicePCIChoicesArgs', 'VirtDevicePCIChoicesResult',
+    'VirtInstanceBootableDiskArgs', 'VirtInstanceBootableDiskResult',
 ]
 
 
@@ -196,3 +197,12 @@ class VirtDevicePCIChoicesArgs(BaseModel):
 
 class VirtDevicePCIChoicesResult(BaseModel):
     result: dict
+
+
+class VirtInstanceBootableDiskArgs(BaseModel):
+    id: NonEmptyString
+    disk: NonEmptyString
+
+
+class VirtInstanceBootableDiskResult(BaseModel):
+    result: bool


### PR DESCRIPTION
## Context

UI wanted a simpler way to allow users to select which disk they want to boot virt VM instance from. After discussing with William, an endpoint has been added which when called will get the boot priorities of existing devices and then set the boot priority of the specified disk higher then the highest one already configured to make sure OS boots from the specified disk.