### PR TITLE
NAS-135715 / 25.10 / default accept_ra sysctl to 2

### DIFF
--- a/src/freenas/etc/sysctl.d/10-truenas.conf
+++ b/src/freenas/etc/sysctl.d/10-truenas.conf
@@ -5,6 +5,7 @@ kernel.panic_on_unrecovered_nmi = 1
 kernel.unknown_nmi_panic = 1
 kernel.watchdog_thresh = 60
 vm.swappiness = 1
+
 # we set these because our nginx
 # reverse proxy service often starts
 # before required IP addresses have
@@ -17,3 +18,22 @@ vm.swappiness = 1
 # carefully reviewed the side-effects.
 net.ipv4.ip_nonlocal_bind = 1
 net.ipv6.ip_nonlocal_bind = 1
+
+# we set this because docker enables
+# net.ipv6.*.forwarding sysctls for all
+# interfaces on the system. This subtly
+# breaks ANYONE that expects any type of
+# auto configuration provided by SLAAC.
+# The kernel, when forwarding=1, ignores
+# router advertisements (RA) and therefore
+# any type of auto config. The easiest
+# path forward is to default the accept_ra
+# sysctl to a value of 2 which means the
+# kernel will acknowledge RA's when forwarding
+# is set to 1.
+# NOTE: this does not change existing interfaces
+# and only works on newly created interfaces AFTER
+# this setting has been applied. Users will need
+# to use the tunable API to manually set each
+# interface's accept_ra parameter to 2.
+net.ipv6.conf.default.accept_ra = 2


### PR DESCRIPTION
Commit 3b9b1c76032a3f50053fce3c8255f178e4ba3c34 subtly broke users who depend on SLAAC related functionality. When ipv6 was enabled, it causes the net.ipv6.conf.*.forwarding sysctl to get set to 1 on _ALL_ interfaces on the host. This causes the kernel to ignore any router advertisements on those interfaces because it treats the host as a "router". To fix this problem we need to set `accept_ra=2` which will tell the kernel to accept RA's on interfaces when forwarding=1.