### PR TITLE
NAS-135605 / 25.04.1 / Robustize AlertMixin.clear_alert (by bmeagherix)

### DIFF
--- a/src/middlewared/middlewared/test/integration/assets/alert.py
+++ b/src/middlewared/middlewared/test/integration/assets/alert.py
@@ -1,10 +1,19 @@
+from time import sleep
+
 from middlewared.test.integration.utils import call
 
 
 class AlertMixin:
-    def assert_alert_count(self, count):
-        alerts = [alert for alert in call('alert.list') if alert['klass'] == self.ALERT_CLASS_NAME]
-        assert len(alerts) == count, alerts
+    def alert_count(self):
+        return len([alert for alert in call('alert.list') if alert['klass'] == self.ALERT_CLASS_NAME])
+
+    def assert_alert_count(self, count, retries=5):
+        # Give a few seconds for the alerts to update
+        for i in range(retries):
+            if count == self.alert_count():
+                return
+            sleep(1)
+        assert self.alert_count() == count
 
     def clear_alert(self):
         call('alert.oneshot_delete', self.ALERT_CLASS_NAME)


### PR DESCRIPTION
Noticed that occasionally this would cause a CI failure.  Add some retry code to avoid.

Original PR: https://github.com/truenas/middleware/pull/16365
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135605