### PR TITLE
NAS-134929 / 25.10 / load drivetemp kernel module

### DIFF
--- a/src/freenas/usr/lib/modules-load.d/truenas.conf
+++ b/src/freenas/usr/lib/modules-load.d/truenas.conf
@@ -1,3 +1,4 @@
 ioatdma
 ntb_split
 ntb_netdev
+drivetemp


### PR DESCRIPTION
This kernel module has been extended to report SCSI (SAS) drive temperatures via sysfs. Let's load it always. This PR is a prerequisite for a following PR.