### PR TITLE
NAS-135270 / 25.10 / Better group name validation

### DIFF
--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -25,6 +25,8 @@ DEFAULT_VALID_CHARS = string.ascii_letters + string.digits + '_' + '-' + '.'
 DEFAULT_VALID_START = string.ascii_letters + '_'
 DEFAULT_MAX_LENGTH = 32  # WARNING UT_NAMESIZE = 32. If we go above this then utmp accounting may break
 
+GROUP_VALID_START = string.ascii_letters + string.digits + '_' + '.'
+
 
 def validate_name(
     val: str,
@@ -71,7 +73,7 @@ LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
 RemoteUsername = Annotated[str, Field(min_length=1)]
 GroupName = Annotated[
     str,
-    AfterValidator(lambda x: validate_name(x, valid_start_chars=DEFAULT_VALID_START + '.', max_length=None))
+    AfterValidator(lambda x: validate_name(x, valid_start_chars=GROUP_VALID_START, max_length=None))
 ]
 LocalUID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -33,14 +33,17 @@ def validate_name(
     max_length: int | None = DEFAULT_MAX_LENGTH
 ) -> str:
     val_len = len(val)
-    assert val_len > 0, 'Must be at least 1 character in length'
-    if max_length is not None:
-        assert val_len <= max_length, f'Cannot exceed {max_length} charaters in length'
+    if val_len == 0:
+        raise ValueError('Must be at least 1 character in length')
+    if max_length is not None and val_len > max_length:
+        raise ValueError(f'Cannot exceed {max_length} charaters in length')
 
     if valid_start_chars is not None:
-        assert val[0] in valid_start_chars, f'Cannot start with "{val[0]!r}"'
+        if val[0] not in valid_start_chars:
+            raise ValueError(f'Cannot start with "{val[0]!r}"')
 
-    assert all(char in valid_chars for char in val), f'Valid characters are: {", ".join(valid_chars)!r}'
+    if not all(char in valid_chars for char in val):
+        raise ValueError(f'Valid characters are: {", ".join(valid_chars)!r}')
 
     return val
 

--- a/src/middlewared/middlewared/api/base/types/user.py
+++ b/src/middlewared/middlewared/api/base/types/user.py
@@ -6,7 +6,7 @@ from pydantic.functional_validators import AfterValidator
 
 from middlewared.utils.sid import sid_is_valid
 
-__all__ = ["LocalUsername", "RemoteUsername", "LocalUID", "LocalGID", "SID", "ContainerXID"]
+__all__ = ["LocalUsername", "RemoteUsername", "GroupName", "LocalUID", "LocalGID", "SID", "ContainerXID"]
 
 XID_MAX = 2 ** 32 - 2  # uid_t -1 can have special meaning depending on context
 # TRUENAS_IDMAP_MAX + 1
@@ -26,20 +26,22 @@ DEFAULT_VALID_START = string.ascii_letters + '_'
 DEFAULT_MAX_LENGTH = 32  # WARNING UT_NAMESIZE = 32. If we go above this then utmp accounting may break
 
 
-def validate_username(
+def validate_name(
     val: str,
     valid_chars: str = DEFAULT_VALID_CHARS,
     valid_start_chars: str | None = DEFAULT_VALID_START,
     max_length: int | None = DEFAULT_MAX_LENGTH
 ) -> str:
     val_len = len(val)
-    assert val_len > 0, 'Username must be at least 1 character in length'
+    assert val_len > 0, 'Must be at least 1 character in length'
     if max_length is not None:
-        assert val_len <= max_length, f'Username cannot exceed {max_length} charaters in length'
-    if valid_start_chars is not None:
-        assert val[0] in valid_start_chars, 'Username must start with a letter or an underscore'
+        assert val_len <= max_length, f'Cannot exceed {max_length} charaters in length'
 
-    assert all(char in valid_chars for char in val), f'Valid characters for a username are: {", ".join(valid_chars)!r}'
+    if valid_start_chars is not None:
+        assert val[0] in valid_start_chars, f'Cannot start with "{val[0]!r}"'
+
+    assert all(char in valid_chars for char in val), f'Valid characters are: {", ".join(valid_chars)!r}'
+
     return val
 
 
@@ -48,7 +50,7 @@ def validate_local_username(val: str) -> str:
     # NOTE: we are ignoring the man page's recommendation for insistence
     # upon the starting character of a username be a lower-case letter.
     # We aren't enforcing this for maximum backwards compatibility
-    return validate_username(val)
+    return validate_name(val)
 
 
 def validate_sid(value: str) -> str:
@@ -64,6 +66,10 @@ def validate_sid(value: str) -> str:
 
 LocalUsername = Annotated[str, AfterValidator(validate_local_username)]
 RemoteUsername = Annotated[str, Field(min_length=1)]
+GroupName = Annotated[
+    str,
+    AfterValidator(lambda x: validate_name(x, valid_start_chars=DEFAULT_VALID_START + '.', max_length=None))
+]
 LocalUID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]
 
 LocalGID = Annotated[int, Field(ge=0, le=TRUENAS_IDMAP_DEFAULT_LOW - 1)]

--- a/src/middlewared/middlewared/api/v25_10_0/group.py
+++ b/src/middlewared/middlewared/api/v25_10_0/group.py
@@ -2,8 +2,10 @@ from typing import Literal
 
 from pydantic import Field
 
-from middlewared.api.base import (BaseModel, ContainerXID, Excluded, excluded_field, ForUpdateMetaclass, LocalUID,
-                                  NonEmptyString, single_argument_args, single_argument_result)
+from middlewared.api.base import (
+    BaseModel, ContainerXID, Excluded, excluded_field, ForUpdateMetaclass, LocalUID, GroupName, NonEmptyString,
+    single_argument_args, single_argument_result
+)
 
 __all__ = ["GroupEntry",
            "GroupCreateArgs", "GroupCreateResult",
@@ -52,6 +54,7 @@ class GroupCreate(GroupEntry):
 
     gid: LocalUID | None = None
     "If `null`, it is automatically filled with the next one available."
+    name: GroupName
 
 
 class GroupCreateArgs(BaseModel):
@@ -107,22 +110,22 @@ class GroupGetGroupObjArgs(BaseModel):
 @single_argument_result
 class GroupGetGroupObjResult(BaseModel):
     gr_name: str
-    "name of the group"
+    "Name of the group."
     gr_gid: int
-    "group id of the group"
+    "Group ID of the group."
     gr_mem: list[str]
-    "list of group names that are members of the group"
+    "List of group names that are members of the group."
     sid: str | None = None
-    "optional SID value for the account that is present if `sid_info` is specified in payload."
+    "Optional SID value for the account that is present if `sid_info` is specified in payload."
     source: Literal['LOCAL', 'ACTIVEDIRECTORY', 'LDAP']
     """
-    the name server switch module that provided the user. Options are:
+    The name server switch module that provided the user. Options are:
         FILES - local user in passwd file of server,
         WINBIND - user provided by winbindd,
         SSS - user provided by SSSD.
     """
     local: bool
-    "boolean indicating whether this group is local to the NAS or provided by a directory service."
+    "Boolean indicating whether this group is local to the NAS or provided by a directory service."
 
 
 class GroupHasPasswordEnabledUserArgs(BaseModel):

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
@@ -1,13 +1,13 @@
+from pydantic import ValidationError
 import pytest
 
 from middlewared.api.base import BaseModel, GroupName
-from middlewared.service_exception import ValidationErrors
 
 
 @pytest.mark.parametrize("value, error", [
     ("", "Must be at least 1 character in length"),
-    ("-group", "Cannot start with \"-\""),
-    ("$group", "Valid characters are:"),
+    ("-group", "Cannot start with"),
+    ("group$", "Valid characters are:"),
     ("_abcd-1234.ABCD", None),
 ])
 def test_group_name(value, error: str | None):
@@ -15,8 +15,8 @@ def test_group_name(value, error: str | None):
         group: GroupName
 
     if error:
-        with pytest.raises(ValidationErrors) as ve:
+        with pytest.raises(ValidationError) as ve:
             Model(group=value)
-        assert error in ve.value.errors[0].errmsg
+        assert ve.match(error)
     else:
         Model(group=value)

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
@@ -5,13 +5,18 @@ from middlewared.service_exception import ValidationErrors
 
 
 @pytest.mark.parametrize("value, error", [
-    ("0" * 2000, "String should have at most 1024 characters")
+    ("", "Must be at least 1 character in length"),
+    ("-group", "Cannot start with \"-\""),
+    ("$group", "Valid characters are:"),
+    ("_abcd-1234.ABCD", None),
 ])
-def test_base_types(value, error):
+def test_group_name(value, error: str | None):
     class Model(BaseModel):
         group: GroupName
 
-    with pytest.raises(ValidationErrors) as ve:
+    if error:
+        with pytest.raises(ValidationErrors) as ve:
+            Model(group=value)
+        assert error in ve.value.errors[0].errmsg
+    else:
         Model(group=value)
-
-    assert ve.value.errors[0].errmsg == error

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
@@ -1,0 +1,17 @@
+import pytest
+
+from middlewared.api.base import BaseModel, GroupName
+from middlewared.service_exception import ValidationErrors
+
+
+@pytest.mark.parametrize("value, error", [
+    ("0" * 2000, "String should have at most 1024 characters")
+])
+def test_base_types(value, error):
+    class Model(BaseModel):
+        group: GroupName
+
+    with pytest.raises(ValidationErrors) as ve:
+        Model(group=value)
+
+    assert ve.value.errors[0].errmsg == error

--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -221,7 +221,7 @@ def test_update_user_with_random_password():
 
 
 def test_account_create_invalid_username():
-    with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+    with pytest.raises(ValidationErrors, match="Valid characters are:"):
         with user({
             "username": "_блин",
             "full_name": "bob",
@@ -238,5 +238,5 @@ def test_account_update_invalid_username():
         "group_create": True,
         "password": "canary"
     }, get_instance=True) as u:
-        with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+        with pytest.raises(ValidationErrors, match="Valid characters are:"):
             call("user.update", u["id"], {"username": "_блин"})


### PR DESCRIPTION
Group names are validated similarly to how usernames are validated, only allowing characters in the [portable filename character set](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282). Furthermore, they cannot start with a hyphen "-".

See https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_166.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4045/