### PR TITLE
NAS-135599 / 25.10 / Slightly drop password prompt age

### DIFF
--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -26,7 +26,7 @@ ENTERPRISE_OPTIONS = frozenset([
     'password_history_length',
 ])
 
-PASSWORD_PROMPT_AGE = 7  # Number of days before expiry at which point we prompt for new password
+PASSWORD_PROMPT_AGE = 6  # Number of days before expiry at which point we prompt for new password
 
 
 class PasswordComplexity(enum.StrEnum):


### PR DESCRIPTION
This commit drops the password prompt age (the amount of days before account expiration at which we start to nag users) from seven days to six days. This is because our validator sets the absolute minimum value of max_password_age at seven days, and if both are at seven days then newly-created users will be automatically prompted to set passwords. That said, setting a 7 day max age for user account passwords is a questionable life choice for an administrator.