### PR TITLE
NAS-135041 / 25.10 / fix zvol detection in pool.dataset.details

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -251,15 +251,16 @@ class PoolDatasetService(Service):
                         'type': 'DISK',
                         'path': f'/dev/{share["extent"]["path"]}',
                     })
-            elif share['extent']['type'] == 'FILE' and share['mount_info'].get('mount_source') == ds['id']:
-                # this isn't common but possible, you can share a "file"
-                # via iscsi which means it's not a dataset but a file inside
-                # a dataset so we need to find the source dataset for the file
-                iscsi_shares.append({
-                    'enabled': share['extent']['enabled'],
-                    'type': 'FILE',
-                    'path': share['extent']['path'],
-                })
+            elif share['extent']['type'] == 'FILE' and ds['type'] == 'FILESYSTEM':
+                if share['mount_info'].get('mount_source') == ds['id']:
+                    # this isn't common but possible, you can share a "file"
+                    # via iscsi which means it's not a dataset but a file inside
+                    # a dataset so we need to find the source dataset for the file
+                    iscsi_shares.append({
+                        'enabled': share['extent']['enabled'],
+                        'type': 'FILE',
+                        'path': share['extent']['path'],
+                    })
 
         return iscsi_shares
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -108,6 +108,9 @@ class PoolDatasetService(Service):
     @private
     def get_mount_info(self, path, mntinfo):
         mount_info = {}
+        if path.startswith('zvol/'):
+            path = f'/dev/{path}'
+
         try:
             devid = os.stat(path).st_dev
         except Exception:

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -243,13 +243,14 @@ class PoolDatasetService(Service):
     def get_iscsi_shares(self, ds, iscsishares):
         iscsi_shares = []
         for share in iscsishares:
-            if share['extent']['type'] == 'DISK' and share['extent']['path'].removeprefix('zvol/') == ds['id']:
-                # we store extent information prefixed with `zvol/` (i.e. zvol/tank/zvol01).
-                iscsi_shares.append({
-                    'enabled': share['extent']['enabled'],
-                    'type': 'DISK',
-                    'path': f'/dev/{share["extent"]["path"]}',
-                })
+            if share['extent']['type'] == 'DISK' and ds['type'] == 'VOLUME':
+                if zvol_path_to_name(f"/dev/{share['extent']['path']}") == ds['id']:
+                    # we store extent information prefixed with `zvol/` (i.e. zvol/tank/zvol01).
+                    iscsi_shares.append({
+                        'enabled': share['extent']['enabled'],
+                        'type': 'DISK',
+                        'path': f'/dev/{share["extent"]["path"]}',
+                    })
             elif share['extent']['type'] == 'FILE' and share['mount_info'].get('mount_source') == ds['id']:
                 # this isn't common but possible, you can share a "file"
                 # via iscsi which means it's not a dataset but a file inside


### PR DESCRIPTION
Fix 2 issues:
1. properly stat the zvol's path
2. properly normalize the zvol's name (spaces in zvol names are replaced with plus signs in /dev/ directory)

Minor optimization:
1. short-circuit in get_iscsi_shares() based on dataset type (i.e. zvol or filesystem)