### PR TITLE
NAS-135977 / 25.10 / Fix `/var/lib/systemd/coredump` permissions

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -397,7 +397,6 @@ class SystemDatasetService(ConfigService):
 
         corepath = f'{SYSDATASET_PATH}/cores'
         if os.path.exists(corepath):
-
             if self.middleware.call_sync('keyvalue.get', 'run_migration', False):
                 try:
                     cores = Path(corepath)

--- a/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
+++ b/src/middlewared/middlewared/plugins/system_dataset/hierarchy.py
@@ -103,7 +103,7 @@ def get_system_dataset_spec(pool_name: str, uuid: str) -> list:
             'chown_config': {
                 'uid': 0,
                 'gid': 0,
-                'mode': 0o775,
+                'mode': 0o755,
             },
         },
         {


### PR DESCRIPTION
This non-standard permission was there since the plugin was written. It's probably something related to FreeBSD.

Linux has this directory set to `755` which causes `truenas_verify` to alert.