### PR TITLE
Better validation errors in pool.dataset.create

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -480,7 +480,7 @@ class PoolDatasetService(CRUDService):
                 raise ValidationError(
                     'pool_dataset_create.name',
                     f'{parent_name} must be unlocked to create {data["name"]}.'
-            )
+                )
             if parent_ds['encrypted']:
                 if unencrypted_parent is not None:
                     raise ValidationError(


### PR DESCRIPTION
Initially this started by want of changing the validation error when someone specifies a dataset to be created for a zpool that doesn't exist. Our validation error makes mention of "parent dataset" which is non-intuitive. While I was here I discovered a bunch of inefficiencies so I took the liberty of fixing them.

1. remove the `while` loop since that was doing it's own version of splitting up the `data['name']` variable into dependent datasets when we already provided a helper function `get_dataset_parents`
2. we were iterating over `data['name']`'s parents more than once since we had another `get_dataset_parents` call further down in this method. Remove the 2nd call in favor of the first.
3. Don't call `pool.dataset.query` and `pool.dataset.get_instance_quick` for every parent dataset. Instead only call `pool.dataset.query` since all the metadata that we need is provided via that call.
4. Call `filesystem.mount_info` when checking if the parent dataset is mounted as readonly, this is far more efficient (and faster). I also moved this validation check into `pool.dataset.create` from `_common_validation` because it only was checking this during the create operation.
5. Stop trying to add a bunch of children entries to the `verrors` object. Just short-circuit and raise a `ValidationError` when the first error is encountered. This allows the for loop to be much more straightforward.
6. logically order the validation steps in a more cohesive manner so that we remove distracting alterations to the `data` variable. (i.e. validation comes first, then alterations can be made)