### PR TITLE
NAS-135886 / 25.10 / Fix fragile behavior of config method

### DIFF
--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -119,12 +119,12 @@ class ConfigService(ServiceChangeMixin, Service, metaclass=ConfigServiceMetabase
 
     @private
     async def _get_or_insert(self, datastore, options):
-        try:
-            return await self.middleware.call('datastore.config', datastore, options)
-        except IndexError:
+        rows = await self.middleware.call('datastore.query', datastore, [], options)
+        if not rows:
             async with get_or_insert_lock:
-                try:
-                    return await self.middleware.call('datastore.config', datastore, options)
-                except IndexError:
+                rows = await self.middleware.call('datastore.query', datastore, [], options)
+                if not rows:
                     await self.middleware.call('datastore.insert', datastore, {})
                     return await self.middleware.call('datastore.config', datastore, options)
+
+        return rows[0]


### PR DESCRIPTION
This PR adds changes to fix fragile behaviour of config method where what happens is that we try to see if a row exists in the config service table by selecting first index which if it does not exist will raise `IndexError` and in that case we used to insert a row in the database.

The problem with this logic is that if any service has an extend in place which also raises `IndexError` and is not caught will result in duplicate entry being created in the config service table as the code assumed `IndexError` was being originated because it had tried to select the first row whereas that was not the case.

Now we instead call `query` directly and get the first row like `get=True` was doing already in `datastore.config` method. This is safe in terms of that if the underlying service is doing anything else, that error gets raised as is and we don't make false assumptions that this exception is coming because we don't have a row available and let's insert now.