### PR TITLE
NAS-135603 / 25.04.1 / Expand documentation for password_history_length (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/api/v25_04_1/system_security.py
+++ b/src/middlewared/middlewared/api/v25_04_1/system_security.py
@@ -61,10 +61,11 @@ class SystemSecurityEntry(BaseModel):
     The minimum length of passwords used for local accounts. The value of None
     means that there is no minimum password length.
     """
-    password_history_length: Annotated[int, Ge(1), Le(MAX_PASSWORD_HISTORY)] | None
+    password_history_length: Annotated[int, Ge(1), Le(MAX_PASSWORD_HISTORY)] | None = None
     """
     The number of password generations to keep in history for checks against
-    password reuse for local user accounts.
+    password reuse for local user accounts. The value of None means that history checks
+    for password reuse are not performed.
     """
 
 


### PR DESCRIPTION
Make it more clear to API consumers that None / null is an okay value for the length of password history.

Original PR: https://github.com/truenas/middleware/pull/16362
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135603