### PR TITLE
NAS-134716 / 25.04.0 / Make sure incus networking settings are reflected in incus (by Qubad786) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1434,6 +1434,10 @@ class InterfaceService(CRUDService):
                 filters = [('type', '=', 'VLAN'), ('vlan_parent_interface', '=', iface['id'])]
                 if vlans := ', '.join([i['name'] for i in await self.middleware.call('interface.query', filters)]):
                     verrors.add(schema, f'The following VLANs depend on this interface: {vlans}')
+            if iface['type'] == 'BRIDGE' and (
+                iface['name'] == (await self.middleware.call('virt.global.config'))['bridge']
+            ):
+                verrors.add(schema, 'Virt is using this interface as its bridge interface.')
 
         verrors.check()
 

--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -522,6 +522,11 @@ class VirtGlobalService(ConfigService):
                 else:
                     netconfig['ipv6.address'] = config['v6_network']
 
+                update_network |= any(
+                    config[f'v{i}_network'] != result['metadata']['config'][f'ipv{i}.address']
+                    for i in (4, 6)
+                )
+
                 if update_network:
                     result = await incus_call(f'1.0/networks/{INCUS_BRIDGE}', 'put', {'json': {
                         'config': netconfig,


### PR DESCRIPTION
## Problem

If incus settings are changed, they are not reflected in the incus configuration currently and if a bridge is specified to be used with incus, that bridge can be deleted even though it is specified in virt settings.

i.e
```
❯ incus network show incusbr0
config:
  ipv4.address: 10.0.0.3/24
  ipv4.nat: "true"
  ipv6.address: fd42:6de4:130e:129d::1/64
  ipv6.nat: "true"
description: ""
name: incusbr0
type: bridge
used_by:
- /1.0/instances/ubuntu-c2
- /1.0/instances/ubuntu-v10
- /1.0/instances/ubuntu-v11
- /1.0/instances/ubuntu-v9
- /1.0/profiles/default
managed: true
status: Created
locations:
- none
project: default
❯ 
❯ midclt call -j virt.global.update '{"storage_pools": ["tank"], "pool": "tank", "v4_network": "10.2.2.3/24", "v6_network": "fd42:6de4:130e:129d::1/64"}'
Status: (none)
Total Progress: [########################################] 100.00%
{"id": 1, "pool": "tank", "storage_pools": ["tank"], "bridge": null, "v4_network": "10.2.2.3/24", "v6_network": "fd42:6de4:130e:129d::1/64", "dataset": "tank/.ix-virt", "state": "INITIALIZED"}
❯ incus network show incusbr0
config:
  ipv4.address: 10.0.0.3/24
  ipv4.nat: "true"
  ipv6.address: fd42:6de4:130e:129d::1/64
  ipv6.nat: "true"
description: ""
name: incusbr0
type: bridge
used_by:
- /1.0/instances/ubuntu-c2
- /1.0/instances/ubuntu-v10
- /1.0/instances/ubuntu-v11
- /1.0/instances/ubuntu-v9
- /1.0/profiles/default
managed: true
status: Created
locations:
- none
project: default
~ ❯  
```

## Solution

Make sure configured incus settings are reflected in incus configuration and do not allow deleting a bridge interface which is being used by incus.

Original PR: https://github.com/truenas/middleware/pull/16063
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134716

Original PR: https://github.com/truenas/middleware/pull/16064
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134716