### PR TITLE
NAS-135195 / 25.04.1 / Improve docstring for system.security.update (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -300,9 +300,9 @@ class SystemSecurityService(ConfigService):
         """
         Update System Security Service Configuration.
 
-        `enable_fips` when set, enables FIPS mode.
-        `enable_gpos_stig` when set, enables compatibility with the General
-        Purpose Operating System STIG.
+        This method is used to change the FIPS, STIG, and local account
+        policies for TrueNAS Enterprise. These features are not
+        available in community editions of TrueNAS.
         """
         is_ha = await self.middleware.call('failover.licensed')
         reasons = await self.middleware.call('failover.disabled.reasons')


### PR DESCRIPTION
This improves the docstring to give a basic overview of features controlled by system.security.update and emphasize that they are only available for TrueNAS enterprise.

Original PR: https://github.com/truenas/middleware/pull/16200
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135195