### PR TITLE
NAS-135536 / 25.04.2 / Make `mail.local_administrator_email` public as it is used by WebUI (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -486,7 +486,7 @@ class MailService(ConfigService):
             ["email", "!=", None]
         ])))
 
-    @private
+    @accepts()
     async def local_administrator_email(self):
         emails = await self.local_administrators_emails()
         if emails:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2abe882cf8d5fe24429620f193a691c4ec79fb5e

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 5655cde96f40cd624241721528c535662033fad2



Original PR: https://github.com/truenas/middleware/pull/16478
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135536