### PR TITLE
NAS-134820 / 25.04.0 / Add test for SERVICE_START exclusion. (by mgrimesix)

### DIFF
--- a/tests/unit/test_auditd_rules.py
+++ b/tests/unit/test_auditd_rules.py
@@ -10,15 +10,15 @@ MODULE_STIG_RULE = "-a always,exit -F arch=b64 -S init_module,finit_module -F ke
 SAMPLE_STIG_RULE = "-a always,exit -F arch=b64 -S all -F path=/etc/gshadow -F perm=wa -F key=identity"
 IMMUTABLE_STIG_RULE = "-e 2"
 # Non-STIG test items
-SAMPLE_CE_RULE = "-a always,exclude -F msgtype=USER_START"
+SAMPLE_CE_RULES = ["-a always,exclude -F msgtype=USER_START", "-a always,exclude -F msgtype=SERVICE_START"]
 # Common test items
 INCUS_RULE = "-a always,exit -F arch=b64 -S all -F path=/usr/bin/incus -F perm=x -F auid!=-1 -F key=escalation"
 REBOOT_RULE = "-a always,exit -F arch=b64 -S execve -F path=/usr/sbin/reboot -F key=escalation"
 
 STIG_ASSERT_IN = [MODULE_STIG_RULE, SAMPLE_STIG_RULE, REBOOT_RULE]  # TODO:  IMMUTABLE_STIG_RULE when enabled
-STIG_ASSERT_NOT_IN = [SAMPLE_CE_RULE]
+STIG_ASSERT_NOT_IN = SAMPLE_CE_RULES
 
-NON_STIG_ASSERT_IN = [SAMPLE_CE_RULE, INCUS_RULE, REBOOT_RULE]
+NON_STIG_ASSERT_IN = [INCUS_RULE, REBOOT_RULE] + SAMPLE_CE_RULES
 NON_STIG_ASSERT_NOT_IN = [SAMPLE_STIG_RULE]
 
 


### PR DESCRIPTION
This PR is to add the CI test for changes in `audit_rules` and `ixdiagnose`.  This PR is dependent on the companion PR in `audit_rules` and `ixdiagnose`.

The issue being address is the excessive `SERVICE_START` and `SERVICE_STOP` audit messages.

Original PR: https://github.com/truenas/middleware/pull/16032
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134820