### PR TITLE
fix validation error in pool.dataset.create

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -200,10 +200,11 @@ class PoolDatasetService(CRUDService):
     async def __common_validation(self, verrors, schema, data, mode, parent=None, cur_dataset=None):
         assert mode in ('CREATE', 'UPDATE')
 
+        parents = get_dataset_parents(data['name'])
         if parent is None:
             parent = await self.middleware.call(
                 'pool.dataset.query',
-                [('id', '=', data['name'].rsplit('/', 1)[0])],
+                [('id', '=', parents[-1])],
                 {'extra': {'retrieve_children': False}}
             )
 
@@ -221,7 +222,12 @@ class PoolDatasetService(CRUDService):
                     'Please specify a pool which exists for the dataset/volume to be created'
                 )
             else:
-                verrors.add(f'{schema}.name', 'Parent dataset does not exist for specified name')
+                msg = f'({parents[-1]}) does not exist.'
+                if len(parents) == 1:
+                    msg = f'zpool {msg}'
+                else:
+                    msg = f'Parent dataset {msg}'
+                verrors.add(f'{schema}.name', msg)
         else:
             parent = parent[0]
             if mode == 'CREATE' and parent['readonly']['rawvalue'] == 'on':

--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -2,8 +2,16 @@ from itertools import product
 
 import pytest
 
+from middlewared.service_exception import ValidationErrors
 from middlewared.test.integration.assets.pool import dataset
 from middlewared.test.integration.utils import call
+
+
+def test_create_dataset_nonexistent_pool():
+    bad = "does_not_exist_zpool"
+    with pytest.raises(ValidationErrors, match=f"zpool ({bad}) does not exist"):
+        with dataset("zz", pool=bad):
+            pass
 
 
 @pytest.mark.parametrize("child", ["a/b", "a/b/c"])


### PR DESCRIPTION
A non-intuitive error message was raised when someone tried to create a dataset underneath a zpool that doesn't exist. This fixes the problem and adds a simple test.