### PR TITLE
NAS-135489 / 25.10 / Do not enforce boot priority for ISO volumes

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -366,8 +366,6 @@ class VirtInstanceDeviceService(Service):
                         available_volumes = {v['id']: v for v in await self.middleware.call('virt.volume.query')}
                         if source not in available_volumes:
                             verrors.add(schema, f'No {source!r} incus volume found which can be used for source')
-                        elif available_volumes[source]['content_type'] == 'ISO' and device['boot_priority'] is None:
-                            verrors.add(schema, 'Boot priority is required for ISO volumes.')
                         else:
                             # We need to specify the storage pool for device adding to VM
                             # copy in what is known for the virt volume


### PR DESCRIPTION
## Context

We were enforcing that user specify boot priority when they added a disk device which was based off an ISO volume so it was a conscious decision on the user part in terms of knowing they want to boot from the ISO or not. However with recent changes made to UI on how it handles boot priority and allowing users to boot from X disk device, this is no longer required and actually hurts usability hence this check is being removed.