### PR TITLE
NAS-135117 / 25.10 / Add disable of 'usage' reporting when GPOS STIG is enabled.

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -88,6 +88,12 @@ class SystemSecurityService(ConfigService):
         # compatibility.
         await self.middleware.run_in_thread(set_io_uring_enabled, False)
 
+        # Disable non-critical outgoing network activity
+        await self.middleware.call(
+            'network.configuration.update',
+            {"activity": {"type": "DENY", "activities": ["usage"]}}
+        )
+
     @private
     async def validate_stig(self, current_cred):
         # The following validation steps ensure that users have the ability to


### PR DESCRIPTION
Usage reporting should be disabled when in GPOS STIG mode.

Added CI test (config only, the functionality of the `network.configuration` `activity` field should be tested elsewhere)

Update test cleanup and setup to improve repeatability.

The CI test that covers both collection and the collection reporting: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3964/