### PR TITLE
NAS-135878 / 25.10 / Fix test_virt_utils

### DIFF
--- a/tests/unit/test_virt_utils.py
+++ b/tests/unit/test_virt_utils.py
@@ -18,11 +18,11 @@ def default_storage_pool():
 
 
 def test__init_storage_value():
-    assert storage.state is utils.Status.INITIALIZING
+    assert storage.state is utils.VirtGlobalStatus.INITIALIZING
     assert storage.default_storage_pool is None
 
 
-@pytest.mark.parametrize('status', utils.Status)
+@pytest.mark.parametrize('status', utils.VirtGlobalStatus)
 def test__setting_storage_state(status):
     storage.state = status
     assert storage.state is status


### PR DESCRIPTION
Change import of 'Status' to 'VirtGlobalStatus'.
This was blocking the Goldeye unit test runs.  Do not backport.

This commit is the source: https://github.com/truenas/middleware/pull/16467
