### PR TITLE
NAS-134863 / 25.04.1 / Fix remote audit logging (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/conf.d/tnfilters.conf.mako
@@ -33,6 +33,7 @@ filter f_tnremote_f_debug { level(debug..emerg); };
 
 filter f_tnremote {
     filter(f_tnremote_${adv_conf["sysloglevel"].lower()})
+## syslog_audit is associated with remote logging only
 % if not adv_conf['syslog_audit']:
     and not filter(f_tnaudit_all)
 % endif

--- a/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
+++ b/src/middlewared/middlewared/etc_files/syslog-ng/syslog-ng.conf.mako
@@ -118,6 +118,14 @@ source tn_auditd_src {
 ##################
 @include "/etc/syslog-ng/conf.d/tndestinations.conf"
 
+## Remote syslog stanza needs to here _before_ the audit-related configuration
+% if render_ctx['system.advanced.config']['syslogserver']:
+##################
+# remote logging
+##################
+${generate_syslog_remote_destination(render_ctx['system.advanced.config'])}
+% endif
+
 ##################
 # audit-related configuration
 ##################
@@ -132,7 +140,6 @@ log {
   destination { file("/var/log/scst.log"); };
   flags(final);
 };
-
 
 #######################
 # Middlewared-related log files
@@ -157,8 +164,3 @@ log { source(s_src); filter(f_error); destination(d_error); };
 log { source(s_src); filter(f_messages); destination(d_messages); };
 log { source(s_src); filter(f_console); destination(d_console_all); destination(d_xconsole); };
 log { source(s_src); filter(f_crit); destination(d_console); };
-
-
-% if render_ctx['system.advanced.config']['syslogserver']:
-${generate_syslog_remote_destination(render_ctx['system.advanced.config'])}
-% endif

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -141,7 +141,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         self.api_versions_adapter = api_versions_adapter  # FIXME: Only necessary as a class member for legacy WS API
         return self._create_apis(api_versions, api_versions_adapter)
 
-    def _load_api_versions(self) -> [APIVersion]:
+    def _load_api_versions(self) -> list[APIVersion]:
         versions = []
         api_dir = os.path.join(os.path.dirname(__file__), 'api')
         api_versions = [
@@ -962,7 +962,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             }
         })
 
-        self.__audit_logger.debug(message)
+        self.__audit_logger.info(message)
 
     async def call(self, name, *params, app=None, audit_callback=None, job_on_progress_cb=None, pipes=None,
                    profile=False):

--- a/src/middlewared/middlewared/test/integration/assets/system.py
+++ b/src/middlewared/middlewared/test/integration/assets/system.py
@@ -1,0 +1,62 @@
+import contextlib
+import os
+import sys
+from middlewared.test.integration.utils import ssh, truenas_server, restart_systemd_svc
+from functions import send_file
+
+try:
+    apifolder = os.getcwd()
+    sys.path.append(apifolder)
+    from auto_config import ha, user, password
+except ImportError:
+    ha = False
+
+
+@contextlib.contextmanager
+def standby_syslog_to_remote_syslog(remote_log_path="/var/log/remote_log.txt"):
+    '''
+    Temporarily convert the syslog server on the standby node
+    to a remote syslog server.  HA systems only.
+    NOTE: Any operation that involves restarting or reloading syslog-ng may
+          break the remote syslog configuration.
+    NOTE: This is unstable when run from Jenkins.  It fails in restart_systemd_svc.
+    '''
+    assert ha is True, "Remote log config is available on HA systems only."
+
+    remote_syslog_config = (
+        '@version: 3.38\n'
+        '@include "scl.conf"\n'
+        'options { time-reap(30); mark-freq(10); keep-hostname(yes); };\n'
+        '\n'
+        'source s_remote_non_tls {\n'
+        '    syslog ( ip-protocol(6) transport("tcp") port(514) );\n'
+        '};\n'
+        '\n'
+        'destination d_logs {\n'
+        f'    file( "{remote_log_path}"  owner("root")  group("root")  perm(0777) );\n'
+        '};\n'
+        '\n'
+        'log {\n'
+        '    source(s_remote_non_tls);\n'
+        '    destination(d_logs);\n'
+        '};\n'
+    )
+    remote_ip = truenas_server.ha_ips()['standby']
+    restore_syslog_config = "ORIG_syslog-ng.config_ORIG"
+    try:
+        ssh(f"cp /etc/syslog-ng/syslog-ng.conf /etc/syslog-ng/{restore_syslog_config}", ip=remote_ip)
+        cmd_file = open('syslogconf.py', 'w')
+        cmd_file.writelines(remote_syslog_config)
+        cmd_file.close()
+        results = send_file('syslogconf.py', '/etc/syslog-ng/syslog-ng.conf', user, password, remote_ip)
+        assert results['result'], str(results['output'])
+        restart_systemd_svc("syslog-ng", remote_node=True)
+        yield (remote_ip, remote_log_path)
+    finally:
+        if ssh(f"ls /etc/syslog-ng/{restore_syslog_config}", ip=remote_ip):
+            ssh(f"mv /etc/syslog-ng/{restore_syslog_config} /etc/syslog-ng/syslog-ng.conf", ip=remote_ip)
+        restart_systemd_svc("syslog-ng", remote_node=True)
+        try:
+            os.unlink('syslogconf.py')
+        except FileNotFoundError:
+            pass

--- a/src/middlewared/middlewared/test/integration/utils/__init__.py
+++ b/src/middlewared/middlewared/test/integration/utils/__init__.py
@@ -8,3 +8,4 @@ from .pool import *  # noqa
 from .pytest import * # noqa
 from .run import * # noqa
 from .ssh import *  # noqa
+from .system import * # noqa

--- a/src/middlewared/middlewared/test/integration/utils/system.py
+++ b/src/middlewared/middlewared/test/integration/utils/system.py
@@ -1,4 +1,16 @@
+import os
+import sys
 from .ssh import ssh
+from middlewared.test.integration.utils import truenas_server
+
+try:
+    apifolder = os.getcwd()
+    sys.path.append(apifolder)
+    from auto_config import ha
+except ImportError:
+    ha = False
+
+__all__ = ["reset_systemd_svcs", "restart_systemd_svc"]
 
 
 def reset_systemd_svcs(svcs_to_reset):
@@ -10,3 +22,21 @@ def reset_systemd_svcs(svcs_to_reset):
         reset_systemd_svcs("nfs-idmapd nfs-mountd nfs-server rpcbind rpc-statd")
     '''
     ssh(f"systemctl reset-failed {svcs_to_reset}")
+
+
+def restart_systemd_svc(svc_to_restart: str, remote_node: bool = False):
+    '''
+    --- CI testing function ---
+    Command a service restart via systemctl.
+    Optional to request command on remote node (HA only)
+    NOTE: May be unstable with calls to standby node.
+    '''
+    assert ssh(f"systemctl status {svc_to_restart}")
+    node_ip = None
+    if remote_node:
+        assert ha is True, "Cannot select remote_node on non-HA system"
+        ha_ips = truenas_server.ha_ips()
+        node_ip = ha_ips['standby']
+
+    assert ssh(f"systemctl restart {svc_to_restart}", ip=node_ip), \
+        (ssh(f"systemctl status {svc_to_restart}", ip=node_ip), ssh(f"journalctl -xeu {svc_to_restart} | tail -100", ip=node_ip))


### PR DESCRIPTION
--Backport PR--

Remote audit logging required two small tweaks to get full function:  Removed the 'final' statement from the syslog audit log stanza and, to avoid remote log filtering, changed the priority of the audit log messages from `debug` to `info`.

Other tweaks:  fixed flake8 complaint, added a comment.

The majority of the changes are in CI where functional remote logging tests are added.  The remote logging test will run on HA systems only and uses the standby node as the 'remote syslog server'.

The actual code changes are small, The majority of the changes are in the testing modules.

NOTE: Unable to get stable test runs via jenkins.   I was able to run the test successfully (repeatedly) when the runner was outside of jenkins.

Original PR: https://github.com/truenas/middleware/pull/16219
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134863