### PR TITLE
NAS-135091 / 25.10 / remove failed_to_connect in reporting.realtime

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -38,14 +38,13 @@ class ReportingRealtimeService(Service):
             else:
                 break
 
-        if failed_to_connect := not bool(netdata_metrics):
-            data = {'failed_to_connect': failed_to_connect}
-        else:
+        data = dict()
+        if netdata_metrics:
             disks = get_disk_names()
             if len(disks) != len(disk_mapping):
                 disk_mapping = get_disks_with_identifiers()
 
-            data = {
+            data.update({
                 'zfs': get_arc_stats(netdata_metrics),  # ZFS ARC Size
                 'memory': get_memory_info(netdata_metrics),
                 'cpu': get_cpu_stats(netdata_metrics),
@@ -58,8 +57,7 @@ class ReportingRealtimeService(Service):
                     ]
                 ),
                 'pools': get_pool_stats(netdata_metrics),
-                'failed_to_connect': False,
-            }
+            })
 
         return data
 
@@ -125,7 +123,9 @@ class RealtimeEventSource(EventSource):
         disk_mapping = get_disks_with_identifiers()
 
         while not self._cancel_sync.is_set():
-            self.send_event('ADDED', fields=self.middleware.call_sync('reporting.realtime.stats', disk_mapping))
+            fields = self.middleware.call_sync('reporting.realtime.stats', disk_mapping)
+            if fields:
+                self.send_event('ADDED', fields=fields)
             time.sleep(interval)
 
 

--- a/tests/api2/test_reporting_realtime.py
+++ b/tests/api2/test_reporting_realtime.py
@@ -15,5 +15,3 @@ def test_reporting_realtime():
         time.sleep(5)
 
         assert events
-
-        assert not events[0][1]["fields"]["failed_to_connect"]


### PR DESCRIPTION
5a9e300141e introduced the `failed_to_connect` paradigm but I've been told that the UI team has never used it. They actually have a bug whereby they're not guarding against this type of response. I'm doing 2 things here (after discussion with UI team).
1. remove that response altogether (it's not used)
2. don't send events if we don't have any data to report