### PR TITLE
NAS-135811 / 25.10 / `service.control` job method

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/service.py
+++ b/src/middlewared/middlewared/api/v25_10_0/service.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 
 from middlewared.api.base import BaseModel
@@ -7,7 +9,7 @@ __all__ = [
     "ServiceEntry", "ServiceReloadArgs", "ServiceReloadResult", "ServiceRestartArgs", "ServiceRestartResult",
     "ServiceStartArgs", "ServiceStartResult", "ServiceStartedArgs", "ServiceStartedResult",
     "ServiceStartedOrEnabledArgs", "ServiceStartedOrEnabledResult", "ServiceStopArgs", "ServiceStopResult",
-    "ServiceUpdateArgs", "ServiceUpdateResult",
+    "ServiceUpdateArgs", "ServiceUpdateResult", "ServiceControlArgs", "ServiceControlResult",
 ]
 
 
@@ -23,11 +25,26 @@ class ServiceOptions(BaseModel):
     ha_propagate: bool = True
     silent: bool = True
     """Return `false` instead of an error if the operation fails."""
+    timeout: int | None = 120
 
 
 class ServiceUpdate(BaseModel):
     enable: bool
     """Whether the service should start on boot."""
+
+
+class ServiceControlArgs(BaseModel):
+    verb: Literal["START", "STOP", "RESTART", "RELOAD"]
+    service: str
+    options: ServiceOptions = Field(default_factory=ServiceOptions)
+
+
+class ServiceControlResult(BaseModel):
+    result: bool
+    """
+    For "START", "RESTART", "RELOAD", it will indicate whether the service is running after performing the operation.
+    For "STOP", it will indicate whether the service was successfully stopped.
+    """
 
 
 class ServiceReloadArgs(BaseModel):

--- a/src/middlewared/middlewared/common/attachment/__init__.py
+++ b/src/middlewared/middlewared/common/attachment/__init__.py
@@ -95,7 +95,7 @@ class LockableFSAttachmentDelegate(FSAttachmentDelegate):
         ) or not service_obj[0]['enable'] or service_obj[0]['state'] == 'RUNNING':
             return
 
-        await self.middleware.call('service.start', self.service)
+        await (await self.middleware.call('service.control', 'START', self.service)).wait(raise_error=True)
 
     async def query(self, path, enabled, options=None):
         results = []

--- a/src/middlewared/middlewared/common/attachment/certificate.py
+++ b/src/middlewared/middlewared/common/attachment/certificate.py
@@ -23,7 +23,7 @@ class CertificateServiceAttachmentDelegate(CertificateAttachmentDelegate, Servic
 
     CERT_FIELD = 'certificate'
     SERVICE = NotImplementedError
-    SERVICE_VERB = 'reload'
+    SERVICE_VERB = 'RELOAD'
 
     async def get_namespace(self):
         return self.SERVICE if self.NAMESPACE is NotImplementedError else self.NAMESPACE
@@ -37,7 +37,9 @@ class CertificateServiceAttachmentDelegate(CertificateAttachmentDelegate, Servic
 
     async def redeploy(self, cert_id):
         if await self.middleware.call('service.started', self.SERVICE):
-            await self.middleware.call(f'service.{self.SERVICE_VERB}', self.SERVICE)
+            await (
+                await self.middleware.call('service.control', self.SERVICE_VERB, self.SERVICE)
+            ).wait(raise_error=True)
 
 
 class CertificateCRUDServiceAttachmentDelegate(CertificateAttachmentDelegate, ServiceChangeMixin):

--- a/src/middlewared/middlewared/migration/0002_shell_linux.py
+++ b/src/middlewared/middlewared/migration/0002_shell_linux.py
@@ -27,4 +27,4 @@ def migrate(middleware):
         updated = True
 
     if updated:
-        middleware.call_sync("service.reload", "user")
+        middleware.call_sync("service.control", "RELOAD", "user").wait_sync(raise_error=True)

--- a/src/middlewared/middlewared/migration/0003_iscsi_vendor.py
+++ b/src/middlewared/middlewared/migration/0003_iscsi_vendor.py
@@ -12,4 +12,4 @@ async def migrate(middleware):
         )
 
     if extents:
-        await middleware.call('service.reload', 'iscsitarget')
+        await (await middleware.call('service.control', 'RELOAD', 'iscsitarget')).wait(raise_error=True)

--- a/src/middlewared/middlewared/migration/0004_ntp_default_servers_linux.py
+++ b/src/middlewared/middlewared/migration/0004_ntp_default_servers_linux.py
@@ -12,4 +12,4 @@ async def migrate(middleware):
         )
 
     if servers:
-        await middleware.call('service.restart', 'ntpd')
+        await (await middleware.call('service.control', 'RESTART', 'ntpd')).wait(raise_error=True)

--- a/src/middlewared/middlewared/migration/0006_system_cert.py
+++ b/src/middlewared/middlewared/migration/0006_system_cert.py
@@ -8,4 +8,4 @@ async def migrate(middleware):
         'certificate.cert_services_validation', system_cert['id'], 'certificate', False
     ):
         await middleware.call('certificate.setup_self_signed_cert_for_ui')
-        await middleware.call('service.restart', 'http')
+        await (await middleware.call('service.control', 'RESTART', 'http')).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/account_/2fa.py
+++ b/src/middlewared/middlewared/plugins/account_/2fa.py
@@ -208,7 +208,7 @@ class UserService(Service):
 
         if (await self.middleware.call('auth.twofactor.config'))['services']['ssh']:
             # This needs to be reloaded so that user's new secret can be reflected in sshd configuration
-            await self.middleware.call('service.reload', 'ssh')
+            await (await self.middleware.call('service.control', 'RELOAD', 'ssh')).wait(raise_error=True)
 
         user_entry = await self.translate_username(username)
         twofactor_config = await self.twofactor_config(username)

--- a/src/middlewared/middlewared/plugins/auth_/2fa.py
+++ b/src/middlewared/middlewared/plugins/auth_/2fa.py
@@ -98,7 +98,7 @@ class TwoFactorAuthService(ConfigService):
         if not config['enabled']:
             await self.middleware.call('auth.set_authenticator_assurance_level', 'LEVEL_1')
 
-        await self.middleware.call('service.reload', 'ssh')
+        await (await self.middleware.call('service.control', 'RELOAD', 'ssh')).wait(raise_error=True)
         await self.middleware.call('etc.generate', 'user')
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/cloud_backup/crud.py
+++ b/src/middlewared/middlewared/plugins/cloud_backup/crud.py
@@ -102,7 +102,7 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
         cloud_backup = await self._compress(cloud_backup)
         cloud_backup["id"] = await self.middleware.call("datastore.insert", "tasks.cloud_backup",
                                                         {**cloud_backup, "job": None})
-        await self.middleware.call("service.restart", "cron")
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
 
         return await self.get_instance(cloud_backup["id"])
 
@@ -129,7 +129,7 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
         cloud_backup = await self._compress(cloud_backup)
 
         await self.middleware.call("datastore.update", "tasks.cloud_backup", id_, cloud_backup)
-        await self.middleware.call("service.restart", "cron")
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -141,7 +141,7 @@ class CloudBackupService(TaskPathService, CloudTaskServiceMixin, TaskStateMixin)
         await self.middleware.call("cloud_backup.abort", id_)
         await self.middleware.call("alert.oneshot_delete", "CloudBackupTaskFailed", id_)
         rv = await self.middleware.call("datastore.delete", "tasks.cloud_backup", id_)
-        await self.middleware.call("service.restart", "cron")
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
         return rv
 
     @private
@@ -189,7 +189,7 @@ class CloudBackupFSAttachmentDelegate(LockableFSAttachmentDelegate):
     resource_name = "path"
 
     async def restart_reload_services(self, attachments):
-        await self.middleware.call("service.restart", "cron")
+        await (await self.middleware.call("service.control", "RESTART", "cron")).wait(raise_error=True)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -139,7 +139,7 @@ class CronJobService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(data['id'])
 
@@ -169,7 +169,7 @@ class CronJobService(CRUDService):
                 {'prefix': self._config.datastore_prefix}
             )
 
-            await self.middleware.call('service.restart', 'cron')
+            await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -184,7 +184,7 @@ class CronJobService(CRUDService):
             id_
         )
 
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return response
 

--- a/src/middlewared/middlewared/plugins/crypto_/certificates.py
+++ b/src/middlewared/middlewared/plugins/crypto_/certificates.py
@@ -317,7 +317,7 @@ class CertificateService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self.middleware.call('service.start', 'ssl')
+        await (await self.middleware.call('service.control', 'START', 'ssl')).wait(raise_error=True)
 
         job.set_progress(100, 'Certificate created successfully')
 
@@ -461,7 +461,7 @@ class CertificateService(CRUDService):
                 {'prefix': self._config.datastore_prefix}
             )
 
-            await self.middleware.call('service.start', 'ssl')
+            await (await self.middleware.call('service.control', 'START', 'ssl')).wait(raise_error=True)
 
         job.set_progress(90, 'Finalizing changes')
 
@@ -532,7 +532,7 @@ class CertificateService(CRUDService):
             id_
         )
 
-        self.middleware.call_sync('service.start', 'ssl')
+        self.middleware.call_sync('service.control', 'START', 'ssl').wait_sync(raise_error=True)
 
         self.middleware.call_sync('alert.alert_source_clear_run', 'CertificateChecks')
 

--- a/src/middlewared/middlewared/plugins/crypto_/default_cert.py
+++ b/src/middlewared/middlewared/plugins/crypto_/default_cert.py
@@ -32,7 +32,7 @@ class CertificateService(Service):
             {'stg_guicertificate': cert_id}
         )
 
-        await self.middleware.call('service.start', 'ssl')
+        await (await self.middleware.call('service.control', 'START', 'ssl')).wait(raise_error=True)
 
     @private
     async def setup_self_signed_cert_for_ui_impl(self, cert_name):

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -194,7 +194,7 @@ class DirectoryServices(Service):
             ['enable', '=', True],
             ['state', '=', 'RUNNING']
         ]], ['service', 'in', DEPENDENT_SERVICES]]):
-            self.middleware.call_sync('service.restart', svc['service'])
+            self.middleware.call_sync('service.control', 'RESTART', svc['service']).wait_sync(raise_error=True)
 
     @private
     @job(lock='ds_init', lock_queue_size=1)

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_health_mixin.py
@@ -92,8 +92,8 @@ class ADHealthMixin:
 
         self._test_machine_account_password(domain_info['kdc_server'], machine_pass)
 
-        self.middleware.call_sync('service.stop', 'idmap')
-        self.middleware.call_sync('service.start', 'idmap', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'idmap').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'idmap', {'silent': False}).wait_sync(raise_error=True)
         self.logger.warning('Recovered from broken or missing AD secrets file')
 
     def _recover_ad(self, error: ADHealthError) -> None:
@@ -120,8 +120,8 @@ class ADHealthMixin:
                 # not recoverable
                 raise error from None
 
-        self.middleware.call_sync('service.stop', 'idmap')
-        self.middleware.call_sync('service.start', 'idmap', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'idmap').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'idmap', {'silent': False}).wait_sync(raise_error=True)
 
     def _health_check_ad(self):
         """
@@ -207,7 +207,7 @@ class ADHealthMixin:
 
         if not self.middleware.call_sync('service.started', 'idmap'):
             try:
-                self.middleware.call_sync('service.start', 'idmap', {'silent': False})
+                self.middleware.call_sync('service.control', 'START', 'idmap', {'silent': False}).wait_sync(raise_error=True)
             except CallError as e:
                 faulted_reason = str(e.errmsg)
                 raise ADHealthError(

--- a/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/activedirectory_join_mixin.py
@@ -44,8 +44,8 @@ class ADJoinMixin:
         for etc_file in DSType.AD.etc_files:
             self.middleware.call_sync('etc.generate', etc_file)
 
-        self.middleware.call_sync('service.stop', 'idmap')
-        self.middleware.call_sync('service.start', 'idmap', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'idmap').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'idmap', {'silent': False}).wait_sync(raise_error=True)
 
         # Wait for winbind to come online to provide some time for sysvol replication
         self._ad_wait_wbclient()

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_health_mixin.py
@@ -35,8 +35,8 @@ class IPAHealthMixin:
                 # not recoverable
                 raise error from None
 
-        self.middleware.call_sync('service.stop', 'sssd')
-        self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'sssd').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
 
     def _health_check_ipa(self) -> None:
         """
@@ -135,7 +135,7 @@ class IPAHealthMixin:
         # it appears in our directory services summary
         if not self.middleware.call_sync('service.started', 'sssd'):
             try:
-                self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+                self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
             except CallError as e:
                 self._faulted_reason = str(e)
                 raise IPAHealthError(

--- a/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ipa_join_mixin.py
@@ -136,8 +136,8 @@ class IPAJoinMixin:
         for etc_file in DSType.IPA.etc_files:
             self.middleware.call_sync('etc.generate', etc_file)
 
-        self.middleware.call_sync('service.stop', 'sssd')
-        self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'sssd').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
         self.middleware.call_sync('kerberos.start')
 
     def _ipa_insert_keytab(self, service: ipa_constants.IpaConfigName, keytab_data: str) -> None:

--- a/src/middlewared/middlewared/plugins/directoryservices_/ldap_health_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ldap_health_mixin.py
@@ -21,8 +21,8 @@ class LDAPHealthMixin:
                 # not recoverable
                 raise error from None
 
-        self.middleware.call_sync('service.stop', 'sssd')
-        self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'sssd').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
 
     def _health_check_ldap(self) -> None:
         """
@@ -57,7 +57,7 @@ class LDAPHealthMixin:
         # it appears in our directory services summary
         if not self.middleware.call_sync('service.started', 'sssd'):
             try:
-                self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+                self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
             except CallError as e:
                 self._faulted_reason = str(e)
                 raise LDAPHealthError(

--- a/src/middlewared/middlewared/plugins/directoryservices_/ldap_join_mixin.py
+++ b/src/middlewared/middlewared/plugins/directoryservices_/ldap_join_mixin.py
@@ -8,8 +8,8 @@ class LDAPJoinMixin:
 
         ldap_config = self.middleware.call_sync('ldap.config')
 
-        self.middleware.call_sync('service.stop', 'sssd')
-        self.middleware.call_sync('service.start', 'sssd', {'silent': False})
+        self.middleware.call_sync('service.control', 'STOP', 'sssd').wait_sync(raise_error=True)
+        self.middleware.call_sync('service.control', 'START', 'sssd', {'silent': False}).wait_sync(raise_error=True)
 
         if ldap_config['kerberos_realm']:
             self.middleware.call_sync('kerberos.start')

--- a/src/middlewared/middlewared/plugins/docker/attachments.py
+++ b/src/middlewared/middlewared/plugins/docker/attachments.py
@@ -37,7 +37,7 @@ class DockerFSAttachmentDelegate(FSAttachmentDelegate):
         if not attachments:
             return
         try:
-            await self.middleware.call('service.stop', self.service)
+            await (await self.middleware.call('service.control', 'STOP', self.service)).wait(raise_error=True)
         except Exception as e:
             self.middleware.logger.error('Failed to stop docker: %s', e)
 

--- a/src/middlewared/middlewared/plugins/docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/docker/migrate.py
@@ -21,7 +21,7 @@ class DockerService(Service):
             raise CallError(f'Failed to backup docker apps: {backup_job.error}')
 
         job.set_progress(35, 'Stopping docker service')
-        await self.middleware.call('service.stop', 'docker')
+        await (await self.middleware.call('service.control', 'STOP', 'docker')).wait(raise_error=True)
 
         try:
             job.set_progress(40, f'Replicating datasets from {old_config["pool"]!r} to {new_pool!r} pool')

--- a/src/middlewared/middlewared/plugins/docker/restore_backup.py
+++ b/src/middlewared/middlewared/plugins/docker/restore_backup.py
@@ -35,7 +35,7 @@ class DockerService(Service):
         job.set_progress(10, 'Basic validation complete')
 
         logger.debug('Restoring backup %r', backup_name)
-        self.middleware.call_sync('service.stop', 'docker')
+        self.middleware.call_sync('service.control', 'STOP', 'docker').wait_sync(raise_error=True)
         job.set_progress(20, 'Stopped Docker service')
 
         docker_config = self.middleware.call_sync('docker.config')

--- a/src/middlewared/middlewared/plugins/docker/state_management.py
+++ b/src/middlewared/middlewared/plugins/docker/state_management.py
@@ -52,7 +52,7 @@ class DockerStateService(Service):
             # Make sure correct ix-apps dataset is mounted
             if not await self.middleware.call('docker.fs_manage.ix_apps_is_mounted', config['dataset']):
                 raise CallError(f'{config["dataset"]!r} dataset is not mounted on {IX_APPS_MOUNT_PATH!r}')
-            await self.middleware.call('service.start', 'docker')
+            await (await self.middleware.call('service.control', 'START', 'docker')).wait(raise_error=True)
         except Exception as e:
             await self.set_status(Status.FAILED.value, str(e))
             raise
@@ -126,7 +126,7 @@ async def _event_system_ready(middleware, event_type, args):
 
 async def _event_system_shutdown(middleware, event_type, args):
     if await middleware.call('service.started', 'docker'):
-        middleware.create_task(middleware.call('service.stop', 'docker'))
+        await middleware.call('service.control', 'STOP', 'docker')  # No need to wait for this to complete
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/docker/update.py
+++ b/src/middlewared/middlewared/plugins/docker/update.py
@@ -184,7 +184,7 @@ class DockerService(ConfigService):
             if pool_changed or address_pools_changed or nvidia_changed:
                 job.set_progress(20, 'Stopping Docker service')
                 try:
-                    await self.middleware.call('service.stop', 'docker')
+                    await (await self.middleware.call('service.control', 'STOP', 'docker')).wait(raise_error=True)
                 except Exception as e:
                     raise CallError(f'Failed to stop docker service: {e}')
 
@@ -218,7 +218,7 @@ class DockerService(ConfigService):
                 if catalog_sync_job:
                     await catalog_sync_job.wait()
 
-                await self.middleware.call('service.start', 'docker')
+                await (await self.middleware.call('service.control', 'START', 'docker')).wait(raise_error=True)
 
             if config['pool'] and address_pools_changed:
                 job.set_progress(95, 'Initiating redeployment of applications to apply new address pools changes')

--- a/src/middlewared/middlewared/plugins/failover.py
+++ b/src/middlewared/middlewared/plugins/failover.py
@@ -1089,7 +1089,7 @@ async def hook_setup_ha(middleware, *args, **kwargs):
 
     if ssh_enabled and not remote_ssh_started:
         middleware.logger.debug('[HA] Starting SSH on standby node')
-        await middleware.call('failover.call_remote', 'service.start', ['ssh'])
+        await middleware.call('failover.call_remote', 'service.control', ['START', 'ssh'], {'job': True})
 
     middleware.logger.debug('[HA] Refreshing failover status')
     await middleware.call('failover.status_refresh')
@@ -1169,7 +1169,7 @@ async def service_remote(middleware, service, verb, options):
 
     try:
         await middleware.call('failover.call_remote', 'core.bulk', [
-            f'service.{verb}', [[service, options]]
+            'service.control', [[verb.upper(), service, options]]
         ], {'raise_connect_error': False})
     except Exception:
         middleware.logger.warning('Failed to run %s(%s)', verb, service, exc_info=True)

--- a/src/middlewared/middlewared/plugins/failover_/event.py
+++ b/src/middlewared/middlewared/plugins/failover_/event.py
@@ -74,10 +74,7 @@ class FailoverEventsService(Service):
 
     async def restart_service(self, service, timeout):
         logger.info('Restarting %s', service)
-        return await asyncio.wait_for(
-            self.middleware.create_task(self.middleware.call('service.restart', service, self.HA_PROPAGATE)),
-            timeout=timeout,
-        )
+        return await (await self.middleware.call('service.control', 'RESTART', service, self.HA_PROPAGATE)).wait(timeout=timeout)
 
     async def become_active_service(self, service, timeout):
         logger.info('Become active %s', service)
@@ -162,9 +159,12 @@ class FailoverEventsService(Service):
             except Exception:
                 self.logger.warning('Failed to refresh failover status on active node')
 
-    def run_call(self, method, *args):
+    def run_call(self, method, *args, job=False):
         try:
-            return self.middleware.call_sync(method, *args)
+            result = self.middleware.call_sync(method, *args)
+            if job:
+                result = result.wait_sync(raise_error=True, raise_error_forward_classes=(Exception,))
+            return result
         except IgnoreFailoverEvent:
             # `self.validate()` calls this method
             raise
@@ -509,7 +509,7 @@ class FailoverEventsService(Service):
         logger.info('Pausing failover event processing')
         self.run_call('vrrpthread.pause_events')
         logger.info('Taking ownership of all VIPs')
-        self.run_call('service.reload', 'keepalived', self.HA_PROPAGATE)
+        self.run_call('service.control', 'RELOAD', 'keepalived', self.HA_PROPAGATE, job=True)
         logger.info('Unpausing failover event processing')
         self.run_call('vrrpthread.unpause_events')
         logger.info('Done unpausing failover event processing')
@@ -732,7 +732,7 @@ class FailoverEventsService(Service):
         logger.info('Done restarting remaining services')
 
         logger.info('Restarting reporting metrics')
-        self.run_call('service.restart', 'netdata')
+        self.run_call('service.control', 'RESTART', 'netdata', job=True)
         logger.info('Done restarting reporting metrics')
 
         logger.info('Updating replication tasks')
@@ -851,7 +851,7 @@ class FailoverEventsService(Service):
         # We stop netdata before exporting pools because otherwise we might have erroneous stuff
         # getting logged and causing spam
         logger.info('Stopping reporting metrics')
-        self.run_call('service.stop', 'netdata', self.HA_PROPAGATE)
+        self.run_call('service.control', 'STOP', 'netdata', self.HA_PROPAGATE, job=True)
 
         logger.info('Blocking network traffic.')
         fw_drop_job = self.run_call('failover.firewall.drop_all')
@@ -865,7 +865,7 @@ class FailoverEventsService(Service):
         logger.info('Pausing failover event processing')
         self.run_call('vrrpthread.pause_events')
         logger.info('Transitioning all VIPs off this node')
-        self.run_call('service.stop', 'keepalived', self.HA_PROPAGATE)
+        self.run_call('service.control', 'STOP', 'keepalived', self.HA_PROPAGATE, job=True)
 
         # ticket 23361 enabled a feature to send email alerts when an unclean reboot occurrs.
         # TrueNAS HA, by design, has a triggered unclean shutdown.
@@ -949,14 +949,14 @@ class FailoverEventsService(Service):
         self.run_call('truecommand.stop_truecommand_service')
 
         logger.info('Stopping NFS mountd service')
-        self.run_call('service.stop', 'mountd')
+        self.run_call('service.control', 'STOP', 'mountd', job=True)
 
         # we keep SSH running on both controllers (if it's enabled by user)
         filters = [['srv_service', '=', 'ssh']]
         options = {'get': True}
         if self.run_call('datastore.query', 'services.services', filters, options)['srv_enable']:
             logger.info('Restarting SSH')
-            self.run_call('service.restart', 'ssh', self.HA_PROPAGATE)
+            self.run_call('service.control', 'RESTART', 'ssh', self.HA_PROPAGATE, job=True)
 
         if self.run_call('iscsi.global.alua_enabled'):
             if self.run_call('service.started_or_enabled', 'iscsitarget'):
@@ -967,20 +967,20 @@ class FailoverEventsService(Service):
 
                 # The most likely situation is that scst is not running
                 if self.run_call('iscsi.scst.is_kernel_module_loaded'):
-                    self.run_call('service.restart', 'iscsitarget', self.HA_PROPAGATE)
+                    self.run_call('service.control', 'RESTART', 'iscsitarget', self.HA_PROPAGATE, job=True)
                 else:
-                    self.run_call('service.start', 'iscsitarget', self.HA_PROPAGATE)
+                    self.run_call('service.control', 'START', 'iscsitarget', self.HA_PROPAGATE, job=True)
 
         if self.run_call('nvmet.global.ana_active') and self.run_call('service.started_or_enabled', 'nvmet'):
             if self.run_call('nvmet.global.running'):
                 logger.info('Reloading NVMe-oF target for ANA')
-                self.run_call('service.reload', 'nvmet', self.HA_PROPAGATE)
+                self.run_call('service.control', 'RELOAD', 'nvmet', self.HA_PROPAGATE, job=True)
             else:
                 logger.info('Starting NVMe-oF target for ANA')
-                self.run_call('service.start', 'nvmet', self.HA_PROPAGATE)
+                self.run_call('service.control', 'START', 'nvmet', self.HA_PROPAGATE, job=True)
         elif self.run_call('nvmet.global.running'):
             logger.info('Stopping NVMe-oF target')
-            self.run_call('service.stop', 'nvmet', self.HA_PROPAGATE)
+            self.run_call('service.control', 'STOP', 'nvmet', self.HA_PROPAGATE, job=True)
         else:
             logger.info('No changes required for NVMe-oF target')
 
@@ -999,7 +999,7 @@ class FailoverEventsService(Service):
                            exc_info=True)
 
         logger.info('Starting VRRP daemon')
-        self.run_call('service.start', 'keepalived', self.HA_PROPAGATE)
+        self.run_call('service.control', 'START', 'keepalived', self.HA_PROPAGATE, job=True)
         logger.info('Unpausing failover event processing')
         self.run_call('vrrpthread.unpause_events')
 
@@ -1037,7 +1037,7 @@ class FailoverEventsService(Service):
 
         logger.info('Trying to gracefully stop docker service')
         try:
-            self.run_call('service.stop', 'docker')
+            self.run_call('service.control', 'STOP', 'docker', job=True)
         except Exception:
             logger.error('Failed to stop docker service gracefully', exc_info=True)
         else:

--- a/src/middlewared/middlewared/plugins/fcport.py
+++ b/src/middlewared/middlewared/plugins/fcport.py
@@ -398,5 +398,6 @@ class FCPortService(CRUDService):
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             if do_module_load:
                 await self.middleware.call('failover.call_remote', 'fcport.load_kernel_module')
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call('failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'],
+                                       {'job': True})
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -183,7 +183,7 @@ class FTPService(SystemServiceService):
         await self._update_service(old, new)
 
         if not old['tls'] and new['tls']:
-            await self.middleware.call('service.start', 'ssl')
+            await (await self.middleware.call('service.control', 'START', 'ssl')).wait(raise_error=True)
 
         return new
 
@@ -200,7 +200,7 @@ async def pool_post_import(middleware, pool):
         finally:
             return
 
-    await middleware.call("service.reload", "ftp")
+    await (await middleware.call("service.control", "RELOAD", "ftp")).wait(raise_error=True)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/interface/configure.py
+++ b/src/middlewared/middlewared/plugins/interface/configure.py
@@ -86,9 +86,9 @@ class InterfaceService(Service):
 
         if vip or alias_vips:
             if not self.middleware.call_sync('service.started', 'keepalived'):
-                self.middleware.call_sync('service.start', 'keepalived')
+                self.middleware.call_sync('service.control', 'START', 'keepalived').wait_sync(raise_error=True)
             else:
-                self.middleware.call_sync('service.reload', 'keepalived')
+                self.middleware.call_sync('service.control', 'RELOAD', 'keepalived').wait_sync(raise_error=True)
 
         # Add addresses in database and not configured
         for addr in (addrs_database - addrs_configured):

--- a/src/middlewared/middlewared/plugins/ipmi.py
+++ b/src/middlewared/middlewared/plugins/ipmi.py
@@ -26,4 +26,4 @@ async def setup(middleware):
         # BMC device, it always reports as a failure which is expected since no IPMI device exists. Instead
         # we check to see if dmidecode reports an ipmi device via type "38" of the SMBIOS spec. It's not
         # fool-proof but it's the best we got atm.
-        await middleware.call('service.start', 'openipmi')
+        await (await middleware.call('service.control', 'START', 'openipmi')).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/iscsi_global.py
@@ -156,18 +156,24 @@ class ISCSIGlobalService(SystemServiceService):
         licensed = await self.middleware.call('failover.licensed')
         if licensed and old['alua'] != new['alua']:
             if not new['alua']:
-                await self.middleware.call('failover.call_remote', 'service.stop', ['iscsitarget'])
+                await self.middleware.call(
+                    'failover.call_remote', 'service.control', ['STOP', 'iscsitarget'], {'job': True}
+                )
                 await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_targets')
 
         await self._update_service(old, new, options={'ha_propagate': False})
 
         if licensed and old['alua'] != new['alua']:
             if new['alua']:
-                await self.middleware.call('failover.call_remote', 'service.start', ['iscsitarget'])
+                await self.middleware.call(
+                    'failover.call_remote', 'service.control', ['START', 'iscsitarget'], {'job': True},
+                )
             # Force a scst.conf update
             # When turning off ALUA we want to clean up scst.conf, and when turning it on
             # we want to give any existing target a kick to come up as a dev_disk
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call(
+                'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+            )
 
         # If we have just turned off iSNS then work around a short-coming in scstadmin reload
         if old['isns_servers'] != new['isns_servers'] and not servers:
@@ -181,10 +187,14 @@ class ISCSIGlobalService(SystemServiceService):
         # If we have changed the iSER setting and the service is running then restart it
         if old['iser'] != new['iser']:
             if await self.middleware.call('service.started', 'iscsitarget'):
-                await self.middleware.call('service.restart', 'iscsitarget', {'ha_propagate': False})
+                await (
+                    await self.middleware.call('service.control', 'RESTART', 'iscsitarget', {'ha_propagate': False})
+                ).wait(raise_error=True)
                 if licensed and new['alua'] and old['alua']:
                     # Only need to restart the remote service if it was already running
-                    await self.middleware.call('failover.call_remote', 'service.restart', ['iscsitarget'])
+                    await self.middleware.call(
+                        'failover.call_remote', 'service.control', ['RESTART', 'iscsitarget'], {'job': True},
+                    )
 
         return await self.config()
 

--- a/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/target_to_extent.py
@@ -70,7 +70,9 @@ class iSCSITargetToExtentService(CRUDService):
 
         await self._service_change('iscsitarget', 'reload', options={'ha_propagate': False})
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call(
+                'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+            )
             await self.middleware.call('iscsi.alua.wait_cluster_mode', data['target'], data['extent'])
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
@@ -182,7 +184,9 @@ class iSCSITargetToExtentService(CRUDService):
                 if e.errno != CallError.ENOMETHOD:
                     self.logger.warning('Failed up update STANDBY node', exc_info=True)
                     # Better to continue than to raise the exception
-                await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+                await self.middleware.call(
+                    'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+                )
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return result

--- a/src/middlewared/middlewared/plugins/iscsi_/targets.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/targets.py
@@ -141,7 +141,9 @@ class iSCSITargetService(CRUDService):
 
         # Then process the remote (BACKUP) config if we are HA and ALUA is enabled.
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call(
+                'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+            )
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 
         return await self.get_instance(pk)
@@ -355,7 +357,9 @@ class iSCSITargetService(CRUDService):
         alua_enabled = await self.middleware.call("iscsi.global.alua_enabled")
         run_on_peer = alua_enabled and await self.middleware.call('failover.remote_connected')
         if run_on_peer:
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call(
+                'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+            )
 
         # NOTE: Any parameters whose keys are omitted will be removed from the config i.e. we
         # will deliberately revert removed items to the SCST default value
@@ -417,7 +421,9 @@ class iSCSITargetService(CRUDService):
         # If HA and ALUA handle BACKUP first
         if await self.middleware.call("iscsi.global.alua_enabled") and await self.middleware.call('failover.remote_connected'):
             await self.middleware.call('failover.call_remote', 'iscsi.target.remove_target', [target["name"]])
-            await self.middleware.call('failover.call_remote', 'service.reload', ['iscsitarget'])
+            await self.middleware.call(
+                'failover.call_remote', 'service.control', ['RELOAD', 'iscsitarget'], {'job': True},
+            )
             await self.middleware.call('failover.call_remote', 'iscsi.target.logout_ha_target', [target["name"]])
             await self.middleware.call('iscsi.alua.wait_for_alua_settled')
 

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -620,7 +620,7 @@ class KerberosRealmService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
         await self.middleware.call('etc.generate', 'kerberos')
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
         return await self.get_instance(id_)
 
     @api_method(

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -643,7 +643,7 @@ class KeychainCredentialService(CRUDService):
             self.middleware.call_sync("service.update", "ssh", {"enable": True})
 
         if service["state"] != "RUNNING":
-            self.middleware.call_sync("service.start", "ssh")
+            self.middleware.call_sync("service.control", "START", "ssh").wait_sync(raise_error=True)
 
             # This might be the first time of the service being enabled
             # which will then result in new host keys we need to grab

--- a/src/middlewared/middlewared/plugins/kmip/attachment.py
+++ b/src/middlewared/middlewared/plugins/kmip/attachment.py
@@ -11,7 +11,7 @@ class KmipCertificateAttachment(CertificateServiceAttachmentDelegate):
 
     HUMAN_NAME = 'KMIP Service'
     SERVICE = 'kmip'
-    SERVICE_VERB = 'start'
+    SERVICE_VERB = 'START'
 
 
 class KMIPServicePortDelegate(ServicePortDelegate):

--- a/src/middlewared/middlewared/plugins/kmip/update.py
+++ b/src/middlewared/middlewared/plugins/kmip/update.py
@@ -170,7 +170,7 @@ class KMIPService(ConfigService):
             'datastore.update', self._config.datastore, old['id'], new,
         )
 
-        await self.middleware.call('service.start', 'kmip')
+        await (await self.middleware.call('service.control', 'START', 'kmip')).wait(raise_error=True)
         if new['enabled'] and old['enabled'] != new['enabled']:
             await self.middleware.call('kmip.initialize_keys')
         if any(old[k] != new[k] for k in ('enabled', 'manage_zfs_keys', 'manage_sed_disks')) or change_server:

--- a/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_to_docker/migrate.py
@@ -80,7 +80,7 @@ class K8stoDockerMigrationService(Service):
         docker_config = self.middleware.call_sync('docker.config')
         if docker_config['pool'] and docker_config['pool'] != kubernetes_pool:
             # For good measure we stop docker service and unset docker pool if any configured
-            self.middleware.call_sync('service.stop', 'docker')
+            self.middleware.call_sync('service.control', 'STOP', 'docker').wait_sync(raise_error=True)
             job.set_progress(15, 'Un-configuring docker service if configured')
             docker_job = self.middleware.call_sync('docker.update', {'pool': None})
             docker_job.wait_sync()

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -988,7 +988,7 @@ class LDAPService(ConfigService):
     async def __stop(self, job, ds_type):
         job.set_progress(0, 'Preparing to stop LDAP directory service.')
         await self.middleware.call('directoryservices.health.set_state', ds_type.value, DSStatus.DISABLED.name)
-        await self.middleware.call('service.stop', 'sssd')
+        await (await self.middleware.call('service.control', 'STOP', 'sssd')).wait(raise_error=True)
         for etc_file in ds_type.etc_files:
             await self.middleware.call('etc.generate', etc_file)
 

--- a/src/middlewared/middlewared/plugins/ldap_/cert_attachments.py
+++ b/src/middlewared/middlewared/plugins/ldap_/cert_attachments.py
@@ -5,7 +5,7 @@ class LdapCertificateAttachmentDelegate(CertificateServiceAttachmentDelegate):
 
     HUMAN_NAME = 'LDAP Service'
     SERVICE = 'ldap'
-    SERVICE_VERB = 'start'
+    SERVICE_VERB = 'START'
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/network_/static_routes.py
+++ b/src/middlewared/middlewared/plugins/network_/static_routes.py
@@ -48,7 +48,7 @@ class StaticRouteService(CRUDService):
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
 
-        await self.middleware.call('service.restart', 'routing')
+        await (await self.middleware.call('service.control', 'RESTART', 'routing')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -67,7 +67,7 @@ class StaticRouteService(CRUDService):
             'datastore.update', self._config.datastore, id_, new,
             {'prefix': self._config.datastore_prefix})
 
-        await self.middleware.call('service.restart', 'routing')
+        await (await self.middleware.call('service.control', 'RESTART', 'routing')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -130,7 +130,7 @@ class NTPServerService(CRUDService):
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
 
-        await self.middleware.call('service.restart', 'ntpd')
+        await (await self.middleware.call('service.control', 'RESTART', 'ntpd')).wait(raise_error=True)
 
         return await self.get_instance(data['id'])
 
@@ -150,7 +150,7 @@ class NTPServerService(CRUDService):
             'datastore.update', self._config.datastore, id_, new,
             {'prefix': self._config.datastore_prefix})
 
-        await self.middleware.call('service.restart', 'ntpd')
+        await (await self.middleware.call('service.control', 'RESTART', 'ntpd')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -161,7 +161,7 @@ class NTPServerService(CRUDService):
         """
         response = await self.middleware.call('datastore.delete', self._config.datastore, id_)
 
-        await self.middleware.call('service.restart', 'ntpd')
+        await (await self.middleware.call('service.control', 'RESTART', 'ntpd')).wait(raise_error=True)
 
         return response
 

--- a/src/middlewared/middlewared/plugins/nvmet/global.py
+++ b/src/middlewared/middlewared/plugins/nvmet/global.py
@@ -267,7 +267,7 @@ async def pool_post_import(middleware, pool):
             ('OR', [
                 ('device_path', '^', f'zvol/{name}/'),
                 ('device_path', '^', f'{path}/'),])]):
-            await middleware.call('service.reload', NVMET_SERVICE_NAME)
+            await (await middleware.call('service.control', 'RELOAD', NVMET_SERVICE_NAME)).wait(raise_error=True)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/nvmet/mixin.py
+++ b/src/middlewared/middlewared/plugins/nvmet/mixin.py
@@ -17,8 +17,8 @@ class NVMetStandbyMixin:
                 if new_state:
                     # Start on STANDBY node
                     await self.middleware.call('failover.call_remote',
-                                               'service.start', [NVMET_SERVICE_NAME, {'ha_propagate': False}])
+                                               'service.control', ['START', NVMET_SERVICE_NAME, {'ha_propagate': False}])
                 else:
                     # Stop on STANDBY node
                     await self.middleware.call('failover.call_remote',
-                                               'service.stop', [NVMET_SERVICE_NAME, {'ha_propagate': False}])
+                                               'service.control', ['STOP', NVMET_SERVICE_NAME, {'ha_propagate': False}])

--- a/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_processes.py
@@ -92,10 +92,10 @@ class PoolDatasetService(Service):
                         for attachment_delegate in await self.middleware.call('pool.dataset.get_attachment_delegates')
                     ):
                         self.logger.info('Restarting service %r that holds dataset %r', service, oid)
-                        await self.middleware.call('service.restart', service)
+                        await (await self.middleware.call('service.control', 'RESTART', service)).wait(raise_error=True)
                     else:
                         self.logger.info('Stopping service %r that holds dataset %r', service, oid)
-                        await self.middleware.call('service.stop', service)
+                        await (await self.middleware.call('service.control', 'STOP', service)).wait(raise_error=True)
                 else:
                     self.logger.info('Killing process %r (%r) that holds dataset %r', process['pid'],
                                      process['cmdline'], oid)

--- a/src/middlewared/middlewared/plugins/pool_/export.py
+++ b/src/middlewared/middlewared/plugins/pool_/export.py
@@ -181,7 +181,7 @@ class PoolService(Service):
         await self.middleware.call_hook('dataset.post_delete', pool['name'])
 
         # scrub needs to be regenerated in crontab
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
         self.middleware.send_event('pool.query', 'REMOVED', id=oid)

--- a/src/middlewared/middlewared/plugins/pool_/pool.py
+++ b/src/middlewared/middlewared/plugins/pool_/pool.py
@@ -179,7 +179,7 @@ class PoolService(CRUDService):
     @private
     async def restart_services(self):
         # regenerate crontab because of scrub
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
     async def _process_topology(self, schema_name, data, old=None):
         verrors = ValidationErrors()

--- a/src/middlewared/middlewared/plugins/pool_/resilver.py
+++ b/src/middlewared/middlewared/plugins/pool_/resilver.py
@@ -96,7 +96,7 @@ class PoolResilverService(ConfigService):
                 new_config
             )
 
-            await self.middleware.call('service.restart', 'cron')
+            await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
             await self.middleware.call('pool.configure_resilver_priority')
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/pool_/scrub.py
+++ b/src/middlewared/middlewared/plugins/pool_/scrub.py
@@ -131,7 +131,7 @@ class PoolScrubService(CRUDService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(data['id'])
 
@@ -164,7 +164,7 @@ class PoolScrubService(CRUDService):
                 {'prefix': self._config.datastore_prefix}
             )
 
-            await self.middleware.call('service.restart', 'cron')
+            await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -179,7 +179,7 @@ class PoolScrubService(CRUDService):
             id_
         )
 
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
         return response
 
     @api_method(PoolScrubScrubArgs, PoolScrubScrubResult, roles=['POOL_WRITE'])

--- a/src/middlewared/middlewared/plugins/reporting/export.py
+++ b/src/middlewared/middlewared/plugins/reporting/export.py
@@ -66,7 +66,7 @@ class ReportingExportsService(CRUDService):
 
         if data['enabled']:
             # Only restart if this is enabled
-            await self.middleware.call('service.restart', 'netdata')
+            await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
 
         return await self.get_instance(oid)
 
@@ -90,7 +90,7 @@ class ReportingExportsService(CRUDService):
             new
         )
 
-        await self.middleware.call('service.restart', 'netdata')
+        await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
 
         return await self.get_instance(oid)
 
@@ -104,7 +104,7 @@ class ReportingExportsService(CRUDService):
             self._config.datastore,
             oid,
         )
-        await self.middleware.call('service.restart', 'netdata')
+        await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
         return True
 
     @api_method(ReportingExporterSchemasArgs, ReportingExporterSchemasResult, roles=['REPORTING_READ'])

--- a/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
+++ b/src/middlewared/middlewared/plugins/reporting/netdata_configure.py
@@ -44,4 +44,4 @@ class ReportingService(Service):
         if await self.middleware.call('failover.licensed'):
             return
 
-        await self.middleware.call('service.start', 'netdata')
+        await (await self.middleware.call('service.control', 'START', 'netdata')).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/reporting/update.py
+++ b/src/middlewared/middlewared/plugins/reporting/update.py
@@ -37,7 +37,7 @@ class ReportingService(ConfigService):
 
         await self.middleware.call('datastore.update', self._config.datastore, old_config['id'], config)
 
-        await self.middleware.call('service.restart', 'netdata')
+        await (await self.middleware.call('service.control', 'RESTART', 'netdata')).wait(raise_error=True)
         return await self.config()
 
     @filterable_api_method(roles=['REPORTING_READ'], item=ReportingGraph, cli_private=True)

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -376,7 +376,7 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
             data,
             {'prefix': self._config.datastore_prefix}
         )
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(data['id'])
 
@@ -409,7 +409,7 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
             new,
             {'prefix': self._config.datastore_prefix}
         )
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -419,7 +419,7 @@ class RsyncTaskService(TaskPathService, TaskStateMixin):
         Delete Rsync Task of `id`.
         """
         res = await self.middleware.call('datastore.delete', self._config.datastore, id_)
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
         return res
 
     @private
@@ -580,7 +580,7 @@ class RsyncFSAttachmentDelegate(LockableFSAttachmentDelegate):
     resource_name = 'path'
 
     async def restart_reload_services(self, attachments):
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/service_/services/cifs.py
+++ b/src/middlewared/middlewared/plugins/service_/services/cifs.py
@@ -20,11 +20,11 @@ class CIFSService(SimpleService):
 
     async def after_start(self):
         # We reconfigure mdns (add SMB service, possibly also ADISK)
-        await self.middleware.call('service.reload', 'mdns')
+        await (await self.middleware.call('service.control', 'RELOAD', 'mdns')).wait(raise_error=True)
 
     async def stop(self):
         await self._systemd_unit("smbd", "stop")
 
     async def after_stop(self):
         # reconfigure mdns (remove SMB service, possibly also ADISK)
-        await self.middleware.call('service.reload', 'mdns')
+        await (await self.middleware.call('service.control', 'RELOAD', 'mdns')).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -68,4 +68,4 @@ class ISCSITargetService(SimpleService):
                     self.logger.warning('Failover exception', exc_info=True)
                     # Fall through
         # Fallback to doing a regular restart
-        return await self.middleware.call('service.restart', self.name, {'ha_propagate': False})
+        return await (await self.middleware.call('service.control', 'RESTART', self.name, {'ha_propagate': False})).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -22,7 +22,7 @@ class KmipService(PseudoServiceBase):
     name = "kmip"
 
     async def start(self):
-        await self.middleware.call("service.start", "ssl")
+        await (await self.middleware.call("service.control", "START", "ssl")).wait(raise_error=True)
         await self.middleware.call("etc.generate", "kmip")
 
     async def get_state(self):
@@ -49,7 +49,7 @@ class HostnameService(PseudoServiceBase):
 
     async def reload(self):
         await self.middleware.call("etc.generate", "hostname")
-        await self.middleware.call("service.restart", "mdns")
+        await (await self.middleware.call("service.control", "RESTART", "mdns")).wait(raise_error=True)
 
 
 class HttpService(PseudoServiceBase):
@@ -82,8 +82,8 @@ class NetworkGeneralService(PseudoServiceBase):
     reloadable = True
 
     async def reload(self):
-        await self.middleware.call("service.reload", "resolvconf")
-        await self.middleware.call("service.restart", "routing")
+        await (await self.middleware.call("service.control", "RELOAD", "resolvconf")).wait(raise_error=True)
+        await (await self.middleware.call("service.control", "RESTART", "routing")).wait(raise_error=True)
 
 
 class NfsMountdService(PseudoServiceBase):
@@ -135,7 +135,7 @@ class ResolvConfService(PseudoServiceBase):
     reloadable = True
 
     async def reload(self):
-        await self.middleware.call("service.reload", "hostname")
+        await (await self.middleware.call("service.control", "RELOAD", "hostname")).wait(raise_error=True)
         await self.middleware.call("dns.sync")
 
 
@@ -179,7 +179,7 @@ class TimeservicesService(PseudoServiceBase):
     reloadable = True
 
     async def reload(self):
-        await self.middleware.call("service.restart", "ntpd")
+        await (await self.middleware.call("service.control", "RESTART", "ntpd")).wait(raise_error=True)
 
         settings = await self.middleware.call("datastore.config", "system.settings")
         await self.middleware.call("core.environ_update", {"TZ": settings["stg_timezone"]})

--- a/src/middlewared/middlewared/plugins/service_/services/ups.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ups.py
@@ -23,7 +23,7 @@ class UPSService(SimpleService):
 
     async def after_start(self):
         # Reconfigure mdns (add nut service)
-        await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
+        await (await self.middleware.call('service.control', 'RELOAD', 'mdns', {'ha_propagate': False})).wait(raise_error=True)
 
     async def before_stop(self):
         await self.middleware.call("ups.dismiss_alerts")
@@ -36,4 +36,4 @@ class UPSService(SimpleService):
 
     async def after_stop(self):
         # Reconfigure mdns (remove nut service)
-        await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
+        await (await self.middleware.call('service.control', 'RELOAD', 'mdns', {'ha_propagate': False})).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -353,10 +353,10 @@ class SMBService(ConfigService):
         job.set_progress(70, 'Checking SMB server status.')
         if await self.middleware.call("service.started_or_enabled", "cifs"):
             job.set_progress(80, 'Restarting SMB service.')
-            await self.middleware.call("service.restart", "cifs", {"ha_propagate": False})
+            await (await self.middleware.call("service.control", "RESTART", "cifs", {"ha_propagate": False})).wait(raise_error=True)
 
         # Ensure that winbind is running once we configure SMB service
-        await self.middleware.call('service.restart', 'idmap', {'ha_propagate': False})
+        await (await self.middleware.call('service.control', 'RESTART', 'idmap', {'ha_propagate': False})).wait(raise_error=True)
 
         job.set_progress(100, 'Finished configuring SMB.')
 
@@ -803,7 +803,7 @@ class SharingSMBService(SharingService):
             await self._service_change('cifs', 'reload')
 
         if is_time_machine_share(data):
-            await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
+            await (await self.middleware.call('service.control', 'RELOAD', 'mdns', {'ha_propagate': False})).wait(raise_error=True)
 
         return await self.get_instance(data['id'])
 
@@ -967,7 +967,7 @@ class SharingSMBService(SharingService):
             await self._service_change('cifs', 'reload')
 
         if check_mdns or old['timemachine'] != new['timemachine']:
-            await self.middleware.call('service.reload', 'mdns')
+            await (await self.middleware.call('service.control', 'RELOAD', 'mdns')).wait(raise_error=True)
 
         return await self.get_instance(id_)
 
@@ -997,7 +997,7 @@ class SharingSMBService(SharingService):
                 self.logger.debug('Failed to delete share ACL for [%s].', share_name, exc_info=True)
 
         if is_time_machine_share(share):
-            await self.middleware.call('service.reload', 'mdns', {'ha_propagate': False})
+            await (await self.middleware.call('service.control', 'RELOAD', 'mdns', {'ha_propagate': False})).wait(raise_error=True)
 
         await self.middleware.call('etc.generate', 'smb')
         return result
@@ -1648,7 +1648,7 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
             return
 
         await self.middleware.call('etc.generate', 'smb')
-        await self.middleware.call('service.reload', 'mdns')
+        await (await self.middleware.call('service.control', 'RELOAD', 'mdns')).wait(raise_error=True)
 
     async def is_child_of_path(self, resource, path, check_parent, exact_match):
         return await super().is_child_of_path(resource, path, check_parent, exact_match) if resource.get(

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -702,14 +702,14 @@ class SystemDatasetService(ConfigService):
 
             try:
                 for i in restart:
-                    self.middleware.call_sync('service.stop', i)
+                    self.middleware.call_sync('service.control', 'STOP', i).wait_sync(raise_error=True)
 
                 close_sysdataset_tdb_handles()
                 yield
             finally:
                 restart.reverse()
                 for i in restart:
-                    self.middleware.call_sync('service.start', i)
+                    self.middleware.call_sync('service.control', 'START', i).wait_sync(raise_error=True)
 
     @private
     def get_system_dataset_spec(self, pool, uid):

--- a/src/middlewared/middlewared/plugins/system_advanced/config.py
+++ b/src/middlewared/middlewared/plugins/system_advanced/config.py
@@ -195,20 +195,20 @@ class SystemAdvancedService(ConfigService):
             )
 
             if original_data['boot_scrub'] != config_data['boot_scrub']:
-                await self.middleware.call('service.restart', 'cron')
+                await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
             generate_grub = original_data['kernel_extra_options'] != config_data['kernel_extra_options']
             if original_data['motd'] != config_data['motd']:
                 await self.middleware.call('etc.generate', 'motd')
 
             if original_data['login_banner'] != config_data['login_banner']:
-                await self.middleware.call('service.reload', 'ssh')
+                await (await self.middleware.call('service.control', 'RELOAD', 'ssh')).wait(raise_error=True)
 
             if original_data['powerdaemon'] != config_data['powerdaemon']:
-                await self.middleware.call('service.restart', 'powerd')
+                await (await self.middleware.call('service.control', 'RESTART', 'powerd')).wait(raise_error=True)
 
             if original_data['fqdn_syslog'] != config_data['fqdn_syslog']:
-                await self.middleware.call('service.restart', 'syslogd')
+                await (await self.middleware.call('service.control', 'RESTART', 'syslogd')).wait(raise_error=True)
 
             if (
                 original_data['sysloglevel'].lower() != config_data['sysloglevel'].lower() or
@@ -217,7 +217,7 @@ class SystemAdvancedService(ConfigService):
                 original_data['syslog_tls_certificate'] != config_data['syslog_tls_certificate'] or
                 original_data['syslog_audit'] != config_data['syslog_audit']
             ):
-                await self.middleware.call('service.restart', 'syslogd')
+                await (await self.middleware.call('service.control', 'RESTART', 'syslogd')).wait(raise_error=True)
 
             if config_data['sed_passwd'] and original_data['sed_passwd'] != config_data['sed_passwd']:
                 await self.middleware.call('kmip.sync_sed_keys')

--- a/src/middlewared/middlewared/plugins/system_general/ui.py
+++ b/src/middlewared/middlewared/plugins/system_general/ui.py
@@ -100,7 +100,7 @@ class SystemGeneralService(Service):
         event_loop.call_later(
             delay,
             lambda: self.middleware.create_task(
-                self.middleware.call("service.restart", "http")
+                self.middleware.call("service.control", "RESTART", "http")
             ),
         )
 

--- a/src/middlewared/middlewared/plugins/system_general/update.py
+++ b/src/middlewared/middlewared/plugins/system_general/update.py
@@ -227,13 +227,13 @@ class SystemGeneralService(ConfigService):
 
         if config['timezone'] != new_config['timezone']:
             await self.middleware.call('zettarepl.update_config', {'timezone': new_config['timezone']})
-            await self.middleware.call('service.reload', 'timeservices')
-            await self.middleware.call('service.restart', 'cron')
+            await (await self.middleware.call('service.control', 'RELOAD', 'timeservices')).wait(raise_error=True)
+            await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
         if config['ds_auth'] != new_config['ds_auth']:
             await self.middleware.call('etc.generate', 'pam_middleware')
 
-        await self.middleware.call('service.start', 'ssl')
+        await (await self.middleware.call('service.control', 'START', 'ssl')).wait(raise_error=True)
 
         if rollback_timeout is not None:
             self._original_datastore = original_datastore

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -100,8 +100,8 @@ class TruecommandService(Service):
             if TruecommandStatus(config['api_key_state']) == TruecommandStatus.CONNECTED and all(
                 config[k] for k in ('wg_private_key', 'remote_address', 'endpoint', 'tc_public_key', 'wg_address')
             ):
-                await self.middleware.call('service.start', 'truecommand', {'ha_propagate': False})
-                await self.middleware.call('service.reload', 'http', {'ha_propagate': False})
+                await (await self.middleware.call('service.control', 'START', 'truecommand', {'ha_propagate': False})).wait(raise_error=True)
+                await (await self.middleware.call('service.control', 'RELOAD', 'http', {'ha_propagate': False})).wait(raise_error=True)
                 asyncio.get_event_loop().call_later(
                     30,  # 30 seconds is enough time to initiate a health check to see if the connection is alive
                     lambda: self.middleware.create_task(self.middleware.call('truecommand.health_check')),
@@ -114,6 +114,6 @@ class TruecommandService(Service):
 
     @private
     async def stop_truecommand_service(self):
-        await self.middleware.call('service.reload', 'http')
+        await (await self.middleware.call('service.control', 'RELOAD', 'http')).wait(raise_error=True)
         if await self.middleware.call('service.started', 'truecommand'):
-            await self.middleware.call('service.stop', 'truecommand')
+            await (await self.middleware.call('service.control', 'STOP', 'truecommand')).wait(raise_error=True)

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -95,7 +95,7 @@ class UpdateService(Service):
         """
         config = await self.middleware.call('datastore.config', 'system.update')
         await self.middleware.call('datastore.update', 'system.update', config['id'], {'upd_autocheck': autocheck})
-        await self.middleware.call('service.restart', 'cron')
+        await (await self.middleware.call('service.control', 'RESTART', 'cron')).wait(raise_error=True)
 
     @api_method(UpdateGetTrainsArgs, UpdateGetTrainsResult, roles=['SYSTEM_UPDATE_READ'])
     def get_trains(self):

--- a/src/middlewared/middlewared/plugins/virt/global.py
+++ b/src/middlewared/middlewared/plugins/virt/global.py
@@ -494,7 +494,7 @@ class VirtGlobalService(ConfigService):
             self.logger.debug('No pool set for virtualization, skipping.')
             raise NoPoolConfigured()
         else:
-            await self.middleware.call('service.start', 'incus', {'ha_propagate': False})
+            await (await self.middleware.call('service.control', 'START', 'incus', {'ha_propagate': False})).wait(raise_error=True)
 
         # Set up the default storage pool
         for pool in config['storage_pools']:
@@ -598,7 +598,7 @@ class VirtGlobalService(ConfigService):
 
         if to_import:
             await self.recover(to_import)
-            await self.middleware.call('service.restart', 'incus', {'ha_propagate': False})
+            await (await self.middleware.call('service.control', 'RESTART', 'incus', {'ha_propagate': False})).wait(raise_error=True)
 
     @private
     @job(lock='virt_global_reset')
@@ -621,7 +621,7 @@ class VirtGlobalService(ConfigService):
             if await self.middleware.call('virt.instance.query', [('status', '=', 'RUNNING')]):
                 raise CallError('Failed to stop instances')
 
-        await self.middleware.call('service.stop', 'incus', {'ha_propagate': False})
+        await (await self.middleware.call('service.control', 'STOP', 'incus', {'ha_propagate': False})).wait(raise_error=True)
         if await self.middleware.call('service.started', 'incus'):
             raise CallError('Failed to stop virtualization service')
 
@@ -639,7 +639,7 @@ class VirtGlobalService(ConfigService):
         # and we do have instances datasets that might be mounted beneath
         await run(f'rm -rf --one-file-system /var/lib/incus/*', shell=True, check=True)
 
-        if start and not await self.middleware.call('service.start', 'incus', {'ha_propagate': False}):
+        if start and not await (await self.middleware.call('service.control', 'START', 'incus', {'ha_propagate': False})).wait(raise_error=True):
             raise CallError('Failed to start virtualization service')
 
         if not start:

--- a/src/middlewared/middlewared/service/service_mixin.py
+++ b/src/middlewared/middlewared/service/service_mixin.py
@@ -16,7 +16,9 @@ class ServiceChangeMixin:
         await self.middleware.call('etc.generate', 'rc')
 
         if svc_state == 'running':
-            started = await self.middleware.call(f'service.{verb}', service, options or {})
+            started = await (
+                await self.middleware.call('service.control', verb.upper(), service, options or {})
+            ).wait(raise_error=True)
 
             if not started:
                 raise CallError(

--- a/src/middlewared/middlewared/test/integration/assets/ftp.py
+++ b/src/middlewared/middlewared/test/integration/assets/ftp.py
@@ -10,12 +10,12 @@ from middlewared.test.integration.utils import call, ssh
 def ftp_server(config=None):
     if config is not None:
         call("ftp.update", config)
-    call("service.start", "ftp")
+    call("service.control", "START", "ftp")
 
     try:
         yield
     finally:
-        call("service.stop", "ftp")
+        call("service.control", "STOP", "ftp")
 
 
 @contextlib.contextmanager

--- a/src/middlewared/middlewared/test/integration/assets/nfs.py
+++ b/src/middlewared/middlewared/test/integration/assets/nfs.py
@@ -13,11 +13,11 @@ __all__ = ["nfs_share", "nfs_server"]
 @contextlib.contextmanager
 def nfs_server():
     try:
-        res = call('service.start', 'nfs', {'silent': False})
+        res = call('service.control', 'START', 'nfs', {'silent': False})
         sleep(1)
         yield res
     finally:
-        call('service.stop', 'nfs', {'silent': False})
+        call('service.control', 'STOP', 'nfs', {'silent': False})
 
 
 @contextlib.contextmanager
@@ -25,10 +25,10 @@ def nfs_share(dataset):
     share = call("sharing.nfs.create", {
         "path": f"/mnt/{dataset}",
     })
-    assert call("service.start", "nfs")
+    assert call("service.control", "START", "nfs")
 
     try:
         yield share
     finally:
         call("sharing.nfs.delete", share["id"])
-        call("service.stop", "nfs")
+        call("service.control", "STOP", "nfs")

--- a/src/middlewared/middlewared/test/integration/assets/smb.py
+++ b/src/middlewared/middlewared/test/integration/assets/smb.py
@@ -36,7 +36,7 @@ def smb_share(path, name, options=None):
         "name": name,
         **(options or {})
     })
-    assert call("service.start", "cifs")
+    assert call("service.control", "START", "cifs")
 
     try:
         yield share
@@ -48,7 +48,7 @@ def smb_share(path, name, options=None):
             # this should not cause an error
             pass
 
-        call("service.stop", "cifs")
+        call("service.control", "STOP", "cifs")
 
 
 @contextlib.contextmanager

--- a/src/middlewared/middlewared/test/integration/utils/client.py
+++ b/src/middlewared/middlewared/test/integration/utils/client.py
@@ -7,7 +7,7 @@ import socket
 import requests
 
 from middlewared.service_exception import CallError
-from truenas_api_client import Client as TNClient
+from truenas_api_client import Client as TNClient, ClientException
 from truenas_api_client.utils import undefined
 
 from .pytest import fail
@@ -21,6 +21,7 @@ truenas_server object is used by both websocket client and REST client for deter
 server to access for API calls. For HA, the `ip` attribute should be set to the virtual IP
 of the truenas server.
 """
+
 
 class Client(TNClient):
     def uri_check(self, *args, **kwargs):
@@ -193,6 +194,14 @@ def client(*, auth=undefined, auth_required=True, py_exceptions=True, log_py_exc
                         resp = c.call("auth.login_ex", auth_req)
                     else:
                         raise
+                except ClientException as e:
+                    if e.errno == errno.EBUSY and e.error == 'Rate Limit Exceeded':
+                        # Same as above, but for clients with `py_exceptions=False`
+                        truenas_server.client.call("rate.limit.cache_clear")
+                        resp = c.call("auth.login_ex", auth_req)
+                    else:
+                        raise
+
                 if auth_required:
                     assert resp['response_type'] == 'SUCCESS'
             yield c

--- a/tests/api2/assets/websocket/service.py
+++ b/tests/api2/assets/websocket/service.py
@@ -14,13 +14,13 @@ def ensure_service_started(service_name, delay=0):
     if old_value:
         yield
     else:
-        call('service.start', service_name)
+        call('service.control', 'START', service_name, job=True)
         if delay:
             sleep(delay)
         try:
             yield
         finally:
-            call('service.stop', service_name)
+            call('service.control', 'STOP', service_name, job=True)
             if delay:
                 sleep(delay)
 
@@ -31,13 +31,13 @@ def ensure_service_stopped(service_name, delay=0):
     if not old_value:
         yield
     else:
-        call('service.stop', service_name)
+        call('service.control', 'STOP', service_name, job=True)
         if delay:
             sleep(delay)
         try:
             yield
         finally:
-            call('service.start', service_name)
+            call('service.control', 'START', service_name, job=True)
             if delay:
                 sleep(delay)
 
@@ -65,9 +65,9 @@ def ensure_service_enabled(service_name):
         new_config = call('service.query', [['service', '=', service_name]])[0]
         if new_config['state'] != old_config['state']:
             if old_config['state'] == 'RUNNING':
-                call('service.start', service_name)
+                call('service.control', 'START', service_name, job=True)
             else:
-                call('service.stop', service_name)
+                call('service.control', 'STOP', service_name, job=True)
 
 
 @contextlib.contextmanager
@@ -93,6 +93,6 @@ def ensure_service_disabled(service_name):
         new_config = call('service.query', [['service', '=', service_name]])[0]
         if new_config['state'] != old_config['state']:
             if old_config['state'] == 'RUNNING':
-                call('service.start', service_name)
+                call('service.control', 'START', service_name, job=True)
             else:
-                call('service.stop', service_name)
+                call('service.control', 'STOP', service_name, job=True)

--- a/tests/api2/test_001_ssh.py
+++ b/tests/api2/test_001_ssh.py
@@ -73,7 +73,7 @@ def test_004_enable_and_start_ssh(ws_client):
     assert ws_client.call('datastore.query', 'services.services', filters, options)['srv_enable'] is True
 
     # start ssh
-    ws_client.call('service.start', 'ssh')
+    ws_client.call('service.control', 'START', 'ssh', job=True)
     assert ws_client.call('service.query', [['service', '=', 'ssh']], options)['state'] == 'RUNNING'
 
 

--- a/tests/api2/test_015_services.py
+++ b/tests/api2/test_015_services.py
@@ -6,12 +6,13 @@ sys.path.append(apifolder)
 
 import pytest
 
-from middlewared.service_exception import CallError
+from truenas_api_client import ClientException
 from middlewared.test.integration.utils import call, ssh
 
 def test_001_oom_check():
     pid = call('core.get_pid')
     assert call('core.get_oom_score_adj', pid) == -1000
+
 
 @pytest.mark.flaky(reruns=5, reruns_delay=5)  # Sometimes systemd unit state is erroneously reported as active
 def test_non_silent_service_start_failure():
@@ -22,8 +23,8 @@ def test_non_silent_service_start_failure():
             has a timestamp and that timestamp changes
             with each failure
     """
-    with pytest.raises(CallError) as e:
-        call('service.start', 'ups', {'silent': False})
+    with pytest.raises(ClientException) as e:
+        call('service.control', 'START', 'ups', {'silent': False}, job=True)
 
     # Error looks like
     """
@@ -37,8 +38,8 @@ def test_non_silent_service_start_failure():
     Jan 10 08:49:14 systemd[1]: nut-monitor.service: Failed with result 'exit-code'.
     Jan 10 08:49:14 systemd[1]: Failed to start Network UPS Tools - power device monitor and shutdown controller.
     """
-    lines1 = e.value.errmsg.splitlines()
-    first_ts, len_lines1 = ' '.join(lines1.pop(0).split()[:3]), len(lines1)
+    lines1 = e.value.error.splitlines()
+    first_ts, len_lines1 = ' '.join(lines1.pop(0).split()[:4]), len(lines1)
     assert any('nut-monitor[' in line for line in lines1), lines1
     assert any('systemd[' in line for line in lines1), lines1
 
@@ -52,8 +53,8 @@ def test_non_silent_service_start_failure():
     # with reality
     time.sleep(1)
 
-    with pytest.raises(CallError) as e:
-        call('service.start', 'ups', {'silent': False})
+    with pytest.raises(ClientException) as e:
+        call('service.control', 'START', 'ups', {'silent': False}, job=True)
 
     # Error looks like: (Notice timestamp change, which is what we verify
     """
@@ -67,8 +68,8 @@ def test_non_silent_service_start_failure():
     Jan 10 08:49:15 systemd[1]: nut-monitor.service: Failed with result 'exit-code'.
     Jan 10 08:49:15 systemd[1]: Failed to start Network UPS Tools - power device monitor and shutdown controller.
     """
-    lines2 = e.value.errmsg.splitlines()
-    second_ts, len_lines2 = ' '.join(lines2.pop(0).split()[:3]), len(lines2)
+    lines2 = e.value.error.splitlines()
+    second_ts, len_lines2 = ' '.join(lines2.pop(0).split()[:4]), len(lines2)
     assert any('nut-monitor[' in line for line in lines2), lines2
     assert any('systemd[' in line for line in lines2), lines2
 
@@ -80,4 +81,4 @@ def test_non_silent_service_start_failure():
     assert len_lines1 == len_lines2
 
     # Stop the service to avoid syslog spam
-    call('service.stop', 'ups')
+    call('service.control', 'STOP', 'ups', job=True)

--- a/tests/api2/test_030_activedirectory.py
+++ b/tests/api2/test_030_activedirectory.py
@@ -245,7 +245,7 @@ def test_activedirectory_smb_ops():
                 'type': 'ALLOW'
             }]
         ) as ds:
-            call('service.restart', 'cifs')
+            call('service.control', 'RESTART', 'cifs', job=True)
 
             with smb_share(f'/mnt/{ds}', {'name': SMB_NAME}):
                 with smb_connection(

--- a/tests/api2/test_200_ftp.py
+++ b/tests/api2/test_200_ftp.py
@@ -310,13 +310,13 @@ def ftp_server(service_state=None):
 
     try:
         # Start FTP service
-        call('service.start', 'ftp', {'silent': False})
+        call('service.control', 'START', 'ftp', {'silent': False}, job=True)
         yield
     finally:
         # proftpd can core dump if stopped while it's busy
         # processing a prior config change. Give it a sec.
         sleep(1)
-        call('service.stop', 'ftp', {'silent': False})
+        call('service.control', 'STOP', 'ftp', {'silent': False}, job=True)
         # Restore original service state
         if service_state is not None:
             ftp_set_service_enable_state(restore_state)
@@ -1398,7 +1398,7 @@ def test_085_ftp_service_starts_after_reboot():
 
 
 def test_100_ftp_service_stop():
-    call('service.stop', 'ftp', {'silent': False})
+    call('service.control', 'STOP', 'ftp', {'silent': False}, job=True)
     rv = query_ftp_service()
     assert rv['state'] == 'STOPPED'
     assert rv['enable'] is False

--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -110,12 +110,12 @@ def fix_iscsi_enabled():
 
 @pytest.fixture(scope='module')
 def fix_iscsi_started(fix_iscsi_enabled):
-    call('service.start', 'iscsitarget')
+    call('service.control', 'START', 'iscsitarget', job=True)
     sleep(1)
     try:
         yield
     finally:
-        call('service.stop', 'iscsitarget')
+        call('service.control', 'STOP', 'iscsitarget', job=True)
 
 
 def test_add_iscsi_initiator(fix_initiator):

--- a/tests/api2/test_262_iscsi_alua.py
+++ b/tests/api2/test_262_iscsi_alua.py
@@ -138,7 +138,7 @@ class TestFixtureConfiguredALUA:
     def alua_configured(self):
         assert call('failover.config')['disabled'] is False
         with ensure_service_enabled(SERVICE_NAME):
-            call('service.start', SERVICE_NAME)
+            call('service.control', 'START', SERVICE_NAME, job=True)
             with alua_enabled():
                 self.wait_for_settle()
                 with initiator_portal() as config:

--- a/tests/api2/test_300_nfs.py
+++ b/tests/api2/test_300_nfs.py
@@ -204,11 +204,11 @@ def set_nfs_service_state(do_what=None, expect_to_pass=True, fail_check=False):
 
     retval = None
     if expect_to_pass:
-        call(f'service.{do_what}', 'nfs', {'silent': False})
+        call('service.control', do_what.upper(), 'nfs', {'silent': False}, job=True)
         sleep(1)
     else:
         with pytest.raises(CallError) as e:
-            call(f'service.{do_what}', 'nfs', {'silent': False})
+            call('service.control', do_what.upper(), 'nfs', {'silent': False}, job=True)
         if fail_check:
             assert fail_check in str(e.value)
 
@@ -311,7 +311,7 @@ def run_missing_usrgrp_mapping_test(data: list[str], usrgrp, tmp_path, share, us
 
     # Remove the user/group and restart nfs
     call(f'{usrgrp}.delete', usrgrpInst['id'])
-    call('service.restart', 'nfs')
+    call('service.control', 'RESTART', 'nfs', job=True)
 
     # An alert should be generated
     alerts = call('alert.list')
@@ -326,7 +326,7 @@ def run_missing_usrgrp_mapping_test(data: list[str], usrgrp, tmp_path, share, us
 
     # Modify share to map with a built-in user or group and restart NFS
     call('sharing.nfs.update', share, {data[0]: "ftp"})
-    call('service.restart', 'nfs')
+    call('service.control', 'RESTART', 'nfs', job=True)
 
     # The alert should be cleared
     alerts = call('alert.list')
@@ -576,12 +576,12 @@ class TestNFSops:
         assert bootds_nfs['name'] == sysds['pool'] + "/.system/nfs"
 
         # Confirm the required entries are present
-        required_nfs_entries = set(["nfsdcld", "nfsdcltrack", "sm", "sm.bak", "state", "v4recovery"])
+        required_nfs_entries = {"nfsdcld", "nfsdcltrack", "sm", "sm.bak", "state", "v4recovery"}
         current_nfs_entries = set(list(ssh(f'ls {nfs_state_dir}').splitlines()))
         assert required_nfs_entries.issubset(current_nfs_entries)
 
         # Confirm proc entry reports expected value after nfs restart
-        call('service.restart', 'nfs')
+        call('service.control', 'RESTART', 'nfs', job=True)
         sleep(1)
         recovery_dir = ssh('cat /proc/fs/nfsd/nfsv4recoverydir').strip()
         assert recovery_dir == os.path.join(nfs_state_dir, 'v4recovery'), \
@@ -1955,7 +1955,7 @@ class TestNFSops:
             with nfs_db():
                 monkey_with_db()
                 ssh("rm -f /etc/nfs.conf")
-                call('service.restart', 'nfs')
+                call('service.control', 'RESTART', 'nfs', job=True)
                 confirm_clean()
 
 
@@ -2010,12 +2010,12 @@ def test_missing_or_empty_exports(exports):
     with nfs_config() as nfs_conf:
         try:
             # Start NFS
-            call('service.start', 'nfs')
+            call('service.control', 'START', 'nfs', job=True)
             sleep(1)
             confirm_nfsd_processes(nfs_conf['servers'])
         finally:
             # Return NFS to stopped condition
-            call('service.stop', 'nfs')
+            call('service.control', 'STOP', 'nfs', job=True)
             sleep(1)
 
     # Confirm stopped

--- a/tests/api2/test_310_service_announcement.py
+++ b/tests/api2/test_310_service_announcement.py
@@ -338,7 +338,7 @@ def test_001_initial_config(request):
     assert sa['mdns'] is True, sa
 
     # Let's restart avahi (in case we've updated middleware)
-    call('service.restart', 'mdns')
+    call('service.control', 'RESTART', 'mdns', job=True)
     ac = mDNSAnnounceCollector(truenas_server.ip, current_hostname)
     ac.find_items()
     ac.check_present(smb=False, time_machine=False)

--- a/tests/api2/test_420_smb.py
+++ b/tests/api2/test_420_smb.py
@@ -40,13 +40,13 @@ def smb_info():
                         'guest': SHAREUSER
                     })
                     call('service.update', 'cifs', {'enable': True})
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield {'dataset': ds, 'share': s}
                 finally:
                     call('smb.update', {
                         'guest': 'nobody'
                     })
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
                     call('service.update', 'cifs', {'enable': False})
 
 

--- a/tests/api2/test_425_smb_protocol.py
+++ b/tests/api2/test_425_smb_protocol.py
@@ -95,10 +95,10 @@ def initialize_for_smb_tests(request):
                     'auxsmbconf': 'zfs_core:base_user_quota = 1G'
                 }) as s:
                     try:
-                        call('service.start', 'cifs')
+                        call('service.control', 'START', 'cifs', job=True)
                         yield {'dataset': ds, 'share': s, 'user': u}
                     finally:
-                        call('service.stop', 'cifs')
+                        call('service.control', 'STOP', 'cifs', job=True)
             finally:
                 # In test_140_enable_aapl we turned afp on for the share, so wait until
                 # it has been destroyed before turning off aapl_extensions.

--- a/tests/api2/test_426_smb_vss.py
+++ b/tests/api2/test_426_smb_vss.py
@@ -155,7 +155,7 @@ def test_004_creating_a_smb_share_path(request):
 @pytest.mark.dependency(name="VSS_SMB_SERVICE_STARTED")
 def test_005_starting_cifs_service(request):
     depends(request, ["VSS_SHARE_CREATED"])
-    assert call("service.start", "cifs")
+    assert call("service.control", "START", "cifs", job=True)
 
 
 @pytest.mark.dependency(name="VSS_SMB1_ENABLED")
@@ -299,7 +299,7 @@ def test_051_disable_smb1(request):
 
 def test_052_stopping_smb_service(request):
     depends(request, ["VSS_SMB_SERVICE_STARTED"])
-    assert call("service.stop", "cifs")
+    assert call("service.control", "STOP", "cifs", job=True)
     sleep(1)
 
 

--- a/tests/api2/test_427_smb_acl.py
+++ b/tests/api2/test_427_smb_acl.py
@@ -112,10 +112,10 @@ def initialize_for_smb_tests(request):
         'password': SMB_PWD
     }) as u:
         try:
-            call('service.start', 'cifs')
+            call('service.control', 'START', 'cifs', job=True)
             yield {'user': u}
         finally:
-            call('service.stop', 'cifs')
+            call('service.control', 'STOP', 'cifs', job=True)
 
 
 @pytest.mark.dependency(name="SMB_SERVICE_STARTED")

--- a/tests/api2/test_435_smb_registry.py
+++ b/tests/api2/test_435_smb_registry.py
@@ -86,14 +86,14 @@ def setup_smb_shares(mountpoint):
         })
         SHARE_DICT[share] = new_share['id']
 
-    call('service.start', 'cifs')
+    call('service.control', 'START', 'cifs', job=True)
     try:
         yield SHARE_DICT
     finally:
         for share_id in SHARE_DICT.values():
             call('sharing.smb.delete', share_id)
 
-        call('service.stop', 'cifs')
+        call('service.control', 'STOP', 'cifs', job=True)
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_440_snmp.py
+++ b/tests/api2/test_440_snmp.py
@@ -65,8 +65,8 @@ EXPECTED_DEFAULT_STATE = {
 }
 
 CMD_STATE = {
-    "RUNNING": "start",
-    "STOPPED": "stop"
+    "RUNNING": "START",
+    "STOPPED": "STOP"
 }
 
 
@@ -79,13 +79,13 @@ def initialize_and_start_snmp():
     try:
         # Get initial config and start SNMP
         orig_config = call('snmp.config')
-        call('service.start', 'snmp')
+        call('service.control', 'START', 'snmp', job=True)
         yield orig_config
     finally:
         # Restore default config (which will also delete any created user),
         # stop SNMP and restore default enable state
         call('snmp.update', EXPECTED_DEFAULT_CONFIG)
-        call(f'service.{CMD_STATE[EXPECTED_DEFAULT_STATE["state"]]}', 'snmp')
+        call('service.control', CMD_STATE[EXPECTED_DEFAULT_STATE["state"]], 'snmp', job=True)
         call('service.update', 'snmp', {"enable": EXPECTED_DEFAULT_STATE['enable']})
 
 
@@ -359,9 +359,9 @@ class TestSNMP:
             # Reset the systemd restart counter
             reset_systemd_svcs("snmpd snmp-agent")
 
-            res = call('service.stop', 'snmp')
+            res = call('service.control', 'STOP', 'snmp', job=True)
             assert res is True
-            res = call('service.start', 'snmp')
+            res = call('service.control', 'START', 'snmp', job=True)
             assert res is True
             res = call('snmp.get_snmp_users')
             assert "snmpSystemUser" in res

--- a/tests/api2/test_475_syslog.py
+++ b/tests/api2/test_475_syslog.py
@@ -97,7 +97,7 @@ def test_set_remote_syslog(request):
     try:
         data = call('system.advanced.update', {'syslogserver': '127.0.0.1'})
         assert data['syslogserver'] == '127.0.0.1'
-        call('service.restart', 'syslogd', {'silent': False})
+        call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
     finally:
         call('system.advanced.update', {'syslogserver': ''})
 
@@ -119,7 +119,7 @@ def test_remote_syslog_function():
         payload = {"syslogserver": remote_ip, "syslog_transport": "TCP"}
         data = call('system.advanced.update', payload)
         assert data['syslogserver'] == remote_ip
-        call('service.restart', 'syslogd', {'silent': False})
+        call('service.control', 'RESTART', 'syslogd', {'silent': False}, job=True)
 
         # Make sure we don't have old test cruft and start with a zero byte file
         if not ssh(f'rm -f {test_log}', ip=remote_ip, check=False):

--- a/tests/api2/test_530_ups.py
+++ b/tests/api2/test_530_ups.py
@@ -130,7 +130,7 @@ def test__set_ups_options():
 
 
 def test__start_ups_service():
-    call('service.start', 'ups')
+    call('service.control', 'START', 'ups', job=True)
     results = get_service_state()
     assert results['state'] == 'RUNNING', results
 
@@ -157,7 +157,7 @@ def test__change_ups_options_while_service_is_running():
 def test__stop_ups_service():
     results = get_service_state()
     assert results['state'] == 'RUNNING', results
-    call('service.stop', 'ups')
+    call('service.control', 'STOP', 'ups', job=True)
     results = get_service_state()
     assert results['state'] == 'STOPPED', results
 
@@ -166,7 +166,7 @@ def test__change_ups_options():
     results = call('ups.update', second_ups_payload)
     for data in second_ups_payload.keys():
         assert second_ups_payload[data] == results[data], results
-    call('service.start', 'ups')
+    call('service.control', 'START', 'ups', job=True)
     results = get_service_state()
     assert results['state'] == 'RUNNING', results
     results = call('ups.config')
@@ -189,7 +189,7 @@ def test__disable_and_stop_ups_service():
     call('service.update', 'ups', {'enable': False})
     results = get_service_state()
     assert results['enable'] is False, results
-    call('service.stop', 'ups')
+    call('service.control', 'STOP', 'ups', job=True)
     results = get_service_state()
     assert results['state'] == 'STOPPED', results
 

--- a/tests/api2/test_cloud_sync_script.py
+++ b/tests/api2/test_cloud_sync_script.py
@@ -33,7 +33,7 @@ def test_post_script_not_running_after_failure():
     with local_ftp_task({
         "post_script": "rm /tmp/cloud_sync_test",
     }) as task:
-        call("service.stop", "ftp")
+        call("service.control", "STOP", "ftp", job=True)
 
         with pytest.raises(ClientException) as ve:
             run_task(task)

--- a/tests/api2/test_encrypted_dataset_services_restart.py
+++ b/tests/api2/test_encrypted_dataset_services_restart.py
@@ -25,9 +25,9 @@ def enable_auto_start(service_name):
 @contextlib.contextmanager
 def start_service(service_name):
     try:
-        yield call('service.start', service_name)
+        yield call('service.control', 'START', service_name, job=True)
     finally:
-        call('service.stop', service_name)
+        call('service.control', 'STOP', service_name, job=True)
 
 
 @contextlib.contextmanager
@@ -62,7 +62,7 @@ def test_service_restart_on_unlock_dataset(request):
         with start_service(registered_name) as service_started:
             assert service_started is True
 
-            call('service.stop', registered_name)
+            call('service.control', 'STOP', registered_name, job=True)
             assert call('service.started', registered_name) is False
             with enable_auto_start(registered_name):
                 with lock_dataset(ds):

--- a/tests/api2/test_ftp_crud_roles.py
+++ b/tests/api2/test_ftp_crud_roles.py
@@ -17,14 +17,18 @@ def test_read_role_cant_write(unprivileged_user_fixture, role):
 def test_write_role_can_write(unprivileged_user_fixture, role):
     common_checks(unprivileged_user_fixture, "ftp.update", role, True)
     common_checks(
-        unprivileged_user_fixture, "service.start", role, True, method_args=["ftp"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["START", "ftp"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.restart", role, True, method_args=["ftp"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RESTART", "ftp"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.reload", role, True, method_args=["ftp"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RELOAD", "ftp"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.stop", role, True, method_args=["ftp"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["STOP", "ftp"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )

--- a/tests/api2/test_iscsi_auth_network.py
+++ b/tests/api2/test_iscsi_auth_network.py
@@ -111,11 +111,11 @@ def configured_target_to_extent():
 def configure_iscsi_service():
     with configured_target_to_extent() as iscsi_config:
         try:
-            call('service.start', 'iscsitarget')
+            call('service.control', 'START', 'iscsitarget', job=True)
             assert call('service.started', 'iscsitarget') is True
             yield iscsi_config
         finally:
-            call('service.stop', 'iscsitarget')
+            call('service.control', 'STOP', 'iscsitarget', job=True)
 
 
 @pytest.mark.parametrize('valid', [True, False])

--- a/tests/api2/test_nfs_share_crud_roles.py
+++ b/tests/api2/test_nfs_share_crud_roles.py
@@ -26,14 +26,18 @@ def test_write_role_can_write(unprivileged_user_fixture, role):
     common_checks(unprivileged_user_fixture, "nfs.get_nfs3_clients", role, True, valid_role_exception=False)
     common_checks(unprivileged_user_fixture, "nfs.get_nfs4_clients", role, True, valid_role_exception=False)
     common_checks(
-        unprivileged_user_fixture, "service.start", role, True, method_args=["nfs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["START", "nfs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.restart", role, True, method_args=["nfs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RESTART", "nfs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.reload", role, True, method_args=["nfs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RELOAD", "nfs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.stop", role, True, method_args=["nfs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["STOP", "nfs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )

--- a/tests/api2/test_nfs_snapdir.py
+++ b/tests/api2/test_nfs_snapdir.py
@@ -13,9 +13,9 @@ SNAPDIR_EXPORTS_ENTRY = 'zfs_snapdir'
 
 @pytest.fixture(scope='module')
 def start_nfs():
-    call('service.start', 'nfs')
+    call('service.control', 'START', 'nfs', job=True)
     yield
-    call('service.stop', 'nfs')
+    call('service.control', 'STOP', 'nfs', job=True)
 
 
 @pytest.fixture(scope='function')
@@ -110,8 +110,8 @@ def test__snapdir_enable_enterprise_update(start_nfs, enterprise, nfs_export):
 def test__snapdir_functional(start_nfs, enterprise, nfs_dataset, nfs_export, vers):
     share = call('sharing.nfs.update', nfs_export, {'expose_snapshots': True})
     assert share['expose_snapshots'] is True
-    call('service.stop', 'nfs')
-    call('service.start', 'nfs', {'silent': False})
+    call('service.control', 'STOP', 'nfs', job=True)
+    call('service.control', 'START', 'nfs', {'silent': False}, job=True)
     with SSH_NFS(
         hostname=truenas_server.ip,
         path=f'/mnt/{nfs_dataset}',

--- a/tests/api2/test_pool_dataset_unlock.py
+++ b/tests/api2/test_pool_dataset_unlock.py
@@ -82,7 +82,7 @@ def test_pool_dataset_unlock_smb(smb_user, toggle_attachments):
         smb_share(f'/mnt/{encrypted}', 'encrypted', {'guestok': True})
     ):
         ssh(f'touch /mnt/{encrypted}/secret')
-        assert call('service.start', 'cifs')
+        assert call('service.control', 'START', 'cifs', job=True)
         lock_dataset(encrypted)
         # Mount test SMB share
         with smb_connection(
@@ -128,4 +128,4 @@ def test_pool_dataset_unlock_smb(smb_user, toggle_attachments):
 
             assert e.value.args[0] == ntstatus.NT_STATUS_BAD_NETWORK_NAME
 
-    assert call('service.stop', 'cifs')
+    assert call('service.control', 'STOP', 'cifs', job=True)

--- a/tests/api2/test_smb_camelcase.py
+++ b/tests/api2/test_smb_camelcase.py
@@ -24,10 +24,10 @@ def smb_setup(request):
         }, get_instance=False):
             with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
                 try:
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield {'dataset': ds, 'share': s}
                 finally:
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
 
 
 def test__smb_auth_camel(smb_setup):

--- a/tests/api2/test_smb_client.py
+++ b/tests/api2/test_smb_client.py
@@ -59,10 +59,10 @@ def setup_smb_tests(request):
         }) as u:
             with smb_share(os.path.join('/mnt', ds), 'client_share') as s:
                 try:
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield {'dataset': ds, 'share': s, 'user': u}
                 finally:
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
 
 
 @pytest.fixture(scope='module')

--- a/tests/api2/test_smb_delete_share_dataset.py
+++ b/tests/api2/test_smb_delete_share_dataset.py
@@ -27,10 +27,10 @@ def create_share_ds():
         }, get_instance=False):
             with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
                 try:
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield {'dataset': ds, 'share': s}
                 finally:
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
 
 
 def test__smb_share_dataset_destroy():

--- a/tests/api2/test_smb_encryption.py
+++ b/tests/api2/test_smb_encryption.py
@@ -25,10 +25,10 @@ def smb_setup(request):
         }, get_instance=False):
             with smb_share(os.path.join('/mnt', ds), SMB_NAME) as s:
                 try:
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield {'dataset': ds, 'share': s}
                 finally:
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
 
 
 @contextmanager

--- a/tests/api2/test_smb_share_crud_roles.py
+++ b/tests/api2/test_smb_share_crud_roles.py
@@ -41,16 +41,20 @@ def test_write_role_can_write(unprivileged_user_fixture, role):
     common_checks(unprivileged_user_fixture, "smb.status", role, True, valid_role_exception=False)
 
     common_checks(
-        unprivileged_user_fixture, "service.start", role, True, method_args=["cifs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["START", "cifs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.restart", role, True, method_args=["cifs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RESTART", "cifs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.reload", role, True, method_args=["cifs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["RELOAD", "cifs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
     common_checks(
-        unprivileged_user_fixture, "service.stop", role, True, method_args=["cifs"], valid_role_exception=False
+        unprivileged_user_fixture, "service.control", role, True, method_args=["STOP", "cifs"],
+        method_kwargs=dict(job=True), valid_role_exception=False,
     )
 
 

--- a/tests/api2/test_smb_write_offset.py
+++ b/tests/api2/test_smb_write_offset.py
@@ -29,10 +29,10 @@ def setup_smb_tests():
         }) as u:
             with smb_share(os.path.join('/mnt', ds), SHARE_NAME) as s:
                 try:
-                    call('service.start', 'cifs')
+                    call('service.control', 'START', 'cifs', job=True)
                     yield (ds, s, u)
                 finally:
-                    call('service.stop', 'cifs')
+                    call('service.control', 'STOP', 'cifs', job=True)
 
 
 def test_valid_offset(setup_smb_tests):

--- a/tests/api2/test_snmp_agent.py
+++ b/tests/api2/test_snmp_agent.py
@@ -10,7 +10,7 @@ from middlewared.test.integration.utils import call, host, ssh
 
 @pytest.fixture()
 def snmpd_running():
-    call("service.start", "snmp")
+    call("service.control", "START", "snmp", job=True)
     time.sleep(2)
     yield
 


### PR DESCRIPTION
We decided that https://github.com/truenas/middleware/pull/16380 is too much of a breaking change.

Instead, we introduce `service.control` job method. `service.start/stop/restart/reload` will be removed in 26.04.