### PR TITLE
NAS-135023 / 25.10 / Fix call_remote in MemorySizeMismatchAlertSource

### DIFF
--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -68,7 +68,7 @@ class MemorySizeMismatchAlertSource(AlertSource):
 
         try:
             r2 = await self.middleware.call(
-                'failover.call_remote', 'system.mem_info', {'raise_connect_error': False}
+                'failover.call_remote', 'system.mem_info', [], {'raise_connect_error': False}
             )
             if r2['physmem_size'] is None:
                 return alerts


### PR DESCRIPTION
The `failover.call_remote` was missing a parameter in `MemorySizeMismatchAlertSource`.