### PR TITLE
NAS-135761 / 25.04.2 / Update STIG password complexity ruleset (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -253,8 +253,9 @@ class SystemSecurityService(ConfigService):
             # SRG-OS-000069-GPOS-00037
             # SRG-OS-000070-GPOS-00038
             # SRG-OS-000071-GPOS-00039
-            # Passwords must contain at least one lowercase character, one lowercase character, and
-            # one number.
+            # SRG-OS-000266-GPOS-00101
+            # Passwords must contain at least one lowercase character, one lowercase character,
+            # one number, and one special character.
             ruleset = combined['password_complexity_ruleset'] or set(GPOS_STIG_PASSWORD_COMPLEXITY)
             new['password_complexity_ruleset'] = ruleset
             if missing := GPOS_STIG_PASSWORD_COMPLEXITY - new['password_complexity_ruleset']:

--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -52,10 +52,12 @@ class PasswordComplexity(enum.StrEnum):
 # SRG-OS-000069-GPOS-00037
 # SRG-OS-000070-GPOS-00038
 # SRG-OS-000071-GPOS-00039
+# SRG-OS-000266-GPOS-00101
 GPOS_STIG_PASSWORD_COMPLEXITY = frozenset([
     PasswordComplexity.UPPER,
     PasswordComplexity.LOWER,
     PasswordComplexity.NUMBER,
+    PasswordComplexity.SPECIAL,
 ])
 
 


### PR DESCRIPTION
This commit adds requirement for a special character to the account password complexity ruleset for GPOS STIG per updated STIG runsheet.

Original PR: https://github.com/truenas/middleware/pull/16454
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135761