### PR TITLE
NAS-135100 / 25.10 / Move datastore/* plugins to new API (make them private)

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -5,7 +5,7 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.sql import Alias
 from sqlalchemy.sql.expression import nullsfirst, nullslast
 
-from middlewared.schema import accepts, Bool, Dict, Int, List, Ref, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import Service
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils import filters
@@ -158,14 +158,18 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
 
         return result
 
-    @accepts(Str('name'), Ref('query-options'))
-    async def config(self, name, options):
+    async def config(self, name: str, options: dict | None = None):
         """
         Get configuration settings object for a given `name`.
 
         This is a shortcut for `query(name, {"get": true})`.
         """
-        options['get'] = True
+        if options is None:
+            options = dict()
+
+        options.setdefault('get', True)
+        QueryOptions().__call__(options)
+
         return await self.query(name, [], options)
 
     def _get_queryset_joins(self, table):

--- a/src/middlewared/middlewared/plugins/datastore/util.py
+++ b/src/middlewared/middlewared/plugins/datastore/util.py
@@ -1,5 +1,4 @@
-from middlewared.schema import accepts
-from middlewared.service import CallError, private, Service
+from middlewared.service import CallError, Service
 from middlewared.sqlalchemy import Model
 
 from .schema import SchemaMixin
@@ -10,7 +9,6 @@ class DatastoreService(Service, SchemaMixin):
     class Config:
         private = True
 
-    @private
     async def get_backrefs(self, name):
         """
         Returns list of (datastore_name, column_name) for all tables that reference this table
@@ -32,7 +30,6 @@ class DatastoreService(Service, SchemaMixin):
 
         return result
 
-    @private
     async def sql(self, query, *args):
         try:
             if query.strip().split()[0].upper() == 'SELECT':
@@ -42,7 +39,6 @@ class DatastoreService(Service, SchemaMixin):
         except Exception as e:
             raise CallError(e)
 
-    @accepts()
     async def dump_json(self):
         models = []
         for table, in await self.middleware.call(


### PR DESCRIPTION
I went back and forth on whether or not we even want to use the new API paradigm for these private methods but I ended up converting it as-is with what we were doing in the legacy API.

NOTE: The `datastore.query` endpoint can't be converted since it's the definition for the `query-options` object for our legacy API and we still have endpoints using legacy API.