### PR TITLE
NAS-134981 / 25.04.1 / Remove comment from head of sssd.conf file (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -1,6 +1,3 @@
-#
-# NSLCD.CONF(5)		The configuration file for LDAP nameservice daemon
-#
 <%
     from middlewared.plugins.etc import FileShouldNotExist
     from middlewared.plugins.ldap_ import constants, utils


### PR DESCRIPTION
This commit removes a stray comment from the sssd configuraiton from when we were using nss-pam-ldapd for LDAP functionality.

Original PR: https://github.com/truenas/middleware/pull/16094
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134981