### PR TITLE
NAS-134777 / 25.04.0 / Fix copytree unit test failures (by anodos325)

### DIFF
--- a/tests/unit/test_copytree.py
+++ b/tests/unit/test_copytree.py
@@ -227,7 +227,7 @@ def validate_data(
             return
 
         case stat.S_IFDIR:
-            assert os.listdir(src) == os.listdir(dst)
+            assert set(os.listdir(src)) == set(os.listdir(dst))
             return
 
         case stat.S_IFREG:


### PR DESCRIPTION
This commit changes to using a set comparison insted of list comparison for directory contents.

Original PR: https://github.com/truenas/middleware/pull/15991
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134777