### PR TITLE
NAS-135427 / 25.10 / Add 'support' to the list of denied activities allowed in STIG mode.

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -91,7 +91,7 @@ class SystemSecurityService(ConfigService):
         # Disable non-critical outgoing network activity
         await self.middleware.call(
             'network.configuration.update',
-            {"activity": {"type": "DENY", "activities": ["usage", "update"]}}
+            {"activity": {"type": "DENY", "activities": ["usage", "update", "support"]}}
         )
 
     @private

--- a/tests/api2/test_zzzz_stig.py
+++ b/tests/api2/test_zzzz_stig.py
@@ -348,7 +348,7 @@ def test_stig_usage_collection_disabled(setup_stig):
             c.call('system.general.update', {'usage_collection': True})
 
 
-@pytest.mark.parametrize('activity', ["usage", "update"])
+@pytest.mark.parametrize('activity', ["usage", "update", "support"])
 def test_stig_usage_reporting_disabled(setup_stig, activity):
     ''' In GPOS STIG mode usage reporting should be disabled '''
     assert setup_stig['aal'] == "LEVEL_2"


### PR DESCRIPTION
The 'support' activity attempts to automatically send information to the TrueNAS support team.   This is not allowed in STIG mode.

Include a CI test:  http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4159/