### PR TITLE
Fix validation for SMB share paths that are dirs

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1175,8 +1175,18 @@ class SharingSMBService(SharingService):
             verrors.add(schema, 'Extended attribute support is required for SMB shares')
 
         current_acltype = get_acl_type(this_mnt['super_opts'])
+
         for child in this_mnt['children']:
-            validate_child(child)
+            # The child filesystem may or may not be mounted under the SMB share. Two relevant
+            # cases:
+            #
+            # 1. Share path is a directory without any filesystems mounted under it. In this
+            #    case we don't want to raise validation errors for datasets that aren't mounted
+            #    under the share path.
+            # 2. Share path is a directory, but admin has mounted a remote NFS export under it.
+            #    In this case we want to raise a validation error.
+            if is_child_realpath(path, child['mountpoint']):
+                validate_child(child)
 
     @private
     async def get_path_field(self, data):

--- a/tests/api2/test_smb_share_path_acl.py
+++ b/tests/api2/test_smb_share_path_acl.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+
+from middlewared.test.integration.assets.filesystem import directory
+from middlewared.test.integration.assets.smb import smb_share
+from middlewared.test.integration.assets.pool import dataset
+from middlewared.test.integration.utils import call
+
+
+@pytest.fixture(scope='module')
+def fs_tree():
+    with dataset('nfs4ds', data={'share_type': 'SMB'}) as ds1:
+        with dataset(f'{ds1}/posix') as ds2:
+            # Make sure that we don't end up with collision on dataset name partial match
+            with dataset(f'{ds1}/posixcanary'):
+                mountpoint1 = os.path.join('/mnt', ds1)
+                mountpoint2 = os.path.join('/mnt', ds2)
+                path = os.path.join(mountpoint1, 'subdir')
+                with directory(path):
+                    yield {
+                        'mountpoint1': mountpoint1,
+                        'ds1': ds1,
+                        'mountpoint2': mountpoint2,
+                        'ds2': ds2,
+                        'subdir': path,
+                    }
+
+
+def test__verror_share_create_acltype(fs_tree):
+    with pytest.raises(Exception, match='ACL type mismatch with child mountpoint'):
+        with smb_share(fs_tree['mountpoint1'], SMB_NAME):
+            pass
+
+
+def test__share_create_subdir_allowed(fs_tree):
+    with smb_share(fs_tree['subdir'], SMB_NAME):
+        pass
+
+
+def test__share_create_child_allowed(fs_tree):
+    with smb_share(fs_tree['mountpoint2'], SMB_NAME):
+        pass
+
+
+def test__verror_share_update_acltype(fs_tree):
+    with smb_share(fs_tree['subdir'], SMB_NAME) as share:
+        with pytest.raises(Exception, match='ACL type mismatch with child mountpoint'):
+            call('sharing.smb.update', share['id'], {'path': fs_tree['mountpoint1']})


### PR DESCRIPTION
This commit fixes over-strict validation of ZFS properties for child datasets of SMB shares. If the dataset mountpoint isn't a child path of the share path then we don't need to check its properties.