### PR TITLE
NAS-135528 / 25.10 / Replace `SecretStr` in TrueCommand API (not serializing properly)

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v25_10_0/truecommand.py
@@ -55,7 +55,7 @@ class TruecommandEntry(BaseModel):
 @single_argument_args('truecommand_update')
 class TruecommandUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
-    api_key: SecretStr | None = Field(min_length=16, max_length=16)
+    api_key: Secret[str | None] = Field(min_length=16, max_length=16)
 
 
 class TrueCommandUpdateResult(BaseModel):


### PR DESCRIPTION
In every case, `SecretStr` can be replaced with `Secret[str]` and function in the same way. `Secret` is handled explicitly in our custom `BaseModel` class and should *always* be used over `SecretStr`.