### PR TITLE
NAS-134713 / 25.04.0 / Override empty string for LDAP-provided shell (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1230,7 +1230,7 @@ class IdmapDomainService(CRUDService):
             'smbhash': None,
             'group': {},
             'home': passwd['pw_dir'],
-            'shell': passwd['pw_shell'],
+            'shell': passwd['pw_shell'] or '/usr/sbin/nologin',
             'full_name': passwd['pw_gecos'],
             'builtin': False,
             'email': None,


### PR DESCRIPTION
Apparently some admins will set an empty string for the shell for their LDAP users. This commit converts that invalid value to nologin.

Original PR: https://github.com/truenas/middleware/pull/15955
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134713