### PR TITLE
NAS-135294 / 25.04.1 / Fix handling of frozenset (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -248,7 +248,7 @@ class SystemSecurityService(ConfigService):
             # SRG-OS-000071-GPOS-00039
             # Passwords must contain at least one lowercase character, one lowercase character, and
             # one number.
-            ruleset = combined['password_complexity_ruleset'] or GPOS_STIG_PASSWORD_COMPLEXITY
+            ruleset = combined['password_complexity_ruleset'] or set(GPOS_STIG_PASSWORD_COMPLEXITY)
             new['password_complexity_ruleset'] = ruleset
             if missing := GPOS_STIG_PASSWORD_COMPLEXITY - new['password_complexity_ruleset']:
                 raise ValidationError(


### PR DESCRIPTION
Recast frozenset to set to allow for json serialization.
Without this change JSON serialization throws an exception:
`truenas_api_client.exc.ClientException: Object of type frozenset is not JSON serializable`

Original PR: https://github.com/truenas/middleware/pull/16242
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135294