### PR TITLE
NAS-135898 / 25.04.1 / Add special case handling of user password disable. (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -104,8 +104,9 @@ def shadow_parse_aging(
     outstr = ''
 
     # Special cases
-    if user['username'] == 'root' and user['password_disabled']:
-        # NAS-135872, NAS-135863: Prevent root account from being disabled
+    if user['password_disabled']:
+        # NAS-135872, NAS-135863: Prevent a password disabled account from being
+        # disabled due to password change requirements.
         return '::::::'
 
     # man (5) shadow "date of last password change"

--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -103,6 +103,11 @@ def shadow_parse_aging(
     max_age_skip_users = max_age_overrides or set()
     outstr = ''
 
+    # Special cases
+    if user['username'] == 'root' and user['password_disabled']:
+        # NAS-135872, NAS-135863: Prevent root account from being disabled
+        return '::::::'
+
     # man (5) shadow "date of last password change"
     # Expressed as number of days since Jan 1, 1970 00:00 UTC
     # The value of zero (0) has special meaning that password change is required

--- a/tests/unit/test_shadow_account_policy.py
+++ b/tests/unit/test_shadow_account_policy.py
@@ -91,9 +91,42 @@ def create_old_user(name, **kwargs):
             yield c.call('user.get_instance', u['id']) | {'password': u['password']}
 
 
+@contextmanager
+def modify_root(payload: dict):
+    """ Temporarily modify root options and restore when done
+    payload: A valid 'user.update' payload
+    yield:
+        The user struct associated with root as returned by the setting
+    """
+    with Client() as c:
+        current_root_user = c.call('user.query', [['username', '=', 'root']], {'get': True})
+        root_id = current_root_user['id']
+        restore_root = {key: val for (key, val) in current_root_user.items() if key in payload.keys()}
+
+        # Process the request
+        root_update = c.call('user.update', root_id, payload)
+
+        # Let the caller do its thing
+        try:
+            yield root_update
+
+        # Restore to original
+        finally:
+            c.call('user.update', root_id, restore_root)
+
+
 @pytest.fixture(scope='function')
 def old_admin():
     with create_old_user('old_admin_user') as u:
+        with Client() as c:
+            ba_id = c.call('group.query', [['name', '=', 'builtin_administrators']], {'get': True})['id']
+            c.call('user.update', u['id'], {'groups': u['groups'] + [ba_id]})
+            yield u
+
+
+@pytest.fixture(scope='function')
+def local_full_admin():
+    with create_user('local_full_admin') as u:
         with Client() as c:
             ba_id = c.call('group.query', [['name', '=', 'builtin_administrators']], {'get': True})['id']
             c.call('user.update', u['id'], {'groups': u['groups'] + [ba_id]})
@@ -137,12 +170,13 @@ def get_shadow_entry(username):
     return {
         'name': name,
         'unixhash': pwd,
-        'lastchange': int(chg),
+        'lastchange': int(chg) if chg else None,
         'min_password_age': int(min_age) if min_age else None,
         'max_password_age': int(max_age) if max_age else None,
         'password_warn_period': int(warning) if warning else None,
         'password_inactivity_period': int(inactive) if inactive else None,
         'expiration': int(expiration) if expiration else None,
+        'raw_value': entry_str.strip(),
     }
 
 
@@ -393,6 +427,7 @@ def test__password_expiry_warning(old_admin):
         })
         assert resp['response_type'] == 'SUCCESS'
         user = c.call('user.get_instance', old_admin['id'])
+        sec = c.call('system.security.config')
         assert not user['password_change_required'], str({"user": user, "sec": sec})
 
         alerts = c.call('alert.run_source', 'SecurityLocalUserAccountExpiration')
@@ -526,3 +561,12 @@ def test_stig_min_password_age(readonly_admin):
 
         with Client() as c:
             c.call('user.update', readonly_admin['id'], {'password': 'canary'})
+
+
+def test_root_password_disable(local_full_admin):
+    """ Verify the root shadow entry is 'root:*:::::::' when password is disabled """
+
+    with modify_root({'password_disabled': True}) as root_user:
+        assert root_user['password_disabled'] is True
+        shadow = get_shadow_entry('root')
+        assert shadow['raw_value'] == "root:*:::::::"


### PR DESCRIPTION
When user passwords are disabled the user can no longer manage password change requirements or any password policy restrictions.  Under certain configurations, e.g. STIG, this can lead to the user account being disabled.   We want to avoid this condition.

The fix for this is to special case the user shadow entry to disable all expiration type settings when the user has password authentication disabled.

The shadow entry for a password disabled user will be `*:::::::`. This will prevent the user getting disabled due to password requirements.

Also added a CI unit test.
Also fixed a small error in the unit test.  Reporting info on an assert was missing some data.

This fixes the issue raised in [NAS-135863](https://ixsystems.atlassian.net/browse/NAS-135863)

Original PR: https://github.com/truenas/middleware/pull/16508
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135898