### PR TITLE
NAS-134733 / 25.04.0 / Mark raw attribute in virt instance as secret in the API (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -82,7 +82,7 @@ class VirtInstanceEntry(BaseModel):
     aliases: list[VirtInstanceAlias]
     image: Image
     userns_idmap: UserNsIdmap | None
-    raw: dict | None
+    raw: Secret[dict | None]
     vnc_enabled: bool
     vnc_port: int | None
     vnc_password: Secret[NonEmptyString | None]


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 54bebb6c936ad46eb7f3f33b1e47a8b0c591a679

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 45e64aa310424ebce69346f218b8bb712d7fd8a4

## Context

`raw` attribute can contain VNC password configuration so we should mark it as a secret in the pydantic model.

Original PR: https://github.com/truenas/middleware/pull/15983
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134733