### PR TITLE
NAS-135946 / 25.10 / Allow password aging bypass for admin OTPW

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -53,7 +53,7 @@ from middlewared.service import CallError, CRUDService, ValidationErrors, pass_a
 from middlewared.service_exception import MatchNotFound
 import middlewared.sqlalchemy as sa
 from middlewared.utils import run, filter_list
-from middlewared.utils.account.authenticator import UserPamAuthenticator
+from middlewared.utils.account.authenticator import UserPamAuthenticator, AccountFlag
 from middlewared.utils.account.faillock import tally_locked_users, reset_tally
 from middlewared.utils.crypto import generate_nt_hash, sha512_crypt, generate_string, check_unixhash
 from middlewared.utils.directoryservices.constants import DSType, DSStatus
@@ -1755,11 +1755,16 @@ class UserService(CRUDService):
         is_full_admin = credential_has_full_admin(app.authenticated_credentials)
         is_otp_login = False
         authenticated_user = None
+        password_aging_override = is_full_admin
 
         if app.authenticated_credentials.is_user_session:
             authenticated_user = app.authenticated_credentials.user['username']
-            if 'OTPW' in app.authenticated_credentials.user['account_attributes']:
+            if AccountFlag.OTPW in app.authenticated_credentials.user['account_attributes']:
                 is_otp_login = True
+
+            if not password_aging_override:
+                if AccountFlag.PASSWORD_CHANGE_REQUIRED in app.authenticated_credentials.user['account_attributes']:
+                    password_aging_override = True
 
         username = data['username']
         password = data['new_password']
@@ -1821,7 +1826,7 @@ class UserService(CRUDService):
 
         verrors.check()
 
-        if min_password_age and entry['password_age'] < min_password_age:
+        if not password_aging_override and min_password_age and entry['password_age'] < min_password_age:
             verrors.add(
                 'user.set_password.username',
                 f'{username}: password changed too recently. Minimum password age is: {min_password_age}'

--- a/tests/unit/test_otpw_manager.py
+++ b/tests/unit/test_otpw_manager.py
@@ -1,44 +1,45 @@
-from middlewared.utils.auth import OTPW_MANAGER, OTPWResponse
+from middlewared.utils.auth import OTPW_MANAGER, OTPWResponseCode
 
 
 def test__auth_success():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
     resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    assert resp.code is OTPWResponseCode.SUCCESS
+    assert resp.data['password_set_override'] is False
 
 
 def test__auth_used():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.ALREADY_USED
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.ALREADY_USED
 
 
 def test__auth_nokey():
-    resp = OTPW_MANAGER.authenticate(1000, '80000_canary')
-    assert resp is OTPWResponse.NO_KEY
+    resp = OTPW_MANAGER.authenticate(1000, '80000_canary').code
+    assert resp is OTPWResponseCode.NO_KEY
 
 
 def test__auth_bad_passkey():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1000, passwd + 'bad')
-    assert resp is OTPWResponse.BAD_PASSKEY
+    resp = OTPW_MANAGER.authenticate(1000, passwd + 'bad').code
+    assert resp is OTPWResponseCode.BAD_PASSKEY
 
     # This shouldn't prevent using correct passkey
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
 
 def test__auth_wrong_user():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1001, passwd)
-    assert resp is OTPWResponse.WRONG_USER
+    resp = OTPW_MANAGER.authenticate(1001, passwd).code
+    assert resp is OTPWResponseCode.WRONG_USER
 
     # This shouldn't prevent correct user
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
 
 def test__auth_expired():
@@ -47,5 +48,12 @@ def test__auth_expired():
 
     OTPW_MANAGER.otpasswd[idx].expires = 1
 
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.EXPIRED
+
+
+def test__auth_flag():
+    passwd = OTPW_MANAGER.generate_for_uid(1000, True)
     resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.EXPIRED
+    assert resp.code is OTPWResponseCode.SUCCESS
+    assert resp.data['password_set_override'] is True


### PR DESCRIPTION
This commit fixes a usability issue with generating temporary passwords for user accounts while in STIG compatibility mode with a minimum password age set. There are various situations in which an account administrator may need to generate a password for users so that they can authenticate and then set their password and two-factor settings. When the OTPW has been generated in this manner, set a flag that is then used to bypass the minimum password age validation.