### PR TITLE
NAS-135270 / 25.04.1 / Better group name validation (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_1/group.py
+++ b/src/middlewared/middlewared/api/v25_04_1/group.py
@@ -2,8 +2,10 @@ from typing import Literal
 
 from pydantic import Field
 
-from middlewared.api.base import (BaseModel, ContainerXID, Excluded, excluded_field, ForUpdateMetaclass, LocalUID,
-                                  NonEmptyString, single_argument_args, single_argument_result)
+from middlewared.api.base import (
+    BaseModel, ContainerXID, Excluded, excluded_field, ForUpdateMetaclass, LocalUID, GroupName, NonEmptyString,
+    single_argument_args, single_argument_result
+)
 
 __all__ = ["GroupEntry",
            "GroupCreateArgs", "GroupCreateResult",
@@ -52,6 +54,7 @@ class GroupCreate(GroupEntry):
 
     gid: LocalUID | None = None
     "If `null`, it is automatically filled with the next one available."
+    name: GroupName
 
 
 class GroupCreateArgs(BaseModel):
@@ -107,22 +110,22 @@ class GroupGetGroupObjArgs(BaseModel):
 @single_argument_result
 class GroupGetGroupObjResult(BaseModel):
     gr_name: str
-    "name of the group"
+    "Name of the group."
     gr_gid: int
-    "group id of the group"
+    "Group ID of the group."
     gr_mem: list[str]
-    "list of group names that are members of the group"
+    "List of group names that are members of the group."
     sid: str | None = None
-    "optional SID value for the account that is present if `sid_info` is specified in payload."
+    "Optional SID value for the account that is present if `sid_info` is specified in payload."
     source: Literal['LOCAL', 'ACTIVEDIRECTORY', 'LDAP']
     """
-    the name server switch module that provided the user. Options are:
+    The name server switch module that provided the user. Options are:
         FILES - local user in passwd file of server,
         WINBIND - user provided by winbindd,
         SSS - user provided by SSSD.
     """
     local: bool
-    "boolean indicating whether this group is local to the NAS or provided by a directory service."
+    "Boolean indicating whether this group is local to the NAS or provided by a directory service."
 
 
 class GroupHasPasswordEnabledUserArgs(BaseModel):

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_user.py
@@ -1,0 +1,22 @@
+from pydantic import ValidationError
+import pytest
+
+from middlewared.api.base import BaseModel, GroupName
+
+
+@pytest.mark.parametrize("value, error", [
+    ("", "Must be at least 1 character in length"),
+    ("-group", "Cannot start with"),
+    ("group$", "Valid characters are:"),
+    ("_abcd-1234.ABCD", None),
+])
+def test_group_name(value, error: str | None):
+    class Model(BaseModel):
+        group: GroupName
+
+    if error:
+        with pytest.raises(ValidationError) as ve:
+            Model(group=value)
+        assert ve.match(error)
+    else:
+        Model(group=value)

--- a/tests/api2/test_account.py
+++ b/tests/api2/test_account.py
@@ -221,7 +221,7 @@ def test_update_user_with_random_password():
 
 
 def test_account_create_invalid_username():
-    with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+    with pytest.raises(ValidationErrors, match="Valid characters are:"):
         with user({
             "username": "_блин",
             "full_name": "bob",
@@ -238,5 +238,5 @@ def test_account_update_invalid_username():
         "group_create": True,
         "password": "canary"
     }, get_instance=True) as u:
-        with pytest.raises(ValidationErrors, match="Valid characters for a username"):
+        with pytest.raises(ValidationErrors, match="Valid characters are:"):
             call("user.update", u["id"], {"username": "_блин"})


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b1101df888cf6b3628cf42b10e18d68d919ea9b2
    git cherry-pick -x eed06735dc93e5d3061e872819cda96c1c48277e
    git cherry-pick -x 892ba988739366c74752eaaf3afb48b580df87e6
    git cherry-pick -x b6ee20d8c4f9e7034036eab16a08c8fcbc684c70
    git cherry-pick -x 743c05bedf2f98ece1d310d698af7a54a4dab15c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x fa7a5295c0a362f1f68356d0a534b6cd0ae4d070

Group names are validated similarly to how usernames are validated, only allowing characters in the [portable filename character set](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282). Furthermore, they cannot start with a hyphen "-".

See https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_166.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4045/

Original PR: https://github.com/truenas/middleware/pull/16322
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135270