### PR TITLE
NAS-136065 / 25.04.2 / Fix pam_faillock ordering (by anodos325)

### DIFF
--- a/src/freenas/etc/pam.d/common-auth-unix
+++ b/src/freenas/etc/pam.d/common-auth-unix
@@ -1,2 +1,0 @@
-auth	requisite			pam_deny.so
-auth	required			pam_permit.so

--- a/src/middlewared/middlewared/etc_files/pam.d/common-auth-unix.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-auth-unix.mako
@@ -1,0 +1,10 @@
+<%
+    from middlewared.utils.pam import FAILLOCK_AUTH_FAIL
+%>
+
+% if render_ctx['system.security.config']['enable_gpos_stig']:
+${FAILLOCK_AUTH_FAIL.as_conf()}
+% else:
+auth	requisite			pam_deny.so
+% endif
+auth	required			pam_permit.so

--- a/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-auth.mako
@@ -26,17 +26,16 @@
             raise TypeError(f'{dstype}: unknown DSType')
 %>\
 
-%if render_ctx['system.security.config']['enable_gpos_stig']:
+% if render_ctx['system.security.config']['enable_gpos_stig']:
 auth	optional	pam_faildelay.so	delay=4000000
-%endif
+% endif
 % if conf.primary:
 ${'\n'.join(line.as_conf() for line in conf.primary)}
 % endif
-%if render_ctx['system.security.config']['enable_gpos_stig']:
-${FAILLOCK_AUTH_FAIL.as_conf()}
+@include common-auth-unix
+% if render_ctx['system.security.config']['enable_gpos_stig']:
 ${FAILLOCK_AUTH_SUCC.as_conf()}
 % endif
-@include common-auth-unix
 % if conf.secondary:
 ${'\n'.join(line.as_conf() for line in conf.secondary)}
 % endif

--- a/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/middleware-api-key.mako
@@ -20,11 +20,10 @@ auth		[success=1 default=die]		pam_tdb.so ${truenas_admin_string}
 @include common-account
 %else:
 ${'\n'.join(line.as_conf() for line in STANDALONE_ACCOUNT.primary)}
+@include common-account-unix
 %if render_ctx['system.security.config']['enable_gpos_stig']:
-${FAILLOCK_AUTH_FAIL.as_conf()}
 ${FAILLOCK_AUTH_SUCC.as_conf()}
 %endif
-@include common-account-unix
 %endif
 password	required			pam_deny.so
 @include middleware-session

--- a/src/middlewared/middlewared/etc_files/pam.d/middleware.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/middleware.mako
@@ -9,11 +9,10 @@
 @include common-auth
 %else:
 ${'\n'.join(line.as_conf() for line in STANDALONE_AUTH.primary)}
+@include common-auth-unix
 %if render_ctx['system.security.config']['enable_gpos_stig']:
-${FAILLOCK_AUTH_FAIL.as_conf()}
 ${FAILLOCK_AUTH_SUCC.as_conf()}
 %endif
-@include common-auth-unix
 %endif
 @include common-account
 password	required	pam_deny.so

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -190,6 +190,7 @@ class EtcService(Service):
             'entries': [
                 {'type': 'mako', 'path': 'pam.d/common-account'},
                 {'type': 'mako', 'path': 'pam.d/common-auth'},
+                {'type': 'mako', 'path': 'pam.d/common-auth-unix'},
                 {'type': 'mako', 'path': 'pam.d/common-password'},
                 {'type': 'mako', 'path': 'pam.d/common-session-noninteractive'},
                 {'type': 'mako', 'path': 'pam.d/common-session'},

--- a/src/middlewared/middlewared/utils/pam.py
+++ b/src/middlewared/middlewared/utils/pam.py
@@ -321,7 +321,7 @@ FAILLOCK_AUTH_FAIL = PAMLine(
 
 FAILLOCK_AUTH_SUCC = PAMLine(
     pam_service=PAMService.AUTH,
-    pam_control=PAMSimpleControl.SUFFICIENT,
+    pam_control=PAMSimpleControl.REQUIRED,
     pam_module=PAMModule.FAILLOCK,
     pam_module_args=(
         'authsucc',


### PR DESCRIPTION
This comit fixes several issues with pam_faillock configuration in the common-auth pam include file.

When pam_faillock is configured in common-auth and pam_oath is configured in the SSH pam configuration file, the pam_faillock sufficient control causes authentication to short-circuit potentially bypassing oath authentication.

This commit changes common-auth-unix file so that it is dynamically generated depending on whether pam_faillock is enabled. If pam_faillock is enabled, then the the pam_deny line is replaced with the pam_faillock failure line.

This commit changes the control directive for the pam_faillock success line so that it is no longer sufficient (avoiding the short-circuit).

Original PR: https://github.com/truenas/middleware/pull/16563
Jira URL: https://ixsystems.atlassian.net/browse/NAS-136065