### PR TITLE
NAS-135274 / 25.04.0 / Fix empty shell entry in DS cache (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/util_cache.py
@@ -250,7 +250,7 @@ class DSCacheFill:
                     'smbhash': None,
                     'group': {},
                     'home': user_data.pw_dir,
-                    'shell': user_data.pw_shell,
+                    'shell': user_data.pw_shell or '/usr/bin/sh',  # An empty string as pw_shell means sh
                     'full_name': user_data.pw_gecos,
                     'builtin': False,
                     'email': None,

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -1230,7 +1230,7 @@ class IdmapDomainService(CRUDService):
             'smbhash': None,
             'group': {},
             'home': passwd['pw_dir'],
-            'shell': passwd['pw_shell'] or '/usr/sbin/nologin',
+            'shell': passwd['pw_shell'] or '/usr/bin/sh',  # An empty string as pw_shell means sh
             'full_name': passwd['pw_gecos'],
             'builtin': False,
             'email': None,


### PR DESCRIPTION
Our directory services cache builds out UserEntry objects from passwd responses. An empty pw_shell is a valid response that the OS reinterprets as /bin/sh. See man (5) passwd. This commit performs this translation explicitly in order to make things clearer for the administrator and to avoid validation errors on the user.query API response.

Original PR: https://github.com/truenas/middleware/pull/16223
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135274