### PR TITLE
NAS-135123 / 25.04.1 / Fix validation error for FailoverRebootOtherNodeResult (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/reboot.py
+++ b/src/middlewared/middlewared/plugins/failover_/reboot.py
@@ -208,7 +208,6 @@ class FailoverRebootService(Service):
             raise CallError('Other controller failed to reboot')
 
         job.set_progress(100, 'Other controller rebooted successfully')
-        return True
 
     async def _ensure_remote_be(self, id_: str):
         try:


### PR DESCRIPTION
```
1 validation error for FailoverRebootOtherNodeResult
result
  Input should be None [type=none_required, input_value=True, input_type=bool]
```

Original PR: https://github.com/truenas/middleware/pull/16166
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135123