### PR TITLE
NAS-134445 / 25.04.0 / Improve confusing error message (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -93,11 +93,17 @@ class VirtInstanceEntry(BaseModel):
     "Storage pool in which the root of the instance is located."
 
 
+def validate_memory(value: int) -> int:
+    if value < 33554432:
+        raise ValueError('Value must be 32MiB or larger')
+    return value
+
+
 # Lets require at least 32MiB of reserved memory
 # This value is somewhat arbitrary but hard to think lower value would have to be used
 # (would most likely be a typo).
 # Running container with very low memory will probably cause it to be killed by the cgroup OOM
-MemoryType: TypeAlias = Annotated[int, Field(strict=True, ge=33554432)]
+MemoryType: TypeAlias = Annotated[int, AfterValidator(validate_memory)]
 
 
 @single_argument_args('virt_instance_create')


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x b347004f5f74c10d75145a695c3a2b82bfb6b6ab

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8e0043609a6c273d485b3787608176ab3fe32e23

## Problem

The memory error message is confusing on the UI side currently where UI allows users to specify something like `32 MiB` as well and middleware saying input should be greater then xyz.

## Solution

Be more descriptive in the error message so it is acceptable on the UI side as well.

Original PR: https://github.com/truenas/middleware/pull/16030
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134445