### PR TITLE
NAS-135200 / 25.10 / Add support for directory services authentication for FTP.

### DIFF
--- a/src/middlewared/middlewared/etc_files/proftpd/proftpd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/proftpd/proftpd.conf.mako
@@ -3,6 +3,7 @@
 
     ftp = render_ctx['ftp.config']
     network_configuration = render_ctx['network.configuration.config']
+    directory_services = render_ctx['directoryservices.config']
 
     # Confirm necessary directories, files and permissions
     os.makedirs("/var/log/proftpd", exist_ok=True)
@@ -56,7 +57,13 @@ UseReverseDNS ${'on' if ftp['reversedns'] else 'off'}
     PassivePorts  ${ftp['passiveportsmin']} ${ftp['passiveportsmax']}
 % endif
 
+% if directory_services['enable']:
+AuthPAMConfig proftpd
+AuthOrder mod_auth_pam.c* mod_auth_unix.c
+% else:
 AuthOrder mod_auth_unix.c
+% endif
+
 % if ftp['onlyanonymous'] and anonpath:
 <Anonymous ${ftp['anonpath']}>
     User ftp

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -10,7 +10,7 @@ from middlewared.service import Service, private, job
 from middlewared.service_exception import MatchNotFound
 from middlewared.utils.directoryservices.health import DSHealthObj
 
-DEPENDENT_SERVICES = ['smb', 'nfs', 'ssh']
+DEPENDENT_SERVICES = ['smb', 'nfs', 'ssh', 'ftp']
 
 
 class DirectoryServices(Service):

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -237,7 +237,8 @@ class EtcService(Service):
             'ctx': [
                 {'method': 'ftp.config'},
                 {'method': 'user.query', 'args': [[["builtin", "=", True], ["username", "!=", "ftp"]]]},
-                {'method': 'network.configuration.config'}
+                {'method': 'network.configuration.config'},
+                {'method': 'directoryservices.config'}
             ],
             'entries': [
                 {'type': 'mako', 'path': 'proftpd/proftpd.conf'},

--- a/src/middlewared/middlewared/utils/directoryservices/constants.py
+++ b/src/middlewared/middlewared/utils/directoryservices/constants.py
@@ -18,7 +18,7 @@ class DSType(enum.Enum):
     def etc_files(self):
         match self:
             case DSType.AD:
-                return ('pam', 'nss', 'smb', 'kerberos')
+                return ('pam', 'nss', 'smb', 'kerberos', 'ftp')
             case DSType.IPA:
                 return ('ldap', 'ipa', 'pam', 'nss', 'smb', 'kerberos')
             case DSType.LDAP:


### PR DESCRIPTION
Active Directory users are not able to authenticate via the FTP protocol. 

This PR fixes that with a configuration change in the `proftpd.conf` file when a directory service is enabled.

This has been manually tested against an AD server. 
```
grimes@debianix:~/scale-repos/middleware.generic$ ftp MCGDOMAIN\\ftpuser@192.168.45.154
Connected to 192.168.45.154.
220 ProFTPD Server (tnge-hv-ftp FTP Server) [::ffff:192.168.45.154]
331 Password required for MCGDOMAIN\ftpuser
Password:
230-Welcome to TrueNAS FTP Server
230 User MCGDOMAIN\ftpuser logged in
Remote system type is UNIX.
Using binary mode to transfer files.
ftp> quit
421 No transfer timeout (300 seconds): closing control connection

```
---------------------------------------
Testing against a FreeIPA server and CI tests will be implemented in a separate PR.
