### PR TITLE
NAS-135784 / 25.10 / Avoid TOCTOU issues in account and iscsi.target

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -237,7 +237,7 @@ class UserService(CRUDService):
         role_prefix = 'ACCOUNT'
         entry = UserEntry
 
-    self.ReservedUids = ReservedXid({}, Lock())
+    ReservedUids = ReservedXid({}, Lock())
 
     @private
     async def user_extend_context(self, rows, extra):
@@ -1877,7 +1877,7 @@ class GroupService(CRUDService):
         role_prefix = 'ACCOUNT'
         entry = GroupEntry
 
-    self.ReservedGids = ReservedXid({}, AsyncioLock())
+    ReservedGids = ReservedXid({}, AsyncioLock())
 
     @private
     async def group_extend_context(self, rows, extra):

--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -1,5 +1,6 @@
 ADMIN_UID = 950
 ADMIN_GID = 950
+MIN_AUTO_XID = 3000  # See NAS-117892 - purpose is to avoid collision with apps uids/gids
 SKEL_PATH = '/etc/skel/'  # TODO evaluate whether this is still needed
 
 # TrueNAS historically used /nonexistent as the default home directory for new

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import re
 import subprocess
-from asynio import Lock
+from asyncio import Lock
 from collections import defaultdict
 
 from pydantic import IPvAnyNetwork

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import subprocess
+from asynio import Lock
 from collections import defaultdict
 
 from pydantic import IPvAnyNetwork
@@ -21,6 +22,7 @@ from .utils import AUTHMETHOD_LEGACY_MAP, sanitize_extent
 
 RE_TARGET_NAME = re.compile(r'^[-a-z0-9\.:]+$')
 MODE_FC_CAPABLE = ['FC', 'BOTH']
+ISCSI_RELTGT_LOCK = Lock()
 
 
 class iSCSITargetModel(sa.Model):
@@ -121,10 +123,13 @@ class iSCSITargetService(CRUDService):
 
         await self.compress(data)
         groups = data.pop('groups')
-        data['rel_tgt_id'] = await self.middleware.call('iscsi.target.get_rel_tgt_id')
-        pk = await self.middleware.call(
-            'datastore.insert', self._config.datastore, data,
-            {'prefix': self._config.datastore_prefix})
+
+        async with ISCSI_RELTGT_LOCK:
+            data['rel_tgt_id'] = await self.middleware.call('iscsi.target.get_rel_tgt_id')
+            pk = await self.middleware.call(
+                'datastore.insert', self._config.datastore, data,
+                {'prefix': self._config.datastore_prefix})
+
         try:
             await self.__save_groups(pk, groups)
         except Exception as e:
@@ -440,10 +445,16 @@ class iSCSITargetService(CRUDService):
 
     @private
     async def get_rel_tgt_id(self):
-        existing = {target['rel_tgt_id'] for target in await self.middleware.call(f'{self._config.namespace}.query', [], {'select': ['rel_tgt_id']})}
+        """ WARNING: this endpoint must be called while holding ISCSI_RELTGT_LOCK """
+        existing = {
+            target['rel_tgt_id']
+            for target in await self.middleware.call(f'{self._config.namespace}.query', [], {'select': ['rel_tgt_id']})
+        }
+
         for i in range(1, 32000):
             if i not in existing:
                 return i
+
         raise ValueError("Unable to deletmine rel_tgt_id")
 
     @private

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -28,9 +28,3 @@ class ReservedXid:
 
     def in_use(self) -> set:
         return set([entry for entry in self.in_flight.keys() if not self.available(entry)])
-
-
-# WARNING: the lock type for this dataclass will need to update if changed from sync to async
-# or vice-versa
-ReservedUids = ReservedXid({}, Lock())
-ReservedGids = ReservedXid({}, AsyncioLock())

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -1,0 +1,36 @@
+from asyncio import Lock as AsyncioLock
+from dataclasses import dataclass
+from threading import Lock
+from time import monotonic
+from typing import Union
+
+
+LOCKED_XID_TTL = 3600
+
+
+@dataclass(slots=True)
+class ReservedXid:
+    in_flight: dict[int, int]
+    lock: Union[Lock, AsyncioLock]
+
+    def available(self, xid: int) -> bool:
+        if (expiry := self.in_flight.get(xid)) is None:
+            return True
+
+        return monotonic() > expiry
+
+    def add_entry(self, xid: int) -> None:
+        assert self.available(xid)
+        self.in_flight[xid] = monotonic() + LOCKED_XID_TTL
+
+    def remove_entry(self, xid: int) -> None:
+        self.in_flight.pop(xid, None)
+
+    def in_use(self) -> set:
+        return set([entry for entry in self.in_flight.keys() if not self.available(entry)])
+
+
+# WARNING: the lock type for this dataclass will need to update if changed from sync to async
+# or vice-versa
+ReservedUids = ReservedXid({}, Lock())
+ReservedGids = ReservedXid({}, AsyncioLock())

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -27,4 +27,4 @@ class ReservedXid:
         self.in_flight.pop(xid, None)
 
     def in_use(self) -> set:
-        return set([entry for entry in self.in_flight.keys() if not self.available(entry)])
+        return set([entry for entry in list(self.in_flight.keys()) if not self.available(entry)])

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -1,8 +1,5 @@
-from asyncio import Lock as AsyncioLock
 from dataclasses import dataclass
-from threading import Lock
 from time import monotonic
-from typing import Union
 
 
 LOCKED_XID_TTL = 3600
@@ -11,7 +8,6 @@ LOCKED_XID_TTL = 3600
 @dataclass(slots=True)
 class ReservedXid:
     in_flight: dict[int, int]
-    lock: Union[Lock, AsyncioLock]
 
     def available(self, xid: int) -> bool:
         if (expiry := self.in_flight.get(xid)) is None:

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -17,7 +17,11 @@ class ReservedXid:
         if (expiry := self.in_flight.get(xid)) is None:
             return True
 
-        return monotonic() > expiry
+        if monotonic() > expiry:
+            self.in_flight.pop(xid, None)
+            return True
+
+        return False
 
     def add_entry(self, xid: int) -> None:
         assert self.available(xid)

--- a/tests/unit/test_reserved_ids.py
+++ b/tests/unit/test_reserved_ids.py
@@ -1,0 +1,47 @@
+import pytest
+from middlewared.utils import reserved_ids
+from threading import Lock
+from time import monotonic
+from truenas_api_client import Client
+
+
+@pytest.fixture(scope='function')
+def reserve_obj():
+    return reserved_ids.ReservedXid({}, Lock())
+
+
+def test_add_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+    assert 865 in reserve_obj.in_use()
+
+
+def test_remove_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+
+    reserve_obj.remove_entry(865)
+    assert reserve_obj.available(865)
+    assert 865 not in reserve_obj.in_use()
+
+
+def test_expire_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+
+    reserve_obj.in_flight[865] = monotonic() - reserved_ids.LOCKED_XID_TTL - 1
+    assert reserve_obj.available(865)
+    assert 865 not in reserve_obj.in_use()
+
+
+@pytest.mark.parametrize('method,minimum', [
+    ('user.get_next_uid', 3000),
+    ('group.get_next_gid', 3000),
+])
+def test_check_increment_method(method, minimum):
+    with Client() as c:
+        xid = c.call(method)
+        assert xid == minimum
+
+        xid = c.call(method)
+        assert xid == minimum + 1

--- a/tests/unit/test_reserved_ids.py
+++ b/tests/unit/test_reserved_ids.py
@@ -8,7 +8,7 @@ from truenas_api_client import Client
 
 @pytest.fixture(scope='function')
 def reserve_obj():
-    return reserved_ids.ReservedXid({}, Lock())
+    return reserved_ids.ReservedXid({})
 
 
 def test_add_entry(reserve_obj):


### PR DESCRIPTION
This commit changes the behavior of get_next_uid and get_next_gid such that we keep track of uids/gids handed out by this endpoint and prevent them from being reused in concurrent calls. These reservations of uid / gids time out after one hour.

During investigation it was discovered that additional simpler toctou issues existed related to iscsi.target and nvmet namespaces. These ones were remedied by adding locking.