### PR TITLE
Add validation to make sure host supports virtualization

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware/virt_detection.py
+++ b/src/middlewared/middlewared/plugins/hardware/virt_detection.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from middlewared.service import Service
@@ -17,3 +18,8 @@ class HardwareVirtualization(Service):
     def is_virtualized(self) -> bool:
         """Detect if the TrueNAS system is virtualized"""
         return self.variant() != 'none'
+
+    @cache
+    def guest_vms_supported(self) -> bool:
+        """Detect if TrueNAS system supports guest VMs"""
+        return os.path.exists('/dev/kvm')

--- a/src/middlewared/middlewared/plugins/virt/instance.py
+++ b/src/middlewared/middlewared/plugins/virt/instance.py
@@ -224,6 +224,11 @@ class VirtInstanceService(CRUDService):
                         'vnc_password': None,
                     })
         else:
+            if new['instance_type'] == 'VM' and not await self.middleware.call(
+                'hardware.virtualization.guest_vms_supported'
+            ):
+                verrors.add(f'{schema_name}.instance_type', 'Virtualization is not supported on this system')
+
             # Creation case
             if new['source_type'] == 'ISO' and not await self.middleware.call(
                 'virt.volume.query', [['content_type', '=', 'ISO'], ['id', '=', new['iso_volume']]]
@@ -594,6 +599,12 @@ class VirtInstanceService(CRUDService):
             raise ValidationError(
                 'virt.instance.start.id',
                 f'{oid}: instance may not be started because current status is: {instance["status"]}'
+            )
+
+        if instance['type'] == 'VM' and not await self.middleware.call('hardware.virtualization.guest_vms_supported'):
+            raise ValidationError(
+                'virt.instance.start.id',
+                f'Cannot start {oid!r} as virtualization is not supported on this system'
             )
 
         # Apply any idmap changes


### PR DESCRIPTION
## Context

We should make sure that we raise proper validation error if the underlying host does not support virtualization and user tries to create incus based VMs or start existing ones.