### PR TITLE
NAS-135588 / 25.04.1 / Avoid JSON decode error on failed failover send (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/failover_/remote.py
+++ b/src/middlewared/middlewared/plugins/failover_/remote.py
@@ -196,6 +196,11 @@ class RemoteClient:
                 'Authorization': f'Token {token}',
             },
         )
+        if r.status_code != 200:
+            # The POST request to remote side failed as opposed to the job being initialized
+            # and then failing. In this case the best we can do is pass through the error text.
+            raise CallError(f'Failed to send {local_path} to Standby Controller: {r.text}')
+
         job_id = r.json()['job_id']
         # TODO: use event subscription in the client instead of polling
         while True:


### PR DESCRIPTION
This commit adds handling for failed POST request to send a file to the remote node in an HA pair. This protects against JSON decoder error and hopefully provides a useful error message from the remote node.

Original PR: https://github.com/truenas/middleware/pull/16348
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135588