### PR TITLE
NAS-134585 / 25.04.0 / Make sure timeout is set when force is unset on stopping/restarting virt instance (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -215,14 +215,19 @@ class VirtInstanceStopArgs(BaseModel):
     id: str
     stop_args: StopArgs = StopArgs()
 
+    @model_validator(mode='after')
+    def validate_attrs(self):
+        if self.stop_args.force is False and self.stop_args.timeout == -1:
+            raise ValueError('Timeout should be set if force is disabled')
+        return self
+
 
 class VirtInstanceStopResult(BaseModel):
     result: bool
 
 
-class VirtInstanceRestartArgs(BaseModel):
-    id: str
-    stop_args: StopArgs = StopArgs()
+class VirtInstanceRestartArgs(VirtInstanceStopArgs):
+    pass
 
 
 class VirtInstanceRestartResult(BaseModel):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x e4f2df52c72477d73456f7aeeec434693ab31f26

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7da9e5e02c0060b95bb5280e7ad7e6aeda138d6e

## Problem

If force flag is unset and timeout is not specified, there are cases where a virt instance can hang indefinitely on stopping/restarting it.

## Solution

Make sure that when force flag is not set, we force the user to specify a timeout value so we don't have a job which is indefinitely stuck.

Original PR: https://github.com/truenas/middleware/pull/15979
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134585