### PR TITLE
NAS-135429 / 25.04.1 / Remove `cipher` from `system_keychaincredential` table in case it has been re-added (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
+++ b/src/middlewared/middlewared/alembic/versions/25.04/2025-04-29_16-48_remove-cipher-column.py
@@ -1,0 +1,30 @@
+"""Copy of revision 0e5949153c20 in 23.10
+
+Revision ID: 249b95f63f76
+Revises: ec62dbbeb7aa
+Create Date: 2025-04-29 16:48:45.824930+00:00
+
+"""
+import json
+
+from alembic import op
+
+from middlewared.plugins.pwenc import encrypt, decrypt
+
+
+# revision identifiers, used by Alembic.
+revision = '249b95f63f76'
+down_revision = 'ec62dbbeb7aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    for c in map(dict, conn.execute("SELECT * FROM system_keychaincredential WHERE type = 'SSH_CREDENTIALS'").fetchall()):
+        if attributes := decrypt(c["attributes"]):
+            attributes = json.loads(attributes)
+            attributes.pop("cipher", None)
+            conn.execute("UPDATE system_keychaincredential SET attributes = ? WHERE id = ?", (
+                encrypt(json.dumps(attributes)), c["id"]
+            ))


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 1cb04e35f541bf04eff4c4da2162f629e9140a39
    git cherry-pick -x 6604a29fb5c6a798b806bc1b48eb1773e5bffa39

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 70cdb356fcaea0fee463322f72ff0030e78a6293

Add a copy of the revision in 23.10 that removed `cipher` from `system_keychaincredential.attributes`. It is possible for this field to have been added back to the database by an uploaded configuration. Due to strictly enforced API return schemas introduced in 25.04, having the extra field causes some `keychaincredential` API calls to fail.

Related PR: https://github.com/truenas/middleware/pull/16091

Original PR: https://github.com/truenas/middleware/pull/16378
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135429