### PR TITLE
NAS-135375 / 25.04.1 / Add a synthetic container root user (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -30,6 +30,7 @@ ALLOWED_BUILTIN_GIDS = {
     952,  # truenas_sharing_administrators
 }
 
+# TRUENAS_IDMAP_MAX + 1, this is also first ID in range allocated for Incus idmaps
 CONTAINER_ROOT_UID = 2147000001
 
 SYNTHETIC_CONTAINER_ROOT = {

--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -29,3 +29,18 @@ ALLOWED_BUILTIN_GIDS = {
     951,  # truenas_readonly_administrators
     952,  # truenas_sharing_administrators
 }
+
+CONTAINER_ROOT_UID = 2147000001
+
+SYNTHETIC_CONTAINER_ROOT = {
+    'pw_name': 'truenas_container_unpriv_root',
+    'pw_uid': CONTAINER_ROOT_UID,
+    'pw_gid': 2147000001,
+    'pw_gecos': 'Unprivileged root user for containers',
+    'pw_dir': '/var/empty',
+    'pw_shell': '/usr/sbin/nologin',
+    'grouplist': None,
+    'sid': None,
+    'source': 'LOCAL',
+    'local': True
+}

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -29,6 +29,7 @@ from middlewared.api.current import (
 )
 from middlewared.event import EventSource
 from middlewared.plugins.pwenc import PWENC_FILE_SECRET, PWENC_FILE_SECRET_MODE
+from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
 from middlewared.plugins.docker.state_utils import IX_APPS_DIR_NAME
 from middlewared.service import private, CallError, filterable_api_method, Service, job
 from middlewared.utils import filter_list
@@ -404,7 +405,10 @@ class FilesystemService(Service):
         try:
             stat['user'] = pwd.getpwuid(stat['uid']).pw_name
         except KeyError:
-            stat['user'] = None
+            if stat['uid'] == SYNTHETIC_CONTAINER_ROOT['pw_uid']:
+                stat['user'] = SYNTHETIC_CONTAINER_ROOT['pw_name']
+            else:
+                stat['user'] = None
 
         try:
             stat['group'] = grp.getgrgid(stat['gid']).gr_name

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -11,6 +11,7 @@ from middlewared.service import (
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import SSL
 from middlewared.utils.directoryservices.constants import DSType as DirectoryServiceType
+from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID
 from middlewared.plugins.idmap_.idmap_constants import (
     BASE_SYNTHETIC_DATASTORE_ID, IDType, SID_LOCAL_USER_PREFIX, SID_LOCAL_GROUP_PREFIX, TRUENAS_IDMAP_MAX
 )
@@ -1216,7 +1217,12 @@ class IdmapDomainService(CRUDService):
         match passwd['source']:
             case 'LOCAL':
                 # local user, should be retrieved via user.query
-                return None
+                # with exception of our special synthetic account for the container root
+                if passwd['pw_uid'] != CONTAINER_ROOT_UID:
+                    return None
+
+                id_type_both = False
+
             case 'ACTIVEDIRECTORY':
                 id_type_both = await self.has_id_type_both(passwd['pw_uid'])
             case _:

--- a/tests/unit/test_container_root.py
+++ b/tests/unit/test_container_root.py
@@ -1,0 +1,41 @@
+import os
+
+from truenas_api_client import Client
+from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
+
+
+def test__query_by_name():
+    with Client() as c:
+        entry = c.call('user.query', [['username', '=', SYNTHETIC_CONTAINER_ROOT['pw_name']]], {'get': True})
+        assert entry['local']
+        assert entry['builtin']
+        assert entry['uid'] == SYNTHETIC_CONTAINER_ROOT['pw_uid']
+
+
+def test__query_by_id():
+    with Client() as c:
+        entry = c.call('user.query', [['uid', '=', SYNTHETIC_CONTAINER_ROOT['pw_uid']]], {'get': True})
+        assert entry['local']
+        assert entry['builtin']
+        assert entry['username'] == SYNTHETIC_CONTAINER_ROOT['pw_name']
+
+
+def test__user_obj_by_name():
+    with Client() as c:
+        obj = c.call('user.get_user_obj', {'username': SYNTHETIC_CONTAINER_ROOT['pw_name']})
+        assert obj == SYNTHETIC_CONTAINER_ROOT
+
+
+def test__user_obj_by_uid():
+    with Client() as c:
+        obj = c.call('user.get_user_obj', {'uid': SYNTHETIC_CONTAINER_ROOT['pw_uid']})
+        assert obj == SYNTHETIC_CONTAINER_ROOT
+
+
+def test__user_obj_stat():
+    DIR = '/tmp/container_root_stat_test'
+    os.mkdir(DIR)
+    os.chown(DIR, SYNTHETIC_CONTAINER_ROOT['pw_uid'], 0)
+    with Client() as c:
+        st = c.call('filesystem.stat', DIR)
+        assert st['user'] == SYNTHETIC_CONTAINER_ROOT['pw_name']


### PR DESCRIPTION
This commit adds a user truenas_container_root that doesn't get written to passwd and shadow files, but exists in user-related API responses. This allows users to assign permissions to the root uid in non-privileged containers and generally have UI look less confusing.

Original PR: https://github.com/truenas/middleware/pull/16319
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135375