### PR TITLE
NAS-136079 / 25.10 / Fix setting PASSWORD_CHANGE_REQUIRED account attribute

### DIFF
--- a/src/middlewared/middlewared/utils/account/authenticator.py
+++ b/src/middlewared/middlewared/utils/account/authenticator.py
@@ -334,7 +334,9 @@ class UserPamAuthenticator(pam.PamAuthenticator):
         match otpw_resp.code:
             case OTPWResponseCode.SUCCESS:
                 self.truenas_state.passwd['account_attributes'].append(AccountFlag.OTPW)
-                if otpw_resp.data['password_set_override']:
+                # PASSWORD_CHANGE_REQUIRED can only be set for local accounts. We don't allow
+                # password changes through middleware currently for directory services.
+                if otpw_resp.data['password_set_override'] and passwd_entry['source'] == 'LOCAL':
                     self.truenas_state.passwd['account_attributes'].append(AccountFlag.PASSWORD_CHANGE_REQUIRED)
 
                 code = pam.PAM_SUCCESS


### PR DESCRIPTION
This flag should never be set for directory services accounts so that the UI team can properly rely on it for password reset prompts.

This commit fixes incorrect behavior introduced by fix for NAS-135946. NAS-135946 added the `PASSWORD_CHANGE_REQUIRED` flag unilaterally when OTPW generated by an administrator was created. This change allowed a limited bypass of password aging rules so that users could set new passwords.