### PR TITLE
NAS-135598 / 25.10 / persist MAC addresses in sync_to_peer

### DIFF
--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -361,6 +361,9 @@ class FailoverService(ConfigService):
         """
         standby = ' standby controller.'
 
+        self.logger.debug('Persisting interface link addresses')
+        self.middleware.call_sync('interface.persist_link_addresses')
+
         self.logger.debug('Pulling system dataset UUID from' + standby)
         self.middleware.call_sync('systemdataset.ensure_standby_uuid')
 


### PR DESCRIPTION
Our HA CI has exposed an egde-case failure condition. The steps for setting up our HA VMs are as follows:
1. set up SSH
2. apply license
3. disable HA
4. apply interface changes (set up virtual IP, failover alias, etc)
5. sync to peer and reboot standby controller
6. create zpool and enable HA

The scenario that this exposes is that we're not persisting the interface mac addresses thereby producing a `MISMATCH_NICS` error in `failover.disabled.reasons`. This boils down to the fact that when we run `sync_to_peer` we're overwriting the B node's mac address column because a failover event has _NOT_ occurred at this point in the setup. The fix is rather simple, in the `failover.sync_to_peer` method we'll persist the interface mac addresses BEFORE we sync the database over to it. (This is similar in principle to how we're handling the system dataset UUID value as well).

This should also fix some STIG related CI test failures that we're seeing:
```
truenas_api_client.exc.ValidationErrors: [EINVAL] system_security_update.enable_fips: Security settings cannot be updated while HA is in an unhealthy state: (Network interfaces do not match between storage controllers.)