### PR TITLE
Handle edge case to make sure selected source is used to boot

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -15,7 +15,7 @@ from middlewared.api.current import (
     VirtInstanceBootableDiskArgs, VirtInstanceBootableDiskResult,
 )
 from middlewared.async_validators import check_path_resides_within_volume
-from .utils import incus_call_and_wait, storage_pool_to_incus_pool, incus_pool_to_storage_pool
+from .utils import get_max_boot_priority_device, incus_call_and_wait, incus_pool_to_storage_pool, storage_pool_to_incus_pool
 
 
 class VirtInstanceDeviceService(Service):
@@ -539,16 +539,11 @@ class VirtInstanceDeviceService(Service):
 
         device_list = await self.device_list(id)
         desired_disk = None
-        max_boot_priority_device = None
 
-        for device_entry in device_list:
-            if (max_boot_priority_device is None and device_entry.get('boot_priority') is not None) or (
-                (device_entry.get('boot_priority') or 0) > ((max_boot_priority_device or {}).get('boot_priority') or 0)
-            ):
-                max_boot_priority_device = device_entry
-
-            if device_entry['name'] == disk:
-                desired_disk = device_entry
+        max_boot_priority_device = get_max_boot_priority_device(device_list)
+        for device in device_list:
+            if device['name'] == disk:
+                desired_disk = device
 
         if desired_disk is None:
             raise CallError(f'{disk!r} device does not exist.', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -202,6 +202,18 @@ def incus_pool_to_storage_pool(incus_pool_name: str) -> str:
     return incus_pool_name
 
 
+def get_max_boot_priority_device(device_list: list[dict]) -> dict | None:
+    max_boot_priority_device = None
+
+    for device_entry in device_list:
+        if (max_boot_priority_device is None and device_entry.get('boot_priority') is not None) or (
+            (device_entry.get('boot_priority') or 0) > ((max_boot_priority_device or {}).get('boot_priority') or 0)
+        ):
+            max_boot_priority_device = device_entry
+
+    return max_boot_priority_device
+
+
 @dataclass(slots=True, frozen=True, kw_only=True)
 class PciEntry:
     pci_addr: str


### PR DESCRIPTION
## Problem

If devices are attached to a virt instance at the time of creation, the user can set the boot_priority of an attached disk to a value greater than 1. This would override the intended boot_device that the user set as the source_type.

## Solution

Ensure that the selected `source_type` has the highest boot_priority so that the instance may boot from it even if devices are attached to it during creation.