### PR TITLE
NAS-134781 / 25.04.0 / Standardize prefix for incus storage pool property (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -8,6 +8,7 @@ import httpx
 import json
 from collections.abc import Callable
 
+from middlewared.plugins.zfs_.utils import TNUserProp
 from middlewared.service import CallError
 from middlewared.utils import MIDDLEWARE_RUN_DIR
 
@@ -18,7 +19,7 @@ SOCKET = '/var/lib/incus/unix.socket'
 HTTP_URI = 'http://unix.socket'
 VNC_BASE_PORT = 5900
 VNC_PASSWORD_DIR = os.path.join(MIDDLEWARE_RUN_DIR, 'incus/passwords')
-TRUENAS_STORAGE_PROP_STR = 'truenas:incus_storage_pool'
+TRUENAS_STORAGE_PROP_STR = TNUserProp.INCUS_POOL.value
 
 
 class Status(enum.StrEnum):

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -45,6 +45,7 @@ class TNUserProp(enum.Enum):
     REFQUOTA_WARN = f'{LEGACY_USERPROP_PREFIX}:refquota_warning'
     REFQUOTA_CRIT = f'{LEGACY_USERPROP_PREFIX}:refquota_critical'
     MANAGED_BY = f'{USERPROP_PREFIX}:managedby'
+    INCUS_POOL = f'{USERPROP_PREFIX}:incus_storage_pool'  # used only in virt/global.py
 
     def default(self):
         match self:


### PR DESCRIPTION
This commit fixes an issue with the incus storage pool ZFS user property prefix and puts it in the enum of truenas-manaaged user properties.

Original PR: https://github.com/truenas/middleware/pull/15993
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134781