### PR TITLE
NAS-134491 / 25.10 / Shorten TrueCloud Backup log excerpt

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -584,31 +584,32 @@ class Job:
         if self.logs_fd:
             self.logs_fd.close()
 
-            def get_logs_excerpt():
-                head = []
-                tail = []
-                lines = 0
-                try:
-                    with open(self.logs_path, "r", encoding="utf-8", errors="ignore") as f:
-                        for line in f:
-                            if len(head) < 10:
-                                head.append(line)
-                            else:
-                                tail.append(line)
-                                tail = tail[-10:]
+            if not self.logs_excerpt:
+                def get_logs_excerpt():
+                    head = []
+                    tail = []
+                    lines = 0
+                    try:
+                        with open(self.logs_path, "r", encoding="utf-8", errors="ignore") as f:
+                            for line in f:
+                                if len(head) < 10:
+                                    head.append(line)
+                                else:
+                                    tail.append(line)
+                                    tail = tail[-10:]
 
-                            lines += 1
-                except FileNotFoundError:
-                    return "Log file was removed"
+                                lines += 1
+                    except FileNotFoundError:
+                        return "Log file was removed"
 
-                if lines > 20:
-                    excerpt = "%s... %d more lines ...\n%s" % ("".join(head), lines - 20, "".join(tail))
-                else:
-                    excerpt = "".join(head + tail)
+                    if lines > 20:
+                        excerpt = "%s... %d more lines ...\n%s" % ("".join(head), lines - 20, "".join(tail))
+                    else:
+                        excerpt = "".join(head + tail)
 
-                return excerpt
+                    return excerpt
 
-            self.logs_excerpt = await self.middleware.run_in_thread(get_logs_excerpt)
+                self.logs_excerpt = await self.middleware.run_in_thread(get_logs_excerpt)
 
     async def __close_pipes(self):
         def close_pipes():

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -2,7 +2,6 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import json
-import pprint
 import subprocess
 
 from middlewared.job import JobProgressBuffer
@@ -127,7 +126,7 @@ async def restic_check_progress(job, proc, track_progress=False):
 
             case "summary":
                 await job.logs_fd_write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
-                job.logs_excerpt = pprint.pformat(read)
+                job.logs_excerpt = "\n".join(f"{k}: {v}" for k, v in read.items())
                 continue
 
             case "error":

--- a/src/middlewared/middlewared/plugins/cloud_backup/restic.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/restic.py
@@ -2,6 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import json
+import pprint
 import subprocess
 
 from middlewared.job import JobProgressBuffer
@@ -126,6 +127,7 @@ async def restic_check_progress(job, proc, track_progress=False):
 
             case "summary":
                 await job.logs_fd_write((json.dumps(read) + "\n").encode("utf-8", "ignore"))
+                job.logs_excerpt = pprint.pformat(read)
                 continue
 
             case "error":


### PR DESCRIPTION
Log excerpt will now appear like this in the UI:
```
message_type: summary
files_new: 3
files_changed: 0
files_unmodified: 0
dirs_new: 0
dirs_changed: 0
dirs_unmodified: 0
data_blobs: 0
tree_blobs: 1
data_added: 826
total_files_processed: 3
total_bytes_processed: 0
total_duration: 4.006957777
snapshot_id: 16a186de3e444d637cc37df96faab79850bde402f447a575dfbce040d9d10e6a
```
The full log will still be available at the given log path.

This change has the side-effect of being able to manually set log excerpts for other jobs in middleware.