### PR TITLE
NAS-135584 / 25.04.1 / Gracefully handle edge case when we are missing separator (by sonicaj) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/utils/mount.py
+++ b/src/middlewared/middlewared/utils/mount.py
@@ -71,20 +71,23 @@ def __iter_mountinfo(dev_id=None, mnt_id=None, callback=None, private_data=None)
 
     with open('/proc/self/mountinfo') as f:
         for line in f:
-            if maj_min:
-                if line.find(maj_min) == -1:
-                    continue
+            try:
+                if maj_min:
+                    if line.find(maj_min) == -1:
+                        continue
+
+                    callback(line, private_data)
+                    break
+                elif mnt_id is not None:
+                    if not line.startswith(mount_id):
+                        continue
+
+                    callback(line, private_data)
+                    break
 
                 callback(line, private_data)
-                break
-            elif mnt_id is not None:
-                if not line.startswith(mount_id):
-                    continue
-
-                callback(line, private_data)
-                break
-
-            callback(line, private_data)
+            except Exception as e:
+                raise RuntimeError(f'Failed to parse {line!r} line: {e}')
 
 
 def getmntinfo(dev_id=None, mnt_id=None):

--- a/src/middlewared/middlewared/utils/mount.py
+++ b/src/middlewared/middlewared/utils/mount.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import logging
 
@@ -61,16 +60,7 @@ def __create_tree(info, mount_id):
     return info[mount_id or root_id]
 
 
-def __iter_mountinfo(dev_id=None, mnt_id=None, callback_func=None, private_data=None):
-    def callback(*args, **kwargs):
-        # This should not be required but check NAS-135584
-        # Basically it seems after an upgrade for some reason "-" separator
-        # was missing in a line which resulted in this logic failing and triggering
-        # a chain of events which ended up with multiple duplicate records of a
-        # config service
-        with contextlib.suppress(IndexError):
-            return callback_func(*args, **kwargs)
-
+def __iter_mountinfo(dev_id=None, mnt_id=None, callback=None, private_data=None):
     if dev_id:
         maj_min = f'{os.major(dev_id)}:{os.minor(dev_id)}'
     else:
@@ -136,9 +126,9 @@ def getmntinfo(dev_id=None, mnt_id=None):
     """
     info = {}
     if mnt_id:
-        __iter_mountinfo(mnt_id=mnt_id, callback_func=__parse_to_mnt_id, private_data=info)
+        __iter_mountinfo(mnt_id=mnt_id, callback=__parse_to_mnt_id, private_data=info)
     else:
-        __iter_mountinfo(dev_id=dev_id, callback_func=__parse_to_dev, private_data=info)
+        __iter_mountinfo(dev_id=dev_id, callback=__parse_to_dev, private_data=info)
 
     return info
 
@@ -149,5 +139,5 @@ def getmnttree(mount_id=None):
     filesystem specified by mnt_id. cf. documentation for getmntinfo().
     """
     info = {}
-    __iter_mountinfo(callback_func=__parse_to_mnt_id, private_data=info)
+    __iter_mountinfo(callback=__parse_to_mnt_id, private_data=info)
     return __create_tree(info, mount_id)


### PR DESCRIPTION
This commit adds changes to gracefully handle the case when we are missing a required separator in mount info line.

Basically what happened is that it seems on boot after upgrade for this user (we saw an earlier ticket as well with the same issue), somewhere a call to `catalog.config` was called. Now this call made use of `filesystem.mountinfo` which was using `getmntinfo` call.

The function `getmntinfo` raised an `IndexError` (more on this later), which was propagated above to
```
    @private
    async def _get_or_insert(self, datastore, options):
        try:
            return await self.middleware.call('datastore.config', datastore, options)
        except IndexError:
            async with get_or_insert_lock:
                try:
                    return await self.middleware.call('datastore.config', datastore, options)
                except IndexError:
                    await self.middleware.call('datastore.insert', datastore, {})
                    return await self.middleware.call('datastore.config', datastore, options)
```

which resulted in a duplicate entry being inserted to the database which was an invalid entry as we have unique constraint on `LABEL` for this specific table and another subsequent call to `catalog.config` resulted in another entry being added but that failing which resulted in the user not being able to utilize apps and we catching it.

Now coming back to `getmntinfo`, basically what happens is that we expect `-` separator to be there in each line for `/proc/self/mountinfo` as documented in https://www.man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html as well.
However it appears we might have a race condition where this is not the case which is why it results in an index error.

```
def __mntent_dict(line):
    mnt_id, parent_id, maj_min, root, mp, opts, extra = line.split(" ", 6)
    fstype, mnt_src, super_opts = extra.split(' - ')[1].split()
```

So the changes done here make sure that whenever these functions are called, if we do end up raising an `IndexError` on some line, we make sure that that we just silently skip that line. Full traceback below:

```
  File "/usr/lib/python3/dist-packages/middlewared/service/config_service.py", line 110, in config
    return await self._get_or_insert(self._config.datastore, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/service/config_service.py", line 130, in _get_or_insert
    return await self.middleware.call('datastore.config', datastore, options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/api/base/decorator.py", line 96, in wrapped
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/filesystem.py", line 135, in mount_info
    mntinfo = getmntinfo()
              ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/mount.py", line 131, in getmntinfo
    __iter_mountinfo(dev_id=dev_id, callback=__parse_to_dev, private_data=info)
  File "/usr/lib/python3/dist-packages/middlewared/utils/mount.py", line 87, in __iter_mountinfo
    callback(line, private_data)
  File "/usr/lib/python3/dist-packages/middlewared/utils/mount.py", line 34, in __parse_to_dev
    entry = __mntent_dict(line)
            ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/utils/mount.py", line 11, in __mntent_dict
    fstype, mnt_src, super_opts = extra.split(' - ')[1].split()
                                  ~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Original PR: https://github.com/truenas/middleware/pull/16498
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135584

Original PR: https://github.com/truenas/middleware/pull/16503
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135584