### PR TITLE
Fix typo in set-authentication-method script

### DIFF
--- a/src/freenas/usr/local/bin/truenas-set-authentication-method.py
+++ b/src/freenas/usr/local/bin/truenas-set-authentication-method.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     c = conn.cursor()
     if username == "root":
         c.execute(
-            "UPDATE account_bsdusers SET bsdusr_password_disabled = ? bsdusr_unixhash = ?, bsdusr_last_password_change = ?"
+            "UPDATE account_bsdusers SET bsdusr_password_disabled = ?, bsdusr_unixhash = ?, bsdusr_last_password_change = ?"
             "WHERE bsdusr_username = 'root'", (False, password, now)
         )
     else:


### PR DESCRIPTION
This commit fixes a typo introduced by the fix to remove the password_disabled flag from the root account when being set up in lieu of truenas_admin.