### PR TITLE
NAS-135475 / 25.04.1 / Do not allow to unset userns_idmap for builtins (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -2240,7 +2240,7 @@ class GroupService(CRUDService):
                 f'{schema}.smb', 'SMB groups may not be configured while SMB service backend is unitialized.'
             )
 
-        if data.get('userns_idmap') and pk:
+        if 'userns_idmap' in data and pk:
             entry = await self.query([['local', '=', True], ['id', '=', pk]], {'get': True})
             if entry['roles']:
                 verrors.add(


### PR DESCRIPTION
## Problem

We had validation in place to prevent changing `userns_idmap` attr for builtin groups, however the validation was missing an edge case. We checked if user tried to change the attr to something else but if the attr was set and had `null ` in it - then it would bypass the existing validation we have.

## Solution

Make sure we properly handle the case where someone could unset `userns_idmap` for builtin users and also add integration tests to properly validate this.

Original PR: https://github.com/truenas/middleware/pull/16361
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135475