### PR TITLE
Add a defer flag to iscsi target/extent/targetextent create/update/delete

### DIFF
--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_extent.py
@@ -47,6 +47,7 @@ class IscsiExtentCreate(IscsiExtentEntry):
     naa: Excluded = excluded_field()
     vendor: Excluded = excluded_field()
     locked: Excluded = excluded_field()
+    defer: Bool = False
 
 
 class IscsiExtentCreateArgs(BaseModel):
@@ -74,6 +75,7 @@ class IscsiExtentDeleteArgs(BaseModel):
     id: int
     remove: bool = False
     force: bool = False
+    defer: Bool = False
 
 
 class IscsiExtentDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_target.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_target.py
@@ -63,6 +63,7 @@ class IscsiTargetValidateNameResult(BaseModel):
 class IscsiTargetCreate(IscsiTargetEntry):
     id: Excluded = excluded_field()
     rel_tgt_id: Excluded = excluded_field()
+    defer: Bool = False
 
 
 class IscsiTargetCreateArgs(BaseModel):
@@ -90,6 +91,7 @@ class IscsiTargetDeleteArgs(BaseModel):
     id: int
     force: bool = False
     delete_extents: bool = False
+    defer: Bool = False
 
 
 class IscsiTargetDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/api/v25_10_0/iscsi_target_to_extent.py
+++ b/src/middlewared/middlewared/api/v25_10_0/iscsi_target_to_extent.py
@@ -23,6 +23,7 @@ class IscsiTargetToExtentEntry(BaseModel):
 class IscsiTargetToExtentCreate(IscsiTargetToExtentEntry):
     id: Excluded = excluded_field()
     lunid: int | None = None
+    defer: Bool = False
 
 
 class IscsiTargetToExtentCreateArgs(BaseModel):
@@ -34,7 +35,7 @@ class IscsiTargetToExtentCreateResult(BaseModel):
 
 
 class IscsiTargetToExtentUpdate(IscsiTargetToExtentEntry, metaclass=ForUpdateMetaclass):
-    pass
+    defer: Bool = False
 
 
 class IscsiTargetToExtentUpdateArgs(BaseModel):
@@ -49,6 +50,7 @@ class IscsiTargetToExtentUpdateResult(BaseModel):
 class IscsiTargetToExtentDeleteArgs(BaseModel):
     id: int
     force: bool = False
+    defer: Bool = False
 
 
 class IscsiTargetToExtentDeleteResult(BaseModel):

--- a/src/middlewared/middlewared/plugins/iscsi_/extents.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/extents.py
@@ -95,6 +95,12 @@ class iSCSITargetExtentService(SharingService):
 
         `ro` when set to true prevents the initiator from writing to this LUN.
         """
+        defer = False
+        try:
+            defer = data.pop('defer')
+        except KeyError:
+            pass
+
         await self.validate(data)
         verrors = ValidationErrors()
         await self.clean(data, 'iscsi_extent_create', verrors)
@@ -133,6 +139,12 @@ class iSCSITargetExtentService(SharingService):
         """
         Update iSCSI Extent of `id`.
         """
+        defer = False
+        try:
+            defer = data.pop('defer')
+        except KeyError:
+            pass
+
         verrors = ValidationErrors()
         old = await self.get_instance(id_)
         audit_callback(old['name'])
@@ -169,10 +181,11 @@ class iSCSITargetExtentService(SharingService):
             {'prefix': self._config.datastore_prefix}
         )
 
-        await self._service_change('iscsitarget', 'reload')
+        if not defer:
+            await self._service_change('iscsitarget', 'reload')
 
-        # scstadmin can have issues when modifying an existing extent, re-run
-        await self._service_change('iscsitarget', 'reload')
+            # scstadmin can have issues when modifying an existing extent, re-run
+            await self._service_change('iscsitarget', 'reload')
 
         return await self.get_instance(id_)
 
@@ -182,7 +195,7 @@ class iSCSITargetExtentService(SharingService):
         audit='Delete iSCSI extent',
         audit_callback=True
     )
-    async def do_delete(self, audit_callback, id_, remove, force):
+    async def do_delete(self, audit_callback, id_, remove, force, defer):
         """
         Delete iSCSI Extent of `id`.
 
@@ -210,7 +223,7 @@ class iSCSITargetExtentService(SharingService):
                 raise CallError(f'Failed to remove extent file: {delete!r}')
 
         for target_to_extent in target_to_extents:
-            await self.middleware.call('iscsi.targetextent.delete', target_to_extent['id'], force)
+            await self.middleware.call('iscsi.targetextent.delete', target_to_extent['id'], force, defer)
 
         # This change is being made in conjunction with threads_num being specified in scst.conf
         if data['type'] == 'DISK' and data['path'].startswith('zvol/'):
@@ -226,7 +239,8 @@ class iSCSITargetExtentService(SharingService):
                 'datastore.delete', self._config.datastore, id_
             )
         finally:
-            await self._service_change('iscsitarget', 'reload')
+            if not defer:
+                await self._service_change('iscsitarget', 'reload')
             if all([await self.middleware.call("iscsi.global.alua_enabled"),
                     await self.middleware.call('failover.remote_connected')]):
                 await self.middleware.call('iscsi.alua.wait_for_alua_settled')

--- a/src/middlewared/middlewared/plugins/iscsi_/fs_attachment_delegate.py
+++ b/src/middlewared/middlewared/plugins/iscsi_/fs_attachment_delegate.py
@@ -25,7 +25,7 @@ class ISCSIFSAttachmentDelegate(LockableFSAttachmentDelegate):
         for te in await self.middleware.call('iscsi.targetextent.query', [['target', 'in', orphan_targets_ids]]):
             orphan_targets_ids.discard(te['target'])
         for target_id in orphan_targets_ids:
-            await self.middleware.call('iscsi.target.delete', target_id, True)
+            await self.middleware.call('iscsi.target.delete', target_id, True, True)
 
         await self._service_change('iscsitarget', 'reload')
 


### PR DESCRIPTION
Add a defer flag to iscsi target/extent/targetextent create/update/delete. This results in a measureable speedup in iscsi performance: roughly 3.75x faster per create/delete cycle. This commit is part of the effort to add a TrueNAS driver to Incus.

This results in a measureable speedup in iscsi performance: roughly 3.75x faster per create/delete cycle. This commit is part of the effort to add a TrueNAS driver to Incus.

This is BEFORE

```
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --debug --config fangtooth share iscsi create --target-prefix=incus dozer/jacks-incus/iscsi-vol2
[[["alias","in",["dozer/jacks-incus/iscsi-vol2"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
tncdaemon connection time: 886.063µs
iscsi.target.query: 185.321513ms
resultsList was empty
iscsi.portal.query: 40.013578ms
iscsi.initiator.query: 33.608441ms
iscsi.target.create: 43.041363ms
defer not supported - was not aware
[{"alias":"dozer/jacks-incus/iscsi-vol2","groups":[{"initiator":1,"portal":1}],"name":"incus:dozer:jacks-incus:iscsi-vol2"}]
iscsi.target.create: 2.169660167s
[[["disk","in",["zvol/dozer/jacks-incus/iscsi-vol2"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
iscsi.extent.query: 166.283708ms
resultsList was empty
defer not supported - aware
[{"disk":"zvol/dozer/jacks-incus/iscsi-vol2","name":"incus:dozer:jacks-incus:iscsi-vol2","ro":false}]
iscsi.extent.create: 390.085498ms
[[],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
iscsi.targetextent.query: 40.775749ms
defer not supported - aware
[{"extent":12233,"lunid":0,"target":12255}]
iscsi.targetextent.create: 2.187420955s
created	dozer/jacks-incus/iscsi-vol2
undoIscsiCreateList

real	0m5.304s
user	0m0.001s
sys	0m0.010s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --debug --config fangtooth share iscsi delete --target-prefix=incus dozer/jacks-incus/iscsi-vol2
[[["alias","in",["dozer/jacks-incus/iscsi-vol2"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
tncdaemon connection time: 888.107µs
iscsi.target.query: 160.478358ms
[[["name","in",["dozer/jacks-incus/iscsi-vol2"]]],{"extra":{"flat":false,"properties":[],"retrieve_children":true,"user_properties":false}}]
pool.dataset.query: 49.809661ms
iscsi.target.delete: 40.862491ms
defer not supported - was not aware
[12255,true,true]
iscsi.target.delete: 14.918416722s
deleted	dozer/jacks-incus/iscsi-vol2
undoIscsiDeleteList

real	0m15.220s
user	0m0.002s
sys	0m0.009s
```

So, 5.3s to create a share. 15.22s to delete it.
And then the same tool, when running against a “defer” enhanced middleware.

```
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --debug --config testing share iscsi create puddle/defer-testing/vol
[[["alias","in",["puddle/defer-testing/vol"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
tncdaemon connection time: 368.361µs
iscsi.target.query: 87.970319ms
resultsList was empty
iscsi.portal.query: 33.123852ms
iscsi.initiator.query: 30.907891ms
iscsi.target.create: 209.844556ms
[[["disk","in",["zvol/puddle/defer-testing/vol"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
iscsi.extent.query: 74.20844ms
resultsList was empty
iscsi.extent.create: 210.260233ms
[[],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
iscsi.targetextent.query: 51.338144ms
iscsi.targetextent.create: 139.465783ms
created	puddle/defer-testing/vol
undoIscsiCreateList
reloading iscsitarget
["iscsitarget",{}]
service.reload: 1.079414432s
{"jsonrpc": "2.0", "result": true, "id": 24}

real	0m1.934s
user	0m0.003s
sys	0m0.008s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --debug --config testing share iscsi delete puddle/defer-testing/vol
[[["alias","in",["puddle/defer-testing/vol"]]],{"extra":{"flat":false,"properties":null,"retrieve_children":false,"user_properties":false}}]
tncdaemon connection time: 440.288µs
iscsi.target.query: 119.316894ms
[[["name","in",["puddle/defer-testing/vol"]]],{"extra":{"flat":false,"properties":[],"retrieve_children":true,"user_properties":false}}]
pool.dataset.query: 49.232517ms
iscsi.target.delete: 2.788363735s
deleted	puddle/defer-testing/vol
undoIscsiDeleteList
reloading iscsitarget
["iscsitarget",{}]
service.reload: 577.556624ms
{"jsonrpc": "2.0", "result": true, "id": 28}

real	0m3.552s
user	0m0.002s
sys	0m0.009s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ 
```

1.934s to create, and 3.5s to delete.

That makes deleting 4.3x faster, and creating 2.74x faster.
Here’s a clearer run without all the debug:

```
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --config fangtooth share iscsi create --target-prefix=incus dozer/jacks-incus/iscsi-vol2
created	dozer/jacks-incus/iscsi-vol2

real	0m6.210s
user	0m0.003s
sys	0m0.008s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --config fangtooth share iscsi delete --target-prefix=incus dozer/jacks-incus/iscsi-vol2
deleted	dozer/jacks-incus/iscsi-vol2

real	0m16.167s
user	0m0.002s
sys	0m0.008s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --config testing share iscsi create puddle/defer-testing/vol
created	puddle/defer-testing/vol

real	0m3.403s
user	0m0.003s
sys	0m0.008s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ time sudo ./truenas_incus_ctl --config testing share iscsi delete puddle/defer-testing/vol
deleted	puddle/defer-testing/vol

real	0m3.233s
user	0m0.002s
sys	0m0.008s
jack@jack-desktop:~/truenas/truenas_incus_ctl$ 
```

Showing 5x faster deletes.

Here’s where the rubber hits the road.
Previously, when performing the basic usage tests… they’d take about 30 minutes.

```
==> TEST DONE: test_basic_usage (1752s)
+ TEST_RESULT=success
```

But with the changes to defer reload until the end of the procedure its under 10 minutes.

```
==> TEST DONE: test_basic_usage (563s)
+ TEST_RESULT=success
```

That is a 3.1x improvement in the test run time… and not all of the run time is due to create/delete overhead, but it is very significant.
The full standalone tests take about 5hrs to run. I’m hoping they reduce with these changes.

@kmoore134 
@william-gr 
