### PR TITLE
NAS-135312 / 25.10 / dont send empty pool stats in reporting.realtime

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
+++ b/src/middlewared/middlewared/plugins/reporting/realtime_reporting/pool.py
@@ -6,14 +6,19 @@ from .utils import safely_retrieve_dimension
 
 
 def get_pool_stats(netdata_metrics: dict) -> dict:
-    data = defaultdict(lambda: {'available': None, 'used': None, 'total': None})
+    data = defaultdict(dict)
     pool_data = query_imported_fast_impl()
-
-    for dimension_name, value in (safely_retrieve_dimension(netdata_metrics, 'truenas_pool.usage') or {}).items():
-        value = value or {}
-        pool_guid, stat_key = dimension_name.split('.')
-        if pool_guid not in pool_data:
-            continue
-
-        data[pool_data[pool_guid]['name']][stat_key] = value
+    for dimension_name, value in (
+        safely_retrieve_dimension(netdata_metrics, "truenas_pool.usage") or {}
+    ).items():
+        # this data eventually gets reported to our reporting.realtime
+        # subscription and so the UI team does not want us to send
+        # events with empty data. We only want to report on pools for
+        # which we're able to retrieve data from.
+        if value:
+            pool_guid, stat_key = dimension_name.split(".")
+            try:
+                data[pool_data[pool_guid]["name"]].update({stat_key: value})
+            except KeyError:
+                continue
     return data


### PR DESCRIPTION
UI team is being sent empty zpool space usage stats in certain scenarios (i.e. when exporting a zpool). Data looks like
```
{
  "pools": {
    "boot-pool": {
      "available": {},
      "used": {},
      "total": {}
    },
    "dozer": {
      "available": {},
      "used": {},
      "total": {}
    }
  }
}
```
At their request, change it so that we only send data for pools we get info from OR if we can't get any data from any pools then report an empty dict at the top-level.
