### PR TITLE
NAS-135221 / 25.04.1 / Rewire when FC HBAs are added or replaced (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/alert/source/fibre_channel.py
+++ b/src/middlewared/middlewared/alert/source/fibre_channel.py
@@ -1,0 +1,26 @@
+from middlewared.alert.base import AlertCategory, AlertClass, AlertLevel, SimpleOneShotAlertClass
+
+
+class FCHardwareAddedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = 'Fibre Channel HBAs added.'
+    text = (
+        'Fibre Channel HBAs added.  '
+        'Fibre Channel switches may require reconfiguration.'
+    )
+
+    deleted_automatically = False
+
+
+class FCHardwareReplacedAlertClass(AlertClass, SimpleOneShotAlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.CRITICAL
+    title = 'Fibre Channel HBAs replaced.'
+    text = (
+        'Fibre Channel HBAs replaced.  '
+        'Target/WWPN mapping may have changed.  '
+        'Fibre Channel switches may require reconfiguration.'
+    )
+
+    deleted_automatically = False

--- a/src/middlewared/middlewared/test/integration/assets/alert.py
+++ b/src/middlewared/middlewared/test/integration/assets/alert.py
@@ -1,0 +1,11 @@
+from middlewared.test.integration.utils import call
+
+
+class AlertMixin:
+    def assert_alert_count(self, count):
+        alerts = [alert for alert in call('alert.list') if alert['klass'] == self.ALERT_CLASS_NAME]
+        assert len(alerts) == count, alerts
+
+    def clear_alert(self):
+        call('alert.oneshot_delete', self.ALERT_CLASS_NAME)
+        self.assert_alert_count(0)

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -1056,7 +1056,7 @@ class TestFibreChannelHardwareReplace(AbstractFibreChannel, AlertMixin):
                 assert_fc_host(fc_hosts[0], 'fc0', NODE_A_2_WWPN, NODE_B_2_WWPN, 0)
                 assert_fc_host(fc_hosts[1], 'fc1', NODE_A_3_WWPN, NODE_B_3_WWPN, 0)
             else:
-                assert_fc_host(fc_hosts[2], 'fc0', NODE_A_2_WWPN, None, 0)
-                assert_fc_host(fc_hosts[3], 'fc1', NODE_A_3_WWPN, None, 0)
+                assert_fc_host(fc_hosts[0], 'fc0', NODE_A_2_WWPN, None, 0)
+                assert_fc_host(fc_hosts[1], 'fc1', NODE_A_3_WWPN, None, 0)
             self.assert_alert_count(1)
         self.clear_alert()

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -8,6 +8,7 @@ from assets.websocket.pool import zvol
 from auto_config import ha, pool_name
 
 from middlewared.service_exception import InstanceNotFound, ValidationError, ValidationErrors
+from middlewared.test.integration.assets.alert import AlertMixin
 from middlewared.test.integration.utils import call, mock, ssh
 
 SLOT_0 = 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 0'
@@ -976,16 +977,6 @@ class TestFixtureNoSlotFibreChannel(AbstractFibreChannel):
             assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, None, 0)
             assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, None, 0)
             assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, None, 0)
-
-
-class AlertMixin:
-    def assert_alert_count(self, count):
-        alerts = [alert for alert in call('alert.list') if alert['klass'] == self.ALERT_CLASS_NAME]
-        assert len(alerts) == count, alerts
-
-    def clear_alert(self):
-        call('alert.oneshot_delete', self.ALERT_CLASS_NAME)
-        self.assert_alert_count(0)
 
 
 class TestFibreChannelHardwareAdd(AbstractFibreChannel, AlertMixin):

--- a/tests/api2/test_fibre_channel.py
+++ b/tests/api2/test_fibre_channel.py
@@ -10,6 +10,12 @@ from auto_config import ha, pool_name
 from middlewared.service_exception import InstanceNotFound, ValidationError, ValidationErrors
 from middlewared.test.integration.utils import call, mock, ssh
 
+SLOT_0 = 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 0'
+SLOT_1 = 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 1'
+SLOT_2 = 'CPU SLOT5 PCI-E 3.0 X16 / PCI Function 0'
+SLOT_3 = 'CPU SLOT5 PCI-E 3.0 X16 / PCI Function 1'
+
+
 NODE_A_0_WWPN = '0x210000aaaaaaaa01'
 NODE_A_0_WWPN_NPIV_1 = '0x220000aaaaaaaa01'
 NODE_A_0 = {
@@ -25,7 +31,7 @@ NODE_A_0 = {
     'max_npiv_vports': 254,
     'npiv_vports_inuse': 0,
     'physical': True,
-    'slot': 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 0'
+    'slot': SLOT_0
 }
 
 NODE_A_1_WWPN = '0x210000aaaaaaaa02'
@@ -42,8 +48,43 @@ NODE_A_1 = {
     'max_npiv_vports': 254,
     'npiv_vports_inuse': 0,
     'physical': True,
-    'slot': 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 1'
+    'slot': SLOT_1
 }
+
+NODE_A_2_WWPN = '0x210000aaaaaaaa03'
+NODE_A_2 = {
+    'name': 'host17',
+    'path': '/sys/class/fc_host/host17',
+    'node_name': '0x200000aaaaaaaa03',
+    'port_name': NODE_A_2_WWPN,
+    'port_type': 'NPort (fabric via point-to-point)',
+    'port_state': 'Online',
+    'model': 'QLE2692',
+    'speed': '8 Gbit',
+    'addr': 'pci0000:b2/0000:b2:00.0/0000:b4:00.1',
+    'max_npiv_vports': 254,
+    'npiv_vports_inuse': 0,
+    'physical': True,
+    'slot': SLOT_2
+}
+
+NODE_A_3_WWPN = '0x210000aaaaaaaa04'
+NODE_A_3 = {
+    'name': 'host17',
+    'path': '/sys/class/fc_host/host18',
+    'node_name': '0x200000aaaaaaaa04',
+    'port_name': NODE_A_3_WWPN,
+    'port_type': 'NPort (fabric via point-to-point)',
+    'port_state': 'Online',
+    'model': 'QLE2692',
+    'speed': '8 Gbit',
+    'addr': 'pci0000:b2/0000:b2:00.0/0000:b4:00.2',
+    'max_npiv_vports': 254,
+    'npiv_vports_inuse': 0,
+    'physical': True,
+    'slot': SLOT_3
+}
+
 
 NODE_A_FC_PHYSICAL_PORTS = [NODE_A_0, NODE_A_1]
 
@@ -62,7 +103,7 @@ NODE_B_0 = {
     'max_npiv_vports': 254,
     'npiv_vports_inuse': 0,
     'physical': True,
-    'slot': 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 0'
+    'slot': SLOT_0
 }
 
 NODE_B_1_WWPN = '0x210000bbbbbbbb02'
@@ -79,7 +120,41 @@ NODE_B_1 = {
     'max_npiv_vports': 254,
     'npiv_vports_inuse': 0,
     'physical': True,
-    'slot': 'CPU SLOT4 PCI-E 3.0 X16 / PCI Function 1'
+    'slot': SLOT_1
+}
+
+NODE_B_2_WWPN = '0x210000bbbbbbbb03'
+NODE_B_2 = {
+    'name': 'host17',
+    'path': '/sys/class/fc_host/host17',
+    'node_name': '0x200000bbbbbbbb03',
+    'port_name': NODE_B_2_WWPN,
+    'port_type': 'NPort (fabric via point-to-point)',
+    'port_state': 'Online',
+    'model': 'QLE2692',
+    'speed': '8 Gbit',
+    'addr': 'pci0000:b2/0000:b2:00.0/0000:b4:00.1',
+    'max_npiv_vports': 254,
+    'npiv_vports_inuse': 0,
+    'physical': True,
+    'slot': SLOT_2
+}
+
+NODE_B_3_WWPN = '0x210000bbbbbbbb04'
+NODE_B_3 = {
+    'name': 'host18',
+    'path': '/sys/class/fc_host/host18',
+    'node_name': '0x200000bbbbbbbb04',
+    'port_name': NODE_B_3_WWPN,
+    'port_type': 'NPort (fabric via point-to-point)',
+    'port_state': 'Online',
+    'model': 'QLE2692',
+    'speed': '8 Gbit',
+    'addr': 'pci0000:b2/0000:b2:00.0/0000:b4:00.2',
+    'max_npiv_vports': 254,
+    'npiv_vports_inuse': 0,
+    'physical': True,
+    'slot': SLOT_3
 }
 
 NODE_B_FC_PHYSICAL_PORTS = [NODE_B_0, NODE_B_1]
@@ -273,6 +348,13 @@ NO_SLOT_NODE_B_FC_PHYSICAL_PORTS = [
 ]
 
 
+@pytest.fixture
+def clear_ratelimit():
+    call('rate.limit.cache_clear')
+    if ha:
+        call('failover.call_remote', 'rate.limit.cache_clear')
+
+
 def _str_to_naa(string):
     if isinstance(string, str):
         if string.startswith('0x'):
@@ -366,6 +448,52 @@ def node_hardware(physical_ports, remote=False):
 
 
 @contextlib.contextmanager
+def mock_ports(node_a_physical_ports, node_b_physical_ports):
+    if ha:
+        node = call('failover.node')
+        if node == 'A':
+            with node_hardware(node_a_physical_ports):
+                with node_hardware(node_b_physical_ports, True):
+                    yield
+        else:
+            with node_hardware(node_a_physical_ports, True):
+                with node_hardware(node_b_physical_ports):
+                    yield
+    else:
+        with node_hardware(node_a_physical_ports):
+            yield
+
+
+def unmock_ports():
+    physical_port_filter = [['physical', '=', True]]
+    call('test.remove_mock', 'fc.fc_hosts', None)
+    call('test.remove_mock', 'fc.fc_hosts', physical_port_filter)
+    if ha:
+        call('failover.call_remote', 'test.remove_mock', ['fc.fc_hosts', None])
+        call('failover.call_remote', 'test.remove_mock', ['fc.fc_hosts', physical_port_filter])
+
+
+@contextlib.contextmanager
+def remock_ports(node_a_physical_ports, node_b_physical_ports):
+    unmock_ports()
+    with mock_ports(node_a_physical_ports, node_b_physical_ports):
+        # Normally changing the hardware would have required rebooting the controllers, which
+        # would clear cache.  Do that now.
+        call('cache.pop', 'fc.fc_host_nport_wwpn_choices')
+        call('cache.pop', 'fc.fc_host.hbas_changed')
+        if ha:
+            call('failover.call_remote', 'cache.pop', ['fc.fc_host_nport_wwpn_choices'])
+            call('failover.call_remote', 'cache.pop', ['fc.fc_host.hbas_changed'])
+        yield
+
+
+@contextlib.contextmanager
+def nport_wwpn_choices(choices, remote=False):
+    with mock('fc.fc_host_nport_wwpn_choices', args=[], return_value=choices, remote=remote):
+        yield
+
+
+@contextlib.contextmanager
 def fcport_create(alias, target_id, allow_deleted=False):
     config = call('fcport.create', {'port': alias, 'target_id': target_id})
     try:
@@ -380,8 +508,20 @@ def fcport_create(alias, target_id, allow_deleted=False):
             call('fcport.delete', config['id'])
 
 
-class TestFixtureFibreChannel:
-    """Fixture with Fibre Channel"""
+def assert_fc_host(fc_host, alias, wwpn, wwpn_b, npiv):
+    assert fc_host['alias'] == alias
+    assert fc_host['wwpn'] == str_to_wwpn_naa(wwpn)
+    if wwpn_b is None:
+        assert fc_host['wwpn_b'] is None
+    else:
+        assert fc_host['wwpn_b'] == str_to_wwpn_b_naa(wwpn_b)
+    assert fc_host['npiv'] == npiv
+
+
+class AbstractFibreChannel:
+
+    NODE_A_PORTS = NODE_A_FC_PHYSICAL_PORTS
+    NODE_B_PORTS = NODE_B_FC_PHYSICAL_PORTS
 
     @pytest.fixture(scope='class')
     def fibre_channel_hardware(self):
@@ -390,19 +530,8 @@ class TestFixtureFibreChannel:
         with mock('fc.capable', return_value=True):
             with mock('system.feature_enabled', args=['FIBRECHANNEL',], return_value=True):
                 call('fc.fc_host.reset_wired', True)
-                if ha:
-                    node = call('failover.node')
-                    if node == 'A':
-                        with node_hardware(NODE_A_FC_PHYSICAL_PORTS):
-                            with node_hardware(NODE_B_FC_PHYSICAL_PORTS, True):
-                                yield
-                    else:
-                        with node_hardware(NODE_A_FC_PHYSICAL_PORTS, True):
-                            with node_hardware(NODE_B_FC_PHYSICAL_PORTS):
-                                yield
-                else:
-                    with node_hardware(NODE_A_FC_PHYSICAL_PORTS):
-                        yield
+                with mock_ports(self.NODE_A_PORTS, self.NODE_B_PORTS):
+                    yield
 
     @pytest.fixture(scope='class')
     def fibre_channel_wired(self, fibre_channel_hardware):
@@ -424,24 +553,18 @@ class TestFixtureFibreChannel:
     def fc_hosts(self, fibre_channel_wired):
         yield sorted(call('fc.fc_host.query'), key=lambda d: d['alias'])
 
-    def assert_fc_host(self, fc_host, alias, wwpn, wwpn_b, npiv):
-        assert fc_host['alias'] == alias
-        assert fc_host['wwpn'] == str_to_wwpn_naa(wwpn)
-        if wwpn_b is None:
-            assert fc_host['wwpn_b'] is None
-        else:
-            assert fc_host['wwpn_b'] == str_to_wwpn_b_naa(wwpn_b)
-        assert fc_host['npiv'] == npiv
 
-    def test_wired(self, fc_hosts):
+class TestFixtureFibreChannel(AbstractFibreChannel):
+    """Fixture with Fibre Channel"""
+
+    def test_wired(self, fc_hosts, clear_ratelimit):
         assert len(fc_hosts) == 2
         if ha:
-            self.assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, NODE_B_0_WWPN, 0)
-            self.assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, NODE_B_1_WWPN, 0)
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, NODE_B_0_WWPN, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, NODE_B_1_WWPN, 0)
         else:
-            self.assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, None, 0)
-        self.fc_hosts = fc_hosts
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, None, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, None, 0)
 
     def test_target(self, fc_hosts):
         with target_lun_zero('fctarget0', 'fcextent0', 100) as config:
@@ -829,72 +952,111 @@ class TestFixtureFibreChannel:
             }
 
 
-class TestFixtureNoSlotFibreChannel:
+class TestFixtureNoSlotFibreChannel(AbstractFibreChannel):
     """
     Fixture with Fibre Channel without slot information
     reported in fc.fc_hosts
     """
-
-    @pytest.fixture(scope='class')
-    def fibre_channel_hardware(self):
-        # Make sure iSCSI service is not running.  Would go boom
-        assert call('service.query', [['service', '=', 'iscsitarget']], {'get': True})['state'] == 'STOPPED'
-        with mock('fc.capable', return_value=True):
-            with mock('system.feature_enabled', args=['FIBRECHANNEL',], return_value=True):
-                call('fc.fc_host.reset_wired', True)
-                if ha:
-                    node = call('failover.node')
-                    if node == 'A':
-                        with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS):
-                            with node_hardware(NO_SLOT_NODE_B_FC_PHYSICAL_PORTS, True):
-                                yield
-                    else:
-                        with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS, True):
-                            with node_hardware(NO_SLOT_NODE_B_FC_PHYSICAL_PORTS):
-                                yield
-                else:
-                    with node_hardware(NO_SLOT_NODE_A_FC_PHYSICAL_PORTS):
-                        yield
-
-    @pytest.fixture(scope='class')
-    def fibre_channel_wired(self, fibre_channel_hardware):
-        """
-        Wire the mocked FC ports together.
-        """
-        assert call('fcport.query') == []
-        try:
-            yield
-        finally:
-            for fc in call('fc.fc_host.query'):
-                call('fc.fc_host.delete', fc['id'])
-
-    @pytest.fixture(scope='class')
-    def fc_hosts(self, fibre_channel_wired):
-        yield sorted(call('fc.fc_host.query'), key=lambda d: d['alias'])
-
-    def assert_fc_host(self, fc_host, alias, wwpn, wwpn_b, npiv):
-        assert fc_host['alias'] == alias
-        assert fc_host['wwpn'] == str_to_wwpn_naa(wwpn)
-        if wwpn_b is None:
-            assert fc_host['wwpn_b'] is None
-        else:
-            assert fc_host['wwpn_b'] == str_to_wwpn_b_naa(wwpn_b)
-        assert fc_host['npiv'] == npiv
+    NODE_A_PORTS = NO_SLOT_NODE_A_FC_PHYSICAL_PORTS
+    NODE_B_PORTS = NO_SLOT_NODE_B_FC_PHYSICAL_PORTS
 
     def test_wired(self, fc_hosts):
         assert len(fc_hosts) == 6
         if ha:
-            self.assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, NO_SLOT_NODE_B_0_WWPN, 0)
-            self.assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, NO_SLOT_NODE_B_1_WWPN, 0)
-            self.assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, NO_SLOT_NODE_B_2_WWPN, 0)
-            self.assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, NO_SLOT_NODE_B_3_WWPN, 0)
-            self.assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, NO_SLOT_NODE_B_4_WWPN, 0)
-            self.assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, NO_SLOT_NODE_B_5_WWPN, 0)
+            assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, NO_SLOT_NODE_B_0_WWPN, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, NO_SLOT_NODE_B_1_WWPN, 0)
+            assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, NO_SLOT_NODE_B_2_WWPN, 0)
+            assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, NO_SLOT_NODE_B_3_WWPN, 0)
+            assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, NO_SLOT_NODE_B_4_WWPN, 0)
+            assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, NO_SLOT_NODE_B_5_WWPN, 0)
         else:
-            self.assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, None, 0)
-            self.assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, None, 0)
-        self.fc_hosts = fc_hosts
+            assert_fc_host(fc_hosts[0], 'fc0', NO_SLOT_NODE_A_0_WWPN, None, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NO_SLOT_NODE_A_1_WWPN, None, 0)
+            assert_fc_host(fc_hosts[2], 'fc2', NO_SLOT_NODE_A_2_WWPN, None, 0)
+            assert_fc_host(fc_hosts[3], 'fc3', NO_SLOT_NODE_A_3_WWPN, None, 0)
+            assert_fc_host(fc_hosts[4], 'fc4', NO_SLOT_NODE_A_4_WWPN, None, 0)
+            assert_fc_host(fc_hosts[5], 'fc5', NO_SLOT_NODE_A_5_WWPN, None, 0)
+
+
+class AlertMixin:
+    def assert_alert_count(self, count):
+        alerts = [alert for alert in call('alert.list') if alert['klass'] == self.ALERT_CLASS_NAME]
+        assert len(alerts) == count, alerts
+
+    def clear_alert(self):
+        call('alert.oneshot_delete', self.ALERT_CLASS_NAME)
+        self.assert_alert_count(0)
+
+
+class TestFibreChannelHardwareAdd(AbstractFibreChannel, AlertMixin):
+    ALERT_CLASS_NAME = 'FCHardwareAdded'
+
+    @pytest.mark.dependency(name="fc_add_baseline")
+    def test_add_baseline(self, fc_hosts, clear_ratelimit):
+        assert len(fc_hosts) == 2
+        if ha:
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, NODE_B_0_WWPN, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, NODE_B_1_WWPN, 0)
+        else:
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, None, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, None, 0)
+        assert call('fc.fc_host.hbas_changed') == {'added': False, 'removed': False}
+
+    @pytest.mark.dependency(depends=['fc_add_baseline'])
+    def test_add(self, fc_hosts):
+        self.clear_alert()
+        # Add another dual-port HBA to each controller
+        with remock_ports([NODE_A_0, NODE_A_1, NODE_A_2, NODE_A_3], [NODE_B_0, NODE_B_1, NODE_B_2, NODE_B_3]):
+            # Normally changing the hardware would have required rebooting the controllers, which
+            # would clear cache.  Do that now.
+            call('fc.fc_host.reset_check_hardware')
+            assert call('fcport.query') == []
+            fc_hosts = sorted(call('fc.fc_host.query'), key=lambda d: d['alias'])
+            assert len(fc_hosts) == 4
+            if ha:
+                assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, NODE_B_0_WWPN, 0)
+                assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, NODE_B_1_WWPN, 0)
+                assert_fc_host(fc_hosts[2], 'fc2', NODE_A_2_WWPN, NODE_B_2_WWPN, 0)
+                assert_fc_host(fc_hosts[3], 'fc3', NODE_A_3_WWPN, NODE_B_3_WWPN, 0)
+            else:
+                assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, None, 0)
+                assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, None, 0)
+                assert_fc_host(fc_hosts[2], 'fc2', NODE_A_2_WWPN, None, 0)
+                assert_fc_host(fc_hosts[3], 'fc3', NODE_A_3_WWPN, None, 0)
+            self.assert_alert_count(1)
+        self.clear_alert()
+
+
+class TestFibreChannelHardwareReplace(AbstractFibreChannel, AlertMixin):
+    ALERT_CLASS_NAME = 'FCHardwareReplaced'
+
+    @pytest.mark.dependency(name="fc_replace_baseline")
+    def test_replace_baseline(self, fc_hosts, clear_ratelimit):
+        assert len(fc_hosts) == 2
+        if ha:
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, NODE_B_0_WWPN, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, NODE_B_1_WWPN, 0)
+        else:
+            assert_fc_host(fc_hosts[0], 'fc0', NODE_A_0_WWPN, None, 0)
+            assert_fc_host(fc_hosts[1], 'fc1', NODE_A_1_WWPN, None, 0)
+        assert call('fc.fc_host.hbas_changed') == {'added': False, 'removed': False}
+
+    @pytest.mark.dependency(depends=['fc_replace_baseline'])
+    def test_replace(self, fc_hosts):
+        self.clear_alert()
+        # Add another dual-port HBA to each controller
+        with remock_ports([NODE_A_2, NODE_A_3], [NODE_B_2, NODE_B_3]):
+            # Normally changing the hardware would have required rebooting the controllers, which
+            # would clear cache.  Do that now.
+            call('fc.fc_host.reset_check_hardware')
+            assert call('fcport.query') == []
+            fc_hosts = sorted(call('fc.fc_host.query'), key=lambda d: d['alias'])
+            assert len(fc_hosts) == 2
+            if ha:
+                assert_fc_host(fc_hosts[0], 'fc0', NODE_A_2_WWPN, NODE_B_2_WWPN, 0)
+                assert_fc_host(fc_hosts[1], 'fc1', NODE_A_3_WWPN, NODE_B_3_WWPN, 0)
+            else:
+                assert_fc_host(fc_hosts[2], 'fc0', NODE_A_2_WWPN, None, 0)
+                assert_fc_host(fc_hosts[3], 'fc1', NODE_A_3_WWPN, None, 0)
+            self.assert_alert_count(1)
+        self.clear_alert()


### PR DESCRIPTION
React when Fibre Channel cards are either added to a system, or existing cards are replaced.
- Rewire when FC HBAs are added or replaced.  Generate a oneshot alert.
- Add CI tests for FC HBA addition or replacement

----
Fibre Channel CI tests pass for [HA](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3924/) and [single-node](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3927/).

Original PR: https://github.com/truenas/middleware/pull/16241
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135221