### PR TITLE
NAS-132103 / 25.10 / Simplify smb.configure logic for HA failover

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -4,7 +4,7 @@ import struct
 from base64 import b64decode
 from middlewared.schema import accepts, Dict, List, OROperator, returns, Str
 from middlewared.service import no_authz_required, Service, private, job
-from middlewared.service_exception import CallError, MatchNotFound
+from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import (
     DSStatus, DSType, NSS_Info
 )

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -302,9 +302,6 @@ class SMBService(ConfigService):
         job.set_progress(0, 'Setting up SMB directories.')
         await self.setup_directories()
 
-        job.set_progress(10, 'Generating stub SMB config.')
-        await self.middleware.call('etc.generate', 'smb')
-
         """
         We cannot continue without network.
         Wait here until we see the ix-netif completion sentinel.

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -502,7 +502,6 @@ class SMBService(ConfigService):
                     'multi-protocol NFS access.'
                 )
 
-
         if new['enable_smb1']:
             if audited_shares := await self.middleware.call(
                 'sharing.smb.query', [['audit.enable', '=', True]], {'select': ['audit', 'name']}

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -293,20 +293,16 @@ class SMBService(ConfigService):
 
     @private
     @job(lock="smb_configure")
-    async def configure(self, job, create_paths=True):
+    async def configure(self, job):
         """
         Many samba-related tools will fail if they are unable to initialize
         a messaging context, which will happen if the samba-related directories
         do not exist or have incorrect permissions.
         """
         job.set_progress(0, 'Setting up SMB directories.')
-        if create_paths:
-            await self.setup_directories()
+        await self.setup_directories()
 
         job.set_progress(10, 'Generating stub SMB config.')
-        await self.middleware.call('etc.generate', 'smb')
-
-        job.set_progress(25, 'generating SMB, idmap, and directory service config.')
         await self.middleware.call('etc.generate', 'smb')
 
         """
@@ -1666,6 +1662,11 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
         ) else False
 
 
+async def systemdataset_setup_hook(middleware, data):
+    if not data['in_progress']:
+        await self.middleware.call('smb.setup_directories')
+
+
 async def setup(middleware):
     await middleware.call(
         'interface.register_listen_delegate',
@@ -1673,3 +1674,4 @@ async def setup(middleware):
     )
     await middleware.call('pool.dataset.register_attachment_delegate', SMBFSAttachmentDelegate(middleware))
     middleware.register_hook('pool.post_import', pool_post_import, sync=True)
+    middleware.register_hook("sysdataset.setup", systemdataset_setup_hook)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1664,7 +1664,7 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
 
 async def systemdataset_setup_hook(middleware, data):
     if not data['in_progress']:
-        await self.middleware.call('smb.setup_directories')
+        await middleware.call('smb.setup_directories')
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -200,14 +200,6 @@ class SystemDatasetService(ConfigService):
             p: p for p in sorted(set(pools))
         }
 
-    @private
-    async def _post_setup_service_restart(self):
-        await self.middleware.call('smb.setup_directories')
-
-        # The following should be backgrounded since they may be quite
-        # long-running.
-        await self.middleware.call('smb.configure', False)
-
     @accepts(Dict(
         'sysdataset_update',
         Str('pool', null=True),
@@ -357,7 +349,6 @@ class SystemDatasetService(ConfigService):
                 if job.error:
                     raise CallError(job.error)
 
-                self.middleware.call_sync('systemdataset._post_setup_service_restart')
                 return
 
         mntinfo = self.middleware.call_sync('filesystem.mount_info')
@@ -435,9 +426,6 @@ class SystemDatasetService(ConfigService):
             subprocess.run(['umount', '/var/lib/systemd/coredump'], check=False)
             os.makedirs('/var/lib/systemd/coredump', exist_ok=True)
             subprocess.run(['mount', '--bind', corepath, '/var/lib/systemd/coredump'])
-
-        if mounted:
-            self.middleware.call_sync('systemdataset._post_setup_service_restart')
 
         return self.middleware.call_sync('systemdataset.config')
 


### PR DESCRIPTION
This commit alters the order and circumstances in which smb.configure is called. Originally this was called during system dataset setup and during directory services setup. The new behavior is to have SMB-related directories automatically created when the system dataset setup is complete (triggered via hook) and call into the larger method of configuring the SMB service during directory services initialization. This resolves a race between smb.configure and directoryservice.setup calls that could occur during vrrp_master events.