### PR TITLE
NAS-136147 / 25.10 / Remove almost all remaining `@filterable`s

### DIFF
--- a/docs/source/middleware/roles.rst
+++ b/docs/source/middleware/roles.rst
@@ -69,7 +69,7 @@ Roles for methods that are decorated with `@filterable_api_method` may be specif
 
 .. code-block:: python
 
-   @filterable_api_method(MethodArgs, MethodResult, roles=['REPORTING_READ'])
+   @filterable_api_method(item=ItemEntry, roles=['REPORTING_READ'])
 
 Subscribable event roles
 ========================

--- a/docs/source/middleware/roles.rst
+++ b/docs/source/middleware/roles.rst
@@ -51,28 +51,25 @@ The common practice is to define the corresponding roles like this:
         ...
     }
 
-@accepts decorator
+@api_method decorator
 ==================
 
-Roles for an arbitrary method can be specified using `roles` parameter of the `@accepts` decorator:
+Roles for an arbitrary method can be specified using `roles` parameter of the `@api_method` decorator:
 
 .. code-block:: python
 
-    @accepts(
-        Int("id"),
-        roles=["TASK_RUN"],
-    )
+    @api_method(MethodArgs, MethodResult, roles=["TASK_RUN"])
 
 When multiple roles are specified, each of them will have access to the decorated method (without requiring others).
 
-@filterable decorator
+@filterable_api_method decorator
 =====================
 
-Roles for methods that are decorated with `@filterable` may be specified using the `roles` parameter:
+Roles for methods that are decorated with `@filterable_api_method` may be specified using the `roles` parameter:
 
 .. code-block:: python
 
-   @filterable(roles=['REPORTING_READ'])
+   @filterable_api_method(MethodArgs, MethodResult, roles=['REPORTING_READ'])
 
 Subscribable event roles
 ========================

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -33,7 +33,7 @@ from middlewared.api.current import (
     AuditExportArgs, AuditExportResult, AuditUpdateArgs, AuditUpdateResult
 )
 from middlewared.plugins.zfs_.utils import TNUserProp
-from middlewared.service import filterable, job, private, ConfigService
+from middlewared.service import filterable_api_method, job, private, ConfigService
 from middlewared.service_exception import CallError, ValidationErrors, ValidationError
 from middlewared.utils import filter_list
 from middlewared.utils.mount import getmntinfo
@@ -488,8 +488,7 @@ class AuditService(ConfigService):
         except Exception:
             self.logger.error('Error detected in truenas_verify setup.', exc_info=True)
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     async def json_schemas(self, filters, options):
         return filter_list(
             AUDIT_EVENT_MIDDLEWARE_JSON_SCHEMAS + AUDIT_EVENT_SMB_JSON_SCHEMAS + AUDIT_EVENT_SUDO_JSON_SCHEMAS,

--- a/src/middlewared/middlewared/plugins/disk_/info.py
+++ b/src/middlewared/middlewared/plugins/disk_/info.py
@@ -1,11 +1,10 @@
-from middlewared.service import filterable, private, Service
+from middlewared.service import filterable_api_method, private, Service
 from middlewared.utils import filter_list
 
 
 class DiskService(Service):
 
-    @private
-    @filterable
+    @filterable_api_method(private=True)
     async def list_all_partitions(self, filters, options):
         """
         Returns list of all partitions present in the system

--- a/src/middlewared/middlewared/plugins/fc/fc.py
+++ b/src/middlewared/middlewared/plugins/fc/fc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from middlewared.api import api_method
 from middlewared.api.current import FCCapableArgs, FCCapableResult
-from middlewared.service import Service, filterable
+from middlewared.service import Service, filterable_api_method
 from middlewared.service_exception import CallError
 from middlewared.utils import filter_list
 from .utils import dmi_pci_slot_info
@@ -61,7 +61,7 @@ class FCService(Service):
             return True
         return False
 
-    @filterable
+    @filterable_api_method(private=True)
     def fc_hosts(self, filters, options):
         result = []
         if self.middleware.call_sync('fc.capable'):


### PR DESCRIPTION
We still have one more use of `filterable` for `CRUDService.query`. This one will have to be handled in a larger PR.