### PR TITLE
NAS-134985 / 25.10 / Hard-code LDAP domain name in sssd.config

### DIFF
--- a/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/sssd/sssd.conf.mako
@@ -29,7 +29,7 @@
             )['realm']
 
         ldap_enabled = ldap['enable']
-        domain = kerberos_realm or ldap['hostname'][0]
+        domain = kerberos_realm or 'LDAP'
 
         ldap_enabled = ldap['enable']
         for param in ldap['auxiliary_parameters'].splitlines():


### PR DESCRIPTION
We were using the first hostname provided by the admin in the LDAP configuration for naming the domain section of the sssd.config.

This is a cosmetic change to prevent user confusion, and mirrors configuration in Example section of man (5) sssd.conf.