### PR TITLE
NAS-134992 / 25.04.1 / Prevent constraint violation on kerberos realm deletion (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -854,6 +854,12 @@ class ActiveDirectoryService(ConfigService):
             )
 
         if ad['kerberos_realm']:
+            # Forcibly unset kerberos realm from LDAP plugin. This is OK because the
+            # two plugins may not be enabled simultaneously. In 25.10 these plugins
+            # will be unified into single directoryservices plugin
+            await self.middleware.call(
+                'datastore.update', 'directoryservice.ldap', 1, {'ldap_kerberos_realm': None}
+            )
             try:
                 await self.middleware.call(
                     'datastore.delete', 'directoryservice.kerberosrealm', ad['kerberos_realm']

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -56,6 +56,12 @@ class IPAJoinMixin:
             job.set_progress(80, 'Removing kerberos configuration.')
 
         if ldap_config['kerberos_realm']:
+            # TODO: remove after unifying the directory services plugins
+            # User may have configured our kerberos realm in AD plugin
+            # necessitating deletion from config
+            self.middleware.call_sync(
+                'datastore.update', 'directoryservice.activedirectory', 1, {'ad_kerberos_realm': None}
+            )
             self.middleware.call_sync('kerberos.realm.delete', ldap_config['kerberos_realm'])
 
         if (host_kt := self.middleware.call_sync('kerberos.keytab.query', [
@@ -509,7 +515,9 @@ class IPAJoinMixin:
                 case KRB5ErrCode.KRB5_REALM_UNKNOWN:
                     # DNS is broken in the IPA domain and so we need to roll back our config
                     # changes.
-                    self._ipa_remove_kerberos_cert_config(None, None)
+
+                    saved_config = self.middleware.call_sync('ldap.config')
+
                     self.logger.warning(
                         'Unable to resolve kerberos realm via DNS. This may indicate misconfigured '
                         'nameservers on the TrueNAS server or a misconfigured IPA domain.', exc_info=True
@@ -519,6 +527,8 @@ class IPAJoinMixin:
                         'ldap_kerberos_principal': '',
                         'ldap_bindpw': ldap_config['bindpw']
                     })
+
+                    self._ipa_remove_kerberos_cert_config(None, saved_config)
 
                     # remove any configuration files we have written
                     for p in (


### PR DESCRIPTION
This commit fixes an out-of-order operation in error handling
in cleanup in case of IPA join failure due to invalid DNS
configuration (failure to detect kerberos realm).

During the investigation of a sentry-reported error, additional
obscure edge cases were discovered related to users partially
configuring AD + LDAP plugins that could also lead to a
constraint violation in other code paths. These are now
protected against and will be fully addressed in 25.10 when
AD and LDAP plugins stored in a single table.

Original PR: https://github.com/truenas/middleware/pull/16102
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134992