### PR TITLE
NAS-135265 / 25.10 / Fix validation for local usernames

### DIFF
--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -21,7 +21,7 @@ INCUS_IDMAP_COUNT = 65536 * INCUS_MAX_ISOLATED_CONTAINER
 INCUS_IDMAP_MAX = INCUS_IDMAP_MIN + INCUS_IDMAP_COUNT
 TRUENAS_IDMAP_DEFAULT_LOW = 90000001
 
-DEFAULT_VALID_CHARS = string.ascii_letters + string.digits + '_' + '-' + '$' + '.'
+DEFAULT_VALID_CHARS = string.ascii_letters + string.digits + '_' + '-' + '.'
 DEFAULT_VALID_START = string.ascii_letters + '_'
 DEFAULT_MAX_LENGTH = 32
 
@@ -39,7 +39,6 @@ def validate_username(
     if valid_start_chars is not None:
         assert val[0] in valid_start_chars, 'Username must start with a letter or an underscore'
 
-    assert '$' not in val or val[-1] == '$', 'Username must end with a dollar sign character'
     assert all(char in valid_chars for char in val), f'Valid characters for a username are: {", ".join(valid_chars)!r}'
     return val
 

--- a/src/middlewared/middlewared/api/v25_04_0/user.py
+++ b/src/middlewared/middlewared/api/v25_04_0/user.py
@@ -99,6 +99,13 @@ class UserCreate(UserEntry):
 
     uid: LocalUID | None = None
     "UNIX UID. If not provided, it is automatically filled with the next one available."
+    username: LocalUsername
+    """
+    String used to uniquely identify the user on the server. In order to be portable across
+    systems, local user names must be composed of characters from the POSIX portable filename
+    character set (IEEE Std 1003.1-2024 section 3.265). This means alphanumeric characters,
+    hyphens, underscores, and periods. Usernames also may not begin with a hyphen or a period.
+    """
     full_name: NonEmptyString
 
     group_create: bool = False

--- a/src/middlewared/middlewared/api/v25_04_1/user.py
+++ b/src/middlewared/middlewared/api/v25_04_1/user.py
@@ -115,6 +115,13 @@ class UserCreate(UserEntry):
 
     uid: LocalUID | None = None
     "UNIX UID. If not provided, it is automatically filled with the next one available."
+    username: LocalUsername
+    """
+    String used to uniquely identify the user on the server. In order to be portable across
+    systems, local user names must be composed of characters from the POSIX portable filename
+    character set (IEEE Std 1003.1-2024 section 3.265). This means alphanumeric characters,
+    hyphens, underscores, and periods. Usernames also may not begin with a hyphen or a period.
+    """
     full_name: NonEmptyString
 
     group_create: bool = False

--- a/src/middlewared/middlewared/api/v25_10_0/user.py
+++ b/src/middlewared/middlewared/api/v25_10_0/user.py
@@ -114,6 +114,13 @@ class UserCreate(UserEntry):
 
     uid: LocalUID | None = None
     "UNIX UID. If not provided, it is automatically filled with the next one available."
+    username: LocalUsername
+    """
+    String used to uniquely identify the user on the server. In order to be portable across
+    systems, local user names must be composed of characters from the POSIX portable filename
+    character set (IEEE Std 1003.1-2024 section 3.265). This means alphanumeric characters,
+    hyphens, underscores, and periods. Usernames also may not begin with a hyphen or a period.
+    """
     full_name: NonEmptyString
 
     group_create: bool = False

--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -218,3 +218,25 @@ def test_update_user_with_random_password():
 
         new = call('user.update', u['id'], {'full_name': 'bob2'})
         assert not new['password']
+
+
+def test_account_create_invalid_username():
+    with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+        with user({
+            "username": "_блин",
+            "full_name": "bob",
+            "group_create": True,
+            "password": "canary"
+        }):
+            pass
+
+
+def test_account_update_invalid_username():
+    with user({
+        "username": "bob",
+        "full_name": "bob",
+        "group_create": True,
+        "password": "canary"
+    }, get_instance=True) as u:
+        with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+            call("user.update", u["id"], {"username": "_блин"})


### PR DESCRIPTION
This fixes a regression in local username validation that allowed non-portable characters to be used in usernames.