### PR TITLE
NAS-135376 / 25.10 / Fix enabling the root account

### DIFF
--- a/src/freenas/usr/local/bin/truenas-set-authentication-method.py
+++ b/src/freenas/usr/local/bin/truenas-set-authentication-method.py
@@ -19,7 +19,10 @@ if __name__ == "__main__":
 
     c = conn.cursor()
     if username == "root":
-        c.execute("UPDATE account_bsdusers SET bsdusr_unixhash = ?, bsdusr_last_password_change = ?  WHERE bsdusr_username = 'root'", (password, now))
+        c.execute(
+            "UPDATE account_bsdusers SET bsdusr_password_disabled = ? bsdusr_unixhash = ?, bsdusr_last_password_change = ?"
+            "WHERE bsdusr_username = 'root'", (False, password, now)
+        )
     else:
         home = f"/home/{username}"
 


### PR DESCRIPTION
A recent migration that to set password_disabled field when the unixhash was "*" exposed a slight flaw in our logic for enabling the root account through setting authentication method to root (we didn't enable password authentication if it was disabled).