### PR TITLE
NAS-135181 / 25.10 / Fix mismatch between AlertCategory enum and dict

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -197,6 +197,7 @@ alert_category_names = {
     AlertCategory.PLUGINS: "Plugins",
     AlertCategory.NETWORK: "Network",
     AlertCategory.REPORTING: "Reporting",
+    AlertCategory.SECURITY: "Security",
     AlertCategory.SHARING: "Sharing",
     AlertCategory.STORAGE: "Storage",
     AlertCategory.SYSTEM: "System",
@@ -204,6 +205,9 @@ alert_category_names = {
     AlertCategory.TRUENAS_CONNECT: "TrueNAS Connect Service",
     AlertCategory.UPS: "UPS",
 }
+
+
+assert all([category in alert_category_names for category in AlertCategory]), 'Alert Category Mismatch'
 
 
 class AlertLevel(enum.Enum):


### PR DESCRIPTION
This commit fixes a mismatch in objects related to Alert Categories that was introduced by a recent merge to add account policies to TrueNAS. A check is also added to prevent middleware startup if the alert categories get out of sync since I may not be the only developer who will somehow overlook this.