### PR TITLE
NAS-135884 / 25.04.2 / fix zpool capacity tests (by yocalebo)

### DIFF
--- a/tests/api2/test_zpool_capacity_alert.py
+++ b/tests/api2/test_zpool_capacity_alert.py
@@ -32,7 +32,7 @@ def test__emits_alert(request):
     ]):
         alerts = call("alert.run_source", "ZpoolCapacity")
         assert len(alerts) == 1
-        assert alerts[0]["klass"] == "ZpoolCapacityWarning"
+        assert alerts[0]["klass"] == "ZpoolCapacityNotice"
         assert alerts[0]["key"] == f'["{pool}"]'
         assert alerts[0]["args"] == {"volume": pool, "capacity": 85}
 
@@ -43,7 +43,7 @@ def test__does_not_flap_alert(request):
             "name": pool,
             "properties": {
                 "capacity": {
-                    "parsed": "79",
+                    "parsed": "84",
                 }
             },
         }


### PR DESCRIPTION
Recent changes rendered these tests incorrect so this updates them to be inline with current logic.

Original PR: https://github.com/truenas/middleware/pull/16501
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135884