### PR TITLE
NAS-136182 / 25.10 / disable STIG/FIPS tests temporarily

### DIFF
--- a/tests/api2/test_zzzz_stig.py
+++ b/tests/api2/test_zzzz_stig.py
@@ -9,6 +9,8 @@ from middlewared.test.integration.assets.two_factor_auth import (
 from middlewared.test.integration.utils import call, client, mock, password
 from truenas_api_client import ValidationErrors
 
+pytestmark = pytest.mark.skip('100% fail. Needs to be reworked.')
+
 # Alias
 pp = pytest.param
 

--- a/tests/api2/test_zzzzz_openssl.py
+++ b/tests/api2/test_zzzzz_openssl.py
@@ -3,6 +3,8 @@ import pytest
 from middlewared.test.integration.utils import call, ssh
 from auto_config import ha
 
+pytestmark = pytest.mark.skip('100% fail. Needs to be reworked.')
+
 retry = 5
 fips_version = "3.0.9"
 


### PR DESCRIPTION
These fail 100% of the time. If they fail 100% of the time, they're testing nothing. Disable them until we can rework the tests and figure out a path forward. A ticket has been opened up for this: https://ixsystems.atlassian.net/browse/NAS-135969