### PR TITLE
NAS-135582 / 25.04.1 / Allow `None` SFTP private key (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -534,10 +534,7 @@ class CredentialsService(CRUDService):
         """
         await self.middleware.call("network.general.will_perform_activity", "cloud_sync")
 
-        data = dict(name="", provider=data)
-        await self._validate("cloud_sync_credentials_create", data)
-
-        async with RcloneConfig({"credentials": data}) as config:
+        async with RcloneConfig({"credentials": {"provider": data}}) as config:
             proc = await run(["rclone", "--config", config.config_path, "--contimeout", "15s", "--timeout", "30s",
                               "lsjson", "remote:"],
                              check=False, encoding="utf8")

--- a/src/middlewared/middlewared/rclone/remote/sftp.py
+++ b/src/middlewared/middlewared/rclone/remote/sftp.py
@@ -13,7 +13,7 @@ class SFTPRcloneRemote(BaseRcloneRemote):
     async def get_credentials_extra(self, credentials):
         result = {}
 
-        if "private_key" in credentials["provider"]:
+        if credentials["provider"].get("private_key") is not None:
             with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp_file:
                 tmp_file.write((await self.middleware.call("keychaincredential.get_of_type",
                                                            credentials["provider"]["private_key"],
@@ -24,5 +24,5 @@ class SFTPRcloneRemote(BaseRcloneRemote):
         return result
 
     async def cleanup(self, task, config):
-        if "private_key" in task["credentials"]["provider"]:
+        if task["credentials"]["provider"].get("private_key") is not None:
             os.unlink(config["key_file"])


### PR DESCRIPTION
User may choose not to specify a private key for an SFTP backup in which case password authentication or authentication with an ssh-agent will be attempted instead.

https://rclone.org/sftp/#ssh-authentication

Original PR: https://github.com/truenas/middleware/pull/16389
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135582