### PR TITLE
NAS-133828 / 25.10 / Remove IP validation on TNC configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -67,15 +67,7 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         if data['enabled'] and not data['ips']:
             verrors.add('tn_connect_update.ips', 'This field is required when TrueNAS Connect is enabled')
 
-        ip_choices = await self.ip_choices()
-        ips = []
-        for index, ip in enumerate(data['ips']):
-            ip = str(ip)
-            if ip not in ip_choices:
-                verrors.add(f'tn_connect_update.ips.{index}', 'Provided IP is not valid')
-            ips.append(ip)
-
-        data['ips'] = ips
+        data['ips'] = [str(ip) for ip in data['ips']]
 
         ips_changed = set(old_config['ips']) != set(data['ips'])
         if ips_changed and (
@@ -174,6 +166,8 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         """
         Returns IP choices which can be used with TrueNAS Connect.
         """
+        # This is used by UI to present some options to the user but user can choose any other
+        # IP as well of course
         return {
             ip['address']: ip['address']
             for ip in await self.middleware.call('interface.ip_in_use', {'static': True, 'any': False})


### PR DESCRIPTION
This PR removes ip validation from tnc configuration allowing users to specify an valid IP they want to work with TNC. 