### PR TITLE
NAS-135222 / 25.04.1 / Fix ability to su to root (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -112,7 +112,10 @@ def shadow_parse_aging(
     else:
         # We set timestamp on UI / API initiated password changes
         # unexpected None here should result in forcing password change
-        outstr += '0'
+        # We cannot do this for the root account though because it will break
+        # ability to su to root.
+        if user['username'] != 'root':
+            outstr += '0'
 
     outstr += SHADOW_SEPARATOR
 


### PR DESCRIPTION
This commit avoids setting flag that root must set its password. In some situations the root account may never have had an explicit password set, but we need to leave account open interactive sessions.

Original PR: https://github.com/truenas/middleware/pull/16211
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135222