### PR TITLE
NAS-135799 / 25.10 / fix unit test

### DIFF
--- a/tests/unit/test_get_disks.py
+++ b/tests/unit/test_get_disks.py
@@ -48,7 +48,6 @@ def test__read_partitions():
             assert uuid.UUID(a.unique_partition_guid) == uuid.UUID(b["uuid"])
             assert a.first_lba == b["start"]
             assert a.last_lba == (b["start"] + b["size"]) - 1
-            assert disk.size_bytes == b["size"] * 512
 
     assert at_least_one, "No disks with partitions! (or get_disks() failed)"
 


### PR DESCRIPTION
This assert statement will never be true because the `disk.size_bytes` is the total disk size in bytes. The right operand of the assert is the partition size in bytes. We already have sufficient checks with the 2x assert statements before.