### PR TITLE
NAS-134708 / 25.04.0 / Add better validation for existing zfs dataset against volume names (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -394,6 +394,7 @@ class VirtGlobalService(ConfigService):
         2. After change to the storage pool path
         3. After an HA failover event
         4. After TrueNAS upgrades
+        5. After we see user trying to add a volume whose dataset already exists
 
         NOTE: this will potentially cause user-initiated changes from incus commands to be lost.
         """

--- a/tests/api2/test_virt_vm.py
+++ b/tests/api2/test_virt_vm.py
@@ -113,6 +113,20 @@ def test_volume_name_validation(virt_pool, vol_name, should_work):
             call('virt.volume.create', {'name': vol_name})
 
 
+def test_volume_name_dataset_existing_validation_error(virt_pool):
+    pool_name = virt_pool['pool']
+    vol_name = 'test_ds_volume_exist'
+    ds_name = f'{pool_name}/.ix-virt/custom/default_{vol_name}'
+    ssh(f'zfs create -V 500MB -s {ds_name}')
+    try:
+        with pytest.raises(ClientValidationErrors):
+            call('virt.volume.create', {'name': vol_name})
+
+        assert call('zfs.dataset.query', [['id', '=', ds_name]], {'count': True}) == 1
+    finally:
+        ssh(f'zfs destroy {ds_name}')
+
+
 def test_upload_iso_file(virt_pool):
     vol_name = 'test_uploaded_iso'
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Problem

Currently if a user tries to create a volume with a name where the underlying zfs dataset already exists, that will result in volume creation to fail and the dataset lying there to get deleted by incus.

## Solution

Make sure we translate the volume name/pool to zfs dataset and check if the underlying dataset exists before or not as otherwise incus will force delete it.

Original PR: https://github.com/truenas/middleware/pull/16016
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134708