### PR TITLE
NAS-135641 / 25.10 / fix invalid AuditService.setup log message

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -13,6 +13,7 @@ from truenas_api_client import json as ejson
 from .utils import (
     AUDIT_DATASET_PATH,
     AUDIT_LIFETIME,
+    AUDIT_LOG_PATH_NAME,
     AUDIT_DEFAULT_RESERVATION,
     AUDIT_DEFAULT_QUOTA,
     AUDIT_DEFAULT_FILL_CRITICAL,
@@ -37,7 +38,6 @@ from middlewared.service_exception import CallError, ValidationErrors, Validatio
 from middlewared.utils import filter_list
 from middlewared.utils.mount import getmntinfo
 from middlewared.utils.functools_ import cache
-
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]
 BULK_AUDIT = ['SMB', 'SYSTEM']
@@ -481,9 +481,9 @@ class AuditService(ConfigService):
             current_version = await self.middleware.call('system.version')
             rc = await setup_truenas_verify(self.middleware, current_version)
             if rc:
-                self.logger.error(
-                    'Did not get clean result from truenas_verify initial setup. '
-                    'See /var/log/truenas_verify.%s.log', current_version
+                self.logger.warning(
+                    'Did not get clean result from truenas_verify initial setup. See %s'
+                    f'{AUDIT_LOG_PATH_NAME}.{current_version}.log'
                 )
         except Exception:
             self.logger.error('Error detected in truenas_verify setup.', exc_info=True)

--- a/src/middlewared/middlewared/plugins/audit/utils.py
+++ b/src/middlewared/middlewared/plugins/audit/utils.py
@@ -26,7 +26,7 @@ SQL_SAFE_FIELDS = (
     AuditEventParam.EVENT.value,
     AuditEventParam.SUCCESS.value,
 )
-
+AUDIT_LOG_PATH_NAME = mtree_verify.LOG_PATH_NAME
 
 AuditBase = declarative_base()
 


### PR DESCRIPTION
`AuditService.setup()` produces invalid log entry in `middlewared.log`.
```
[2025/04/30 12:00:30] (ERROR) AuditService.setup():484 - Did not get clean result from truenas_verify initial setup. See /var/log/truenas_verify.TrueNAS-25.10.0-MASTER-20250430-104814.log
```

Fix 2 issues here:
1. this is not an error, bump it down to a warning
2. use the `LOG_PATH_NAME` constant defined in the `truenas_verify` package.