### PR TITLE
NAS-135741 / 25.10 / remove license alert check for fseries NR variant

### DIFF
--- a/src/middlewared/middlewared/alert/source/license_status.py
+++ b/src/middlewared/middlewared/alert/source/license_status.py
@@ -71,11 +71,7 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
         model = self.middleware.call_sync('truenas.get_chassis_hardware').removeprefix('TRUENAS-').split('-')[0]
         if model == 'UNKNOWN':
             alerts.append(Alert(LicenseAlertClass, 'TrueNAS is running on unsupported hardware.'))
-        elif any((
-            # f-series has 2 license models F60 and F60-NR (NR is single-node only)
-            (local_license['model'][0] == 'F' and model != local_license['model'].split('-')[0]),
-            (model != local_license['model'])
-        )):
+        elif model != local_license['model']:
             alerts.append(Alert(
                 LicenseAlertClass,
                 (


### PR DESCRIPTION
We never ended up shipping a fseries "NR" variant so this removes the obsolete logic (and comment).