### PR TITLE
NAS-135126 / 25.10 / Handle platforms without FC PCI slot info

### DIFF
--- a/src/middlewared/middlewared/plugins/fc/fc_host.py
+++ b/src/middlewared/middlewared/plugins/fc/fc_host.py
@@ -396,7 +396,7 @@ class FCHostService(CRUDService):
             if all(['slot' in fc_host for fc_host in raw_fc_hosts]):
                 fc_hosts = sorted(raw_fc_hosts, key=lambda d: d['slot'])
             else:
-                # When we were paiting in HA we used the model and PCI function
+                # When we were pairing in HA we used the model and PCI function
                 # to check that the entries on both controllers matched.  That's
                 # not useful on non-HA. so just use the /sys/class/fc_host host
                 # number, from the name (always present).

--- a/src/middlewared/middlewared/plugins/fc/fc_host.py
+++ b/src/middlewared/middlewared/plugins/fc/fc_host.py
@@ -235,7 +235,8 @@ class FCHostService(CRUDService):
                         alias = old.get('alias')
                     if alias:
                         vpfilter = [['port', '~', f'^{alias}/[1-9][0-9]*$']]
-                        vports = [int(p['port'].split('/')[-1]) for p in await self.middleware.call('fcport.query', vpfilter, {'select': ['port']})]
+                        vports = [int(p['port'].split('/')[-1]) for p in
+                                  await self.middleware.call('fcport.query', vpfilter, {'select': ['port']})]
                         for chan in vports:
                             if chan > npiv:
                                 verrors.add(
@@ -303,11 +304,36 @@ class FCHostService(CRUDService):
                     node_b_fc_hosts = await self.middleware.call('fc.fc_hosts', physical_port_filter)
                 case _:
                     raise CallError('Cannot configure FC until HA is configured')
-            # Match pairs by slot (includes PCI function)
-            for fc_host in node_a_fc_hosts:
-                slot_2_fc_host_wwpn[fc_host['slot']]['A'] = str_to_naa(fc_host.get('port_name'))
-            for fc_host in node_b_fc_hosts:
-                slot_2_fc_host_wwpn[fc_host['slot']]['B'] = str_to_naa(fc_host.get('port_name'))
+
+            # Assume that we will match pairs by slot (includes PCI function), but will
+            # have a fall-back mechanism to handle platforms with deficient BIOS so that
+            # DMI information is missing.
+            do_match_by_slot = all(
+                [
+                    all(['slot' in fc_host for fc_host in node_a_fc_hosts]),
+                    all(['slot' in fc_host for fc_host in node_b_fc_hosts])
+                ])
+            if do_match_by_slot:
+                for fc_host in node_a_fc_hosts:
+                    slot_2_fc_host_wwpn[fc_host['slot']]['A'] = str_to_naa(fc_host.get('port_name'))
+                for fc_host in node_b_fc_hosts:
+                    slot_2_fc_host_wwpn[fc_host['slot']]['B'] = str_to_naa(fc_host.get('port_name'))
+            else:
+                # If we can't rely upon slots then we will still use slot_2_fc_host_wwpn, but
+                # instead use different keys.  Assume that the host names in /sys/class/fc_host
+                # increment in order on both controllers.  We'll augment this will the model name
+                # and PCI function.
+                for _controller, _fc_hosts in [('A', node_a_fc_hosts), ('B', node_b_fc_hosts)]:
+                    _fc_host_dict = {fc_host['name']: fc_host for fc_host in _fc_hosts}
+                    # We expect the keys to be 'hostX'.  Sort them.
+                    keys = [key for key in _fc_host_dict.keys() if key.startswith('host')]
+                    keys.sort(key=lambda x: int(x[4:]))
+                    for index, key in enumerate(keys):
+                        fc_host = _fc_host_dict[key]
+                        _pci_function = fc_host['addr'].rsplit('.', 1)[-1]
+                        _fake_slot = f'Index:{index}:{fc_host.get("model")}:PCI Function:{_pci_function}'
+                        slot_2_fc_host_wwpn[_fake_slot][_controller] = str_to_naa(fc_host.get('port_name'))
+
             # Iterate over each slot and make sure the corresponding fc_host entry is present
             sorted_slots = sorted(list(slot_2_fc_host_wwpn.keys()))
             result = True
@@ -398,6 +424,12 @@ class FCHostService(CRUDService):
             self.logger.info('Reset wired')
             self.wired = False
             self.do_reset_wired = False
+            await self.middleware.call('cache.pop', 'fc.fc_host_nport_wwpn_choices')
+            if await self.middleware.call('failover.licensed'):
+                await self.middleware.call('failover.call_remote',
+                                           'cache.pop',
+                                           ['fc.fc_host_nport_wwpn_choices'],
+                                           {'raise_connect_error': False})
 
 
 async def _failover_status_change(middleware, event_type, args):

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -19,6 +19,7 @@ NODE_A_0 = {
     'port_name': NODE_A_0_WWPN,
     'port_type': 'NPort (fabric via point-to-point)',
     'port_state': 'Online',
+    'model': 'QLE2692',
     'speed': '8 Gbit',
     'addr': 'pci0000:b2/0000:b2:00.0/0000:b3:00.0',
     'max_npiv_vports': 254,
@@ -35,6 +36,7 @@ NODE_A_1 = {
     'port_name': NODE_A_1_WWPN,
     'port_type': 'NPort (fabric via point-to-point)',
     'port_state': 'Online',
+    'model': 'QLE2692',
     'speed': '8 Gbit',
     'addr': 'pci0000:b2/0000:b2:00.0/0000:b3:00.1',
     'max_npiv_vports': 254,
@@ -54,6 +56,7 @@ NODE_B_0 = {
     'port_name': NODE_B_0_WWPN,
     'port_type': 'NPort (fabric via point-to-point)',
     'port_state': 'Online',
+    'model': 'QLE2692',
     'speed': '8 Gbit',
     'addr': 'pci0000:b2/0000:b2:00.0/0000:b3:00.0',
     'max_npiv_vports': 254,
@@ -70,6 +73,7 @@ NODE_B_1 = {
     'port_name': NODE_B_1_WWPN,
     'port_type': 'NPort (fabric via point-to-point)',
     'port_state': 'Online',
+    'model': 'QLE2692',
     'speed': '8 Gbit',
     'addr': 'pci0000:b2/0000:b2:00.0/0000:b3:00.1',
     'max_npiv_vports': 254,
@@ -79,6 +83,194 @@ NODE_B_1 = {
 }
 
 NODE_B_FC_PHYSICAL_PORTS = [NODE_B_0, NODE_B_1]
+
+NO_SLOT_NODE_A_0_WWPN = '0x210011aa22bb1864'
+NO_SLOT_NODE_A_1_WWPN = '0x210011aa22bb1865'
+NO_SLOT_NODE_A_2_WWPN = '0x210012345678bde4'
+NO_SLOT_NODE_A_3_WWPN = '0x210012345678bde5'
+NO_SLOT_NODE_A_4_WWPN = '0x210012345678bde6'
+NO_SLOT_NODE_A_5_WWPN = '0x210012345678bde7'
+
+NO_SLOT_NODE_A_FC_PHYSICAL_PORTS = [
+    {
+        'name': 'host5',
+        'path': '/sys/class/fc_host/host5',
+        'node_name': '0x200012345678bde7',
+        'port_name': NO_SLOT_NODE_A_5_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.3',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host3',
+        'path': '/sys/class/fc_host/host3',
+        'node_name': '0x200012345678bde5',
+        'port_name': NO_SLOT_NODE_A_3_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.1',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host1',
+        'path': '/sys/class/fc_host/host1',
+        'node_name': '0x200011aa22bb1865',
+        'port_name': NO_SLOT_NODE_A_1_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2742',
+        'speed': 'unknown',
+        'addr': 'pci0000:80/0000:80:03.1/0000:87:00.1',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host4',
+        'path': '/sys/class/fc_host/host4',
+        'node_name': '0x200012345678bde6',
+        'port_name': NO_SLOT_NODE_A_4_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.2',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host2',
+        'path': '/sys/class/fc_host/host2',
+        'node_name': '0x200012345678bde4',
+        'port_name': NO_SLOT_NODE_A_2_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.0',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host0',
+        'path': '/sys/class/fc_host/host0',
+        'node_name': '0x200011aa22bb1864',
+        'port_name': NO_SLOT_NODE_A_0_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2742',
+        'speed': 'unknown',
+        'addr': 'pci0000:80/0000:80:03.1/0000:87:00.0',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    }
+]
+
+NO_SLOT_NODE_B_0_WWPN = '0x210011aa22bb18f8'
+NO_SLOT_NODE_B_1_WWPN = '0x210011aa22bb18f9'
+NO_SLOT_NODE_B_2_WWPN = '0x210012345678bd54'
+NO_SLOT_NODE_B_3_WWPN = '0x210012345678bd55'
+NO_SLOT_NODE_B_4_WWPN = '0x210012345678bd56'
+NO_SLOT_NODE_B_5_WWPN = '0x210012345678bd57'
+
+NO_SLOT_NODE_B_FC_PHYSICAL_PORTS = [
+    {
+        'name': 'host5',
+        'path': '/sys/class/fc_host/host5',
+        'node_name': '0x200012345678bd57',
+        'port_name': NO_SLOT_NODE_B_5_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.3',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host3',
+        'path': '/sys/class/fc_host/host3',
+        'node_name': '0x200012345678bd55',
+        'port_name': NO_SLOT_NODE_B_3_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.1',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host1',
+        'path': '/sys/class/fc_host/host1',
+        'node_name': '0x200011aa22bb18f9',
+        'port_name': NO_SLOT_NODE_B_1_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2742',
+        'speed': 'unknown',
+        'addr': 'pci0000:80/0000:80:03.1/0000:8d:00.1',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host4',
+        'path': '/sys/class/fc_host/host4',
+        'node_name': '0x200012345678bd56',
+        'port_name': NO_SLOT_NODE_B_4_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.2',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host2',
+        'path': '/sys/class/fc_host/host2',
+        'node_name': '0x200012345678bd54',
+        'port_name': NO_SLOT_NODE_B_2_WWPN,
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'model': 'QLE2694L',
+        'speed': 'unknown',
+        'addr': 'pci0000:00/0000:00:03.1/0000:09:00.0',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    },
+    {
+        'name': 'host0',
+        'path': '/sys/class/fc_host/host0',
+        'node_name': '0x200011aa22bb18f8',
+        'port_name': NO_SLOT_NODE_B_0_WWPN,
+        'model': 'QLE2742',
+        'port_type': 'Unknown',
+        'port_state': 'Linkdown',
+        'speed': 'unknown',
+        'addr': 'pci0000:80/0000:80:03.1/0000:8d:00.0',
+        'max_npiv_vports': 254,
+        'npiv_vports_inuse': 0,
+        'physical': True
+    }
+]
 
 
 def _str_to_naa(string):
@@ -166,18 +358,10 @@ def target_lun_zero(target_name, zvol_name, mb):
 
 
 @contextlib.contextmanager
-def node_a_hardware(remote=False):
-    with mock('fc.fc_hosts', return_value=NODE_A_FC_PHYSICAL_PORTS, remote=remote):
+def node_hardware(physical_ports, remote=False):
+    with mock('fc.fc_hosts', return_value=physical_ports, remote=remote):
         physical_port_filter = [['physical', '=', True]]
-        with mock('fc.fc_hosts', args=physical_port_filter, return_value=NODE_A_FC_PHYSICAL_PORTS, remote=remote):
-            yield
-
-
-@contextlib.contextmanager
-def node_b_hardware(remote=False):
-    with mock('fc.fc_hosts', return_value=NODE_B_FC_PHYSICAL_PORTS, remote=remote):
-        physical_port_filter = [['physical', '=', True]]
-        with mock('fc.fc_hosts', args=physical_port_filter, return_value=NODE_B_FC_PHYSICAL_PORTS, remote=remote):
+        with mock('fc.fc_hosts', args=physical_port_filter, return_value=physical_ports, remote=remote):
             yield
 
 
@@ -209,15 +393,15 @@ class TestFixtureFibreChannel:
                 if ha:
                     node = call('failover.node')
                     if node == 'A':
-                        with node_a_hardware():
-                            with node_b_hardware(True):
+                        with node_hardware(NODE_A_FC_PHYSICAL_PORTS):
+                            with node_hardware(NODE_B_FC_PHYSICAL_PORTS, True):
                                 yield
                     else:
-                        with node_a_hardware(True):
-                            with node_b_hardware():
+                        with node_hardware(NODE_A_FC_PHYSICAL_PORTS, True):
+                            with node_hardware(NODE_B_FC_PHYSICAL_PORTS):
                                 yield
                 else:
-                    with node_a_hardware():
+                    with node_hardware(NODE_A_FC_PHYSICAL_PORTS):
                         yield
 
     @pytest.fixture(scope='class')
@@ -234,6 +418,7 @@ class TestFixtureFibreChannel:
         finally:
             for fc in call('fc.fc_host.query'):
                 call('fc.fc_host.delete', fc['id'])
+            call('fc.fc_host.reset_wired', True)
 
     @pytest.fixture(scope='class')
     def fc_hosts(self, fibre_channel_wired):
@@ -407,15 +592,23 @@ class TestFixtureFibreChannel:
                             call('iscsi.target.update', target3_id, {'mode': 'FC'})
 
                             # Make sure we CAN update the old fcport to this target
-                            assert call('fcport.update', map0['id'], {'target_id': target3_id})['target']['id'] == target3_id
+                            assert call('fcport.update',
+                                        map0['id'],
+                                        {'target_id': target3_id})['target']['id'] == target3_id
                             # Then put is back
-                            assert call('fcport.update', map0['id'], {'target_id': target_id})['target']['id'] == target_id
+                            assert call('fcport.update',
+                                        map0['id'],
+                                        {'target_id': target_id})['target']['id'] == target_id
 
                     # We've just left the context where the 2nd fcport was created
                     # So now ensure we CAN update the old fcport to this port
-                    assert call('fcport.update', map0['id'], {'port': fc_hosts[1]['alias']})['port'] == fc_hosts[1]['alias']
+                    assert call('fcport.update',
+                                map0['id'],
+                                {'port': fc_hosts[1]['alias']})['port'] == fc_hosts[1]['alias']
                     # Then put is back
-                    assert call('fcport.update', map0['id'], {'port': fc_hosts[0]['alias']})['port'] == fc_hosts[0]['alias']
+                    assert call('fcport.update',
+                                map0['id'],
+                                {'port': fc_hosts[0]['alias']})['port'] == fc_hosts[0]['alias']
 
     def test_target_delete(self, fc_hosts):
         """Ensure that we can delete a mapped FC target."""
@@ -634,3 +827,74 @@ class TestFixtureFibreChannel:
                     'wwpn_b': str_to_wwpn_b_naa(NODE_B_1_WWPN)
                 }
             }
+
+
+class TestFixtureNoSlotFibreChannel:
+    """
+    Fixture with Fibre Channel without working BIOS, so
+    no slot information reported in fc.fc_hosts
+    """
+
+    @pytest.fixture(scope='class')
+    def fibre_channel_hardware(self):
+        # Make sure iSCSI service is not running.  Would go boom
+        assert call('service.query', [['service', '=', 'iscsitarget']], {'get': True})['state'] == 'STOPPED'
+        with mock('fc.capable', return_value=True):
+            with mock('system.feature_enabled', args=['FIBRECHANNEL',], return_value=True):
+                call('fc.fc_host.reset_wired', True)
+                if ha:
+                    node = call('failover.node')
+                    if node == 'A':
+                        with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS):
+                            with node_hardware(NO_SLOT_NODE_B_FC_PHYSICAL_PORTS, True):
+                                yield
+                    else:
+                        with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS, True):
+                            with node_hardware(NO_SLOT_NODE_B_FC_PHYSICAL_PORTS):
+                                yield
+                else:
+                    with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS):
+                        yield
+
+    @pytest.fixture(scope='class')
+    def fibre_channel_wired(self, fibre_channel_hardware):
+        """
+        Wire the mocked FC ports together.
+        """
+        assert call('fcport.query') == []
+        try:
+            yield
+        finally:
+            for fc in call('fc.fc_host.query'):
+                call('fc.fc_host.delete', fc['id'])
+
+    @pytest.fixture(scope='class')
+    def fc_hosts(self, fibre_channel_wired):
+        yield sorted(call('fc.fc_host.query'), key=lambda d: d['alias'])
+
+    def assert_fc_host(self, fc_host, alias, wwpn, wwpn_b, npiv):
+        assert fc_host['alias'] == alias
+        assert fc_host['wwpn'] == str_to_wwpn_naa(wwpn)
+        if wwpn_b is None:
+            assert fc_host['wwpn_b'] is None
+        else:
+            assert fc_host['wwpn_b'] == str_to_wwpn_b_naa(wwpn_b)
+        assert fc_host['npiv'] == npiv
+
+    def test_wired(self, fc_hosts):
+        assert len(fc_hosts) == 6
+        if ha:
+            self.assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, NO_SLOT_NODE_B_0_WWPN, 0)
+            self.assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, NO_SLOT_NODE_B_1_WWPN, 0)
+            self.assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, NO_SLOT_NODE_B_2_WWPN, 0)
+            self.assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, NO_SLOT_NODE_B_3_WWPN, 0)
+            self.assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, NO_SLOT_NODE_B_4_WWPN, 0)
+            self.assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, NO_SLOT_NODE_B_5_WWPN, 0)
+        else:
+            self.assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, None, 0)
+            self.assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, None, 0)
+            self.assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, None, 0)
+            self.assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, None, 0)
+            self.assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, None, 0)
+            self.assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, None, 0)
+        self.fc_hosts = fc_hosts

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -831,8 +831,8 @@ class TestFixtureFibreChannel:
 
 class TestFixtureNoSlotFibreChannel:
     """
-    Fixture with Fibre Channel without working BIOS, so
-    no slot information reported in fc.fc_hosts
+    Fixture with Fibre Channel without slot information
+    reported in fc.fc_hosts
     """
 
     @pytest.fixture(scope='class')


### PR DESCRIPTION
Add a backup mechanism to `fc.fc_host.wire` to handle platforms that lack certain DMI information, and thus have no 'slot' in the information returned by `fc.fc_hosts`

Also:
- Allow clearing cached `fc.fc_host_nport_wwpn_choices` (for CI)
- Some `flake8` fixes
- Add `TestFixtureNoSlotFibreChannel::test_wired` to test the new mechanism

----
- Custom build #[1025](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1025/) - [tests](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3797/) passed.
- Non-HA fix tested locally.