### PR TITLE
NAS-135531 / 25.04.1 / Improve validation for ZFS resource creation (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -590,8 +590,14 @@ class PoolDatasetService(CRUDService):
         verrors.check()
 
         parent_ds = parent_ds[0]
+        if parent_ds['type'] == 'VOLUME':
+            verrors.add(
+                'pool_dataset_create.name',
+                f'{parent_ds["name"]}: parent may not be a ZFS volume'
+            )
+
         parent_mp = parent_ds['mountpoint']
-        if parent_ds['locked']:
+        if parent_ds['locked'] or not parent_mp:
             parent_st = {'acl': False}
         else:
             parent_st = await self.middleware.call('filesystem.stat', parent_mp)


### PR DESCRIPTION
This commit improves our validation message when an API consumer tries to create a ZFS resource with a zvol for its parent.

Original PR: https://github.com/truenas/middleware/pull/16329
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135531