### PR TITLE
NAS-134810 / 25.04.0 / Improve error message for pool name containing whitespaces

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/import_pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/import_pool.py
@@ -66,7 +66,10 @@ class PoolService(Service):
     @accepts(Dict(
         'pool_import',
         Str('guid', required=True),
-        Str('name', validators=[Match(r'^\S+$')]),
+        Str(
+            'name',
+            validators=[Match(r'^\S+$', explanation='Pool name must not contain whitespace')]
+        ),
         Bool('enable_attachments'),
     ), roles=['POOL_WRITE'])
     @returns(Bool('successful_import'))

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -400,7 +400,12 @@ class PoolService(CRUDService):
 
     @accepts(Dict(
         'pool_create',
-        Str('name', max_length=50, validators=[Match(r'^\S+$')], required=True),
+        Str(
+            'name',
+            max_length=50,
+            validators=[Match(r'^\S+$', explanation='Pool name must not contain whitespace')],
+            required=True
+        ),
         Bool('encryption', default=False),
         Str('dedup_table_quota', default='AUTO', enum=['AUTO', None, 'CUSTOM'], null=True),
         Int('dedup_table_quota_value', null=True, default=None, validators=[Range(min_=1)]),


### PR DESCRIPTION
## Context

Improving error message for a pool name containing whitespaces as regex being shown in validation error is not very UX friendly.