### PR TITLE
NAS-134501 / 25.10 / Make sure we adjust ARC for incus VMs like we did with libvirt

### DIFF
--- a/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
+++ b/src/middlewared/middlewared/plugins/sysctl/sysctl_info.py
@@ -18,12 +18,66 @@ class SysctlService(Service):
             raise CallError(f'Unable to retrieve value of "{sysctl_name}" sysctl : {cp.stderr.decode()}')
         return cp.stdout.decode().split('=')[-1].strip()
 
+    def store_default_arc_max(self):
+        """This method should be called _BEFORE_ we initialize any VMs
+        so that we can capture what the ARC max value was before we start
+        changing the various ARC sysctls based on VM memory configurations"""
+        val = self.get_arcstats()['c_max']
+        try:
+            with open(DEFAULT_ARC_MAX_FILE, 'x') as f:
+                f.write(str(val))
+                f.flush()
+        except FileExistsError:
+            return self.get_default_arc_max()
+        else:
+            return val
+
+    def get_default_arc_max(self):
+        try:
+            with open(DEFAULT_ARC_MAX_FILE) as f:
+                return int(f.read())
+        except FileNotFoundError:
+            return self.store_default_arc_max()
+
+    def get_arc_max(self):
+        return self.get_arcstats()['c_max']
+
+    def get_arc_min(self):
+        return self.get_arcstats()['c_min']
+
+    async def get_pagesize(self):
+        cp = await run(['getconf', 'PAGESIZE'], check=False)
+        if cp.returncode:
+            raise CallError(f'Unable to retrieve pagesize value: {cp.stderr.decode()}')
+        return int(cp.stdout.decode().strip())
+
+    def get_arcstats(self):
+        stats = {}
+        with open('/proc/spl/kstat/zfs/arcstats') as f:
+            for lineno, line in enumerate(f, start=1):
+                if lineno > 2:  # skip first 2 lines
+                    try:
+                        key, _, value = line.strip().split()
+                        key, value = key.strip(), value.strip()
+                    except ValueError:
+                        continue
+                    else:
+                        stats[key] = int(value) if value.isdigit() else value
+
+        return stats
+
+    def get_arcstats_size(self):
+        return self.get_arcstats()['size']
+
     async def set_value(self, key, value):
         await run(['sysctl', f'{key}={value}'])
 
     def write_to_file(self, path, value):
         with open(path, 'w') as f:
             f.write(str(value))
+
+    def set_arc_max(self, value):
+        return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zfs_arc_max'), value)
 
     def set_zvol_volmode(self, value):
         return self.write_to_file(os.path.join(ZFS_MODULE_PARAMS_PATH, 'zvol_volmode'), value)

--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -665,9 +665,14 @@ async def _event_system_ready(middleware: 'Middleware', event_type, args):
 
 
 async def setup(middleware: 'Middleware'):
+    # it's _very_ important that we run this before we do
+    # any type of VM initialization. We have to capture the
+    # zfs c_max value before we start manipulating these
+    # sysctls during vm start/stop
+    await middleware.call('sysctl.store_default_arc_max')
     middleware.event_register(
         'virt.global.config',
-        'Sent on virtualziation configuration changes.',
+        'Sent on virtualization configuration changes.',
         roles=['VIRT_GLOBAL_READ']
     )
     middleware.event_subscribe('system.ready', _event_system_ready)

--- a/src/middlewared/middlewared/plugins/virt/memory.py
+++ b/src/middlewared/middlewared/plugins/virt/memory.py
@@ -1,0 +1,89 @@
+import errno
+
+from middlewared.api import api_method
+from middlewared.api.current import VirtInstanceGetMemoryUsageArgs, VirtInstanceGetMemoryUsageResult
+from middlewared.service import CallError, private, Service
+
+from .utils import get_max_requested_memory_of_instance
+
+
+class VirtInstanceService(Service):
+
+    class Config:
+        namespace = 'virt.instance'
+        cli_namespace = 'virt.instance'
+
+    async def _set_guest_vmemory(self, vm, overcommit):
+        memory_details = await self.middleware.call('virt.instance.get_vm_memory_info', vm['id'])
+        if not memory_details['overcommit_required']:
+            # There really isn't anything to be done if over-committing is not required
+            return
+
+        if not overcommit:
+            raise CallError(f'Cannot guarantee memory for guest {vm["name"]}', errno.ENOMEM)
+
+        if memory_details['current_arc_max'] != memory_details['arc_max_after_shrink']:
+            self.logger.debug(
+                'Setting ARC from %s to %s', memory_details['current_arc_max'], memory_details['arc_max_after_shrink']
+            )
+            await self.middleware.call('sysctl.set_arc_max', memory_details['arc_max_after_shrink'])
+
+    @private
+    async def init_guest_vmemory(self, vm, overcommit):
+        guest = await self.middleware.call('virt.instance.get_instance', vm) if isinstance(vm, str) else vm
+        if guest['status'] == 'STOPPED':
+            await self._set_guest_vmemory(guest, overcommit)
+        else:
+            raise CallError('VM process is running, we won\'t allocate memory')
+
+    @private
+    async def teardown_guest_vmemory(self, vm):
+        vm = await self.middleware.call('virt.instance.get_instance', vm) if isinstance(vm, str) else vm
+        if vm['status'] != 'STOPPED':
+            return
+
+        guest_memory = get_max_requested_memory_of_instance(vm)
+        arc_max = await self.middleware.call('sysctl.get_arc_max')
+        arc_min = await self.middleware.call('sysctl.get_arc_min')
+        new_arc_max = min(
+            await self.middleware.call('sysctl.get_default_arc_max'),
+            arc_max + guest_memory
+        )
+        if arc_max != new_arc_max:
+            if new_arc_max > arc_min:
+                self.logger.debug(f'Giving back guest memory to ARC: {new_arc_max}')
+                await self.middleware.call('sysctl.set_arc_max', new_arc_max)
+            else:
+                self.logger.warn(
+                    f'Not giving back memory to ARC because new arc_max ({new_arc_max}) <= arc_min ({arc_min})'
+                )
+
+    @api_method(VirtInstanceGetMemoryUsageArgs, VirtInstanceGetMemoryUsageResult, roles=['VIRT_INSTANCE_READ'])
+    async def get_memory_usage(self, oid):
+        instance_details = await self.middleware.call('virt.instance.get_instance', oid, {'extra': {'raw': True}})
+        usage = await self.get_memory_usage_internal(instance_details)
+        return {
+            'total': get_max_requested_memory_of_instance(instance_details),
+            'usage': usage['usage'],
+        }
+
+    @private
+    async def get_memory_usage_internal(self, instance_details):
+        return instance_details['raw'].get('state', {}).get('memory', {}) or {
+            'usage': 0,
+            'total': 0,
+        }
+
+
+async def _event_virt_instances(middleware, event_type, args):
+    instance = await middleware.call('virt.instance.query', [['id', '=', args['id']]])
+    status = args.get('fields', {}).get('status')
+    if not instance or instance['type'] != 'VM' or instance[0]['status'] != 'STOPPED' or status != 'STOPPED':
+        return
+
+    middleware.create_task(middleware.call('virt.instance.teardown_guest_vmemory', instance))
+
+
+async def setup(middleware):
+    middleware.event_subscribe('virt.instance.query', _event_virt_instances)
+

--- a/src/middlewared/middlewared/plugins/virt/utils.py
+++ b/src/middlewared/middlewared/plugins/virt/utils.py
@@ -214,6 +214,13 @@ def get_max_boot_priority_device(device_list: list[dict]) -> dict | None:
     return max_boot_priority_device
 
 
+def get_max_requested_memory_of_instance(instance: dict) -> int:
+    return instance['memory'] if instance['memory'] else (
+        instance['raw'].get('state', {}).get('memory', {}).get('total') or 0
+        # Can happen if VM is stopped and explicit memory is not requested
+    )
+
+
 @dataclass(slots=True, frozen=True, kw_only=True)
 class PciEntry:
     pci_addr: str

--- a/src/middlewared/middlewared/plugins/virt/vm_memory_info.py
+++ b/src/middlewared/middlewared/plugins/virt/vm_memory_info.py
@@ -1,0 +1,103 @@
+import errno
+
+from middlewared.api import api_method
+from middlewared.api.current import (
+    VirtInstanceGetAvailableMemoryArgs, VirtInstanceGetAvailableMemoryResult, VirtInstanceGetVMMemoryInfoArgs,
+    VirtInstanceGetVMMemoryInfoResult,
+)
+from middlewared.service import CallError, Service
+from middlewared.utils.memory import get_memory_info
+
+from .utils import get_max_requested_memory_of_instance
+
+
+class VirtInstanceService(Service):
+
+    class Config:
+        namespace = 'virt.instance'
+        cli_namespace = 'virt.instance'
+
+    @api_method(VirtInstanceGetAvailableMemoryArgs, VirtInstanceGetAvailableMemoryResult, roles=['VIRT_INSTANCE_READ'])
+    async def get_available_memory(self, overcommit):
+        """
+        Get the current maximum amount of available memory to be allocated for VMs.
+
+        In case of `overcommit` being `true`, calculations are done in the following manner:
+        1. If a VM has requested 10G but is only consuming 5G, only 5G will be counted
+        2. System will consider shrinkable ZFS ARC as free memory ( shrinkable ZFS ARC is current ZFS ARC
+           minus ZFS ARC minimum )
+
+        In case of `overcommit` being `false`, calculations are done in the following manner:
+        1. Complete VM requested memory will be taken into account regardless of how much actual physical
+           memory the VM is consuming
+        2. System will not consider shrinkable ZFS ARC as free memory
+
+        Memory is of course a very "volatile" resource, values may change abruptly between a
+        second but I deem it good enough to give the user a clue about how much memory is
+        available at the current moment and if a VM should be allowed to be launched.
+        """
+        # Use 90% of available memory to play safe
+        free = int(get_memory_info()['available'] * 0.9)
+
+        # Difference between current ARC total size and the minimum allowed
+        arc_total = await self.middleware.call('sysctl.get_arcstats_size')
+        arc_min = await self.middleware.call('sysctl.get_arc_min')
+        arc_shrink = max(0, arc_total - arc_min)
+        total_free = free + arc_shrink
+
+        vms_memory_used = 0
+        if overcommit is False:
+            # If overcommit is not wanted its verified how much physical memory
+            # the vm process is currently using and add the maximum memory its
+            # supposed to have.
+            for vm in await self.middleware.call(
+                'virt.instance.query', [['type', '=', 'VM'], ['status', '=', 'RUNNING']], {
+                    'extra': {'raw': True},
+                }
+            ):
+                if (memory_info := vm['raw'].get('state', {}).get('memory', {})) and memory_info.get('usage'):
+                    current_vm_mem = memory_info['usage']
+                    vm_max_mem = vm['memory'] if vm['memory'] else (memory_info['total'] or current_vm_mem)
+                else:
+                    continue
+
+                # We handle edge case with vm_max_mem < current_vm_mem
+                if vm_max_mem > current_vm_mem:
+                    vms_memory_used += vm_max_mem - current_vm_mem
+
+        return max(0, total_free - vms_memory_used)
+
+    @api_method(VirtInstanceGetVMMemoryInfoArgs, VirtInstanceGetVMMemoryInfoResult, roles=['VIRT_INSTANCE_READ'])
+    async def get_vm_memory_info(self, vm_id):
+        """
+        Returns memory information for `vm_id` virt VM if it is going to be started.
+
+        All memory attributes are expressed in bytes.
+        """
+        vm = await self.middleware.call('virt.instance.get_instance', vm_id, {'extra': {'raw': True}})
+        if vm['type'] != 'VM':
+            raise CallError(f'Virt instance is not a VM: {vm["name"]}', errno.EINVAL)
+
+        arc_max = await self.middleware.call('sysctl.get_arc_max')
+        arc_min = await self.middleware.call('sysctl.get_arc_min')
+        shrinkable_arc_max = max(0, arc_max - arc_min)
+
+        available_memory = await self.get_available_memory(False)
+        available_memory_with_overcommit = await self.get_available_memory(True)
+        vm_requested_memory = get_max_requested_memory_of_instance(vm)
+
+        overcommit_required = vm_requested_memory > available_memory
+        arc_to_shrink = 0
+        if overcommit_required:
+            arc_to_shrink = min(shrinkable_arc_max, vm_requested_memory - available_memory)
+
+        return {
+            'total_memory_requested': vm_requested_memory,
+            'overcommit_required': overcommit_required,
+            'arc_to_shrink': arc_to_shrink,
+            'memory_req_fulfilled_after_overcommit': vm_requested_memory < available_memory_with_overcommit,
+            'current_arc_max': arc_max,
+            'arc_min': arc_min,
+            'arc_max_after_shrink': arc_max - arc_to_shrink,
+            'actual_vm_requested_memory': vm_requested_memory,
+        }


### PR DESCRIPTION
## Context

We would like to adjust ARC for incus VMs similar to how we were doing with our libvirt based VMs as in the past we experienced various memory related issues under memory pressure.

Most of the logic has been copied as is from our old implementation as that had been refined over time as we came across various issues.