### PR TITLE
NAS-135735 / 25.10 / fix API schema for disk.query

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/disk.py
+++ b/src/middlewared/middlewared/api/v25_10_0/disk.py
@@ -37,7 +37,7 @@ class DiskEntry(BaseModel):
     number: int
     serial: str
     lunid: str | None
-    size: int
+    size: int | None
     description: str
     transfermode: str
     hddstandby: Literal["ALWAYS ON", "5", "10", "20", "30", "60", "120", "180", "240", "300", "330"]


### PR DESCRIPTION
The `disk_extend` method explicitly sets `disk['size'] = None` (which is rather strange) so we need to fix the API schema so we don't crash unnecessarily.