### PR TITLE
NAS-135814 / 25.10 / Fix iscsi enum use for modern cython

### DIFF
--- a/tests/protocols/iscsi_proto.py
+++ b/tests/protocols/iscsi_proto.py
@@ -125,8 +125,8 @@ class ISCSIDiscover:
         connected = False
         try:
             ctx = iscsi.Context(self._initiator_name)
-            ctx.set_session_type(iscsi.ISCSI_SESSION_DISCOVERY)
-            ctx.set_header_digest(iscsi.ISCSI_HEADER_DIGEST_NONE)
+            ctx.set_session_type(iscsi.iscsi_session_type.ISCSI_SESSION_DISCOVERY)
+            ctx.set_header_digest(iscsi.iscsi_header_digest.ISCSI_HEADER_DIGEST_NONE)
             if self._initiator_username and self._initiator_password:
                 ctx.set_initiator_username_pwd(self._initiator_username, self._initiator_password)
             if self._target_username and self._target_password:


### PR DESCRIPTION
Modern `cython` changes how `cpdef enum`s are exposed.  Update the tests so that they will work with **both** old and new cython.

Given
```
    cpdef enum iscsi_session_type:
        ISCSI_SESSION_DISCOVERY
        ISCSI_SESSION_NORMAL
```
We used to be able to _**either**_ use `iscsi.ISCSI_SESSION_NORMAL` or `iscsi.iscsi_session_type.ISCSI_SESSION_NORMAL`.  With modern cython, only the latter works.

From https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#structs-unions-enums

> Up to Cython version 3.0.x, this used to copy all item names into the global module namespace, so that they were available both as attributes of the Python enum type (CheseState above) and as global constants. This was changed in Cython 3.1 to distinguish between anonymous cpdef enums, which only create global Python constants for their items, and named cpdef enums, where the items live only in the namespace of the enum type and do not create global Python constants.

Verified the breakage and fix **in a venv** on Debian Trixie nightly, and on Bookworm.

The https://pypi.org/project/Cython/ shows
- 3.1.0 (2025-05-08)