### PR TITLE
NAS-132373 / 25.04.1 / Fix ALUA breakage with particular input (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -519,9 +519,10 @@ class iSCSITargetExtentService(SharingService):
 
         global_basename = (await self.middleware.call('iscsi.global.config'))['basename']
         ha_basename = f'{global_basename}:HA:'
+        ha_basename_len = len(ha_basename)
 
         for iqn in filter(lambda x: x.startswith(ha_basename), iqns):
-            target_name = iqn.split(':')[-1]
+            target_name = iqn[ha_basename_len:]
             target_id = target_to_id[target_name]
             for ctl in iqns[iqn]:
                 lun = int(ctl.split(':')[-1])

--- a/src/middlewared/middlewared/plugins/iscsi_/scst.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/scst.py
@@ -69,7 +69,9 @@ class iSCSITargetService(Service):
             return "UNKNOWN"
 
     async def set_device_cluster_mode(self, device, value):
-        await self.middleware.call('iscsi.scst.path_write', f'{SCST_DEVICES}/{sanitize_extent(device)}/cluster_mode', f'{int(value)}\n')
+        await self.middleware.call('iscsi.scst.path_write',
+                                   f'{SCST_DEVICES}/{sanitize_extent(device)}/cluster_mode',
+                                   f'{int(value)}\n')
 
     async def set_devices_cluster_mode(self, devices, value):
         text = f'{int(value)}\n'

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -717,9 +717,8 @@ class iSCSITargetService(CRUDService):
     def clustered_extents(self):
         # Extents may have had their names sanitized for SCST.  We want the official
         # unsanitized names as output.
-        sys_to_name = {sanitize_extent(ext['name']): ext['name'] for ext in self.middleware.call_sync('iscsi.extent.query',
-                                                                                                      [],
-                                                                                                      {'select': ['name']})}
+        sys_to_name = {sanitize_extent(ext['name']): ext['name'] for ext in
+                       self.middleware.call_sync('iscsi.extent.query', [], {'select': ['name']})}
         extents = []
         basepath = pathlib.Path('/sys/kernel/scst_tgt/handlers')
         for p in basepath.glob('*/*/cluster_mode'):

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -12,12 +12,12 @@ import middlewared.sqlalchemy as sa
 from middlewared.api import api_method
 from middlewared.api.base import BaseModel
 from middlewared.api.current import (IscsiTargetCreateArgs, IscsiTargetCreateResult, IscsiTargetDeleteArgs,
-                                     IscsiTargetDeleteResult, IscsiTargetEntry,
-                                     IscsiTargetUpdateArgs, IscsiTargetUpdateResult,
-                                     IscsiTargetValidateNameArgs, IscsiTargetValidateNameResult)
+                                     IscsiTargetDeleteResult, IscsiTargetEntry, IscsiTargetUpdateArgs,
+                                     IscsiTargetUpdateResult, IscsiTargetValidateNameArgs,
+                                     IscsiTargetValidateNameResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
 from middlewared.utils import UnexpectedFailure, run
-from .utils import AUTHMETHOD_LEGACY_MAP
+from .utils import AUTHMETHOD_LEGACY_MAP, sanitize_extent
 
 RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 MODE_FC_CAPABLE = ['FC', 'BOTH']
@@ -715,12 +715,20 @@ class iSCSITargetService(CRUDService):
 
     @private
     def clustered_extents(self):
+        # Extents may have had their names sanitized for SCST.  We want the official
+        # unsanitized names as output.
+        sys_to_name = {sanitize_extent(ext['name']): ext['name'] for ext in self.middleware.call_sync('iscsi.extent.query',
+                                                                                                      [],
+                                                                                                      {'select': ['name']})}
         extents = []
         basepath = pathlib.Path('/sys/kernel/scst_tgt/handlers')
         for p in basepath.glob('*/*/cluster_mode'):
             with p.open() as f:
                 if f.readline().strip() == '1':
-                    extents.append(p.parent.name)
+                    try:
+                        extents.append(sys_to_name[p.parent.name])
+                    except KeyError:
+                        extents.append(p.parent.name)
         return extents
 
     @private

--- a/src/middlewared/middlewared/plugins/iscsi_/utils.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/utils.py
@@ -1,4 +1,7 @@
+import re
 from enum import StrEnum
+
+HBTL = re.compile('^\\d:\\d:\\d:\\d$')
 
 
 class IscsiAuthType(StrEnum):
@@ -29,3 +32,9 @@ MAX_EXTENT_NAME_LEN = 64
 # We deliberately only support a subset of target parameters
 ISCSI_TARGET_PARAMETERS = ['QueuedCommands']
 ISCSI_HA_TARGET_PARAMETERS = ['QueuedCommands']
+
+
+def sanitize_extent(device):
+    if HBTL.match(device):
+        return device
+    return device.replace('.', '_').replace('/', '-')


### PR DESCRIPTION
Fix some aspects of ALUA that are broken on particular input
- Fix ALUA extents that contain a period character
- Fix ALUA target names that contain a colon character

Also add CI `test__target_extent_special_characters`

----
CI with passing iSCSI tests [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3913/).


Original PR: https://github.com/truenas/middleware/pull/16229
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132373