### PR TITLE
Only have SAN as a required field for CSR

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -349,11 +349,6 @@ class CertificateService(CRUDService):
     @accepts(
         Patch(
             'certificate_create', 'certificate_create_csr',
-            ('edit', _set_required('country')),
-            ('edit', _set_required('state')),
-            ('edit', _set_required('city')),
-            ('edit', _set_required('organization')),
-            ('edit', _set_required('email')),
             ('edit', _set_required('san')),
             ('rm', {'name': 'create_type'}),
             register=True


### PR DESCRIPTION
This PR adds changes along with https://github.com/truenas/truenas_crypto_utils/pull/5 to only have SAN as a required attribute for generating CSR because it is not a requirement of CSR itself and ACME service like let's encrypt strips away everything apart from CN and SAN because it is a DV based certificate only.