### PR TITLE
NAS-134549 / 25.10 / improve network check in HA check

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -447,24 +447,40 @@ class FailoverService(ConfigService):
         """Determine if NICs match between both controllers."""
         result = {'missing_local': list(), 'missing_remote': list()}
         try:
-            local_nics = await self.middleware.call('interface.query', [], {'extra': {'retrieve_names_only': True}})
-            local_nics = set(i['name'] for i in local_nics)
+            local_nics = await self.middleware.call('interface.query')
+            local_nonphysical_names = {i['name'] for i in local_nics if i['type'] != 'PHYSICAL'}
+            local_physical_mac_to_name = {i['link_address']: i['name'] for i in local_nics if i['type'] == 'PHYSICAL'}
         except Exception:
             self.logger.error('Unhandled exception querying ifaces on local controller', exc_info=True)
             return result
 
         try:
             remote_nics = await self.middleware.call(
-                'failover.call_remote', 'interface.query', [[], {'extra': {'retrieve_names_only': True}}],
+                'failover.call_remote', 'interface.query', [],
                 {'raise_connect_error': False, 'timeout': 2, 'connect_timeout': 2}
             )
         except Exception:
             self.logger.error('Unhandled exception querying ifaces on remote controller', exc_info=True)
         else:
             if remote_nics is not None:
-                remote_nics = set(i['name'] for i in remote_nics)
-                result['missing_local'] = sorted(remote_nics - local_nics)
-                result['missing_remote'] = sorted(local_nics - remote_nics)
+                remote_nonphysical_names = {i['name'] for i in remote_nics if i['type'] != 'PHYSICAL'}
+                remote_physical_mac_to_name = {i['link_address']: i['name']
+                                               for i in remote_nics
+                                               if i['type'] == 'PHYSICAL'}
+
+                # Physical NICs can't be just matched by name, because names can change due to OS kernel upgrades.
+                # Match them by hardware addresses instead.
+                missing_local, missing_remote = mismatch_nics(
+                    local_physical_mac_to_name,
+                    remote_physical_mac_to_name,
+                    await self.middleware.call('interface.local_macs_to_remote_macs'),
+                )
+
+                missing_local += list(remote_nonphysical_names - local_nonphysical_names)
+                missing_remote += list(local_nonphysical_names - remote_nonphysical_names)
+
+                result['missing_local'] = sorted(missing_local)
+                result['missing_remote'] = sorted(missing_remote)
 
         return result
 
@@ -1165,6 +1181,33 @@ async def _event_system_ready(middleware, event_type, args):
 
 def remote_status_event(middleware, *args, **kwargs):
     middleware.call_sync('failover.status_refresh')
+
+
+def mismatch_nics(
+    local_mac_to_name: dict[str, str],
+    remote_mac_to_name: dict[str, str],
+    local_macs_to_remote_macs: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    missing_local = []
+    missing_remote = []
+
+    remote_macs_to_local_macs = {v: k for k, v in local_macs_to_remote_macs.items()}
+
+    for local_mac, local_name in local_mac_to_name.items():
+        remote_mac = local_macs_to_remote_macs.get(local_mac)
+        if remote_mac is None:
+            missing_remote.append(f"{local_name} (has no known remote pair)")
+        elif remote_mac not in remote_mac_to_name:
+            missing_remote.append(f"{remote_mac} (local name {local_name})")
+
+    for remote_mac, remote_name in remote_mac_to_name.items():
+        local_mac = remote_macs_to_local_macs.get(remote_mac)
+        if local_mac is None:
+            missing_local.append(f"{remote_name} (has no known local pair)")
+        elif local_mac not in local_mac_to_name:
+            missing_local.append(f"{local_mac} (remote name {remote_name})")
+
+    return missing_local, missing_remote
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_failover.py
@@ -1,0 +1,29 @@
+import pytest
+
+from middlewared.plugins.failover import mismatch_nics
+
+
+@pytest.mark.parametrize(
+    "local_mac_to_name,remote_mac_to_name,local_macs_to_remote_macs,missing_local,missing_remote",
+    [
+        ({"00:01": "eth0"}, {"00:02": "eth0"}, {"00:01": "00:02"}, [], []),
+        ({"00:01": "eth0"}, {"00:02": "enp0s3"}, {"00:01": "00:02"}, [], []),
+        ({"00:01": "eth0", "00:a1": "eth1"}, {"00:02": "eth0"}, {"00:01": "00:02"},
+         [], ["eth1 (has no known remote pair)"]),
+        ({"00:01": "eth0"}, {"00:02": "eth0", "00:a2": "eth1"}, {"00:01": "00:02"},
+         ["eth1 (has no known local pair)"], []),
+        ({"00:01": "eth0"}, {"00:03": "enp0s3"}, {"00:01": "00:02"},
+         ["enp0s3 (has no known local pair)"], ["00:02 (local name eth0)"]),
+        ({"00:03": "eth0"}, {"00:02": "enp0s3"}, {"00:01": "00:02"},
+         ["00:01 (remote name enp0s3)"], ["eth0 (has no known remote pair)"]),
+    ],
+)
+def test_mismatch_nics(local_mac_to_name, remote_mac_to_name, local_macs_to_remote_macs, missing_local, missing_remote):
+    assert mismatch_nics(
+        local_mac_to_name,
+        remote_mac_to_name,
+        local_macs_to_remote_macs,
+    ) == (
+        missing_local,
+        missing_remote,
+    )


### PR DESCRIPTION
Physical NICs can't be just matched by name, because names can change due to OS kernel upgrades. Match them by hardware addresses instead.