### PR TITLE
NAS-134930 / 25.10 / add temperature data to disk_class.py

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -17,8 +17,6 @@ VALID_WHOLE_DISK = rcompile(r"^pmem\d+$|^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$")
 class TempEntry:
     temp_c: float | None = None
     """The current temperature in celsius"""
-    temp_f: float | None = None
-    """The current temperature in farenheit"""
     crit: float | None = None
     """This value is reported as celsius.
 
@@ -179,7 +177,6 @@ class DiskEntry:
         else:
             return f"{{devicename}}{self.name}"
 
-    @property
     def temp(self) -> TempEntry:
         """Return temperature information as reported via sysfs.
         This information is obtained via the drivetemp kernel
@@ -195,7 +192,7 @@ class DiskEntry:
         else:
             path = f"{base}/device/hwmon"
 
-        rv = {"temp_c": None, "temp_f": None, "crit": None}
+        rv = {"temp_c": None, "crit": None}
         try:
             with scandir(path) as sdir:
                 for i in filter(
@@ -217,9 +214,6 @@ class DiskEntry:
                     else:
                         # sysfs values are stored in millidegrees celsius
                         rv["temp_c"] = milli_c / 1000
-                        rv["temp_f"] = round(
-                            (rv["temp_c"] * (9 / 5)) + 32 if rv["temp_c"] != 0 else 0, 2
-                        )
 
                     try:
                         crit = int(self.__opener(absolute_path=f"{i.path}/temp1_crit"))

--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -13,6 +13,42 @@ __all__ = ("DiskEntry", "iterate_disks")
 VALID_WHOLE_DISK = rcompile(r"^pmem\d+$|^sd[a-z]+$|^vd[a-z]+$|^nvme\d+n\d+$")
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TempEntry:
+    temp_c: float | None = None
+    """The current temperature in celsius"""
+    temp_f: float | None = None
+    """The current temperature in farenheit"""
+    crit: float | None = None
+    """This value is reported as celsius.
+
+    For SCSI drives (as described in SPC-6):
+        The REFERENCE TEMPERATURE field indicates
+        the maximum reported sensor temperature in
+        degrees Celsius at which the SCSI target
+        device is capable of operating continuously
+        without degrading the SCSI target device's
+        operation or reliability beyond manufacturer
+        accepted limits.
+
+    For NVMe drives (as described in base spec 2.0e)
+        The critical composite temperature threshold
+        (CCTEMP) field. This field indicates the
+        minimum Composite Temperature field value that
+        indicates a critical overheating condition
+        (e.g., may prevent continued normal operation,
+            possibility of data loss, automatic device
+            shutdown, extreme performance throttling,
+            or permanent damage)
+
+    For ATA drives (as described in ATA/ATAPI Command Set)
+        The "Over Limit" field (byte 7) represents the
+        maximum temperature limit. Operating the device
+        over this temperature may cause physical damage to
+        the device.
+    """
+
+
 @dataclass(frozen=True, kw_only=True)
 class DiskEntry:
     name: str | None = None
@@ -20,9 +56,18 @@ class DiskEntry:
     devpath: str | None = None
     """The disk's /dev path (i.e. '/dev/sda')"""
 
-    def __opener(self, relative_path: str, mode: str = "r") -> str | None:
+    def __opener(
+        self,
+        *,
+        relative_path: str | None = None,
+        absolute_path: str | None = None,
+        mode: str = "r",
+    ) -> str | None:
+        if relative_path is None and absolute_path is None:
+            raise ValueError("relative_path or absolute_path is required")
+
         try:
-            with open(f"/sys/block/{self.name}/{relative_path}", mode) as f:
+            with open(relative_path or absolute_path, mode) as f:
                 return f.read().strip()
         except Exception:
             pass
@@ -31,7 +76,7 @@ class DiskEntry:
     def lbs(self) -> int:
         """The disk's logical block size as reported by sysfs"""
         try:
-            return int(self.__opener("queue/logical_block_size"))
+            return int(self.__opener(relative_path="queue/logical_block_size"))
         except Exception:
             # fallback to 512 always
             return 512
@@ -40,7 +85,7 @@ class DiskEntry:
     def pbs(self) -> int:
         """The disk's physical block size as reported by sysfs"""
         try:
-            return int(self.__opener("queue/physical_block_size"))
+            return int(self.__opener(relative_path="queue/physical_block_size"))
         except Exception:
             # fallback to 512 always
             return 512
@@ -54,7 +99,7 @@ class DiskEntry:
         # regardless of the disk's reported
         # block size.
         try:
-            return int(self.__opener("size"))
+            return int(self.__opener(relative_path="size"))
         except Exception:
             # rare but dont crash here
             return 0
@@ -72,15 +117,15 @@ class DiskEntry:
     @cached_property
     def serial(self) -> str | None:
         """The disk's serial number as reported by sysfs"""
-        if not (serial := self.__opener("device/serial")):
-            if serial := self.__opener("device/vpd_pg80", mode="rb"):
+        if not (serial := self.__opener(relative_path="device/serial")):
+            if serial := self.__opener(relative_path="device/vpd_pg80", mode="rb"):
                 serial = "".join(
-                    chr(b) if 32 <= b <= 126 else "\uFFFD" for b in serial
-                ).replace("\uFFFD", "")
+                    chr(b) if 32 <= b <= 126 else "\ufffd" for b in serial
+                ).replace("\ufffd", "")
 
         if not serial:
             # pmem devices have a uuid attribute that we use as serial
-            serial = self.__opener("uuid")
+            serial = self.__opener(relative_path="uuid")
 
         return serial
 
@@ -92,9 +137,9 @@ class DiskEntry:
             we're using the 'wwid' property of the disk
             but it is the same principle and it allows us
             to use common terms that most recognize."""
-        wwid = self.__opener("device/wwid")
+        wwid = self.__opener(relative_path="device/wwid")
         if wwid is None:
-            wwid = self.__opener("wwid")
+            wwid = self.__opener(relative_path="wwid")
 
         if wwid is not None:
             wwid = wwid.removeprefix("naa.").removeprefix("0x").removeprefix("eui.")
@@ -104,17 +149,17 @@ class DiskEntry:
     @cached_property
     def model(self) -> str | None:
         """The disk's model as reported by sysfs"""
-        return self.__opener("device/model")
+        return self.__opener(relative_path="device/model")
 
     @cached_property
     def vendor(self) -> str | None:
-        return self.__opener("device/vendor")
+        return self.__opener(relative_path="device/vendor")
 
     @cached_property
     def firmware_revision(self) -> str | None:
-        fr = self.__opener("device/rev")
+        fr = self.__opener(relative_path="device/rev")
         if fr is None:
-            fr = self.__opener("device/firmware_rev")
+            fr = self.__opener(relative_path="device/firmware_rev")
         return fr
 
     @cached_property
@@ -133,6 +178,61 @@ class DiskEntry:
             return f"{{serial}}{self.serial}"
         else:
             return f"{{devicename}}{self.name}"
+
+    @property
+    def temp(self) -> TempEntry:
+        """Return temperature information as reported via sysfs.
+        This information is obtained via the drivetemp kernel
+        module.
+
+        NOTE: The `temp1_input` file will issue a command to the
+        disk each time it's accessed from user-space. It's the
+        callers responsibility to ensure this value is accessed
+        at a frequency that makes sense."""
+        base = f"/sys/block/{self.name}"
+        if "nvme" in self.name:
+            path = f"{base}/device"
+        else:
+            path = f"{base}/device/hwmon"
+
+        rv = {"temp_c": None, "temp_f": None, "crit": None}
+        try:
+            with scandir(path) as sdir:
+                for i in filter(
+                    lambda x: x.is_dir() and x.name.startswith("hwmon"), sdir
+                ):
+                    try:
+                        name = self.__opener(absolute_path=f"{i.path}/name")
+                        if name not in ("nvme", "drivetemp"):
+                            continue
+                    except Exception:
+                        continue
+
+                    try:
+                        milli_c = int(
+                            self.__opener(absolute_path=f"{i.path}/temp1_input")
+                        )
+                    except (ValueError, FileNotFoundError):
+                        continue
+                    else:
+                        # sysfs values are stored in millidegrees celsius
+                        rv["temp_c"] = milli_c / 1000
+                        rv["temp_f"] = round(
+                            (rv["temp_c"] * (9 / 5)) + 32 if rv["temp_c"] != 0 else 0, 2
+                        )
+
+                    try:
+                        crit = int(self.__opener(absolute_path=f"{i.path}/temp1_crit"))
+                    except (ValueError, FileNotFoundError):
+                        continue
+                    else:
+                        # syfs values are stored in millidegrees celsius
+                        rv["crit"] = crit / 1000
+        except FileNotFoundError:
+            # pmem devices dont have this, for example
+            pass
+
+        return TempEntry(**rv)
 
     @property
     def partitions(self, dev_fd: int | None = None) -> tuple[GptPartEntry] | None:


### PR DESCRIPTION
With the drivetemp kernel module now reporting SAS drive temperatures, we're able to retrieve drive temperatures for all drive types (SATA/SAS/NVMe) via the `hwmon` interface via sysfs. This adds a `temp` method to retrieve said temperatures.

NOTE: This has not been plumbed in anywhere (yet). That will come in a subsequent PR.