### PR TITLE
NAS-135048 / 25.04.1 / fix MemorySizeMismatch alert (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/alert/source/memory_errors.py
+++ b/src/middlewared/middlewared/alert/source/memory_errors.py
@@ -67,15 +67,21 @@ class MemorySizeMismatchAlertSource(AlertSource):
             return alerts
 
         try:
-            r2 = await self.middleware.call(
-                'failover.call_remote', 'system.mem_info', {'raise_connect_error': False}
-            )
-            if r2['physmem_size'] is None:
+            r2 = (await self.middleware.call(
+                'failover.call_remote', 'system.mem_info', [], {'raise_connect_error': False}
+            ))['physmem_size']
+            if r2 is None:
                 return alerts
         except Exception:
             return alerts
 
-        if r1 != r2:
+        # UEFI reserves parts of memory at every boot so
+        # this means the exact amount of bytes is not
+        # guaranteed. This also means that each controller
+        # might not have the _exact_ amount of bytes. We're
+        # going to consider > 2% of difference is too much
+        # and alert on it.
+        if abs(r1 - r2) > (0.02 * max(abs(r1), abs(r2))):
             alerts.append(Alert(
                 MemorySizeMismatchAlertClass,
                 {'r1': format_size(r1), 'r2': format_size(r2)}


### PR DESCRIPTION
Working on unrelated tickets, I noticed an internal HA system have an error message in the alert system.
```
"key": "{\"source_name\": \"MemorySizeMismatch\", \"traceback\": \"'>=' not supported between instances of 'dict' and 'int'\"}"
```
Investigating showed further that the alert was broken. After fixing this issue, I saw this alert get raised on a machine because the `MemTotal` values presented by procfs were off by 12 bytes. This is expected behavior because of how UEFI can reserve RAM at each boot. After discussion with OS team, we decided it safe to consider 2% of a difference between controllers to be large enough for this alert to be raised.

Original PR: https://github.com/truenas/middleware/pull/16126
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135048