### PR TITLE
NAS-135910 / 25.10 / Eliminate a type check error.

### DIFF
--- a/src/middlewared/middlewared/utils/security.py
+++ b/src/middlewared/middlewared/utils/security.py
@@ -69,11 +69,12 @@ class STIGType(enum.IntFlag):
     of our product
     """
     # https://www.stigviewer.com/stig/general_purpose_operating_system_srg/
+    NONE = 0
     GPOS = enum.auto()  # General Purpose Operating System
 
 
 def system_security_config_to_stig_type(config: dict[str, bool]) -> STIGType:
-    return STIGType.GPOS if config['enable_gpos_stig'] else 0
+    return STIGType.GPOS if config['enable_gpos_stig'] else STIGType.NONE
 
 
 def shadow_parse_aging(


### PR DESCRIPTION
This call:
`return STIGType.GPOS if config['enable_gpos_stig'] else 0`

Generates this type check error:
`"Literal[0]" is not assignable to "STIGType"`

The fix:
Add the `0` case to STIGType class.