### PR TITLE
make PSU alerts proactive

### DIFF
--- a/src/middlewared/middlewared/alert/source/sensors.py
+++ b/src/middlewared/middlewared/alert/source/sensors.py
@@ -21,6 +21,7 @@ class PowerSupplyAlertClass(AlertClass):
     title = "Power Supply Error"
     text = "%(psu)s is %(state)s showing: %(errors)s"
     products = (ProductType.ENTERPRISE,)
+    proactive_support = True
 
 
 class SensorsAlertSource(AlertSource):


### PR DESCRIPTION
Support team has requested that the PSU alerts that are raised in the UI also open a proactive support case with us. This implements the changes requested by them.