### PR TITLE
NAS-135603 / 25.10 / Expand documentation for password_history_length

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_1/system_security.py
+++ b/src/middlewared/middlewared/api/v25_04_1/system_security.py
@@ -61,10 +61,11 @@ class SystemSecurityEntry(BaseModel):
     The minimum length of passwords used for local accounts. The value of None
     means that there is no minimum password length.
     """
-    password_history_length: Annotated[int, Ge(1), Le(MAX_PASSWORD_HISTORY)] | None
+    password_history_length: Annotated[int, Ge(1), Le(MAX_PASSWORD_HISTORY)] | None = None
     """
     The number of password generations to keep in history for checks against
-    password reuse for local user accounts.
+    password reuse for local user accounts. The value of None means that history checks
+    for password reuse are not performed.
     """
 
 

--- a/src/middlewared/middlewared/api/v25_10_0/system_security.py
+++ b/src/middlewared/middlewared/api/v25_10_0/system_security.py
@@ -62,10 +62,11 @@ class SystemSecurityEntry(BaseModel):
     The minimum length of passwords used for local accounts. The value of None
     means that there is no minimum password length.
     """
-    password_history_length: Annotated[int, Field(ge=1, le=MAX_PASSWORD_HISTORY)] | None
+    password_history_length: Annotated[int, Field(ge=1, le=MAX_PASSWORD_HISTORY)] | None = None
     """
     The number of password generations to keep in history for checks against
-    password reuse for local user accounts.
+    password reuse for local user accounts. The value of None means that history checks
+    for password reuse are not performed.
     """
 
 


### PR DESCRIPTION
Make it more clear to API consumers that None / null is an okay value for the length of password history.