### PR TITLE
NAS-135466 / 25.10 / fix schema validtaion in pool.validate_name

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/pool.py
+++ b/src/middlewared/middlewared/api/v25_10_0/pool.py
@@ -460,7 +460,7 @@ class PoolUpgradeResult(BaseModel):
 
 
 class PoolValidateNameArgs(BaseModel):
-    pool_name: str
+    pool_name: POOL_NAME
 
 
 class PoolValidateNameResult(BaseModel):


### PR DESCRIPTION
This decorates a public endpoint `pool.validate_name` which the UI uses to "validate" the zpool name. The public endpoint just passes off the string to libzfs. However, libzfs is much more lenient on what it allows to be used in zpool names. We had to add stricter validation because incus has bugs whereby it can't handle zpools with spaces in the names. We miseed, on the other hand, adding the same validation to this endpoint so it causes incongruity.