### PR TITLE
Allow blank LDAP password if using client certificate

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -400,7 +400,7 @@ class LDAPService(ConfigService):
                 new["certificate"], "ldap_update.certificate", False
             ))
 
-        if not new["bindpw"] and not new["kerberos_principal"] and not new["anonbind"]:
+        if not new["bindpw"] and not new["kerberos_principal"] and not new["anonbind"] and not new["certificate"]:
             verrors.add(
                 "ldap_update.binddn",
                 "Bind credentials or kerberos keytab are required for an authenticated bind."


### PR DESCRIPTION
This allows using a client certificate without a bind password, without having to also select anonymous binding

An alternative to https://github.com/truenas/middleware/pull/16414