### PR TITLE
NAS-134768 / 25.10 / Use virtio-scsi when source type is iso

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -389,7 +389,7 @@ class VirtInstanceService(CRUDService):
                 'destination': None,
                 'readonly': False,
                 'boot_priority': 1,
-                'io_bus': data['root_disk_io_bus'],
+                'io_bus': 'VIRTIO-SCSI',
             }
 
         if root_device_to_add:


### PR DESCRIPTION
## Problem

Windows does not has built-in drivers of NVME for installation media, so when setting source type to ISO and choosing a windows image to bootstrap a VM - that does not sit well by default as we default to NVME IO bus.

## Solution

`VIRTIO-SCSI` is a better default for installation media when source type is set to ISO as most popular OS support it out of the box.

Tested with Windows/Ubuntu/debian
```
  Win11_24H2_English_x64_incus.iso:
    boot.priority: "1"
    io.bus: virtio-scsi
    pool: evo
    source: Win11_24H2_English_x64_incus.iso

---

  ubuntu-24.04.1-live-server-amd64.iso:
    boot.priority: "1"
    io.bus: virtio-scsi
    pool: evo
    source: ubuntu-24.04.1-live-server-amd64.iso
    type: disk

---

  debian-12.7.0-amd64-netinst.iso:
    boot.priority: "1"
    io.bus: virtio-scsi
    pool: evo
    source: debian-12.7.0-amd64-netinst.iso
    type: disk
```