### PR TITLE
NAS-135643 / 25.10 / Fix API calls when connected to /websocket

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1381,30 +1381,10 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
 
         apis = self._load_apis()
 
-        # FIXME: handle this in a more appropriate place
-        def create_model(model_provider, model_factory, arg_model_name):
-            try:
-                arg = model_provider.models[arg_model_name]
-            except KeyError:
-                pass
-            else:
-                return model_factory(arg)
-
         for service in self.get_services().values():
             for current_api_model, model_factory, arg_model_name in getattr(service, '_register_models', []):
-                # Newest version has `ModuleModelProvider`, we can add directly to the models list
-                self.api_versions[-1].model_provider.models[current_api_model.__name__] = current_api_model
-                for api_version in self.api_versions[:-1]:
-                    # All others have `LazyModuleModelProvider`.
-                    # FIXME: We must initialize derived models lazily since they are not loaded yet.
-                    # This abstraction exposes unnecessary implementation details, we must come up with something better
-                    model_provider = api_version.model_provider
-                    model_provider.models_factories[current_api_model.__name__] = functools.partial(
-                        create_model,
-                        model_provider,
-                        model_factory,
-                        arg_model_name,
-                    )
+                for api_version in self.api_versions:
+                    api_version.register_model(current_api_model, model_factory, arg_model_name)
 
         self._console_write('registering services')
 


### PR DESCRIPTION
Connecting to /websocket will attempt to use the 24.10 version of the API.

For all old versions of the API, we use factory functions to lazily load the version when it is needed. When a method model is not found in an older version (e.g. 24.10), we register it to the older version with a value of `None` since `None` is returned by this function when a `KeyError` is raised.
https://github.com/truenas/middleware/blob/accfe25027d247ab4e0cac2ba42a34eb6ca41972/src/middlewared/middlewared/main.py#L1385
The solution is to instead allow `KeyError` to propagate so that we make use of the `passthrough_nonexistent_methods` feature and use the most recent version of the method.

While here, I've also resolved a related FIXME comment and added more type hints.

http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4335/