### PR TITLE
NAS-135967 / 25.04.2 / Fix error handling for deleted local users (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -6,7 +6,7 @@ import wbclient
 
 from middlewared.schema import accepts, Bool, Dict, Int, Password, Patch, Ref, Str, LDAP_DN, OROperator
 from middlewared.service import (
-    CallError, CRUDService, job, private, ValidationErrors, filterable, filterable_api_method
+    CallError, CRUDService, job, private, ValidationError, ValidationErrors, filterable, filterable_api_method
 )
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.constants import SSL
@@ -959,7 +959,7 @@ class IdmapDomainService(CRUDService):
         for sid in sidlist:
             try:
                 entry = self.__local_sid_to_entry(server_sid, netbiosname, sid, client.separator)
-            except (KeyError, ValidationErrors):
+            except (KeyError, ValidationError):
                 # This is a Unix SID or a local SID, but account doesn't exist
                 unmapped.update({sid: sid})
                 continue


### PR DESCRIPTION
This commit fixes error handling on trying to retrieve SID information about local accounts that have been deleted. We were checking for ValidationErrors when it should have been ValidationError. CI test is added to ensure we don't regress again in future.

Original PR: https://github.com/truenas/middleware/pull/16548
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135967