### PR TITLE
NAS-136149 / 25.04.2 / Use default for NFS RPC pipefs-directory (by mgrimesix)

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfs.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.mako
@@ -34,9 +34,6 @@
 #
 # TrueNAS configuration file for NFS
 #
-[general]
-pipefs-directory = /var/lib/nfs/rpc_pipefs
-
 [nfsd]
 syslog = 1
 vers2 = n

--- a/src/middlewared/middlewared/etc_files/nfs.conf.mako
+++ b/src/middlewared/middlewared/etc_files/nfs.conf.mako
@@ -35,7 +35,7 @@
 # TrueNAS configuration file for NFS
 #
 [general]
-pipefs-directory = /run/rpc_pipefs
+pipefs-directory = /var/lib/nfs/rpc_pipefs
 
 [nfsd]
 syslog = 1


### PR DESCRIPTION
The default path for NFS rpc idmapd is `/var/lib/nfs/rpc_pipefs`.  We are overriding this in `nfs.conf` with the legacy setting `/run/rpc_pipefs`.

Using the legacy path with our startup process and Linux 6.12 has exposed a deficiency in using the transitory paths in the `/run` directory where the `idmap` daemon cannot start because the legacy path is not available.

The fix:
Use the default setting for `pipefs-directory`.

Tested manually.

Original PR: https://github.com/truenas/middleware/pull/16580
Jira URL: https://ixsystems.atlassian.net/browse/NAS-136149