### PR TITLE
NAS-135477 / 25.10 / Make sure certs are only renewed on active node

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -747,6 +747,10 @@ class FailoverEventsService(Service):
         self.run_call('alert.initialize', False)
         logger.info('Done initializing alert system')
 
+        logger.info('Initializing task to renew certs if necessary')
+        self.middleware.create_task(self.middleware.call('certificate.renew_certs'))
+        logger.info('Done initializing task to renew certs if necessary')
+
         logger.info('Starting truecommand service (if necessary)')
         self.run_call('truecommand.start_truecommand_service')
         logger.info('Done starting truecommand service (if necessary)')


### PR DESCRIPTION
This PR adds changes to make sure that certs are only renewed on the active node and standby/active both do not try to do that.