### PR TITLE
NAS-134715 / 25.04.0 / Gracefully handle unsupported USB string descriptors (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/device.py
+++ b/src/middlewared/middlewared/plugins/virt/device.py
@@ -36,9 +36,14 @@ class VirtDeviceService(Service):
                 'product_id': format(i.idProduct, '04x'),
                 'bus': i.bus,
                 'dev': i.address,
-                'product': i.product,
-                'manufacturer': i.manufacturer,
             }
+            # Would like to carefully get product/manufacturer as some USB devices can not support string
+            # descriptors or the device can be malfunctioning and it can result in this.
+            for k in ('product', 'manufacturer'):
+                try:
+                    choices[name][k] = getattr(i, k)
+                except Exception:
+                    choices[name][k] = f'Unknown {k}'
         return choices
 
     @api_method(VirtDeviceGPUChoicesArgs, VirtDeviceGPUChoicesResult, roles=['VIRT_INSTANCE_READ'])


### PR DESCRIPTION
## Problem

There could be USB devices which either don't support string descriptors or could be malfunctioning which will result in our usb choices endpoint to break down.

## Solution

Safely retrieve product/manufacturer information in this case - we should expect a small subset of users who could be affected by this so marking the USB device as unknown should be good enough.

Original PR: https://github.com/truenas/middleware/pull/16017
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134715