### PR TITLE
Disallow empty string for user password field

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-04-14_15-57_disallow_empty_passwords.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-04-14_15-57_disallow_empty_passwords.py
@@ -1,0 +1,23 @@
+"""Disable password when empty string is used.
+
+Revision ID: 595b38b52541
+Revises: d7e3a916db65
+Create Date: 2025-04-14 15:57:08.141738+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '595b38b52541'
+down_revision = 'd7e3a916db65'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('UPDATE account_bsdusers SET bsdusr_password_disabled = TRUE WHERE bsdusr_unixhash = "*"')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/api/v25_10_0/user.py
+++ b/src/middlewared/middlewared/api/v25_10_0/user.py
@@ -128,7 +128,7 @@ class UserCreate(UserEntry):
     "Required if `group_create` is `false`."
     home_create: bool = False
     home_mode: str = "700"
-    password: Secret[str | None] = None
+    password: Secret[NonEmptyString | None] = None
     random_password: bool = False
     "Generate a random 20 character password for the user"
 


### PR DESCRIPTION
We currently accept an empty string to disable password for a user. We should no longer do this and instead use the `password_disabled` field.