### PR TITLE
NAS-135623 / 25.10 / Relax security check for password aging data

### DIFF
--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -115,7 +115,10 @@ def shadow_parse_aging(
         # unexpected None here should result in forcing password change
         # We cannot do this for the root account though because it will break
         # ability to su to root.
-        if user['username'] != 'root':
+        #
+        # NAS-135623 -- this check was relaxed to only set zero here if
+        # password authentication is not disabled.
+        if user['username'] != 'root' and not user['password_disabled']:
             outstr += '0'
 
     outstr += SHADOW_SEPARATOR


### PR DESCRIPTION
If password authentication is disabled and user has never had a password set, then we should not set the flag that a password change is required. The reason for this is that the account may still be used for an SSH session that is authenticated via key and we need to allow normal login to succeed (and not prompt for a password change).