### PR TITLE
NAS-135909 / 25.10 / add thread local storage to our thread pool

### DIFF
--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -15,6 +15,7 @@ def service_config(klass, config):
         'event_register': True,
         'event_send': True,
         'events': [],
+        'pass_thread_local_storage': False,
         'service': None,
         'service_verb': 'reload',
         'service_verb_sync': True,

--- a/src/middlewared/middlewared/service/decorators.py
+++ b/src/middlewared/middlewared/service/decorators.py
@@ -241,6 +241,12 @@ def pass_app(*, message_id=False, require=False, rest=False):
     return wrapper
 
 
+def pass_thread_local_storage(fn):
+    """Pass a thread-local storage object as a parameter to the method."""
+    fn._pass_thread_local_storage = True
+    return fn
+
+
 def periodic(interval, run_on_start=True):
     def wrapper(fn):
         fn._periodic = PeriodicTaskDescriptor(interval, run_on_start)

--- a/src/middlewared/middlewared/utils/threading.py
+++ b/src/middlewared/middlewared/utils/threading.py
@@ -4,15 +4,34 @@ import logging
 import os
 import threading
 
+from truenas_pylibzfs import open_handle
+
 from .prctl import set_name
 
+thread_local_storage = threading.local()
 logger = logging.getLogger(__name__)
 counter = count(1)
-__all__ = ["set_thread_name", "start_daemon_thread", "IoThreadPoolExecutor", "io_thread_pool_executor"]
+__all__ = [
+    "set_thread_name",
+    "start_daemon_thread",
+    "IoThreadPoolExecutor",
+    "io_thread_pool_executor",
+    "thread_local_storage",
+]
 
 
 def set_thread_name(name):
     set_name(name)
+
+
+def initializer(thread_name, tls):
+    set_name(thread_name)
+    tls.lzh = open_handle(
+        history_prefix="tn-mw: ",
+        # TODO: investigate mnttab_cache
+        # wrt to zfs native encryption
+        mnttab_cache=True
+    )
 
 
 def start_daemon_thread(*args, **kwargs):
@@ -31,21 +50,27 @@ class IoThreadPoolExecutor(Executor):
         self.executor = ThreadPoolExecutor(
             self.thread_count,
             "IoThread",
-            initializer=lambda: set_thread_name("IoThread"),
+            initializer=initializer,
+            initargs=("IoThread", thread_local_storage),
         )
 
     def submit(self, fn, *args, **kwargs):
-        if len(self.executor._threads) == self.thread_count and self.executor._idle_semaphore._value - 1 <= 1:
-            fut = Future()
-            logger.trace("Calling %r in a single-use thread", fn)
-            start_daemon_thread(name=f"ExtraIoThread_{next(counter)}", target=worker, args=(fut, fn, args, kwargs))
-            return fut
+        if len(self.executor._threads) == self.thread_count:
+            if self.executor._idle_semaphore._value - 1 <= 1:
+                fut = Future()
+                logger.trace("Calling %r in a single-use thread", fn)
+                start_daemon_thread(
+                    name=f"ExtraIoThread_{next(counter)}",
+                    target=worker,
+                    args=(fut, fn, thread_local_storage, args, kwargs),
+                )
+                return fut
 
         return self.executor.submit(fn, *args, **kwargs)
 
 
-def worker(fut, fn, args, kwargs):
-    set_thread_name("ExtraIoThread")
+def worker(fut, fn, tls, args, kwargs):
+    initializer("ExtraIoThread", tls)
     try:
         fut.set_result(fn(*args, **kwargs))
     except Exception as e:


### PR DESCRIPTION
This does a few things:
1. adds a thread local storage object to the threads in our thread pool
2. uses the newly added `truenas_pylibzfs` module to open a persistent handle and store it in the thread-local storage for the threads in our thread pool
3. adds a `pass_thread_local_storage` keyword argument to our `api_method` decorator as well as adds a standalone decorator called `@pass_thread_local_storage`.
4. adds a sub `Config` boolean attribute called `pass_thread_local_storage`

This is the beginning steps of removing our process pool in favor of using our thread pool for libzfs operations.

This behaves similar to how we decorate other methods or configure plugins in middleware. The design works as follows:
1. if the sub `Config` object of a plugin has the boolean attribute `pass_thread_local_storage` set to `True`, the thread local storage object is injected as an argument to _ALL_ methods within the plugin.
2. or if the method is decorated with the `@pass_thread_local_storage` decorator, the thread local storage object is injected as an argument to the decorated method/function.