### PR TITLE
Fix remote audit logging

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnaudit.conf.mako
@@ -89,7 +89,6 @@ log {
   parser(p_tnaudit);
   rewrite(r_rewrite_success);
   destination(d_tnaudit_${svc.lower()});
-  flags(final);
 };
 %endif
 % endfor

--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -33,6 +33,7 @@ filter f_tnremote_f_debug { level(debug..emerg); };
 
 filter f_tnremote {
     filter(f_tnremote_${adv_conf["sysloglevel"].lower()})
+## syslog_audit is associated with remote logging only
 % if not adv_conf['syslog_audit']:
     and not filter(f_tnaudit_all)
 % endif

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -142,7 +142,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         self.api_versions_adapter = api_versions_adapter  # FIXME: Only necessary as a class member for legacy WS API
         return self._create_apis(api_versions, api_versions_adapter)
 
-    def _load_api_versions(self) -> [APIVersion]:
+    def _load_api_versions(self) -> list[APIVersion]:
         versions = []
         api_dir = os.path.join(os.path.dirname(__file__), 'api')
         api_versions = [
@@ -963,7 +963,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             }
         })
 
-        self.__audit_logger.debug(message)
+        self.__audit_logger.info(message)
 
     async def call(self, name, *params, app=None, audit_callback=None, job_on_progress_cb=None, pipes=None,
                    profile=False):

--- a/src/middlewared/middlewared/test/integration/assets/system.py
+++ b/src/middlewared/middlewared/test/integration/assets/system.py
@@ -1,0 +1,52 @@
+import contextlib
+import os
+import sys
+from middlewared.test.integration.utils import ssh, truenas_server, restart_systemd_svc
+
+try:
+    apifolder = os.getcwd()
+    sys.path.append(apifolder)
+    from auto_config import ha
+except ImportError:
+    ha = False
+
+
+@contextlib.contextmanager
+def standby_syslog_to_remote_syslog(remote_log_path="/var/log/remote_log.txt"):
+    '''
+    Temporarily convert the syslog server on the standby node
+    to a remote syslog server.  HA systems only.
+    NOTE: Any operation that involves restarting or reloading syslog-ng may
+          break the remote syslog configuration.
+    '''
+    assert ha is True, "Remote log config is available on HA systems only."
+
+    remote_syslog_config = (
+        '@version: 3.38\n'
+        '@include "scl.conf"\n'
+        'options { time-reap(30); mark-freq(10); keep-hostname(yes); };\n'
+        '\n'
+        'source s_remote_non_tls {\n'
+        '    syslog ( ip-protocol(6) transport("tcp") port(514) );\n'
+        '};\n'
+        '\n'
+        'destination d_logs {\n'
+        f'    file( "{remote_log_path}"  owner("root")  group("root")  perm(0777) );\n'
+        '};\n'
+        '\n'
+        'log {\n'
+        '    source(s_remote_non_tls);\n'
+        '    destination(d_logs);\n'
+        '};\n'
+    )
+    remote_ip = truenas_server.ha_ips()['standby']
+    restore_syslog_config = "ORIG_syslog-ng.config_ORIG"
+    try:
+        ssh(f"cp /etc/syslog-ng/syslog-ng.conf /etc/syslog-ng/{restore_syslog_config}", ip=remote_ip)
+        ssh(f"echo {remote_syslog_config} > etc/syslog-ng/syslog-ng.conf", ip=remote_ip)
+        restart_systemd_svc("syslog-ng", remote_node=True)
+        yield remote_log_path
+    finally:
+        if ssh("ls /etc/syslog-ng/{restore_syslog_config}", ip=remote_ip):
+            ssh(f"mv /etc/syslog-ng/{restore_syslog_config} /etc/syslog-ng/syslog-ng.conf", ip=remote_ip)
+        restart_systemd_svc("syslog-ng", remote_node=True)

--- a/src/middlewared/middlewared/test/integration/utils/__init__.py
+++ b/src/middlewared/middlewared/test/integration/utils/__init__.py
@@ -8,3 +8,4 @@ from .pool import *  # noqa
 from .pytest import * # noqa
 from .run import * # noqa
 from .ssh import *  # noqa
+from .system import * # noqa


### PR DESCRIPTION
### Currently in testing: WIP
-------------------------------------------------------------------------------
Remote audit logging required two small tweaks to get full function:  Removed the 'final' statement from the syslog audit log stanza and, to avoid remote log filtering, changed the priority of the audit log messages from `debug` to `info`.

Other tweaks:  fixed flake8 complaint, added a comment.

The majority of the changes are in CI where functional remote logging tests are added.  The remote logging test will run on HA systems only and uses the standby node as the 'remote syslog server'.

----------------------------------------------------------------------------------
### WIP:   testing...