### PR TITLE
NAS-135215 / 25.10 / Expand whitelist of FULL_ADMIN endpoints

### DIFF
--- a/tests/unit/test_role_manager.py
+++ b/tests/unit/test_role_manager.py
@@ -30,6 +30,9 @@ EXPECTED_FA_RESOURCES = frozenset({
     'config.upload',
     'filesystem.get',
     'config.save',
+    'core.ping_remote',
+    'core.arp',
+    'core.debug',
 })
 
 


### PR DESCRIPTION
This commit expands the whitelist we keep of expected plugins for FULL_ADMIN role. This helps us to ensure that we don't have any unexpected endpoints becoming available in GPOS STIG mode.