### PR TITLE
NAS-135052 / 25.10 / Fix io_bus not persisting when selecting bootable disk

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -563,5 +563,6 @@ class VirtInstanceDeviceService(Service):
             'dev_type': 'DISK',
             'name': disk,
             'source': desired_disk.get('source'),
+            'io_bus': desired_disk.get('io_bus'),
             'boot_priority': max_boot_priority_device['boot_priority'] + 1 if max_boot_priority_device else 1,
         } | ({'destination': desired_disk['destination']} if disk != 'root' else {}))


### PR DESCRIPTION
## Problem

When `virt.instance.set_bootable_disk` endpoint is called, the selected disk loses it's `io_bus` value.

## Solution

Ensure that the selected disk's `io_bus` value persists.