### PR TITLE
NAS-135053 / 25.04.1 / fix partition detection on SED for HA (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_events.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_events.py
@@ -1,10 +1,26 @@
 from middlewared.utils.disks import DISKS_TO_IGNORE
+from middlewared.utils.disks_.get_disks import get_disks
 
 
 async def added_disk(middleware, disk_name):
     await middleware.call('disk.sync', disk_name)
     await middleware.call('disk.sed_unlock', disk_name)
     await middleware.call('alert.oneshot_delete', 'SMART', disk_name)
+    if await middleware.call('failover.status') == 'MASTER':
+        for i in await middleware.run_in_thread(get_disks):
+            if i.name == disk_name:
+                try:
+                    await middleware.call(
+                        'failover.call_remote',
+                        'disk.retaste',
+                        [[i.serial]],
+                        {'raise_connect_error': False}
+                    )
+                except Exception:
+                    middleware.logger.exception(
+                        "Unexpected failure retasting disk on standby"
+                    )
+                break
 
 
 async def remove_disk(middleware, disk_name):


### PR DESCRIPTION
Platform has very simple test to reproduce an issue whereby the standby controller doesn't retaste the disk AFTER it has been unlocked on active.

1. have SED disk on HA system
2. physically remove SED disk from HA system
3. physically reinsert SED disk on HA system
4. active controller receives a kernel udev event and `added_disk` kicks off and runs `disk.sed_unlock`
5. standby controller receives udev event, however, after the disk is unlocked it does not detect there are partitions on it

To remedy this situation following has been done:
1. add a `failover.call_remote` to `added_event` hook so that standby retastes the disk
2. change the private `disk.retaste` endpoint to receive a list of serial numbers of disks. (This is vitally important on HA because the `sd` or `nvme` device names are not guaranteed to match up.

Original PR: https://github.com/truenas/middleware/pull/16135
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135053