### PR TITLE
NAS-135667 / 25.04.2 / Fix update.get_pending (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/pending_linux.py
+++ b/src/middlewared/middlewared/plugins/update_/pending_linux.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from middlewared.service import private, Service
-from .utils import SCALE_MANIFEST_FILE, DOWNLOAD_UPDATE_FILE
+from .utils import can_update, SCALE_MANIFEST_FILE, DOWNLOAD_UPDATE_FILE
 from .utils_linux import mount_update
 
 
@@ -23,16 +23,18 @@ class UpdateService(Service):
             self.middleware.logger.error("Failed reading update", exc_info=True)
             return []
 
-        return [
-            {
-                "operation": "upgrade",
-                "old": {
-                    "name": "TrueNAS",
-                    "version": old_manifest["version"],
-                },
-                "new": {
-                    "name": "TrueNAS",
-                    "version": new_manifest["version"],
+        if can_update(old_manifest["version"], new_manifest["version"]):
+            return [
+                {
+                    "operation": "upgrade",
+                    "old": {
+                        "name": "TrueNAS",
+                        "version": old_manifest["version"],
+                    },
+                    "new": {
+                        "name": "TrueNAS",
+                        "version": new_manifest["version"],
+                    }
                 }
-            }
-        ]
+            ]
+        return []


### PR DESCRIPTION
UI team has switched to using this endpoint which has exposed a bug that has probably been here since it was written. For reasons unknown, systems running version can be the same as the file that has been downloaded. In this instance, this returned an "update" but the versions were the same. Regardless of that the `can_update` function has been written for this exact scenario.

Original PR: https://github.com/truenas/middleware/pull/16409
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135667