### PR TITLE
NAS-135767 / 25.04.2 / fix leaving stale db entries on interface delete (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1430,11 +1430,10 @@ class InterfaceService(CRUDService):
         await self.middleware.call('network.common.check_failover_disabled', schema, verrors)
 
         if iface := await self.get_instance(oid):
-            if iface['type'] == 'LINK_AGGREGATION':
-                filters = [('type', '=', 'VLAN'), ('vlan_parent_interface', '=', iface['id'])]
-                if vlans := ', '.join([i['name'] for i in await self.middleware.call('interface.query', filters)]):
-                    verrors.add(schema, f'The following VLANs depend on this interface: {vlans}')
-            if iface['type'] == 'BRIDGE' and (
+            filters = [('type', '=', 'VLAN'), ('vlan_parent_interface', '=', iface['id'])]
+            if vlans := ', '.join([i['name'] for i in await self.middleware.call('interface.query', filters)]):
+                verrors.add(schema, f'The following VLANs depend on this interface: {vlans}')
+            elif iface['type'] == 'BRIDGE' and (
                 iface['name'] == (await self.middleware.call('virt.global.config'))['bridge']
             ):
                 verrors.add(schema, 'Virt is using this interface as its bridge interface.')


### PR DESCRIPTION
5 years ago in 4b8186fd4f0181a8406b19fccc55da22f126b309 a check was removed to allow `interface.delete` for physical interfaces. This was fine at the time, but it has exposed issues with how we currently do HA.

This is the following scenario that this fixes:
1. create vlan1 with parent (physical) interface of ens1
2. give vlan1 ip address information
3. HA is healthy and functional
4. delete ens1 from UI
5. network_vlan table removes entry
6. network_interface leaves a vlan1 entry in network_interface table
7. keepalived.conf gets generated with an invalid config which prevents `keepalived` service from running, which, ultimately causes failover and/or HA to go completely down

To remedy the above situation, we ensure that any interface being deleted that has a vlan on top of it will raise a validation error. We did this _ONLY_ for bond type interfaces but I've changed it so that it applies to any interface that can carry a vlan.

Original PR: https://github.com/truenas/middleware/pull/16461
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135767