### PR TITLE
NAS-135663 / 25.04.1 / increase middlewared.service timeout (by yocalebo)

### DIFF
--- a/src/middlewared/debian/middlewared.service
+++ b/src/middlewared/debian/middlewared.service
@@ -11,7 +11,7 @@ Conflicts=reboot.target shutdown.target halt.target
 [Service]
 Type=notify
 ExecStart=/usr/bin/middlewared --log-handler=file
-TimeoutStartSec=240
+TimeoutStartSec=900
 Restart=always
 Environment="REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 # SIGTERM will only happen if systemd kills process that timed out booting (it is the only case in which we don't


### PR DESCRIPTION
We have a few users unable to upgrade to 25.04.0 because the middlewared.service is being killed during boot process because our default timeout is 4mins (240 seconds). I have a fear this is a combination of pydantic and really poor performing boot drives. Either way, we are adding more and more to the monolithic middlewared service and so it's inevitable that service initialization takes longer.

Original PR: https://github.com/truenas/middleware/pull/16406
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135663