### PR TITLE
NAS-136020 / 25.10 / fix IndexError in pool.dataset.create

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset.py
@@ -208,7 +208,7 @@ class PoolDatasetService(CRUDService):
             # changes to the root dataset (zpool)
             parent_name = data['name']
         else:
-            parent_name = parents[-1]
+            parent_name = parents[0]
 
         if not parent:
             parent = await self.middleware.call(


### PR DESCRIPTION
To try and fix the unhelpful validation error as described (and fixed in) cc12ccc9303bb1465930c7bacc2143bb3259ec06, this introduced an `IndexError` crash when someone tries to create a dataset when the parent dataset doesn't exist and `create_ancestors` isn't set to True....the _EXACT_ problem that the original commit set out to fix 🤦 . The current error message that gets raised is
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/pool_/dataset.py", line 480, in do_create
    parent_ds = parent_ds[0]
                ~~~~~~~~~^^^
IndexError: list index out of range
```

The reason for this is that we're accessing the last element of the list instead of the first. The last element of the list is the zpool. This is how `get_dataset_parents` works so resolving the issue is simply accessing the first element of the list which will be the closest parent to the dataset trying to be created. With this fixed, the error message is more intuitive.
```
[EINVAL] pool_dataset_create.name: Parent dataset (dozer/nope) does not exist.
```