### PR TITLE
Fix pydantic warnings coming from nfs_/debug.py

### DIFF
--- a/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
+++ b/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
@@ -21,7 +21,7 @@ def __complexity_impl(
     required_cnt: int,
     min_length: int,
     max_length: int,
-) -> str:
+) -> SecretStr:
     passwd_length = len(value)
     if passwd_length < min_length:
         raise ValueError(f"Length of password must be at least {min_length} chars")
@@ -85,7 +85,7 @@ def passwd_complexity_validator(
     required_cnt: int = 0,
     min_length: int = 8,
     max_length: int = 16,
-) -> str:
+) -> partial[SecretStr]:
     """Enforce password complexity.
 
     Args:

--- a/src/middlewared/middlewared/plugins/nfs_/debug.py
+++ b/src/middlewared/middlewared/plugins/nfs_/debug.py
@@ -1,4 +1,5 @@
 import os
+from typing import Literal
 
 from contextlib import suppress
 from middlewared.api import api_method
@@ -82,10 +83,10 @@ class RPC_DBGFLAGS(enum.Enum):
 
 
 class NfsDebug(BaseModel):
-    NFS: UniqueList[NFS_DBGFLAGS.__members__] | None = None
-    NFSD: UniqueList[NFSD_DBGFLAGS.__members__] | None = None
-    NLM: UniqueList[NLM_DBGFLAGS.__members__] | None = None
-    RPC: UniqueList[RPC_DBGFLAGS.__members__] | None = None
+    NFS: UniqueList[Literal[*NFS_DBGFLAGS.__members__]] | None = None
+    NFSD: UniqueList[Literal[*NFSD_DBGFLAGS.__members__]] | None = None
+    NLM: UniqueList[Literal[*NLM_DBGFLAGS.__members__]] | None = None
+    RPC: UniqueList[Literal[*RPC_DBGFLAGS.__members__]] | None = None
 
 
 class NfsDebugGetArgs(BaseModel):


### PR DESCRIPTION
`UniqueList` requires a type, but `__members__` is an instance of `mappingproxy`. Here's one of the warnings this causes:

<code>/usr/lib/python3/dist-packages/pydantic/_internal/_generate_schema.py:547: UserWarning: mappingproxy({'NONE': <NFS_DBGFLAGS.NONE: 0>, 'VFS': <NFS_DBGFLAGS.VFS: 1>, 'DIRCACHE': <NFS_DBGFLAGS.DIRCACHE: 2>, 'LOOKUPCACHE': <NFS_DBGFLAGS.LOOKUPCACHE: 4>, 'PAGECACHE': <NFS_DBGFLAGS.PAGECACHE: 8>, 'PROC': <NFS_DBGFLAGS.PROC: 16>, 'XDR': <NFS_DBGFLAGS.XDR: 32>, 'FILE': <NFS_DBGFLAGS.FILE: 64>, 'ROOT': <NFS_DBGFLAGS.ROOT: 128>, 'CALLBACK': <NFS_DBGFLAGS.CALLBACK: 256>, 'CLIENT': <NFS_DBGFLAGS.CLIENT: 512>, 'MOUNT': <NFS_DBGFLAGS.MOUNT: 1024>, 'FSCACHE': <NFS_DBGFLAGS.FSCACHE: 2048>, 'PNFS': <NFS_DBGFLAGS.PNFS: 4096>, 'PNFS_LD': <NFS_DBGFLAGS.PNFS_LD: 8192>, 'STATE': <NFS_DBGFLAGS.STATE: 16384>, 'XATTR_CACHE': <NFS_DBGFLAGS.XATTR_CACHE: 32768>, 'ALL': <NFS_DBGFLAGS.ALL: 65535>}) is not a Python type (it may be an instance of an object), Pydantic will allow any object with no validation since we cannot even enforce that the input is an instance of the given type. To get rid of this error wrap the type with `pydantic.SkipValidation`.</code>

We can also correct some unrelated type hints I found in validators_/passwd_complexity.py.