### PR TITLE
NAS-135959 / 25.04.2 / Fix API doc generation so that we recurse into nested objects (by creatorcary)

### DIFF
--- a/src/middlewared/middlewared/api/base/jsonschema.py
+++ b/src/middlewared/middlewared/api/base/jsonschema.py
@@ -3,7 +3,7 @@ __all__ = ["get_json_schema"]
 
 def get_json_schema(model):
     schema = model.model_json_schema()
-    schema = replace_refs(schema, schema.get("$defs", {}))
+    schema = replace_refs(schema)
     schema = add_attrs(schema)
 
     return [schema["properties"][name] for name in model.schema_model_fields()]
@@ -11,6 +11,7 @@ def get_json_schema(model):
 
 def replace_refs(data, defs=None):
     if isinstance(data, dict):
+        defs = data.pop("$defs", defs)
         if "$ref" in data:
             ref = data.pop("$ref")
             data = {**defs[ref.removeprefix("#/$defs/")], **data}

--- a/src/middlewared/middlewared/api/base/jsonschema.py
+++ b/src/middlewared/middlewared/api/base/jsonschema.py
@@ -9,7 +9,12 @@ def get_json_schema(model):
     return [schema["properties"][name] for name in model.schema_model_fields()]
 
 
-def replace_refs(data, defs=None):
+def replace_refs(data, defs: dict | None = None):
+    """Recursively replace all refs in the given schema with their respective definitions.
+
+    :param data: JSON schema. Contents are not preserved.
+    :return: The new JSON schema with refs replaced by their definitions.
+    """
     if isinstance(data, dict):
         defs = data.pop("$defs", defs)
         if "$ref" in data:

--- a/src/middlewared/middlewared/api/base/server/doc.py
+++ b/src/middlewared/middlewared/api/base/server/doc.py
@@ -86,10 +86,10 @@ class APIDumper:
 
     def _dump_method_schemas(self, method: Method):
         accepts_json_schema = method.methodobj.new_style_accepts.model_json_schema()
-        accepts_json_schema = replace_refs(accepts_json_schema, accepts_json_schema.get("$defs", {}))
+        accepts_json_schema = replace_refs(accepts_json_schema)
 
         returns_json_schema = method.methodobj.new_style_returns.model_json_schema(mode="serialization")
-        returns_json_schema = replace_refs(returns_json_schema, returns_json_schema.get("$defs", {}))
+        returns_json_schema = replace_refs(returns_json_schema)
 
         return {
             "type": "object",
@@ -137,7 +137,7 @@ class APIDumper:
         properties = {}
         for name, model in event.event["models"].items():
             schema = model.model_json_schema()
-            schema = replace_refs(schema, schema.get("$defs", {}))
+            schema = replace_refs(schema)
             properties[name] = schema
 
         return {


### PR DESCRIPTION
The one-line fix makes it so that we are not updating `$def` in `replace_refs`.

![image](https://github.com/user-attachments/assets/429bdc98-b791-4937-83e6-a0449939d6fc)
(See ticket for the before picture)

Original PR: https://github.com/truenas/middleware/pull/16530
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135959