### PR TITLE
NAS-134908 / 25.10 / Convert private nfs debug to new api.

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/debug.py
+++ b/src/middlewared/middlewared/plugins/nfs_/debug.py
@@ -4,7 +4,6 @@ from contextlib import suppress
 from middlewared.api import api_method
 from middlewared.api.base import (BaseModel, UniqueList)
 from middlewared.service import Service
-from typing import Optional
 
 import enum
 
@@ -83,10 +82,10 @@ class RPC_DBGFLAGS(enum.Enum):
 
 
 class NfsDebug(BaseModel):
-    NFS: Optional[UniqueList[NFS_DBGFLAGS.__members__]] | None = None
-    NFSD: Optional[UniqueList[NFSD_DBGFLAGS.__members__]] | None = None
-    NLM: Optional[UniqueList[NLM_DBGFLAGS.__members__]] | None = None
-    RPC: Optional[UniqueList[RPC_DBGFLAGS.__members__]] | None = None
+    NFS: UniqueList[NFS_DBGFLAGS.__members__] | None = None
+    NFSD: UniqueList[NFSD_DBGFLAGS.__members__] | None = None
+    NLM: UniqueList[NLM_DBGFLAGS.__members__] | None = None
+    RPC: UniqueList[RPC_DBGFLAGS.__members__] | None = None
 
 
 class NfsDebugGetArgs(BaseModel):


### PR DESCRIPTION
The NFS `get_debug` and `set_debug` are private methods (not included in the versioned api) but are also used to help debug customer issues.  As such maintaining the validation on the 'set' command is good.  

This PR moves the `nfs.get_debug` and `nfs.set_debug` methods to the new api method.

The passing CI is [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3622/testReport/).