### PR TITLE
NAS-135886 / 25.04.1 / Fix fragile behavior of config method (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_get_or_insert.py
+++ b/src/middlewared/middlewared/pytest/unit/test_get_or_insert.py
@@ -1,0 +1,45 @@
+import unittest.mock
+
+import pytest
+
+from middlewared.pytest.unit.middleware import Middleware
+from middlewared.service.config_service import ConfigService
+
+
+@pytest.mark.parametrize('rows, new_row, should_work', [
+    (
+        [{'label': 'TRUENAS', 'preferred_trains': ['community', 'stable']}],
+        {},
+        True,
+    ),
+    (
+        [],
+        {'label': 'TRUENAS', 'preferred_trains': ['community', 'stable']},
+        True
+    ),
+    (
+        [],
+        {},
+        False
+    )
+])
+@pytest.mark.asyncio
+async def test_get_or_insert(rows, new_row, should_work):
+    middleware = Middleware()
+    middleware['datastore.query'] = lambda *args: rows
+    middleware['datastore.insert'] = lambda *args: new_row
+    middleware['datastore.config'] = lambda *args: new_row
+    config_service_obj = ConfigService(middleware)
+
+    if should_work:
+        response = await config_service_obj._get_or_insert('service.catalog', {})
+        if rows:
+            assert response == rows[0]
+        else:
+            assert response == new_row
+    else:
+        query_mock = unittest.mock.Mock()
+        query_mock.side_effect = IndexError
+        with pytest.raises(IndexError):
+            middleware['datastore.query'] = query_mock
+            await config_service_obj._get_or_insert('service.catalog', {})

--- a/src/middlewared/middlewared/pytest/unit/test_get_or_insert.py
+++ b/src/middlewared/middlewared/pytest/unit/test_get_or_insert.py
@@ -1,45 +1,72 @@
+import json
 import unittest.mock
 
 import pytest
+import sqlalchemy as sa
 
 from middlewared.pytest.unit.middleware import Middleware
+from middlewared.pytest.unit.plugins.test_datastore import datastore_test, Model
 from middlewared.service.config_service import ConfigService
 
 
-@pytest.mark.parametrize('rows, new_row, should_work', [
+class CatalogModel(Model):
+    __tablename__ = 'services_catalog'
+
+    label = sa.Column(sa.String(255), nullable=False, unique=True, primary_key=True)
+    preferred_trains = sa.Column(sa.JSON(list))
+
+
+@pytest.mark.parametrize('rows, should_work', [
     (
         [{'label': 'TRUENAS', 'preferred_trains': ['community', 'stable']}],
-        {},
         True,
     ),
     (
         [],
-        {'label': 'TRUENAS', 'preferred_trains': ['community', 'stable']},
         True
     ),
     (
         [],
-        {},
         False
     )
 ])
 @pytest.mark.asyncio
-async def test_get_or_insert(rows, new_row, should_work):
-    middleware = Middleware()
-    middleware['datastore.query'] = lambda *args: rows
-    middleware['datastore.insert'] = lambda *args: new_row
-    middleware['datastore.config'] = lambda *args: new_row
-    config_service_obj = ConfigService(middleware)
+async def test_get_or_insert(rows, should_work):
+    async with datastore_test() as ds:
+        middleware = Middleware()
+        middleware['datastore.query'] = ds.query
+        middleware['datastore.insert'] = ds.insert
+        middleware['datastore.config'] = ds.config
+        config_service_obj = ConfigService(middleware)
 
-    if should_work:
-        response = await config_service_obj._get_or_insert('service.catalog', {})
-        if rows:
-            assert response == rows[0]
+        if should_work:
+            if rows:
+                # Testing case where the row exists already
+                ds.execute(
+                    'INSERT INTO `services_catalog` VALUES (?, ?)',
+                    (rows[0]['label'], json.dumps(rows[0]['preferred_trains']))
+                )
+                response = await config_service_obj._get_or_insert('services.catalog', {})
+                assert response == rows[0]
+            else:
+                # Testing case where the row does not exist and is added by config service
+                # get_or_insert
+                response = await config_service_obj._get_or_insert('services.catalog', {})
+                assert response == {'label': '', 'preferred_trains': None}
         else:
-            assert response == new_row
-    else:
-        query_mock = unittest.mock.Mock()
-        query_mock.side_effect = IndexError
-        with pytest.raises(IndexError):
+            # Testing case where the row does exist but the query method raises some exception
+            # in this case we say IndexError - so we make sure that we don't have datastore.insert
+            # called in this case
+            query_mock = unittest.mock.Mock(side_effect=IndexError)
             middleware['datastore.query'] = query_mock
-            await config_service_obj._get_or_insert('service.catalog', {})
+
+            insert_mock = unittest.mock.Mock()
+            config_mock = unittest.mock.Mock()
+            middleware['datastore.insert'] = insert_mock
+            middleware['datastore.config'] = config_mock
+
+            with pytest.raises(IndexError):
+                await config_service_obj._get_or_insert('service.catalog', {})
+
+            insert_mock.assert_not_called()
+            config_mock.assert_not_called()

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -119,12 +119,12 @@ class ConfigService(ServiceChangeMixin, Service, metaclass=ConfigServiceMetabase
 
     @private
     async def _get_or_insert(self, datastore, options):
-        try:
-            return await self.middleware.call('datastore.config', datastore, options)
-        except IndexError:
+        rows = await self.middleware.call('datastore.query', datastore, [], options)
+        if not rows:
             async with get_or_insert_lock:
-                try:
-                    return await self.middleware.call('datastore.config', datastore, options)
-                except IndexError:
+                rows = await self.middleware.call('datastore.query', datastore, [], options)
+                if not rows:
                     await self.middleware.call('datastore.insert', datastore, {})
                     return await self.middleware.call('datastore.config', datastore, options)
+
+        return rows[0]

--- a/src/middlewared/middlewared/service/config_service.py
+++ b/src/middlewared/middlewared/service/config_service.py
@@ -122,6 +122,8 @@ class ConfigService(ServiceChangeMixin, Service, metaclass=ConfigServiceMetabase
         rows = await self.middleware.call('datastore.query', datastore, [], options)
         if not rows:
             async with get_or_insert_lock:
+                # We do this again here to avoid TOCTOU as we don't want multiple calls inserting records
+                # and we ending up with duplicates again
                 rows = await self.middleware.call('datastore.query', datastore, [], options)
                 if not rows:
                     await self.middleware.call('datastore.insert', datastore, {})


### PR DESCRIPTION
This PR adds changes to fix fragile behaviour of config method where what happens is that we try to see if a row exists in the config service table by selecting first index which if it does not exist will raise `IndexError` and in that case we used to insert a row in the database.

The problem with this logic is that if any service has an extend in place which also raises `IndexError` and is not caught will result in duplicate entry being created in the config service table as the code assumed `IndexError` was being originated because it had tried to select the first row whereas that was not the case.

Now we instead call `query` directly and get the first row like `get=True` was doing already in `datastore.config` method. This is safe in terms of that if the underlying service is doing anything else, that error gets raised as is and we don't make false assumptions that this exception is coming because we don't have a row available and let's insert now.

Original PR: https://github.com/truenas/middleware/pull/16504
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135886