### PR TITLE
NAS-135892 / 25.10 / Allow addr_trsvcid to be None for FC transport

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/25.10/2025-05-16_15-58_nvmet_trsvcid.py
+++ b/src/middlewared/middlewared/alembic/versions/25.10/2025-05-16_15-58_nvmet_trsvcid.py
@@ -1,0 +1,30 @@
+"""NVMe target does not require trsvcid for FC
+
+Revision ID: dae46dda9606
+Revises: c227e49be4d8
+Create Date: 2025-05-16 15:58:38.849619+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dae46dda9606'
+down_revision = 'c227e49be4d8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_nvmet_port', schema=None) as batch_op:
+        batch_op.alter_column('nvmet_port_addr_trsvcid',
+               existing_type=sa.VARCHAR(length=255),
+               nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('services_nvmet_port', schema=None) as batch_op:
+        batch_op.alter_column('nvmet_port_addr_trsvcid',
+               existing_type=sa.VARCHAR(length=255),
+               nullable=False)

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_port.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_port.py
@@ -28,7 +28,7 @@ class NVMetPortEntry(BaseModel):
     """ Index of the port, for internal use. """
     addr_trtype: FabricTransportType
     """ Fabric transport technology name. """
-    addr_trsvcid: int | NonEmptyString
+    addr_trsvcid: int | NonEmptyString | None
     """ Transport-specific TRSVCID field.  When configured for TCP/IP or RDMA this will be the port number. """
     addr_traddr: str
     """
@@ -71,8 +71,8 @@ class NVMetPortCreateRDMATCP(NVMetPortCreateTemplate):
 
 class NVMetPortCreateFC(NVMetPortCreateTemplate):
     addr_trtype: Literal['FC']
-    addr_trsvcid: NonEmptyString
     addr_traddr: NonEmptyString
+    addr_trsvcid: Excluded = excluded_field()
 
 
 class NVMetPortCreateArgs(BaseModel):


### PR DESCRIPTION
Allow `addr_trsvcid` to be `None` for FC transport.