### PR TITLE
NAS-134689 / 25.04.0 / Do not allow users to create pool with whitespaces in name (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -6,6 +6,7 @@ import subprocess
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
 from middlewared.schema import accepts, Bool, Dict, List, returns, Str
 from middlewared.service import CallError, InstanceNotFound, job, private, Service
+from middlewared.validators import Match
 
 from .utils import ZPOOL_CACHE_FILE
 
@@ -65,7 +66,7 @@ class PoolService(Service):
     @accepts(Dict(
         'pool_import',
         Str('guid', required=True),
-        Str('name'),
+        Str('name', validators=[Match(r'^\S+$')]),
         Bool('enable_attachments'),
     ), roles=['POOL_WRITE'])
     @returns(Bool('successful_import'))

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -10,7 +10,7 @@ from middlewared.plugins.zfs_.validation_utils import validate_pool_name
 from middlewared.schema import Bool, Dict, Int, List, Patch, Str
 from middlewared.service import accepts, CallError, CRUDService, job, private, returns, ValidationErrors
 from middlewared.utils.size import format_size
-from middlewared.validators import Range
+from middlewared.validators import Match, Range
 
 from .utils import (
     ZFS_CHECKSUM_CHOICES, ZFS_ENCRYPTION_ALGORITHM_CHOICES, ZPOOL_CACHE_FILE, RE_DRAID_DATA_DISKS, RE_DRAID_SPARE_DISKS
@@ -400,7 +400,7 @@ class PoolService(CRUDService):
 
     @accepts(Dict(
         'pool_create',
-        Str('name', max_length=50, required=True),
+        Str('name', max_length=50, validators=[Match(r'^\S+$')], required=True),
         Bool('encryption', default=False),
         Str('dedup_table_quota', default='AUTO', enum=['AUTO', None, 'CUSTOM'], null=True),
         Int('dedup_table_quota_value', null=True, default=None, validators=[Range(min_=1)]),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 555ea46582899fff53135fec9188f2b999a6b350

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a510b66662b38ac00395f81d3d5e4187a203d11b

## Context

We had added validation earlier to not allow users to set a pool for incus which has whitespaces in it's name because incus is not able to handle pool names which have whitespaces in it. Now we are adding changes to not allow user to create/import a pool with a name which contains whitespaces.

Original PR: https://github.com/truenas/middleware/pull/15984
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134689