### PR TITLE
NAS-134951 / 25.10 / fix __opener method in disk_class.py

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -64,8 +64,13 @@ class DiskEntry:
         if relative_path is None and absolute_path is None:
             raise ValueError("relative_path or absolute_path is required")
 
+        if relative_path is not None:
+            path = f'/sys/block/{self.name}/{relative_path}'
+        else:
+            path = absolute_path
+
         try:
-            with open(relative_path or absolute_path, mode) as f:
+            with open(path, mode) as f:
                 return f.read().strip()
         except Exception:
             pass


### PR DESCRIPTION
6e01bf80c2b forgot to add logic when the `relative_path` kwarg is passed to it. This fixes said logic.