### PR TITLE
NAS-134795 / 25.04.0 / Fix stig unit test. (by mgrimesix)

### DIFF
--- a/tests/unit/test_auditd_rules.py
+++ b/tests/unit/test_auditd_rules.py
@@ -13,7 +13,7 @@ IMMUTABLE_STIG_RULE = "-e 2"
 SAMPLE_CE_RULE = "-a always,exclude -F msgtype=USER_START"
 # Common test items
 INCUS_RULE = "-a always,exit -F arch=b64 -S all -F path=/usr/bin/incus -F perm=x -F auid!=-1 -F key=escalation"
-REBOOT_RULE = "-a exit,always -F arch=b64 -S execve -F path=/usr/sbin/reboot -k escalation"
+REBOOT_RULE = "-a always,exit -F arch=b64 -S execve -F path=/usr/sbin/reboot -F key=escalation"
 
 STIG_ASSERT_IN = [MODULE_STIG_RULE, SAMPLE_STIG_RULE, REBOOT_RULE]  # TODO:  IMMUTABLE_STIG_RULE when enabled
 STIG_ASSERT_NOT_IN = [SAMPLE_CE_RULE]
@@ -55,9 +55,9 @@ def test__auditd_enable_gpos_stig(auditd_gpos_stig_enable):
     assert stig_rule_set != 'No rules'
 
     for audit_rule in STIG_ASSERT_IN:
-        assert audit_rule in stig_rule_set
+        assert audit_rule in stig_rule_set, f"stig_rule_set:\n{stig_rule_set}"
     for audit_rule in STIG_ASSERT_NOT_IN:
-        assert audit_rule not in stig_rule_set
+        assert audit_rule not in stig_rule_set, f"stig_rule_set:\n{stig_rule_set}"
 
 
 def test__auditd_disable_gpos_stig(auditd_gpos_stig_disable):
@@ -68,6 +68,6 @@ def test__auditd_disable_gpos_stig(auditd_gpos_stig_disable):
     assert non_stig_rule_set != 'No rules'
 
     for audit_rule in NON_STIG_ASSERT_IN:
-        assert audit_rule in non_stig_rule_set
+        assert audit_rule in non_stig_rule_set, f"non_stig_rule_set:\n{non_stig_rule_set}"
     for audit_rule in NON_STIG_ASSERT_NOT_IN:
-        assert audit_rule not in non_stig_rule_set
+        assert audit_rule not in non_stig_rule_set, f"non_stig_rule_set:\n{non_stig_rule_set}"


### PR DESCRIPTION
The STIG unit test is failing because the recently added test used an incorrect string.  The test used the _source_ rule, but the `augenrules` utility reformats the rule.

Updated the test to use the rule as formatted by `augenrules`.

The auditd rule is included in 25.04.0 and this test fix should be backported accordingly.

Original PR: https://github.com/truenas/middleware/pull/16000
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134795