### PR TITLE
NAS-135290 / 25.04.1 / Fix network.configuration domain validation

### DIFF
--- a/src/middlewared/middlewared/plugins/network_/global_config.py
+++ b/src/middlewared/middlewared/plugins/network_/global_config.py
@@ -43,7 +43,7 @@ class NetworkConfigurationService(ConfigService):
         'network_configuration_entry',
         Int('id', required=True),
         Str('hostname', required=True, validators=[Hostname()]),
-        Str('domain', validators=[Match(r'^[a-zA-Z\.\-\0-9]*$')],),
+        Str('domain', validators=[Match(r'^[a-zA-Z\.\-0-9]*$')],),
         IPAddr('ipv4gateway', required=True),
         IPAddr('ipv6gateway', required=True, allow_zone_index=True),
         IPAddr('nameserver1', required=True),


### PR DESCRIPTION
This regex is not doing any validation due to the unnecessary backslash, allowing any character to be included in the domain.