### PR TITLE
NAS-135850 / 25.10 / Fix virt integration tests

### DIFF
--- a/tests/api2/test_virt_storage_pool.py
+++ b/tests/api2/test_virt_storage_pool.py
@@ -9,7 +9,7 @@ from middlewared.test.integration.assets.virt import (
     volume,
 )
 from middlewared.test.integration.utils import call
-from truenas_api_client import ValidationErrors as ClientValidationErrors
+from truenas_api_client.exc import ValidationErrors as ClientValidationErrors
 
 
 @pytest.fixture(scope='module')
@@ -22,8 +22,18 @@ def virt_init():
 @pytest.fixture(scope='module')
 def virt_two_pools(virt_init):
     with another_pool() as pool:
+        assert call('pool.dataset.attachments', pool['name']) == []
         call('virt.global.update', {'storage_pools': [virt_init['pool'], pool['name']]}, job=True)
         config = call('virt.global.config')
+        # Make sure that VMs also generate attachments properly
+        dsa = call('pool.dataset.attachments', pool['name'])
+
+        assert dsa == [
+            {'attachments': ['virt'], 'service': 'incus', 'type': 'Virtualization'}
+        ]
+        assert dsa[0]['type'] == 'Virtualization'
+        assert dsa[0]['attachments'] == ['virt']
+
         assert len(config['storage_pools']) == 2
 
         try:
@@ -50,9 +60,6 @@ def test_add_second_pool(virt_init):
 def test_add_instance_second_pool(virt_two_pools):
     pool, config = virt_two_pools
 
-    # Simply adding the pool should not be treated as an attachment
-    assert call('pool.dataset.attachments', pool['name']) == []
-
     with virt_instance('inst-second-pool', storage_pool=pool['name']) as instance:
         assert instance['storage_pool'] == pool['name']
 
@@ -60,37 +67,25 @@ def test_add_instance_second_pool(virt_two_pools):
         assert len(dsa) == 1
 
         assert dsa[0]['type'] == 'Virtualization'
-        assert dsa[0]['attachments'] == ['inst-second-pool']
+        assert dsa[0]['attachments'] == ['virt']
 
-        with pytest.raises(ClientValidationErrors, match='pool to be removed is used by the following assets'):
+        with pytest.raises(ClientValidationErrors, match='Virt-Instances: inst-second-pool'):
 
             # Trying to remove pool holding instances should fail
             call('virt.global.update', {'storage_pools': [config['pool']]}, job=True)
-
-    # Removing instance should cause attachment to be removed
-    assert call('pool.dataset.attachments', pool['name']) == []
 
 
 def test_add_volume_second_pool(virt_two_pools):
     pool, config = virt_two_pools
     VOLNAME = 'test-vol-pool2'
 
-    # Make sure we're in a clean state
-    assert call('pool.dataset.attachments', pool['name']) == []
-
     with volume(VOLNAME, 1024, pool['name']):
         vol = call('virt.volume.get_instance', VOLNAME)
         assert vol['storage_pool'] == pool['name']
 
-        # Simply creating a volume handled by incus should not create a pool attachment
-        assert call('pool.dataset.attachments', pool['name']) == []
-
 
 def test_virt_device_second_pool(virt_two_pools):
     pool, config = virt_two_pools
-
-    # Make sure we're in a clean state
-    assert call('pool.dataset.attachments', pool['name']) == []
 
     with virt_instance(
         'inst-second-pool',
@@ -100,13 +95,6 @@ def test_virt_device_second_pool(virt_two_pools):
         instance_name = instance['name']
 
         assert instance['storage_pool'] == pool['name']
-
-        # Make sure that VMs also generate attachments properly
-        dsa = call('pool.dataset.attachments', pool['name'])
-        assert len(dsa) == 1
-
-        assert dsa[0]['type'] == 'Virtualization'
-        assert dsa[0]['attachments'] == ['inst-second-pool']
 
         call('virt.instance.stop', instance_name, {'force': True, 'timeout': 1}, job=True)
 
@@ -132,10 +120,6 @@ def test_virt_device_second_pool(virt_two_pools):
 def test_virt_span_two_pools(virt_two_pools):
     pool, config = virt_two_pools
 
-    # Make sure we're in a clean state
-    assert call('pool.dataset.attachments', pool['name']) == []
-    assert call('pool.dataset.attachments', config['pool']) == []
-
     # Sanity check that we're properly testing both pools
     assert pool['name'] != config['pool']
 
@@ -147,16 +131,6 @@ def test_virt_span_two_pools(virt_two_pools):
         instance_name = instance['name']
 
         assert instance['storage_pool'] == pool['name']
-
-        # Make sure that VMs also generate attachments properly
-        dsa = call('pool.dataset.attachments', pool['name'])
-        assert len(dsa) == 1
-
-        assert dsa[0]['type'] == 'Virtualization'
-        assert dsa[0]['attachments'] == ['inst-second-pool']
-
-        # Make sure VM is not attached to the other pool
-        assert call('pool.dataset.attachments', config['pool']) == []
 
         call('virt.instance.stop', instance_name, {'force': True, 'timeout': 1}, job=True)
 
@@ -178,18 +152,6 @@ def test_virt_span_two_pools(virt_two_pools):
 
                 assert root_pool == pool['name']
                 assert test_disk_pool == config['pool']
-
-                # The volume on other pool should cause VM to show as attached to it
-                dsa = call('pool.dataset.attachments', config['pool'])
-                assert len(dsa) == 1
-                assert dsa[0]['type'] == 'Virtualization'
-                assert dsa[0]['attachments'] == ['inst-second-pool']
-
-        # volume should be removed from VM now, removing attachment
-        assert call('pool.dataset.attachments', config['pool']) == []
-
-    # instance should be removed now
-    assert call('pool.dataset.attachments', pool['name']) == []
 
 
 def check_volumes(volumes):


### PR DESCRIPTION
## Problem

Recent changes have made the attachment delegate name a constant value. This has caused some integration tests, which were dependent on the previous dynamic naming behaviour, to fail.

## Solution

Update and fix the affected integration tests to align with the new behaviour where the delegate name is constant.