### PR TITLE
NAS-134702 / 25.04.0 / Make sure same source is not added to multiple devices (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -407,7 +407,7 @@ class VirtInstanceService(CRUDService):
         }
         for i in data_devices:
             await self.middleware.call(
-                'virt.instance.validate_device', i, 'virt_instance_create', verrors, data['instance_type'],
+                'virt.instance.validate_device', i, 'virt_instance_create', verrors, data['name'], data['instance_type']
             )
             if i['name'] is None:
                 i['name'] = await self.middleware.call(

--- a/src/middlewared/middlewared/test/integration/assets/virt.py
+++ b/src/middlewared/middlewared/test/integration/assets/virt.py
@@ -57,7 +57,7 @@ def virt_device(instance_name: str, device_name: str, payload: dict):
 @contextlib.contextmanager
 def virt_instance(
     instance_name: str = 'tmp-instance',
-    image: str = 'debian/trixie',
+    image: str | None = 'debian/trixie',  # Can be null when source is null
     **kwargs
 ) -> dict:
     # Create a virt instance and return dict containing full config and raw info


### PR DESCRIPTION
## Problem

Same source could be currently added to multiple disk devices of same/different virt instances.

## Solution

Make sure we don't allow same source to be configured across multiple disk devices or same/different virt instances by having proper validation in place.

Original PR: https://github.com/truenas/middleware/pull/16013
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134702