### PR TITLE
NAS-132600 / 25.10 / Improve directoryservices.health.recover

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/health.py
+++ b/src/middlewared/middlewared/utils/directoryservices/health.py
@@ -3,6 +3,8 @@ import enum
 from .constants import DSStatus, DSType
 from threading import Lock
 
+MAX_RECOVER_ATTEMPTS = 5
+
 
 class KRB5HealthCheckFailReason(enum.IntEnum):
     KRB5_NO_CONFIG = enum.auto()


### PR DESCRIPTION
directoryservices.health.recover is a private endpoint that is used to recover from various FAULTED conditions that may arise in directory services. The initial design was to perform a health check, get the error, recover from the error, and then redo the health check.

This runs into a problem if, for instance, there are multiple reasons why the directory service is faulted. The recovery attempt will fix one problem, but leave the others (which are also potentially recoverable).

This commit adjusts the internal behavior of the private API endpoint so that it will step through configuration problems attempting to fix them unless one of two condition occurs:

1. Max retry attempts is hit
2. Recovery fails with same reason twice in a row