### PR TITLE
NAS-134736 / 25.04.0 / fix KeyError crash in ipmi.lan.query (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/ipmi_/lan.py
+++ b/src/middlewared/middlewared/plugins/ipmi_/lan.py
@@ -122,7 +122,7 @@ class IPMILanService(CRUDService):
             if not stdout:
                 continue
 
-            data = {'channel': channel, 'id': channel}
+            data = {'channel': channel, 'id': channel, 'vlan_id_enable': False}
             for line in filter(lambda x: x.startswith('\t') and not x.startswith('\t#'), stdout):
                 try:
                     name, value = line.strip().split()


### PR DESCRIPTION
Fix a KeyError crash by initializing the dictionary with the `vlan_id_enable` key. Not all IPMI implementations support vlans.

Original PR: https://github.com/truenas/middleware/pull/16044
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134736