### PR TITLE
NAS-135601 / 25.04.1 / Add status validation for instance start (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -660,6 +660,11 @@ class VirtInstanceService(CRUDService):
         """
         await self.middleware.call('virt.global.check_initialized')
         instance = await self.middleware.call('virt.instance.get_instance', id)
+        if instance['status'] not in ('RUNNING', 'STOPPED'):
+            raise ValidationError(
+                f'virt.instance.restart.{id}',
+                f'{id}: instance may not be restarted because current status is: {instance["status"]}'
+            )
 
         if instance['status'] == 'RUNNING':
             await incus_call_and_wait(f'1.0/instances/{id}/state', 'put', {'json': {
@@ -669,7 +674,8 @@ class VirtInstanceService(CRUDService):
             }})
 
         # Apply any idmap changes
-        await self.set_account_idmaps(id)
+        if instance['type'] == 'CONTAINER':
+            await self.set_account_idmaps(id)
 
         if instance['vnc_password']:
             await self.middleware.run_in_thread(create_vnc_password_file, id, instance['vnc_password'])


### PR DESCRIPTION
We should immediately raise a ValidationError if in virt.instance.start if instance status is an unexpected value (for example "ERROR").

Original PR: https://github.com/truenas/middleware/pull/16359
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135601