### PR TITLE
NAS-135323 / 25.10 / fix network iface check on HA

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -190,7 +190,7 @@ class FailoverDisabledReasonsService(Service):
     def get_reasons(self, app):
         reasons = set()
         if self.middleware.call_sync("failover.licensed"):
-            ifaces = self.middleware.call_sync("interface.query", ["failover_critical", "=", True])
+            ifaces = self.middleware.call_sync("interface.query", [["failover_critical", "=", True]])
             self.get_local_reasons(app, ifaces, reasons)
             self.get_remote_reasons(app, ifaces, reasons)
 

--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -190,7 +190,7 @@ class FailoverDisabledReasonsService(Service):
     def get_reasons(self, app):
         reasons = set()
         if self.middleware.call_sync("failover.licensed"):
-            ifaces = self.middleware.call_sync("interface.query")
+            ifaces = self.middleware.call_sync("interface.query", ["failover_critical", "=", True])
             self.get_local_reasons(app, ifaces, reasons)
             self.get_remote_reasons(app, ifaces, reasons)
 


### PR DESCRIPTION
QE found following bug:
1. be on HA system
2. only 1 interface marked critical for failover
3. physically unplug interface on standby controller
4. no alerts in UI/MW about the fact the only network interface is NO_CARRIER

Seems like this logic has _almost_ been in our checks for awhile but it was never plumbed in.