### PR TITLE
NAS-134463 / 25.04.1 / fix {ref}quota_warning properties in pool.dataset.details (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -20,7 +20,7 @@ class PoolDatasetService(Service):
     def build_filters_and_options(self):
         options = {
             'extra': {
-                'retrieve_user_props': False,
+                'retrieve_user_props': True,
                 'flat': True,
                 'order_by': 'name',
                 'properties': [


### PR DESCRIPTION
This was changed by mistake in 064f768d953. It has to be because I was testing my changes locally and then mistakenly included this in the upstream PR :man_facepalming: 

Original PR: https://github.com/truenas/middleware/pull/16157
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134463