### PR TITLE
NAS-134913 / 25.10 / ZVOL source type being removed from virt instance creation

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -372,20 +372,8 @@ class VirtInstanceService(CRUDService):
         data_devices = data['devices'] or []
         iso_volume = data.pop('iso_volume', None)
         root_device_to_add = None
-        zvol_path = data.pop('zvol_path', None)
         volume = data.pop('volume', None)
-        if data['source_type'] == 'ZVOL':
-            data['source_type'] = None
-            root_device_to_add = {
-                'name': 'ix_virt_zvol_root',
-                'dev_type': 'DISK',
-                'source': zvol_path,
-                'destination': None,
-                'readonly': False,
-                'boot_priority': 1,
-                'io_bus': data['root_disk_io_bus'],
-            }
-        elif data['source_type'] == 'ISO':
+        if data['source_type'] == 'ISO':
             root_device_to_add = {
                 'name': iso_volume,
                 'dev_type': 'DISK',


### PR DESCRIPTION
## Context

We now allow creating virt instances using virt volumes which can be created using zvols (we recently allowed importing zvol as virt volumes). Here it was requested by UI that they are no longer now consuming ZVOL as source type and so it can be removed from middleware.