### PR TITLE
Prefer SASL EXTERNAL over ANONYMOUS when using an LDAP client cert

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -272,10 +272,10 @@ class LDAPService(ConfigService):
                 "dns_timeout": data["dns_timeout"],
             }
         }
-        if data['anonbind']:
-            client_config['bind_type'] = 'ANONYMOUS'
-        elif data['cert_name']:
+        if data['cert_name']:
             client_config['bind_type'] = 'EXTERNAL'
+        elif data['anonbind']:
+            client_config['bind_type'] = 'ANONYMOUS'
         elif data['kerberos_realm']:
             client_config['bind_type'] = 'GSSAPI'
         else:


### PR DESCRIPTION
When LDAP is configured with a client certificate but no bind DN (which happens to be the recommended configuration for Google's Secure LDAP service), `sssd` (and other LDAP tools such as `ldapsearch`) default to SASL `EXTERNAL` authentication. 

However, `ldap.py` always uses `ANONYMOUS` authentication if there is no bind DN, even if a certificate is present. This prevents TrueNAS SCALE from being able to connect to Google Secure LDAP; `sssd` comes up fine and uses and groups are synchronized, but then the health check that is done as part of saving the LDAP configuration fails, because the health check can't bind to the server.

This changes `ldap.py` to prefer `EXTERNAL` when a client certificate is present.

As seen in https://forums.truenas.com/t/ldap-health-check-seems-broken-with-truenas-scale-google-secure-ldap/40661