### PR TITLE
NAS-135429 / 25.10 / Remove `cipher` from `system_keychaincredential` table in case it has been re-added

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
@@ -1,0 +1,30 @@
+"""Copy of revision 0e5949153c20 in 23.10
+
+Revision ID: 249b95f63f76
+Revises: ec62dbbeb7aa
+Create Date: 2025-04-29 16:48:45.824930+00:00
+
+"""
+import json
+
+from alembic import op
+
+from middlewared.plugins.pwenc import encrypt, decrypt
+
+
+# revision identifiers, used by Alembic.
+revision = '249b95f63f76'
+down_revision = 'ec62dbbeb7aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    for c in map(dict, conn.execute("SELECT * FROM system_keychaincredential WHERE type = 'SSH_CREDENTIALS'").fetchall()):
+        if attributes := decrypt(c["attributes"]):
+            attributes = json.loads(attributes)
+            del attributes["cipher"]
+            conn.execute("UPDATE system_keychaincredential SET attributes = ? WHERE id = ?", (
+                encrypt(json.dumps(attributes)), c["id"]
+            ))

--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
@@ -24,7 +24,7 @@ def upgrade():
     for c in map(dict, conn.execute("SELECT * FROM system_keychaincredential WHERE type = 'SSH_CREDENTIALS'").fetchall()):
         if attributes := decrypt(c["attributes"]):
             attributes = json.loads(attributes)
-            del attributes["cipher"]
+            attributes.pop("cipher", None)
             conn.execute("UPDATE system_keychaincredential SET attributes = ? WHERE id = ?", (
                 encrypt(json.dumps(attributes)), c["id"]
             ))

--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-04-02_15-40_merge-migration.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-04-02_15-40_merge-migration.py
@@ -1,7 +1,7 @@
 """ Merge migration after adding account policy columns
 
 Revision ID: d7e3a916db65
-Revises: f15312414057, ec62dbbeb7aa
+Revises: f15312414057, 249b95f63f76
 Create Date: 2025-04-02 15:40:46.829354+00:00
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd7e3a916db65'
-down_revision = ('f15312414057', 'ec62dbbeb7aa')
+down_revision = ('f15312414057', '249b95f63f76')
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Add a copy of the revision in 23.10 that removed `cipher` from `system_keychaincredential.attributes`. It is possible for this field to have been added back to the database by an uploaded configuration. Due to strictly enforced API return schemas introduced in 25.04, having the extra field causes some `keychaincredential` API calls to fail.

Related PR: https://github.com/truenas/middleware/pull/16091