### PR TITLE
NAS-135848 / 25.04.2 / Add validation to make sure host supports virtualization (by Qubad786)

### DIFF
--- a/src/middlewared/middlewared/plugins/hardware/virt_detection.py
+++ b/src/middlewared/middlewared/plugins/hardware/virt_detection.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from middlewared.service import Service
@@ -17,3 +18,8 @@ class HardwareVirtualization(Service):
     def is_virtualized(self) -> bool:
         """Detect if the TrueNAS system is virtualized"""
         return self.variant() != 'none'
+
+    @cache
+    def guest_vms_supported(self) -> bool:
+        """Detect if TrueNAS system supports guest VMs"""
+        return os.path.exists('/dev/kvm')


### PR DESCRIPTION
## Context

We should make sure that we raise proper validation error if the underlying host does not support virtualization and user tries to create incus based VMs or start existing ones.

Original PR: https://github.com/truenas/middleware/pull/16569
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135848