### PR TITLE
NAS-134791 / 25.10 / Add CDROM device type

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/virt_device.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_device.py
@@ -126,8 +126,14 @@ class PCI(Device):
     address: NonEmptyString
 
 
+class CDROM(Device):
+    dev_type: Literal['CDROM']
+    source: NonEmptyString
+    boot_priority: int | None = Field(default=None, ge=0)
+
+
 DeviceType: TypeAlias = Annotated[
-    Disk | GPU | Proxy | TPM | USB | NIC | PCI,
+    Disk | GPU | Proxy | TPM | USB | NIC | PCI | CDROM,
     Field(discriminator='dev_type')
 ]
 


### PR DESCRIPTION
## Problem

Currently users need to repack windows iso because it is not supported out of the box by incus as there are missing drivers.

## Solution

While this gets fixed upstream, we have decided to use `raw.qemu` and specify relevant CDROM directly so it works as expected with windows. However while doing this, we see boot priority does not take effect for CDROM entry as incus first initiates qemu process with qemu cmd where this CDROM entry is specified and then using QMP, it dynamically handles devices for the virt instance which overrides boot entry. So to get that to work, we still need to specify the CDROM as a disk device in incus and everything else falls into place nicely. It has been confirmed that this works as expected with windows and that it boots nicely.