### PR TITLE
NAS-135035 / 25.04.1 / JSON database columns should use their type param  (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/helpers.py
+++ b/src/middlewared/middlewared/pytest/unit/helpers.py
@@ -1,12 +1,15 @@
 import functools
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from middlewared.api.base import BaseModel
 from middlewared.api.base.handler.model_provider import ModelProvider
 from middlewared.utils.plugins import LoadPluginsMixin
+if TYPE_CHECKING:
+    from middlewared.service import Service
 
 
-def load_compound_service(name):
+def load_compound_service(name: str) -> 'functools.partial[Service]':
     lpm = LoadPluginsMixin()
     lpm.event_register = Mock()
     lpm.get_events = Mock(return_value=[])

--- a/src/middlewared/middlewared/pytest/unit/helpers.py
+++ b/src/middlewared/middlewared/pytest/unit/helpers.py
@@ -1,15 +1,16 @@
 import functools
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 from unittest.mock import Mock
 
-from middlewared.api.base import BaseModel
 from middlewared.api.base.handler.model_provider import ModelProvider
 from middlewared.utils.plugins import LoadPluginsMixin
 if TYPE_CHECKING:
-    from middlewared.service import Service
+    from middlewared.api.base import BaseModel
+    from middlewared.pytest.unit.middleware import Middleware
+    from middlewared.service import Service, CompoundService
 
 
-def load_compound_service(name: str) -> 'functools.partial[Service]':
+def load_compound_service(name: str) -> 'Callable[[Middleware], CompoundService]':
     lpm = LoadPluginsMixin()
     lpm.event_register = Mock()
     lpm.get_events = Mock(return_value=[])
@@ -18,22 +19,22 @@ def load_compound_service(name: str) -> 'functools.partial[Service]':
     return functools.partial(_compound_service_wrapper, service)
 
 
-def _compound_service_wrapper(service, fake_middleware):
+def _compound_service_wrapper(service: 'CompoundService', fake_middleware: 'Middleware') -> 'CompoundService':
     service.middleware = fake_middleware
     for part in service.parts:
         part.middleware = fake_middleware
     return service
 
 
-def create_service(middleware, cls):
+def create_service(middleware: 'Middleware', cls: 'type[Service]') -> 'Service':
     service = cls(middleware)
     middleware._resolve_methods([service], [])
     return service
 
 
 class TestModelProvider(ModelProvider):
-    def __init__(self, models: dict[str, type[BaseModel]]):
+    def __init__(self, models: 'dict[str, type[BaseModel]]'):
         self.models = models
 
-    async def get_model(self, name: str) -> type[BaseModel]:
+    async def get_model(self, name: str) -> 'type[BaseModel]':
         return self.models[name]

--- a/src/middlewared/middlewared/utils/plugins.py
+++ b/src/middlewared/middlewared/utils/plugins.py
@@ -5,8 +5,11 @@ import itertools
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from middlewared.schema import Schemas
+if TYPE_CHECKING:
+    from middlewared.service import Service
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +93,8 @@ class SchemasMixin:
 class LoadPluginsMixin(SchemasMixin):
 
     def __init__(self):
-        self._services = {}
-        self._services_aliases = {}
+        self._services: dict[str, 'Service'] = {}
+        self._services_aliases: dict[str, 'Service'] = {}
         super().__init__()
 
     def _load_plugins(self, on_module_begin=None, on_module_end=None, on_modules_loaded=None, whitelist=None):
@@ -134,12 +137,12 @@ class LoadPluginsMixin(SchemasMixin):
         # to make sure every schema is patched and references match
         self._resolve_methods(list(self._services.values()), self.get_events())
 
-    def add_service(self, service):
+    def add_service(self, service: 'Service'):
         self._services[service._config.namespace] = service
         if service._config.namespace_alias:
             self._services_aliases[service._config.namespace_alias] = service
 
-    def get_service(self, name):
+    def get_service(self, name: str) -> 'Service':
         service = self._services.get(name)
         if service:
             return service

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -1990,7 +1990,7 @@ def test_threadpool_mode():
 @pytest.mark.parametrize('exports', ['missing', 'empty'])
 def test_missing_or_empty_exports(exports):
     '''
-    NAS-123498: Eliminate conditions on exports for service start                                                                                                                                                                                                    NAS-123498: Eliminate conditions on exports for service start
+    NAS-123498: Eliminate conditions on exports for service start
     The goal is to make the NFS server behavior similar to the other protocols
     '''
     # Setup /etc/exports
@@ -2053,3 +2053,12 @@ def test_files_in_exportsd(expect_NFS_start):
             assert any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts
         else:  # Alert should have been cleared
             assert not any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts
+
+
+def test_bad_json_db_value():
+    '''
+    NAS-135035: Verify that JSON columns of type=list are using list as their default
+    '''
+    with nfs_db():
+        ssh("sqlite3 /data/freenas-v1.db 'UPDATE services_nfs SET nfs_srv_protocols=\"[\"'")
+        assert isinstance(call("nfs.config")["protocols"], list)

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -2053,12 +2053,3 @@ def test_files_in_exportsd(expect_NFS_start):
             assert any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts
         else:  # Alert should have been cleared
             assert not any(alert["klass"] == "NFSblockedByExportsDir" for alert in alerts), alerts
-
-
-def test_bad_json_db_value():
-    '''
-    NAS-135035: Verify that JSON columns of type=list are using list as their default
-    '''
-    with nfs_db():
-        ssh("sqlite3 /data/freenas-v1.db 'UPDATE services_nfs SET nfs_srv_protocols=\"[\"'")
-        assert isinstance(call("nfs.config")["protocols"], list)


### PR DESCRIPTION
Passing `list` to `sa.JSON` does not work unless we use `TypeDecorator` instead of `UserDefinedType`.

Original PR: https://github.com/truenas/middleware/pull/16130
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135035