### PR TITLE
Replace non-printable characters in NFSv4 client info

### DIFF
--- a/src/middlewared/middlewared/plugins/nfs_/status.py
+++ b/src/middlewared/middlewared/plugins/nfs_/status.py
@@ -98,6 +98,11 @@ class NFSService(Service):
             with open(f"/proc/fs/nfsd/clients/{id_}/info", "r") as f:
                 info = yaml.safe_load(f.read())
 
+                # NFS-135435: Fixup non-printable chars
+                for item in ['name', 'Implementation domain', 'Implementation name']:
+                    if raw_val := info.get(item):
+                        info[item] = "".join(c if c.isprintable() else "\uFFFD" for c in raw_val)
+
         return info
 
     @private


### PR DESCRIPTION
Some clients, e.g. Veeam, can present binary data for the 'name' field in the NFS attachment.  This PR cleans up that string and the 'Implementation' strings replacing non-printable characters with the universal replacement character �.

Binary values for these fields will still appear as unreadable, but it's the value offered by the client.

Tested via manual testing.