### PR TITLE
NAS-135426 / 25.04.1 / Disable the 'update' activity in STIG mode. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -91,7 +91,7 @@ class SystemSecurityService(ConfigService):
         # Disable non-critical outgoing network activity
         await self.middleware.call(
             'network.configuration.update',
-            {"activity": {"type": "DENY", "activities": ["usage"]}}
+            {"activity": {"type": "DENY", "activities": ["usage", "update"]}}
         )
 
     @private


### PR DESCRIPTION
The automatic OS update check and download should be disabled in STIG mode.

Includes a CI test for this state.

Original PR: https://github.com/truenas/middleware/pull/16339
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135426