### PR TITLE
NAS-134658 / 25.04.0 / Fix typo. STIG -> GPOSSTIG (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -214,7 +214,7 @@ class SystemSecurityService(ConfigService):
 
         if new['enable_gpos_stig'] != old['enable_gpos_stig']:
             if not fips_toggled:
-                reboot_reason = RebootReason.STIG
+                reboot_reason = RebootReason.GPOSSTIG
                 # Trigger reboot on standby to apply STIG-related configuration
                 # This should only happen if user already set FIPS and is subsequently changing
                 # STIG as a separate operation.


### PR DESCRIPTION
The typo is the source of the generated trace.


Original PR: https://github.com/truenas/middleware/pull/16047
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134658