### PR TITLE
NAS-135828 / 25.10 / Add dhchap_dhgroup_choices and dhchap_hash_choices APIs

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_host.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_host.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import Field, Secret, model_validator
 
@@ -13,8 +13,15 @@ __all__ = [
     "NVMetHostDeleteArgs",
     "NVMetHostDeleteResult",
     "NVMetHostGenerateKeyArgs",
-    "NVMetHostGenerateKeyResult"
+    "NVMetHostGenerateKeyResult",
+    "NVMetHostDHChapDHGroupChoicesArgs",
+    "NVMetHostDHChapDHGroupChoicesResult",
+    "NVMetHostDHChapHashChoicesArgs",
+    "NVMetHostDHChapHashChoicesResult",
 ]
+
+DHChapHashType: TypeAlias = Literal['SHA-256', 'SHA-384', 'SHA-512']
+DHChapDHGroupType: TypeAlias = Literal['2048-BIT', '3072-BIT', '4096-BIT', '6144-BIT', '8192-BIT']
 
 
 class NVMetHostEntry(BaseModel):
@@ -33,11 +40,11 @@ class NVMetHostEntry(BaseModel):
 
     A suitable secret can be generated using `nvme gen-dhchap-key`, or by using the `nvmet.host.generate_key` API.
     """
-    dhchap_dhgroup: Literal['2048-BIT', '3072-BIT', '4096-BIT', '6144-BIT', '8192-BIT'] | None = None
+    dhchap_dhgroup: DHChapDHGroupType | None = None
     """
     If selected, the DH (Diffie-Hellman) key exchange built on top of CHAP to be used for authentication.
     """
-    dhchap_hash: Literal['SHA-256', 'SHA-384', 'SHA-512'] = 'SHA-256'
+    dhchap_hash: DHChapHashType = 'SHA-256'
     """
     HMAC (Hashed Message Authentication Code) to be used in conjunction if a `dhchap_dhgroup` is selected.
     """
@@ -90,7 +97,7 @@ class NVMetHostDeleteResult(BaseModel):
 
 
 class NVMetHostGenerateKeyArgs(BaseModel):
-    dhchap_hash: Literal['SHA-256', 'SHA-384', 'SHA-512'] = 'SHA-256'
+    dhchap_hash: DHChapHashType = 'SHA-256'
     """ Hash to be used with the generated key.  """
     nqn: str | None = None
     """ NQN to be used for the transformation. """
@@ -98,3 +105,19 @@ class NVMetHostGenerateKeyArgs(BaseModel):
 
 class NVMetHostGenerateKeyResult(BaseModel):
     result: str
+
+
+class NVMetHostDHChapDHGroupChoicesArgs(BaseModel):
+    pass
+
+
+class NVMetHostDHChapDHGroupChoicesResult(BaseModel):
+    result: list[DHChapDHGroupType]
+
+
+class NVMetHostDHChapHashChoicesArgs(BaseModel):
+    pass
+
+
+class NVMetHostDHChapHashChoicesResult(BaseModel):
+    result: list[DHChapHashType]

--- a/src/middlewared/middlewared/plugins/nvmet/host.py
+++ b/src/middlewared/middlewared/plugins/nvmet/host.py
@@ -10,7 +10,12 @@ from middlewared.api.current import (NVMetHostCreateArgs,
                                      NVMetHostGenerateKeyArgs,
                                      NVMetHostGenerateKeyResult,
                                      NVMetHostUpdateArgs,
-                                     NVMetHostUpdateResult)
+                                     NVMetHostUpdateResult,
+                                     NVMetHostDHChapDHGroupChoicesArgs,
+                                     NVMetHostDHChapDHGroupChoicesResult,
+                                     NVMetHostDHChapHashChoicesArgs,
+                                     NVMetHostDHChapHashChoicesResult
+                                     )
 from middlewared.service import CRUDService, ValidationErrors, private
 from middlewared.service_exception import CallError
 from middlewared.utils import run
@@ -185,3 +190,18 @@ class NVMetHostService(CRUDService):
                 f'Failed to key with exit code ({cp.returncode}): {cp.stderr.decode()}'
             )
         return key
+
+    @api_method(NVMetHostDHChapDHGroupChoicesArgs, NVMetHostDHChapDHGroupChoicesResult)
+    async def dhchap_dhgroup_choices(self):
+        """
+        Returns possible choices for `dhchap_dhgroup` attribute of `host` create and update.
+        None is an additional choice.
+        """
+        return ['2048-BIT', '3072-BIT', '4096-BIT', '6144-BIT', '8192-BIT']
+
+    @api_method(NVMetHostDHChapHashChoicesArgs, NVMetHostDHChapHashChoicesResult)
+    async def dhchap_hash_choices(self):
+        """
+        Returns possible choices for `dhchap_hash` attribute of `host` create and update.
+        """
+        return ['SHA-256', 'SHA-384', 'SHA-512']

--- a/tests/api2/test_nvmet_tcp.py
+++ b/tests/api2/test_nvmet_tcp.py
@@ -1082,6 +1082,18 @@ class TestNVMeHostAuth(NVMeRunning):
         self.assert_single_namespace(nc, subnqn, ZVOL1_MB, dhchap_secret=dhchap_secret,
                                      dhchap_ctrl_secret=dhchap_ctrl_secret)
 
+    def test__host_dhchap_dhgroup_choices(self):
+        assert set(call('nvmet.host.dhchap_dhgroup_choices')) == set(['2048-BIT',
+                                                                      '3072-BIT',
+                                                                      '4096-BIT',
+                                                                      '6144-BIT',
+                                                                      '8192-BIT'])
+
+    def test__host_dhchap_hash_choices(self):
+        assert set(call('nvmet.host.dhchap_hash_choices')) == set(['SHA-256',
+                                                                   'SHA-384',
+                                                                   'SHA-512'])
+
 
 class TestForceDelete(NVMeRunning):
 


### PR DESCRIPTION
- Add `nvmet.host.dhchap_dhgroup_choices` and `nvmet.host.dhchap_hash_choices` APIs
- Add nvmet CI
  - `test__host_dhchap_dhgroup_choices`
  - `test__host_dhchap_hash_choices`

----
(Tested locally.)