### PR TITLE
NAS-134733 / 25.10 / Mark raw attribute in virt instance as secret in the API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -82,7 +82,7 @@ class VirtInstanceEntry(BaseModel):
     aliases: list[VirtInstanceAlias]
     image: Image
     userns_idmap: UserNsIdmap | None
-    raw: dict | None
+    raw: Secret[dict | None]
     vnc_enabled: bool
     vnc_port: int | None
     vnc_password: Secret[NonEmptyString | None]

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -82,7 +82,7 @@ class VirtInstanceEntry(BaseModel):
     aliases: list[VirtInstanceAlias]
     image: Image
     userns_idmap: UserNsIdmap | None
-    raw: dict | None
+    raw: Secret[dict | None]
     vnc_enabled: bool
     vnc_port: int | None
     vnc_password: Secret[NonEmptyString | None]


### PR DESCRIPTION
## Context

`raw` attribute can contain VNC password configuration so we should mark it as a secret in the pydantic model.