### PR TITLE
NAS-135169 / 25.10 / Adjust LDAP-related tests for new LDAP server

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/directory_service.py
+++ b/src/middlewared/middlewared/test/integration/assets/directory_service.py
@@ -30,6 +30,7 @@ try:
         LDAPBINDPASSWORD,
         LDAPHOSTNAME,
         LDAPUSER,
+        LDAPADMIN,
         LDAPPASSWORD
     )
 except ImportError:
@@ -37,6 +38,7 @@ except ImportError:
     LDAPBINDDN = None
     LDAPBINDPASSWORD = None
     LDAPHOSTNAME = None
+    LDAPADMIN = None
     LDAPUSER = None
     LDAPPASSWORD = None
 
@@ -199,9 +201,9 @@ def ldap(
         "binddn": binddn,
         "bindpw": bindpw,
         "hostname": [hostname],
-        "ssl": "ON",
+        "ssl": "OFF",
         "auxiliary_parameters": "",
-        "validate_certificates": True,
+        "validate_certificates": False,
         "enable": True,
         **kwargs
     }, job=True)

--- a/tests/api2/test_275_ldap.py
+++ b/tests/api2/test_275_ldap.py
@@ -70,8 +70,12 @@ def test_account_privilege_authentication(do_ldap_connection):
         }):
             with client(auth=(LDAPUSER, LDAPPASSWORD)) as c:
                 methods = c.call("core.get_methods")
+                me = c.call("auth.me")
 
             assert "system.info" in methods
             assert "pool.create" not in methods
+            assert "DIRECTORY_SERVICE" in me['account_attributes']
+            assert "LDAP" in me['account_attributes']
+
     finally:
         call("system.general.update", {"ds_auth": False})


### PR DESCRIPTION
This commit tweaks our LDAP test assets and tests slightly for a new openldap server in the jenkins pipeline.