### PR TITLE
NAS-134738 / 25.10 / Fix typo in vfs_fruit configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -183,7 +183,7 @@ def generate_smb_share_conf_dict(
         config_out['posix locking'] = False
 
     if share_config['timemachine']:
-        config_out['fruit:timemachine'] = True
+        config_out['fruit:time machine'] = True
 
         if share_config['timemachine_quota']:
             config_out['fruit:time machine max size'] = share_config['timemachine_quota']

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -362,7 +362,7 @@ def test__tmprotect_preset(nfsacl_dataset):
     ]
 
     assert conf['zfs_core:zfs_auto_create'] == 'true'
-    assert conf['fruit:timemachine'] is True
+    assert conf['fruit:time machine'] is True
 
 
 def test__worm_preset(nfsacl_dataset):
@@ -428,10 +428,10 @@ def test__timemachine(nfsacl_dataset, enabled):
     }, BASE_SMB_CONFIG)
 
     if enabled:
-        assert conf['fruit:timemachine'] is True
+        assert conf['fruit:time machine'] is True
 
     else:
-        assert 'fruit:timemachine' not in conf
+        assert 'fruit:time machine' not in conf
 
 
 @pytest.mark.parametrize('hostsconfig', [
@@ -479,7 +479,7 @@ def test__timemachine_preset(nfsacl_dataset):
         'purpose': 'TIMEMACHINE',
     }, BASE_SMB_CONFIG)
 
-    assert conf['fruit:timemachine'] is True
+    assert conf['fruit:time machine'] is True
 
 
 @pytest.mark.parametrize('audit_config', [


### PR DESCRIPTION
There is supposed to be a space in the configuration parameter for VFS fruit that I accidentally omitted when refactoring from the registry share configuration to flat files. The vfs_fruit parameter "time machine" controls whether the server advertises SMB2_CRTCTX_AAPL_FULL_SYNC among the filesystem capabilities for a share. Originally, this feature was required for time machine, but later MacOS versions appear to not require this.

Unfortunately, smbtorture also does not check for this capability in its tests which means that internally there was no coverage for this typo. Functional test coverage will be added once our jenkins VMs have updated py-libsmb.