### PR TITLE
NAS-135538 / 25.10 / Remove all references to `pydantic.SecretStr`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,22 +20,22 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 flake8-builtins
+        pip install flake8 flake8-builtins flake8-tidy-imports
     - name: Get current errors
       run: |
         tmpafter=$(mktemp)
-        find src -name \*.py -exec flake8 --ignore=A003,E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
+        find src -name \*.py -exec flake8 --config=src/middlewared/setup.cfg {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpafter
         num_errors_after=`cat $tmpafter | wc -l`
         echo "CURRENT_ERROR_FILE=${tmpafter}" >> $GITHUB_ENV
         echo "CURRENT_ERRORS=${num_errors_after}" >> $GITHUB_ENV
     - name: Checkout base branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.base_ref }}
     - name: Get errors from base branch
       run: |
         tmpbefore=$(mktemp)
-        find src -name \*.py -exec flake8 --ignore=E402,E501,W504 {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpbefore
+        find src -name \*.py -exec flake8 --config=src/middlewared/setup.cfg {} + | egrep -v "alembic/versions/|usr/local/share/pysnmp/mibs/" > $tmpbefore
         num_errors_before=`cat $tmpbefore | wc -l`
         echo "OLD_ERROR_FILE=${tmpbefore}" >> $GITHUB_ENV
         echo "OLD_ERRORS=${num_errors_before}" >> $GITHUB_ENV

--- a/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
+++ b/src/middlewared/middlewared/api/base/validators_/passwd_complexity.py
@@ -1,8 +1,6 @@
 from functools import partial
 from string import digits, ascii_uppercase, ascii_lowercase, punctuation
 
-from pydantic import SecretStr
-
 
 __all__ = ("passwd_complexity_validator",)
 
@@ -15,13 +13,13 @@ ALLOWED_TYPES = (
 
 
 def __complexity_impl(
-    value: SecretStr,
+    value: str,
     *,
     required_types: list[str] | None,
     required_cnt: int,
     min_length: int,
     max_length: int,
-) -> SecretStr:
+) -> str:
     passwd_length = len(value)
     if passwd_length < min_length:
         raise ValueError(f"Length of password must be at least {min_length} chars")
@@ -31,8 +29,7 @@ def __complexity_impl(
     cnt = 0
     reqs = []
     errstr = ""
-    cleartext_passwd = value.get_secret_value()
-    if cleartext_passwd and required_types:
+    if value and required_types:
         for rt in filter(lambda x: x not in ALLOWED_TYPES, required_types):
             raise ValueError(
                 f"{rt} is in invalid type. Allowed types are {','.join(ALLOWED_TYPES)}"
@@ -40,7 +37,7 @@ def __complexity_impl(
 
         if "ASCII_LOWER" in required_types:
             reqs.append("lowercase character")
-            if not any(c in ascii_lowercase for c in cleartext_passwd):
+            if not any(c in ascii_lowercase for c in value):
                 if required_cnt is None:
                     errstr += "Must contain at least one lowercase character. "
             else:
@@ -48,7 +45,7 @@ def __complexity_impl(
 
         if "ASCII_UPPER" in required_types:
             reqs.append("uppercase character")
-            if not any(c in ascii_uppercase for c in cleartext_passwd):
+            if not any(c in ascii_uppercase for c in value):
                 if required_cnt is None:
                     errstr += "Must contain at least one uppercase character. "
             else:
@@ -56,7 +53,7 @@ def __complexity_impl(
 
         if "DIGIT" in required_types:
             reqs.append("digits 0-9")
-            if not any(c in digits for c in cleartext_passwd):
+            if not any(c in digits for c in value):
                 if required_cnt is None:
                     errstr += "Must contain at least one numeric digit (0-9). "
             else:
@@ -64,7 +61,7 @@ def __complexity_impl(
 
         if "SPECIAL" in required_types:
             reqs.append("special characters (!, $, #, %, etc.)")
-            if not any(c in punctuation for c in cleartext_passwd):
+            if not any(c in punctuation for c in value):
                 if required_cnt is None:
                     errstr += "Must contain at least one special character (!, $, #, %, etc.). "
             else:
@@ -85,7 +82,7 @@ def passwd_complexity_validator(
     required_cnt: int = 0,
     min_length: int = 8,
     max_length: int = 16,
-) -> partial[SecretStr]:
+) -> partial[str]:
     """Enforce password complexity.
 
     Args:

--- a/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
@@ -43,9 +43,12 @@ class TrueNASConnectSchemaArgs(TrueNASConnectSchema):
 
 class CloudFlareSchema(BaseModel):
     authenticator: Literal['cloudflare']
-    cloudflare_email: NonEmptyString | None = Field(default=None, description='Cloudflare Email')
-    api_key: Secret[NonEmptyString | None] = Field(default=None, description='API Key')
-    api_token: Secret[NonEmptyString | None] = Field(default=None, description='API Token')
+    cloudflare_email: NonEmptyString | None = None
+    """Cloudflare Email"""
+    api_key: Secret[NonEmptyString | None] = None
+    """API Key"""
+    api_token: Secret[NonEmptyString | None] = None
+    """API Token"""
 
 
 @single_argument_args('attributes')
@@ -55,7 +58,8 @@ class CloudFlareSchemaArgs(CloudFlareSchema):
 
 class DigitalOceanSchema(BaseModel):
     authenticator: Literal['digitalocean']
-    digitalocean_token: Secret[NonEmptyString] = Field(description='DigitalOcean Token')
+    digitalocean_token: Secret[NonEmptyString]
+    """DigitalOcean Token"""
 
 
 @single_argument_args('attributes')
@@ -65,10 +69,14 @@ class DigitalOceanSchemaArgs(DigitalOceanSchema):
 
 class OVHSchema(BaseModel):
     authenticator: Literal['OVH']
-    application_key: NonEmptyString = Field(description='OVH Application Key')
-    application_secret: NonEmptyString = Field(description='OVH Application Secret')
-    consumer_key: NonEmptyString = Field(description='OVH Consumer Key')
-    endpoint: Literal[tuple(ENDPOINTS.keys())] = Field(description='OVH Endpoint')
+    application_key: NonEmptyString
+    """OVH Application Key"""
+    application_secret: NonEmptyString
+    """OVH Application Secret"""
+    consumer_key: NonEmptyString
+    """OVH Consumer Key"""
+    endpoint: Literal[tuple(ENDPOINTS.keys())]
+    """OVH Endpoint"""
 
 
 @single_argument_args('attributes')
@@ -78,8 +86,10 @@ class OVHSchemaArgs(OVHSchema):
 
 class Route53Schema(BaseModel):
     authenticator: Literal['route53']
-    access_key_id: NonEmptyString = Field(description='AWS Access Key ID')
-    secret_access_key: NonEmptyString = Field(description='AWS Secret Access Key')
+    access_key_id: NonEmptyString
+    """AWS Access Key ID"""
+    secret_access_key: NonEmptyString
+    """AWS Secret Access Key"""
 
 
 @single_argument_args('attributes')
@@ -89,10 +99,14 @@ class Route53SchemaArgs(Route53Schema):
 
 class ShellSchema(BaseModel):
     authenticator: Literal['shell']
-    script: FilePathStr = Field(description='Authentication Script')
-    user: NonEmptyString = Field(description='Running user', default='nobody')
-    timeout: Annotated[int, Field(ge=5, description='Script Timeout', default=60)]
-    delay: Annotated[int, Field(ge=10, description='Propagation delay', default=60)]
+    script: FilePathStr
+    """Authentication Script"""
+    user: NonEmptyString = 'nobody'
+    """Running user"""
+    timeout: int = Field(ge=5, default=60)
+    """Script Timeout"""
+    delay: int = Field(ge=10, default=60)
+    """Propagation delay"""
 
 
 @single_argument_args('attributes')

--- a/src/middlewared/middlewared/api/v25_10_0/api_key.py
+++ b/src/middlewared/middlewared/api/v25_10_0/api_key.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Annotated, Literal
+from typing import Literal
 
-from pydantic import Secret, StringConstraints
+from pydantic import Secret, Field
 
 from middlewared.api.base import (
     BaseModel, Excluded, excluded_field, ForUpdateMetaclass, NonEmptyString,
@@ -16,7 +16,7 @@ class AllowListItem(BaseModel):
 
 class ApiKeyEntry(BaseModel):
     id: int
-    name: Annotated[NonEmptyString, StringConstraints(max_length=200)]
+    name: NonEmptyString = Field(max_length=200)
     username: LocalUsername | RemoteUsername | None
     user_identifier: int | str
     keyhash: Secret[str]

--- a/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
+++ b/src/middlewared/middlewared/api/v25_10_0/ipmi_lan.py
@@ -1,7 +1,7 @@
 from ipaddress import IPv4Address
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, Field, SecretStr
+from pydantic import AfterValidator, Field, Secret
 
 from middlewared.api.base import BaseModel, query_result, ForUpdateMetaclass
 from middlewared.api.base.validators import passwd_complexity_validator
@@ -43,17 +43,18 @@ class IPMILanQuery(BaseModel):
 class IPMILanUpdateOptionsDHCP(BaseModel):
     dhcp: Literal[True] = True
     """Turn on DHCP protocol for IP address management."""
-    password: Annotated[
-        SecretStr,
-        AfterValidator(
-            passwd_complexity_validator(
+    password: Secret[
+        Annotated[
+            str,
+            AfterValidator(passwd_complexity_validator(
                 required_types=["ASCII_UPPER", "ASCII_LOWER", "DIGIT", "SPECIAL"],
                 required_cnt=3,
                 min_length=8,
                 max_length=16,
-            )
-        )
-    ] | None = None
+            ))
+        ]
+        | None
+    ] = None
     """The password to be applied. Must be between 8 and 16 characters long and
     contain only ascii upper,lower, 0-9, and special characters."""
     vlan: Annotated[int, Field(ge=0, le=4096)] | None = None

--- a/src/middlewared/middlewared/api/v25_10_0/truecommand.py
+++ b/src/middlewared/middlewared/api/v25_10_0/truecommand.py
@@ -1,7 +1,7 @@
 import enum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field, Secret, SecretStr
+from pydantic import Field, Secret
 
 from middlewared.api.base import BaseModel, ForUpdateMetaclass, single_argument_args
 
@@ -55,7 +55,7 @@ class TruecommandEntry(BaseModel):
 @single_argument_args('truecommand_update')
 class TruecommandUpdateArgs(BaseModel, metaclass=ForUpdateMetaclass):
     enabled: bool
-    api_key: Secret[str | None] = Field(min_length=16, max_length=16)
+    api_key: Secret[Annotated[str, Field(min_length=16, max_length=16)] | None]
 
 
 class TrueCommandUpdateResult(BaseModel):

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
@@ -54,9 +54,9 @@ def test_long_string_default():
 
 def test_no_secretstr():
     result = subprocess.run(
-        ["grep", "-r", "/usr/local/lib/python3.11/dist-packages/middlewared/", "SecretStr"],
+        ["grep", "-r", "--exclude-dir=pytest", "SecretStr", "/usr/local/lib/python3.11/dist-packages/middlewared/"],
         capture_output=True,
         text=True
     )
     errmsg = result.stdout + "References to pydantic.SecretStr not allowed; use Secret[str] instead"
-    assert len("\n".split(result.stdout)) == 1, errmsg
+    assert result.stdout.strip() == "", errmsg

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
@@ -1,5 +1,3 @@
-import subprocess
-
 from pydantic import Secret
 import pytest
 
@@ -50,13 +48,3 @@ class LongStringDefaultMethodArgs(BaseModel):
 
 def test_long_string_default():
     assert accept_params(LongStringDefaultMethodArgs, []) == [""]
-
-
-def test_no_secretstr():
-    result = subprocess.run(
-        ["grep", "-r", "--exclude-dir=pytest", "SecretStr", "/usr/local/lib/python3.11/dist-packages/middlewared/"],
-        capture_output=True,
-        text=True
-    )
-    errmsg = result.stdout + "References to pydantic.SecretStr not allowed; use Secret[str] instead"
-    assert result.stdout.strip() == "", errmsg

--- a/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
+++ b/src/middlewared/middlewared/pytest/unit/api/base/types/test_base.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from pydantic import Secret
 import pytest
 
@@ -48,3 +50,13 @@ class LongStringDefaultMethodArgs(BaseModel):
 
 def test_long_string_default():
     assert accept_params(LongStringDefaultMethodArgs, []) == [""]
+
+
+def test_no_secretstr():
+    result = subprocess.run(
+        ["grep", "-r", "/usr/local/lib/python3.11/dist-packages/middlewared/", "SecretStr"],
+        capture_output=True,
+        text=True
+    )
+    errmsg = result.stdout + "References to pydantic.SecretStr not allowed; use Secret[str] instead"
+    assert len("\n".split(result.stdout)) == 1, errmsg

--- a/src/middlewared/setup.cfg
+++ b/src/middlewared/setup.cfg
@@ -18,4 +18,7 @@ output_dir = middlewared/locale
 previous = true
 
 [flake8]
-max-line-length=120
+ignore = A003,E402,E501,W504
+max-line-length = 120
+banned-modules =
+    pydantic.Secret = Use pydantic.Secret[str]

--- a/src/middlewared/setup.cfg
+++ b/src/middlewared/setup.cfg
@@ -21,4 +21,4 @@ previous = true
 ignore = A003,E402,E501,W504
 max-line-length = 120
 banned-modules =
-    pydantic.Secret = Use pydantic.Secret[str]
+    pydantic.SecretStr = Use pydantic.Secret[str]


### PR DESCRIPTION
...plus a little API cleanup.

The added flake8 lint condition will fail if `pydantic.SecretStr` is imported anywhere in middlewared.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4091/

Security context: The TrueNAS API uses `pydantic.Secret` and `pydantic.SecretStr` to mark sensitive API fields like API keys and passwords that should be hidden in log files and the like. 