### PR TITLE
NAS-135425 / 25.04.1 / Fix typo in failover.disabled.get_reasons

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
+++ b/src/middlewared/middlewared/plugins/failover_/disabled_reasons.py
@@ -186,7 +186,7 @@ class FailoverDisabledReasonsService(Service):
     def get_reasons(self, app):
         reasons = set()
         if self.middleware.call_sync("failover.licensed"):
-            ifaces = self.middleware.call_sync("interface.query", ["failover_critical", "=", True])
+            ifaces = self.middleware.call_sync("interface.query", [["failover_critical", "=", True]])
             self.get_local_reasons(app, ifaces, reasons)
             self.get_remote_reasons(app, ifaces, reasons)
 


### PR DESCRIPTION
https://github.com/truenas/middleware/pull/16260

This typo is not present in GE.