### PR TITLE
NAS-134805 / 25.10 / remove accepts from device_to_identifier

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/identify.py
+++ b/src/middlewared/middlewared/plugins/disk_/identify.py
@@ -1,17 +1,14 @@
 import re
 
-from middlewared.schema import accepts, Dict, Str
 from middlewared.service import Service, private
 from middlewared.utils.disks import get_disks_with_identifiers
 
 
 class DiskService(Service):
-
     RE_IDENTIFIER = re.compile(r'^\{(?P<type>.+?)\}(?P<value>.+)$')
 
     @private
-    @accepts(Str('name'), Dict('disks', additional_attrs=True))
-    def device_to_identifier(self, name, disks):
+    def device_to_identifier(self, name: str, disks: dict):
         """
         Given a device `name` (e.g. sda) returns an unique identifier string
         for this device.


### PR DESCRIPTION
This is private so no reason to expose to public, therefore preventing us from needing to convert it.