### PR TITLE
NAS-135700 / 25.10 / Don't require `rx_queues` or `tx_queues` in interface.create result

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/interface.py
+++ b/src/middlewared/middlewared/api/v25_10_0/interface.py
@@ -61,8 +61,8 @@ class InterfaceEntryState(BaseModel):
     link_address: str
     permanent_link_address: str | None
     hardware_link_address: str
-    rx_queues: int
-    tx_queues: int
+    rx_queues: int = NotRequired
+    tx_queues: int = NotRequired
     aliases: list[InterfaceEntryStateAlias]
     vrrp_config: list | None = []
     # lagg section


### PR DESCRIPTION
These fields are not always returned.