### PR TITLE
NAS-136132 / 25.10 / Perform some fixup with iSCSI Authorized Access CHAP secrets

### DIFF
--- a/src/middlewared/middlewared/alert/source/iscsi.py
+++ b/src/middlewared/middlewared/alert/source/iscsi.py
@@ -101,7 +101,6 @@ class ISCSIAuthSecretAlertSource(AlertSource):
                                         'user': auth[userfield],
                                         'char': char,
                                     },
-                                    key=auth['id'],
                                 )
                             )
                     if auth[secretfield] != auth[secretfield].strip():
@@ -114,7 +113,6 @@ class ISCSIAuthSecretAlertSource(AlertSource):
                                     'userfield': private_to_public[userfield],
                                     'user': auth[userfield],
                                 },
-                                key=auth['id']
                             )
                         )
 

--- a/src/middlewared/middlewared/alert/source/iscsi.py
+++ b/src/middlewared/middlewared/alert/source/iscsi.py
@@ -51,3 +51,57 @@ class ISCSIPortalIPAlertSource(AlertSource):
 
         if ips:
             return Alert(ISCSIPortalIPAlertClass, ', '.join(ips))
+
+
+class ISCSIAuthSecretInvalidCharAlertClass(AlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = 'iSCSI Authorized Access has an invalid character'
+    text = 'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r has a %(field)s containing the invalid character: %(char)r.'
+
+
+class ISCSIAuthSecretWhitespaceAlertClass(AlertClass):
+    category = AlertCategory.SHARING
+    level = AlertLevel.WARNING
+    title = 'iSCSI Authorized Access has leading or trailing whitespace'
+    text = 'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r has a %(field)s containing leading or trailing whitespace.'
+
+
+class ISCSIAuthSecretAlertSource(AlertSource):
+    schedule = IntervalSchedule(timedelta(hours=24))
+    run_on_backup_node = False
+    INVALID_CHARS = '#'
+
+    async def check(self):
+        alerts = []
+
+        private_to_public = {
+            'user': 'User',
+            'secret': 'Secret',
+            'peeruser': 'Peer User',
+            'peersecret': 'Peer Secret'
+        }
+
+        auths = await self.middleware.call('iscsi.auth.query')
+        for auth in auths:
+            for userfield, secretfield in [('user', 'secret'),
+                                           ('peeruser', 'peersecret')]:
+                if auth[userfield] and auth[secretfield]:
+                    for char in self.INVALID_CHARS:
+                        if char in auth[secretfield]:
+                            alerts.append(Alert(ISCSIAuthSecretInvalidCharAlertClass,
+                                                {'field': private_to_public[secretfield],
+                                                 'tag': auth['tag'],
+                                                 'userfield': private_to_public[userfield],
+                                                 'user': auth[userfield],
+                                                 'char': char
+                                                 }, key=auth['id']))
+                    if auth[secretfield] != auth[secretfield].strip():
+                        alerts.append(Alert(ISCSIAuthSecretWhitespaceAlertClass,
+                                            {'field': private_to_public[secretfield],
+                                             'tag': auth['tag'],
+                                             'userfield': private_to_public[userfield],
+                                             'user': auth[userfield],
+                                             }, key=auth['id']))
+
+        return alerts

--- a/src/middlewared/middlewared/alert/source/iscsi.py
+++ b/src/middlewared/middlewared/alert/source/iscsi.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 
-from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, AlertSource
+from middlewared.alert.base import Alert, AlertCategory, AlertClass, AlertLevel, AlertSource
 from middlewared.alert.schedule import IntervalSchedule
+from middlewared.plugins.iscsi_.auth import INVALID_CHARACTERS
 
 
 class ISCSIPortalIPAlertClass(AlertClass):
@@ -70,7 +71,6 @@ class ISCSIAuthSecretWhitespaceAlertClass(AlertClass):
 class ISCSIAuthSecretAlertSource(AlertSource):
     schedule = IntervalSchedule(timedelta(hours=24))
     run_on_backup_node = False
-    INVALID_CHARS = '#'
 
     async def check(self):
         alerts = []
@@ -88,9 +88,8 @@ class ISCSIAuthSecretAlertSource(AlertSource):
                 ('user', 'secret'),
                 ('peeruser', 'peersecret')
             ):
-                                           ('peeruser', 'peersecret')]:
                 if auth[userfield] and auth[secretfield]:
-                    for char in self.INVALID_CHARS:
+                    for char in INVALID_CHARACTERS:
                         if char in auth[secretfield]:
                             alerts.append(
                                 Alert(
@@ -105,18 +104,18 @@ class ISCSIAuthSecretAlertSource(AlertSource):
                                     key=auth['id'],
                                 )
                             )
-                                                {'field': private_to_public[secretfield],
-                                                 'tag': auth['tag'],
-                                                 'userfield': private_to_public[userfield],
-                                                 'user': auth[userfield],
-                                                 'char': char
-                                                 }, key=auth['id']))
                     if auth[secretfield] != auth[secretfield].strip():
-                        alerts.append(Alert(ISCSIAuthSecretWhitespaceAlertClass,
-                                            {'field': private_to_public[secretfield],
-                                             'tag': auth['tag'],
-                                             'userfield': private_to_public[userfield],
-                                             'user': auth[userfield],
-                                             }, key=auth['id']))
+                        alerts.append(
+                            Alert(
+                                ISCSIAuthSecretWhitespaceAlertClass,
+                                {
+                                    'field': private_to_public[secretfield],
+                                    'tag': auth['tag'],
+                                    'userfield': private_to_public[userfield],
+                                    'user': auth[userfield],
+                                },
+                                key=auth['id']
+                            )
+                        )
 
         return alerts

--- a/src/middlewared/middlewared/alert/source/iscsi.py
+++ b/src/middlewared/middlewared/alert/source/iscsi.py
@@ -84,12 +84,27 @@ class ISCSIAuthSecretAlertSource(AlertSource):
 
         auths = await self.middleware.call('iscsi.auth.query')
         for auth in auths:
-            for userfield, secretfield in [('user', 'secret'),
+            for userfield, secretfield in (
+                ('user', 'secret'),
+                ('peeruser', 'peersecret')
+            ):
                                            ('peeruser', 'peersecret')]:
                 if auth[userfield] and auth[secretfield]:
                     for char in self.INVALID_CHARS:
                         if char in auth[secretfield]:
-                            alerts.append(Alert(ISCSIAuthSecretInvalidCharAlertClass,
+                            alerts.append(
+                                Alert(
+                                    ISCSIAuthSecretInvalidCharAlertClass,
+                                    {
+                                        'field': private_to_public[secretfield],
+                                        'tag': auth['tag'],
+                                        'userfield': private_to_public[userfield],
+                                        'user': auth[userfield],
+                                        'char': char,
+                                    },
+                                    key=auth['id'],
+                                )
+                            )
                                                 {'field': private_to_public[secretfield],
                                                  'tag': auth['tag'],
                                                  'userfield': private_to_public[userfield],

--- a/src/middlewared/middlewared/alert/source/iscsi.py
+++ b/src/middlewared/middlewared/alert/source/iscsi.py
@@ -58,14 +58,20 @@ class ISCSIAuthSecretInvalidCharAlertClass(AlertClass):
     category = AlertCategory.SHARING
     level = AlertLevel.WARNING
     title = 'iSCSI Authorized Access has an invalid character'
-    text = 'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r has a %(field)s containing the invalid character: %(char)r.'
+    text = (
+        'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r '
+        'has a %(field)s containing the invalid character: %(char)r.'
+    )
 
 
 class ISCSIAuthSecretWhitespaceAlertClass(AlertClass):
     category = AlertCategory.SHARING
     level = AlertLevel.WARNING
     title = 'iSCSI Authorized Access has leading or trailing whitespace'
-    text = 'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r has a %(field)s containing leading or trailing whitespace.'
+    text = (
+        'The iSCSI Authorized Access with Group ID %(tag)d and %(userfield)s %(user)r '
+        'has a %(field)s containing leading or trailing whitespace.'
+    )
 
 
 class ISCSIAuthSecretAlertSource(AlertSource):

--- a/src/middlewared/middlewared/plugins/iscsi_/auth.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/auth.py
@@ -94,6 +94,10 @@ class iSCSITargetAuthCredentialService(CRUDService):
         )
 
         await self.middleware.call('iscsi.auth.recalc_mutual_chap_alert', orig_peerusers)
+
+        # We might have cleared some junk
+        await self.middleware.call('alert.alert_source_clear_run', 'ISCSIAuthSecret')
+
         await self._service_change('iscsitarget', 'reload')
 
         return await self.get_instance(id_)
@@ -119,6 +123,10 @@ class iSCSITargetAuthCredentialService(CRUDService):
         )
         if orig_peerusers:
             await self.middleware.call('iscsi.auth.recalc_mutual_chap_alert', orig_peerusers)
+
+        # We might have cleared some junk
+        await self.middleware.call('alert.alert_source_clear_run', 'ISCSIAuthSecret')
+
         await self._service_change('iscsitarget', 'reload')
 
         return result

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -824,7 +824,6 @@ def test__mutual_chap(iscsi_running):
                  id='Bad character in peersecret'),
 ])
 def test__auth_secret(data, valid, attr, message):
-    # print(data, valid, attr, message)
     if valid:
         with iscsi_auth_data(data):
             pass

--- a/tests/api2/test_261_iscsi_cmd.py
+++ b/tests/api2/test_261_iscsi_cmd.py
@@ -26,6 +26,7 @@ from pytest_dependency import depends
 
 from middlewared.service_exception import CallError, InstanceNotFound, ValidationError, ValidationErrors
 from middlewared.test.integration.assets.iscsi import target_login_test
+from middlewared.test.integration.assets.iscsi import iscsi_auth as iscsi_auth_data
 from middlewared.test.integration.assets.pool import dataset, snapshot
 from middlewared.test.integration.utils import call, ssh
 from middlewared.test.integration.utils.client import truenas_server
@@ -754,6 +755,83 @@ def test__mutual_chap(iscsi_running):
                                 # Finally ensure we can connect with the right Mutual CHAP creds
                                 with iscsi_scsi_connection(truenas_server.ip, iqn, 0, user, secret, peer_user, peer_secret) as s:
                                     _verify_inquiry(s)
+
+
+@pytest.mark.parametrize('data, valid, attr, message', [
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12'},
+                 True, None, None,
+                 id='Valid user/secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'test secret12'},
+                 True, None, None,
+                 id='Valid user/secret with space'),
+    pytest.param({'tag': 1, 'user': 'testuser1'},
+                 False, 'data.secret', 'Field required',
+                 id='No secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': ''},
+                 False, 'iscsi_auth_create.secret', 'Secret must be between 12 and 16 characters.',
+                 id='Empty secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'short'},
+                 False, 'iscsi_auth_create.secret', 'Secret must be between 12 and 16 characters.',
+                 id='Short secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'averylongsecretcausesproblems'},
+                 False, 'iscsi_auth_create.secret', 'Secret must be between 12 and 16 characters.',
+                 id='Long secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': ' testpassword12'},
+                 False, 'iscsi_auth_create.secret', 'Secret contains leading or trailing space.',
+                 id='Leading space in secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testpassword12 '},
+                 False, 'iscsi_auth_create.secret', 'Secret contains leading or trailing space.',
+                 id='Trailing space in secret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': '#testpassword12'},
+                 False, 'iscsi_auth_create.secret', 'Secret contains invalid characters: #',
+                 id='Bad character in secret'),
+    # Peer
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': 'test secret!!'},
+                 True, None, None,
+                 id='Valid peeruser/peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': 'test secret12'},
+                 True, None, None,
+                 id='Valid peeruser/peersecret with space'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2'},
+                 False, 'iscsi_auth_create.peersecret', 'The peer secret is required if you set a peer user.',
+                 id='No peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': ''},
+                 False, 'iscsi_auth_create.peersecret', 'The peer secret is required if you set a peer user.',
+                 id='Empty peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': 'short'},
+                 False, 'iscsi_auth_create.peersecret', 'Peer Secret must be between 12 and 16 characters.',
+                 id='Short peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': 'averylongsecretcausesproblems'},
+                 False, 'iscsi_auth_create.peersecret', 'Peer Secret must be between 12 and 16 characters.',
+                 id='Long peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': ' testpassword12'},
+                 False, 'iscsi_auth_create.peersecret', 'Peer Secret contains leading or trailing space.',
+                 id='Leading space in peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': 'testpassword12 '},
+                 False, 'iscsi_auth_create.peersecret', 'Peer Secret contains leading or trailing space.',
+                 id='Trailing space in peersecret'),
+    pytest.param({'tag': 1, 'user': 'testuser1', 'secret': 'testsecret12',
+                  'peeruser': 'testuser2', 'peersecret': '#testpassword12'},
+                 False, 'iscsi_auth_create.peersecret', 'Peer Secret contains invalid characters: #',
+                 id='Bad character in peersecret'),
+])
+def test__auth_secret(data, valid, attr, message):
+    # print(data, valid, attr, message)
+    if valid:
+        with iscsi_auth_data(data):
+            pass
+    else:
+        with assert_validation_errors(attr, message):
+            with iscsi_auth_data(data):
+                pass
 
 
 def _assert_auth(auth, tag, user, secret, peeruser, peersecret, discovery_auth):


### PR DESCRIPTION
Perform some fixup with iSCSI Authorized Access CHAP secrets
- Add `ISCSIAuthSecretAlertSource` to warn about existing bad secrets
- Enhance iSCSI auth `secret` and `peersecret` validation
- Add `test__auth_secret`

It was found that `scstadmin`/`scst `have problems with the `#` character and _some_ issues with whitespace (e.g. all whitespace secret).  We will warn users if they currently have such secrets configured and prevent them from being added going forward.

----
[CI run](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4641/): passing (wrt iSCSI)