### PR TITLE
NAS-135377 / 25.10 / Expand possible incus instance status results in API

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_0/virt_instance.py
@@ -74,7 +74,7 @@ class VirtInstanceEntry(BaseModel):
     id: str
     name: Annotated[NonEmptyString, StringConstraints(max_length=200)]
     type: InstanceType = 'CONTAINER'
-    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN']
+    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN', 'ERROR', 'FROZEN', 'STARTING', 'STOPPING', 'FREEZING', 'THAWED', 'ABORTING']
     cpu: str | None
     memory: int | None
     autostart: bool

--- a/src/middlewared/middlewared/api/v25_04_1/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_04_1/virt_instance.py
@@ -74,7 +74,7 @@ class VirtInstanceEntry(BaseModel):
     id: str
     name: Annotated[NonEmptyString, StringConstraints(max_length=200)]
     type: InstanceType = 'CONTAINER'
-    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN']
+    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN', 'ERROR', 'FROZEN', 'STARTING', 'STOPPING', 'FREEZING', 'THAWED', 'ABORTING']
     cpu: str | None
     memory: int | None
     autostart: bool

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance.py
@@ -74,7 +74,7 @@ class VirtInstanceEntry(BaseModel):
     id: str
     name: Annotated[NonEmptyString, StringConstraints(max_length=200)]
     type: InstanceType = 'CONTAINER'
-    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN']
+    status: Literal['RUNNING', 'STOPPED', 'UNKNOWN', 'ERROR', 'FROZEN', 'STARTING', 'STOPPING', 'FREEZING', 'THAWED', 'ABORTING']
     cpu: str | None
     memory: int | None
     autostart: bool


### PR DESCRIPTION
This commit adds FROZEN and ERROR as possible incus instance status since they are mentioned in incus documentation. Lxc additionally defines state strings of STARTING, STOPPING, FREEZING, and THAWED which technically possibly surface as instance state. C.f src/lxc/state.c in lxc codebase.