### PR TITLE
NAS-134552 / 25.04.0 / Be more aggressive in reading contents from pipe (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/volume.py
+++ b/src/middlewared/middlewared/plugins/virt/volume.py
@@ -185,8 +185,12 @@ class VirtVolumeService(CRUDService):
         }
 
         def read_input_stream():
-            for stream in job.pipes.input.r:
-                yield stream
+            while True:
+                chunk = job.pipes.input.r.read(1048576)
+                if not chunk:
+                    break
+
+                yield chunk
 
         def upload_file():
             job.set_progress(25, 'Importing ISO as incus volume')


### PR DESCRIPTION
## Problem

Uploading a 2 GiB iso currently is taking around 3 minutes 20 secs which is not very nice.

## Solution

Be more aggressive about each chunk size we read from the job pipe and with the changes done, we are at 32 seconds approximately for an ISO of 2 GiB.

Original PR: https://github.com/truenas/middleware/pull/16065
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134552