### PR TITLE
NAS-135510 / 25.10 / Fix passwd and shadow file generation

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -4,6 +4,7 @@ import imp
 import os
 
 from mako import exceptions
+from middlewared.plugins.account_.constants import CONTAINER_ROOT_UID
 from middlewared.service import CallError, Service
 from middlewared.utils.io import write_if_changed, FileChanges
 from middlewared.utils.mako import get_template
@@ -86,7 +87,7 @@ class EtcService(Service):
         ],
         'shadow': {
             'ctx': [
-                {'method': 'user.query', 'args': [[['local', '=', True]]]},
+                {'method': 'user.query', 'args': [[['local', '=', True], ['uid', '!=', CONTAINER_ROOT_UID]]]},
                 {'method': 'system.security.config'},
             ],
             'entries': [
@@ -96,7 +97,7 @@ class EtcService(Service):
         'user': {
             'ctx': [
                 {'method': 'system.security.config'},
-                {'method': 'user.query', 'args': [[['local', '=', True]]]},
+                {'method': 'user.query', 'args': [[['local', '=', True], ['uid', '!=', CONTAINER_ROOT_UID]]]},
                 {'method': 'group.query', 'args': [[['local', '=', True]]]},
             ],
             'entries': [

--- a/tests/unit/test_container_root.py
+++ b/tests/unit/test_container_root.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from truenas_api_client import Client
 from middlewared.plugins.account_.constants import SYNTHETIC_CONTAINER_ROOT
@@ -39,3 +40,10 @@ def test__user_obj_stat():
     with Client() as c:
         st = c.call('filesystem.stat', DIR)
         assert st['user'] == SYNTHETIC_CONTAINER_ROOT['pw_name']
+
+
+@pytest.mark.parametrize('file', ['/etc/shadow', '/etc/passwd'])
+def test__no_sythentic_entry(file):
+    with open(file, 'r') as f:
+        data = f.read()
+        assert SYNTHETIC_CONTAINER_ROOT['pw_name'] not in data


### PR DESCRIPTION
This commit fixes an error is passwd and shadow file generation that was introduced by adding a synthetic account for the container root user, the uid of this account is now explicitly filtered out of the user query passed as render state to the respective mako files. Test coverage is also added.