### PR TITLE
NAS-134982 / 25.10 / Better report validation error of storage pools

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -1,10 +1,11 @@
-from typing import TYPE_CHECKING
 import asyncio
 import errno
 import shutil
 import subprocess
-import middlewared.sqlalchemy as sa
+from collections import defaultdict
+from typing import TYPE_CHECKING
 
+import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.current import (
     VirtGlobalEntry,
@@ -141,12 +142,24 @@ class VirtGlobalService(ConfigService):
         if new['pool'] and old['pool']:
             # If we're stopping or starting the virt plugin then we don't need to worry
             # about how storage changes will impact the overall running configuration.
+            error_message = []
             for pool in removed_storage_pools:
                 if usage := (await self.storage_pool_usage(pool)):
-                    verrors.add(
-                        'virt_global_update.storage_pools',
-                        f'{pool}: pool to be removed is used by the following assets: {usage}'
+                    grouped_usage = defaultdict(list)
+                    for item in usage:
+                        grouped_usage[item["type"].capitalize()].append(item["name"])
+
+                    usage_list = '\n'.join(
+                        f'- Virt-{key}: {", ".join(value)}'
+                        for key, value in grouped_usage.items()
                     )
+
+                    error_message.append(
+                        f'The pool {pool!r} cannot be removed because it is currently used by the following asset(s):\n'
+                        f'{usage_list}'
+                    )
+            if error_message:
+                verrors.add('virt_global_update.storage_pools', '\n\n'.join(error_message))
 
         if new['pool'] in removed_storage_pools:
             verrors.add(


### PR DESCRIPTION
## Context

We were reporting json dict converted to string as is when showing error for storage pools and that has been improved.

Validation error now:
```
[EINVAL] virt_global_update.storage_pools: The pool 'tank' cannot be removed because it is currently used by the following asset(s):
- Virt-Instances: tank-container-1, tank-vm-1
- Virt-Volumes: alpine-standard-3.21.3-x86_64.iso, tank-vol, test-volume-1, test-volume-2

The pool 'mypool' cannot be removed because it is currently used by the following asset(s):
- Virt-Instances: mypool-container
- Virt-Volumes: mypool-volume

The pool 'test' cannot be removed because it is currently used by the following asset(s):
- Virt-Instances: container-1, vm-1
- Virt-Volumes: test-vol
```