### PR TITLE
NAS-136128 / 25.10 / Normalize nvmet device_path

### DIFF
--- a/src/middlewared/middlewared/api/base/types/filesystem.py
+++ b/src/middlewared/middlewared/api/base/types/filesystem.py
@@ -1,8 +1,11 @@
+import os
+
 from typing import Annotated
 
 from pydantic.functional_validators import AfterValidator
+from .string import NonEmptyString
 
-__all__ = ["UnixPerm"]
+__all__ = ["UnixPerm", "NormalPath"]
 
 
 def validate_unix_perm(value: str) -> str:
@@ -17,4 +20,9 @@ def validate_unix_perm(value: str) -> str:
     return value
 
 
+def normalize_path(value) -> str:
+    return os.path.normpath(value)
+
+
 UnixPerm = Annotated[str, AfterValidator(validate_unix_perm)]
+NormalPath = Annotated[NonEmptyString, AfterValidator(normalize_path)]

--- a/src/middlewared/middlewared/api/v25_10_0/nvmet_namespace.py
+++ b/src/middlewared/middlewared/api/v25_10_0/nvmet_namespace.py
@@ -2,7 +2,7 @@ from typing import Annotated, Literal, TypeAlias
 
 from pydantic import Field
 
-from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, NonEmptyString, excluded_field
+from middlewared.api.base import BaseModel, Excluded, ForUpdateMetaclass, NormalPath, NonEmptyString, excluded_field
 from .nvmet_subsys import NVMetSubsysEntry
 
 __all__ = [
@@ -31,7 +31,7 @@ class NVMetNamespaceEntry(BaseModel):
     subsys: NVMetSubsysEntry
     device_type: DeviceType
     """ Type of device (or file) used to implement the namespace. """
-    device_path: str
+    device_path: NonEmptyString
     """
     Path to the device or file being used to implement the namespace.
 
@@ -66,6 +66,7 @@ class NVMetNamespaceCreate(NVMetNamespaceEntry):
     device_nguid: Excluded = excluded_field()
     locked: Excluded = excluded_field()
     subsys_id: int
+    device_path: NormalPath
 
 
 class NVMetNamespaceCreateArgs(BaseModel):


### PR DESCRIPTION
Normalize nvmet `device_path` for namespaces.

(Tested locally with `test_nvmet_tcp.py` CI tests.)