### PR TITLE
NAS-135383 / 25.10 / Allow specifying custom MAC address for NIC device in virt instance

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_device.py
@@ -1,8 +1,9 @@
 from typing import Annotated, Literal, TypeAlias
 
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field, field_validator
 
-from middlewared.api.base import BaseModel, LocalGID, LocalUID, NonEmptyString, single_argument_args
+from middlewared.api.base import BaseModel, LocalGID, LocalUID, match_validator, NonEmptyString, single_argument_args
+from middlewared.validators import RE_MAC_ADDRESS
 
 
 __all__ = [
@@ -16,6 +17,15 @@ __all__ = [
 
 
 InstanceType: TypeAlias = Literal['CONTAINER', 'VM']
+MAC: TypeAlias = Annotated[
+    str | None,
+    AfterValidator(
+        match_validator(
+            RE_MAC_ADDRESS,
+            'MAC address is not valid.'
+        )
+    )
+]
 
 
 class Device(BaseModel):
@@ -66,6 +76,7 @@ class NIC(Device):
     network: NonEmptyString | None = None
     nic_type: NicType | None = None
     parent: NonEmptyString | None = None
+    mac: MAC = None
 
 
 class USB(Device):

--- a/src/middlewared/middlewared/plugins/virt/instance_device.py
+++ b/src/middlewared/middlewared/plugins/virt/instance_device.py
@@ -72,14 +72,21 @@ class VirtInstanceDeviceService(Service):
                     'io_bus': incus['io.bus'].upper() if incus.get('io.bus') else None,
                 })
             case 'nic':
-                device['dev_type'] = 'NIC'
-                device['network'] = incus.get('network')
+                device.update({
+                    'dev_type': 'NIC',
+                    'network': incus.get('network'),
+                    'mac': incus.get('hwaddr'),
+                })
                 if device['network']:
-                    device['parent'] = None
-                    device['nic_type'] = None
+                    device.update({
+                        'parent': None,
+                        'nic_type': None,
+                    })
                 elif incus.get('nictype'):
-                    device['nic_type'] = incus.get('nictype').upper()
-                    device['parent'] = incus.get('parent')
+                    device.update({
+                        'nic_type': incus.get('nictype').upper(),
+                        'parent': incus.get('parent'),
+                    })
                 device['description'] = device['network']
             case 'proxy':
                 device['dev_type'] = 'PROXY'
@@ -190,10 +197,13 @@ class VirtInstanceDeviceService(Service):
                     new['io.bus'] = device['io_bus'].lower()
 
             case 'NIC':
-                new['type'] = 'nic'
-                new['network'] = device['network']
-                new['nictype'] = device['nic_type'].lower()
-                new['parent'] = device['parent']
+                new.update({
+                    'type': 'nic',
+                    'network': device['network'],
+                    'nictype': device['nic_type'].lower(),
+                    'parent': device['parent'],
+                    'hwaddr': device['mac'],
+                })
             case 'PROXY':
                 new['type'] = 'proxy'
                 # For now follow docker lead for simplification


### PR DESCRIPTION
## Context

As of now, user was not allowed to set `MAC address` to VMs. This PR ensures that the user can specify `mac` when adding a device type of `nic` to the incus instance.