### PR TITLE
NAS-134585 / 25.10 / Make sure timeout is set when force is unset on stopping/restarting virt instance

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -215,14 +215,19 @@ class VirtInstanceStopArgs(BaseModel):
     id: str
     stop_args: StopArgs = StopArgs()
 
+    @model_validator(mode='after')
+    def validate_attrs(self):
+        if self.stop_args.force is False and self.stop_args.timeout == -1:
+            raise ValueError('Timeout should be set if force is disabled')
+        return self
+
 
 class VirtInstanceStopResult(BaseModel):
     result: bool
 
 
-class VirtInstanceRestartArgs(BaseModel):
-    id: str
-    stop_args: StopArgs = StopArgs()
+class VirtInstanceRestartArgs(VirtInstanceStopArgs):
+    pass
 
 
 class VirtInstanceRestartResult(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -215,14 +215,19 @@ class VirtInstanceStopArgs(BaseModel):
     id: str
     stop_args: StopArgs = StopArgs()
 
+    @model_validator(mode='after')
+    def validate_attrs(self):
+        if self.stop_args.force is False and self.stop_args.timeout == -1:
+            raise ValueError('Timeout should be set if force is disabled')
+        return self
+
 
 class VirtInstanceStopResult(BaseModel):
     result: bool
 
 
-class VirtInstanceRestartArgs(BaseModel):
-    id: str
-    stop_args: StopArgs = StopArgs()
+class VirtInstanceRestartArgs(VirtInstanceStopArgs):
+    pass
 
 
 class VirtInstanceRestartResult(BaseModel):


### PR DESCRIPTION
## Problem

If force flag is unset and timeout is not specified, there are cases where a virt instance can hang indefinitely on stopping/restarting it.

## Solution

Make sure that when force flag is not set, we force the user to specify a timeout value so we don't have a job which is indefinitely stuck.