### PR TITLE
NAS-135357 / 25.04.1 / Fix validation of NT hashes (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/util_passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_passdb.py
@@ -54,6 +54,8 @@ MINOR_VERSION_VAL = b64encode(pack('<I', 0))
 MAJOR_VERSION_KEY = 'INFO/version'
 MAJOR_VERSION_VAL = b64encode(pack('<I', 4))
 
+NTHASH_LEN = 16
+
 # The following constants are taken from default values
 # generated in samu_new() in source3/passdb/passdb.c
 DEFAULT_HOURS_LEN = 21
@@ -482,6 +484,10 @@ def user_smbhash_to_nt_pw(username, smbhash) -> str:
     if ':' in smbhash:
         # we may have a legacy entry in smbpasswd format
         smbhash = smbhash.split(':')[3]
+
+    # Check that the SMB hash is actually a hex string of the required length
+    if len(bytes.fromhex(smbhash)) != NTHASH_LEN:
+        raise ValueError('smbhash has incorrect length')
 
     return smbhash
 

--- a/tests/unit/test_passdb.py
+++ b/tests/unit/test_passdb.py
@@ -267,3 +267,19 @@ def test__validate_account_policy(policy_item):
                 assert value == 10 * 86400
         else:
             assert value == to_check.default
+
+
+@pytest.mark.parametrize('nthash_str,error', [
+    ('', 'SMB hash not available'),
+    ('*', 'failed to parse SMB hash'),
+    ('canary', 'failed to parse SMB hash'),
+    ('B3F34FF0FBB772A1A70810CBB3320740B3F34FF0FBB772A1A70810CBB3320740', 'failed to parse SMB hash'),
+    ('B3F34FF0FBB772A1A70810CBB3320740', None),
+])
+def test__invalid_smb_hash(nthash_str, error):
+    user = SAMPLE_USER | {'smbhash': nthash_str}
+    if error:
+        with pytest.raises(ValueError, match=error):
+            util_passdb.user_entry_to_passdb_entry(PDB_DOMAIN, user)
+    else:
+        util_passdb.user_entry_to_passdb_entry(PDB_DOMAIN, user)


### PR DESCRIPTION
This commit addresses an incomplete fix for cases where users have invalid SMB hashes in their configuration files due to an API validation issue that allowed entering empty strings for the user password.

Original PR: https://github.com/truenas/middleware/pull/16271
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135357