### PR TITLE
NAS-134443 / 25.10 / Make sure virt instance is stopped before attempting to delete it

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -71,10 +71,6 @@ def virt_instance(
     try:
         yield instance
     finally:
-        # NAS-134443: currently virt.instance.delete doesn't properly check
-        # for the instance actually stopping before deletion. Once this
-        # is fixed, remove the sleep.
-        sleep(5)
         call('virt.instance.delete', instance_name, job=True)
 
 


### PR DESCRIPTION
## Problem

There has been a case where an incus instance was not able to delete because incus complained that it can't delete a running instance. I have not been able to reproduce it specifically but there was a case which was being missed which was that if the instance is in `UNKNOWN` state which it can be but very briefly - that can result in this issue.


## Solution

Make sure if instance is not stopped, we attempt to force stop it before attempting deletion and if it fails (which it can if the instance is already stopped, we just silently log it) and let deletion go through.