### PR TITLE
NAS-134809 / 25.10 / Better parse out size for virt instances

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/volume.py
+++ b/src/middlewared/middlewared/plugins/virt/volume.py
@@ -1,6 +1,6 @@
-import datetime
 import errno
 import os.path
+from time import time
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -11,7 +11,7 @@ from middlewared.api.current import (
 from middlewared.plugins.zfs_.utils import zvol_path_to_name
 from middlewared.service import CallError, CRUDService, job, ValidationErrors
 from middlewared.utils import filter_list
-from time import time
+from middlewared.utils.size import normalize_size
 
 from .utils import incus_call, incus_call_sync, Status, incus_wait, storage_pool_to_incus_pool
 
@@ -49,7 +49,8 @@ class VirtVolumeService(CRUDService):
                     'used_by': [instance.replace('/1.0/instances/', '') for instance in storage_device['used_by']]
                 })
                 if storage_device['config'].get('size'):
-                    entries[-1]['config']['size'] = int(storage_device['config']['size']) // (1024 * 1024)
+                    normalized_size = normalize_size(storage_device['config']['size'], False)
+                    entries[-1]['config']['size'] = normalized_size // (1024 * 1024) if normalized_size else 0
 
         return filter_list(entries, filters, options)
 

--- a/src/middlewared/middlewared/pytest/unit/utils/test_size_normalization.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_size_normalization.py
@@ -1,0 +1,39 @@
+import pytest
+
+from middlewared.utils.size import normalize_size
+
+
+@pytest.mark.parametrize('input_value, expected', [
+    ('2 GiB', 2 * 2**30),
+    ('500 MiB', 500 * 2**20),
+    ('100K', 100 * 10**3),
+    ('10G', 10 * 10**9),
+    ('1 TiB', 1 * 2**40),
+    ('2P', 2 * 10**15),
+    ('2 gib', 2 * 2**30),
+    ('500 mIb', 500 * 2**20),
+    ('100k', 100 * 10**3),
+    ('123', 123),
+    (1024, 1024),
+    (3.14, 3.14),
+    (None, None)
+])
+def test_normalize_size_valid(input_value, expected):
+    assert normalize_size(input_value) == expected
+
+
+@pytest.mark.parametrize('input_value', [
+    'XYZ',
+    '10 XB'
+])
+def test_normalize_size_invalid(input_value):
+    with pytest.raises(ValueError, match=f'Invalid size format: {input_value}'):
+        normalize_size(input_value)
+
+
+@pytest.mark.parametrize('input_value', [
+    'XYZ',
+    '10 XB'
+])
+def test_normalize_size_invalid_no_exception(input_value):
+    assert normalize_size(input_value, raise_exception=False) is None

--- a/src/middlewared/middlewared/utils/size.py
+++ b/src/middlewared/middlewared/utils/size.py
@@ -1,7 +1,88 @@
 import humanfriendly
+import re
+import types
 
+
+DECIMAL_UNITS = types.MappingProxyType(
+    {
+        '': 1,
+        'B': 1,
+        'K': 10**3,
+        'KB': 10**3,
+        'M': 10**6,
+        'MB': 10**6,
+        'G': 10**9,
+        'GB': 10**9,
+        'T': 10**12,
+        'TB': 10**12,
+        'P': 10**15,
+        'PB': 10**15,
+        'E': 10**18,
+        'EB': 10**18,
+        'Z': 10**21,
+        'ZB': 10**21,
+    }
+)
+BINARY_UNITS = types.MappingProxyType(
+    {
+        'KI': 2**10,
+        'KIB': 2**10,
+        'MI': 2**20,
+        'MIB': 2**20,
+        'GI': 2**30,
+        'GIB': 2**30,
+        'TI': 2**40,
+        'TIB': 2**40,
+        'PI': 2**50,
+        'PIB': 2**50,
+        'EI': 2**60,
+        'EIB': 2**60,
+        'ZI': 2**70,
+        'ZIB': 2**70,
+    }
+)
 MB = 1048576
+RE_SIZE = re.compile(r'([\d\.]+)\s*([A-Za-z]*)')
 
 
 def format_size(size):
     return humanfriendly.format_size(size, binary=True)
+
+
+def normalize_size(size: str, raise_exception: bool = True) -> int | None:
+    """
+    Convert a size string (e.g., '1GB', '1GiB', '1G', '10M', '24B') into bytes.
+    Supports both decimal (GB, MB, etc.) and binary (GiB, MiB, etc.) prefixes.
+
+    Args:
+        raise_exception: bool, when True will raise a ValueError in the event
+        the `size` argument doesn't match a valid unit.
+
+        size: str, the size string to convert into bytes.
+    """
+    if not isinstance(size, str):
+        return size
+
+    size = size.strip().upper()
+    match = RE_SIZE.match(size)
+    if not match:
+        if raise_exception:
+            raise ValueError(f'Invalid size format: {size}')
+        return None
+
+    value, unit = match.groups()
+    value = float(value)
+    unit = unit.upper()
+    try:
+        return int(value * DECIMAL_UNITS[unit])
+    except KeyError:
+        pass
+
+    try:
+        return int(value * BINARY_UNITS[unit])
+    except KeyError:
+        pass
+
+    if raise_exception:
+        raise ValueError(f'Invalid size format: {size}')
+    return None


### PR DESCRIPTION
## Problem

Users can manually manipulate sizes for incus instances which will break how we are parsing out sizes and that would be disastrous as querying is used extensively in middleware.

## Solution

Better parse out various variations which can occur and report in bytes finally.