### PR TITLE
NAS-134717 / 25.10 / Allow specifying image OS for virt VMs

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -1,4 +1,3 @@
-import os
 import re
 from typing import Annotated, Literal, TypeAlias
 
@@ -20,6 +19,8 @@ __all__ = [
 ]
 
 
+# Some popular OS choices
+OS_ENUM = Literal['LINUX', 'FREEBSD', 'WINDOWS', 'ARCHLINUX', None]
 REMOTE_CHOICES: TypeAlias = Literal['LINUX_CONTAINERS']
 ENV_KEY: TypeAlias = Annotated[
     str,
@@ -140,6 +141,7 @@ class VirtInstanceCreateArgs(BaseModel):
     be used to boot the VM instance.
     '''
     vnc_password: Secret[NonEmptyString | None] = None
+    image_os: str | OS_ENUM = None
 
     @model_validator(mode='after')
     def validate_attrs(self):
@@ -160,6 +162,9 @@ class VirtInstanceCreateArgs(BaseModel):
 
             if self.source_type == 'VOLUME' and self.volume is None:
                 raise ValueError('volume must be set when source type is "VOLUME"')
+
+            if self.image_os and self.source_type != 'ISO':
+                raise ValueError('image_os can only be set when source type is "ISO"')
 
         if self.source_type == 'IMAGE' and self.image is None:
             raise ValueError('Image must be set when source type is "IMAGE"')
@@ -185,6 +190,7 @@ class VirtInstanceUpdate(BaseModel, metaclass=ForUpdateMetaclass):
     secure_boot: bool = False
     root_disk_size: int | None = Field(ge=5, default=None)
     root_disk_io_bus: Literal['NVME', 'VIRTIO-BLK', 'VIRTIO-SCSI', None] = None
+    image_os: str | OS_ENUM = None
 
 
 class VirtInstanceUpdateArgs(BaseModel):

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -158,6 +158,9 @@ class VirtInstanceService(CRUDService):
                 f'{schema_name}.instance_type', f'System is not licensed to manage {instance_type!r} instances'
             )
 
+        if instance_type == 'CONTAINER' and new.get('image_os'):
+            verrors.add(f'{schema_name}.image_os', 'This attribute is only valid for VMs')
+
         if new.get('storage_pool'):
             valid_pools = await self.middleware.call('virt.global.pool_choices')
             if new['storage_pool'] not in valid_pools:
@@ -274,6 +277,9 @@ class VirtInstanceService(CRUDService):
             config['user.autostart'] = str(data['autostart']).lower()
 
         if instance_type == 'VM':
+            if data.get('image_os'):
+                config['image.os'] = data['image_os'].capitalize()
+
             config.update({
                 'security.secureboot': 'true' if data['secure_boot'] else 'false',
                 'user.ix_old_raw_qemu_config': raw.get('raw.qemu', '') if raw else '',


### PR DESCRIPTION
### Context

RTC for incus VMs are by default set to UTC, which is fine for linux base VMs but it is problematic for Windows VMs because Windows requires RTC to be set to `localtime` in order to work correctly. To resolve this, it is required that `image.os` property is set to `Windows`, by doing this, incus will set rtc to localtime internally.

This PR introduces a `image_os` field which a user can specify at the time of creating an instance or updating it. We specify a few popular OS choices but let the user specify anything else he might want as well.