### PR TITLE
fix pool.dataset.path_in_locked_datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_encryption_info.py
@@ -226,7 +226,13 @@ class PoolDatasetService(Service):
         """
         # WARNING: _EXTREMELY_ hot code path. Do not add more
         # things here unless you fully understand the side-effects.
-        for i in get_dataset_parents(path.removeprefix('/mnt/')):
+        if path.startswith('/dev/zvol/'):
+            # 10 comes from len("/dev/zvol/")
+            path = path[10:].replace('+', ' ')
+        else:
+            path = path.removeprefix('/mnt/')
+
+        for i in get_dataset_parents(path):
             try:
                 crypto = tls.lzh.open_resource(name=i).crypto()
                 if crypto and not crypto.info().key_is_loaded:


### PR DESCRIPTION
Regression introduced in https://github.com/truenas/middleware/pull/16524. Need to handle with path given to us is an absolute path to a zvol. Tests that regressed are 100% clean [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4559/)