### PR TITLE
NAS-135243 / 25.10 / Do not delete initiator group when last target in use is deleted

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -421,7 +421,7 @@ class iSCSITargetService(CRUDService):
 
         # Attempt to cleanup initiators as the wizard may have created a single-use one
         try:
-            initiators = [group['initiator'] for group in target['groups'] if group['initiator'] is not None]
+            initiators = [group['initiator'] for group in target['groups']]
             for initiator in initiators:
                 # Ensure not used elsewhere
                 targets = await self.middleware.call('iscsi.target.query', [['groups.*.initiator', '=', initiator]])

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -419,16 +419,6 @@ class iSCSITargetService(CRUDService):
         await self.middleware.call('iscsi.target.remove_target', target["name"])
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
 
-        # Attempt to cleanup initiators as the wizard may have created a single-use one
-        try:
-            initiators = [group['initiator'] for group in target['groups']]
-            for initiator in initiators:
-                # Ensure not used elsewhere
-                targets = await self.middleware.call('iscsi.target.query', [['groups.*.initiator', '=', initiator]])
-                if not targets:
-                    await self.middleware.call('iscsi.initiator.delete', initiator)
-        except Exception:
-            self.logger.error('Failed to clean up target initiators for %r', target['name'], exc_info=True)
         return rv
 
     @api_method(


### PR DESCRIPTION
Revert the behavior previously requested in NAS-128872.

We will no longer auto-delete initiators if all associated targets are deleted.