### PR TITLE
NAS-135103 / 25.04.1 / Convert ID_TYPE_BOTH to either USER or GROUP (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap_/idmap_winbind.py
+++ b/src/middlewared/middlewared/plugins/idmap_/idmap_winbind.py
@@ -41,6 +41,12 @@ class WBClient:
     def _as_dict(self, results, convert_unmapped=False):
         for entry in list(results['mapped'].keys()):
             new = self._pyuidgid_to_dict(results['mapped'][entry])
+            if new['id_type'] == IDType.BOTH.name:
+                if results['mapped'][entry].sid_type['parsed'] in ('SID_DOM_GROUP', 'SID_ALIAS'):
+                    new['id_type'] = IDType.GROUP.name
+                else:
+                    new['id_type'] = IDType.USER.name
+
             results['mapped'][entry] = new
 
         # The unmapped entry value may be uidgid type or simply SID string


### PR DESCRIPTION
This commit changes how we convert ID_TYPE_BOTH into a string for backend consumption. Originally we were translating it to 'BOTH' with the understanding that the underlying SID maps to both a user and a group in the NSS backend. This apparently got mapped to 'Unknown' in our UI, which appears very broken to our enterprise userbase. This commit dumbs down the backend somewhat so that we no longer report 'BOTH' and resolve to either USER or GROUP based on the underlying sid_type of the winbind entry.

Original PR: https://github.com/truenas/middleware/pull/16148
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135103