### PR TITLE
NAS-134996 / 25.10 / Fix two issues with the pool.* conversion

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -127,7 +127,7 @@ class PoolCreateEncryptionOptions(BaseModel):
     not desired, dataset should be created with a passphrase as a key."""
     generate_key: bool = False
     """Automatically generate the key to be used for dataset encryption."""
-    pbkdf2iters: Annotated[int, Field(ge=100000)] = 350000
+    pbkdf2iters: int = Field(ge=100000, default=350000)
     algorithm: Literal[
         "AES-128-CCM", "AES-192-CCM", "AES-256-CCM", "AES-128-GCM", "AES-192-GCM", "AES-256-GCM"
     ] = "AES-256-GCM"
@@ -177,7 +177,7 @@ class PoolCreateTopologyLogVdev(BaseModel):
 
 
 class PoolCreateTopology(BaseModel):
-    data: Annotated[list[PoolCreateTopologyDataVdev], Field(min_length=1)]
+    data: list[PoolCreateTopologyDataVdev] = Field(min_length=1)
     """All vdevs must be of the same `type`."""
     special: list[PoolCreateTopologySpecialVdev] = []
     dedup: list[PoolCreateTopologyDedupVdev] = []
@@ -201,21 +201,21 @@ class PoolCreate(BaseModel):
     ] = None
     encryption_options: PoolCreateEncryptionOptions = Field(default_factory=PoolCreateEncryptionOptions)
     """Specify configuration for encryption of root dataset."""
-    topology: PoolCreateTopology
-    """```
-    {
-        "data": [
-            {"type": "RAIDZ1", "disks": ["da1", "da2", "da3"]}
-        ],
-        "cache": [
-            {"type": "STRIPE", "disks": ["da4"]}
-        ],
-        "log": [
-            {"type": "STRIPE", "disks": ["da5"]}
-        ],
+    topology: PoolCreateTopology = Field(examples=[{
+        "data": [{
+            "type": "RAIDZ1",
+            "disks": ["da1", "da2", "da3"]
+        }],
+        "cache": [{
+            "type": "STRIPE",
+            "disks": ["da4"]
+        }],
+        "log": [{
+            "type": "STRIPE",
+            "disks": ["da5"]
+        }],
         "spares": ["da6"]
-    }
-    ```"""
+    }])
     allow_duplicate_serials: bool = False
 
 
@@ -262,7 +262,7 @@ class PoolReplace(BaseModel):
 
 class PoolUpdateTopology(PoolCreateTopology, metaclass=ForUpdateMetaclass):
     """Cannot change type of existing vdevs."""
-    pass
+    data: list[PoolCreateTopologyDataVdev]
 
 
 class PoolUpdate(PoolCreate, metaclass=ForUpdateMetaclass):

--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -52,36 +52,36 @@ class PoolEntry(BaseModel):
     guid: str
     status: str
     path: str
-    scan: dict | None
-    """
-    example={
-        'function': None,
-        'state': None,
-        'start_time': None,
-        'end_time': None,
-        'percentage': None,
-        'bytes_to_process': None,
-        'bytes_processed': None,
-        'bytes_issued': None,
-        'pause': None,
-        'errors': None,
-        'total_secs_left': None,
-    }
-    """
-    expand: dict | None
-    """
-    example={
-        'state': 'FINISHED',
-        'expanding_vdev': 0,
-        'start_time': None,
-        'end_time': None,
-        'bytes_to_reflow': 835584,
-        'bytes_reflowed': 978944,
-        'waiting_for_resilver': 0,
-        'total_secs_left': None,
-        'percentage': 85.35564853556485,
-    }
-    """
+    scan: Annotated[
+        dict,
+        Field(examples=[{
+            'function': None,
+            'state': None,
+            'start_time': None,
+            'end_time': None,
+            'percentage': None,
+            'bytes_to_process': None,
+            'bytes_processed': None,
+            'bytes_issued': None,
+            'pause': None,
+            'errors': None,
+            'total_secs_left': None,
+        }])
+    ] | None
+    expand: Annotated[
+        dict,
+        Field(examples=[{
+            'state': 'FINISHED',
+            'expanding_vdev': 0,
+            'start_time': None,
+            'end_time': None,
+            'bytes_to_reflow': 835584,
+            'bytes_reflowed': 978944,
+            'waiting_for_resilver': 0,
+            'total_secs_left': None,
+            'percentage': 85.35564853556485,
+        }])
+    ] | None
     is_upgraded: bool = False
     healthy: bool
     warning: bool
@@ -98,15 +98,12 @@ class PoolEntry(BaseModel):
     allocated_str: str | None
     free_str: str | None
     freeing_str: str | None
-    autotrim: dict
-    """
-    example={
+    autotrim: dict = Field(examples=[{
         'parsed': 'off',
         'rawvalue': 'off',
         'source': 'DEFAULT',
         'value': 'off',
-    }
-    """
+    }])
     topology: PoolTopology | None
 
 

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -311,7 +311,7 @@ class PoolService(CRUDService):
                     )
                 lastdatatype = vdev['type']
 
-        for i in ('cache', 'log', 'spares'):
+        for i in ('cache', 'log'):
             value = data['topology'].get(i)
             if value and len(value) > 1:
                 verrors.add(
@@ -361,9 +361,6 @@ class PoolService(CRUDService):
             verrors.add('pool_create.name', 'A pool with this name already exists.', errno.EEXIST)
         elif not validate_pool_name(data['name']):
             verrors.add('pool_create.name', 'Invalid pool name', errno.EINVAL)
-
-        if not data['topology']['data']:
-            verrors.add('pool_create.topology.data', 'At least one data vdev is required')
 
         encryption_dict = await self.middleware.call(
             'pool.dataset.validate_encryption_data', None, verrors, {

--- a/tests/api2/test_pool_spare.py
+++ b/tests/api2/test_pool_spare.py
@@ -44,5 +44,5 @@ def test_pool_update_spare():
         spares = [disk["name"] for disk in call("disk.get_unused")[:2]]
         assert len(spares) == 2
 
-        result = call("pool.update", pool["id"], {"topology": {"spares": spares}})
+        result = call("pool.update", pool["id"], {"topology": {"spares": spares}}, job=True)
         assert {disk["disk"] for disk in result["topology"]["spare"]} == set(spares)

--- a/tests/api2/test_pool_spare.py
+++ b/tests/api2/test_pool_spare.py
@@ -27,8 +27,9 @@ def test_pool_create_too_small_spare():
         assert ve.value.errors[0].errmsg.startswith("Spare sdz (1 GiB) is smaller than the smallest data disk")
 
 
-def test_pool_update_too_small_spare():
+def test_pool_update_spare():
     with another_pool() as pool:
+        # Test too small
         with fake_disks({"sdz": {"size_bytes": 1024 * 1024 * 1024}}):
             with pytest.raises(ValidationErrors) as ve:
                 call("pool.update", pool["id"], {
@@ -38,3 +39,10 @@ def test_pool_update_too_small_spare():
                 }, job=True)
 
             assert ve.value.errors[0].errmsg.startswith("Spare sdz (1 GiB) is smaller than the smallest data disk")
+
+        # Test multiple spares
+        spares = [disk["name"] for disk in call("disk.get_unused")[:2]]
+        assert len(spares) == 2
+
+        result = call("pool.update", pool["id"], {"topology": {"spares": spares}})
+        assert {disk["disk"] for disk in result["topology"]["spare"]} == set(spares)


### PR DESCRIPTION
1. pool.create enforces at least one data vdev is provided. The conversion pr #15848 made this the case for pool.update as well (it should not be).
2. The conversion PR fixed a typo that caused no more than one spare disk to be allowed. The typo had actually been preventing this incorrect behavior.