### PR TITLE
NAS-135593 / 24.10.1 / removing blocking I/O in main event loop (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -441,8 +441,8 @@ class UpdateService(Service):
         job.set_progress(100, 'Update completed')
 
     @private
-    async def get_update_location(self):
-        syspath = (await self.middleware.call('systemdataset.config'))['path']
+    def get_update_location(self):
+        syspath = self.middleware.call_sync('systemdataset.config')['path']
         if syspath:
             path = f'{syspath}/update'
         else:


### PR DESCRIPTION
There is an `os.makedirs` call in this method so convert this from a coroutine to a synchronous method.

Original PR: https://github.com/truenas/middleware/pull/16350
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135593