### PR TITLE
NAS-134796 / 25.04.0 / Do not use a variable when doing rm -rf (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from middlewared.main import Middleware
 
 
-INCUS_PATH = '/var/lib/incus'
 INCUS_BRIDGE = 'incusbr0'
 
 BRIDGE_AUTO = '[AUTO]'
@@ -605,7 +604,7 @@ class VirtGlobalService(ConfigService):
         # Have incus start fresh
         # Use subprocess because shutil.rmtree will traverse filesystems
         # and we do have instances datasets that might be mounted beneath
-        await run(f'rm -rf --one-file-system {INCUS_PATH}/*', shell=True, check=True)
+        await run(f'rm -rf --one-file-system /var/lib/incus/*', shell=True, check=True)
 
         if start and not await self.middleware.call('service.start', 'incus', {'ha_propagate': False}):
             raise CallError('Failed to start virtualization service')


### PR DESCRIPTION
## Context

We are doing `rm -rf` on a path where the path is coming from the variable. Now we want to be really careful with what the variable holds to as we are doing a `rm -rf` here, so instead of using the variable, the path is being hard coded directly (we don't have any other usages of the variable either) to prevent an accidental mistake on the dev part and this resulting in accidentally nuking something else.

Original PR: https://github.com/truenas/middleware/pull/16015
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134796