### PR TITLE
NAS-136051 / 25.10 / Add NVMET missing in RdmaCapableProtocolsResult API

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/rdma.py
+++ b/src/middlewared/middlewared/api/v25_10_0/rdma.py
@@ -34,4 +34,4 @@ class RdmaCapableProtocolsArgs(BaseModel):
 
 
 class RdmaCapableProtocolsResult(BaseModel):
-    result: list[Literal["ISER", "NFS"]]
+    result: list[Literal["ISER", "NFS", "NVMET"]]


### PR DESCRIPTION
Add NVMET missing in `RdmaCapableProtocolsResult` API definition.

This should have been added as part of PR #16213 when the allowed return values changed.