### PR TITLE
NAS-131474 / 25.10 / Upload multiple files

### DIFF
--- a/docs/source/middleware/jobs.rst
+++ b/docs/source/middleware/jobs.rst
@@ -33,7 +33,7 @@ Using the pipes in the job object
 =================================
 
 .. automodule:: middlewared.pipe
-    :members: Pipes
+    :members: Pipes, InputPipes
 
 .. automodule:: middlewared.pipe
     :members: Pipe
@@ -114,6 +114,28 @@ You can upload a file to the job's `input` pipe using `/_upload` API endpoint.
         -F 'file=@config.tar'
 
     {"job_id": 4501}
+
+Uploading multiple files to the job's `inputs` pipes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can upload multiple files to the job's `inputs` pipes using the same `/_upload` API endpoint.
+
+.. code-block:: bash
+
+    curl localhost/_upload \
+        -u root:abcd1234 \
+        -F 'data={"method": "vm.create", "params": []}' \
+        -F 'file=@metadata.json' \
+        -F 'file=@rootfs.squashfs'
+
+    {"job_id": 4501}
+
+The files must be accessed sequentially iterating over the `job.pipes.inputs`:
+
+.. code-block:: python
+
+    for pipe in job.pipes.inputs:
+        pipe.r.read()
 
 Downloading the job's `output` pipe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/middlewared/middlewared/apps/file_app.py
+++ b/src/middlewared/middlewared/apps/file_app.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs
 
 from aiohttp import web
 
-from middlewared.pipe import Pipes
+from middlewared.pipe import Pipes, InputPipes
 from middlewared.restful import (
     parse_credentials,
     authenticate,
@@ -15,6 +15,8 @@ from middlewared.service_exception import CallError
 from truenas_api_client import json
 
 __all__ = ("FileApplication",)
+
+MAX_UPLOADED_FILES = 5
 
 
 class FileApplication:
@@ -175,7 +177,6 @@ class FileApplication:
         )
 
         filepart = await reader.next()
-
         if not filepart or filepart.name != "file":
             resp = web.Response(
                 status=405, body='"file" not found as second part on payload'
@@ -184,17 +185,9 @@ class FileApplication:
             return resp
 
         try:
-            serviceobj, methodobj = self.middleware.get_method(data["method"])
-            if authenticated_credentials.authorize("CALL", data["method"]):
-                job = await self.middleware.call_with_audit(
-                    data["method"],
-                    serviceobj,
-                    methodobj,
-                    data.get("params") or [],
-                    app,
-                    pipes=Pipes(input_=self.middleware.pipe()),
-                )
-            else:
+            params = data.get("params") or []
+            serviceobj, methodobj = self.middleware.get_method(data["method"], mocks=True, params=params)
+            if not authenticated_credentials.authorize("CALL", data["method"]):
                 await self.middleware.log_audit_message_for_method(
                     data["method"],
                     methodobj,
@@ -205,9 +198,36 @@ class FileApplication:
                     False,
                 )
                 raise web.HTTPForbidden()
-            await self.middleware.run_in_thread(
-                copy_multipart_to_pipe, self.loop, filepart, job.pipes.input
-            )
+
+            first_pipe = self.middleware.pipe()
+            with InputPipes(first_pipe) as input_pipes:
+                job = await self.middleware.call_with_audit(
+                    data["method"],
+                    serviceobj,
+                    methodobj,
+                    params,
+                    app,
+                    pipes=Pipes(inputs=input_pipes),
+                )
+
+                await self.middleware.run_in_thread(copy_multipart_to_pipe, self.loop, filepart, first_pipe)
+
+                for i in range(MAX_UPLOADED_FILES - 1):
+                    filepart = await reader.next()
+                    if not filepart:
+                        break
+
+                    if filepart.name != "file":
+                        resp = web.Response(status=405, body=f'Unknown payload part {filepart.name!r}')
+                        return resp
+
+                    next_pipe = self.middleware.pipe()
+                    input_pipes.add_pipe(next_pipe)
+                    await self.middleware.run_in_thread(copy_multipart_to_pipe, self.loop, filepart, next_pipe)
+
+                if await reader.next():
+                    resp = web.Response(status=405, body='Too many uploaded files')
+                    return resp
         except CallError as e:
             if e.errno == CallError.ENOMETHOD:
                 status_code = 422

--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -294,7 +294,7 @@ class Job:
         self.method = method
         self.args = args
         self.options = options
-        self.pipes = pipes or Pipes(input_=None, output=None)
+        self.pipes = pipes or Pipes(inputs=None, output=None)
         self.on_progress_cb = on_progress_cb
         self.app = app
         self.message_ids = [message_id] if message_id else []
@@ -613,8 +613,9 @@ class Job:
 
     async def __close_pipes(self):
         def close_pipes():
-            if self.pipes.input:
-                self.pipes.input.r.close()
+            if self.pipes.inputs:
+                for pipe in self.pipes.inputs.pipes_to_close:
+                    pipe.r.close()
             if self.pipes.output:
                 self.pipes.output.w.close()
 

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -129,6 +129,15 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         self.api_versions_adapter = None
         self.__audit_logger = setup_audit_logging()
 
+    def get_method(self, name, *, mocks=False, params=None):
+        serviceobj, methodobj = super().get_method(name)
+
+        if mocks:
+            if mock := self._mock_method(name, params):
+                methodobj = mock
+
+        return serviceobj, methodobj
+
     def create_task(self, coro, *, name=None):
         task = self.loop.create_task(coro, name=name)
         self.tasks.add(task)
@@ -737,12 +746,9 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         if method is None:
             if method_name is not None:
                 try:
-                    method = self.get_method(method_name)[1]
+                    method = self.get_method(method_name, mocks=True, params=args)[1]
                 except Exception:
                     return args
-
-                if mock := self._mock_method(method_name, args):
-                    method = mock
 
         if not hasattr(method, 'accepts'):
             if crud_method := real_crud_method(method):
@@ -992,10 +998,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
     async def call(self, name, *params, app=None, audit_callback=None, job_on_progress_cb=None, pipes=None,
                    profile=False):
-        serviceobj, methodobj = self.get_method(name)
-
-        if mock := self._mock_method(name, params):
-            methodobj = mock
+        serviceobj, methodobj = self.get_method(name, mocks=True, params=params)
 
         if profile:
             methodobj = profile_wrap(methodobj)
@@ -1012,10 +1015,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
         if background:
             return self.loop.call_soon_threadsafe(lambda: self.create_task(self.call(name, *params, app=app)))
 
-        serviceobj, methodobj = self.get_method(name)
-
-        if mock := self._mock_method(name, params):
-            methodobj = mock
+        serviceobj, methodobj = self.get_method(name, mocks=True, params=params)
 
         prepared_call = self._call_prepare(name, serviceobj, methodobj, params, app=app, audit_callback=audit_callback,
                                            job_on_progress_cb=job_on_progress_cb, in_event_loop=False)

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -17,7 +17,7 @@ from middlewared.api.current import (
     SupportNewTicketArgs, SupportNewTicketResult, SupportSimilarIssuesArgs, SupportSimilarIssuesResult,
     SupportUpdateArgs, SupportUpdateResult,
 )
-from middlewared.pipe import Pipes
+from middlewared.pipe import Pipes, InputPipes
 from middlewared.plugins.system.utils import DEBUG_MAX_SIZE
 from middlewared.service import CallError, ConfigService, job, ValidationErrors
 import middlewared.sqlalchemy as sa
@@ -262,7 +262,7 @@ class SupportService(ConfigService):
                     if 'token' in data:
                         t['token'] = data['token']
                     tjob = await self.middleware.call(
-                        'support.attach_ticket', t, pipes=Pipes(input_=self.middleware.pipe()),
+                        'support.attach_ticket', t, pipes=Pipes(inputs=InputPipes(self.middleware.pipe())),
                     )
 
                     def copy2():

--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -16,7 +16,7 @@ from truenas_api_client import json
 from .api.base.server.app import App
 from .auth import ApiKeySessionManagerCredentials, LoginPasswordSessionManagerCredentials, AuthenticationContext
 from .job import Job
-from .pipe import Pipes
+from .pipe import Pipes, InputPipes
 from .schema import Error as SchemaError
 from .service_exception import adapt_exception, CallError, MatchNotFound, ValidationError, ValidationErrors
 from .utils.account.authenticator import ApiKeyPamAuthenticator, UnixPamAuthenticator, UserPamAuthenticator
@@ -780,9 +780,9 @@ class Resource(object):
                     return resp
 
         if upload_pipe and download_pipe:
-            method_kwargs['pipes'] = Pipes(input_=upload_pipe, output=download_pipe)
+            method_kwargs['pipes'] = Pipes(inputs=InputPipes(upload_pipe), output=download_pipe)
         elif upload_pipe:
-            method_kwargs['pipes'] = Pipes(input_=upload_pipe)
+            method_kwargs['pipes'] = Pipes(inputs=InputPipes(upload_pipe))
         elif download_pipe:
             method_kwargs['pipes'] = Pipes(output=download_pipe)
 

--- a/tests/api2/test_upload.py
+++ b/tests/api2/test_upload.py
@@ -1,0 +1,59 @@
+import io
+import json
+
+from middlewared.test.integration.utils import client, mock, session, url
+
+
+def test_upload_multiple_files():
+    with mock("test.test1", """    
+        from middlewared.service import job
+
+        @job(pipes=["input"])
+        def mock(self, job, *args):
+            return "".join([pipe.r.read().decode() for pipe in job.pipes.inputs])
+    """):
+        with session() as s:
+            r = s.post(
+                f"{url()}/_upload",
+                files=[
+                    ("data", (None, io.StringIO(json.dumps({
+                        "method": "test.test1",
+                        "params": []
+                    })))),
+                    ("file", (None, io.StringIO("FILE1"))),
+                    ("file", (None, io.StringIO("FILE2"))),
+                    ("file", (None, io.StringIO("FILE3"))),
+                ],
+            )
+            r.raise_for_status()
+            job_id = r.json()["job_id"]
+
+        with client() as c:
+            assert c.call("core.job_wait", job_id, job=True) == 'FILE1FILE2FILE3'
+
+
+def test_upload_multiple_files_job_does_not_consume_completely():
+    with mock("test.test1", """    
+        from middlewared.service import job
+
+        @job(pipes=["input"])
+        def mock(self, job, *args):
+            return "".join([pipe.r.read(2).decode() for pipe in job.pipes.inputs])
+    """):
+        with session() as s:
+            r = s.post(
+                f"{url()}/_upload",
+                files=[
+                    ("data", (None, io.StringIO(json.dumps({
+                        "method": "test.test1",
+                        "params": []
+                    })))),
+                    ("file", (None, io.StringIO("ABCD" * 1000000))),
+                    ("file", (None, io.StringIO("EFGH" * 1000000))),
+                ],
+            )
+            r.raise_for_status()
+            job_id = r.json()["job_id"]
+
+        with client() as c:
+            assert c.call("core.job_wait", job_id, job=True) == 'ABEF'


### PR DESCRIPTION
The lxc integration has exposed a feature that we do not have with job framework. We need to be able to upload 2 different files at once using the upload endpoint.

The use-case is simple, distrobuilder will create a metadata file and a rootfs image. Both of these files are needed to “import” and subsequently run the container. This will be important for the VEEAM container image that is being worked on by solutions team.

We need to change the middleware job framework so that it accepts >= 2 files.