### PR TITLE
NAS-134852 / 25.04.0 / use correct tuple position for mapping R40 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/enclosure_/map2.py
+++ b/src/middlewared/middlewared/plugins/enclosure_/map2.py
@@ -72,7 +72,7 @@ def combine_enclosures(enclosures):
                     head_unit_idx = r40_sas_ids[0][1]
                     _update_idx = r40_sas_ids[1][1]
                 else:
-                    head_unit_idx = r40_sas_ids[1][0]
+                    head_unit_idx = r40_sas_ids[1][1]
                     _update_idx = r40_sas_ids[0][1]
 
                 # we know which enclosure has the larger sas address so we'll update


### PR DESCRIPTION
The `else` branch on line 74 was never being reached when this was originally written. The internal R40 we have uses the `if` branch on line 71. We have _another_ R40 in-house where-by the `else` branch is exercised. It crashes with an `IndexError` because we're associating the `head_unit_idx` variable with the incorrect value. Fix this by accessing index position 1 instead of 0. This fixes the crash, thereby fixing the UI enclosure page for this particular variant of the R40.

Original PR: https://github.com/truenas/middleware/pull/16026
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134852