### PR TITLE
NAS-135386 / 25.10 / hide macvlan interfaces from network API

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/utils.py
@@ -7,7 +7,16 @@ __all__ = ["bitmask_to_set", "INTERNAL_INTERFACES", "run"]
 # is used all over the place and we don't want
 # the contents to change
 INTERNAL_INTERFACES = (
-    "wg", "lo", "tun", "tap", "docker", "veth", "vnet", "macvtap", "ix", "tailscale",
+    "wg",
+    "lo",
+    "tun",
+    "tap",
+    "docker",
+    "veth",
+    "vnet",
+    "ix",
+    "tailscale",
+    "mac",  # macvtap AND mac (latter being macvlan)
 )
 
 


### PR DESCRIPTION
Change this so that we just have `mac` as a prefix. This hides macvtap (like previously) but also hides mac vlan based nics (start with `mac`). The macvlan interfaces for VMs are bleeding into the network UI page and it's causing confusion.