### PR TITLE
NAS-135291 / 25.04.1 / Restrict the size of AdminSession Alerts (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/alert/source/auth.py
+++ b/src/middlewared/middlewared/alert/source/auth.py
@@ -5,6 +5,9 @@ from middlewared.utils.audit import UNAUTHENTICATED
 from time import time
 
 
+MAX_ADMIN_LOGINS_LISTED = 100
+
+
 class AdminSessionAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
@@ -65,7 +68,7 @@ class AdminSessionAlertSource(AlertSource):
         if not admin_logins:
             return
 
-        audit_msg = ','.join([audit_entry_to_msg(entry) for entry in admin_logins])
+        audit_msg = ','.join([audit_entry_to_msg(entry) for entry in admin_logins[-MAX_ADMIN_LOGINS_LISTED:]])
         return Alert(
             AdminSessionAlertClass,
             {'count': len(admin_logins), 'sessions': audit_msg},


### PR DESCRIPTION
Impose a limit on the number of admin logins report in `AdminSessionAlertClass`.

The number of logins will still be reported, but limit the details included.


Original PR: https://github.com/truenas/middleware/pull/16237
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135291