### PR TITLE
NAS-135059 / 25.04.0 / Flag smbhash of '*' as broken for passdb insertion (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -504,6 +504,13 @@ def user_entry_to_passdb_entry(
     if not user_entry['smbhash']:
         raise ValueError(f'{user_entry["username"]}: SMB hash not available')
 
+    try:
+        nt_pw = user_smbhash_to_nt_pw(user_entry['username'], user_entry['smbhash'])
+    except Exception:
+        raise ValueError(
+            f'{user_entry["username"]}: failed to parse SMB hash of {user_entry["smbhash"]}'
+        )
+
     pdb_times = PDBTimes(
         logon=0,
         logoff=PASSDB_TIME_T_MAX,
@@ -528,7 +535,7 @@ def user_entry_to_passdb_entry(
         'group_rid': 513,  # samba default -- domain users rid
         'acct_desc': '',
         'acct_ctrl': user_entry_to_uac_flags(user_entry),
-        'nt_pw': user_smbhash_to_nt_pw(user_entry['username'], user_entry['smbhash']),
+        'nt_pw': nt_pw,
         'logon_count': 0,
         'bad_pw_count': 0,
         'times': pdb_times


### PR DESCRIPTION
It appears that some users may have a wildcard character with
accounts that have SMB enabled. This commit shifts NT hash
conversion from hex value to earlier and raises a ValueError
if it fails. The ValueError will get picked up when doing bulk
sync of passdb file and converted into an alert for user to
redo their password.

Original PR: https://github.com/truenas/middleware/pull/16137
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135059