### PR TITLE
NAS-136212 / 25.10 / fix quota api tests

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
+++ b/src/middlewared/middlewared/plugins/pool_/dataset_quota.py
@@ -69,7 +69,7 @@ def quota_alert_cb(hdl, state):
     info = hdl.asdict(
         properties={
             truenas_pylibzfs.ZFSProperty.USED,
-            truenas_pylibzfs.ZFSProperty.USEDDS,
+            truenas_pylibzfs.ZFSProperty.USEDBYDATASET,
             truenas_pylibzfs.ZFSProperty.QUOTA,
             truenas_pylibzfs.ZFSProperty.REFQUOTA,
             truenas_pylibzfs.ZFSProperty.AVAILABLE,


### PR DESCRIPTION
I made a change in our new libzfs module here https://github.com/truenas/truenas_pylibzfs/pull/74 whereby it changed the ZFSProperty's enum field names to match the upstream zfs property name. The USEDDS property was changed to USEDBYDATASET and so this fixes it which should resolve the API test failures.