### PR TITLE
NAS-135978 / 25.10 / Run `configure_fips` on config upload

### DIFF
--- a/src/middlewared/middlewared/etc_files/fips.py
+++ b/src/middlewared/middlewared/etc_files/fips.py
@@ -1,9 +1,2 @@
-import subprocess
-
-
 def render(service, middleware):
-    try:
-        subprocess.run(['configure_fips'], capture_output=True, check=True)
-    except subprocess.CalledProcessError as e:
-        middleware.logger.error('configure_fips error:\n%s', e.stderr)
-        raise
+    middleware.call_sync('system.security.configure_fips')

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -19,10 +19,8 @@ class SystemSecurityInfoService(Service):
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_available(self):
-        """Returns a boolean identifying whether or not FIPS
-        mode may be toggled on this system"""
-        # being able to toggle fips mode is hinged on whether
-        # or not this is an iX licensed piece of hardware
+        """Returns a boolean identifying whether FIPS mode may be toggled on this system"""
+        # being able to toggle fips mode is hinged on whether this is an iX licensed piece of hardware
         return bool(self.middleware.call_sync('system.license'))
 
     @api_method(
@@ -30,8 +28,7 @@ class SystemSecurityInfoService(Service):
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_enabled(self):
-        """Returns a boolean identifying whether or not FIPS
-        mode has been enabled on this system"""
+        """Returns a boolean identifying whether FIPS mode has been enabled on this system"""
         cp = run(['openssl', 'list', '-providers'], capture_output=True)
         if cp.returncode:
             raise CallError(f'Failed to determine if fips is enabled: {cp.stderr.decode()}')

--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -1,4 +1,4 @@
-import middlewared.sqlalchemy as sa
+import subprocess
 
 from middlewared.api import api_method
 from middlewared.api.current import (
@@ -7,6 +7,7 @@ from middlewared.api.current import (
 from middlewared.plugins.failover_.enums import DisabledReasonsEnum
 from middlewared.plugins.system.reboot import RebootReason
 from middlewared.service import ConfigService, ValidationError, job, private
+import middlewared.sqlalchemy as sa
 from middlewared.utils.io import set_io_uring_enabled
 from middlewared.utils.security import (
     GPOS_STIG_MIN_PASSWORD_AGE,
@@ -53,7 +54,7 @@ class SystemSecurityService(ConfigService):
 
         remote_reboot_reasons = await self.middleware.call('failover.call_remote', 'system.reboot.list_reasons')
         if reason.name in remote_reboot_reasons:
-            # This means the we're toggling a change in security settings but other node is
+            # This means that we're toggling a change in security settings but other node is
             # already pending a reboot, which means the user has toggled changes twice and
             # somehow the other node didn't reboot (even though this should be automatic).
             # This is an edge case and means someone or something is doing things behind our backs
@@ -367,6 +368,27 @@ class SystemSecurityService(ConfigService):
 
         return await self.config()
 
+    @private
+    def configure_fips(self, database_path=None):
+        args = ['configure_fips']
+        if database_path is not None:
+            args.append(database_path)
+
+        try:
+            p = subprocess.run(args, capture_output=True, check=True, encoding='utf-8', errors='ignore')
+            output = p.stderr.strip()
+            if output:
+                self.logger.error('configure_fips output:\n%s', output)
+        except subprocess.CalledProcessError as e:
+            self.logger.error('configure_fips error:\n%s', e.stderr)
+            raise
+
+
+async def on_config_upload(middleware, path):
+    await middleware.call('system.security.configure_fips', path)
+
 
 async def setup(middleware):
+    middleware.register_hook('config.on_upload', on_config_upload, sync=True)
+
     await middleware.call('system.security.configure_stig')

--- a/src/middlewared/middlewared/scripts/configure_fips.py
+++ b/src/middlewared/middlewared/scripts/configure_fips.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
+import logging
 import os
 import shutil
 import sqlite3
 import subprocess
+import sys
 
 from middlewared.utils.db import query_config_table
 
@@ -38,13 +40,21 @@ def configure_fips(enable_fips: bool) -> None:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s")
+
+    if len(sys.argv) == 2:
+        database_path = sys.argv[1]
+    else:
+        database_path = None
+
     validate_system_state()
     try:
-        security_settings = query_config_table('system_security')
-    except (sqlite3.OperationalError, IndexError):
+        security_settings = query_config_table('system_security', database_path)
+    except (sqlite3.OperationalError, IndexError) as e:
         # This is for the case when users are upgrading and in that case table will not exist,
         # so we should always disable fips as a default because users might not be able to ssh
         # into the system
+        logging.warning("Error querying system_security table: %r. Assuming that FIPS is disabled", e)
         security_settings = {'enable_fips': False}
 
     configure_fips(security_settings['enable_fips'])


### PR DESCRIPTION
This will also lead to FIPS being configured on `failover.sync_from_peer`.

Additionally, add some logging to `configure_fips` to catch additional errors.