### PR TITLE
NAS-134742 / 25.10 / Improve validation when configuring STIG mode

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -139,6 +139,13 @@ class SystemSecurityService(ConfigService):
                 'Please disable VMs as VMs are not supported under General Purpose OS STIG compatibility mode.'
             )
 
+        if (await self.middleware.call('tn_connect.config'))['enabled']:
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Please disable TrueNAS Connect as it is not supported under '
+                'General Purpose OS STIG compatibility mode.'
+            )
+
     @private
     async def validate(self, is_ha, ha_disabled_reasons):
         schema = 'system_security_update.enable_fips'

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -127,18 +127,16 @@ class SystemSecurityService(ConfigService):
                 'authentication for the currently-authenticated session.'
             )
 
-        if await self.middleware.call('app.query', [], {'count': True}):
+        if (await self.middleware.call('docker.config'))['pool']:
             raise ValidationError(
                 'system_security_update.enable_gpos_stig',
-                'Apps are not supported under General Purpose OS STIG compatibility '
-                'mode.'
+                'Please disable Apps as Apps are not supported under General Purpose OS STIG compatibility mode.'
             )
 
-        if await self.middleware.call('virt.instance.query', [], {'count': True}):
+        if (await self.middleware.call('virt.global.config'))['pool']:
             raise ValidationError(
                 'system_security_update.enable_gpos_stig',
-                'VMs are not supported under General Purpose OS STIG compatibility '
-                'mode.'
+                'Please disable VMs as VMs are not supported under General Purpose OS STIG compatibility mode.'
             )
 
     @private


### PR DESCRIPTION
This PR adds changes to not have docker/incus be configured at the time incus is configured. Motivation behind this is that if we don't want to allow users to have apps/vms when STIG is enabled, there is no reason to have docker/incus daemons run when this is being configured. Secondly we already don't allow to change TNC settings when STIG is enabled, however we were not validating if TNC was already configured at the time STIG was being enabled, so a validation for that has been added as well.