### PR TITLE
NAS-134952 / 25.10 / Unlink leftover files when uploading a config that is lacking some files

### DIFF
--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import datetime
 import glob
 import os
@@ -290,12 +291,24 @@ def setup(middleware):
 
         if os.path.exists(PWENC_UPLOADED):
             shutil.move(PWENC_UPLOADED, PWENC_FILE_SECRET)
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(PWENC_FILE_SECRET)
 
         if os.path.exists(ADMIN_KEYS_UPLOADED):
             shutil.move(ADMIN_KEYS_UPLOADED, CONFIG_FILES['admin_authorized_keys'])
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(CONFIG_FILES['admin_authorized_keys'])
 
         if os.path.exists(TRUENAS_ADMIN_KEYS_UPLOADED):
             shutil.move(TRUENAS_ADMIN_KEYS_UPLOADED, CONFIG_FILES['truenas_admin_authorized_keys'])
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(CONFIG_FILES['truenas_admin_authorized_keys'])
 
         if os.path.exists(ROOT_KEYS_UPLOADED):
             shutil.move(ROOT_KEYS_UPLOADED, CONFIG_FILES['root_authorized_keys'])
+        else:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(CONFIG_FILES['root_authorized_keys'])


### PR DESCRIPTION
If we upload a config file that does not contain pwenc secret or `authorized_keys` files, we must remove old pwenc secret and `authorized_keys` files so that they are not unintentionally re-used.

When uploading a config file that uses the current pwenc secret (but does not contain a pwenc secret), the migration does not "see" the "new" secret and does not perform data migration. However, after a reboot, previous pwenc secret was being used, leading to unmigrated data being decryptable again (and subsequenr crash).

This also fixes the potential case of unintentionally allowing unexpected SSH keys to access the system.