### PR TITLE
NAS-135537 / 25.10 / Fix check for enabled generic accounts

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -423,7 +423,7 @@ class UserService(CRUDService):
         container_root = await self.middleware.call('idmap.synthetic_user', SYNTHETIC_CONTAINER_ROOT.copy(), None)
         # NOTE: we deliberately don't include a userns_idmap value here because it is
         # implicit when we set up subuid for container
-        container_root.update({'builtin': True, 'local': True})
+        container_root.update({'builtin': True, 'local': True, 'locked': True})
 
         return await self.middleware.run_in_thread(
             filter_list, result + ds_users + [container_root], filters, options

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -423,7 +423,7 @@ class UserService(CRUDService):
         container_root = await self.middleware.call('idmap.synthetic_user', SYNTHETIC_CONTAINER_ROOT.copy(), None)
         # NOTE: we deliberately don't include a userns_idmap value here because it is
         # implicit when we set up subuid for container
-        container_root.update({'builtin': True, 'local': True, 'locked': True})
+        container_root.update({'builtin': True, 'local': True, 'locked': True, 'smb': False})
 
         return await self.middleware.run_in_thread(
             filter_list, result + ds_users + [container_root], filters, options

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -169,7 +169,8 @@ class SystemSecurityService(ConfigService):
             user['username'] for user in await self.middleware.call(
                 'user.query', [
                     ["immutable", "=", True], ["password_disabled", "=", False],
-                    ["locked", "=", False], ["unixhash", "!=", "*"]
+                    ["locked", "=", False], ["unixhash", "!=", "*"],
+                    ["local", "=", True]
                 ],
             )
         ]


### PR DESCRIPTION
This commit fixes a check when enabling STIG that was supposed to validate that generic accounts such as "admin" or "truenas_admin" are disabled. Unfortunately, the original check included directory services uses which had the effect of preventing admins from enabling STIG while joined to AD.