### PR TITLE
NAS-134576 / 25.10 / STIG rule: All users individually identified and authenticated

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -802,6 +802,8 @@ class UserService(CRUDService):
         if user['smb'] is False and data.get('smb') is True:
             must_change_pdb_entry = True
 
+        verrors.check()
+
         # Copy the home directory if it changed
         home_copy = False
         home_old = None

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -777,6 +777,8 @@ class UserService(CRUDService):
             verrors.add('user_update.smb',
                         'Password must be reset in order to enable SMB authentication')
 
+        verrors.check()
+
         must_change_pdb_entry = False
         for k in ('username', 'password', 'locked'):
             new_val = data.get(k)
@@ -801,8 +803,6 @@ class UserService(CRUDService):
 
         if user['smb'] is False and data.get('smb') is True:
             must_change_pdb_entry = True
-
-        verrors.check()
 
         # Copy the home directory if it changed
         home_copy = False

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -109,19 +109,12 @@ class SystemSecurityService(ConfigService):
                 'prior to enabling General Purpose OS STIG compatibility mode.'
             )
 
-        all_local_admins = await self.middleware.call('privilege.local_administrators')
-        excluded_admins = [user["username"] for user in all_local_admins if user['uid'] < 1000]
-
-        if not any([
-            user for user in two_factor_users
-            if user['uid'] >= 1000 and 'FULL_ADMIN' in user['roles']
-        ]):
+        if not any([user for user in two_factor_users if 'FULL_ADMIN' in user['roles']]):
             raise ValidationError(
                 'system_security_update.enable_gpos_stig',
                 'At least one local user with full admin privileges must be '
                 'configured with a two factor authentication token prior to enabling '
-                f'General Purpose OS STIG compatibility mode.  '
-                f'EXCLUDED ACCOUNTS: {", ".join(excluded_admins)}.'
+                'General Purpose OS STIG compatibility mode.'
             )
 
         if current_cred and current_cred.is_user_session and '2FA' not in current_cred.user['account_attributes']:
@@ -133,6 +126,15 @@ class SystemSecurityService(ConfigService):
                 'must have two factor authentication enabled, and have used two factor '
                 'authentication for the currently-authenticated session.'
             )
+
+        excluded_admins = [
+            user['username'] for user in await self.middleware.call(
+                'user.query', [
+                    ["immutable", "=", True], ["password_disabled", "=", False],
+                    ["locked", "=", False], ["unixhash", "!=", "*"]
+                ],
+            )
+        ]
 
         if excluded_admins:
             # For STIG compatibility, all general purpose administrative accounts,

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
@@ -103,6 +103,7 @@ async def test_use_ssh_enabled_validation(data, old_data, twofactor_enabled, two
     m['smb.is_configured'] = lambda *arg: False
     m['auth.twofactor.config'] = lambda *arg: twofactor_config
     m['user.translate_username'] = lambda *args: {'twofactor_auth_configured': twofactor_enabled}
+    m['system.security.config'] = lambda *arg: {"enable_fips": False, "enable_gpos_stig": False}
     data['smb'] = False
     data.update(
         {

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_user_ssh_enabled_validation.py
@@ -105,6 +105,7 @@ async def test_use_ssh_enabled_validation(data, old_data, twofactor_enabled, two
     m['user.translate_username'] = lambda *args: {'twofactor_auth_configured': twofactor_enabled}
     m['system.security.config'] = lambda *arg: {"enable_fips": False, "enable_gpos_stig": False}
     data['smb'] = False
+    data['immutable'] = False
     data.update(
         {
             'smb': False,

--- a/tests/api2/test_zzzz_stig.py
+++ b/tests/api2/test_zzzz_stig.py
@@ -81,11 +81,11 @@ def two_factor_full_admin_as_builtin_admin(two_factor_enabled, unprivileged_user
     privilege = call('privilege.query', [['local_groups.0.group', '=', unprivileged_user_fixture.group_name]])
     assert len(privilege) > 0, 'Privilege not found'
     builtin_admin = call('group.query', [['name', '=', 'builtin_administrators']], {'get': True})
-    call('group.update', builtin_admin['id'], {'users': builtin_admin['users'] + [privilege[0]['id']]})
+    user_obj_id = call('user.query', [['username', '=', unprivileged_user_fixture.username]], {'get': True})['id']
+    call('group.update', builtin_admin['id'], {'users': builtin_admin['users'] + [user_obj_id]})
 
     try:
         call('user.renew_2fa_secret', unprivileged_user_fixture.username, {'interval': 60})
-        user_obj_id = call('user.query', [['username', '=', unprivileged_user_fixture.username]], {'get': True})['id']
         secret = get_user_secret(user_obj_id)
         yield (unprivileged_user_fixture, secret)
     finally:


### PR DESCRIPTION
Enforce STIG rule (SRG-OS-000109-GPOS-00056) that all users be individually identified and authenticated.
This excludes accounts such as 'root' and 'truenas_admin'.


Passing CI tests are [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3778/).
