### PR TITLE
NAS-135782 / 25.10 / Fix app edit custom YAML failure cases

### DIFF
--- a/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
+++ b/src/middlewared/middlewared/plugins/apps/custom_app_utils.py
@@ -16,7 +16,12 @@ def validate_payload(data: dict, schema: str) -> dict:
         try:
             compose_config = yaml.safe_load(data['custom_compose_config_string'])
         except yaml.YAMLError:
-            verrors.add('app_create.custom_compose_config_string', 'Invalid YAML provided')
+            verrors.add(f'{schema}.custom_compose_config_string', 'Invalid YAML provided')
+        else:
+            if not isinstance(compose_config, dict):
+                verrors.add(f'{schema}.custom_compose_config_string', 'YAML must represent a dictionary/object')
+            elif 'services' not in compose_config:
+                verrors.add(f'{schema}.custom_compose_config_string', 'YAML is missing required \"services\" key')
 
     verrors.check()
 


### PR DESCRIPTION
Will leave this as a draft PR until I have confirmation on the ticket that I'm okay to submit this, but I believe this should be a sufficient fix.

======

Fixes [NAS-135782](https://ixsystems.atlassian.net/browse/NAS-135782).

Previously, calls to `app.update` / `app.create` did not sufficiently validate the `custom_compose_config_string` payload. This allowed users to pass malformed YAML or YAML that did not represent a valid Compose structure.

For example, the following calls would be accepted:
```bash
midclt call app.update hello-world '{"custom_compose_config_string": "a"}'
midclt call app.update hello-world '{"custom_compose_config_string": "a:"}'
```

`yaml.safe_load` is not sufficient to catch malformed entries and will simply parse `"a"` as a string, not a dictionary.
Subsequently, attempting to query the application's configuration via `app.config` would fail:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for AppConfigResult
result
  Input should be a valid dictionary [type=dict_type, input_value='a', input_type=str]
```
This leads to a lockout of the webui app management pane until appropriate configuration is applied via `app.update` in CLI.

This change introduces further validation to `validate_payload` to ensure that the parsed `compose_config`:
* Is actually a dictionary (`isinstance(compose_config, dict)`). If not, a validation error is added with the message "YAML must represent a dictionary/object".
* If the parsed `compose_config` (which is now confirmed to be a dictionary) contains the required top-level `services` key. If not, a validation error is added with the message 'YAML is missing required "services" key'.


Also fixes a small issue with a hardcoded `app_create` value instead of using `{schema}`

![image](https://github.com/user-attachments/assets/cea8fb34-3e25-463b-996b-8bc47576a850)
![image](https://github.com/user-attachments/assets/2db2e738-2e22-4671-b840-7066f96a324c)
![image](https://github.com/user-attachments/assets/926738ff-ad94-482e-bf17-4de92dc81215)
![image](https://github.com/user-attachments/assets/24e9757e-1ca7-4048-9ce5-8b606be55812)
![image](https://github.com/user-attachments/assets/cda4ce26-0113-4337-a912-6aa193e19c5d)

