### PR TITLE
NAS-135788 / 25.10 / remove comment from debian/control

### DIFF
--- a/src/middlewared/debian/control
+++ b/src/middlewared/debian/control
@@ -158,7 +158,6 @@ Depends: alembic,
          python3-websocket,
          python3-zeroconf,
          python3-zettarepl,
-         # This is required by incus VMs
          qemu-system-modules-spice,
          qemu-utils,
          rclone,


### PR DESCRIPTION
Nightly builds are failing because of this comment line.