### PR TITLE
NAS-134807 / 25.04.0 / Allow import of zvols into incus volumes (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_volume.py
@@ -102,3 +102,30 @@ class VirtVolumeImportISOArgs(BaseModel):
 
 class VirtVolumeImportISOResult(BaseModel):
     result: VirtVolumeEntry
+
+
+class ZvolImportEntry(BaseModel):
+    virt_volume_name: VOLUME_NAME
+    '''Specify name of the newly created volume from the ISO specified'''
+    zvol_path: NonEmptyString
+    '''Specify path of zvol in /dev/zvol'''
+
+    @field_validator('zvol_path')
+    @classmethod
+    def validate_source(cls, zvol_path):
+        if not zvol_path.startswith('/dev/zvol/'):
+            raise ValueError('Not a valid /dev/zvol path')
+
+        return zvol_path
+
+
+@single_argument_args('virt_volume_import_iso')
+class VirtVolumeImportZvolArgs(BaseModel):
+    to_import: list[ZvolImportEntry]
+    '''List of zvols to import as volumes'''
+    clone: bool = False
+    '''Optionally clone and promote zvol'''
+
+
+class VirtVolumeImportZvolResult(BaseModel):
+    result: VirtVolumeEntry


### PR DESCRIPTION
This commit adds an API endpoint to allow converting existing zvols into custom incus volumes. The new API endpoint takes the following parameters:

to_import - list of zvols to import as custom storage volumes in incus.

clone - boolean (default False) clone and promote a temporary snapshot of the zvol into a custom storage volume. This is an option for users who are more paranoid about migration.

This endpoint takes multiple zvols because the recovery operation is somewhat slow and expensive. It's better to do everything in one large batch.

Original PR: https://github.com/truenas/middleware/pull/16011
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134807