### PR TITLE
NAS-135634 / 25.10 / Avoid vacuum operation on audit databases

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/backend.py
+++ b/src/middlewared/middlewared/plugins/audit/backend.py
@@ -71,7 +71,6 @@ class SQLConn:
                 connect_args={'check_same_thread': False}
             )
             self.connection = self.engine.connect()
-            self.connection.connection.execute('VACUUM')
             self.connection.execute('PRAGMA journal_mode=WAL')
             self.dbfd = os.open(self.path, os.O_PATH)
 


### PR DESCRIPTION
We perform VACUUM after applying retention settings via cron and so we don't need to VACUUM on middleware startup. This reduces the amount of DB operations on audit tables during middleware startup.