### PR TITLE
fix KeyError crash in ipmi.lan.query

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -123,7 +123,7 @@ class IPMILanService(Service):
             if not stdout:
                 continue
 
-            data = {'channel': channel, 'id': channel}
+            data = {'channel': channel, 'id': channel, 'vlan_id_enable': False}
             for line in filter(lambda x: x.startswith('\t') and not x.startswith('\t#'), stdout):
                 try:
                     name, value = line.strip().split()


### PR DESCRIPTION
Fix a KeyError crash by initializing the dictionary with the `vlan_id_enable` key. Not all IPMI implementations support vlans.