### PR TITLE
NAS-135946 / 25.04.1 / Allow password aging bypass for admin OTPW (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/auth.py
+++ b/src/middlewared/middlewared/plugins/auth.py
@@ -336,12 +336,19 @@ class AuthService(Service):
         roles=['ACCOUNT_WRITE'],
         audit='Generate onetime password for user'
     )
-    def generate_onetime_password(self, data):
+    @pass_app(require=True)
+    def generate_onetime_password(self, app, data):
         """
         Generate a password for the specified username that may be used only a single time to authenticate
         to TrueNAS. This may be used by server administrators to allow users authenticate and then set
         a proper password and two-factor authentication token.
         """
+        if app.authenticated_credentials.is_user_session:
+            account_admin = app.authenticated_credentials.has_role('ACCOUNT_WRITE')
+        else:
+            # credentials that aren't associated with user sessions are root-equivalent
+            account_admin = True
+
         username = data['username']
         user_data = self.middleware.call_sync('user.query', [['username', '=', username]])
         if not user_data:
@@ -363,8 +370,7 @@ class AuthService(Service):
 
         verrors.check()
 
-        passwd = OTPW_MANAGER.generate_for_uid(user_data[0]['uid'])
-        return passwd
+        return OTPW_MANAGER.generate_for_uid(user_data[0]['uid'], account_admin)
 
     @api_method(
         AuthGenerateTokenArgs, AuthGenerateTokenResult,

--- a/tests/unit/test_otpw_manager.py
+++ b/tests/unit/test_otpw_manager.py
@@ -1,44 +1,45 @@
-from middlewared.utils.auth import OTPW_MANAGER, OTPWResponse
+from middlewared.utils.auth import OTPW_MANAGER, OTPWResponseCode
 
 
 def test__auth_success():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
     resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    assert resp.code is OTPWResponseCode.SUCCESS
+    assert resp.data['password_set_override'] is False
 
 
 def test__auth_used():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.ALREADY_USED
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.ALREADY_USED
 
 
 def test__auth_nokey():
-    resp = OTPW_MANAGER.authenticate(1000, '80000_canary')
-    assert resp is OTPWResponse.NO_KEY
+    resp = OTPW_MANAGER.authenticate(1000, '80000_canary').code
+    assert resp is OTPWResponseCode.NO_KEY
 
 
 def test__auth_bad_passkey():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1000, passwd + 'bad')
-    assert resp is OTPWResponse.BAD_PASSKEY
+    resp = OTPW_MANAGER.authenticate(1000, passwd + 'bad').code
+    assert resp is OTPWResponseCode.BAD_PASSKEY
 
     # This shouldn't prevent using correct passkey
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
 
 def test__auth_wrong_user():
     passwd = OTPW_MANAGER.generate_for_uid(1000)
-    resp = OTPW_MANAGER.authenticate(1001, passwd)
-    assert resp is OTPWResponse.WRONG_USER
+    resp = OTPW_MANAGER.authenticate(1001, passwd).code
+    assert resp is OTPWResponseCode.WRONG_USER
 
     # This shouldn't prevent correct user
-    resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.SUCCESS
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.SUCCESS
 
 
 def test__auth_expired():
@@ -47,5 +48,12 @@ def test__auth_expired():
 
     OTPW_MANAGER.otpasswd[idx].expires = 1
 
+    resp = OTPW_MANAGER.authenticate(1000, passwd).code
+    assert resp is OTPWResponseCode.EXPIRED
+
+
+def test__auth_flag():
+    passwd = OTPW_MANAGER.generate_for_uid(1000, True)
     resp = OTPW_MANAGER.authenticate(1000, passwd)
-    assert resp is OTPWResponse.EXPIRED
+    assert resp.code is OTPWResponseCode.SUCCESS
+    assert resp.data['password_set_override'] is True


### PR DESCRIPTION
This commit fixes a usability issue with generating temporary passwords for user accounts while in STIG compatibility mode with a minimum password age set. There are various situations in which an account administrator may need to generate a password for users so that they can authenticate and then set their password and two-factor settings. When the OTPW has been generated in this manner, set a flag that is then used to bypass the minimum password age validation.

Original PR: https://github.com/truenas/middleware/pull/16529
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135946