### PR TITLE
NAS-135962 / 25.10 / Fix roles typo

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/utils.py
+++ b/src/middlewared/middlewared/plugins/service_/utils.py
@@ -26,7 +26,7 @@ def app_has_write_privilege_for_service(
     if credential_has_full_admin(app.authenticated_credentials):
         return True
 
-    if app.authenticated_credentials.has_role('SERVICES_WRITE'):
+    if app.authenticated_credentials.has_role('SERVICE_WRITE'):
         return True
 
     try:


### PR DESCRIPTION
Correct typo, change: 'SERVICES_WRITE' to 'SERVICE_WRITE'

[api](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4528/) and [unit](http://jenkins.eng.ixsystems.net:8080/job/tests/job/unit_tests/1401/) tests look good.