### PR TITLE
NAS-135657 / 25.10 / Fix typo in iscsi.target.update schema

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -323,7 +323,7 @@ class iSCSITargetService(CRUDService):
                              new['mode'] not in MODE_FC_CAPABLE])
 
         verrors = ValidationErrors()
-        await self.__validate(verrors, new, 'iscsi_target_create', old=old)
+        await self.__validate(verrors, new, 'iscsi_target_update', old=old)
         verrors.check()
 
         await self.compress(new)


### PR DESCRIPTION
Fix typo in `iscsi.target.update` schema.  Was `iscsi_target_create` but should have been `iscsi_target_update`.

Manually verified that WebUI still handles the updated value properly.