### PR TITLE
NAS-134887 / 25.10 / Fix disk details/used methods

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/disk.py
+++ b/src/middlewared/middlewared/api/v25_10_0/disk.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
+from middlewared.api.base import BaseModel, NonEmptyString
 from .alert import Alert
 
 __all__ = (
@@ -15,8 +15,7 @@ __all__ = (
 )
 
 
-@single_argument_args("data")
-class DiskGetDetailsArgs(BaseModel):
+class DiskGetDetails(BaseModel):
     join_partitions: bool = False
     """When True will return all partitions currently
     written to disk.
@@ -27,6 +26,10 @@ class DiskGetDetailsArgs(BaseModel):
     If `USED`, only disks that are IN USE will be returned.
     If `UNUSED`, only disks that are NOT IN USE are returned.
     If `BOTH`, used and unused disks will be returned."""
+
+
+class DiskGetDetailsArgs(BaseModel):
+    data: DiskGetDetails = DiskGetDetails()
 
 
 class DiskGetDetailsResult(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/disk.py
+++ b/src/middlewared/middlewared/api/v25_10_0/disk.py
@@ -30,7 +30,7 @@ class DiskGetDetailsArgs(BaseModel):
 
 
 class DiskGetDetailsResult(BaseModel):
-    result: dict
+    result: list | dict
 
 
 class DiskGetUsedArgs(BaseModel):
@@ -42,7 +42,7 @@ class DiskGetUsedArgs(BaseModel):
 
 
 class DiskGetUsedResult(BaseModel):
-    result: dict
+    result: list
 
 
 class DiskTemperatureAlertsArgs(BaseModel):


### PR DESCRIPTION
This PR adds changes to fix disk details/used endpoints as they are erroring out atm. Basically for details endpoint, we want list + dict as return type being valid and for it's arguments we want to make sure consumer can get away with `disk.details` instead of doing `disk.details '{}'` because we have existing consumers which rely on this behaviour. Secondly return type for disk used endpoint needed to be addressed.