### PR TITLE
NAS-135619 / 25.10 / Have exponential time back-off for finalizing TNC registration

### DIFF
--- a/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/heartbeat.py
@@ -84,7 +84,7 @@ class TNCHeartbeatService(Service, TNCAPIMixin):
                 else:
                     last_failure = tnc_config['last_heartbeat_failure_datetime']
 
-                sleep_secs = calculate_sleep(last_failure)
+                sleep_secs = calculate_sleep(last_failure, HEARTBEAT_INTERVAL)
                 if sleep_secs is None:
                     # This means that either we have a time mismatch or it's been 48 hours and we have
                     # not been able to establish contact with TNC, so an alert should be raised

--- a/src/middlewared/middlewared/plugins/truenas_connect/utils.py
+++ b/src/middlewared/middlewared/plugins/truenas_connect/utils.py
@@ -24,7 +24,7 @@ def get_unset_payload() -> dict:
     }
 
 
-def calculate_sleep(failure_dt_str: str | None) -> int | None:
+def calculate_sleep(failure_dt_str: str | None, base_sleep: int | None = None) -> int | None:
     """
     Calculates the number of seconds to sleep before the next retry.
 
@@ -42,7 +42,7 @@ def calculate_sleep(failure_dt_str: str | None) -> int | None:
         If the calculated sleep time is 0 or negative (i.e. we’re past the scheduled time),
         returns None (meaning no sleep is needed; try immediately).
     """
-    base_sleep = HEARTBEAT_INTERVAL
+    base_sleep = base_sleep or HEARTBEAT_INTERVAL
 
     # If no failure datetime is provided, return base_sleep.
     if not failure_dt_str:


### PR DESCRIPTION
This PR implements faster retry attempts for TNC registration finalization as requested by the TNC team. The retry schedule now uses a 5-second base interval, resulting in attempts after 5s, 10s, 20s, 40s, etc., following an exponential backoff pattern for quicker recovery from transient failures.