### PR TITLE
NAS-135031 / 25.10 / Fix disk stats netdata plugin

### DIFF
--- a/src/freenas/usr/lib/netdata/python.d/truenas_disk_stats.chart.py
+++ b/src/freenas/usr/lib/netdata/python.d/truenas_disk_stats.chart.py
@@ -1,6 +1,5 @@
 from bases.FrameworkServices.SimpleService import SimpleService
 
-from middlewared.utils.disks import get_disks_with_identifiers
 from middlewared.utils.disk_stats import get_disk_stats
 
 
@@ -8,36 +7,21 @@ class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.disk_mapping = {}
+        self.added_disks = set()
 
     def check(self):
-        self.disk_mapping = get_disks_with_identifiers()
-        self.add_disk_to_charts(self.disk_mapping.values())
         return True
 
     def get_data(self):
-        disk_data = get_disk_stats(self.disk_mapping)
-        disk_data_len = len(disk_data)
-        current_disk_mapping_len = len(self.disk_mapping)
-        if disk_data_len != current_disk_mapping_len:
-            # This means that some disk has been added/removed
-            self.disk_mapping = get_disks_with_identifiers()
-            # Now that we have updated our mapping, we would like to normalize the identifier
-            # for the disk which was added, for removal case we don't care as it is fine
-            new_disks = []
-            if disk_data_len > current_disk_mapping_len:
-                for new_disk in filter(lambda d: not d.startswith('{'), list(disk_data)):
-                    # We still use .get() here for safety, ideally we should have the identifier
-                    # but for whatever reason that didn't happen, we will then report it as such
-                    new_identifier = self.disk_mapping.get(new_disk, new_disk)
-                    disk_data[new_identifier] = disk_data.pop(new_disk)
-                    new_disks.append(new_identifier)
-
-                self.add_disk_to_charts(new_disks)
-
         disks_stats = {}
-        for disk_id, disks_io in disk_data.items():
+        disks_to_add = set()
+        for disk_id, disks_io in get_disk_stats().items():
             for op, value in disks_io.items():
                 disks_stats[f'{disk_id}.{op}'] = value
+            if disk_id not in self.added_disks:
+                disks_to_add.add(disk_id)
+
+        self.add_disk_to_charts(disks_to_add)
         return disks_stats
 
     def add_disk_to_charts(self, disk_ids):
@@ -68,3 +52,5 @@ class Service(SimpleService):
             self.charts[f'ops.{disk_id}'].add_dimension([f'{disk_id}.read_ops', 'read_ops', 'incremental'])
             self.charts[f'ops.{disk_id}'].add_dimension([f'{disk_id}.write_ops', 'write_ops', 'incremental'])
             self.charts[f'busy.{disk_id}'].add_dimension([f'{disk_id}.busy', 'busy', 'incremental'])
+
+            self.added_disks.add(disk_id)

--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -3,12 +3,18 @@ import time
 from middlewared.event import EventSource
 from middlewared.schema import Dict, Float, Int
 from middlewared.service import Service
-from middlewared.utils.disks import get_disk_names, get_disks_with_identifiers
+from middlewared.utils.disks import get_disk_names
+from middlewared.utils.disks_.disk_class import iterate_disks
 from middlewared.validators import Range
 
 from .realtime_reporting import (
     get_arc_stats, get_cpu_stats, get_disk_stats, get_interface_stats, get_memory_info, get_pool_stats,
 )
+
+
+def get_disks_with_identifiers() -> dict[str, str]:
+    return {i.name: i.identifier for i in iterate_disks()}
+
 
 class ReportingRealtimeService(Service):
 

--- a/src/middlewared/middlewared/plugins/reporting/rest.py
+++ b/src/middlewared/middlewared/plugins/reporting/rest.py
@@ -90,5 +90,5 @@ class NetdataService(Service):
             self.calculated_metrics_count(), config['tier1_days'], TIER_1_POINT_SIZE, config['tier1_update_interval'],
         )
 
-    def get_disk_stats(self, disk_identifier_mapping=None):
-        return get_disk_stats(disk_identifier_mapping)
+    def get_disk_stats(self):
+        return get_disk_stats()

--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -8,7 +8,7 @@ from truenas_connect_utils.status import Status
 from truenas_connect_utils.urls import get_heartbeat_url
 
 from middlewared.service import CallError, Service
-from middlewared.utils.disks import get_disks_with_identifiers
+from middlewared.utils.disks_.disk_class import iterate_disks
 from middlewared.utils.version import parse_version_string
 
 from .mixin import TNCAPIMixin
@@ -39,7 +39,7 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
             system_id=creds['system_id'],
             version=parse_version_string(await self.middleware.call('system.version_short')),
         )
-        disk_mapping = await self.middleware.run_in_thread(get_disks_with_identifiers)
+        disk_mapping = {i.name: i.identifier for i in iterate_disks()}
         while tnc_config['status'] in CONFIGURED_TNC_STATES:
             sleep_error = False
             resp = await self.call(heartbeat_url, 'post', await self.payload(disk_mapping), get_response=False)

--- a/src/middlewared/middlewared/utils/disk_stats.py
+++ b/src/middlewared/middlewared/utils/disk_stats.py
@@ -2,15 +2,14 @@ import contextlib
 import logging
 import os
 
-from .disks import get_disk_names, get_disks_with_identifiers
+from .disks_.disk_class import iterate_disks
 
 
 logger = logging.getLogger(__name__)
 
 
-def get_disk_stats(disk_identifier_mapping: dict | None = None) -> dict[str, dict]:
-    disk_identifier_mapping = disk_identifier_mapping or get_disks_with_identifiers()
-    available_disks = get_disk_names()
+def get_disk_stats() -> dict[str, dict]:
+    available_disks = {d.name: d for d in iterate_disks()}
     stats = {}
     with contextlib.suppress(IOError):
         with open('/proc/diskstats', 'r') as disk_stats_fd:
@@ -38,7 +37,7 @@ def get_disk_stats(disk_identifier_mapping: dict | None = None) -> dict[str, dic
                     logger.error('Failed to parse disk stats for %r: %r', disk_name, e)
                     continue
 
-                stats[disk_identifier_mapping.get(disk_name, disk_name)] = {
+                stats[available_disks[disk_name].identifier] = {
                     'reads': (read_sectors * sector_size) / 1024,  # convert to kb
                     'writes': (write_sectors * sector_size) / 1024,  # convert to kb
                     'read_ops': read_ops,


### PR DESCRIPTION
## Problem

There were a few problems with our disk stats plugin:
1. The conditionals in place in the disk stats plugin to detect if disk has changed won't work if a single disk was replaced with another one as the counts of the cached mapping won't change in this regard.
2. There is no need to get the same information twice in the netdata plugin i.e once when length change is detected and secondly when stats are actually retrieved and normalized.
3. Context building for historical reporting of disk stats can be improved using new implementation of disk querying.

## Solution

Addressing (1), we do not do any fancy caching mechanism as that is not required really and when we get the information we just use the values we have retrieved for disk id already via disk stats implementation. In netdata plugin, we have no desire to translate identifier to name which means we can then just save it as is after making sure it is added to netdata's db.