### PR TITLE
NAS-136151 / 25.10 / Default to building getmntinfo keyed by mount id

### DIFF
--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -37,7 +37,7 @@ from middlewared.service import filterable_api_method, job, private, ConfigServi
 from middlewared.service_exception import CallError, ValidationErrors, ValidationError
 from middlewared.utils import filter_list
 from middlewared.utils.mount import getmntinfo
-from middlweared.utils.filesystem.stat_x import statx
+from middlewared.utils.filesystem.stat_x import statx
 from middlewared.utils.functools_ import cache
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]

--- a/src/middlewared/middlewared/plugins/audit/audit.py
+++ b/src/middlewared/middlewared/plugins/audit/audit.py
@@ -37,6 +37,7 @@ from middlewared.service import filterable_api_method, job, private, ConfigServi
 from middlewared.service_exception import CallError, ValidationErrors, ValidationError
 from middlewared.utils import filter_list
 from middlewared.utils.mount import getmntinfo
+from middlweared.utils.filesystem.stat_x import statx
 from middlewared.utils.functools_ import cache
 
 ALL_AUDITED = [svc[0] for svc in AUDITED_SERVICES]
@@ -71,8 +72,8 @@ class AuditService(ConfigService):
     @private
     @cache
     def audit_dataset_name(self):
-        audit_dev = os.stat(AUDIT_DATASET_PATH).st_dev
-        return getmntinfo(audit_dev)[audit_dev]['mount_source']
+        audit_mnt_id = statx(AUDIT_DATASET_PATH).stx_mnt_id
+        return getmntinfo(mnt_id=audit_mnt_id)[audit_mnt_id]['mount_source']
 
     @private
     def get_audit_dataset(self):

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -8,6 +8,7 @@ from middlewared.api.current import (
 )
 from middlewared.plugins.zfs_.utils import zvol_path_to_name, TNUserProp
 from middlewared.service import Service, private
+from middlewared.utils.filesystem.stat_x import statx
 from middlewared.utils.mount import getmntinfo
 
 
@@ -112,13 +113,13 @@ class PoolDatasetService(Service):
             path = f'/dev/{path}'
 
         try:
-            devid = os.stat(path).st_dev
+            mnt_id = statx(path).stx_mnt_id
         except Exception:
             # path deleted/umounted/locked etc
             pass
         else:
-            if devid in mntinfo:
-                mount_info = mntinfo[devid]
+            if mnt_id in mntinfo:
+                mount_info = mntinfo[mnt_id]
 
         return mount_info
 

--- a/src/middlewared/middlewared/plugins/pool_/dataset_details.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_details.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 
 from middlewared.api import api_method

--- a/src/middlewared/middlewared/plugins/zfs_/utils.py
+++ b/src/middlewared/middlewared/plugins/zfs_/utils.py
@@ -8,6 +8,7 @@ from middlewared.plugins.audit.utils import AUDIT_DEFAULT_FILL_CRITICAL, AUDIT_D
 from middlewared.service_exception import CallError, MatchNotFound
 from middlewared.utils import BOOT_POOL_NAME_VALID
 from middlewared.utils.filesystem.constants import ZFSCTL
+from middlewared.utils.filesystem.stat_x import statx
 from middlewared.utils.mount import getmntinfo
 from middlewared.utils.path import is_child
 from middlewared.utils.tdb import (
@@ -357,11 +358,11 @@ def path_to_dataset_impl(path: str, mntinfo: dict | None = None) -> str:
     can be raised by a failed call to os.stat() are
     possible.
     """
-    st = os.stat(path)
+    stx = statx(path)
     if mntinfo is None:
-        mntinfo = getmntinfo(st.st_dev)[st.st_dev]
+        mntinfo = getmntinfo(stx.stx_mnt_id)[stx.stx_mnt_id]
     else:
-        mntinfo = mntinfo[st.st_dev]
+        mntinfo = mntinfo[stx.stx_mnt_id]
 
     ds_name = mntinfo['mount_source']
     if mntinfo['fs_type'] != 'zfs':

--- a/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
+++ b/src/middlewared/middlewared/pytest/unit/utils/test_mountinfo.py
@@ -1,5 +1,5 @@
 import pytest
-from middlewared.utils.mount import __mntent_dict, __parse_to_dev, __parse_to_mnt_id, __create_tree
+from middlewared.utils.mount import __mntent_dict, __parse_to_mnt_id, __create_tree
 
 
 fake_mntinfo = r"""21 26 0:19 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - sysfs sysfs rw
@@ -73,9 +73,9 @@ fake_mntinfo = r"""21 26 0:19 / /sys rw,nosuid,nodev,noexec,relatime shared:7 - 
 def test__mntinfo_spaces():
     line = r'474 467 0:77 / /mnt/tank\040space\040/Dataset\040With\040a\040space rw,noatime shared:265 - zfs tank\040space\040/Dataset\040With\040a\040space rw,xattr,posixacl'
     data = {}
-    __parse_to_dev(line, data)
-    assert 77 in data
-    mntent = data[77]
+    __parse_to_mnt_id(line, data)
+    assert 474 in data
+    mntent = data[474]
     assert mntent['mount_id'] == 474
     assert mntent['parent_id'] == 467
     assert mntent['device_id'] == {'major': 0, 'minor': 77, 'dev_t': 77}
@@ -98,7 +98,7 @@ def test__getmntinfo():
 
     for line in fake_mntinfo.splitlines():
         data = {}
-        __parse_to_dev(line, data)
+        __parse_to_mnt_id(line, data)
 
         mnt_data = list(data.values())[0]
         assert __rebuild_device_info(mnt_data) in line
@@ -113,26 +113,26 @@ def test__getmntinfo():
 def test__atime_and_casesentivity_in_mntinfo():
     line = r'7460 572 0:1005 / /mnt/zz/ds920 rw,noatime shared:4257 - zfs zz/ds920 rw,xattr,posixacl,casesensitive'
     data = {}
-    __parse_to_dev(line, data)
-    assert 3145965 in data
-    mntent = data[3145965]
+    __parse_to_mnt_id(line, data)
+    assert 7460 in data
+    mntent = data[7460]
     assert 'NOATIME' in mntent['mount_opts']
     assert 'CASESENSITIVE' in mntent['super_opts']
 
     line = r'8069 306 0:1214 / /mnt/zz/mixy rw,noatime shared:4507 - zfs zz/mixy rw,xattr,posixacl,casemixed'
     data = {}
-    __parse_to_dev(line, data)
-    assert 4194494 in data
-    mntent = data[4194494]
+    __parse_to_mnt_id(line, data)
+    assert 8069 in data
+    mntent = data[8069]
     assert 'CASEMIXED' in mntent['super_opts']
 
 
 def test__readonly_in_mntinfo():
     line = r'537 327 0:75 / /mnt/dozer/TESTFUN/mp29-nfs0016K ro shared:301 - zfs dozer/TESTFUN/mp29-nfs0016K ro,xattr,posixacl,casesensitive'
     data = {}
-    __parse_to_dev(line, data)
-    assert 75 in data
-    assert 'RO' in data[75]['mount_opts']
+    __parse_to_mnt_id(line, data)
+    assert 537 in data
+    assert 'RO' in data[537]['mount_opts']
 
 
 def test__mount_id_key():

--- a/src/middlewared/middlewared/utils/mount.py
+++ b/src/middlewared/middlewared/utils/mount.py
@@ -30,11 +30,6 @@ def __mntent_dict(line):
     }
 
 
-def __parse_to_dev(line, out_dict):
-    entry = __mntent_dict(line)
-    out_dict.update({entry['device_id']['dev_t']: entry})
-
-
 def __parse_to_mnt_id(line, out_dict):
     entry = __mntent_dict(line)
     out_dict.update({entry['mount_id']: entry})
@@ -90,14 +85,10 @@ def __iter_mountinfo(dev_id=None, mnt_id=None, callback=None, private_data=None)
                 raise RuntimeError(f'Failed to parse {line!r} line: {e}')
 
 
-def getmntinfo(dev_id=None, mnt_id=None):
+def getmntinfo(mnt_id=None):
     """
     Get mount information. Takes the following arguments for faster lookup of
     information for a mounted filesystem.
-
-    `dev_id` - the device ID of the mounted filesystem of interest. This will
-    uniquely identify the filesystem, but not uniquely identify the mount point.
-    If specified results are a dictionary indexed by dev_t.
 
     `mnt_id` - specify the unique ID for the mount. This is unique only for the
     lifetime of the mount. statx() may be used to retrieve the mnt_id for a given
@@ -128,11 +119,7 @@ def getmntinfo(dev_id=None, mnt_id=None):
     `super_opts` - per-superblock options (see mount(2)).
     """
     info = {}
-    if mnt_id:
-        __iter_mountinfo(mnt_id=mnt_id, callback=__parse_to_mnt_id, private_data=info)
-    else:
-        __iter_mountinfo(dev_id=dev_id, callback=__parse_to_dev, private_data=info)
-
+    __iter_mountinfo(mnt_id=mnt_id, callback=__parse_to_mnt_id, private_data=info)
     return info
 
 


### PR DESCRIPTION
This commit fixes edge cases where incorrect mount info could be returned to some callers of getmntinfo when the server has bind mounts present. The mapping based on dev_t was kept originally for backwards-compatibility, but at this point it should just be removed to prevent incorrect usage.