### PR TITLE
Introduce endpoint to allow renaming zfs resources used by virt

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/__init__.py
+++ b/src/middlewared/middlewared/api/v25_10_0/__init__.py
@@ -115,6 +115,7 @@ from .user import *  # noqa
 from .virt_device import *  # noqa
 from .virt_global import *  # noqa
 from .virt_instance import *  # noqa
+from .virt_instance_storage import *  # noqa
 from .virt_volume import *  # noqa
 from .vmware import *  # noqa
 from .webui_crypto import *  # noqa

--- a/src/middlewared/middlewared/api/v25_10_0/virt_instance_storage.py
+++ b/src/middlewared/middlewared/api/v25_10_0/virt_instance_storage.py
@@ -1,0 +1,18 @@
+from pydantic import Field
+
+from middlewared.api.base import BaseModel, NonEmptyString, single_argument_args
+
+from .pool_dataset import ZFS_MAX_DATASET_NAME_LEN
+
+
+__all__ = ['VirtInstanceStorageRenameArgs', 'VirtInstanceStorageRenameResult']
+
+
+@single_argument_args('virt_instance_storage_rename')
+class VirtInstanceStorageRenameArgs(BaseModel):
+    name: NonEmptyString
+    new_name: NonEmptyString = Field(..., max_length=ZFS_MAX_DATASET_NAME_LEN)
+
+
+class VirtInstanceStorageRenameResult(BaseModel):
+    result: bool

--- a/src/middlewared/middlewared/plugins/virt/storage.py
+++ b/src/middlewared/middlewared/plugins/virt/storage.py
@@ -1,0 +1,57 @@
+import errno
+import os
+
+from middlewared.api import api_method
+from middlewared.api.current import VirtInstanceStorageRenameArgs, VirtInstanceStorageRenameResult
+from middlewared.plugins.zfs_.utils import zvol_path_to_name
+from middlewared.service import CallError, private, Service
+
+
+class VirtInstanceStorageService(Service):
+
+    class Config:
+        namespace = 'virt.instance.storage'
+        cli_namespace = 'virt.instance.storage'
+
+    @private
+    async def virt_path(self, path):
+        """
+        Returns a boolean which is set when path provided is being used by virt.
+        """
+        # We are only factoring in zvols and not host path mounts because that can
+        # be used by other attachments as well
+        global_config = await self.middleware.call('virt.global.config')
+        instance_paths = {
+            zvol_path_to_name(p)
+            for p in set((await self.middleware.call('virt.instance.get_all_disk_sources')).keys())
+            if p.startswith('/dev/zvol/')
+        }
+        return any(
+            p == path or path.startswith(f'{p}/')
+            for p in instance_paths | {os.path.join(p, '.ix-virt') for p in global_config['storage_pools']}
+        )
+
+    @api_method(VirtInstanceStorageRenameArgs, VirtInstanceStorageRenameResult, roles=['VIRT_INSTANCE_WRITE'])
+    async def rename(self, data):
+        """
+        Rename a zfs dataset/snapshot used by virt
+        """
+        zfs_resource = data['name']
+        if '@' in zfs_resource:
+            ds_name = zfs_resource.split('@')[0]
+            namespace = 'zfs.snapshot'
+            args = data['new_name']
+        else:
+            ds_name = zfs_resource
+            namespace = 'zfs.dataset'
+            args = {'new_name': data['new_name']}
+
+        # Let's make sure zfs resource actually exists
+        await self.middleware.call(f'{namespace}.get_instance', zfs_resource)
+
+        # Check if the dataset is being used by virt
+        if await self.virt_path(ds_name) is False:
+            raise CallError('Only zfs resources used by virt can be renamed', errno.EINVAL)
+
+        await self.middleware.call(f'{namespace}.rename', zfs_resource, args)
+        return True

--- a/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
+++ b/src/middlewared/middlewared/plugins/zfs_/snapshot_actions.py
@@ -97,7 +97,7 @@ class ZFSSnapshotService(Service):
         except libzfs.ZFSException as err:
             raise CallError(f'Failed to hold snapshot: {err}')
 
-    def release(self, id_, options={}):
+    def release(self, id_, options=None):
         """
         Release held snapshot `id`.
 
@@ -107,6 +107,7 @@ class ZFSSnapshotService(Service):
             parent snapshot will be removed.
 
         """
+        options = options or {}
         try:
             with libzfs.ZFS() as zfs:
                 snapshot = zfs.get_snapshot(id_)
@@ -114,3 +115,11 @@ class ZFSSnapshotService(Service):
                     snapshot.release(tag, options.get('recursive', False))
         except libzfs.ZFSException as err:
             raise CallError(f'Failed to release snapshot: {err}')
+
+    def rename(self, id_, new_name):
+        try:
+            with libzfs.ZFS() as zfs:
+                snapshot = zfs.get_snapshot(id_)
+                snapshot.rename(new_name)
+        except libzfs.ZFSException as err:
+            raise CallError(f'Failed to rename snapshot: {err}')

--- a/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_path.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/virt/test_virt_path.py
@@ -1,0 +1,60 @@
+import pytest
+
+from middlewared.plugins.virt.storage import VirtInstanceStorageService
+from middlewared.pytest.unit.middleware import Middleware
+
+
+CONFIG = {
+    'id': 1,
+    'pool': 'tank',
+    'dataset': 'tank/.ix-virt',
+    'storage_pools': ['tank', 'mypool'],
+    'bridge': None,
+    'v4_network': '10.163.122.1/24',
+    'v6_network': 'fd42:4c07:7d8a:dbab::1/64',
+    'state': 'INITIALIZED',
+}
+
+
+@pytest.mark.parametrize('all_disk_sources,path,expected', [
+    (
+        {'/dev/zvol/tank/abc': 'vm'},
+        'tank/abc',
+        True
+    ),
+    (
+        {
+            '/dev/zvol/tank/abc': 'vm',
+            '/dev/zvol/tank/zvol': 'vm'
+        },
+        'tank/zvol',
+        True
+    ),
+    (
+        {'/dev/zvol/tank/abc': 'vm'},
+        'tank/zvol',
+        False
+    ),
+    (
+        {},
+        'tank/abc',
+        False
+    ),
+    (
+        {},
+        'tank/.ix-virt/abcd',
+        True
+    ),
+    (
+        {},
+        'non_incus_pool/.ix-virt/abcd',
+        False
+    )
+])
+@pytest.mark.asyncio
+async def test_virt_path(all_disk_sources, path, expected):
+    m = Middleware()
+    m['virt.global.config'] = lambda *arg: CONFIG
+    m['virt.instance.get_all_disk_sources'] = lambda *args: all_disk_sources
+    result = await VirtInstanceStorageService(m).virt_path(path)
+    assert result == expected


### PR DESCRIPTION
## Context

It was requested that we have an endpoint which allows renaming zfs resources being consumed by virt plugin. Relevant changes have been added which basically allow renaming a zfs dataset/snapshot as long as it is being consumed by virt.

However one thing to note is that we do not make any assumptions here wrt that resource being used by virt in what context and what would happen to the instance consuming it if one is consuming it or if the service itself is consuming it.