### PR TITLE
NAS-136070 / 25.04.2 / Improve alert text for SMB users missing passwords (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/alert/source/smb.py
+++ b/src/middlewared/middlewared/alert/source/smb.py
@@ -154,10 +154,10 @@ class SMBUserMissingHashAlertClass(AlertClass, SimpleOneShotAlertClass):
     level = AlertLevel.WARNING
     title = "SMB user is missing required password hash"
     text = (
-        "The following users lack valid password hashes. "
-        "This may occur if the TrueNAS configuration was restored without the "
-        "secret seed and may be fixed by resetting the user password through the "
-        "TrueNAS UI or API: %(entries)s"
+        "One or more SMB users do not have a valid SMB password hash. This can happen if the TrueNAS configuration "
+        "was restored without the secret seed. This can also happen if an SMB user was created with an empty password "
+        "in an older version of TrueNAS. To correct this, do one of these steps: reset the user password in the TrueNAS "
+        "UI or API, or disable SMB access for the user. Affected users: %(entries)s"
     )
 
     async def delete(self, alerts, query):


### PR DESCRIPTION
Our webui does not display the alert title which renders the original alert for this mishap ambiguous to the end-user when viewed through the webui. This commit reworks the alert text to simplify the sentence syntax and clarify the nature of the issue.

Original PR: https://github.com/truenas/middleware/pull/16561
Jira URL: https://ixsystems.atlassian.net/browse/NAS-136070