### PR TITLE
NAS-135430 / 25.10 / Fix cloud_backup test

### DIFF
--- a/tests/api2/test_cloud_backup.py
+++ b/tests/api2/test_cloud_backup.py
@@ -436,7 +436,7 @@ def test_script_shebang(cloud_backup_task, expected):
     ssh(f"touch /mnt/{cloud_backup_task.local_dataset}/blob")
     run_task(cloud_backup_task.task)
     job = call("core.get_jobs", [["method", "=", "cloud_backup.sync"]], {"order_by": ["-id"], "get": True})
-    assert job["logs_excerpt"].strip().split("\n")[-2] == expected
+    assert ssh("cat " + job["logs_path"]).strip().split("\n")[-2] == expected
 
 
 @pytest.mark.parametrize("cloud_backup_task", [


### PR DESCRIPTION
http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/3990/testReport/api2/test_008_cloud_backup/

https://github.com/truenas/middleware/pull/16291 cut out most of the log file from the log excerpt. Use the full log in this test instead of the excerpt.