### PR TITLE
NAS-135040 / 25.04.1 / Change how oplocks are handled for multiprotocol shares (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -517,13 +517,6 @@ class SMBService(ConfigService):
                     'smb_update.aapl_extensions',
                     'This option must be enabled when AFP or time machine shares are present'
                 )
-        else:
-            if await self.middleware.call('sharing.smb.query', [['purpose', '=', 'MULTI_PROTOCOL_NFS']]):
-                verrors.add(
-                    'smb_update.aapl_extensions',
-                    'This option may not be enabled concurrently with shares that are configured for '
-                    'multi-protocol NFS access.'
-                )
 
         if new['enable_smb1']:
             if audited_shares := await self.middleware.call(
@@ -1342,12 +1335,6 @@ class SharingSMBService(SharingService):
                 'This feature may be enabled in the general SMB server configuration.'
             )
 
-        if data['purpose'] == 'MULTI_PROTOCOL_NFS' and smb_config['aapl_extensions']:
-            verrors.add(
-                f'{schema_name}.purpose',
-                'MULTI_PROTOCOL_NFS purpose requires global changes that are incompatible '
-                'with the enabling of Apple SMB protocol extensions.'
-            )
 
         if data['timemachine'] or data['purpose'] in ('TIMEMACHINE', 'ENHANCED_TIMEMACHINE'):
             if not smb_config['aapl_extensions']:

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1335,7 +1335,6 @@ class SharingSMBService(SharingService):
                 'This feature may be enabled in the general SMB server configuration.'
             )
 
-
         if data['timemachine'] or data['purpose'] in ('TIMEMACHINE', 'ENHANCED_TIMEMACHINE'):
             if not smb_config['aapl_extensions']:
                 verrors.add(

--- a/src/middlewared/middlewared/plugins/smb_/constants.py
+++ b/src/middlewared/middlewared/plugins/smb_/constants.py
@@ -139,7 +139,7 @@ class SMBSharePreset(enum.Enum):
     MULTI_PROTOCOL_NFS = {"verbose_name": "Multi-protocol (NFSv4/SMB) shares", "params": {
         'streams': True,
         'durablehandle': False,
-        'auxsmbconf': 'kernel oplocks=True',
+        'auxsmbconf': 'oplocks=no\nlevel2 oplocks=no',
     }, "cluster": False}
     PRIVATE_DATASETS = {"verbose_name": "Private SMB Datasets and Shares", "params": {
         'path_suffix': '%U',

--- a/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
+++ b/src/middlewared/middlewared/plugins/smb_/util_smbconf.py
@@ -292,7 +292,6 @@ def generate_smb_conf_dict(
         case _:
             pass
 
-    has_mixed_mode = filter_list(smb_shares, [['purpose', '=', 'MULTI_PROTOCOL_NFS']])
     home_share = filter_list(smb_shares, [['home', '=', True]])
     if home_share:
         if ds_type is DSType.AD:
@@ -557,13 +556,6 @@ def generate_smb_conf_dict(
                     value = v
 
             smbconf.update({f'{idmap_prefix} {backend_parameter}': value})
-
-    """
-    Mixed NFS / SMB shares enables kernel oplock support, which requires
-    globally disabling SMB2 leases
-    """
-    if has_mixed_mode:
-        smbconf['smb2 leases'] = False
 
     for e in smb_service_config['smb_options'].splitlines():
         # Add relevant auxiliary parameters

--- a/tests/unit/test_smb_share.py
+++ b/tests/unit/test_smb_share.py
@@ -389,7 +389,7 @@ def test__multiprotocol_nfs_preset(nfsacl_dataset):
     }, BASE_SMB_CONFIG)
 
     assert conf['path'] == nfsacl_dataset
-    assert conf['kernel oplocks'] == 'True'
+    assert conf['oplocks'] == 'no'
 
 
 def test__shadow_copy_off(nfsacl_dataset):


### PR DESCRIPTION
This commit removes kernel oplocks in favor of disabling oplocks
on a per-share basis when they have been flagged for mixed-mode
use. This avoids issues observed in the field with kernel lease
breaks possibly blocking smbd main loop and causing client timeouts
as well allowing SMB leases globally. If client requests an SMB
lease on a multiprotocol share as part of an SMB2 create request
then no lease will be granted, but the open itself will succeed.
This matches older behavior in TrueNAS core and has not resulted
in any bug reports historically.

Original PR: https://github.com/truenas/middleware/pull/16421
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135040