### PR TITLE
NAS-135137 / 25.10 / Fix SMB guest account on HA when standalone

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -303,6 +303,17 @@ class SMBService(ConfigService):
         await self.setup_directories()
 
         """
+        We may have failed over and changed our netbios name, which would also
+        change the system SID. Flush out gencache entries before proceeding with
+        local user account setup, otherwise we may end up with the incorrect
+        domain SID for the guest account.
+        """
+        try:
+            await self.middleware.call('idmap.gencache.flush')
+        except Exception:
+            self.logger.warning('SMB gencache flush failed', exc_info=True)
+
+        """
         We cannot continue without network.
         Wait here until we see the ix-netif completion sentinel.
         """


### PR DESCRIPTION
With the current design for HA in TrueNAS, the active and standby controllers have different netbios names. This commit forcibly flushes samba's gencache after setting up samba directories and the smb.conf file, but before the remaining local account setup steps.