### PR TITLE
NAS-134764 / 25.04.0 / Fix discrepancy between 2510 and 2504 virt pydantic models (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -186,7 +186,7 @@ class VirtInstanceUpdate(BaseModel, metaclass=ForUpdateMetaclass):
     '''Setting vnc_password to null will unset VNC password'''
     secure_boot: bool = False
     root_disk_size: int | None = Field(ge=5, default=None)
-    root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI'] = None
+    root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None] = None
 
 
 class VirtInstanceUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 
-RE_VOLUME_NAME = re.compile(r'^[A-Za-z][A-Za-z0-9-_.]*[A-Za-z0-9]$', re.IGNORECASE)
+RE_VOLUME_NAME = re.compile(r'^[A-Za-z][A-Za-z0-9-._]*[A-Za-z0-9]$', re.IGNORECASE)
 VOLUME_NAME: TypeAlias = Annotated[
     NonEmptyString,
     AfterValidator(


### PR DESCRIPTION
## Context

A small diff between 2504 and 2510 had leaked in backporting changes and is being fixed.

Original PR: https://github.com/truenas/middleware/pull/15989
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134764