### PR TITLE
NAS-135978 / 25.04.2 / Run `configure_fips` on config upload (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/etc_files/fips.py
+++ b/src/middlewared/middlewared/etc_files/fips.py
@@ -1,9 +1,2 @@
-import subprocess
-
-
 def render(service, middleware):
-    try:
-        subprocess.run(['configure_fips'], capture_output=True, check=True)
-    except subprocess.CalledProcessError as e:
-        middleware.logger.error('configure_fips error:\n%s', e.stderr)
-        raise
+    middleware.call_sync('system.security.configure_fips')

--- a/src/middlewared/middlewared/plugins/security/info.py
+++ b/src/middlewared/middlewared/plugins/security/info.py
@@ -19,10 +19,8 @@ class SystemSecurityInfoService(Service):
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_available(self):
-        """Returns a boolean identifying whether or not FIPS
-        mode may be toggled on this system"""
-        # being able to toggle fips mode is hinged on whether
-        # or not this is an iX licensed piece of hardware
+        """Returns a boolean identifying whether FIPS mode may be toggled on this system"""
+        # being able to toggle fips mode is hinged on whether this is an iX licensed piece of hardware
         return bool(self.middleware.call_sync('system.license'))
 
     @api_method(
@@ -30,8 +28,7 @@ class SystemSecurityInfoService(Service):
         roles=['SYSTEM_SECURITY_READ']
     )
     def fips_enabled(self):
-        """Returns a boolean identifying whether or not FIPS
-        mode has been enabled on this system"""
+        """Returns a boolean identifying whether FIPS mode has been enabled on this system"""
         cp = run(['openssl', 'list', '-providers'], capture_output=True)
         if cp.returncode:
             raise CallError(f'Failed to determine if fips is enabled: {cp.stderr.decode()}')

--- a/src/middlewared/middlewared/scripts/configure_fips.py
+++ b/src/middlewared/middlewared/scripts/configure_fips.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
+import logging
 import os
 import shutil
 import sqlite3
 import subprocess
+import sys
 
 from middlewared.utils.db import query_config_table
 
@@ -38,13 +40,21 @@ def configure_fips(enable_fips: bool) -> None:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s")
+
+    if len(sys.argv) == 2:
+        database_path = sys.argv[1]
+    else:
+        database_path = None
+
     validate_system_state()
     try:
-        security_settings = query_config_table('system_security')
-    except (sqlite3.OperationalError, IndexError):
+        security_settings = query_config_table('system_security', database_path)
+    except (sqlite3.OperationalError, IndexError) as e:
         # This is for the case when users are upgrading and in that case table will not exist,
         # so we should always disable fips as a default because users might not be able to ssh
         # into the system
+        logging.warning("Error querying system_security table: %r. Assuming that FIPS is disabled", e)
         security_settings = {'enable_fips': False}
 
     configure_fips(security_settings['enable_fips'])


### PR DESCRIPTION
This will also lead to FIPS being configured on `failover.sync_from_peer`.

Additionally, add some logging to `configure_fips` to catch additional errors.

Original PR: https://github.com/truenas/middleware/pull/16543
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135978