### PR TITLE
NAS-135320 / 25.04.1 / Fix regex filters on nullable string fields (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_filter_list.py
@@ -591,3 +591,7 @@ def test__filter_list_undefined():
 
 def test__filter_list_invalid_key():
     assert len(filter_list(DATA_WITH_NULL, [['canary', 'in', 'canary2']])) == 0
+
+
+def test__filter_list_regex_null():
+    assert len(filter_list(DATA_WITH_NULL, [['foo', '~', '(?i)Foo1']])) == 1

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -214,7 +214,9 @@ class filters(object):
         return not operator.contains(x, y)
 
     def op_re(x, y):
-        return re.match(y, x)
+        # Some string fields are nullable. If this is the case then we will treat the null as an empty string
+        # so that the regex match doesn't raise an exception.
+        return re.match(y, x or '')
 
     def op_startswith(x, y):
         if x is None:


### PR DESCRIPTION
This commit fixes a bug encountered by the UI team when using a regex on a nullable string field (fails with a TypeError). For convenience, we will convert the None to an empty string.

Original PR: https://github.com/truenas/middleware/pull/16249
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135320