### PR TITLE
NAS-135133 / 25.10 / fix test_audit_ha_query

### DIFF
--- a/tests/api2/test_audit_basic.py
+++ b/tests/api2/test_audit_basic.py
@@ -346,7 +346,7 @@ class TestAuditOpsHA:
             assert "failed to communicate" in str(e.value)
 
             # Wait for the remote to return
-            assert call("core.job_wait", job_id, job=True)
+            call("core.job_wait", job_id, job=True)
         else:
             # Handle delays in the audit database
             remote_audit_entry = []


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/16166 changed the return of `failover.reboot.other_node` from `True` to `None` on success.