### PR TITLE
NAS-135971 / 25.10 / Fix `_name_` and `_required_` not appearing in API docs

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
+++ b/src/middlewared/middlewared/api/v25_10_0/acme_dns_authenticator.py
@@ -165,9 +165,9 @@ class ACMEDNSAuthenticatorDeleteResult(BaseModel):
 
 
 class ACMEDNSAuthenticatorAttributeSchema(BaseModel):
-    _name_: str
+    name: str = Field(alias='_name_')
     title: str
-    _required_: bool
+    required: bool = Field(alias='_required_')
 
     model_config = ConfigDict(extra='allow')
 

--- a/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
+++ b/src/middlewared/middlewared/api/v25_10_0/reporting_exporters.py
@@ -75,9 +75,9 @@ class ReportingExporterSchemasArgs(BaseModel):
 
 
 class ReportingExporterAttributeSchema(BaseModel):
-    _name_: str
+    name: str = Field(alias='_name_')
     title: str
-    _required_: bool
+    required: bool = Field(alias='_required_')
 
     model_config = ConfigDict(extra='allow')
 


### PR DESCRIPTION
The leading underscore in these field names prevents them from being parsed into the API docs. Use aliases instead.

https://docs.pydantic.dev/latest/concepts/models/#private-model-attributes:~:text=Attributes%20whose%20name%20has%20a%20leading%20underscore%20are%20not%20treated%20as%20fields%20by%20Pydantic%2C%20and%20are%20not%20included%20in%20the%20model%20schema.