### PR TITLE
NAS-134728 / 25.10 / Make sure migration does not fail if user has encrypted fields not readable in DNS auth table

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2024-11-05_23-35_authenticator_normalization.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2024-11-05_23-35_authenticator_normalization.py
@@ -7,6 +7,7 @@ Create Date: 2024-11-05 23:35:45.960915+00:00
 
 """
 import json
+from collections import defaultdict
 
 from alembic import op
 
@@ -19,16 +20,66 @@ branch_labels = None
 depends_on = None
 
 
+def remove_authenticator_ref(authenticator_id, cert_ids, conn):
+    if not cert_ids:
+        return
+
+    for cert in conn.execute(
+        f"SELECT * FROM system_certificate WHERE id IN ({','.join(['?'] * len(cert_ids))})", tuple(cert_ids)
+    ).fetchall():
+        cert = dict(cert)
+
+        try:
+            authenticators = json.loads(cert['cert_domains_authenticators'] or '{}')
+        except json.decoder.JSONDecodeError:
+            # Shouldn't happen, but just being safe
+            continue
+
+        # Filter out the authenticator reference
+        updated_authenticators = {
+            domain: aid for domain, aid in authenticators.items() if aid != authenticator_id
+        }
+
+        # Only update if a change was made
+        if updated_authenticators != authenticators:
+            conn.execute(
+                "UPDATE system_certificate SET cert_domains_authenticators = :auths WHERE id = :id",
+                {'auths': json.dumps(updated_authenticators), 'id': cert['id']}
+            )
+
+
 def upgrade():
     conn = op.get_bind()
-    for authenticator_config in conn.execute("SELECT * FROM system_acmednsauthenticator").fetchall():
+    authenticator_configs = [
+        dict(config) for config in conn.execute("SELECT * FROM system_acmednsauthenticator").fetchall()
+    ]
+    authenticator_mapping = defaultdict(list)
+    for cert in conn.execute("SELECT * FROM system_certificate").fetchall():
+        cert = dict(cert)
+        try:
+            authenticators = json.loads(cert['cert_domains_authenticators'] or '{}')
+        except json.JSONDecodeError:
+            # Shouldn't happen but just being safe
+            continue
+
+        for value in authenticators.values():
+            authenticator_mapping[value].append(cert['id'])
+
+    for authenticator_config in authenticator_configs:
         authenticator_config = dict(authenticator_config)
-        attributes = json.loads(decrypt(authenticator_config['attributes']))
-        attributes['authenticator'] = authenticator_config['authenticator']
-        conn.execute(
-            "UPDATE system_acmednsauthenticator SET attributes = ? WHERE id = ?",
-            (encrypt(json.dumps(attributes)), authenticator_config['id'])
-        )
+        try:
+            attributes = json.loads(decrypt(authenticator_config['attributes']))
+        except json.JSONDecodeError:
+            remove_authenticator_ref(
+                authenticator_config['id'], authenticator_mapping[authenticator_config['id']], conn
+            )
+            conn.execute("DELETE FROM system_acmednsauthenticator WHERE id = :id", {'id': authenticator_config['id']})
+        else:
+            attributes['authenticator'] = authenticator_config['authenticator']
+            conn.execute(
+                "UPDATE system_acmednsauthenticator SET attributes = ? WHERE id = ?",
+                (encrypt(json.dumps(attributes)), authenticator_config['id'])
+            )
 
     with op.batch_alter_table('system_acmednsauthenticator', schema=None) as batch_op:
         batch_op.drop_column('authenticator')

--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -30,16 +30,19 @@ class PWEncService(Service):
         return self.secret_path
 
     def _reset_passwords(self):
-        for table, field in (
-            ('directoryservice_ldap', 'ldap_bindpw'),
-            ('services_ups', 'ups_monpwd'),
-            ('system_email', 'em_pass'),
+        for table, field, value in (
+            ('directoryservice_ldap', 'ldap_bindpw', ''),
+            ('services_ups', 'ups_monpwd', ''),
+            ('system_email', 'em_pass', ''),
+            ('system_certificate', 'cert_domains_authenticators', 'NULL'),
         ):
-            self.middleware.call_sync('datastore.sql', f'UPDATE {table} SET {field} = \'\'')
+            value = value or '\'\''
+            self.middleware.call_sync('datastore.sql', f'UPDATE {table} SET {field} = {value}')
 
         self.middleware.call_sync('datastore.sql', 'DELETE FROM tasks_cloud_backup')
         self.middleware.call_sync('datastore.sql', 'DELETE FROM tasks_cloudsync')
         self.middleware.call_sync('datastore.sql', 'DELETE FROM system_cloudcredentials')
+        self.middleware.call_sync('datastore.sql', 'DELETE FROM system_acmednsauthenticator')
         self.middleware.call_sync(
             'datastore.sql',
             'DELETE FROM storage_replication WHERE repl_ssh_credentials_id IS NOT NULL',

--- a/src/middlewared/middlewared/plugins/pwenc.py
+++ b/src/middlewared/middlewared/plugins/pwenc.py
@@ -36,7 +36,7 @@ class PWEncService(Service):
             ('system_email', 'em_pass', ''),
             ('system_certificate', 'cert_domains_authenticators', 'NULL'),
         ):
-            value = value or '\'\''
+            value = value or "''"
             self.middleware.call_sync('datastore.sql', f'UPDATE {table} SET {field} = {value}')
 
         self.middleware.call_sync('datastore.sql', 'DELETE FROM tasks_cloud_backup')


### PR DESCRIPTION
This PR fixes out one of our migrations where we were not taking into account that certain columns could be null if the secret seed had changed and expected them to behave as they were decrypted.

So the changes now go through those rows and update them appropriately including their usage to make sure if secret seed has been changed, we reset the database to a form which is acceptable to middleware.

While i was here, i noticed that we are not resetting ACME DNS authenticator table when secret seed is reset, so that has been done as well including cert dns mapping.