### PR TITLE
Improve certificate/privatekey validation

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -174,7 +174,7 @@ class CertificateService(CRUDService):
                 'Please provide a valid csr_id'
             )
 
-        if create_type == 'CERTIFICATE_CREATE_IMPORTED' and (err := await self.middleware.run_in_thread(
+        if not verrors and create_type == 'CERTIFICATE_CREATE_IMPORTED' and (err := await self.middleware.run_in_thread(
             validate_certificate_with_key, certificate, private_key, passphrase
         )):
             verrors.add(


### PR DESCRIPTION
This commit adds changes to only validate certificate/privatekey together if individually both of those are valid as the resulting error is not nice otherwise.