### PR TITLE
NAS-135792 / 25.04.2 / Fix mutual TLS authentication for LDAP

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -400,10 +400,11 @@ class LDAPService(ConfigService):
                 new["certificate"], "ldap_update.certificate", False
             ))
 
-        if not new["bindpw"] and not new["kerberos_principal"] and not new["anonbind"]:
+        if not any([new['bindpw'], new['kerberos_principal'], new['anonbind'], new['certificate']]):
             verrors.add(
                 "ldap_update.binddn",
-                "Bind credentials or kerberos keytab are required for an authenticated bind."
+                "Some form of credentials (plain, kerberos, or client certificate) are required "
+                "for an authenticated bind."
             )
         if new["bindpw"] and new["kerberos_principal"]:
             new["bindpw"] = ""

--- a/src/middlewared/middlewared/plugins/ldap_/ldap_client.py
+++ b/src/middlewared/middlewared/plugins/ldap_/ldap_client.py
@@ -86,8 +86,11 @@ class LDAPClient:
             if data['bind_type'] == 'ANONYMOUS':
                 bound = self._handle.simple_bind_s()
             elif data['bind_type'] == 'EXTERNAL':
-                bound = self._handle.sasl_non_interactive_bind_s('EXTERNAL')
+                # SASL binds raise an exception if they fail, simple binds return a boolean value
+                self._handle.sasl_non_interactive_bind_s('EXTERNAL')
+                bound = True
             elif data['bind_type'] == 'GSSAPI':
+                # SASL binds raise an exception if they fail, simple binds return a boolean value
                 self._handle.set_option(pyldap.OPT_X_SASL_NOCANON, 1)
                 self._handle.sasl_gssapi_bind_s()
                 bound = True


### PR DESCRIPTION
This commit fixes a longstanding validation bug in mutual tls authentication for the LDAP plugin. Tests will be added once CI pipeline added with this authentication type and an LDAP identity provider. This commit is not targeted for master since the underlying fix will be rolled into the overall larger rewrite project.