### PR TITLE
NAS-135964 / 25.10 / Add STIG validation check for two factor authentication with SSH.

### DIFF
--- a/src/middlewared/middlewared/plugins/security/update.py
+++ b/src/middlewared/middlewared/plugins/security/update.py
@@ -106,6 +106,13 @@ class SystemSecurityService(ConfigService):
                 'enabling General Purpose OS STIG compatibility mode.'
             )
 
+        if two_factor['services']['ssh'] is False:
+            raise ValidationError(
+                'system_security_update.enable_gpos_stig',
+                'Two factor authentication for SSH access must be enabled before '
+                'enabling General Purpose OS STIG compatibility mode.'
+            )
+
         tc_config = await self.middleware.call('truecommand.config')
         if tc_config['enabled']:
             raise ValidationError(


### PR DESCRIPTION
STIG requires two factor authentication.
This PR add validation of that requirement to enforce two factor authentication for SSH access in STIG mode.
Add CI test.


CI [test](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4547/)