### PR TITLE
NAS-133982 / 25.10 / Allow backing up apps to a specific pool

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/docker.py
+++ b/src/middlewared/middlewared/api/v25_10_0/docker.py
@@ -11,7 +11,7 @@ __all__ = [
     'DockerEntry', 'DockerUpdateArgs', 'DockerUpdateResult', 'DockerStatusArgs', 'DockerStatusResult',
     'DockerNvidiaPresentArgs', 'DockerNvidiaPresentResult', 'DockerBackupArgs', 'DockerBackupResult',
     'DockerListBackupArgs', 'DockerListBackupResult', 'DockerRestoreBackupArgs', 'DockerRestoreBackupResult',
-    'DockerDeleteBackupArgs', 'DockerDeleteBackupResult',
+    'DockerDeleteBackupArgs', 'DockerDeleteBackupResult', 'DockerBackupToPoolArgs', 'DockerBackupToPoolResult',
 ]
 
 
@@ -141,4 +141,12 @@ class DockerDeleteBackupArgs(BaseModel):
 
 
 class DockerDeleteBackupResult(BaseModel):
+    result: None
+
+
+class DockerBackupToPoolArgs(BaseModel):
+    target_pool: NonEmptyString
+
+
+class DockerBackupToPoolResult(BaseModel):
     result: None

--- a/src/middlewared/middlewared/plugins/docker/backup.py
+++ b/src/middlewared/middlewared/plugins/docker/backup.py
@@ -36,6 +36,8 @@ class DockerService(Service):
     def backup(self, job, backup_name):
         """
         Create a backup of existing apps.
+
+        This creates a backup of existing apps on the same pool in which docker is initialized.
         """
         self.middleware.call_sync('docker.state.validate')
         docker_config = self.middleware.call_sync('docker.config')

--- a/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
+++ b/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
@@ -2,7 +2,9 @@ import errno
 
 from middlewared.api import api_method
 from middlewared.api.current import DockerBackupToPoolArgs, DockerBackupToPoolResult
-from middlewared.service import CallError, job, Service
+from middlewared.service import CallError, job, private, Service
+
+from .utils import applications_ds_name
 
 
 class DockerService(Service):
@@ -17,19 +19,56 @@ class DockerService(Service):
         roles=['DOCKER_WRITE']
     )
     @job(lock='docker_backup_to_pool')
-    def backup_to_pool(self, job, target_pool):
+    async def backup_to_pool(self, job, target_pool):
         """
         Create a backup of existing apps on `target_pool`.
 
         This creates a backup of existing apps on the `target_pool` specified. If this is executed multiple times,
         in the next iteration it will incrementally backup the apps that have changed since the last backup.
         """
-        docker_config = self.middleware.call_sync('docker.config')
+        docker_config = await self.middleware.call('docker.config')
         if docker_config['pool'] is None:
             raise CallError('Docker is not configured', errno=errno.EINVAL)
 
         # TODO: See how locking plays a role here
-        if not self.middleware.call_sync('pool.query', [['name', '=', target_pool]]):
+        if not await self.middleware.call('pool.query', [['name', '=', target_pool]]):
             raise CallError(f'{target_pool!r} pool does not exist', errno=errno.ENOENT)
 
         job.set_progress(10, 'Initial validation has been completed')
+        await self.middleware.call('service.stop', 'docker')
+        job.set_progress(20, 'Docker service has been stopped')
+
+        try:
+            await self.incrementally_replicate_apps_dataset(docker_config['pool'], target_pool)
+        finally:
+            self.middleware.call_sync('service.start', 'docker')
+
+    @private
+    async def incrementally_replicate_apps_dataset(self, source_pool, target_pool):
+        schema = f'ix-apps-{source_pool}-backup-%Y-%m-%d_%H-%M'
+        await self.middleware.call(
+            'zfs.snapshot.create', {
+                'dataset': applications_ds_name(source_pool),
+                'naming_schema': schema,
+                'recursive': True,
+            }
+        )
+        old_ds = applications_ds_name(source_pool)
+        new_ds = applications_ds_name(target_pool)
+        replication_job = await self.middleware.call(
+            'replication.run_onetime', {
+                'direction': 'PUSH',
+                'transport': 'LOCAL',
+                'source_datasets': [old_ds],
+                'target_dataset': new_ds,
+                'recursive': True,
+                'also_include_naming_schema': [schema],
+                'retention_policy': 'SOURCE',
+                'replicate': True,
+                'readonly': 'IGNORE',
+                'exclude_mountpoint_property': False,
+            }
+        )
+        await replication_job.wait()
+        if replication_job.error:
+            raise CallError(f'Failed to replicate {old_ds} to {new_ds}: {replication_job.error}')

--- a/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
+++ b/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
@@ -57,7 +57,7 @@ class DockerService(Service):
         else:
             job.set_progress(100, 'Successfully incrementally replicated apps dataset')
         finally:
-            self.middleware.call_sync('service.start', 'docker')
+            await self.middleware.call('service.start', 'docker')
 
     @private
     async def incrementally_replicate_apps_dataset(self, source_pool, target_pool):

--- a/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
+++ b/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
@@ -23,6 +23,9 @@ class DockerService(Service):
 
         This creates a backup of existing apps on the `target_pool` specified. If this is executed multiple times,
         in the next iteration it will incrementally backup the apps that have changed since the last backup.
+
+        Note: This will stop the docker service (which means current active apps will be stopped) and
+        then start it again after snapshot has been taken of the current apps dataset.
         """
         verrors = ValidationErrors()
         docker_config = await self.middleware.call('docker.config')

--- a/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
+++ b/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
@@ -1,6 +1,8 @@
+import errno
+
 from middlewared.api import api_method
 from middlewared.api.current import DockerBackupToPoolArgs, DockerBackupToPoolResult
-from middlewared.service import job, Service
+from middlewared.service import CallError, job, Service
 
 
 class DockerService(Service):
@@ -22,3 +24,12 @@ class DockerService(Service):
         This creates a backup of existing apps on the `target_pool` specified. If this is executed multiple times,
         in the next iteration it will incrementally backup the apps that have changed since the last backup.
         """
+        docker_config = self.middleware.call_sync('docker.config')
+        if docker_config['pool'] is None:
+            raise CallError('Docker is not configured', errno=errno.EINVAL)
+
+        # TODO: See how locking plays a role here
+        if not self.middleware.call_sync('pool.query', [['name', '=', target_pool]]):
+            raise CallError(f'{target_pool!r} pool does not exist', errno=errno.ENOENT)
+
+        job.set_progress(10, 'Initial validation has been completed')

--- a/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
+++ b/src/middlewared/middlewared/plugins/docker/backup_to_pool.py
@@ -1,0 +1,24 @@
+from middlewared.api import api_method
+from middlewared.api.current import DockerBackupToPoolArgs, DockerBackupToPoolResult
+from middlewared.service import job, Service
+
+
+class DockerService(Service):
+
+    class Config:
+        cli_namespace = 'app.docker'
+
+    @api_method(
+        DockerBackupToPoolArgs, DockerBackupToPoolResult,
+        audit='Docker: Backup to pool',
+        audit_extended=lambda target_pool: target_pool,
+        roles=['DOCKER_WRITE']
+    )
+    @job(lock='docker_backup_to_pool')
+    def backup_to_pool(self, job, target_pool):
+        """
+        Create a backup of existing apps on `target_pool`.
+
+        This creates a backup of existing apps on the `target_pool` specified. If this is executed multiple times,
+        in the next iteration it will incrementally backup the apps that have changed since the last backup.
+        """

--- a/tests/api2/test_docker_backup.py
+++ b/tests/api2/test_docker_backup.py
@@ -56,5 +56,8 @@ def test_docker_incremental_backup(docker_pool, target_pool):
 
 
 def test_docker_on_replica_pool(docker_pool, target_pool):
-    call('docker.update', {'pool': TARGET_POOL_NAME}, job=True)
-    assert call('app.get_instance', APP2_NAME)['name'] == APP2_NAME
+    try:
+        call('docker.update', {'pool': TARGET_POOL_NAME}, job=True)
+        assert call('app.get_instance', APP2_NAME)['name'] == APP2_NAME
+    finally:
+        call('docker.update', {'pool': None}, job=True)

--- a/tests/api2/test_docker_backup.py
+++ b/tests/api2/test_docker_backup.py
@@ -1,0 +1,60 @@
+import pytest
+
+from middlewared.test.integration.assets.docker import docker
+from middlewared.test.integration.assets.pool import another_pool
+from middlewared.test.integration.utils import call
+
+
+APP_NAME = 'actual-budget'
+APP2_NAME = 'syncthing'
+SOURCE_POOL_NAME = 'test_source_pool'
+TARGET_POOL_NAME = 'test_target_pool'
+
+
+@pytest.fixture(scope='module')
+def docker_pool():
+    with another_pool({'name': SOURCE_POOL_NAME}) as pool:
+        with docker(pool) as docker_config:
+            call('app.create', {
+                'app_name': APP_NAME,
+                'train': 'community',
+                'catalog_app': 'actual-budget',
+            }, job=True)
+            assert call('app.get_instance', APP_NAME)['name'] == APP_NAME
+
+            yield docker_config
+
+
+@pytest.fixture(scope='module')
+def target_pool():
+    with another_pool({'name': TARGET_POOL_NAME}) as pool:
+        yield pool
+
+
+def test_docker_backup_to_another_pool(docker_pool, target_pool):
+    call('docker.backup_to_pool', TARGET_POOL_NAME, job=True)
+    assert call('zfs.dataset.query', [['id', 'rin', f'{TARGET_POOL_NAME}/ix-apps/app_mounts/{APP_NAME}']]) != []
+
+
+def test_docker_incremental_backup(docker_pool, target_pool):
+    call('app.create', {
+        'app_name': APP2_NAME,
+        'train': 'stable',
+        'catalog_app': 'syncthing',
+    }, job=True)
+
+    assert call('docker.config')['pool'] == SOURCE_POOL_NAME
+    assert call('app.get_instance', APP2_NAME)['name'] == APP2_NAME
+
+    call('app.delete', APP_NAME, {'remove_ix_volumes': True}, job=True)
+
+    assert call('app.query', [['name', '=', APP_NAME]]) == []
+
+    call('docker.backup_to_pool', TARGET_POOL_NAME, job=True)
+    assert call('zfs.dataset.query', [['id', 'rin', f'{TARGET_POOL_NAME}/ix-apps/app_mounts/{APP_NAME}']]) == []
+    assert call('zfs.dataset.query', [['id', 'rin', f'{TARGET_POOL_NAME}/ix-apps/app_mounts/{APP2_NAME}']]) != []
+
+
+def test_docker_on_replica_pool(docker_pool, target_pool):
+    call('docker.update', {'pool': TARGET_POOL_NAME}, job=True)
+    assert call('app.get_instance', APP2_NAME)['name'] == APP2_NAME

--- a/tests/api2/test_docker_backup.py
+++ b/tests/api2/test_docker_backup.py
@@ -55,7 +55,7 @@ def test_docker_incremental_backup(docker_pool, target_pool):
     assert call('zfs.dataset.query', [['id', 'rin', f'{TARGET_POOL_NAME}/ix-apps/app_mounts/{APP2_NAME}']]) != []
 
 
-def test_docker_on_replica_pool(docker_pool, target_pool):
+def test_docker_on_replicated_pool(docker_pool, target_pool):
     try:
         call('docker.update', {'pool': TARGET_POOL_NAME}, job=True)
         assert call('app.get_instance', APP2_NAME)['name'] == APP2_NAME


### PR DESCRIPTION
This PR adds changes to allow consumers to backup their app pool to a specific pool. This will ensure if another backup is triggered, we do not face any issues and the changes are incrementally applied (under the hood handled by replication).
