### PR TITLE
NAS-135784 / 25.04.2 / Avoid TOCTOU issues in account and iscsi.target (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 
 from sqlalchemy.orm import relationship
 
+from asyncio import Lock as AsyncioLock
 from dataclasses import asdict
 from datetime import datetime
 from middlewared.api import api_method
@@ -61,6 +62,7 @@ from middlewared.utils.nss import pwd, grp
 from middlewared.utils.nss.nss_common import NssModule
 from middlewared.utils.privilege import credential_has_full_admin, privileges_group_mapping
 from middlewared.async_validators import check_path_resides_within_volume
+from middlewared.utils.reserved_ids import ReservedXid
 from middlewared.utils.security import (
     check_password_complexity,
     MAX_PASSWORD_HISTORY,
@@ -71,7 +73,7 @@ from middlewared.utils.time_utils import utc_now, UTC
 from middlewared.plugins.account_.constants import (
     ADMIN_UID, ADMIN_GID, SKEL_PATH, DEFAULT_HOME_PATH, DEFAULT_HOME_PATHS,
     USERNS_IDMAP_DIRECT, USERNS_IDMAP_NONE, ALLOWED_BUILTIN_GIDS,
-    SYNTHETIC_CONTAINER_ROOT,
+    SYNTHETIC_CONTAINER_ROOT, MIN_AUTO_XID,
 )
 from middlewared.plugins.smb_.constants import SMBBuiltin
 from middlewared.plugins.idmap_.idmap_constants import (
@@ -80,6 +82,11 @@ from middlewared.plugins.idmap_.idmap_constants import (
 )
 from middlewared.plugins.idmap_ import idmap_winbind
 from middlewared.plugins.idmap_ import idmap_sss
+from threading import Lock
+
+
+SYNC_NEXT_UID_LOCK = Lock()
+ASYNC_NEXT_GID_LOCK = AsyncioLock()
 
 
 def pw_checkname(verrors, attribute, name):
@@ -233,6 +240,8 @@ class UserService(CRUDService):
         cli_namespace = 'account.user'
         role_prefix = 'ACCOUNT'
         entry = UserEntry
+
+    ReservedUids = ReservedXid({})
 
     @private
     async def user_extend_context(self, rows, extra):
@@ -671,7 +680,7 @@ class UserService(CRUDService):
             ))['id'])
 
         if data.get('uid') is None:
-            data['uid'] = self.middleware.call_sync('user.get_next_uid')
+            data['uid'] = self.get_next_uid()
 
         new_homedir = False
         home_mode = data.pop('home_mode')
@@ -689,6 +698,9 @@ class UserService(CRUDService):
                 # Homedir setup failed, we should remove any auto-generated group
                 if group_created:
                     self.middleware.call_sync('group.delete', data['group'])
+
+                with SYNC_NEXT_UID_LOCK:
+                    self.ReservedUids.remove_entry(data['uid'])
 
                 raise
 
@@ -715,6 +727,9 @@ class UserService(CRUDService):
                 # commands failed to execute cleanly.
                 shutil.rmtree(data['home'])
             raise
+        finally:
+            with SYNC_NEXT_UID_LOCK:
+                self.ReservedUids.remove_entry(data['uid'])
 
         self.middleware.call_sync('service.reload', 'ssh')
         self.middleware.call_sync('service.reload', 'user')
@@ -1221,26 +1236,29 @@ class UserService(CRUDService):
         return user_obj
 
     @api_method(UserGetNextUidArgs, UserGetNextUidResult, roles=['ACCOUNT_READ'])
-    async def get_next_uid(self):
+    def get_next_uid(self):
         """
         Get the next available/free uid.
         """
         # We want to create new users from 3000 to avoid potential conflicts - Reference: NAS-117892
-        last_uid = 2999
-        builtins = await self.middleware.call(
-            'datastore.query', 'account.bsdusers',
-            [('builtin', '=', False)], {'order_by': ['uid'], 'prefix': 'bsdusr_'}
-        )
-        for i in builtins:
-            # If the difference between the last uid and the current one is
-            # bigger than 1, it means we have a gap and can use it.
-            if i['uid'] - last_uid > 1:
-                return last_uid + 1
+        with SYNC_NEXT_UID_LOCK:
+            allocated_uids = set([u['uid'] for u in self.middleware.call_sync(
+                'datastore.query', 'account.bsdusers',
+                [('builtin', '=', False), ('uid', '>=', MIN_AUTO_XID)], {'prefix': 'bsdusr_'}
+            )])
 
-            if i['uid'] > last_uid:
-                last_uid = i['uid']
+            in_flight_uids = self.ReservedUids.in_use()
 
-        return last_uid + 1
+            total_uids = allocated_uids | in_flight_uids
+            max_uid = max(total_uids) if total_uids else MIN_AUTO_XID - 1
+
+            if gap_uids := set(range(MIN_AUTO_XID, max_uid)) - total_uids:
+                next_uid = min(gap_uids)
+            else:
+                next_uid = max_uid + 1
+
+            self.ReservedUids.add_entry(next_uid)
+            return next_uid
 
     @api_method(
         UserHasLocalAdministratorSetUpArgs, UserHasLocalAdministratorSetUpResult,
@@ -1863,6 +1881,8 @@ class GroupService(CRUDService):
         role_prefix = 'ACCOUNT'
         entry = GroupEntry
 
+    ReservedGids = ReservedXid({})
+
     @private
     async def group_extend_context(self, rows, extra):
         privileges = await self.middleware.call('datastore.query', 'account.privilege')
@@ -1984,8 +2004,13 @@ class GroupService(CRUDService):
         group = data.copy()
         group['group'] = group.pop('name')
 
-        group = await self.group_compress(group)
-        pk = await self.middleware.call('datastore.insert', 'account.bsdgroups', group, {'prefix': 'bsdgrp_'})
+        try:
+            group = await self.group_compress(group)
+            pk = await self.middleware.call('datastore.insert', 'account.bsdgroups', group, {'prefix': 'bsdgrp_'})
+        finally:
+            # Once the data store entry is created we can safely remove the reservation
+            async with ASYNC_NEXT_GID_LOCK:
+                self.ReservedGids.remove_entry(data['gid'])
 
         if reload_users:
             await self.middleware.call('service.reload', 'user')
@@ -2144,18 +2169,23 @@ class GroupService(CRUDService):
         """
         Get the next available/free gid.
         """
-        used_gids = {
-            group['bsdgrp_gid']
-            for group in await self.middleware.call('datastore.query', 'account.bsdgroups')
-        }
-        used_gids |= set((await self.middleware.call('privilege.used_local_gids')).keys())
+        async with ASYNC_NEXT_GID_LOCK:
+            groups = await self.middleware.call(
+                'datastore.query', 'account.bsdgroups', [['bsdgrp_gid', '>=', MIN_AUTO_XID], ['bsdgrp_builtin', '=', False]]
+            )
+            used_gids = set(group['bsdgrp_gid'] for group in groups)
+            used_gids |= set([gid for gid in (await self.middleware.call('privilege.used_local_gids')).keys() if gid >= MIN_AUTO_XID])
+            in_flight_gids = self.ReservedGids.in_use()
+            total_gids = used_gids | in_flight_gids
+            max_gid = max(total_gids) if total_gids else MIN_AUTO_XID - 1
 
-        # We should start gid from 3000 to avoid potential conflicts - Reference: NAS-117892
-        next_gid = 3000
-        while next_gid in used_gids:
-            next_gid += 1
+            if gid_gap := (set(range(MIN_AUTO_XID, max_gid)) - total_gids):
+                next_gid = min(gid_gap)
+            else:
+                next_gid = max_gid + 1
 
-        return next_gid
+            self.ReservedGids.add_entry(next_gid)
+            return next_gid
 
     @api_method(GroupGetGroupObjArgs, GroupGetGroupObjResult, roles=['ACCOUNT_READ'])
     def get_group_obj(self, data):

--- a/src/middlewared/middlewared/plugins/account_/constants.py
+++ b/src/middlewared/middlewared/plugins/account_/constants.py
@@ -1,5 +1,6 @@
 ADMIN_UID = 950
 ADMIN_GID = 950
+MIN_AUTO_XID = 3000  # See NAS-117892 - purpose is to avoid collision with apps uids/gids
 SKEL_PATH = '/etc/skel/'  # TODO evaluate whether this is still needed
 
 # TrueNAS historically used /nonexistent as the default home directory for new

--- a/src/middlewared/middlewared/utils/reserved_ids.py
+++ b/src/middlewared/middlewared/utils/reserved_ids.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from time import monotonic
+
+
+LOCKED_XID_TTL = 3600
+
+
+@dataclass(slots=True)
+class ReservedXid:
+    in_flight: dict[int, int]
+
+    def available(self, xid: int) -> bool:
+        if (expiry := self.in_flight.get(xid)) is None:
+            return True
+
+        if monotonic() > expiry:
+            self.in_flight.pop(xid, None)
+            return True
+
+        return False
+
+    def add_entry(self, xid: int) -> None:
+        assert self.available(xid)
+        self.in_flight[xid] = monotonic() + LOCKED_XID_TTL
+
+    def remove_entry(self, xid: int) -> None:
+        self.in_flight.pop(xid, None)
+
+    def in_use(self) -> set:
+        return set([entry for entry in list(self.in_flight.keys()) if not self.available(entry)])

--- a/tests/unit/test_reserved_ids.py
+++ b/tests/unit/test_reserved_ids.py
@@ -1,0 +1,58 @@
+import pytest
+from middlewared.utils import reserved_ids
+from multiprocessing import Pool
+from threading import Lock
+from time import monotonic
+from truenas_api_client import Client
+
+
+@pytest.fixture(scope='function')
+def reserve_obj():
+    return reserved_ids.ReservedXid({})
+
+
+def test_add_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+    assert 865 in reserve_obj.in_use()
+
+
+def test_remove_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+
+    reserve_obj.remove_entry(865)
+    assert reserve_obj.available(865)
+    assert 865 not in reserve_obj.in_use()
+
+
+def test_expire_entry(reserve_obj):
+    reserve_obj.add_entry(865)
+    assert not reserve_obj.available(865)
+
+    reserve_obj.in_flight[865] = monotonic() - reserved_ids.LOCKED_XID_TTL - 1
+    assert reserve_obj.available(865)
+    assert 865 not in reserve_obj.in_use()
+
+
+def get_uid():
+    with Client() as c:
+        return c.call('user.get_next_uid')
+
+
+def get_gid():
+    with Client() as c:
+        return c.call('group.get_next_gid')
+
+
+@pytest.mark.parametrize('method,minimum', [
+    (get_uid, 3000),
+    (get_gid, 3000),
+])
+def test_check_increment_method(method, minimum):
+    with Pool(4) as pool:
+        results = [pool.apply_async(method, ()) for i in range(0, 20)]
+        ids = [res.get(timeout=1) for res in results]
+
+    assert min(ids) == minimum
+    assert len(set(ids)) == len(ids), 'duplicate ids assigned'


### PR DESCRIPTION
This commit changes the behavior of get_next_uid and get_next_gid such that we keep track of uids/gids handed out by this endpoint and prevent them from being reused in concurrent calls. These reservations of uid / gids time out after one hour.

During investigation it was discovered that additional simpler toctou issues existed related to iscsi.target and nvmet namespaces. These ones were remedied by adding locking.

Original PR: https://github.com/truenas/middleware/pull/16460
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135784