### PR TITLE
catch Exception in disk_class.py

### DIFF
--- a/src/middlewared/middlewared/utils/disks_/disk_class.py
+++ b/src/middlewared/middlewared/utils/disks_/disk_class.py
@@ -294,16 +294,16 @@ class DiskEntry:
                         milli_c = int(
                             self.__opener(absolute_path=f"{i.path}/temp1_input")
                         )
-                    except (ValueError, FileNotFoundError):
-                        continue
+                    except Exception:
+                        pass
                     else:
                         # sysfs values are stored in millidegrees celsius
                         rv["temp_c"] = milli_c / 1000
 
                     try:
                         crit = int(self.__opener(absolute_path=f"{i.path}/temp1_crit"))
-                    except (ValueError, FileNotFoundError):
-                        continue
+                    except Exception:
+                        pass
                     else:
                         # syfs values are stored in millidegrees celsius
                         rv["crit"] = crit / 1000


### PR DESCRIPTION
A community user running a nightly image has exposed the fact that some nvme drives don't have `temp1_crit` sysfs files. The problem is that it caused a crash like so
```
  File "/usr/lib/python3/dist-packages/middlewared/api/base/decorator.py", line 105, in wrapped
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/disk_/temperature.py", line 43, in temperatures
    self.temp_cache[i.name] = (i.temp(), now)
                               ^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/disks_/disk_class.py", line 304, in temp
    crit = int(self.__opener(absolute_path=f"{i.path}/temp1_crit"))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```
Instead of changing the `ValueError` to a `TypeError`, I change it be more liberal by catching any exception. Furthermore, the user's nvme drive doesn't report the `temp1_crit` value but it reported the `temp1_input`. Instead of continuing to next value in the for loop, just catch the exception and pass. I already protect these values by initializing the object outside the for loop.