### PR TITLE
fix api test

### DIFF
--- a/tests/api2/test_pool_dataset_create.py
+++ b/tests/api2/test_pool_dataset_create.py
@@ -1,4 +1,5 @@
 from itertools import product
+from re import escape
 
 import pytest
 
@@ -9,7 +10,10 @@ from middlewared.test.integration.utils import call
 
 def test_create_dataset_nonexistent_pool():
     bad = "does_not_exist_zpool"
-    with pytest.raises(ValidationErrors, match=f"zpool ({bad}) does not exist"):
+    with pytest.raises(
+        ValidationErrors,
+        match=escape(f"[EINVAL] pool_dataset_create.name: zpool ({bad}) does not exist.\n")
+    ):
         with dataset("zz", pool=bad):
             pass
 


### PR DESCRIPTION
This test is failing simply because of the `match` kwarg to pytest isn't formatted correctly.