### PR TITLE
NAS-135478 / 25.10 / Add change validations for actions and features that are in conflict with STIG.

### DIFF
--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -66,6 +66,15 @@ class DockerService(ConfigService):
                 'System is not licensed to use Applications'
             )
 
+        if config['pool'] and (await self.middleware.call('system.security.config'))['enable_gpos_stig']:
+            verrors.add(
+                f'{schema}.pool',
+                'Apps cannot be enabled under General Purpose OS STIG compatibility mode.'
+            )
+
+        # No point in contining if we're in STIG or not licensed
+        verrors.check()
+
         if config['pool'] and not await self.middleware.run_in_thread(query_imported_fast_impl, [config['pool']]):
             verrors.add(f'{schema}.pool', 'Pool not found.')
 

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -113,6 +113,25 @@ class SystemSecurityService(ConfigService):
                 'TrueCommand is not supported under General Purpose OS STIG compatibility mode.'
             )
 
+        if (await self.middleware.call('docker.config'))['pool']:
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Please disable Apps as Apps are not supported under General Purpose OS STIG compatibility mode.'
+            )
+
+        if (await self.middleware.call('virt.global.config'))['pool']:
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Please disable VMs as VMs are not supported under General Purpose OS STIG compatibility mode.'
+            )
+
+        if (await self.middleware.call('tn_connect.config'))['enabled']:
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Please disable TrueNAS Connect as it is not supported under '
+                'General Purpose OS STIG compatibility mode.'
+            )
+
         # We want to make sure that at least one local user account is usable
         # and has 2fa auth configured.
         two_factor_users = await self.middleware.call('user.query', [
@@ -163,25 +182,6 @@ class SystemSecurityService(ConfigService):
                 'General purpose administrative accounts with password authentication are '
                 'not compatible with STIG compatibility mode.  '
                 f'PLEASE DISABLE PASSWORD AUTHENTICATION ON THE FOLLOWING ACCOUNTS: {", ".join(excluded_admins)}.'
-            )
-
-        if (await self.middleware.call('docker.config'))['pool']:
-            raise ValidationError(
-                'system_security_update.enable_gpos_stig',
-                'Please disable Apps as Apps are not supported under General Purpose OS STIG compatibility mode.'
-            )
-
-        if (await self.middleware.call('virt.global.config'))['pool']:
-            raise ValidationError(
-                'system_security_update.enable_gpos_stig',
-                'Please disable VMs as VMs are not supported under General Purpose OS STIG compatibility mode.'
-            )
-
-        if (await self.middleware.call('tn_connect.config'))['enabled']:
-            raise ValidationError(
-                'system_security_update.enable_gpos_stig',
-                'Please disable TrueNAS Connect as it is not supported under '
-                'General Purpose OS STIG compatibility mode.'
             )
 
     @private

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -114,6 +114,12 @@ class TruecommandService(ConfigService):
                     'API Key must be provided when Truecommand service is enabled.'
                 )
 
+            if new['enabled'] and (await self.middleware.call('system.security.config'))['enable_gpos_stig']:
+                verrors.add(
+                    'truecommand_update.enabled',
+                    'TrueCommand cannot be enabled under General Purpose OS STIG compatibility mode.'
+                )
+
             verrors.check()
 
             if all(old[k] == new[k] for k in ('enabled', 'api_key')):

--- a/src/middlewared/middlewared/plugins/truenas_connect/update.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/update.py
@@ -67,6 +67,14 @@ class TrueNASConnectService(ConfigService, TNCAPIMixin):
         if data['enabled'] and not data['ips']:
             verrors.add('tn_connect_update.ips', 'This field is required when TrueNAS Connect is enabled')
 
+        if data['enabled'] and (await self.middleware.call('system.security.config'))['enable_gpos_stig']:
+            verrors.add(
+                'tn_connect_update.enabled',
+                'TrueNAS Connect cannot be enabled under General Purpose OS STIG compatibility mode.'
+            )
+        # Stop here if STIG is enabled
+        verrors.check()
+
         data['ips'] = [str(ip) for ip in data['ips']]
 
         ips_changed = set(old_config['ips']) != set(data['ips'])


### PR DESCRIPTION
### WIP
Reworking this PR...

-----------------------------------------------------------
This started with CI tests for enabling STIG and expanded to include change validation checks in some features.

Changes in this PR:

- Added STIG validation checks:
    * docker (apps)
    * truecommand
    * VM support
    * TrueNAS Connect. 
- Couple flake8 issues in global.py:
    * Removed unused `new_storage_pool`
    * Removed f-string declaration on a string that is static.


Passing CI tests: http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4025/