### PR TITLE
NAS-135245 / 25.10 / Fix directoryservices.cache._retrieve

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/cache.py
@@ -29,7 +29,7 @@ dscache_idtype = Literal['USER', 'GROUP']
 class DscachePrincipalInfo(BaseModel):
     idtype: dscache_idtype
     who: str | None = None
-    xid: int | None = Field(alias='id', default=None)
+    id: int | None = None
 
     @model_validator(mode='after')
     def check_identifier(self) -> Self:

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1212,7 +1212,7 @@ class IdmapDomainService(CRUDService):
         return False
 
     @private
-    async def synthetic_user(self, passwd, sid):
+    async def synthetic_user(self, passwd: dict, sid: str | None) -> dict | None:
         match passwd['source']:
             case 'LOCAL':
                 # local user, should be retrieved via user.query
@@ -1228,30 +1228,32 @@ class IdmapDomainService(CRUDService):
             'username': passwd['pw_name'],
             'unixhash': None,
             'smbhash': None,
-            'group': {},
             'home': passwd['pw_dir'],
             'shell': passwd['pw_shell'] or '/usr/sbin/nologin',
             'full_name': passwd['pw_gecos'],
             'builtin': False,
-            'email': None,
+            'smb': True,
+            'userns_idmap': None,
+            'group': {},
+            'groups': [],
             'password_disabled': False,
+            'ssh_password_enabled': False,
+            'sshpubkey': None,
             'locked': False,
             'sudo_commands': [],
             'sudo_commands_nopasswd': [],
-            'groups': [],
-            'sshpubkey': None,
-            'local': False,
+            'email': None,
             'id_type_both': id_type_both,
-            'roles': [],
-            'api_keys': [],
+            'local': False,
+            'immutable': True,
+            'twofactor_auth_configured': False,
+            'sid': sid,
             'last_password_change': None,
             'password_age': None,
             'password_history': None,
             'password_change_required': False,
-            'immutable': True,
-            'smb': True,
-            'userns_idmap': None,
-            'sid': sid
+            'roles': [],
+            'api_keys': [],
         }
 
     @private


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/16207 added validation to the private endpoint `directoryservices.cache._insert` that we weren't doing before. This has caused some failures in our API tests.

Add `ssh_password_enabled` and `twofactor_auth_configured` to the returns of `idmap.synthetic_user` to match the `UserEntry` schema; also rearrange the fields to match the order they appear in `UserEntry`.