### PR TITLE
NAS-136203 / 25.10 / Force fallback realm info for IPA to upper case

### DIFF
--- a/src/middlewared/middlewared/utils/directoryservices/credential.py
+++ b/src/middlewared/middlewared/utils/directoryservices/credential.py
@@ -142,7 +142,7 @@ def write_temporary_kerberos_config(schema: str, new: dict, verrors: ValidationE
                 kdc.append(new['configuration']['target_server'])
 
             if not realm:
-                realm = new['configuration']['domain']
+                realm = new['configuration']['domain'].upper()
 
             aux.append('udp_preference_limit=0')
 


### PR DESCRIPTION
If the configuration doesn't have an explicit realm defined, we fallback to what is set as configuration->domain. This must be forced to uppercase (because IPA realms are uppercase).