### PR TITLE
NAS-135940 / 25.10 / Update nvmet APIs to properly handle results wrt foreign keys

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -30,7 +30,7 @@ class QueryOptions(BaseModel):
     are covered in the "Query methods" section of the TrueNAS API documentation. """
     relationships: bool = True
     extend: str | None = None
-    extend_fk: list[str] | None = None
+    extend_fk: list[str] = []
     extend_context: str | None = None
     prefix: str | None = None
     extra: dict = {}

--- a/src/middlewared/middlewared/api/v25_10_0/common.py
+++ b/src/middlewared/middlewared/api/v25_10_0/common.py
@@ -30,6 +30,7 @@ class QueryOptions(BaseModel):
     are covered in the "Query methods" section of the TrueNAS API documentation. """
     relationships: bool = True
     extend: str | None = None
+    extend_fk: list[str] | None = None
     extend_context: str | None = None
     prefix: str | None = None
     extra: dict = {}

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_host_subsys.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_host_subsys.py
@@ -1,6 +1,8 @@
 from typing import Literal
 
 from middlewared.api.base import BaseModel, ForUpdateMetaclass
+from .nvmet_host import NVMetHostEntry
+from .nvmet_subsys import NVMetSubsysEntry
 
 __all__ = [
     "NVMetHostSubsysEntry",
@@ -15,8 +17,8 @@ __all__ = [
 
 class NVMetHostSubsysEntry(BaseModel):
     id: int
-    host: dict | None
-    subsys: dict | None
+    host: NVMetHostEntry
+    subsys: NVMetSubsysEntry
 
 
 class NVMetHostSubsysCreate(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_namespace.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_namespace.py
@@ -3,6 +3,7 @@ from typing import Annotated, Literal, TypeAlias
 from pydantic import Field
 
 from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, NonEmptyString, excluded_field
+from .nvmet_subsys import NVMetSubsysEntry
 
 __all__ = [
     "NVMetNamespaceEntry",
@@ -27,7 +28,7 @@ class NVMetNamespaceEntry(BaseModel):
 
     If not supplied during `namespace` creation then the next available NSID will be used.
     """
-    subsys: dict | None
+    subsys: NVMetSubsysEntry
     device_type: DeviceType
     """ Type of device (or file) used to implement the namespace. """
     device_path: str

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_port_subsys.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_port_subsys.py
@@ -1,6 +1,8 @@
 from typing import Literal
 
 from middlewared.api.base import BaseModel, ForUpdateMetaclass
+from .nvmet_port import NVMetPortEntry
+from .nvmet_subsys import NVMetSubsysEntry
 
 __all__ = [
     "NVMetPortSubsysEntry",
@@ -15,8 +17,8 @@ __all__ = [
 
 class NVMetPortSubsysEntry(BaseModel):
     id: int
-    port: dict | None
-    subsys: dict | None
+    port: NVMetPortEntry
+    subsys: NVMetSubsysEntry
 
 
 class NVMetPortSubsysCreate(BaseModel):

--- a/src/middlewared/middlewared/plugins/datastore/filter.py
+++ b/src/middlewared/middlewared/plugins/datastore/filter.py
@@ -47,6 +47,9 @@ class FilterMixin(SchemaMixin):
                 if '__' in name:
                     fk, name = name.split('__', 1)
                     col = self._get_col(aliases[list(self._get_col(table, fk, prefix).foreign_keys)[0]], name, '')
+                elif '.' in name:
+                    fk, name = name.split('.', 1)
+                    col = self._get_col(aliases[list(self._get_col(table, fk, prefix).foreign_keys)[0]], name, '')
                 else:
                     col = self._get_col(table, name, prefix)
 

--- a/src/middlewared/middlewared/plugins/datastore/filter.py
+++ b/src/middlewared/middlewared/plugins/datastore/filter.py
@@ -22,6 +22,16 @@ def nin(col, value):
 
 
 class FilterMixin(SchemaMixin):
+    def _filters_contains_foreign_key(self, filters):
+        for f in filters:
+            if not isinstance(f, (list, tuple)):
+                raise ValueError('Filter must be a list or tuple: {0}'.format(f))
+            if len(f) == 3:
+                name, _, _ = f
+                if any((x in name for x in ['__', '.'])):
+                    return True
+        return False
+
     def _filters_to_queryset(self, filters, table, prefix, aliases):
         opmap = {
             '=': operator.eq,

--- a/src/middlewared/middlewared/plugins/datastore/filter.py
+++ b/src/middlewared/middlewared/plugins/datastore/filter.py
@@ -44,11 +44,8 @@ class FilterMixin(SchemaMixin):
             if len(f) == 3:
                 name, op, value = f
 
-                if '__' in name:
-                    fk, name = name.split('__', 1)
-                    col = self._get_col(aliases[list(self._get_col(table, fk, prefix).foreign_keys)[0]], name, '')
-                elif '.' in name:
-                    fk, name = name.split('.', 1)
+                if matched := next((x for x in ['__', '.'] if x in name), False):
+                    fk, name = name.split(matched, 1)
                     col = self._get_col(aliases[list(self._get_col(table, fk, prefix).foreign_keys)[0]], name, '')
                 else:
                     col = self._get_col(table, name, prefix)

--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -37,7 +37,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             Bool('relationships', default=True),
             Str('extend', default=None, null=True),
             Str('extend_context', default=None, null=True),
-            List('extend_fk', default=None, null=True),
+            List('extend_fk', default=[], null=True),
             Str('prefix', default=None, null=True),
             Dict('extra', additional_attrs=True),
             List('order_by'),

--- a/src/middlewared/middlewared/plugins/datastore/read.py
+++ b/src/middlewared/middlewared/plugins/datastore/read.py
@@ -36,6 +36,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             Bool('relationships', default=True),
             Str('extend', default=None, null=True),
             Str('extend_context', default=None, null=True),
+            List('extend_fk', default=None, null=True),
             Str('prefix', default=None, null=True),
             Dict('extra', additional_attrs=True),
             List('order_by'),
@@ -86,6 +87,9 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
         # which might happen with "prefix"
         options = options.copy()
 
+        prefix = options['prefix']
+        extend_fk = options.get('extend_fk')
+        fk_attrs = {}
         aliases = {}
         if options['count']:
             qs = select([func.count(self._get_pk(table))])
@@ -95,12 +99,19 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
             if options['relationships']:
                 aliases = self._get_queryset_joins(table)
                 for foreign_key, alias in aliases.items():
+                    if extend_fk and foreign_key.parent.name.endswith('_id'):
+                        # Strip off the trailing '_id'
+                        fk = foreign_key.parent.name[:-3]
+                        # Strip off the prefix
+                        if fk.startswith(prefix):
+                            fk = fk[len(prefix):]
+                        if fk in extend_fk:
+                            if _attrs := await self._get_service_config_attrs(foreign_key.column.table.name):
+                                fk_attrs[fk] = _attrs
                     columns.extend(list(alias.c))
                     from_ = from_.outerjoin(alias, alias.c[foreign_key.column.name] == foreign_key.parent)
 
             qs = select(columns).select_from(from_)
-
-        prefix = options['prefix']
 
         if filters:
             qs = qs.where(and_(*self._filters_to_queryset(filters, table, prefix, aliases)))
@@ -147,7 +158,7 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
         result = await self._queryset_serialize(
             result,
             table, aliases, relationships, options['extend'], options['extend_context'], options['prefix'],
-            options['select'], options['extra'],
+            options['select'], options['extra'], fk_attrs,
         )
 
         if options['get']:
@@ -189,27 +200,50 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
         return result
 
     async def _queryset_serialize(
-        self, qs, table, aliases, relationships, extend, extend_context, field_prefix, select, extra_options,
+        self, qs, table, aliases, relationships, extend, extend_context, field_prefix, select, extra_options, fk_attrs,
     ):
         rows = []
         for i, row in enumerate(qs):
-            rows.append(self._serialize(row, table, aliases, relationships[i], field_prefix))
+            rows.append(self._serialize(row, table, aliases, relationships[i], field_prefix, fk_attrs))
 
         if extend_context:
             extend_context_value = await self.middleware.call(extend_context, rows, extra_options)
         else:
             extend_context_value = None
 
-        return [
+        result = [
             await self._extend(data, extend, extend_context, extend_context_value, select)
             for data in rows
         ]
 
-    def _serialize(self, obj, table, aliases, relationships, field_prefix):
+        for fk, attrs in fk_attrs.items():
+            if not attrs['extend']:
+                continue
+            if attrs['extend_context']:
+                extend_context_value = await self.middleware.call(attrs['extend_context'], rows, extra_options)
+            else:
+                extend_context_value = None
+            for row in result:
+                if fk in row:
+                    row[fk] = await self._extend(row[fk],
+                                                 attrs['extend'],
+                                                 attrs['extend_context'],
+                                                 extend_context_value,
+                                                 {})
+        return result
+
+    def _serialize(self, obj, table, aliases, relationships, field_prefix, fk_attrs):
         data = self._serialize_row(obj, table, aliases)
         data.update(relationships)
 
-        return {self._strip_prefix(k, field_prefix): v for k, v in data.items()}
+        result = {self._strip_prefix(k, field_prefix): v for k, v in data.items()}
+        # Check for nested data as a result of foreign keys
+        for fk, attrs in fk_attrs.items():
+            if not attrs['prefix']:
+                continue
+            if fk in result and isinstance(result[fk], dict):
+                result[fk] = {self._strip_prefix(k, attrs['prefix']): v for k, v in result[fk].items()}
+        return result
 
     async def _extend(self, data, extend, extend_context, extend_context_value, select):
         if extend:
@@ -296,3 +330,22 @@ class DatastoreService(Service, FilterMixin, SchemaMixin):
                     ]
 
         return relationships
+
+    async def _get_service_config_attrs(self, flat_table_name: str) -> dict:
+        cache_key = f'config_attrs_{flat_table_name}'
+        try:
+            return await self.middleware.call('cache.get', cache_key)
+        except KeyError:
+            pass
+        result = {}
+        for service_name, service_obj in self.middleware.get_services().items():
+            if service_obj._config and hasattr(service_obj._config, 'datastore'):
+                if service_obj._config.datastore:
+                    ds = service_obj._config.datastore.replace('.', '_').lower()
+                    if ds == flat_table_name:
+                        for attr in ['prefix', 'extend', 'extend_context']:
+                            key = f'datastore_{attr}'
+                            result[attr] = getattr(service_obj._config, key, None)
+                        await self.middleware.call('cache.put', cache_key, result)
+                        return result
+        return result

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -374,7 +374,7 @@ class iSCSITargetExtentService(SharingService):
             if namespaces := self.middleware.call_sync('nvmet.namespace.query', [['device_path', '=', disk]]):
                 ns = namespaces[0]
                 verrors.add(f'{schema_name}.disk',
-                            f'Disk currently in use by NVMe-oF subsystem {ns["subsys"]["nvmet_subsys_name"]} NSID {ns["nsid"]}')
+                            f'Disk currently in use by NVMe-oF subsystem {ns["subsys"]["name"]} NSID {ns["nsid"]}')
                 raise verrors
 
             device = os.path.join('/dev', disk)

--- a/src/middlewared/middlewared/plugins/nvmet/constants.py
+++ b/src/middlewared/middlewared/plugins/nvmet/constants.py
@@ -9,13 +9,6 @@ NVMET_SERVICE_NAME = 'nvmet'
 
 NVMET_MAX_NSID = 0xFFFFFFFE
 
-HOST_DATASTORE_PREFIX = 'nvmet_host_'
-HOST_DATASTORE_EXTEND = 'nvmet.host.extend'
-SUBSYS_DATASTORE_PREFIX = 'nvmet_subsys_'
-SUBSYS_DATASTORE_EXTEND = 'nvmet.subsys.extend'
-PORT_DATASTORE_PREFIX = 'nvmet_port_'
-PORT_DATASTORE_EXTEND = 'nvmet.port.extend'
-
 
 class ApiMapper(enum.Enum):
 

--- a/src/middlewared/middlewared/plugins/nvmet/constants.py
+++ b/src/middlewared/middlewared/plugins/nvmet/constants.py
@@ -9,6 +9,13 @@ NVMET_SERVICE_NAME = 'nvmet'
 
 NVMET_MAX_NSID = 0xFFFFFFFE
 
+HOST_DATASTORE_PREFIX = 'nvmet_host_'
+HOST_DATASTORE_EXTEND = 'nvmet.host.extend'
+SUBSYS_DATASTORE_PREFIX = 'nvmet_subsys_'
+SUBSYS_DATASTORE_EXTEND = 'nvmet.subsys.extend'
+PORT_DATASTORE_PREFIX = 'nvmet_port_'
+PORT_DATASTORE_EXTEND = 'nvmet.port.extend'
+
 
 class ApiMapper(enum.Enum):
 

--- a/src/middlewared/middlewared/plugins/nvmet/host.py
+++ b/src/middlewared/middlewared/plugins/nvmet/host.py
@@ -6,20 +6,19 @@ from middlewared.api.current import (NVMetHostCreateArgs,
                                      NVMetHostCreateResult,
                                      NVMetHostDeleteArgs,
                                      NVMetHostDeleteResult,
+                                     NVMetHostDHChapDHGroupChoicesArgs,
+                                     NVMetHostDHChapDHGroupChoicesResult,
+                                     NVMetHostDHChapHashChoicesArgs,
+                                     NVMetHostDHChapHashChoicesResult,
                                      NVMetHostEntry,
                                      NVMetHostGenerateKeyArgs,
                                      NVMetHostGenerateKeyResult,
                                      NVMetHostUpdateArgs,
-                                     NVMetHostUpdateResult,
-                                     NVMetHostDHChapDHGroupChoicesArgs,
-                                     NVMetHostDHChapDHGroupChoicesResult,
-                                     NVMetHostDHChapHashChoicesArgs,
-                                     NVMetHostDHChapHashChoicesResult
-                                     )
+                                     NVMetHostUpdateResult)
 from middlewared.service import CRUDService, ValidationErrors, private
 from middlewared.service_exception import CallError
 from middlewared.utils import run
-from .constants import DHCHAP_DHGROUP, DHCHAP_HASH
+from .constants import DHCHAP_DHGROUP, DHCHAP_HASH, HOST_DATASTORE_EXTEND, HOST_DATASTORE_PREFIX
 
 
 class NVMetHostModel(sa.Model):
@@ -38,8 +37,8 @@ class NVMetHostService(CRUDService):
     class Config:
         namespace = 'nvmet.host'
         datastore = 'services.nvmet_host'
-        datastore_prefix = 'nvmet_host_'
-        datastore_extend = 'nvmet.host.extend'
+        datastore_prefix = HOST_DATASTORE_PREFIX
+        datastore_extend = HOST_DATASTORE_EXTEND
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetHostEntry
@@ -111,8 +110,8 @@ class NVMetHostService(CRUDService):
         host = await self.get_instance(id_)
         audit_callback(host['hostnqn'])
 
-        host_subsys_ids = {x['id']: x['subsys']['nvmet_subsys_name'] for x in
-                           await self.middleware.call('nvmet.host_subsys.query', [['host_id', '=', id_]])}
+        host_subsys_ids = {x['id']: x['subsys']['name'] for x in
+                           await self.middleware.call('nvmet.host_subsys.query', [['host.id', '=', id_]])}
         if host_subsys_ids:
             if force:
                 await self.middleware.call('nvmet.host_subsys.delete_ids', list(host_subsys_ids))

--- a/src/middlewared/middlewared/plugins/nvmet/host.py
+++ b/src/middlewared/middlewared/plugins/nvmet/host.py
@@ -18,7 +18,7 @@ from middlewared.api.current import (NVMetHostCreateArgs,
 from middlewared.service import CRUDService, ValidationErrors, private
 from middlewared.service_exception import CallError
 from middlewared.utils import run
-from .constants import DHCHAP_DHGROUP, DHCHAP_HASH, HOST_DATASTORE_EXTEND, HOST_DATASTORE_PREFIX
+from .constants import DHCHAP_DHGROUP, DHCHAP_HASH
 
 
 class NVMetHostModel(sa.Model):
@@ -37,8 +37,8 @@ class NVMetHostService(CRUDService):
     class Config:
         namespace = 'nvmet.host'
         datastore = 'services.nvmet_host'
-        datastore_prefix = HOST_DATASTORE_PREFIX
-        datastore_extend = HOST_DATASTORE_EXTEND
+        datastore_prefix = 'nvmet_host_'
+        datastore_extend = 'nvmet.host.extend'
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetHostEntry

--- a/src/middlewared/middlewared/plugins/nvmet/host_subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/host_subsys.py
@@ -9,7 +9,6 @@ from middlewared.api.current import (NVMetHostSubsysCreateArgs,
                                      NVMetHostSubsysUpdateResult)
 from middlewared.service import CRUDService, ValidationErrors, private
 from middlewared.service_exception import MatchNotFound
-from .constants import HOST_DATASTORE_EXTEND, HOST_DATASTORE_PREFIX, SUBSYS_DATASTORE_EXTEND, SUBSYS_DATASTORE_PREFIX
 
 
 class NVMetHostSubsysModel(sa.Model):
@@ -26,7 +25,7 @@ class NVMetHostSubsysService(CRUDService):
         namespace = 'nvmet.host_subsys'
         datastore = 'services.nvmet_host_subsys'
         datastore_prefix = 'nvmet_host_subsys_'
-        datastore_extend = 'nvmet.host_subsys.extend'
+        datastore_extend_fk = ['host', 'subsys']
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetHostSubsysEntry
@@ -146,16 +145,3 @@ class NVMetHostSubsysService(CRUDService):
 
     def __audit_summary(self, data):
         return f'{data["host"]["hostnqn"]}/{data["subsys"]["name"]}'
-
-    @private
-    async def extend(self, data):
-        if host_data := data.pop('host', {}):
-            data['host'] = await self.process_data(host_data,
-                                                   HOST_DATASTORE_PREFIX,
-                                                   HOST_DATASTORE_EXTEND)
-        if subsys_data := data.pop('subsys', {}):
-            data['subsys'] = await self.process_data(subsys_data,
-                                                     SUBSYS_DATASTORE_PREFIX,
-                                                     SUBSYS_DATASTORE_EXTEND,
-                                                     {})
-        return data

--- a/src/middlewared/middlewared/plugins/nvmet/namespace.py
+++ b/src/middlewared/middlewared/plugins/nvmet/namespace.py
@@ -20,7 +20,6 @@ from .constants import NAMESPACE_DEVICE_TYPE
 from .kernel import lock_namespace as kernel_lock_namespace
 from .kernel import unlock_namespace as kernel_unlock_namespace
 from .kernel import resize_namespace as kernel_resize_namespace
-from .constants import SUBSYS_DATASTORE_EXTEND, SUBSYS_DATASTORE_PREFIX
 
 UUID_GENERATE_RETRIES = 10
 NSID_SEARCH_RANGE = 0xFFFF  # This is much less than NSID, but good enough for practical purposes.
@@ -68,6 +67,7 @@ class NVMetNamespaceService(SharingService):
         datastore = 'services.nvmet_namespace'
         datastore_prefix = 'nvmet_namespace_'
         datastore_extend = 'nvmet.namespace.extend'
+        datastore_extend_fk = ['subsys']
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetNamespaceEntry
@@ -159,11 +159,6 @@ class NVMetNamespaceService(SharingService):
     @private
     async def extend(self, data):
         data['device_type'] = NAMESPACE_DEVICE_TYPE.by_db(data['device_type']).api
-        if subsys_data := data.pop('subsys', {}):
-            data['subsys'] = await self.process_data(subsys_data,
-                                                     SUBSYS_DATASTORE_PREFIX,
-                                                     SUBSYS_DATASTORE_EXTEND,
-                                                     {})
         return data
 
     @private

--- a/src/middlewared/middlewared/plugins/nvmet/port.py
+++ b/src/middlewared/middlewared/plugins/nvmet/port.py
@@ -15,7 +15,7 @@ from middlewared.api.current import (NVMetPortCreateArgs,
 from middlewared.plugins.rdma.constants import RDMAprotocols
 from middlewared.service import CRUDService, private
 from middlewared.service_exception import MatchNotFound, ValidationErrors
-from .constants import PORT_ADDR_FAMILY, PORT_DATASTORE_EXTEND, PORT_DATASTORE_PREFIX, PORT_TRTYPE, similar_ports
+from .constants import PORT_ADDR_FAMILY, PORT_TRTYPE, similar_ports
 
 
 def _port_summary(data):
@@ -43,8 +43,8 @@ class NVMetPortService(CRUDService):
     class Config:
         namespace = 'nvmet.port'
         datastore = 'services.nvmet_port'
-        datastore_prefix = PORT_DATASTORE_PREFIX
-        datastore_extend = PORT_DATASTORE_EXTEND
+        datastore_prefix = 'nvmet_port_'
+        datastore_extend = 'nvmet.port.extend'
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetPortEntry

--- a/src/middlewared/middlewared/plugins/nvmet/port_subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/port_subsys.py
@@ -9,10 +9,6 @@ from middlewared.api.current import (NVMetPortSubsysCreateArgs,
                                      NVMetPortSubsysUpdateResult)
 from middlewared.service import CRUDService, ValidationErrors, private
 from middlewared.service_exception import MatchNotFound
-from .constants import (PORT_DATASTORE_EXTEND,
-                        PORT_DATASTORE_PREFIX,
-                        SUBSYS_DATASTORE_EXTEND,
-                        SUBSYS_DATASTORE_PREFIX)
 from .mixin import NVMetStandbyMixin
 
 
@@ -30,7 +26,7 @@ class NVMetPortSubsysService(CRUDService, NVMetStandbyMixin):
         namespace = 'nvmet.port_subsys'
         datastore = 'services.nvmet_port_subsys'
         datastore_prefix = 'nvmet_port_subsys_'
-        datastore_extend = 'nvmet.port_subsys.extend'
+        datastore_extend_fk = ['port', 'subsys']
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetPortSubsysEntry
@@ -155,16 +151,3 @@ class NVMetPortSubsysService(CRUDService, NVMetStandbyMixin):
         port = data['port']
         port_summary = (f'{port["addr_trtype"]}:{port["addr_traddr"]}:{port["addr_trsvcid"]}')
         return f'{port_summary}/{data["subsys"]["name"]}'
-
-    @private
-    async def extend(self, data):
-        if port_data := data.pop('port', {}):
-            data['port'] = await self.process_data(port_data,
-                                                   PORT_DATASTORE_PREFIX,
-                                                   PORT_DATASTORE_EXTEND)
-        if subsys_data := data.pop('subsys', {}):
-            data['subsys'] = await self.process_data(subsys_data,
-                                                     SUBSYS_DATASTORE_PREFIX,
-                                                     SUBSYS_DATASTORE_EXTEND,
-                                                     {})
-        return data

--- a/src/middlewared/middlewared/plugins/nvmet/subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/subsys.py
@@ -11,6 +11,7 @@ from middlewared.api.current import (NVMetSubsysCreateArgs,
                                      NVMetSubsysUpdateArgs,
                                      NVMetSubsysUpdateResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
+from .constants import SUBSYS_DATASTORE_EXTEND, SUBSYS_DATASTORE_PREFIX
 from .mixin import NVMetStandbyMixin
 
 SERIAL_RETRIES = 10
@@ -40,9 +41,9 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
     class Config:
         namespace = 'nvmet.subsys'
         datastore = 'services.nvmet_subsys'
-        datastore_prefix = 'nvmet_subsys_'
+        datastore_prefix = SUBSYS_DATASTORE_PREFIX
         datastore_extend_context = "nvmet.subsys.extend_context"
-        datastore_extend = "nvmet.subsys.extend"
+        datastore_extend = SUBSYS_DATASTORE_EXTEND
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetSubsysEntry
@@ -139,7 +140,7 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
                                 f'Subsystem {subsys["name"]} contains {count} namespaces: {",".join(names)}{postfix}')
 
         port_subsys_ids = [x['id'] for x in await self.middleware.call('nvmet.port_subsys.query',
-                                                                       [['subsys_id', '=', id_]],
+                                                                       [['subsys.id', '=', id_]],
                                                                        {'select': ['id']})]
         if port_subsys_ids:
             if force:
@@ -153,7 +154,7 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
 
         # We will allow a subsys to be deleted, even if it currently has allowed_hosts configured
         host_subsys_ids = [x['id'] for x in await self.middleware.call('nvmet.host_subsys.query',
-                                                                       [['subsys_id', '=', id_]],
+                                                                       [['subsys.id', '=', id_]],
                                                                        {'select': ['id']})]
         if host_subsys_ids:
             await self.middleware.call('nvmet.host_subsys.delete_ids', host_subsys_ids)

--- a/src/middlewared/middlewared/plugins/nvmet/subsys.py
+++ b/src/middlewared/middlewared/plugins/nvmet/subsys.py
@@ -11,7 +11,6 @@ from middlewared.api.current import (NVMetSubsysCreateArgs,
                                      NVMetSubsysUpdateArgs,
                                      NVMetSubsysUpdateResult)
 from middlewared.service import CallError, CRUDService, ValidationErrors, private
-from .constants import SUBSYS_DATASTORE_EXTEND, SUBSYS_DATASTORE_PREFIX
 from .mixin import NVMetStandbyMixin
 
 SERIAL_RETRIES = 10
@@ -41,9 +40,9 @@ class NVMetSubsysService(CRUDService, NVMetStandbyMixin):
     class Config:
         namespace = 'nvmet.subsys'
         datastore = 'services.nvmet_subsys'
-        datastore_prefix = SUBSYS_DATASTORE_PREFIX
+        datastore_prefix = 'nvmet_subsys_'
         datastore_extend_context = "nvmet.subsys.extend_context"
-        datastore_extend = SUBSYS_DATASTORE_EXTEND
+        datastore_extend = "nvmet.subsys.extend"
         cli_private = True
         role_prefix = 'SHARING_NVME_TARGET'
         entry = NVMetSubsysEntry

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_datastore.py
@@ -857,6 +857,41 @@ class LinkedFromModel(Model):
     pytest.param(
         {},
         [],
+        {'prefix': 'linkedfrom_', 'count': True},
+        2,
+        id='extend_pk NOT supplied, no filter, no extend, count(2)'),
+
+    pytest.param(
+        {},
+        [['id', '=', 2]],
+        {'prefix': 'linkedfrom_', 'count': True},
+        1,
+        id='extend_pk NOT supplied, filter, no extend, count(1)'),
+
+    pytest.param(
+        {},
+        [['id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'count': True},
+        0,
+        id='extend_pk NOT supplied, filter, no extend, count(0)'),
+
+    pytest.param(
+        {},
+        [['linkedto_id', '=', 3]],
+        {'prefix': 'linkedfrom_', 'count': True},
+        1,
+        id='extend_pk NOT supplied, filter(underscore), no extend, count(1)'),
+
+    pytest.param(
+        {},
+        [['linkedto_id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'count': True},
+        0,
+        id='extend_pk NOT supplied, filter(underscore), no extend, count(0)'),
+
+    pytest.param(
+        {},
+        [],
         {'prefix': 'linkedfrom_', 'extend': 'fake.extend.triple_value'},
         [{'id': 1,
           'linkedto': {'id': 2, 'linkedto_value': 42},
@@ -931,6 +966,70 @@ class LinkedFromModel(Model):
           'linkedto': {'id': 2, 'value': 84},
           'value': 426}],
         id='extend_pk supplied, filter (period), extend (twice)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        2,
+        id='extend_pk supplied, no filter, extend, count(2)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['id', '=', 2]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        1,
+        id='extend_pk supplied, filter, extend, count(1)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        0,
+        id='extend_pk supplied, filter, extend, count(0)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto_id', '=', 3]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        1,
+        id='extend_pk supplied, filter(underscore), extend, count(1)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto_id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        0,
+        id='extend_pk supplied, filter(underscore), extend, count(0)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto__id', '=', 3]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        1,
+        id='extend_pk supplied, filter(double underscore), extend, count(1)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto__id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        0,
+        id='extend_pk supplied, filter(double underscore), extend, count(0)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto.id', '=', 3]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        1,
+        id='extend_pk supplied, filter(period), extend, count(1)'),
+
+    pytest.param(
+        {'prefix': 'linkedto_', 'extend': 'fake.extend.double_value', 'extend_context': None},
+        [['linkedto.id', '=', 525600]],
+        {'prefix': 'linkedfrom_', 'extend_fk': ['linkedto'], 'count': True},
+        0,
+        id='extend_pk supplied, filter(period), extend, count(0)'),
+
 ])
 @pytest.mark.asyncio
 async def test__extend_fk(extend_fk_attrs, filter, options, expected_result):

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -8,6 +8,7 @@ def service_config(klass, config):
         'datastore': None,
         'datastore_prefix': '',
         'datastore_extend': None,
+        'datastore_extend_fk': None,
         'datastore_extend_context': None,
         'datastore_primary_key': 'id',
         'datastore_primary_key_type': 'integer',
@@ -55,6 +56,7 @@ class ServiceBase(type):
     Currently the following options are allowed:
       - datastore: name of the datastore mainly used in the service
       - datastore_extend: datastore `extend` option used in common `query` method
+      - datastore_extend_fk: datastore `extend_fk` option used in common `query` method
       - datastore_prefix: datastore `prefix` option used in helper methods
       - service: system service `name` option used by `SystemServiceService`
       - service_verb: verb to be used on update (default to `reload`)

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -106,6 +106,7 @@ class ConfigService(ServiceChangeMixin, Service, metaclass=ConfigServiceMetabase
         options = {}
         options['extend'] = self._config.datastore_extend
         options['extend_context'] = self._config.datastore_extend_context
+        options['extend_fk'] = self._config.datastore_extend_fk
         options['prefix'] = self._config.datastore_prefix
         return await self._get_or_insert(self._config.datastore, options)
 

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -220,6 +220,7 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
         options = options or {}
         options['extend'] = self._config.datastore_extend
         options['extend_context'] = self._config.datastore_extend_context
+        options['extend_fk'] = self._config.datastore_extend_fk
         options['prefix'] = self._config.datastore_prefix
         return options
 
@@ -432,22 +433,3 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
                 }, **data)
 
         return dependencies
-
-    @private
-    async def process_data(self, data, prefix, extend=None, context=None):
-        """
-        Helper function for processing data returned by query of a foreign key.
-        """
-        result = {}
-        prefix_len = len(prefix)
-        for k, v in data.items():
-            if k.startswith(prefix):
-                k = k[prefix_len:]
-            result[k] = v
-        if extend:
-            # Some extend methods require a context, some don't allow one.
-            if context is not None:
-                result = await self.middleware.call(extend, result, context)
-            else:
-                result = await self.middleware.call(extend, result)
-        return result

--- a/src/middlewared/middlewared/service/crud_service.py
+++ b/src/middlewared/middlewared/service/crud_service.py
@@ -432,3 +432,22 @@ class CRUDService(ServiceChangeMixin, Service, metaclass=CRUDServiceMetabase):
                 }, **data)
 
         return dependencies
+
+    @private
+    async def process_data(self, data, prefix, extend=None, context=None):
+        """
+        Helper function for processing data returned by query of a foreign key.
+        """
+        result = {}
+        prefix_len = len(prefix)
+        for k, v in data.items():
+            if k.startswith(prefix):
+                k = k[prefix_len:]
+            result[k] = v
+        if extend:
+            # Some extend methods require a context, some don't allow one.
+            if context is not None:
+                result = await self.middleware.call(extend, result, context)
+            else:
+                result = await self.middleware.call(extend, result)
+        return result


### PR DESCRIPTION
Several nvmet APIs are based on entities which include foreign keys.  Query results are **not** being properly exposed in the API.  Rectify for:
- `nvmet.host_subsys.query`
- `nvmet.port_subsys.query`
- `nvmet.namespace.query`

For example, prior to this change we could have a port (from `nvmet.port.query`):
```
[
  {
    "id": 26,
    "index": 1,
    "addr_trtype": "TCP",
    "addr_trsvcid": 4420,
    "addr_traddr": "192.168.56.115",
    "addr_adrfam": "IPV4",
    "inline_data_size": null,
    "max_queue_size": null,
    "pi_enable": null,
    "enabled": true
  }
]
```

that was being returned in `nvmet.port_subsys.query` as
```
[
  {
    "id": 43,
    "port": {
      "id": 26,
      "nvmet_port_index": 1,
      "nvmet_port_addr_trtype": 3,
      "nvmet_port_addr_trsvcid": "4420",
      "nvmet_port_addr_traddr": "192.168.56.115",
      "nvmet_port_addr_adrfam": 1,
      "nvmet_port_inline_data_size": null,
      "nvmet_port_max_queue_size": null,
      "nvmet_port_pi_enable": null,
      "nvmet_port_enabled": true
    },
    "subsys": {
      "id": 53,
      "nvmet_subsys_name": "foo1",
      "nvmet_subsys_subnqn": "nqn.2011-06.com.truenas:uuid:68bf9433-63ef-49f5-a921-4c0f8190fd94:foo1",
      "nvmet_subsys_serial": "b41845c4d6a4082eaa3a",
      "nvmet_subsys_allow_any_host": false,
      "nvmet_subsys_pi_enable": null,
      "nvmet_subsys_qid_max": null,
      "nvmet_subsys_ieee_oui": null,
      "nvmet_subsys_ana": null
    }
  }
]
```

Just looking at the line
```
"nvmet_port_addr_trtype": 3,
```
demonstrates **two** problems:
1. The wrong key is returned (e.g. `nvmet_port_addr_trtype` rather than `addr_trtype`)
2. The wrong value is returned (e.g. `3` rather than `"TCP"`)

----

CI run #[4531](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4531/).
CI run #[4540](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4540/).
Good CI run #[4546](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4546/).