### PR TITLE
NAS-135292 / 25.10 / Add failover.datastore.sql to message size whitelist

### DIFF
--- a/src/middlewared/middlewared/utils/limits.py
+++ b/src/middlewared/middlewared/utils/limits.py
@@ -10,6 +10,7 @@ from truenas_api_client import json as ejson
 # WARNING: below methods must _not_ be audited. c.f. comment in parse_message() below
 MSG_SIZE_EXTENDED_METHODS = frozenset({
     'filesystem.file_receive',
+    'failover.datastore.sql',
 })
 
 


### PR DESCRIPTION
This addresses an issue seen in log files on standby controller of an HA pair. Rejecting a datastore operations from active controller will lead to the nodes getting out of sync with each other.