### PR TITLE
NAS-132103 / 25.04.1 / Simplify smb.configure logic for HA failover (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -4,7 +4,7 @@ import struct
 from base64 import b64decode
 from middlewared.schema import accepts, Dict, List, OROperator, returns, Str
 from middlewared.service import no_authz_required, Service, private, job
-from middlewared.service_exception import CallError, MatchNotFound
+from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import (
     DSStatus, DSType, NSS_Info
 )

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1678,7 +1678,7 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
 
 async def systemdataset_setup_hook(middleware, data):
     if not data['in_progress']:
-        await self.middleware.call('smb.setup_directories')
+        await middleware.call('smb.setup_directories')
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -307,20 +307,16 @@ class SMBService(ConfigService):
 
     @private
     @job(lock="smb_configure")
-    async def configure(self, job, create_paths=True):
+    async def configure(self, job):
         """
         Many samba-related tools will fail if they are unable to initialize
         a messaging context, which will happen if the samba-related directories
         do not exist or have incorrect permissions.
         """
         job.set_progress(0, 'Setting up SMB directories.')
-        if create_paths:
-            await self.setup_directories()
+        await self.setup_directories()
 
         job.set_progress(10, 'Generating stub SMB config.')
-        await self.middleware.call('etc.generate', 'smb')
-
-        job.set_progress(25, 'generating SMB, idmap, and directory service config.')
         await self.middleware.call('etc.generate', 'smb')
 
         """
@@ -1680,6 +1676,11 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
         ) else False
 
 
+async def systemdataset_setup_hook(middleware, data):
+    if not data['in_progress']:
+        await self.middleware.call('smb.setup_directories')
+
+
 async def setup(middleware):
     await middleware.call(
         'interface.register_listen_delegate',
@@ -1687,3 +1688,4 @@ async def setup(middleware):
     )
     await middleware.call('pool.dataset.register_attachment_delegate', SMBFSAttachmentDelegate(middleware))
     middleware.register_hook('pool.post_import', pool_post_import, sync=True)
+    middleware.register_hook("sysdataset.setup", systemdataset_setup_hook)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -516,7 +516,6 @@ class SMBService(ConfigService):
                     'multi-protocol NFS access.'
                 )
 
-
         if new['enable_smb1']:
             if audited_shares := await self.middleware.call(
                 'sharing.smb.query', [['audit.enable', '=', True]], {'select': ['audit', 'name']}

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -316,9 +316,6 @@ class SMBService(ConfigService):
         job.set_progress(0, 'Setting up SMB directories.')
         await self.setup_directories()
 
-        job.set_progress(10, 'Generating stub SMB config.')
-        await self.middleware.call('etc.generate', 'smb')
-
         """
         We cannot continue without network.
         Wait here until we see the ix-netif completion sentinel.


### PR DESCRIPTION
This commit alters the order and circumstances in which smb.configure is called. Originally this was called during system dataset setup and during directory services setup. The new behavior is to have SMB-related directories automatically created when the system dataset setup is complete (triggered via hook) and call into the larger method of configuring the SMB service during directory services initialization. This resolves a race between smb.configure and directoryservice.setup calls that could occur during vrrp_master events.

Original PR: https://github.com/truenas/middleware/pull/16105
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132103