### PR TITLE
NAS-135950 / 25.10 / remove pass_thread_local_storage attribute for sub-Config class

### DIFF
--- a/src/middlewared/middlewared/api/base/decorator.py
+++ b/src/middlewared/middlewared/api/base/decorator.py
@@ -89,6 +89,9 @@ def api_method(
                 'require': pass_app_require,
                 'rest': pass_app_rest,
             }
+        if pass_thread_local_storage:
+            func._pass_thread_local_storage = True
+
         if skip_args is not None:
             func._skip_arg = skip_args
 
@@ -144,7 +147,6 @@ def api_method(
         wrapped.roles = roles or []
         wrapped._private = private
         wrapped._cli_private = cli_private
-        wrapped._pass_thread_local_storage = pass_thread_local_storage
         if removed_in is not None:
             if not MAJOR_VERSION.match(removed_in):
                 raise ValueError(

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -681,7 +681,7 @@ class Middleware(LoadPluginsMixin, ServiceCallMixin):
             args.append(app)
 
         is_coroutine = asyncio.iscoroutinefunction(methodobj)
-        if serviceobj._config.pass_thread_local_storage or getattr(methodobj, '_pass_thread_local_storage', False):
+        if hasattr(methodobj, '_pass_thread_local_storage'):
             if is_coroutine:
                 raise RuntimeError("Thread local storage is invalid for coroutines")
             args.append(thread_local_storage)

--- a/src/middlewared/middlewared/schema/processor.py
+++ b/src/middlewared/middlewared/schema/processor.py
@@ -202,6 +202,8 @@ def calculate_args_index(f, audit_callback):
         args_index += 1
         if f._pass_app['message_id']:
             args_index += 1
+    if hasattr(f, '_pass_thread_local_storage'):
+        args_index += 1
     if audit_callback:
         args_index += 1
     if hasattr(f, '_job'):

--- a/src/middlewared/middlewared/service/base.py
+++ b/src/middlewared/middlewared/service/base.py
@@ -15,7 +15,6 @@ def service_config(klass, config):
         'event_register': True,
         'event_send': True,
         'events': [],
-        'pass_thread_local_storage': False,
         'service': None,
         'service_verb': 'reload',
         'service_verb_sync': True,


### PR DESCRIPTION
This removes the `pass_thread_local_storage` attribute from the `Config` sub-class object. It's not very conducive to proper API design with how it operates so we'll just mirror the `pass_app` functionality.