### PR TITLE
NAS-135550 / 25.10 / fix IndexError in account.update

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -648,8 +648,10 @@ class UserService(CRUDService):
         else:
             group = self.middleware.call_sync('group.query', [('id', '=', data['group'])])
             if not group:
-                raise CallError(f'Group {data["group"]} not found')
-            group = group[0]
+                verrors.add('user_create.group', f'Group {data["group"]} not found', errno.ENOENT)
+            else:
+                group = group[0]
+        verrors.check()
 
         if data['smb']:
             data['groups'].append((self.middleware.call_sync(
@@ -779,10 +781,12 @@ class UserService(CRUDService):
             ])
             if not group:
                 verrors.add('user_update.group', f'Group {data["group"]} not found', errno.ENOENT)
-            group = group[0]
+            else:
+                group = group[0]
         else:
             group = user['group']
             user['group'] = group['id']
+        verrors.check()
 
         if same_user_logged_in and (
             self.middleware.call_sync('auth.twofactor.config')


### PR DESCRIPTION
2 issues here being addressed:
1. on line 782 we have a check for `if not group`, when that branch is true we add to a verrors object but never check for it. Since we don't check for this verrors object, on line 784 we do not protect the `group[0]` action and so we crash with an IndexError.
2. On line 650, we have the same exact logic, however, we raise a `CallError` in that if branch which protects us from this IndexError crash.

Fixes implemented:
1. protect the `group = group[0]` operation in an `else` branch to prevent `IndexError`
2. be consistent and create a `verrors` object and add a `verrors.check()` call before we move further down the logic